### PR TITLE
Handle possible error that can happen when BatchConverting

### DIFF
--- a/src/Logic/CommandLineConvert.cs
+++ b/src/Logic/CommandLineConvert.cs
@@ -492,7 +492,22 @@ namespace Nikse.SubtitleEdit.Logic
                         }
                         else
                         {
-                            File.WriteAllText(outputFileName, sub.ToText(sf), targetEncoding);
+                            if (!File.Exists(outputFileName))
+                            {
+                                Console.WriteLine("File not found!");
+                                errors++;
+                                return false;
+                            }
+                            if ((File.GetAttributes(outputFileName) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                            {
+                                Console.WriteLine("File is Read-Only!");
+                                errors++;
+                                return false;
+                            }
+                            else
+                            {
+                                File.WriteAllText(outputFileName, sub.ToText(sf), targetEncoding);
+                            }
                         }
 
                         if (format.GetType() == typeof(Sami) || format.GetType() == typeof(SamiModern))


### PR DESCRIPTION
If you set a file to read-only and try batch converting it you will get a unhandled exception same thing would happen if the file is read-only and **Overwrite original file** is uncheck