### PR TITLE
Fixed languageOriginal would always be empty

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -6608,7 +6608,7 @@ namespace Nikse.SubtitleEdit.Forms
             string language = Utilities.AutoDetectGoogleLanguage(_subtitle);
             string languageOriginal = string.Empty;
             if (_subtitleAlternate != null)
-                Utilities.AutoDetectGoogleLanguage(_subtitleAlternate);
+                languageOriginal = Utilities.AutoDetectGoogleLanguage(_subtitleAlternate);
 
             if (SubtitleListview1.SelectedItems.Count > 1)
             {


### PR DESCRIPTION
Fails building because of: 
[01:49:29] EXEC : error : Object reference not set to an instance of an object. [C:\projects\subtitleedit\src\SubtitleEdit.csproj]
[01:49:41] EXEC : error : Something went wrong when generating the revision number... [C:\projects\subtitleedit\src\SubtitleEdit.csproj]

I thinks the problem were caused by language file updates from last commites
try fixing it in your file