### PR TITLE
SE build depency + UpdateLanguageFiles refact

### DIFF
--- a/src/SubtitleEdit.csproj
+++ b/src/SubtitleEdit.csproj
@@ -1953,12 +1953,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>"$(ProjectDir)..\build_helpers.bat" rev</PreBuildEvent>
+    <PreBuildEvent>"$(ProjectDir)..\build_helpers.bat" rev &amp;&amp; "$(ProjectDir)..\build_helpers.bat" lang</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>COPY /Y /V "$(ProjectDir)packages\NHunspell.1.2.5359.26126\content\*.dll" "$(TargetDir)"
-"$(ProjectDir)packages\ILRepack.1.25.0\tools\ILRepack.exe" /out:"$(TargetDir)$(TargetName).exe" "$(TargetDir)$(TargetName).exe" "$(ProjectDir)packages\NHunspell.1.2.5359.26126\lib\net\NHunspell.dll" "$(ProjectDir)packages\zlib.net.1.0.4.0\lib\zlib.net.dll" "$(ProjectDir)DLLs\Interop.QuartzTypeLib.dll" /targetplatform:v4 /internalize /parallel
-"$(ProjectDir)..\build_helpers.bat" lang</PostBuildEvent>
+"$(ProjectDir)packages\ILRepack.1.25.0\tools\ILRepack.exe" /out:"$(TargetDir)$(TargetName).exe" "$(TargetDir)$(TargetName).exe" "$(ProjectDir)packages\NHunspell.1.2.5359.26126\lib\net\NHunspell.dll" "$(ProjectDir)packages\zlib.net.1.0.4.0\lib\zlib.net.dll" "$(ProjectDir)DLLs\Interop.QuartzTypeLib.dll" /targetplatform:v4 /internalize /parallel</PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/UpdateLanguageFiles/Program.cs
+++ b/src/UpdateLanguageFiles/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 
 namespace UpdateLanguageFiles
 {
@@ -25,11 +26,10 @@ namespace UpdateLanguageFiles
                 string oldLanguageAsXml = File.ReadAllText(args[0]);
                 if (oldLanguageAsXml != currentLanguageAsXml)
                 {
-                    File.WriteAllText(args[0], currentLanguageAsXml);
+                    language.Save(args[0]);
                     noOfChanges++;
-                    Console.Write(" LanguageMaster.xml generated... ");
+                    Console.Write(" {0} generated...", Path.GetFileName(args[0]));
                 }
-                language.Save(args[0]);
 
                 string languageDeserializerContent = Nikse.SubtitleEdit.Logic.LanguageDeserializerGenerator.GenerateCSharpXmlDeserializerForLanguage();
                 string languageDeserializerContentOld = string.Empty;
@@ -37,9 +37,9 @@ namespace UpdateLanguageFiles
                     languageDeserializerContentOld = File.ReadAllText(args[1]);
                 if (languageDeserializerContent != languageDeserializerContentOld)
                 {
-                    File.WriteAllText(args[1], languageDeserializerContent);
+                    File.WriteAllText(args[1], languageDeserializerContent, Encoding.UTF8);
                     noOfChanges++;
-                    Console.Write(" LanguageDeserializer.cs generated... ");
+                    Console.Write(" {0} generated...", Path.GetFileName(args[1]));
                 }
 
                 if (noOfChanges == 0)


### PR DESCRIPTION
LanguageDeserializer.cs must be generated before building SE.

No need to always generate LM — only if Language has changed.
