### PR TITLE
[RE] Fix #87 - crash when passing bad font tag in ssa/ass

### DIFF
--- a/src/Logic/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/Logic/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -382,13 +382,13 @@ Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text
             int count = 0;
             while (text.Contains("<font ") && count < 10)
             {
+                text = text.Replace("</font>", string.Empty);
                 int start = text.IndexOf(@"<font ");
                 int end = text.IndexOf('>', start);
                 if (end > 0)
                 {
                     string fontTag = text.Substring(start + 4, end - (start + 4));
                     text = text.Remove(start, end - start + 1);
-                    text = text.Replace("</font>", string.Empty);
 
                     fontTag = FormatTag(ref text, start, fontTag, "face=\"", "\"", "fn", "}");
                     fontTag = FormatTag(ref text, start, fontTag, "face='", "'", "fn", "}");

--- a/src/Logic/SubtitleFormats/SubStationAlpha.cs
+++ b/src/Logic/SubtitleFormats/SubStationAlpha.cs
@@ -137,13 +137,13 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             int count = 0;
             while (text.Contains("<font ") && count < 10)
             {
+                text = text.Replace("</font>", string.Empty);
                 int start = text.IndexOf(@"<font ");
                 int end = text.IndexOf('>', start);
                 if (end > 0)
                 {
                     string fontTag = text.Substring(start + 4, end - (start + 4));
                     text = text.Remove(start, end - start + 1);
-                    text = text.Replace("</font>", string.Empty);
 
                     fontTag = FormatTag(ref text, start, fontTag, "face=\"", "\"", "fn", "}");
                     fontTag = FormatTag(ref text, start, fontTag, "face='", "'", "fn", "}");


### PR DESCRIPTION
Fix #87 , but once corrected, as this font is not converted correctly.
(Is changed to the Fix #87 , font does not seem to be converted correctly.?)
Or you will not need to move even a position to replace it?
