### PR TITLE
OCR fix engine is null, when no dictionary has been selected in OCR engi...

### DIFF
--- a/src/Forms/VobSubOcr.cs
+++ b/src/Forms/VobSubOcr.cs
@@ -3911,7 +3911,8 @@ namespace Nikse.SubtitleEdit.Forms
 
             //ocr fix engine
             string textWithOutFixes = line;
-            if (_ocrFixEngine.IsDictionaryLoaded)
+            //OCR fix engine not loaded, when no dictionary is selected
+            if (_ocrFixEngine != null && _ocrFixEngine.IsDictionaryLoaded)
             {
                 if (checkBoxAutoFixCommonErrors.Checked)
                     line = _ocrFixEngine.FixOcrErrors(line, listViewIndex, _lastLine, true, checkBoxGuessUnknownWords.Checked);


### PR DESCRIPTION
On a fresh installation, the dictionary is not present and the _ocrFixEngine is empty. Checking for null skips the code part and detection works again (albeit without Fix Engine).
