### PR TITLE
Fix subtitle splitting for frame-based formats

### DIFF
--- a/src/Forms/SplitSubtitle.cs
+++ b/src/Forms/SplitSubtitle.cs
@@ -130,8 +130,11 @@ namespace Nikse.SubtitleEdit.Forms
                     int index = 0;
                     foreach (SubtitleFormat format in SubtitleFormat.AllSubtitleFormats)
                     {
-                        if (saveFileDialog1.FilterIndex == index + 1)
+                        if (saveFileDialog1.FilterIndex == index + 1) {
+                            if (format.IsFrameBased)
+                                part.CalculateFrameNumbersFromTimeCodesNoCheck(Configuration.Settings.General.CurrentFrameRate);
                             File.WriteAllText(fileName, part.ToText(format), _encoding);
+                        }
                         index++;
                     }
                 }


### PR DESCRIPTION
Hi again Nikolaj,

I found another issue with subtitle splitting, this time affecting only frame-based output formats (notably MicroDVD): after splitting, the second part has original start and end frames set for all paragraphs (as if you just divided the original file into parts, without rewinding the second part by a proper time offset). I believe this happens because `MicroDvd.cs` uses the `StartFrame` and `EndFrame` members of each `Paragraph`, which are not affected by the `AddTimeToAllParagraphs()` [call](https://github.com/SubtitleEdit/subtitleedit/blob/master/src/Forms/SplitSubtitle.cs#L101) in `SplitSubtitle.cs`.

Commit 3570abd attempts to fix this issue by checking if the output subtitle format is frame-based while splitting. If it is, it makes sure frame numbers for each paragraph are recalculated to reflect the temporal rewind. As with my previous pull request, I shamefully admit I haven't even compiled the modified code. In case my fix is wrong, hopefully it will at least give you a general idea about what needs fixing.
