### PR TITLE
don't remove dash in string- when followed by "and" or "or" (for English...

### DIFF
--- a/src/Forms/FixCommonErrors.cs
+++ b/src/Forms/FixCommonErrors.cs
@@ -1288,6 +1288,9 @@ namespace Nikse.SubtitleEdit.Forms
                             if (after.Length > 0 && after.ToLower() == before.ToLower())
                                 p.Text = p.Text.Remove(idx + 1, 1);
                             else if (before.Length > 0)
+                                if (Language == "nl" && (after.ToLower() == "en" || after.ToLower() == "of")) {}
+                                else if (Language == "en" && (after.ToLower() == "and" || after.ToLower() == "or")) {}
+                                else 
                                 p.Text = p.Text.Remove(idx + 1, 1);
                         }
                         if (idx + 1 < p.Text.Length && idx != -1)


### PR DESCRIPTION
... & Dutch languages)

 Proposition for the "Fix Unneeded Spaces" :

In case of **somestring- nextstring** , when nextstring is either **and** or **or**, do not do the fix.
(for Dutch : **en** or **of**)

Examples :

(English)
_What are your long- and altitude stats ?_
_Did you buy that first- or second-handed ?_

(Dutch)
_Wat is je voor- en familienaam ?_
_Was het in het voor- of najaar ?_

P.S. Take a good look before commiting, I probably made some beginners faults regarding "proper" codewriting. :flushed:
