### PR TITLE
Bugfix: Insert new paragraph with negative time

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -2076,8 +2076,6 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (_subtitle == null || _subtitle.Paragraphs.Count == 0)
                     return false;
-                if (_subtitle.Paragraphs.Count == 1 && string.IsNullOrEmpty(_subtitle.Paragraphs[0].Text))
-                    return false;
                 return true;
             }
         }


### PR DESCRIPTION
Is you start a new empty subtitle and try to insert empty paragraph for second time you will noticed that the paragraph will be inserted before the first inserted paragraph with negative timer code.
PS: take a look here: #178
