### PR TITLE
Use SE exMethod to split lines part 2

### DIFF
--- a/src/Controls/SubtitleListView.cs
+++ b/src/Controls/SubtitleListView.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Controls
 {
@@ -564,7 +565,7 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     int noOfLines = paragraph.Text.Split(Environment.NewLine[0]).Length;
                     string s = Utilities.RemoveHtmlTags(paragraph.Text, true);
-                    foreach (string line in s.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                    foreach (string line in s.SplitToLines())
                     {
                         if (line.Length > Configuration.Settings.General.SubtitleLineMaximumLength)
                         {
@@ -588,7 +589,7 @@ namespace Nikse.SubtitleEdit.Controls
                 if (_settings.Tools.ListViewSyntaxMoreThanXLines &&
                     item.SubItems[ColumnIndexText].BackColor != Configuration.Settings.Tools.ListViewSyntaxErrorColor)
                 {
-                    int newLines = paragraph.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries).Length;
+                    int newLines = paragraph.Text.SplitToLines().Length;
                     if (newLines > Configuration.Settings.Tools.ListViewSyntaxMoreThanXLinesX)
                         item.SubItems[ColumnIndexText].BackColor = Configuration.Settings.Tools.ListViewSyntaxErrorColor;
                 }

--- a/src/Forms/Beamer.cs
+++ b/src/Forms/Beamer.cs
@@ -220,7 +220,7 @@ namespace Nikse.SubtitleEdit.Forms
             g = Graphics.FromImage(bmp);
 
             var lefts = new List<float>();
-            foreach (var line in HtmlUtil.RemoveOpenCloseTags(text, HtmlUtil.TagItalic, HtmlUtil.TagFont).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var line in HtmlUtil.RemoveOpenCloseTags(text, HtmlUtil.TagItalic, HtmlUtil.TagFont).SplitToLines())
             {
                 if (subtitleAlignLeft)
                     lefts.Add(5);

--- a/src/Forms/EbuSaveOptions.cs
+++ b/src/Forms/EbuSaveOptions.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -96,7 +97,7 @@ namespace Nikse.SubtitleEdit.Forms
             int i = 1;
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                string[] arr = p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var arr = p.Text.SplitToLines();
                 foreach (string line in arr)
                 {
                     string s = Utilities.RemoveHtmlTags(line);

--- a/src/Forms/ExportPngXml.cs
+++ b/src/Forms/ExportPngXml.cs
@@ -1896,7 +1896,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                 }
 
                 // align lines with gjpqy, a bit lower
-                var lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var lines = text.SplitToLines();
                 int baseLinePadding = 13;
                 if (parameter.SubtitleFontSize < 30)
                     baseLinePadding = 12;
@@ -1925,7 +1925,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                 var lefts = new List<float>();
                 if (text.Contains("<font", StringComparison.OrdinalIgnoreCase) || text.Contains("<i>", StringComparison.OrdinalIgnoreCase))
                 {
-                    foreach (string line in text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                    foreach (string line in text.SplitToLines())
                     {
                         var lineNoHtml = HtmlUtil.RemoveOpenCloseTags(line, HtmlUtil.TagItalic, HtmlUtil.TagFont);
                         if (parameter.AlignLeft)
@@ -1938,7 +1938,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                 }
                 else
                 {
-                    foreach (var line in HtmlUtil.RemoveOpenCloseTags(text, HtmlUtil.TagItalic, HtmlUtil.TagFont).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                    foreach (var line in HtmlUtil.RemoveOpenCloseTags(text, HtmlUtil.TagItalic, HtmlUtil.TagFont).SplitToLines())
                     {
                         if (parameter.AlignLeft)
                             lefts.Add(5);

--- a/src/Forms/ImportText.cs
+++ b/src/Forms/ImportText.cs
@@ -388,7 +388,7 @@ namespace Nikse.SubtitleEdit.Forms
             text = string.Empty;
             if (input.Length < Configuration.Settings.General.SubtitleLineMaximumLength * 3 && input.Length > Configuration.Settings.General.SubtitleLineMaximumLength * 1.5)
             {
-                var breaked = Utilities.AutoBreakLine(input).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var breaked = Utilities.AutoBreakLine(input).SplitToLines();
                 if (breaked.Length == 2 && (breaked[0].Length > Configuration.Settings.General.SubtitleLineMaximumLength || breaked[1].Length > Configuration.Settings.General.SubtitleLineMaximumLength))
                 {
                     var first = new StringBuilder();
@@ -473,13 +473,13 @@ namespace Nikse.SubtitleEdit.Forms
             string threeliner;
             if (CanMakeThreeLiner(out threeliner, sb.ToString()))
             {
-                var parts = threeliner.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var parts = threeliner.SplitToLines();
                 _subtitle.Paragraphs.Add(new Paragraph { Text = parts[0] + Environment.NewLine + parts[1] });
                 _subtitle.Paragraphs.Add(new Paragraph { Text = parts[2].Trim() });
                 return;
             }
 
-            foreach (string text in Utilities.AutoBreakLineMoreThanTwoLines(sb.ToString(), Configuration.Settings.General.SubtitleLineMaximumLength, string.Empty).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string text in Utilities.AutoBreakLineMoreThanTwoLines(sb.ToString(), Configuration.Settings.General.SubtitleLineMaximumLength, string.Empty).SplitToLines())
             {
                 if (p == null)
                 {
@@ -554,7 +554,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void AutoSplit(List<string> list, string line)
         {
-            foreach (string split in Utilities.AutoBreakLine(line).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string split in Utilities.AutoBreakLine(line).SplitToLines())
             {
                 if (split.Length <= Configuration.Settings.General.SubtitleLineMaximumLength)
                     list.Add(split);

--- a/src/Forms/SplitLongLines.cs
+++ b/src/Forms/SplitLongLines.cs
@@ -129,7 +129,7 @@ namespace Nikse.SubtitleEdit.Forms
                     maxLength = s.Length;
                     maxLengthIndex = i;
                 }
-                string[] arr = s.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var arr = s.SplitToLines();
                 foreach (string line in arr)
                 {
                     if (line.Length > singleLineMaxLengthIndex)
@@ -193,7 +193,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 }
                             }
 
-                            string[] arr = dialogText.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                            var arr = dialogText.SplitToLines();
                             if (arr.Length == 2 && (arr[0].StartsWith('-') || arr[0].StartsWith("<i>-")) && (arr[1].StartsWith('-') || arr[1].StartsWith("<i>-")))
                                 isDialog = true;
 
@@ -216,7 +216,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 text = dialogText;
                             if (text.Contains(Environment.NewLine))
                             {
-                                string[] arr = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                                var arr = text.SplitToLines();
                                 if (arr.Length == 2)
                                 {
                                     int spacing1 = Configuration.Settings.General.MininumMillisecondsBetweenLines / 2;

--- a/src/Forms/Statistics.cs
+++ b/src/Forms/Statistics.cs
@@ -109,7 +109,7 @@ https://github.com/SubtitleEdit/subtitleedit
                     maximumCharsSec = charsSec;
                 totalCharsSec += charsSec;
 
-                foreach (string line in p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string line in p.Text.SplitToLines())
                 {
                     len = line.Length;
                     if (len < minimumSingleLineLength)

--- a/src/Forms/SubStationAlphaProperties.cs
+++ b/src/Forms/SubStationAlphaProperties.cs
@@ -59,7 +59,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (header != null)
             {
-                foreach (string line in header.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string line in header.SplitToLines())
                 {
                     string s = line.ToLower().Trim();
                     if (s.StartsWith("title:"))
@@ -213,7 +213,7 @@ namespace Nikse.SubtitleEdit.Forms
             bool scriptInfoOn = false;
             var sb = new StringBuilder();
             bool found = false;
-            foreach (string line in _subtitle.Header.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in _subtitle.Header.SplitToLines())
             {
                 if (line.StartsWith("[script info]", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Forms/VobSubOcr.cs
+++ b/src/Forms/VobSubOcr.cs
@@ -1287,7 +1287,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (index >= 0 && index < _bdnXmlSubtitle.Paragraphs.Count)
                 {
-                    string[] fileNames = _bdnXmlSubtitle.Paragraphs[index].Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                    var fileNames = _bdnXmlSubtitle.Paragraphs[index].Text.SplitToLines();
                     var bitmaps = new List<Bitmap>();
                     int maxWidth = 0;
                     int totalHeight = 0;

--- a/src/Logic/Dictionaries/OcrFixReplaceList.cs
+++ b/src/Logic/Dictionaries/OcrFixReplaceList.cs
@@ -157,7 +157,7 @@ namespace Nikse.SubtitleEdit.Logic.Dictionaries
             }
 
             // begin fromLine
-            string[] lines = newText.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = newText.SplitToLines();
             var sb = new StringBuilder();
             foreach (string l in lines)
             {

--- a/src/Logic/Forms/RemoveTextForHI.cs
+++ b/src/Logic/Forms/RemoveTextForHI.cs
@@ -89,7 +89,7 @@ namespace Nikse.SubtitleEdit.Logic.Forms
                 return text;
 
             string newText = string.Empty;
-            string[] parts = text.Trim().Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var parts = text.Trim().SplitToLines();
             int noOfNames = 0;
             int count = 0;
             bool removedInFirstLine = false;
@@ -259,7 +259,7 @@ namespace Nikse.SubtitleEdit.Logic.Forms
             {
                 int indexOfDialogChar = newText.IndexOf('-');
                 bool insertDash = true;
-                string[] arr = newText.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var arr = newText.SplitToLines();
                 if (arr.Length == 2 && arr[0].Length > 1 && arr[1].Length > 1)
                 {
                     string arr0 = new StripableText(arr[0]).StrippedText;
@@ -350,7 +350,7 @@ namespace Nikse.SubtitleEdit.Logic.Forms
             }
             var st = new StripableText(text, pre, post);
             var sb = new StringBuilder();
-            string[] parts = st.StrippedText.Trim().Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var parts = st.StrippedText.Trim().SplitToLines();
             int lineNumber = 0;
             bool removedDialogInFirstLine = false;
             int noOfNamesRemoved = 0;
@@ -778,7 +778,7 @@ namespace Nikse.SubtitleEdit.Logic.Forms
                     }
                 }
             }
-            string[] lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = text.SplitToLines();
             if (text != oldText && lines.Length == 2)
             {
                 if (lines[0] == "-" && lines[1] == "-")

--- a/src/Logic/Forms/SplitLongLinesHelper.cs
+++ b/src/Logic/Forms/SplitLongLinesHelper.cs
@@ -13,7 +13,7 @@ namespace Nikse.SubtitleEdit.Logic.Forms
             if (s.Length > totalLineMaxCharacters)
                 return true;
 
-            string[] arr = s.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var arr = s.SplitToLines();
             foreach (string line in arr)
             {
                 if (line.Length > singleLineMaxCharacters)
@@ -31,7 +31,7 @@ namespace Nikse.SubtitleEdit.Logic.Forms
                 if (idx > 1)
                 {
                     string dialogText = tempText.Remove(idx + 1, 1).Insert(idx + 1, Environment.NewLine);
-                    arr = dialogText.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                    arr = dialogText.SplitToLines();
                     foreach (string line in arr)
                     {
                         if (line.Length > singleLineMaxCharacters)
@@ -69,7 +69,7 @@ namespace Nikse.SubtitleEdit.Logic.Forms
                             string text = Utilities.AutoBreakLine(p.Text, language);
                             if (text.Contains(Environment.NewLine))
                             {
-                                string[] arr = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                                var arr = text.SplitToLines();
                                 if (arr.Length == 2)
                                 {
                                     int spacing1 = Configuration.Settings.General.MininumMillisecondsBetweenLines / 2;

--- a/src/Logic/OCR/OcrFixEngine.cs
+++ b/src/Logic/OCR/OcrFixEngine.cs
@@ -645,7 +645,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
         private string FixLowercaseIToUppercaseI(string input, string lastLine)
         {
             var sb = new StringBuilder();
-            string[] lines = input.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = input.SplitToLines();
             for (int i = 0; i < lines.Length; i++)
             {
                 string l = lines[i];

--- a/src/Logic/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/Logic/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -371,7 +371,7 @@ Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text
             if (headerLines == null)
                 headerLines = DefaultStyle;
 
-            foreach (string line in headerLines.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in headerLines.SplitToLines())
             {
                 if (line.StartsWith("style:", StringComparison.OrdinalIgnoreCase))
                 {
@@ -1037,7 +1037,7 @@ Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text
             int marginVIndex = -1;
             int borderStyleIndex = -1;
 
-            foreach (string line in header.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in header.SplitToLines())
             {
                 string s = line.Trim().ToLower();
                 if (s.StartsWith("format:", StringComparison.Ordinal))
@@ -1310,7 +1310,7 @@ Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text
             if (header == null)
                 header = DefaultHeader;
 
-            foreach (string line in header.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in header.SplitToLines())
             {
                 string s = line.Trim().ToLower();
                 if (s.StartsWith("format:", StringComparison.Ordinal))

--- a/src/Logic/SubtitleFormats/Cavena890.cs
+++ b/src/Logic/SubtitleFormats/Cavena890.cs
@@ -328,9 +328,9 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
         {
             string line1 = string.Empty;
             string line2 = string.Empty;
-            string[] lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = text.SplitToLines();
             if (lines.Length > 2)
-                lines = Utilities.AutoBreakLine(text).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                lines = Utilities.AutoBreakLine(text).SplitToLines();
             if (lines.Length > 1)
             {
                 line1 = lines[0];

--- a/src/Logic/SubtitleFormats/Csv3.cs
+++ b/src/Logic/SubtitleFormats/Csv3.cs
@@ -69,11 +69,11 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             sb.AppendLine(string.Format(format, Separator, "Start time (hh:mm:ss:ff)", "End time (hh:mm:ss:ff)", "Line 1", "Line 2"));
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                var arr = p.Text.Trim().Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var arr = p.Text.Trim().SplitToLines();
                 if (arr.Length > 3)
                 {
                     string s = Utilities.AutoBreakLine(p.Text);
-                    arr = s.Trim().Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                    arr = s.Trim().SplitToLines();
                 }
                 string line1 = string.Empty;
                 string line2 = string.Empty;

--- a/src/Logic/SubtitleFormats/DCSubtitle.cs
+++ b/src/Logic/SubtitleFormats/DCSubtitle.cs
@@ -180,7 +180,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                     // remove styles for display text (except italic)
                     string text = RemoveSubStationAlphaFormatting(p.Text);
 
-                    string[] lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                    var lines = text.SplitToLines();
                     int vPos = 1 + lines.Length * 7;
                     int vPosFactor = (int)Math.Round(fontSize / 7.4);
                     if (alignVTop)

--- a/src/Logic/SubtitleFormats/DCinemaSmpte2007.cs
+++ b/src/Logic/SubtitleFormats/DCinemaSmpte2007.cs
@@ -218,7 +218,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                     // remove styles for display text (except italic)
                     string text = RemoveSubStationAlphaFormatting(p.Text);
 
-                    string[] lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                    var lines = text.SplitToLines();
                     int vPos = 1 + lines.Length * 7;
                     int vPosFactor = (int)Math.Round(fontSize / 7.4);
                     if (alignVTop)

--- a/src/Logic/SubtitleFormats/DCinemaSmpte2010.cs
+++ b/src/Logic/SubtitleFormats/DCinemaSmpte2010.cs
@@ -219,7 +219,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                     // remove styles for display text (except italic)
                     string text = RemoveSubStationAlphaFormatting(p.Text);
 
-                    string[] lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                    var lines = text.SplitToLines();
                     int vPos = 1 + lines.Length * 7;
                     int vPosFactor = (int)Math.Round(fontSize / 7.4);
                     if (alignVTop)

--- a/src/Logic/SubtitleFormats/Ebu.cs
+++ b/src/Logic/SubtitleFormats/Ebu.cs
@@ -277,7 +277,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 }
                 else // teletext
                 {
-                    string[] lines = TextField.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                    var lines = TextField.SplitToLines();
                     var sb = new StringBuilder();
                     string veryFirstColor = null;
                     foreach (string line in lines)

--- a/src/Logic/SubtitleFormats/ItunesTimedText.cs
+++ b/src/Logic/SubtitleFormats/ItunesTimedText.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Xml;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -214,7 +215,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 }
 
                 bool first = true;
-                foreach (string line in text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string line in text.SplitToLines())
                 {
                     if (!first)
                     {

--- a/src/Logic/SubtitleFormats/Json.cs
+++ b/src/Logic/SubtitleFormats/Json.cs
@@ -104,7 +104,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             if (!sb.ToString().TrimStart().StartsWith("[{\"start"))
                 return;
 
-            foreach (string line in sb.ToString().Replace("},{", Environment.NewLine).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in sb.ToString().Replace("},{", Environment.NewLine).SplitToLines())
             {
                 string s = line.Trim() + "}";
                 string start = ReadTag(s, "start");

--- a/src/Logic/SubtitleFormats/JsonType2.cs
+++ b/src/Logic/SubtitleFormats/JsonType2.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -59,7 +60,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             if (!sb.ToString().TrimStart().StartsWith("[{\"startMillis"))
                 return;
 
-            foreach (string line in sb.ToString().Replace("},{", Environment.NewLine).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in sb.ToString().Replace("},{", Environment.NewLine).SplitToLines())
             {
                 string s = line.Trim() + "}";
                 string start = Json.ReadTag(s, "startMillis");

--- a/src/Logic/SubtitleFormats/JsonType3.cs
+++ b/src/Logic/SubtitleFormats/JsonType3.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -62,7 +63,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 return;
 
             string text = sb.ToString().Substring(startIndex);
-            foreach (string line in text.Replace("},{", Environment.NewLine).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in text.Replace("},{", Environment.NewLine).SplitToLines())
             {
                 string s = line.Trim() + "}";
                 string start = Json.ReadTag(s, "startTime");

--- a/src/Logic/SubtitleFormats/JsonType4.cs
+++ b/src/Logic/SubtitleFormats/JsonType4.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -67,7 +68,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 return;
 
             string text = sb.ToString().Substring(startIndex);
-            foreach (string line in text.Replace("},{", Environment.NewLine).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in text.Replace("},{", Environment.NewLine).SplitToLines())
             {
                 string s = line.Trim() + "}";
                 string start = Json.ReadTag(s, "startTime");

--- a/src/Logic/SubtitleFormats/MPlayer2.cs
+++ b/src/Logic/SubtitleFormats/MPlayer2.cs
@@ -85,7 +85,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 sb.Append(((int)(p.EndTime.TotalMilliseconds / 100)));
                 sb.Append(']');
 
-                string[] parts = p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var parts = p.Text.SplitToLines();
                 int count = 0;
                 bool italicOn = false;
                 foreach (string line in parts)

--- a/src/Logic/SubtitleFormats/MicroDvd.cs
+++ b/src/Logic/SubtitleFormats/MicroDvd.cs
@@ -93,7 +93,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 //{y:b} is italics for single line
                 //{Y:b} is italics for both lines
 
-                string[] parts = p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var parts = p.Text.SplitToLines();
                 int count = 0;
                 bool italicOn = false;
                 bool boldOn = false;

--- a/src/Logic/SubtitleFormats/PListCaption.cs
+++ b/src/Logic/SubtitleFormats/PListCaption.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -98,7 +99,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 paragraph.AppendChild(valueNode);
 
                 int textNo = 0;
-                string[] lines = p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var lines = p.Text.SplitToLines();
                 foreach (string line in lines)
                 {
                     textNo++;

--- a/src/Logic/SubtitleFormats/Pac.cs
+++ b/src/Logic/SubtitleFormats/Pac.cs
@@ -858,7 +858,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 return "<" + Utilities.RemoveHtmlTags(text).Replace(Environment.NewLine, Environment.NewLine + "<");
 
             var sb = new StringBuilder();
-            string[] parts = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var parts = text.SplitToLines();
             foreach (string line in parts)
             {
                 string s = line.Trim();

--- a/src/Logic/SubtitleFormats/Sami.cs
+++ b/src/Logic/SubtitleFormats/Sami.cs
@@ -206,7 +206,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             var list = new List<string>();
             if (!string.IsNullOrEmpty(header) && header.StartsWith("<style", StringComparison.OrdinalIgnoreCase))
             {
-                foreach (string line in header.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string line in header.SplitToLines())
                 {
                     string s = line.Trim();
                     if (s.StartsWith('.') && s.IndexOf(' ') > 2)

--- a/src/Logic/SubtitleFormats/ScenaristClosedCaptions.cs
+++ b/src/Logic/SubtitleFormats/ScenaristClosedCaptions.cs
@@ -569,7 +569,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 
         private static string FixMax4LinesAndMax32CharsPerLine(string text, string language)
         {
-            var lines = text.Trim().Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = text.Trim().SplitToLines();
             bool allOk = true;
             foreach (string line in lines)
             {
@@ -583,7 +583,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 return text;
 
             text = Utilities.AutoBreakLine(text, 1, 4, language);
-            lines = text.Trim().Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            lines = text.Trim().SplitToLines();
             allOk = true;
             foreach (string line in lines)
             {
@@ -597,7 +597,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 return text;
 
             text = AutoBreakLineMax4Lines(text, 32);
-            lines = text.Trim().Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            lines = text.Trim().SplitToLines();
             allOk = true;
             foreach (string line in lines)
             {
@@ -719,7 +719,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             //text = text.Replace("ã", "aã");
             //text = text.Replace("õ", "oõ");
 
-            var lines = text.Trim().Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = text.Trim().SplitToLines();
             int italic = 0;
             var sb = new StringBuilder();
             int count = 1;

--- a/src/Logic/SubtitleFormats/SoftNiColonSub.cs
+++ b/src/Logic/SubtitleFormats/SoftNiColonSub.cs
@@ -54,7 +54,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 }
 
                 // Split lines (split a subtitle into its lines)
-                var lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var lines = text.SplitToLines();
                 int count = 0;
                 var lineSb = new StringBuilder();
                 string tempLine = string.Empty;
@@ -174,7 +174,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                                 text = text.Replace("]", @"</i>");
 
                                 // Split subtitle lines (one subtitle has one or more lines)
-                                var subtitleLines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                                var subtitleLines = text.SplitToLines();
                                 int count = 0;
                                 var lineSb = new StringBuilder();
                                 string tempLine = string.Empty;

--- a/src/Logic/SubtitleFormats/SoftNiSub.cs
+++ b/src/Logic/SubtitleFormats/SoftNiSub.cs
@@ -54,7 +54,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 }
 
                 // Split lines (split a subtitle into its lines)
-                var lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var lines = text.SplitToLines();
                 int count = 0;
                 var lineSb = new StringBuilder();
                 string tempLine = string.Empty;
@@ -174,7 +174,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                                 text = text.Replace("]", @"</i>");
 
                                 // Split subtitle lines (one subtitle has one or more lines)
-                                var subtitleLines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                                var subtitleLines = text.SplitToLines();
                                 int count = 0;
                                 var lineSb = new StringBuilder();
                                 string tempLine = string.Empty;

--- a/src/Logic/SubtitleFormats/Spt.cs
+++ b/src/Logic/SubtitleFormats/Spt.cs
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             if (Utilities.CountTagInText(text, Environment.NewLine) > 1)
                 text = Utilities.AutoBreakLine(p.Text);
 
-            string[] lines = text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = text.SplitToLines();
             int textLengthFirstLine = 0;
             int textLengthSecondLine = 0;
             if (lines.Length > 0)

--- a/src/Logic/SubtitleFormats/StructuredTitles.cs
+++ b/src/Logic/SubtitleFormats/StructuredTitles.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -55,7 +56,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             {
                 sb.AppendLine(string.Format("{0:0000} : {1},{2},10", index + 1, EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime)));
                 sb.AppendLine("80 80 80");
-                foreach (string line in p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string line in p.Text.SplitToLines())
                     sb.AppendLine("C1Y00 " + line.Trim());
                 sb.AppendLine();
                 index++;

--- a/src/Logic/SubtitleFormats/TimedText10.cs
+++ b/src/Logic/SubtitleFormats/TimedText10.cs
@@ -329,7 +329,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             string text = p.Text;
 
             bool first = true;
-            foreach (string line in text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string line in text.SplitToLines())
             {
                 if (!first)
                 {

--- a/src/Logic/SubtitleFormats/TimedText200604.cs
+++ b/src/Logic/SubtitleFormats/TimedText200604.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -102,7 +103,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 string text = Utilities.RemoveHtmlTags(p.Text);
 
                 bool first = true;
-                foreach (string line in text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string line in text.SplitToLines())
                 {
                     if (!first)
                     {

--- a/src/Logic/SubtitleFormats/UnknownSubtitle11.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle11.cs
@@ -95,7 +95,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 //{y:b} is italics for single line
                 //{Y:b} is italics for both lines
 
-                string[] parts = p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var parts = p.Text.SplitToLines();
                 int count = 0;
                 bool italicOn = false;
                 bool boldOn = false;

--- a/src/Logic/SubtitleFormats/UnknownSubtitle28.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle28.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -55,7 +56,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 
                 paragraph.AppendChild(time);
 
-                string[] arr = p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var arr = p.Text.SplitToLines();
                 for (int i = 0; i < arr.Length; i++)
                 {
                     XmlNode text = xml.CreateElement("text" + (i + 1));

--- a/src/Logic/SubtitleFormats/UnknownSubtitle33.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle33.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -47,7 +48,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             int count2 = 1;
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                string[] lines = Utilities.RemoveHtmlTags(p.Text).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var lines = Utilities.RemoveHtmlTags(p.Text).SplitToLines();
                 if (lines.Length > 0)
                 {
                     sb.AppendLine(string.Format(paragraphWriteFormat, EncodeTimeCode(p.StartTime), count.ToString().PadLeft(2, ' '), lines[0]));

--- a/src/Logic/SubtitleFormats/UnknownSubtitle34.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle34.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -44,7 +45,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             var sb = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                string[] lines = Utilities.RemoveHtmlTags(p.Text).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var lines = Utilities.RemoveHtmlTags(p.Text).SplitToLines();
                 if (lines.Length > 0)
                 {
                     sb.AppendLine(EncodeTimeCode(p.StartTime) + "\t" + lines[0]);

--- a/src/Logic/SubtitleFormats/UnknownSubtitle43.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle43.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -64,7 +65,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 string text = p.Text;
 
                 bool first = true;
-                foreach (string line in text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string line in text.SplitToLines())
                 {
                     if (!first)
                     {

--- a/src/Logic/SubtitleFormats/UnknownSubtitle59.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle59.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -45,7 +46,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             var sb = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                string[] lines = Utilities.RemoveHtmlTags(p.Text).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var lines = Utilities.RemoveHtmlTags(p.Text).SplitToLines();
                 if (lines.Length > 0)
                 {
                     sb.AppendLine(EncodeTimeCode(p.StartTime) + "\t" + lines[0]);

--- a/src/Logic/SubtitleFormats/UnknownSubtitle6.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle6.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -58,10 +59,10 @@ SRPSKI
             {
                 string firstLine = string.Empty;
                 string secondLine = string.Empty;
-                string[] lines = p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var lines = p.Text.SplitToLines();
                 if (lines.Length > 2)
                 {
-                    lines = Utilities.AutoBreakLine(p.Text).Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                    lines = Utilities.AutoBreakLine(p.Text).SplitToLines();
                 }
                 if (lines.Length > 0)
                     firstLine = lines[0];

--- a/src/Logic/SubtitleFormats/UnknownSubtitle70.cs
+++ b/src/Logic/SubtitleFormats/UnknownSubtitle70.cs
@@ -95,7 +95,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                 //{y:b} is italics for single line
                 //{Y:b} is italics for both lines
 
-                string[] parts = p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+                var parts = p.Text.SplitToLines();
                 int count = 0;
                 bool italicOn = false;
                 bool boldOn = false;

--- a/src/Logic/SubtitleFormats/Wsb.cs
+++ b/src/Logic/SubtitleFormats/Wsb.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 {
@@ -41,7 +42,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             {
                 sb.AppendLine(string.Format("{0:0000} : {1},{2},10", index + 1, EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime)));
                 sb.AppendLine("80 80 80");
-                foreach (string line in p.Text.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string line in p.Text.SplitToLines())
                     sb.AppendLine("C1Y00 " + line.Trim());
                 sb.AppendLine();
                 index++;

--- a/src/Test/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrorsTest.cs
@@ -6,6 +6,7 @@ using Nikse.SubtitleEdit.Forms;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Forms;
 using Nikse.SubtitleEdit.Logic.SubtitleFormats;
+using Nikse.SubtitleEdit.Core;
 
 namespace Test
 {
@@ -1213,10 +1214,10 @@ namespace Test
             const string expected3 = "<u>Hello world!</u>\r\n<b>Hello</b>";
             const string expected4 = "<font color=\"#008040\">Hello world!</font>\r\n<font color=\"#008040\">Hello</font>";
 
-            string[] lines1 = input1.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
-            string[] lines2 = input2.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
-            string[] lines3 = input3.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
-            string[] lines4 = input4.Split(Utilities.NewLineChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines1 = input1.SplitToLines();
+            var lines2 = input2.SplitToLines();
+            var lines3 = input3.SplitToLines();
+            var lines4 = input4.SplitToLines();
 
             for (int i = 0; i < lines1.Length; i++)
             {


### PR DESCRIPTION
I think there is no more: StringSplitOptions.RemoveEmptyEntries