### PR TITLE
 don't remove dash in string- when followed by "and" or "or" (for Englis...

### DIFF
--- a/src/Forms/FixCommonErrors.cs
+++ b/src/Forms/FixCommonErrors.cs
@@ -1288,7 +1288,34 @@ namespace Nikse.SubtitleEdit.Forms
                             if (after.Length > 0 && after.ToLower() == before.ToLower())
                                 p.Text = p.Text.Remove(idx + 1, 1);
                             else if (before.Length > 0)
-                                p.Text = p.Text.Remove(idx + 1, 1);
+                                switch (Language)
+                                {
+                                    case "en":
+                                        switch (after.ToLower())
+	                                        {
+                                            case "and":
+                                            case "or":
+                                                break;
+                                            default:
+                                                p.Text = p.Text.Remove(idx + 1, 1);
+                                                break;
+                                            }
+                                        break;
+                                    case "nl":
+                                        switch (after.ToLower())
+                                        {
+                                            case "en":
+                                            case "of":
+                                                break;
+                                            default:
+                                                p.Text = p.Text.Remove(idx + 1, 1);
+                                                break;
+                                        }
+                                        break;
+                                    default:
+                                        p.Text = p.Text.Remove(idx + 1, 1);
+                                        break;
+                                }
                         }
                         if (idx + 1 < p.Text.Length && idx != -1)
                             idx = p.Text.IndexOf("- ", idx + 1);


### PR DESCRIPTION
...h & Dutch languages)

Proposition for the "Fix Unneeded Spaces" :

In case of somestring- nextstring , when nextstring is either and or or, do not do the fix.
(for Dutch : en or of)

Examples :

(English)
What are your long- and altitude stats ?
There is an X- and a Y-chromosome.
Did you buy that first- or second-hand ?

(Dutch)
Wat is je voor- en familienaam ?
Was het in het voor- of najaar ?

P.S. Anything wrong with this code change ? . :flushed:
