### PR TITLE
Fix subtitle splitting for paragraphs ending after split time

### DIFF
--- a/src/Forms/SplitSubtitle.cs
+++ b/src/Forms/SplitSubtitle.cs
@@ -91,6 +91,8 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     else if (p.EndTime.TotalMilliseconds > splitTime.TotalMilliseconds)
                     {
+                        Paragraph p1 = part1.Paragraphs[part1.Paragraphs.Count - 1];
+                        p1.EndTime = new TimeCode(splitTime.TotalMilliseconds);
                         Paragraph p2 = new Paragraph(p);
                         p2.StartTime = new TimeCode(splitTime.TotalMilliseconds);
                         part2.Paragraphs.Add(p2);


### PR DESCRIPTION
Hi Nikolaj,

First, thanks for a great piece of software I use daily.

I noticed a minor glitch while splitting subtitles (_Tools_ -> _Split subtitle..._) containing a paragraph whose end time stretches beyond the split time (e.g. 01:05:48,720 --> 01:05:51,600 with split time 01:05:49,520). Taking a quick look at `SplitSubtitle.cs`, I believe the logic behind this case is contained in [lines 92-95](https://github.com/SubtitleEdit/subtitleedit/blob/master/src/Forms/SplitSubtitle.cs#L92-L95). I presume your intention here was to copy such a paragraph to part 2 and then set the start time of that copy to 00:00:00,001. Yet the code doesn't copy the paragraph - instead it modifies the original _Paragraph_ instance by changing its start time. Commit 9e3fd8e from this pull request attempts to fix this by creating a copy of the paragraph, setting its beginning to the split time (in order for it to become 00:00:00,000 after the [later call](https://github.com/SubtitleEdit/subtitleedit/blob/master/src/Forms/SplitSubtitle.cs#L101) to `AddTimeToAllParagraphs()`) and adding the copy to part 2. I shamefully admit I haven't even compiled the modified code as I currently don't have a Windows machine at hand (which also means my C# skills are very rusty).

The other commit, bd5a796, attempts to add some more elegance to the solution by trimming the end time of paragraphs stretching beyond the split time to the split time itself. I believe this is purely cosmetic, but this is what a "split" intuitively means to me - a division of a larger entity into two parts at an exact point.

If you are happy with both changes, I can squash them into a single commit for your convenience. I created two separate commits only to convey my ideas more clearly.
