### PR TITLE
Fix UnknownSubtitle11 underline subtitles

### DIFF
--- a/src/Logic/SubtitleFormats/UnknownSubtitle11.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle11.cs
@@ -121,8 +121,8 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                     else if (line.StartsWith("<u>") || underlineOn)
                     {
                         italicOn = false;
-                        boldOn = true;
-                        underlineOn = false;
+                        boldOn = false;
+                        underlineOn = true;
                         lineSb.Append("{y:u}"); // underline single line
                     }
 


### PR DESCRIPTION
It seems that UnknownSubtitle11 wasn't processing underline subtitles.
