### PR TITLE
Minor corrections + Translation updates

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -1303,8 +1303,8 @@ Continue?</SubtitleAppendPrompt>
     <EndsWith>Ends with</EndsWith>
     <NoContains>Not contains</NoContains>
     <RegEx>Regular expression</RegEx>
-    <UnequalLines>Unequal lines</UnequalLines>
-    <EqualLines>Equal lines</EqualLines>
+    <UnequalLines>Odd-numbered lines</UnequalLines>
+    <EqualLines>Even-numbered lines</EqualLines>
   </ModifySelection>
   <MultipleReplace>
     <Title>Multiple replace</Title>

--- a/src/Core/StringExtensions.cs
+++ b/src/Core/StringExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 
 namespace Nikse.SubtitleEdit.Core

--- a/src/Forms/BatchConvert.Designer.cs
+++ b/src/Forms/BatchConvert.Designer.cs
@@ -144,7 +144,7 @@
             // checkBoxSplitLongLines
             // 
             this.checkBoxSplitLongLines.AutoSize = true;
-            this.checkBoxSplitLongLines.Location = new System.Drawing.Point(16, 145);
+            this.checkBoxSplitLongLines.Location = new System.Drawing.Point(15, 145);
             this.checkBoxSplitLongLines.Name = "checkBoxSplitLongLines";
             this.checkBoxSplitLongLines.Size = new System.Drawing.Size(93, 17);
             this.checkBoxSplitLongLines.TabIndex = 8;
@@ -165,7 +165,7 @@
             // checkBoxSetMinimumDisplayTimeBetweenSubs
             // 
             this.checkBoxSetMinimumDisplayTimeBetweenSubs.AutoSize = true;
-            this.checkBoxSetMinimumDisplayTimeBetweenSubs.Location = new System.Drawing.Point(16, 191);
+            this.checkBoxSetMinimumDisplayTimeBetweenSubs.Location = new System.Drawing.Point(15, 191);
             this.checkBoxSetMinimumDisplayTimeBetweenSubs.Name = "checkBoxSetMinimumDisplayTimeBetweenSubs";
             this.checkBoxSetMinimumDisplayTimeBetweenSubs.Size = new System.Drawing.Size(208, 17);
             this.checkBoxSetMinimumDisplayTimeBetweenSubs.TabIndex = 9;
@@ -175,7 +175,7 @@
             // checkBoxAutoBalance
             // 
             this.checkBoxAutoBalance.AutoSize = true;
-            this.checkBoxAutoBalance.Location = new System.Drawing.Point(16, 168);
+            this.checkBoxAutoBalance.Location = new System.Drawing.Point(15, 168);
             this.checkBoxAutoBalance.Name = "checkBoxAutoBalance";
             this.checkBoxAutoBalance.Size = new System.Drawing.Size(113, 17);
             this.checkBoxAutoBalance.TabIndex = 8;
@@ -196,7 +196,7 @@
             // checkBoxMultipleReplace
             // 
             this.checkBoxMultipleReplace.AutoSize = true;
-            this.checkBoxMultipleReplace.Location = new System.Drawing.Point(16, 122);
+            this.checkBoxMultipleReplace.Location = new System.Drawing.Point(15, 122);
             this.checkBoxMultipleReplace.Name = "checkBoxMultipleReplace";
             this.checkBoxMultipleReplace.Size = new System.Drawing.Size(100, 17);
             this.checkBoxMultipleReplace.TabIndex = 6;
@@ -206,7 +206,7 @@
             // checkBoxFixCommonErrors
             // 
             this.checkBoxFixCommonErrors.AutoSize = true;
-            this.checkBoxFixCommonErrors.Location = new System.Drawing.Point(16, 97);
+            this.checkBoxFixCommonErrors.Location = new System.Drawing.Point(15, 97);
             this.checkBoxFixCommonErrors.Name = "checkBoxFixCommonErrors";
             this.checkBoxFixCommonErrors.Size = new System.Drawing.Size(111, 17);
             this.checkBoxFixCommonErrors.TabIndex = 4;
@@ -328,7 +328,7 @@
             // checkBoxFixCasing
             // 
             this.checkBoxFixCasing.AutoSize = true;
-            this.checkBoxFixCasing.Location = new System.Drawing.Point(16, 47);
+            this.checkBoxFixCasing.Location = new System.Drawing.Point(15, 47);
             this.checkBoxFixCasing.Name = "checkBoxFixCasing";
             this.checkBoxFixCasing.Size = new System.Drawing.Size(95, 17);
             this.checkBoxFixCasing.TabIndex = 1;
@@ -338,7 +338,7 @@
             // checkBoxRemoveTextForHI
             // 
             this.checkBoxRemoveTextForHI.AutoSize = true;
-            this.checkBoxRemoveTextForHI.Location = new System.Drawing.Point(16, 72);
+            this.checkBoxRemoveTextForHI.Location = new System.Drawing.Point(15, 72);
             this.checkBoxRemoveTextForHI.Name = "checkBoxRemoveTextForHI";
             this.checkBoxRemoveTextForHI.Size = new System.Drawing.Size(115, 17);
             this.checkBoxRemoveTextForHI.TabIndex = 2;
@@ -348,7 +348,7 @@
             // checkBoxRemoveFormatting
             // 
             this.checkBoxRemoveFormatting.AutoSize = true;
-            this.checkBoxRemoveFormatting.Location = new System.Drawing.Point(16, 22);
+            this.checkBoxRemoveFormatting.Location = new System.Drawing.Point(15, 22);
             this.checkBoxRemoveFormatting.Name = "checkBoxRemoveFormatting";
             this.checkBoxRemoveFormatting.Size = new System.Drawing.Size(115, 17);
             this.checkBoxRemoveFormatting.TabIndex = 0;

--- a/src/Forms/ImportSceneChanges.Designer.cs
+++ b/src/Forms/ImportSceneChanges.Designer.cs
@@ -1,4 +1,4 @@
-namespace Nikse.SubtitleEdit.Forms
+﻿namespace Nikse.SubtitleEdit.Forms
 {
     partial class ImportSceneChanges
     {

--- a/src/Forms/ImportSceneChanges.cs
+++ b/src/Forms/ImportSceneChanges.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -1197,7 +1197,7 @@ namespace Nikse.SubtitleEdit.Forms
             toolStripButtonSaveAs.ToolTipText = _language.Menu.ToolBar.SaveAs;
             toolStripButtonFind.ToolTipText = _language.Menu.ToolBar.Find;
             toolStripButtonReplace.ToolTipText = _language.Menu.ToolBar.Replace;
-            toolStripButtonFixCommonErrors.ToolTipText = Configuration.Settings.Language.Settings.FixCommonerrors; // TODO: 3.4 Use Toolbar translation tag
+            toolStripButtonFixCommonErrors.ToolTipText = _language.Menu.ToolBar.FixCommonErrors;
             toolStripButtonVisualSync.ToolTipText = _language.Menu.ToolBar.VisualSync;
             toolStripButtonSpellCheck.ToolTipText = _language.Menu.ToolBar.SpellCheck;
             toolStripButtonSettings.ToolTipText = _language.Menu.ToolBar.Settings;

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -398,6 +398,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 labelWaveformTextSize.Text = language.WaveformTextFontSize;
                 comboBoxWaveformTextSize.Left = labelWaveformTextSize.Left + labelWaveformTextSize.Width + 5;
+                checkBoxWaveformTextBold.Text = language.SubtitleBold;
                 checkBoxWaveformTextBold.Left = comboBoxWaveformTextSize.Left + comboBoxWaveformTextSize.Width + 5;
             }
 

--- a/src/Languages/ar-EG.xml
+++ b/src/Languages/ar-EG.xml
@@ -79,11 +79,11 @@ http://www.alghaamdi.com/vb/index.php</TranslatedBy>
   <About>
     <Title>معلومات عن برنامج محرر الترجمة</Title>
     <AboutText1>محرر الترجمة برنامج مجاني تحت رخصة جنو العمومية
- تستطيع تعديلة  وتوزيعه واستخدامه بحرية
- https://github.com/SubtitleEdit/subtitleedit البرنامج متاح على
- www.nikse.dk للحصول على اخر نسخة زيارة
+تستطيع تعديلة  وتوزيعه واستخدامه بحرية
+https://github.com/SubtitleEdit/subtitleedit البرنامج متاح على
+www.nikse.dk للحصول على اخر نسخة زيارة
 اقتراحاتك هي موضع ترحيب كبير
- mailto:nikse.dk@gmail.com :البريد الإلكتروني
+mailto:nikse.dk@gmail.com :البريد الإلكتروني
 
 Suggestions are very welcome.
 

--- a/src/Languages/da-DK.xml
+++ b/src/Languages/da-DK.xml
@@ -1329,7 +1329,7 @@ Fortsæt?</SubtitleAppendPrompt>
   <NetworkJoin>
     <Title>Deltag i netværks-session</Title>
     <Information>Hop med i en eksisterende session, hvor flere personer
- kan redigere i samme undertekst fil (fælles projekt online)</Information>
+kan redigere i samme undertekst fil (fælles projekt online)</Information>
     <Join>Deltag</Join>
   </NetworkJoin>
   <NetworkLogAndInfo>
@@ -1340,7 +1340,7 @@ Fortsæt?</SubtitleAppendPrompt>
     <Title>Start netværks-session</Title>
     <ConnectionTo>Forbinder til {0}...</ConnectionTo>
     <Information>Start ny session, hvor flere personer
- kan redigere i samme undertekst fil (fælles online projekt)</Information>
+kan redigere i samme undertekst fil (fælles online projekt)</Information>
     <Start>Start</Start>
   </NetworkStart>
   <OpenVideoDvd>

--- a/src/Languages/de-DE.xml
+++ b/src/Languages/de-DE.xml
@@ -110,6 +110,12 @@ E-Mail: mailto:nikse.dk@gmail.com</AboutText1>
     <ExtractingSeconds>Extrahiere Audio: {0:0.0} Sekunden</ExtractingSeconds>
     <ExtractingMinutes>Extrahiere Audio: {0}.{1:00} Minuten</ExtractingMinutes>
   </AddWaveform>
+  <AddWaveformBatch>
+    <Title>Stapelgenerierung von Wellenformdaten</Title>
+    <ExtractingAudio>Audio extrahieren...</ExtractingAudio>
+    <Calculating>Berechnen...</Calculating>
+    <Done>Fertig</Done>
+  </AddWaveformBatch>
   <AdjustDisplayDuration>
     <Title>Längen anpassen</Title>
     <AdjustVia>Anpassen über</AdjustVia>
@@ -161,6 +167,11 @@ E-Mail: mailto:nikse.dk@gmail.com</AboutText1>
     <Recursive>Unterordner einschließen</Recursive>
     <SetMinMsBetweenSubtitles>Min. Millisekunden zwischen Untertitel</SetMinMsBetweenSubtitles>
     <PlainText>Text</PlainText>
+    <Filter>Dateifilter</Filter>
+    <FilterSkipped>Vom Filter ausgeschlossen</FilterSkipped>
+    <FilterSrtNoUtf8BOM>SubRip Dateien ohne UTF-8 Bytereihenfolge-Markierung</FilterSrtNoUtf8BOM>
+    <FilterMoreThanTwoLines>Texte mit mehr als zwei Zeilen</FilterMoreThanTwoLines>
+    <FilterContains>Text enthält...</FilterContains>
   </BatchConvert>
   <Beamer>
     <Title>Beamer</Title>
@@ -734,6 +745,13 @@ E-Mail: mailto:nikse.dk@gmail.com</AboutText1>
         <Redo>Wiederherstellen</Redo>
         <ShowUndoHistory>Verlauf (für Rückgängig) anzeigen</ShowUndoHistory>
         <InsertUnicodeSymbol>Unicode Symbol einfügen</InsertUnicodeSymbol>
+        <InsertUnicodeControlCharacters>Unicode Steuerzeichen einfügen</InsertUnicodeControlCharacters>
+        <InsertUnicodeControlCharactersLRM>Links-nach-rechts-Zeichen (LRM)</InsertUnicodeControlCharactersLRM>
+        <InsertUnicodeControlCharactersRLM>Rechts-nach-links-Zeichen (RLM)</InsertUnicodeControlCharactersRLM>
+        <InsertUnicodeControlCharactersLRE>Links-nach-rechts-Einbettung (LRE)</InsertUnicodeControlCharactersLRE>
+        <InsertUnicodeControlCharactersRLE>Rechts-nach-links-Einbettung (RLE)</InsertUnicodeControlCharactersRLE>
+        <InsertUnicodeControlCharactersLRO>Links-nach-rechts-Zwang (LRO)</InsertUnicodeControlCharactersLRO>
+        <InsertUnicodeControlCharactersRLO>Rechts-nach-links-Zwang (RLO)</InsertUnicodeControlCharactersRLO>
         <Find>&amp;Suchen</Find>
         <FindNext>&amp;Weitersuchen</FindNext>
         <Replace>&amp;Ersetzen</Replace>
@@ -792,6 +810,7 @@ E-Mail: mailto:nikse.dk@gmail.com</AboutText1>
         <CloseVideo>Videodatei schließen</CloseVideo>
         <ImportSceneChanges>Szenenänderungen importieren...</ImportSceneChanges>
         <RemoveSceneChanges>Szenenänderungen entfernen</RemoveSceneChanges>
+        <WaveformBatchGenerate>Wellenforme im Stapel generieren...</WaveformBatchGenerate>
         <ShowHideVideo>Video anzeigen/verbergen</ShowHideVideo>
         <ShowHideWaveform>Wellenform anzeigen/verbergen</ShowHideWaveform>
         <ShowHideWaveformAndSpectrogram>Wellenform und Spektogramm anzeigen/verbergen</ShowHideWaveformAndSpectrogram>
@@ -1609,6 +1628,7 @@ gleiche Untertiteldatei bearbeiten können (Zusammenarbeit)</Information>
     <ToggleDialogDashes>Dialog Striche umschalten</ToggleDialogDashes>
     <Alignment>Ausrichtung (gewählte Zeilen)</Alignment>
     <CopyTextOnly>Nur Text in Zwischenablage kopieren (gewählte Zeilen)</CopyTextOnly>
+    <CopyTextOnlyFromOriginalToCurrent>Nur Text vom Original im aktuellen Untertitel kopieren</CopyTextOnlyFromOriginalToCurrent>
     <AutoDurationSelectedLines>Auto Dauer (gewählte Zeilen)</AutoDurationSelectedLines>
     <ReverseStartAndEndingForRTL>Rechts-nach-Links Start/Ende umkehren</ReverseStartAndEndingForRTL>
     <VerticalZoom>Vertikale vergrößern</VerticalZoom>
@@ -1969,6 +1989,7 @@ gleiche Untertiteldatei bearbeiten können (Zusammenarbeit)</Information>
     <AutoTransparentBackground>Auto transparenter Hintergrund</AutoTransparentBackground>
     <InspectCompareMatchesForCurrentImage>Untersuche Vergleichstreffer für aktuelles Bild...</InspectCompareMatchesForCurrentImage>
     <EditLastAdditions>Bearbeite letzte Bildvergleiche...</EditLastAdditions>
+    <SetUnitalicFactor>Entkursivierungsfaktor setzen...</SetUnitalicFactor>
   </VobSubOcr>
   <VobSubOcrCharacter>
     <Title>VobSub - Manuelles Bild zu Text</Title>
@@ -1995,6 +2016,10 @@ gleiche Untertiteldatei bearbeiten können (Zusammenarbeit)</Information>
     <Title>Neuer Ordner</Title>
     <Message>Name des neuen Zeichendatenbank Ordners</Message>
   </VobSubOcrNewFolder>
+  <VobSubOcrSetItalicFactor>
+    <Title>Entkursivierungsfaktor setzen</Title>
+    <Description>Anpassen bis zur aufrechten Schriftlage. Das Originalbild muss in Kursivschrift vorliegen.</Description>
+  </VobSubOcrSetItalicFactor>
   <Waveform>
     <ClickToAddWaveform>Klicken um Wellenform hinzuzufügen</ClickToAddWaveform>
     <ClickToAddWaveformAndSpectrogram>Klicken um Wellenform/Spektogramm hinzuzufügen</ClickToAddWaveformAndSpectrogram>

--- a/src/Languages/el-GR.xml
+++ b/src/Languages/el-GR.xml
@@ -1333,7 +1333,7 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <OpenPluginsFolder>Άνοιγμα φακέλου 'Plugins'</OpenPluginsFolder>
     <GetPluginsInfo1>Τα πρόσθετα του Subtitle Edit πρέπει να έχουν κατεβεί στο φάκελο 'Plugins'</GetPluginsInfo1>
     <GetPluginsInfo2>Επιλέξτε πρόσθετο και κάντε κλικ στο 'Κατέβασμα'</GetPluginsInfo2>
-    <PluginXDownloaded> {0} πρόσθετα κατέβηκαν</PluginXDownloaded>
+    <PluginXDownloaded>{0} πρόσθετα κατέβηκαν</PluginXDownloaded>
     <Download>&amp;Κατέβασμα</Download>
     <Remove>&amp;Αφαίρεση</Remove>
     <UpdateAllX>Ενημέρωση όλων ({0})</UpdateAllX>

--- a/src/Languages/es-AR.xml
+++ b/src/Languages/es-AR.xml
@@ -1269,7 +1269,7 @@ pueden editar el mismo archivo de subtítulo (colaboración)</Information>
     <Title>Iniciar sesión de red</Title>
     <ConnectionTo>Conectando a {0}...</ConnectionTo>
     <Information>Comenzar una nueva sesión en la que varias personas
- puede editar el mismo archivo de subtítulo (colaboración)</Information>
+puede editar el mismo archivo de subtítulo (colaboración)</Information>
     <Start>Inicio</Start>
   </NetworkStart>
   <OpenVideoDvd>

--- a/src/Languages/es-ES.xml
+++ b/src/Languages/es-ES.xml
@@ -903,7 +903,7 @@ pueden editar el mismo archivo de subtítulo (colaboración)</Information>
     <Title>Iniciar sesión de red</Title>
     <ConnectionTo>Conectando a {0}...</ConnectionTo>
     <Information>Comenzar una nueva sesión en la que varias personas
- puede editar el mismo archivo de subtítulo (colaboración)</Information>
+puede editar el mismo archivo de subtítulo (colaboración)</Information>
     <Start>Inicio</Start>
   </NetworkStart>
   <RemoveTextFromHearImpaired>

--- a/src/Languages/eu-ES.xml
+++ b/src/Languages/eu-ES.xml
@@ -1857,7 +1857,7 @@ Jarraitu nahi duzu?</SubtitleAppendPrompt>
     <GoToSubPosition>Joan azp.</GoToSubPosition>
     <KeepChangesTitle>Aldaketak gorde?</KeepChangesTitle>
     <KeepChangesMessage>Azpidatzian aldaketak 'Ikus aldiberetzearekin' egin dira.
-    Gorde aldaketak?</KeepChangesMessage>
+Gorde aldaketak?</KeepChangesMessage>
     <SynchronizationDone>Aldiberetzea eginda!</SynchronizationDone>
     <StartSceneMustComeBeforeEndScene>Hasierako agerraldia amaierako agerraldia baino lehenago etorri behar da!</StartSceneMustComeBeforeEndScene>
     <Tip>Oharra: Erabili &lt;ktrl+ezk/esk geziak&gt; teklak 100 sm mugitzeko atzera/aurrera</Tip>

--- a/src/Languages/fa-IR.xml
+++ b/src/Languages/fa-IR.xml
@@ -64,7 +64,7 @@
   <About>
     <Title>درباره شادوساب</Title>
     <AboutText1>شادوساب كاملا رايگان است كه براي ساخت و ويرايش زيرنويس ايجاد شده
-    و توسط مهدي حسيني برنامه نويسي شده است
+و توسط مهدي حسيني برنامه نويسي شده است
 
 براي دسترسي به اطلاعات بيشتر و برنامه هاي بيشتر به سايت زير وارد شويد
 http://barnamenevisjavan.com
@@ -73,7 +73,7 @@ http://barnamenevisjavan.com
 http://soft98.ir
 پیشنهادات شما را پذیرا هستم.
 
- پست الکترونیکی : mailto:hellas2012@yahoo.com</AboutText1>
+پست الکترونیکی : mailto:hellas2012@yahoo.com</AboutText1>
   </About>
   <AddToNames>
     <Title>اضافه کردن به لیست نام/غیره</Title>
@@ -364,7 +364,7 @@ http://soft98.ir
     <Unbreak>و Unbreak</Unbreak>
     <FixDoubleDash>اصلاح '--' به '...'</FixDoubleDash>
     <FixDoubleGreaterThan>حذف &lt;&lt;</FixDoubleGreaterThan>
-    <FixEllipsesStart> حذف '...'</FixEllipsesStart>
+    <FixEllipsesStart>حذف '...'</FixEllipsesStart>
     <FixMissingOpenBracket>گذاشتن [ فراموش شده</FixMissingOpenBracket>
     <FixMusicNotation>جابجایی علائم موسیقی</FixMusicNotation>
     <XFixDoubleDash>{0} ثابت '--'</XFixDoubleDash>
@@ -449,7 +449,7 @@ http://soft98.ir
         <OpenContainingFolder>باز شامل پوشه</OpenContainingFolder>
         <Compare>مقایسه</Compare>
         <ImportOcrFromDvd>VOB/IFO (DVD) واردات و نام او سی آر از</ImportOcrFromDvd>
-        <ImportOcrVobSubSubtitle> VobSub (فرعی/idx) واردات/او سی آر</ImportOcrVobSubSubtitle>
+        <ImportOcrVobSubSubtitle>VobSub (فرعی/idx) واردات/او سی آر</ImportOcrVobSubSubtitle>
         <ImportBluRaySupFile>واردات/او سی آر ضبط و پخش فایل</ImportBluRaySupFile>
         <ImportSubtitleFromMatroskaFile>MKVزیرنویس واردات از فایل</ImportSubtitleFromMatroskaFile>
         <ImportSubtitleWithManualChosenEncoding>زیرنویس با واردات کتابچه راهنمای انتخاب را پشتیبانی می کند</ImportSubtitleWithManualChosenEncoding>
@@ -470,9 +470,9 @@ http://soft98.ir
         <Title>ویرایش</Title>
         <ShowUndoHistory>تاریخ نمایش برای خنثی سازی</ShowUndoHistory>
         <InsertUnicodeSymbol>درج نماد یونیکد</InsertUnicodeSymbol>
-        <Find> یافتن</Find>
+        <Find>یافتن</Find>
         <FindNext>مشاهده و بعدی</FindNext>
-        <Replace> به جای</Replace>
+        <Replace>به جای</Replace>
         <MultipleReplace>چندگانه و جایگزین</MultipleReplace>
         <GoToSubtitleNumber>برو به تعداد و نام</GoToSubtitleNumber>
       </Edit>
@@ -698,7 +698,7 @@ http://soft98.ir
     <NewFrameRateUsedToCalculateTimeCodes>جدید نرخ فریم ({0}) برای محاسبه شروع/پایان کدهای زمان استفاده شد</NewFrameRateUsedToCalculateTimeCodes>
     <NewFrameRateUsedToCalculateFrameNumbers>جدید نرخ فریم ({0}) برای محاسبه شروع/پایان اعداد قاب مورد استفاده قرار گرفت</NewFrameRateUsedToCalculateFrameNumbers>
     <FindContinue>مورد جستجو یافت نشد.
- آیا می خواهید از بالا از سند و جستجو یک بار دیگر شروع کنم؟</FindContinue>
+آیا می خواهید از بالا از سند و جستجو یک بار دیگر شروع کنم؟</FindContinue>
     <FindContinueTitle>ادامه یافتن؟</FindContinueTitle>
     <XFoundAtLineNumberY>'{0} در بر داشت در شماره خط {1}</XFoundAtLineNumberY>
     <XNotFound>'{0} یافت نشد</XNotFound>
@@ -728,9 +728,9 @@ http://soft98.ir
     <TextingForHearingImpairedRemovedXLines>Texting for hearing impaired removed : {0} lines</TextingForHearingImpairedRemovedXLines>
     <SubtitleSplitted>نام پذیری</SubtitleSplitted>
     <SubtitleAppendPrompt>این نام موجود در حال حاضر به نام لود پیوست که باید
- در حال حاضر در هماهنگی با فایل تصویری می باشد.
+در حال حاضر در هماهنگی با فایل تصویری می باشد.
 
- ادامه؟</SubtitleAppendPrompt>
+ادامه؟</SubtitleAppendPrompt>
     <SubtitleAppendPromptTitle>نام افزودن پرونده</SubtitleAppendPromptTitle>
     <OpenSubtitleToAppend>نام برای اضافه</OpenSubtitleToAppend>
     <AppendViaVisualSyncTitle>همگام تجسمی -- الحاق بخش دوم زیرنویس</AppendViaVisualSyncTitle>

--- a/src/Languages/fi-FI.xml
+++ b/src/Languages/fi-FI.xml
@@ -74,17 +74,14 @@
   </General>
   <About>
     <Title>Tietoja Subtitle Editistä</Title>
-    <AboutText1>
-Subtitle Edit on ilmainen GNU Public License -ohjelma.Voit jakaa, muokata ja käyttää sitä vapaasti. C# lähdekoodi on saatavilla https://github.com/SubtitleEdit/subtitleedit
+    <AboutText1>Subtitle Edit on ilmainen GNU Public License -ohjelma.Voit jakaa, muokata ja käyttää sitä vapaasti. C# lähdekoodi on saatavilla https://github.com/SubtitleEdit/subtitleedit
 Vieraile www.nikse.dk uusimman version saamiseksi.
 Ehdotukset ovat erittäin tervetulleita.
-Sähköposti: mailto:nikse.dk@gmail.com
-        </AboutText1>
+Sähköposti: mailto:nikse.dk@gmail.com</AboutText1>
   </About>
   <AddToNames>
     <Title>Lisää nimet/etc -luetteloon</Title>
-    <Description>Lisää nimet-/virheluetteloon (sama kirjainkoko)
-        </Description>
+    <Description>Lisää nimet-/virheluetteloon (sama kirjainkoko)</Description>
   </AddToNames>
   <AddToOcrReplaceList>
     <Title>Lisää tekstintunnistuskorvausluetteloon</Title>
@@ -100,11 +97,8 @@ Sähköposti: mailto:nikse.dk@gmail.com
     <GenerateWaveformData>Muodosta aaltomuoto tiedoista</GenerateWaveformData>
     <PleaseWait>Tämä voi kestää muutamia minuutteja - odota</PleaseWait>
     <VlcMediaPlayerNotFoundTitle>VLC media playeria ei löydy</VlcMediaPlayerNotFoundTitle>
-    <VlcMediaPlayerNotFound>Subtitle Edit tarvitsee äänidatan purkamiseksi VLC media playerin (1.1.x tai uudemman).
-        </VlcMediaPlayerNotFound>
-    <GoToVlcMediaPlayerHomePage>
-Siirrytäänkö VLC media playerin kotisivulle?
-        </GoToVlcMediaPlayerHomePage>
+    <VlcMediaPlayerNotFound>Subtitle Edit tarvitsee äänidatan purkamiseksi VLC media playerin (1.1.x tai uudemman).</VlcMediaPlayerNotFound>
+    <GoToVlcMediaPlayerHomePage>Siirrytäänkö VLC media playerin kotisivulle?</GoToVlcMediaPlayerHomePage>
     <GeneratingPeakFile>Muodostetaan huipputiedosto...</GeneratingPeakFile>
     <GeneratingSpectrogram>Muodostetaan spectrogrammi...</GeneratingSpectrogram>
     <ExtractingSeconds>Puretaan audio: {0:0.0} sekuntia</ExtractingSeconds>
@@ -997,14 +991,10 @@ Siirrytäänkö VLC media playerin kotisivulle?
     <NewFrameRateUsedToCalculateTimeCodes>Uutta kuvataajuutta ({0}) käytettiin laskettaessa alku-/loppuaikaleimat</NewFrameRateUsedToCalculateTimeCodes>
     <NewFrameRateUsedToCalculateFrameNumbers>Uutta kuvataajuutta ({0}) käytettiin laskettaessa alku-/loppukuvien numerot</NewFrameRateUsedToCalculateFrameNumbers>
     <FindContinue>Etsittävää kohdetta ei löytynyt.
- Haluatko aloittaa asiakirjan alusta ja hakea kerran vielä?</FindContinue>
+Haluatko aloittaa asiakirjan alusta ja hakea kerran vielä?</FindContinue>
     <FindContinueTitle>Jatketaanko hakua?</FindContinueTitle>
-    <ReplaceContinueNotFound>
-Etsittävää kohdetta ei löytynyt. Haluatko aloittaa asiakirjan alusta ja jatkaa Etsi ja korvaa toimintoa?
-        </ReplaceContinueNotFound>
-    <ReplaceXContinue>
-Etsittävä kohde korvattu {0} kertaa. Haluatko aloittaa asiakirjan alusta ja jatkaa Etsi ja korvaa toimintoa?
-        </ReplaceXContinue>
+    <ReplaceContinueNotFound>Etsittävää kohdetta ei löytynyt. Haluatko aloittaa asiakirjan alusta ja jatkaa Etsi ja korvaa toimintoa?</ReplaceContinueNotFound>
+    <ReplaceXContinue>Etsittävä kohde korvattu {0} kertaa. Haluatko aloittaa asiakirjan alusta ja jatkaa Etsi ja korvaa toimintoa?</ReplaceXContinue>
     <ReplaceContinueTitle>Jatketaanko 'Korvausta'?</ReplaceContinueTitle>
     <SearchingForXFromLineY>Etsitään '{0}' riviltä {1}...</SearchingForXFromLineY>
     <XFoundAtLineNumberY>'{0}' löytyi riviltä {1}</XFoundAtLineNumberY>
@@ -1124,9 +1114,7 @@ Etsittävä kohde korvattu {0} kertaa. Haluatko aloittaa asiakirjan alusta ja ja
     <ShowAllLinesXSecondsLinesLater>Näytä kaikki rivit {0:0.0##} sekuntia myöhemmin</ShowAllLinesXSecondsLinesLater>
     <ShowSelectedLinesXSecondsLinesEarlier>Näytä valitut rivit {0:0.0##} sekuntia aikaisemmin</ShowSelectedLinesXSecondsLinesEarlier>
     <ShowSelectedLinesXSecondsLinesLater>Näytä valitut rivit {0:0.0##} sekuntia myöhemmin</ShowSelectedLinesXSecondsLinesLater>
-    <ShowSelectionAndForwardXSecondsLinesEarlier>
-Näytä valinta ja siitä eteenpäin {0:0.0##} sekuntia aikaisemmin
-        </ShowSelectionAndForwardXSecondsLinesEarlier>
+    <ShowSelectionAndForwardXSecondsLinesEarlier>Näytä valinta ja siitä eteenpäin {0:0.0##} sekuntia aikaisemmin</ShowSelectionAndForwardXSecondsLinesEarlier>
     <ShowSelectionAndForwardXSecondsLinesLater>Näytä valinta ja siitä eteenpäin {0:0.0##} sekuntia myöhemmin</ShowSelectionAndForwardXSecondsLinesLater>
     <ShowSelectedLinesEarlierLaterPerformed>Näytä aikaisemmat/myöhemmät suoritukset valituilla riveillä</ShowSelectedLinesEarlierLaterPerformed>
     <DoubleWordsViaRegEx>Kaksoissanat regexin kautta {0}</DoubleWordsViaRegEx>
@@ -1201,10 +1189,8 @@ Näytä valinta ja siitä eteenpäin {0:0.0##} sekuntia aikaisemmin
     <BeforeDisplaySubtitleJoin>Ennen tekstityksien liittämistä</BeforeDisplaySubtitleJoin>
     <SubtitlesJoined>Liitetyt tekstitykset</SubtitlesJoined>
     <StatusLog>Tilaloki</StatusLog>
-    <XSceneChangesImported>Tuotu {0} kohtausmuutosta
-    </XSceneChangesImported>
-    <PluginXExecuted>Suoritettiin laajennus '{0}'.
-    </PluginXExecuted>
+    <XSceneChangesImported>Tuotu {0} kohtausmuutosta</XSceneChangesImported>
+    <PluginXExecuted>Suoritettiin laajennus '{0}'.</PluginXExecuted>
     <NotAValidXSubFile>Tiedosto ei ole XSub-muodossa!</NotAValidXSubFile>
     <BeforeMergeLinesWithSameText>Ennen samansisältöisten rivien yhdistämistä</BeforeMergeLinesWithSameText>
     <ImportTimeCodesDifferentNumberOfLinesWarning>Aikaleimat sisältävässä tekstityksessä on eri rivimäärä ({0)} kuin nykyisessä tekstityksessä - jatketaanko silti?</ImportTimeCodesDifferentNumberOfLinesWarning>
@@ -1627,8 +1613,7 @@ Näytä valinta ja siitä eteenpäin {0:0.0##} sekuntia aikaisemmin
     <ToggleTranslationMode>Vaihda käännöksen tila</ToggleTranslationMode>
     <SwitchOriginalAndTranslation>Vaihda alkuperäinen ja käännös</SwitchOriginalAndTranslation>
     <MergeOriginalAndTranslation>Yhdistä alkuperäinen ja käännös</MergeOriginalAndTranslation>
-    <ShortcutIsAlreadyDefinedX>Oikotie on jo määritelty: {0}
-    </ShortcutIsAlreadyDefinedX>
+    <ShortcutIsAlreadyDefinedX>Oikotie on jo määritelty: {0}</ShortcutIsAlreadyDefinedX>
     <ToggleTranslationAndOriginalInPreviews>Vaihda käännös ja alkuperäinen video/audio esikatselussa</ToggleTranslationAndOriginalInPreviews>
     <ListViewColumnDelete>Sarake, poista teksti</ListViewColumnDelete>
     <ListViewColumnInsert>Sarake, lisää teksti</ListViewColumnInsert>

--- a/src/Languages/fr-FR.xml
+++ b/src/Languages/fr-FR.xml
@@ -1217,7 +1217,7 @@ Poursuivre ?</SubtitleAppendPrompt>
     <BeforeMergeLinesWithSameText>Avant de fusionner les lignes avec le même texte</BeforeMergeLinesWithSameText>
     <ImportTimeCodesDifferentNumberOfLinesWarning>Le timecode du sous-titre importé a un nombre différent de lignes ({0}) par rapport à l'actuel ({1}).
 
- Continuer ?</ImportTimeCodesDifferentNumberOfLinesWarning>
+Continuer ?</ImportTimeCodesDifferentNumberOfLinesWarning>
     <ParsingTransportStream>Analyse des flux de transport - s'il vous plaît patienter...</ParsingTransportStream>
     <ErrorLoadIdx>Subtitle Edit ne peut pas lire les fichiers .idx :
 - Ils font partie de paires de fichiers idx/sub (également appelés VobSub).
@@ -1232,8 +1232,7 @@ Poursuivre ?</SubtitleAppendPrompt>
 - Ce n’est pas un fichier de sous-titres.</ErrorLoadSrr>
   </Main>
   <MatroskaSubtitleChooser>
-    <Title>Choisir les sous-titres du fichier Matroska
-</Title>
+    <Title>Choisir les sous-titres du fichier Matroska</Title>
     <PleaseChoose>Plus d'un sous-titre trouvé - choisir svp</PleaseChoose>
     <TrackXLanguageYTypeZ>Piste {0} - {1} - langue: {2} - type: {3}</TrackXLanguageYTypeZ>
   </MatroskaSubtitleChooser>
@@ -1320,8 +1319,7 @@ Poursuivre ?</SubtitleAppendPrompt>
   <NetworkJoin>
     <Title>Rejoindre une session réseau</Title>
     <Information>Joignez-vous à la session actuelle, où plusieurs personnes
- peuvent modifier le même fichier de sous-titres (collaboration)
-</Information>
+peuvent modifier le même fichier de sous-titres (collaboration)</Information>
     <Join>Rejoindre</Join>
   </NetworkJoin>
   <NetworkLogAndInfo>
@@ -1332,8 +1330,7 @@ Poursuivre ?</SubtitleAppendPrompt>
     <Title>Démarrer une session réseau</Title>
     <ConnectionTo>Connexion à {0}...</ConnectionTo>
     <Information>Démarrer une nouvelle session, où plusieurs personnes
- peuvent modifier le même fichier de sous-titres (collaboration)
-</Information>
+peuvent modifier le même fichier de sous-titres (collaboration)</Information>
     <Start>Démarrer</Start>
   </NetworkStart>
   <OpenVideoDvd>

--- a/src/Languages/hr-HR.xml
+++ b/src/Languages/hr-HR.xml
@@ -1113,7 +1113,7 @@ koji bi trebao biti usklađen s video datotekom.
     <NetworkInsert>Linija je ubačena: {0} ({1}): popis – {2}, tekst – {3}</NetworkInsert>
     <NetworkDelete>Linija je obrisana: {0} ({1}): popis – {2}</NetworkDelete>
     <NetworkNewUser>pristupi sesiji {0} ({1}).</NetworkNewUser>
-    <NetworkByeUser> napusti sesiju {0} ({1}).</NetworkByeUser>
+    <NetworkByeUser>napusti sesiju {0} ({1}).</NetworkByeUser>
     <NetworkUnableToConnectToServer>Nije moguće povezivanje sa serverom: {0}</NetworkUnableToConnectToServer>
     <UserAndAction>Korisnik/radnja</UserAndAction>
     <NetworkMode>Umreženo</NetworkMode>
@@ -1221,7 +1221,7 @@ koji bi trebao biti usklađen s video datotekom.
   <NetworkJoin>
     <Title>Mrežna sesija</Title>
     <Information>Ovdje se možete pridružiti postojećoj sesiji u kojoj
-    možete uređivati određeni podnaslov s drugim ljudima.</Information>
+možete uređivati određeni podnaslov s drugim ljudima.</Information>
     <Join>&amp;Poveži me</Join>
   </NetworkJoin>
   <NetworkLogAndInfo>
@@ -1232,7 +1232,7 @@ koji bi trebao biti usklađen s video datotekom.
     <Title>Mrežna sesija</Title>
     <ConnectionTo>Povezujem se na {0}...</ConnectionTo>
     <Information>Ovdje možete napraviti sesiju u kojoj ćete moći uređivati
-    određeni podnaslov s drugim ljudima.</Information>
+određeni podnaslov s drugim ljudima.</Information>
     <Start>&amp;Započni</Start>
   </NetworkStart>
   <OpenVideoDvd>
@@ -1731,7 +1731,7 @@ koji bi trebao biti usklađen s video datotekom.
     <KeepChangesTitle>Spremanje izmjena</KeepChangesTitle>
     <KeepChangesMessage>Izmijenili ste podnaslov koristeći Vizualno usklađivanje.
 
-    Želite li spremiti izmjene?</KeepChangesMessage>
+Želite li spremiti izmjene?</KeepChangesMessage>
     <SynchronizationDone>Usklađivanje je završeno.</SynchronizationDone>
     <StartSceneMustComeBeforeEndScene>Početna scena mora biti prije završne!</StartSceneMustComeBeforeEndScene>
     <Tip>Koristi Ctrl i lijevu ili desnu strelicu da pomaknete 100 ms unazad ili unaprijed.</Tip>

--- a/src/Languages/it-IT.xml
+++ b/src/Languages/it-IT.xml
@@ -611,8 +611,7 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <To>A:</To>
     <Translate>Traduci</Translate>
     <PleaseWait>Attendere... ci potrebbe volere un po' di tempo</PleaseWait>
-    <PoweredByGoogleTranslate>Servizio traduzione di Google
-</PoweredByGoogleTranslate>
+    <PoweredByGoogleTranslate>Servizio traduzione di Google</PoweredByGoogleTranslate>
     <PoweredByMicrosoftTranslate>Servizio traduzione di Microsoft</PoweredByMicrosoftTranslate>
   </GoogleTranslate>
   <GoogleOrMicrosoftTranslate>
@@ -1380,7 +1379,7 @@ modificare lo stesso file di sottotitolo (collaborazione)</Information>
     <Brackets>'{' e '}'</Brackets>
     <Parentheses>'(' e ')'</Parentheses>
     <QuestionMarks>'?' e '?'</QuestionMarks>
-    <And> e</And>
+    <And>e</And>
     <RemoveTextBeforeColon>Elimina il testo prima dei due punti (':')</RemoveTextBeforeColon>
     <OnlyIfTextIsUppercase>Solo se il testo è MAIUSCOLO</OnlyIfTextIsUppercase>
     <OnlyIfInSeparateLine>Solo se è in una linea separata</OnlyIfInSeparateLine>

--- a/src/Languages/ko-KR.xml
+++ b/src/Languages/ko-KR.xml
@@ -74,14 +74,12 @@
   </General>
   <About>
     <Title>* Subtitle Edit 정보</Title>
-    <AboutText1>
-Subtitle Edit는 GNU 정책을 따르는 무료 소프트웨어입니다.
+    <AboutText1>Subtitle Edit는 GNU 정책을 따르는 무료 소프트웨어입니다.
 자유롭게 배포할 수 있으며 수정해서 사용할 수 있습니다.
 C# 코드는 https://github.com/SubtitleEdit/subtitleedit 에 있습니다.
 최신 버전은 홈페이지(www.nikse.dk)를 방문하시기 바랍니다.
 귀하의 의견은 아래 이메일 주소로 접수되며 언제나 환영합니다.
-이메일 주소: mailto:nikse.dk@gmail.com
-   </AboutText1>
+이메일 주소: mailto:nikse.dk@gmail.com</AboutText1>
   </About>
   <AddToNames>
     <Title>이름/기타 목록에 단어 추가</Title>
@@ -987,7 +985,7 @@ C# 코드는 https://github.com/SubtitleEdit/subtitleedit 에 있습니다.
     <SaveChangesToX>{0} 이름으로 저장하시겠습니까?</SaveChangesToX>
     <SaveChangesToUntitledOriginal>현재의 원본 자막을 다른 이름으로 저장하시겠습니까?</SaveChangesToUntitledOriginal>
     <SaveChangesToOriginalX>원본 자막을 {0} 이름으로 저장하시겠습니까?</SaveChangesToOriginalX>
-    <SaveSubtitleAs> 자막 저장...</SaveSubtitleAs>
+    <SaveSubtitleAs>자막 저장...</SaveSubtitleAs>
     <SaveOriginalSubtitleAs>원본 자막 다른 이름으로 저장...</SaveOriginalSubtitleAs>
     <NoSubtitleLoaded>로드된 자막이 없습니다!</NoSubtitleLoaded>
     <VisualSyncSelectedLines>시각 동기화 - 선택한 줄</VisualSyncSelectedLines>
@@ -1073,8 +1071,7 @@ C# 코드는 https://github.com/SubtitleEdit/subtitleedit 에 있습니다.
     <SubtitleTranslated>자막이 번역됨!</SubtitleTranslated>
     <TranslateSwedishToDanish>현재 로드된 스웨덴어 자막을 덴마크어로 번역</TranslateSwedishToDanish>
     <TranslateSwedishToDanishWarning>현재 로드된 자막이 스웨덴어가 확실합니까?
-스웨덴어가 맞으면 덴마크어로 번역될 것입니다.
-    </TranslateSwedishToDanishWarning>
+스웨덴어가 맞으면 덴마크어로 번역될 것입니다.</TranslateSwedishToDanishWarning>
     <TranslatingViaNikseDkMt>www.nikse.dk/mt를 통해 번역하는 중...</TranslatingViaNikseDkMt>
     <BeforeSwedishToDanishTranslation>스웨덴어를 덴마크어로 번역 전</BeforeSwedishToDanishTranslation>
     <TranslationFromSwedishToDanishComplete>스웨덴어를 덴마크어로 번역했습니다!</TranslationFromSwedishToDanishComplete>
@@ -1695,7 +1692,7 @@ C# 코드는 https://github.com/SubtitleEdit/subtitleedit 에 있습니다.
     <TitleAll>* 모든 줄 빠르게/느리게 표시</TitleAll>
     <ShowEarlier>빠르게</ShowEarlier>
     <ShowLater>느리게</ShowLater>
-    <TotalAdjustmentX> ☞ 싱크 합계: {0} 초</TotalAdjustmentX>
+    <TotalAdjustmentX>☞ 싱크 합계: {0} 초</TotalAdjustmentX>
     <AllLines>모든 줄</AllLines>
     <SelectedLinesOnly>선택한 줄</SelectedLinesOnly>
     <SelectedLinesAndForward>선택한 줄 이후</SelectedLinesAndForward>

--- a/src/Languages/nl-NL.xml
+++ b/src/Languages/nl-NL.xml
@@ -20,7 +20,7 @@
     <OpenVideoFile>Videobestand openen...</OpenVideoFile>
     <OpenVideoFileTitle>Videobestand openen</OpenVideoFileTitle>
     <NoVideoLoaded>Geen video geladen</NoVideoLoaded>
-    <VideoInformation>Video informatie</VideoInformation>
+    <VideoInformation>Videoinformatie</VideoInformation>
     <PositionX>Positie / tĳdsduur: {0}</PositionX>
     <StartTime>Starttĳd</StartTime>
     <EndTime>Eindtĳd</EndTime>
@@ -28,14 +28,14 @@
     <NumberSymbol>№</NumberSymbol>
     <Number>Aantal</Number>
     <Text>Tekst</Text>
-    <HourMinutesSecondsMilliseconds>uur:min:sec:ms</HourMinutesSecondsMilliseconds>
+    <HourMinutesSecondsMilliseconds>uur:min:sec:msec</HourMinutesSecondsMilliseconds>
     <Bold>Vet</Bold>
     <Italic>Cursief</Italic>
     <Underline>Onderstrepen</Underline>
     <Visible>Zichtbaar</Visible>
     <FrameRate>Beeldsnelheid</FrameRate>
     <Name>Naam</Name>
-    <FileNameXAndSize>Bestandsnaam: {0} ({1})</FileNameXAndSize>
+    <FileNameXAndSize>Bestandsnaam: {0}  ({1})</FileNameXAndSize>
     <ResolutionX>Resolutie: {0}</ResolutionX>
     <FrameRateX>Beeldsnelheid: {0:0.0###}</FrameRateX>
     <TotalFramesX>Totaal aantal beelden: {0:#,##0.##}</TotalFramesX>
@@ -143,7 +143,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
   <BatchConvert>
     <Title>Batch-conversie</Title>
     <Input>Invoer</Input>
-    <InputDescription>Invoerbestanden (blader of sleep en plaats)</InputDescription>
+    <InputDescription>Invoerbestanden (blader of sleep-en-plaats)</InputDescription>
     <Status>Status</Status>
     <Output>Uitvoer</Output>
     <ChooseOutputFolder>Doelmap kiezen</ChooseOutputFolder>
@@ -151,7 +151,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
     <Style>Stĳl...</Style>
     <ConvertOptions>Conversieopties</ConvertOptions>
     <RemoveFormatting>Formateringstekens verwĳderen</RemoveFormatting>
-    <RemoveTextForHI>Tekst voor slechthorenden verwĳderen</RemoveTextForHI>
+    <RemoveTextForHI>D&amp;&amp;SH tekst verwĳderen</RemoveTextForHI>
     <OverwriteOriginalFiles>Originele bestanden vervangen (nieuwe extensie als formaat gewĳzigd is)</OverwriteOriginalFiles>
     <RedoCasing>Hoofd-/kleine letters herzien</RedoCasing>
     <Convert>Converteren</Convert>
@@ -222,7 +222,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
   </ChooseAudioTrack>
   <ChooseEncoding>
     <Title>Codering kiezen</Title>
-    <CodePage>Karaktercodetabel</CodePage>
+    <CodePage>Tekencodetabel</CodePage>
     <DisplayName>Weergavenaam</DisplayName>
     <PleaseSelectAnEncoding>Kies een codering a.u.b.</PleaseSelectAnEncoding>
   </ChooseEncoding>
@@ -332,7 +332,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
     <CodePageNumber>Codepage nummer (CPN)</CodePageNumber>
     <DiskFormatCode>Disk formatcode (DFC)</DiskFormatCode>
     <DisplayStandardCode>Weergavestandaard (DSC)</DisplayStandardCode>
-    <CharacterCodeTable>Karaktertabel (CCT)</CharacterCodeTable>
+    <CharacterCodeTable>Tekencodetabel (CCT)</CharacterCodeTable>
     <LanguageCode>Taalcode (LC)</LanguageCode>
     <OriginalProgramTitle>Originele programmatitel (OPT)</OriginalProgramTitle>
     <OriginalEpisodeTitle>Originele episodetitel (OET)</OriginalEpisodeTitle>
@@ -424,7 +424,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
     <SaveDvdStudioProStlAs>DVD Studio Pro STL bestandsnaam kiezen</SaveDvdStudioProStlAs>
     <SomeLinesWereTooLongX>Enkele regels zĳn te lang: {0}</SomeLinesWereTooLongX>
     <LineHeight>Regelhoogte</LineHeight>
-    <BoxSingleLine>Eénlĳnig kader</BoxSingleLine>
+    <BoxSingleLine>Enkellĳnig kader</BoxSingleLine>
     <BoxMultiLine>Meerlĳnig kader</BoxMultiLine>
     <Forced>Ingebakken</Forced>
   </ExportPngXml>
@@ -474,10 +474,10 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
     <Step1>Stap 1/2 - Te corrigeren fouten selecteren</Step1>
     <WhatToFix>Wat te corrigeren</WhatToFix>
     <Example>Voorbeeld</Example>
-    <SelectAll>Alles selecteren</SelectAll>
+    <SelectAll>Allemaal</SelectAll>
     <InverseSelection>Selectie omkeren</InverseSelection>
-    <Back>&lt; &amp;Terug</Back>
-    <Next>&amp;Volgende &gt;</Next>
+    <Back>&lt;&amp;Terug</Back>
+    <Next>&amp;Volgende&gt;</Next>
     <Step2>Stap 2/2 - Correcties verifiëren</Step2>
     <Fixes>Correcties</Fixes>
     <Log>Logboek</Log>
@@ -500,12 +500,12 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
     <FixUppercaseIInsindeLowercaseWords>Hoofdletter i in klein geschreven woorden (OCR-fout) corrigeren</FixUppercaseIInsindeLowercaseWords>
     <FixDoubleApostrophes>Dubbele apostrof ('') door aanhalingsteken (") vervangen</FixDoubleApostrophes>
     <AddPeriods>Punt invoegen indien de volgende regel met een hoofdletter begint</AddPeriods>
-    <StartWithUppercaseLetterAfterParagraph>Start met hoofdletter na paragraaf</StartWithUppercaseLetterAfterParagraph>
-    <StartWithUppercaseLetterAfterPeriodInsideParagraph>Begin met hoofdletter na punt in paragraaf</StartWithUppercaseLetterAfterPeriodInsideParagraph>
-    <StartWithUppercaseLetterAfterColon>Begin met hoofdletter na dubbele punt/komma</StartWithUppercaseLetterAfterColon>
+    <StartWithUppercaseLetterAfterParagraph>Begin met hoofdletter na een alinea</StartWithUppercaseLetterAfterParagraph>
+    <StartWithUppercaseLetterAfterPeriodInsideParagraph>Begin met hoofdletter na een punt</StartWithUppercaseLetterAfterPeriodInsideParagraph>
+    <StartWithUppercaseLetterAfterColon>Begin met hoofdletter na puntkomma/dubbele punt</StartWithUppercaseLetterAfterColon>
     <FixLowercaseIToUppercaseI>Alleenstaande 'i' door 'I' vervangen (Engels)</FixLowercaseIToUppercaseI>
-    <FixCommonOcrErrors>Gangbare OCR fouten corrigeren (m.b.v. de OCR-correctielĳst)</FixCommonOcrErrors>
-    <CommonOcrErrorsFixed>Gangbare OCR fouten gecorrigeerd (m.b.v. de OCR-correctielĳst): {0}</CommonOcrErrorsFixed>
+    <FixCommonOcrErrors>Gangbare OCR-fouten corrigeren (m.b.v. de OCR-correctielĳst)</FixCommonOcrErrors>
+    <CommonOcrErrorsFixed>Gangbare OCR-fouten gecorrigeerd (m.b.v. de OCR-correctielĳst): {0}</CommonOcrErrorsFixed>
     <RemoveSpaceBetweenNumber>Verwĳder ruimte tussen getallen</RemoveSpaceBetweenNumber>
     <FixDialogsOnOneLine>Eénregelige dialogen corrigeren</FixDialogsOnOneLine>
     <RemoveSpaceBetweenNumbersFixed>Spaties tussen getallen verwĳderd: {0}</RemoveSpaceBetweenNumbersFixed>
@@ -549,7 +549,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
     <FixUppercaseIInsindeLowercaseWordsExample>The earth is fIat. -&gt; The earth is flat.</FixUppercaseIInsindeLowercaseWordsExample>
     <FixLowercaseIToUppercaseIExample>What do i care. -&gt; What do I care.</FixLowercaseIToUppercaseIExample>
     <StartTimeLaterThanEndTime>Tekst nummer {0}: Starttĳd is later dan eindtĳd: {4} {1} -&gt; {2} {3}</StartTimeLaterThanEndTime>
-    <UnableToFixStartTimeLaterThanEndTime>Kan tekst nummer {0} niet corrigeren: startĳdstip is later dan eindtĳdstip: {1}</UnableToFixStartTimeLaterThanEndTime>
+    <UnableToFixStartTimeLaterThanEndTime>Kan tekst nummer {0} niet corrigeren: starttĳd is later dan eindtĳd: {1}</UnableToFixStartTimeLaterThanEndTime>
     <XFixedToYZ>{0} gecorrigeerd naar: {1} {2}</XFixedToYZ>
     <UnableToFixTextXY>Kan tekst nummer {0} niet corrigeren: {1}</UnableToFixTextXY>
     <XOverlappingTimestampsFixed>{0} overlappende tĳden gecorrigeerd</XOverlappingTimestampsFixed>
@@ -635,13 +635,13 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
   </GoogleOrMicrosoftTranslate>
   <GoToLine>
     <Title>Ga naar ondertitel nr.</Title>
-    <XIsNotAValidNumber>{0} is geen geldig getal</XIsNotAValidNumber>
+    <XIsNotAValidNumber>{0} is geen geldig ondertitelnummer</XIsNotAValidNumber>
   </GoToLine>
   <ImportImages>
     <Title>Afbeeldingen importeren</Title>
     <ImageFiles>Beeldbestanden</ImageFiles>
     <Input>Invoer</Input>
-    <InputDescription>Kies invoer bestanden (blader of versleep)</InputDescription>
+    <InputDescription>Kies invoer bestanden (blader of sleep-en-plaats)</InputDescription>
   </ImportImages>
   <ImportSceneChanges>
     <Title>Scènewisselingen importeren</Title>
@@ -745,7 +745,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
         <Redo>&amp;Herhalen</Redo>
         <ShowUndoHistory>Geschiedenis voor ongedaan maken tonen</ShowUndoHistory>
         <InsertUnicodeSymbol>&amp;Unicode symbool invoegen</InsertUnicodeSymbol>
-        <InsertUnicodeControlCharacters>Unicode controle karakters</InsertUnicodeControlCharacters>
+        <InsertUnicodeControlCharacters>Unicode controletekens</InsertUnicodeControlCharacters>
         <InsertUnicodeControlCharactersLRM>Left-to-right markering (LRM)</InsertUnicodeControlCharactersLRM>
         <InsertUnicodeControlCharactersRLM>Right-to-left markering (RLM)</InsertUnicodeControlCharactersRLM>
         <InsertUnicodeControlCharactersLRE>Left-to-right embedding (LRE)</InsertUnicodeControlCharactersLRE>
@@ -758,7 +758,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
         <MultipleReplace>&amp;Meermaals vervangen...</MultipleReplace>
         <GoToSubtitleNumber>&amp;Ga naar ondertitel nummer...</GoToSubtitleNumber>
         <RightToLeftMode>Rechts-naar-links (RTL)</RightToLeftMode>
-        <FixTrlViaUnicodeControlCharacters>RTL via unicode-controlekarakters corigeren (geselecteerde ondertitels)</FixTrlViaUnicodeControlCharacters>
+        <FixTrlViaUnicodeControlCharacters>RTL via Unicode controletekens corigeren (geselecteerde ondertitels)</FixTrlViaUnicodeControlCharacters>
         <ReverseRightToLeftStartEnd>RTL begin/einde omkeren (geselecteerde ondertitels)</ReverseRightToLeftStartEnd>
         <ShowOriginalTextInAudioAndVideoPreview>Originele tekst weergeven in audio/video voorbeeld</ShowOriginalTextInAudioAndVideoPreview>
         <ModifySelection>&amp;Selectie wĳzigen...</ModifySelection>
@@ -766,7 +766,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
       </Edit>
       <Tools>
         <Title>E&amp;xtra</Title>
-        <AdjustDisplayDuration>Duurtĳd &amp;aanpassen...</AdjustDisplayDuration>
+        <AdjustDisplayDuration>&amp;Tĳdsduur aanpassen...</AdjustDisplayDuration>
         <ApplyDurationLimits>Tĳdsduurlimieten toepassen</ApplyDurationLimits>
         <DurationsBridgeGap>Tĳdsduurhiaten overbruggen...</DurationsBridgeGap>
         <FixCommonErrors>Gangbare &amp;fouten corrigeren...</FixCommonErrors>
@@ -789,7 +789,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
         <TextSingleLineMaximumLength>Tekst - max. lengte enkele regel</TextSingleLineMaximumLength>
         <TextTotalLength>Tekst - totale lengte</TextTotalLength>
         <TextNumberOfLines>Tekst - aantal regels</TextNumberOfLines>
-        <TextNumberOfCharactersPerSeconds>Tekst - aantal tekens/sec</TextNumberOfCharactersPerSeconds>
+        <TextNumberOfCharactersPerSeconds>Tekst - aantal tekens/sec.</TextNumberOfCharactersPerSeconds>
         <WordsPerMinute>Tekst - woorden per minuut (wpm)</WordsPerMinute>
         <Style>Stĳl</Style>
         <Ascending>Oplopend</Ascending>
@@ -868,7 +868,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
         <FixCommonErrors>Gangbare fouten corrigeren</FixCommonErrors>
         <VisualSync>Visuele synchronisatie</VisualSync>
         <SpellCheck>Spellingcontrole</SpellCheck>
-        <Settings>Instellingen</Settings>
+        <Settings>Voorkeuren</Settings>
         <Help>Help</Help>
         <ShowHideWaveform>Golfvorm tonen/verbergen</ShowHideWaveform>
         <ShowHideVideo>Video tonen/verbergen</ShowHideVideo>
@@ -893,7 +893,7 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
         <InsertBefore>Invoegen vóór</InsertBefore>
         <InsertAfter>Invoegen na</InsertAfter>
         <InsertSubtitleAfter>Ondertitel invoegen na deze regel...</InsertSubtitleAfter>
-        <CopyToClipboard>Als tekst kopiëren naar het klem&amp;bord</CopyToClipboard>
+        <CopyToClipboard>Naar het klem&amp;bord kopiëren</CopyToClipboard>
         <Column>Kolom</Column>
         <ColumnDeleteText>Tekst verwĳderen</ColumnDeleteText>
         <ColumnDeleteTextAndShiftCellsUp>Tekst verwĳderen en cellen naar boven schuiven</ColumnDeleteTextAndShiftCellsUp>
@@ -1177,8 +1177,8 @@ Verder gaan?</SubtitleAppendPrompt>
     <OcrReplacePairXAdded>Paar '{0} -&gt; {1}' is toegevoegd aan de OCR-correctielĳst</OcrReplacePairXAdded>
     <OcrReplacePairXNotAdded>Paar '{0} -&gt; {1}' is NIET toegevoegd aan de OCR-correctielĳst</OcrReplacePairXNotAdded>
     <XLinesSelected>{0} teksten geselecteerd</XLinesSelected>
-    <UnicodeMusicSymbolsAnsiWarning>Ondertitel bevat unicode muzieknootsymbolen. Bĳ opslaan in ANSI-codering gaan deze verloren. Toch opslaan?</UnicodeMusicSymbolsAnsiWarning>
-    <UnicodeCharactersAnsiWarning>Ondertitel bevat unicode karakters. Bĳ opslaan in ANSI-codering gaan deze verloren. Toch opslaan?</UnicodeCharactersAnsiWarning>
+    <UnicodeMusicSymbolsAnsiWarning>Ondertitel bevat Unicode muzieknootsymbolen. Bĳ opslaan in ANSI-codering gaan deze verloren. Toch opslaan?</UnicodeMusicSymbolsAnsiWarning>
+    <UnicodeCharactersAnsiWarning>Ondertitel bevat Unicode tekens. Bĳ opslaan in ANSI-codering gaan deze verloren. Toch opslaan?</UnicodeCharactersAnsiWarning>
     <NegativeTimeWarning>Ondertitel bevat negatieve tĳdcodes. Toch opslaan?</NegativeTimeWarning>
     <BeforeMergeShortLines>Vóór samenvoegen korte regels</BeforeMergeShortLines>
     <BeforeSplitLongLines>Vóór opdelen lange regels</BeforeSplitLongLines>
@@ -1196,7 +1196,7 @@ Verder gaan?</SubtitleAppendPrompt>
     <BeforeSetEndTimeAndOffsetTheRest>Vóór eindtĳd instellen en overige opschuiven</BeforeSetEndTimeAndOffsetTheRest>
     <BeforeSetEndAndVideoPosition>Vóór eindtĳd op videopositie zetten en automatisch start berekenen</BeforeSetEndAndVideoPosition>
     <ContinueWithCurrentSpellCheck>Doorgaan met de huidige spellingcontrole?</ContinueWithCurrentSpellCheck>
-    <CharactersPerSecond>Karakters/s: {0:0.00}</CharactersPerSecond>
+    <CharactersPerSecond>Tekens/sec.: {0:0.00}</CharactersPerSecond>
     <GetFrameRateFromVideoFile>Beeldsnelheid uit videobestand halen</GetFrameRateFromVideoFile>
     <NetworkMessage>Nieuw bericht: {0} ({1}): {2}</NetworkMessage>
     <NetworkUpdate>Tekst bĳgewerkt: {0} ({1}): Index = {2}, Tekst = {3}</NetworkUpdate>
@@ -1273,7 +1273,7 @@ Verder gaan?</SubtitleAppendPrompt>
   </MergeDoubleLines>
   <MergedShortLines>
     <Title>Korte ondertitels saamenvoegen</Title>
-    <MaximumCharacters>Max. aantal karakters per ondertitel</MaximumCharacters>
+    <MaximumCharacters>Max. aantal tekens per ondertitel</MaximumCharacters>
     <MaximumMillisecondsBetween>Max. milliseconden tussen ondertitels</MaximumMillisecondsBetween>
     <NumberOfMergesX>Aantal samenvoegingen: {0}</NumberOfMergesX>
     <MergedText>Samengevoegde tekst</MergedText>
@@ -1314,7 +1314,7 @@ Verder gaan?</SubtitleAppendPrompt>
     <LinesFoundX>Gevonden regels: {0}</LinesFoundX>
     <Delete>Verwĳderen</Delete>
     <Add>Toevoegen</Add>
-    <Update>&amp;Update</Update>
+    <Update>Bĳwerken</Update>
     <Enabled>Ingeschakeld</Enabled>
     <SearchType>Soort zoekopdracht</SearchType>
     <RemoveAll>Alles verwĳderen</RemoveAll>
@@ -1373,7 +1373,7 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <UnableToDownloadPluginListX>Kan plug-in lĳst niet downloaden: {0}</UnableToDownloadPluginListX>
     <NewVersionOfSubtitleEditRequired>Nieuwere versie van Subtitle Edit nodig!</NewVersionOfSubtitleEditRequired>
     <UpdateAvailable>[Update beschikbaar!]</UpdateAvailable>
-    <UpdateAll>Alles  bĳwerken</UpdateAll>
+    <UpdateAll>Alles bĳwerken</UpdateAll>
     <XPluginsUpdated>{0} plug-in(s) bĳgewerkt</XPluginsUpdated>
   </PluginsGet>
   <RegularExpressionContextMenu>
@@ -1382,16 +1382,16 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <NewLine>Regeleinde (\r\n)</NewLine>
     <NewLineShort>Regeleinde (\n)</NewLineShort>
     <AnyDigit>Elk cĳfer (\d)</AnyDigit>
-    <AnyCharacter>Elk karakter (.)</AnyCharacter>
+    <AnyCharacter>Elk teken (.)</AnyCharacter>
     <AnyWhitespace>Elke witruimte (\s)</AnyWhitespace>
     <ZeroOrMore>Nul of meer (*)</ZeroOrMore>
     <OneOrMore>Eén of meer (+)</OneOrMore>
-    <InCharacterGroup>In karaktergroep ([test])</InCharacterGroup>
-    <NotInCharacterGroup>Niet in karaktergroep ([^test])</NotInCharacterGroup>
+    <InCharacterGroup>In tekengroep ([test])</InCharacterGroup>
+    <NotInCharacterGroup>Niet in tekengroep ([^test])</NotInCharacterGroup>
   </RegularExpressionContextMenu>
   <RemoveTextFromHearImpaired>
-    <Title>Tekst voor slechthorenden verwĳderen</Title>
-    <RemoveTextConditions>Tekstvoorwaarden verwĳderen</RemoveTextConditions>
+    <Title>Tekst voor doven en slechthorenden verwĳderen</Title>
+    <RemoveTextConditions>Voorwaarden voor verwĳderen</RemoveTextConditions>
     <RemoveTextBetween>Tekst verwĳderen tussen</RemoveTextBetween>
     <SquareBrackets>'[' en ']'</SquareBrackets>
     <Brackets>'{' en '}'</Brackets>
@@ -1440,7 +1440,7 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <ShowOnlyModifiedLines>Toon alleen gewĳzigde regels</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum milliseconden tussen regels</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Beeldsnelheid info</FrameInfo>
-    <OneFrameXisYMilliseconds>Een beeld op {0:0.00} fps is {1} milliseconden</OneFrameXisYMilliseconds>
+    <OneFrameXisYMilliseconds>Eén beeld op {0:0.00} fps is {1} milliseconden</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Sync-punt voor tekst {0} bepalen</Title>
@@ -1451,12 +1451,12 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <ThreeSecondsForward>3 sec. &gt;&gt;</ThreeSecondsForward>
   </SetSyncPoint>
   <Settings>
-    <Title>Instellingen</Title>
+    <Title>Voorkeuren</Title>
     <General>Algemeen</General>
     <Toolbar>Werkbalk</Toolbar>
     <VideoPlayer>Videospeler</VideoPlayer>
     <WaveformAndSpectrogram>Golfvorm/Spectrogram</WaveformAndSpectrogram>
-    <Tools>Gereedschappen</Tools>
+    <Tools>Extra</Tools>
     <WordLists>Woordenlĳsten</WordLists>
     <SsaStyle>SSA stĳl</SsaStyle>
     <Proxy>Proxy</Proxy>
@@ -1467,9 +1467,9 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <SaveAs>Opslaan als</SaveAs>
     <Find>Zoeken</Find>
     <Replace>Vervangen</Replace>
-    <VisualSync>Visuele sync</VisualSync>
+    <VisualSync>Visuele synchronisatie</VisualSync>
     <SpellCheck>Spellingcontrole</SpellCheck>
-    <SettingsName>Instellingen</SettingsName>
+    <SettingsName>Voorkeuren</SettingsName>
     <Help>Help</Help>
     <ShowFrameRate>Toon beeldsnelheid in de werkbalk</ShowFrameRate>
     <DefaultFrameRate>Standaard beeldsnelheid</DefaultFrameRate>
@@ -1478,9 +1478,9 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <SubtitleLineMaximumLength>Max. lengte enkele regel</SubtitleLineMaximumLength>
     <MaximumCharactersPerSecond>Max. tekens/sec.</MaximumCharactersPerSecond>
     <AutoWrapWhileTyping>Tekstomloop tĳdens het typen</AutoWrapWhileTyping>
-    <DurationMinimumMilliseconds>Min. tĳdsduur, milliseconden</DurationMinimumMilliseconds>
-    <DurationMaximumMilliseconds>Max. tĳdsduur, milliseconden</DurationMaximumMilliseconds>
-    <MinimumGapMilliseconds>Min. ruimte tussen ondertitels in ms</MinimumGapMilliseconds>
+    <DurationMinimumMilliseconds>Min. tĳdsduur in milliseconden</DurationMinimumMilliseconds>
+    <DurationMaximumMilliseconds>Max. tĳdsduur in milliseconden</DurationMaximumMilliseconds>
+    <MinimumGapMilliseconds>Min. ruimte tussen ondertitels in msec.</MinimumGapMilliseconds>
     <SubtitleFont>Ondertitel lettertype</SubtitleFont>
     <SubtitleFontSize>Ondertitel lettergrootte</SubtitleFontSize>
     <SubtitleBold>Vet</SubtitleBold>
@@ -1500,9 +1500,9 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <MainListViewVideoGoToPositionAndPause>Ga naar videopositie en pauzeer</MainListViewVideoGoToPositionAndPause>
     <MainListViewVideoGoToPositionAndPlay>Ga naar videopositie en speel af</MainListViewVideoGoToPositionAndPlay>
     <MainListViewEditText>Ga naar tekstbewerkingsvak</MainListViewEditText>
-    <MainListViewVideoGoToPositionMinus1SecAndPause>Ga naar videopositie - 1 s en pauzeer</MainListViewVideoGoToPositionMinus1SecAndPause>
-    <MainListViewVideoGoToPositionMinusHalfSecAndPause>Ga naar videopositie - ½ s en pauzeer</MainListViewVideoGoToPositionMinusHalfSecAndPause>
-    <MainListViewVideoGoToPositionMinus1SecAndPlay>Ga naar videopositie - 1 s en speel af</MainListViewVideoGoToPositionMinus1SecAndPlay>
+    <MainListViewVideoGoToPositionMinus1SecAndPause>Ga naar videopositie  min 1 seconde en pauzeer</MainListViewVideoGoToPositionMinus1SecAndPause>
+    <MainListViewVideoGoToPositionMinusHalfSecAndPause>Ga naar videopositie min ½ seconde en pauzeer</MainListViewVideoGoToPositionMinusHalfSecAndPause>
+    <MainListViewVideoGoToPositionMinus1SecAndPlay>Ga naar videopositie min 1 seconde en speel af</MainListViewVideoGoToPositionMinus1SecAndPlay>
     <MainListViewEditTextAndPause>Ga naar tekstbewerkingsvak en pauzeer op videopositie</MainListViewEditTextAndPause>
     <AutoBackup>Automatische back-up</AutoBackup>
     <AutoBackupEveryMinute>Elke minuut</AutoBackupEveryMinute>
@@ -1537,8 +1537,8 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <WaveformShowGridLines>Toon rasterlĳnen</WaveformShowGridLines>
     <ReverseMouseWheelScrollDirection>Muiswiel scrollrichting omkeren</ReverseMouseWheelScrollDirection>
     <WaveformAllowOverlap>Sta overlap toe (bĳ verplaatsen/herschalen)</WaveformAllowOverlap>
-    <WaveformFocusMouseEnter>Op muis invoer focussen</WaveformFocusMouseEnter>
-    <WaveformListViewFocusMouseEnter>Ook op muis invoer focusen in de lĳstweergave</WaveformListViewFocusMouseEnter>
+    <WaveformFocusMouseEnter>Op muisinvoer focussen</WaveformFocusMouseEnter>
+    <WaveformListViewFocusMouseEnter>Ook op muisinvoer focusen in de lĳstweergave</WaveformListViewFocusMouseEnter>
     <WaveformBorderHitMs1>Laat herpositionering toe binnen</WaveformBorderHitMs1>
     <WaveformBorderHitMs2>milliseconden</WaveformBorderHitMs2>
     <WaveformColor>Golfvormkleur</WaveformColor>
@@ -1640,10 +1640,10 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <WaveformFocusListView>Focus lĳstweergave</WaveformFocusListView>
     <GoBack1Frame>Eén frame terug</GoBack1Frame>
     <GoForward1Frame>Eén frame vooruit</GoForward1Frame>
-    <GoBack100Milliseconds>100 ms terug</GoBack100Milliseconds>
-    <GoForward100Milliseconds>100 ms naar voren</GoForward100Milliseconds>
-    <GoBack500Milliseconds>500 ms terug</GoBack500Milliseconds>
-    <GoForward500Milliseconds>500 ms naar voren</GoForward500Milliseconds>
+    <GoBack100Milliseconds>100 msec. terug</GoBack100Milliseconds>
+    <GoForward100Milliseconds>100 msec. vooruit</GoForward100Milliseconds>
+    <GoBack500Milliseconds>500 msec. terug</GoBack500Milliseconds>
+    <GoForward500Milliseconds>500 msec. vooruit</GoForward500Milliseconds>
     <GoBack1Second>Eén seconde terug</GoBack1Second>
     <GoForward1Second>Eén seconde vooruit</GoForward1Second>
     <TogglePlayPause>Verander tussen afspelen/pauze</TogglePlayPause>
@@ -1655,13 +1655,13 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <CustomSearch4>Vertalen, op maat zoeken 4</CustomSearch4>
     <CustomSearch5>Vertalen, op maat zoeken 5</CustomSearch5>
     <CustomSearch6>Vertalen, op maat zoeken 6</CustomSearch6>
-    <SyntaxColoring>Syntaxiskleuren</SyntaxColoring>
-    <ListViewSyntaxColoring>Lĳstweergave syntaxiskleuren</ListViewSyntaxColoring>
-    <SyntaxColorDurationIfTooSmall>Tĳdsduurkleur indien te kort</SyntaxColorDurationIfTooSmall>
-    <SyntaxColorDurationIfTooLarge>Tĳdsduurkleur indien te lang</SyntaxColorDurationIfTooLarge>
-    <SyntaxColorTextIfTooLong>Tekstkleur indien te lang</SyntaxColorTextIfTooLong>
-    <SyntaxColorTextMoreThanXLines>Tekstkleur bĳ meer regels dan:</SyntaxColorTextMoreThanXLines>
-    <SyntaxColorOverlap>Tĳdcodekleur bĳ overlap</SyntaxColorOverlap>
+    <SyntaxColoring>Syntaxiskleuring</SyntaxColoring>
+    <ListViewSyntaxColoring>Lĳstweergave syntaxiskleuring</ListViewSyntaxColoring>
+    <SyntaxColorDurationIfTooSmall>Kleur tĳdsduur indien te kort</SyntaxColorDurationIfTooSmall>
+    <SyntaxColorDurationIfTooLarge>Kleur tĳdsduur indien te lang</SyntaxColorDurationIfTooLarge>
+    <SyntaxColorTextIfTooLong>Kleur tekst indien te lang</SyntaxColorTextIfTooLong>
+    <SyntaxColorTextMoreThanXLines>Kleur tekst bĳ meer regels dan:</SyntaxColorTextMoreThanXLines>
+    <SyntaxColorOverlap>Kleur tĳdcode bĳ overlap</SyntaxColorOverlap>
     <SyntaxErrorColor>Foutkleur</SyntaxErrorColor>
     <GoToFirstSelectedLine>Ga naar eerste geselecteerde regel</GoToFirstSelectedLine>
     <GoToNextEmptyLine>Ga naar volgende lege regel</GoToNextEmptyLine>
@@ -1701,14 +1701,14 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <TotalAdjustmentX>Totale aanpassing: {0}</TotalAdjustmentX>
     <AllLines>Alle regels</AllLines>
     <SelectedLinesOnly>Alleen geselecteerde regels</SelectedLinesOnly>
-    <SelectedLinesAndForward>Geselecteerde en daaropvolgende regel(s)</SelectedLinesAndForward>
+    <SelectedLinesAndForward>Geselecteerde en daaropvolgende regels</SelectedLinesAndForward>
   </ShowEarlierLater>
   <ShowHistory>
     <Title>Geschiedenis (voor ongedaan maken)</Title>
     <SelectRollbackPoint>Selecteer tĳd/omschrĳving voor terugdraaiing</SelectRollbackPoint>
     <Time>Tĳd</Time>
     <Description>Omschrĳving</Description>
-    <CompareHistoryItems>Vergelĳk geschiedenis items</CompareHistoryItems>
+    <CompareHistoryItems>Vergelĳk geschiedenisitems</CompareHistoryItems>
     <CompareWithCurrent>Vergelĳk met de huidige</CompareWithCurrent>
     <Rollback>Terugdraaien</Rollback>
   </ShowHistory>
@@ -1718,9 +1718,9 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <WordNotFound>Woord niet gevonden</WordNotFound>
     <Language>Taal</Language>
     <Change>Deze wĳzigen</Change>
-    <ChangeAll>Allen wĳzigen</ChangeAll>
+    <ChangeAll>Alle &amp;wĳzigen</ChangeAll>
     <SkipOnce>Deze overslaan</SkipOnce>
-    <SkipAll>&amp;Allen overslaan</SkipAll>
+    <SkipAll>Alle &amp;overslaan</SkipAll>
     <AddToUserDictionary>Toevoegen aan gebruikerswoordenboek</AddToUserDictionary>
     <AddToNamesAndIgnoreList>Toevoegen aan naam/ruis-lĳst (hoofdlettergevoelig)</AddToNamesAndIgnoreList>
     <AddToOcrReplaceList>Paar toevoegen aan OCR-correctielĳst</AddToOcrReplaceList>
@@ -1742,13 +1742,13 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
   </SpellCheck>
   <Split>
     <Title>Splits</Title>
-    <SplitOptions>Splits opties</SplitOptions>
+    <SplitOptions>Splitsopties</SplitOptions>
     <Lines>Regels</Lines>
-    <Characters>Karakters</Characters>
+    <Characters>Tekens</Characters>
     <NumberOfEqualParts>Aantal gelĳke delen</NumberOfEqualParts>
     <SubtitleInfo>Ondertitel informatie</SubtitleInfo>
     <NumberOfLinesX>Aantal regels: {0:#,###}</NumberOfLinesX>
-    <NumberOfCharactersX>Aantal karakters: {0:#,###,###}</NumberOfCharactersX>
+    <NumberOfCharactersX>Aantal tekens: {0:#,###,###}</NumberOfCharactersX>
     <Output>Uitvoer</Output>
     <FileName>Bestandsnaam</FileName>
     <OutputFolder>Doelmap</OutputFolder>
@@ -1794,9 +1794,9 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <MostUsedWords>Meest gebruikte woorden</MostUsedWords>
     <NothingFound>Niets gevonden</NothingFound>
     <NumberOfLinesX>Aantal ondertitelregels: {0:#,###}</NumberOfLinesX>
-    <LengthInFormatXinCharactersY>Aantal karakters als {0}: {1: #, ###, ##0}</LengthInFormatXinCharactersY>
-    <NumberOfCharactersInTextOnly>Aantal tekstkarakters alleen: {0:#,###,##0}</NumberOfCharactersInTextOnly>
-    <TotalCharsPerSecond>Totaal karakters/seconde: {0:0.0} seconden</TotalCharsPerSecond>
+    <LengthInFormatXinCharactersY>Aantal tekens als {0}: {1: #, ###, ##0}</LengthInFormatXinCharactersY>
+    <NumberOfCharactersInTextOnly>Aantal teksttekens alleen: {0:#,###,##0}</NumberOfCharactersInTextOnly>
+    <TotalCharsPerSecond>Totaal tekens/seconde: {0:0.0} seconden</TotalCharsPerSecond>
     <NumberOfItalicTags>Aantal cursief tags: {0}</NumberOfItalicTags>
     <NumberOfBoldTags>Aantal vet tags: {0}</NumberOfBoldTags>
     <NumberOfUnderlineTags>Aantal onderstrepen tags: {0}</NumberOfUnderlineTags>
@@ -1812,9 +1812,9 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <DurationMinimum>Duur - minimum: {0:0.000} seconden</DurationMinimum>
     <DurationMaximum>Duur - maximum: {0:0.000} seconden</DurationMaximum>
     <DurationAverage>Duur - gemiddeld: {0:0.000} seconden</DurationAverage>
-    <CharactersPerSecondMinimum>Karakters/sec - minimum: {0:0.000}</CharactersPerSecondMinimum>
-    <CharactersPerSecondMaximum>Karakters/sec - maximum: {0:0.000}</CharactersPerSecondMaximum>
-    <CharactersPerSecondAverage>Karakters/sec - gemiddeld: {0:0.000}</CharactersPerSecondAverage>
+    <CharactersPerSecondMinimum>Tekens/sec. - minimum: {0:0.000}</CharactersPerSecondMinimum>
+    <CharactersPerSecondMaximum>Tekens/sec. - maximum: {0:0.000}</CharactersPerSecondMaximum>
+    <CharactersPerSecondAverage>Tekens/sec. - gemiddeld: {0:0.000}</CharactersPerSecondAverage>
   </Statistics>
   <SubStationAlphaProperties>
     <Title>Advanced SubStation Alpha eigenschappen</Title>
@@ -1908,9 +1908,9 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
     <StartScene>Startscène</StartScene>
     <EndScene>Eindscène</EndScene>
     <Synchronize>Synchroniseren</Synchronize>
-    <HalfASecondBack>&lt; ½ s</HalfASecondBack>
-    <ThreeSecondsBack>&lt; 3 s</ThreeSecondsBack>
-    <PlayXSecondsAndBack>Speel {0} s en terug</PlayXSecondsAndBack>
+    <HalfASecondBack>&lt; ½ sec.</HalfASecondBack>
+    <ThreeSecondsBack>&lt; 3 sec.</ThreeSecondsBack>
+    <PlayXSecondsAndBack>Speel {0} sec. en terug</PlayXSecondsAndBack>
     <FindText>Tekst zoeken</FindText>
     <GoToSubPosition>Ga naar ondertitel positie</GoToSubPosition>
     <KeepChangesTitle>Wĳzigingen behouden?</KeepChangesTitle>
@@ -1919,7 +1919,7 @@ hetzelfde ondertitelbestand bewerken (samenwerking)</Information>
 Wĳzigingen behouden?</KeepChangesMessage>
     <SynchronizationDone>Synchroniseren voltooid!</SynchronizationDone>
     <StartSceneMustComeBeforeEndScene>Startscène moet vóór eindscène komen!</StartSceneMustComeBeforeEndScene>
-    <Tip>Tip: Gebruik &lt;ctrl+pĳl links/rechts&gt; om 100 ms terug/verder te gaan</Tip>
+    <Tip>Tip: Gebruik &lt;ctrl+pĳl links/rechts&gt; om 100 msec. terug/verder te gaan</Tip>
   </VisualSync>
   <VobSubEditCharacters>
     <Title>Bewerken beeld vergelĳken databank</Title>
@@ -1956,7 +1956,7 @@ Wĳzigingen behouden?</KeepChangesMessage>
     <ConvertingImageCompareDatabase>Beeldvergelĳkingsdatabankformaat updaten (images.db/images.xml)...</ConvertingImageCompareDatabase>
     <SubtitleImage>Ondertitel beeld</SubtitleImage>
     <SubtitleText>Ondertitel tekst</SubtitleText>
-    <UnableToCreateCharacterDatabaseFolder>Kan 'Karakter databank map' {0} niet maken</UnableToCreateCharacterDatabaseFolder>
+    <UnableToCreateCharacterDatabaseFolder>Kan tekendatabankmap {0} niet maken</UnableToCreateCharacterDatabaseFolder>
     <SubtitleImageXofY>Ondertitel beeld {0} van {1}</SubtitleImageXofY>
     <ImagePalette>Afbeeldingspalet</ImagePalette>
     <UseCustomColors>Aangepaste kleuren gebruiken</UseCustomColors>
@@ -1968,7 +1968,7 @@ Wĳzigingen behouden?</KeepChangesMessage>
     <PromptForUnknownWords>Vraag naar onbekende woorden</PromptForUnknownWords>
     <TryToGuessUnkownWords>Probeer onbekende woorden te raden</TryToGuessUnkownWords>
     <AutoBreakSubtitleIfMoreThanTwoLines>Auto einde paragraaf als er meer dan twee regels zĳn</AutoBreakSubtitleIfMoreThanTwoLines>
-    <AllFixes>Alle herstellingen</AllFixes>
+    <AllFixes>Alle correcties</AllFixes>
     <GuessesUsed>Gebruikte schattingen</GuessesUsed>
     <UnknownWords>Onbekende woorden</UnknownWords>
     <OcrAutoCorrectionSpellChecking>OCR automatische correctie / spellingcontrole</OcrAutoCorrectionSpellChecking>
@@ -1995,8 +1995,8 @@ Wĳzigingen behouden?</KeepChangesMessage>
     <ShrinkSelection>Selectie verkleinen</ShrinkSelection>
     <ExpandSelection>Selectie uitbreiden</ExpandSelection>
     <SubtitleImage>Ondertitelbeeld</SubtitleImage>
-    <Characters>Karakter(s)</Characters>
-    <CharactersAsText>Karakter(s) als tekst</CharactersAsText>
+    <Characters>Teken(s)</Characters>
+    <CharactersAsText>Teken(s) als tekst</CharactersAsText>
     <Italic>&amp;Cursief</Italic>
     <Abort>&amp;Afbreken</Abort>
     <Skip>&amp;Overslaan</Skip>
@@ -2013,7 +2013,7 @@ Wĳzigingen behouden?</KeepChangesMessage>
   </VobSubOcrCharacterInspect>
   <VobSubOcrNewFolder>
     <Title>Nieuwe map</Title>
-    <Message>Naam van de nieuwe karakter databankmap</Message>
+    <Message>Naam van de nieuwe tekendatabankmap</Message>
   </VobSubOcrNewFolder>
   <VobSubOcrSetItalicFactor>
     <Title>Decursiveringsfactor bepalen</Title>
@@ -2023,8 +2023,8 @@ Wĳzigingen behouden?</KeepChangesMessage>
     <ClickToAddWaveform>Klik om golfvorm toe te voegen</ClickToAddWaveform>
     <ClickToAddWaveformAndSpectrogram>Klik om golfvorm/spectrogram toe te voegen</ClickToAddWaveformAndSpectrogram>
     <Seconds>Seconden</Seconds>
-    <ZoomIn>Zoom in</ZoomIn>
-    <ZoomOut>Zoom uit</ZoomOut>
+    <ZoomIn>Inzoomen</ZoomIn>
+    <ZoomOut>Uitzoomen</ZoomOut>
     <AddParagraphHere>Tekst hier invoegen</AddParagraphHere>
     <AddParagraphHereAndPasteText>Klembordtekst hier invoegen</AddParagraphHereAndPasteText>
     <FocusTextBox>Focus op tekstveld</FocusTextBox>
@@ -2047,7 +2047,7 @@ Wĳzigingen behouden?</KeepChangesMessage>
     <Beginning>Begin</Beginning>
     <DeleteLines>Regels verwĳderen</DeleteLines>
     <FromCurrentVideoPosition>Vanaf de huidige videopositie</FromCurrentVideoPosition>
-    <DetectOptions>Detecteer opties</DetectOptions>
+    <DetectOptions>Detectieopties</DetectOptions>
     <ScanBlocksOfMs>Scan blokken van milliseconden</ScanBlocksOfMs>
     <BlockAverageVolMin1>Blokgemiddelde volume moet boven</BlockAverageVolMin1>
     <BlockAverageVolMin2>% van het totale gemiddelde volume</BlockAverageVolMin2>

--- a/src/Languages/pl-PL.xml
+++ b/src/Languages/pl-PL.xml
@@ -40,7 +40,7 @@
     <FrameRateX>Ilość klatek na sekundę: {0:0.0###}</FrameRateX>
     <TotalFramesX>Ogółem klatek: {0:#,##0.##}</TotalFramesX>
     <VideoEncodingX>Kodowanie wideo: {0}</VideoEncodingX>
-    <SingleLineLengths>Długość pojedynczej linii: </SingleLineLengths>
+    <SingleLineLengths>Długość pojedynczej linii:</SingleLineLengths>
     <TotalLengthX>Długość całkowita: {0}</TotalLengthX>
     <TotalLengthXSplitLine>Długość całkowita: {0} (linia podzielona!)</TotalLengthXSplitLine>
     <SplitLine>Podziel linię!</SplitLine>
@@ -323,7 +323,7 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <Title>Wybierz języka</Title>
     <ChooseLanguageStreamId>Wybierz język (stream-id)</ChooseLanguageStreamId>
     <UnknownLanguage>Nieznany język</UnknownLanguage>
-    <SubtitleImageXofYAndWidthXHeight>Obraz napisów {0}/{1}  -  {2}x{3} </SubtitleImageXofYAndWidthXHeight>
+    <SubtitleImageXofYAndWidthXHeight>Obraz napisów {0}/{1}  -  {2}x{3}</SubtitleImageXofYAndWidthXHeight>
     <SubtitleImage>Obraz napisów</SubtitleImage>
   </DvdSubRipChooseLanguage>
   <EbuSaveOptions>
@@ -1335,7 +1335,7 @@ Kontynuować?</SubtitleAppendPrompt>
   <NetworkJoin>
     <Title>Dołącz do sesji sieciowej</Title>
     <Information>Dołącz do istniejącej sesji, w której wiele osób
- może edytować ten sam plik z napisami (współpracować)</Information>
+może edytować ten sam plik z napisami (współpracować)</Information>
     <Join>Dołącz</Join>
   </NetworkJoin>
   <NetworkLogAndInfo>
@@ -1346,7 +1346,7 @@ Kontynuować?</SubtitleAppendPrompt>
     <Title>Uruchom sesję sieciową</Title>
     <ConnectionTo>Łączenie się z {0}...</ConnectionTo>
     <Information>Rozpocznij nową sesję, w której wiele osób
- może edytować ten sam plik z napisami (współpracować)</Information>
+może edytować ten sam plik z napisami (współpracować)</Information>
     <Start>Start</Start>
   </NetworkStart>
   <OpenVideoDvd>
@@ -1764,8 +1764,8 @@ Kontynuować?</SubtitleAppendPrompt>
     <LineMaximumLength>Maksymalna długość linii</LineMaximumLength>
     <LineContinuationBeginEndStrings>Znak kontynuacji na początku/końcu linii</LineContinuationBeginEndStrings>
     <NumberOfSplits>Ilość podzielonych: {0}</NumberOfSplits>
-    <LongestSingleLineIsXAtY>Najdłuższą pojedynczą linią jest linia o nr {1} - zawiera {0} znaków </LongestSingleLineIsXAtY>
-    <LongestLineIsXAtY>Ogólnie najdłuższą linią jest linia o nr {1} - zawiera {0} znaków </LongestLineIsXAtY>
+    <LongestSingleLineIsXAtY>Najdłuższą pojedynczą linią jest linia o nr {1} - zawiera {0} znaków</LongestSingleLineIsXAtY>
+    <LongestLineIsXAtY>Ogólnie najdłuższą linią jest linia o nr {1} - zawiera {0} znaków</LongestLineIsXAtY>
   </SplitLongLines>
   <SplitSubtitle>
     <Title>Podziel napisy</Title>

--- a/src/Languages/pt-BR.xml
+++ b/src/Languages/pt-BR.xml
@@ -331,8 +331,8 @@ E-mail: mailto:nikse.dk@gmail.com</AboutText1>
     <SubtitleListReferenceCode>Código de referência da lista da legenda</SubtitleListReferenceCode>
     <CountryOfOrigin>País de origem</CountryOfOrigin>
     <RevisionNumber>Número da revisão</RevisionNumber>
-    <MaxNoOfDisplayableChars> Nº máx. caracteres por linha</MaxNoOfDisplayableChars>
-    <MaxNumberOfDisplayableRows> Nº máx. linhas</MaxNumberOfDisplayableRows>
+    <MaxNoOfDisplayableChars>Nº máx. caracteres por linha</MaxNoOfDisplayableChars>
+    <MaxNumberOfDisplayableRows>Nº máx. linhas</MaxNumberOfDisplayableRows>
     <DiskSequenceNumber>Número de sequência do disco</DiskSequenceNumber>
     <TotalNumberOfDisks>Número total de discos</TotalNumberOfDisks>
     <Import>Importar...</Import>
@@ -1325,7 +1325,7 @@ possam editar o mesmo arquivo de legenda (colaboração)</Information>
     <Title>Iniciar sessão de rede</Title>
     <ConnectionTo>Conectando a {0}...</ConnectionTo>
     <Information>Começar nova sesão onde várias pessoas
- podem editar o mesmo arquivo de legenda (colaboração)</Information>
+podem editar o mesmo arquivo de legenda (colaboração)</Information>
     <Start>Início</Start>
   </NetworkStart>
   <OpenVideoDvd>

--- a/src/Languages/pt-PT.xml
+++ b/src/Languages/pt-PT.xml
@@ -3,7 +3,7 @@
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.5</Version>
-    <TranslatedBy> ------------------------------------------------------------------------------------------------
+    <TranslatedBy>------------------------------------------------------------------------------------------------
 Traduzido para Português de Portugal, por moob
 Email: mailto:moob@live.com.pt</TranslatedBy>
     <CultureName>pt-PT</CultureName>

--- a/src/Languages/ro-RO.xml
+++ b/src/Languages/ro-RO.xml
@@ -1082,7 +1082,7 @@ Continui?</SubtitleAppendPrompt>
     <SpellCheck>Verificare ortografică</SpellCheck>
     <BeforeSpellCheck>Anterior verificării ortografice</BeforeSpellCheck>
     <SpellCheckChangedXToY>Verificarea ortografică: Schimbat '{0}' la '{1}'</SpellCheckChangedXToY>
-    <BeforeAddingTagX>Înaintea adăugării indexului &lt;{0}&gt; </BeforeAddingTagX>
+    <BeforeAddingTagX>Înaintea adăugării indexului &lt;{0}&gt;</BeforeAddingTagX>
     <TagXAdded>&lt;{0}&gt; indecși adăugați</TagXAdded>
     <LineXOfY>linia {0} a {1}</LineXOfY>
     <XLinesSavedAsY>{0} linii salvate ca {1}</XLinesSavedAsY>

--- a/src/Languages/sl-SI.xml
+++ b/src/Languages/sl-SI.xml
@@ -1327,7 +1327,7 @@ popravlja enak podnapis (sodelovanje)</Information>
     <Title>Prični mrežno sejo</Title>
     <ConnectionTo>Povezujem z {0}...</ConnectionTo>
     <Information>Prični novo sejo, kjer lahko več uporabnikov
- popravlja en podnapis (sodelovanje)</Information>
+popravlja en podnapis (sodelovanje)</Information>
     <Start>Začni</Start>
   </NetworkStart>
   <OpenVideoDvd>

--- a/src/Languages/sr-Cyrl-RS.xml
+++ b/src/Languages/sr-Cyrl-RS.xml
@@ -881,7 +881,7 @@
   <NetworkJoin>
     <Title>Мрежна сесија</Title>
     <Information>Овде можете да се придружите постојећој сесији у којој
-    можете да уређујете одређени титл с другим људима.</Information>
+можете да уређујете одређени титл с другим људима.</Information>
     <Join>&amp;Повежи ме</Join>
   </NetworkJoin>
   <NetworkLogAndInfo>
@@ -892,7 +892,7 @@
     <Title>Мрежна сесија</Title>
     <ConnectionTo>Повезујем се на {0}...</ConnectionTo>
     <Information>Овде можете да направите сесију у којој ћете моћи да уређујете
-    одређени титл с другим људима.</Information>
+одређени титл с другим људима.</Information>
     <Start>&amp;Започни</Start>
   </NetworkStart>
   <RemoveTextFromHearImpaired>
@@ -1164,7 +1164,7 @@
     <KeepChangesTitle>Чување измена</KeepChangesTitle>
     <KeepChangesMessage>Изменили сте титл користећи Визуелно усклађивање.
 
-    Желите ли да сачувате измене?</KeepChangesMessage>
+Желите ли да сачувате измене?</KeepChangesMessage>
     <SynchronizationDone>Усклађивање је завршено.</SynchronizationDone>
     <StartSceneMustComeBeforeEndScene>Почетна сцена мора бити пре завршне!</StartSceneMustComeBeforeEndScene>
     <Tip>Користите ктрл и леву или десну стрелицу да померите 100 мс уназад или унапред.</Tip>

--- a/src/Languages/sr-Latn-RS.xml
+++ b/src/Languages/sr-Latn-RS.xml
@@ -1009,7 +1009,7 @@ koji bi trebao da bude usklađen sa Video datotekom.
     <NetworkInsert>Linija je ubačena: {0} ({1}): popis – {2}, tekst – {3}</NetworkInsert>
     <NetworkDelete>Linija je obrisana: {0} ({1}): popis – {2}</NetworkDelete>
     <NetworkNewUser>pristupi sesiji {0} ({1}).</NetworkNewUser>
-    <NetworkByeUser> napusti sesiju {0} ({1}).</NetworkByeUser>
+    <NetworkByeUser>napusti sesiju {0} ({1}).</NetworkByeUser>
     <NetworkUnableToConnectToServer>Nije moguće povezivanje sa serverom: {0}</NetworkUnableToConnectToServer>
     <UserAndAction>Korisnik/Radnja</UserAndAction>
     <NetworkMode>Umreženo</NetworkMode>
@@ -1080,7 +1080,7 @@ koji bi trebao da bude usklađen sa Video datotekom.
   <NetworkJoin>
     <Title>Mrežna sesija</Title>
     <Information>Ovde možete da se pridružite postojećoj sesiji u kojoj
-    možete da uređujete određeni prevod s drugim ljudima.</Information>
+možete da uređujete određeni prevod s drugim ljudima.</Information>
     <Join>&amp;Poveži me</Join>
   </NetworkJoin>
   <NetworkLogAndInfo>
@@ -1091,7 +1091,7 @@ koji bi trebao da bude usklađen sa Video datotekom.
     <Title>Mrežna sesija</Title>
     <ConnectionTo>Povezujem se na {0}...</ConnectionTo>
     <Information>Ovde možete da napravite sesiju u kojoj ćete moći da uređujete
-    određeni prevod s drugim ljudima.</Information>
+određeni prevod s drugim ljudima.</Information>
     <Start>&amp;Započni</Start>
   </NetworkStart>
   <PluginsGet>
@@ -1574,7 +1574,7 @@ koji bi trebao da bude usklađen sa Video datotekom.
     <KeepChangesTitle>Čuvanje izmena</KeepChangesTitle>
     <KeepChangesMessage>Izmenili ste prevod koristeći Vizuelno usklađivanje.
 
-    Želite li da sačuvate izmene?</KeepChangesMessage>
+Želite li da sačuvate izmene?</KeepChangesMessage>
     <SynchronizationDone>Usklađivanje je završeno.</SynchronizationDone>
     <StartSceneMustComeBeforeEndScene>Početna scena mora biti pre završne!</StartSceneMustComeBeforeEndScene>
     <Tip>Koristite 'Ctrl' i levu ili desnu strelicu da pomerite 100 ms unazad ili unapred.</Tip>

--- a/src/Languages/th-TH.xml
+++ b/src/Languages/th-TH.xml
@@ -40,7 +40,7 @@
     <FrameRateX>เฟรมเรต: {0:0.0###}</FrameRateX>
     <TotalFramesX>จำนวนเฟรมรวม: {0:#,##0.##}</TotalFramesX>
     <VideoEncodingX>รหัสภาษาวิดีโอ: {0}</VideoEncodingX>
-    <SingleLineLengths>ความยาวบรรทัด: </SingleLineLengths>
+    <SingleLineLengths>ความยาวบรรทัด:</SingleLineLengths>
     <TotalLengthX>ความยาวรวม: {0}</TotalLengthX>
     <TotalLengthXSplitLine>ความยาวรวม: {0} (แยกบรรทัด!)</TotalLengthXSplitLine>
     <SplitLine>แยกบรรทัด!</SplitLine>
@@ -312,7 +312,7 @@
     <Title>เลือกภาษา</Title>
     <ChooseLanguageStreamId>เลือกภาษา (stream-id)</ChooseLanguageStreamId>
     <UnknownLanguage>ภาษาที่ไม่รู้จัก</UnknownLanguage>
-    <SubtitleImageXofYAndWidthXHeight>อิมเมจซับไตเติ้ล {0}/{1} - {2}x{3} </SubtitleImageXofYAndWidthXHeight>
+    <SubtitleImageXofYAndWidthXHeight>อิมเมจซับไตเติ้ล {0}/{1} - {2}x{3}</SubtitleImageXofYAndWidthXHeight>
     <SubtitleImage>อิมเมจซับไตเติ้ล</SubtitleImage>
   </DvdSubRipChooseLanguage>
   <EbuSaveOptions>
@@ -561,8 +561,8 @@
     <ApplyFixes>นำข้อแก้ไขที่เลือกไปใช้</ApplyFixes>
     <AutoBreak>แทรก &amp;br อัตโนมัติ</AutoBreak>
     <Unbreak>&amp;ไม่แยก</Unbreak>
-    <FixDoubleDash>แก้ '--' -&gt; '...' </FixDoubleDash>
-    <FixDoubleGreaterThan>ลบ &gt; </FixDoubleGreaterThan>
+    <FixDoubleDash>แก้ '--' -&gt; '...'</FixDoubleDash>
+    <FixDoubleGreaterThan>ลบ &gt;</FixDoubleGreaterThan>
     <FixEllipsesStart>ลบที่ขึ้นต้นด้วย '...'</FixEllipsesStart>
     <FixMissingOpenBracket>แก้ [ ที่หายไปในบรรทัด</FixMissingOpenBracket>
     <FixMusicNotation>แทนที่สัญลักษณ์ดนตรี (e.g. âTª) ด้วยสัญลักษณ์ที่ชอบ</FixMusicNotation>
@@ -587,7 +587,7 @@
     <OpenOpenOfficeWiki>รายการของ Open Office Wiki Dictionaries</OpenOpenOfficeWiki>
     <GetAllDictionaries>โหลดพจนานุกรมทั้งหมด</GetAllDictionaries>
     <ChooseLanguageAndClickDownload>เลือกภาษาของคุณและคลิกดาวน์โหลด</ChooseLanguageAndClickDownload>
-    <OpenDictionariesFolder>เปิดโฟลเดอร์ 'Dictionaries' </OpenDictionariesFolder>
+    <OpenDictionariesFolder>เปิดโฟลเดอร์ 'Dictionaries'</OpenDictionariesFolder>
     <Download>ดาวน์โหลด</Download>
     <XDownloaded>{0} ถูกดาวน์โหลดและติดตั้งแล้ว</XDownloaded>
   </GetDictionaries>
@@ -597,7 +597,7 @@
     <DownloadFailed>ดาวน์โหลดผิดพลาด!</DownloadFailed>
     <GetDictionariesHere>โหลดพจนานุกรมที่นี่:</GetDictionariesHere>
     <ChooseLanguageAndClickDownload>เลือกภาษาของคุณและคลิกดาวน์โหลด</ChooseLanguageAndClickDownload>
-    <OpenDictionariesFolder>เปิดโฟลเดอร์ 'Dictionaries' </OpenDictionariesFolder>
+    <OpenDictionariesFolder>เปิดโฟลเดอร์ 'Dictionaries'</OpenDictionariesFolder>
     <Download>ดาวน์โหลด</Download>
     <XDownloaded>{0} ถูกดาวน์โหลดและติดตั้งแล้ว</XDownloaded>
   </GetTesseractDictionaries>
@@ -993,7 +993,7 @@
     <OverwriteModifiedFile>เขียนทับไฟล์ {0} ที่ถูกแก้เมื่อ {1} {2}{3} ด้วยไฟล์ปัจจุบันที่โหลดจากดิสก์เมื่อ {4} {5} หรือไม่</OverwriteModifiedFile>
     <FileXIsReadOnly>บันทึกไม่ได้ ไฟล์ {0} อ่านได้อย่างเดียว</FileXIsReadOnly>
     <UnableToSaveSubtitleX>ไม่สามารถบันทึกไฟล์ซับไตเติ้ล {0}
- ซับไตเติ้ลอาจว่างเปล่า - ลองบันทึกใหม่ถ้าแน่ใจว่าซับไตเติ้ลถูกต้อง!</UnableToSaveSubtitleX>
+ซับไตเติ้ลอาจว่างเปล่า - ลองบันทึกใหม่ถ้าแน่ใจว่าซับไตเติ้ลถูกต้อง!</UnableToSaveSubtitleX>
     <BeforeNew>ก่อนสร้าง</BeforeNew>
     <New>สร้าง</New>
     <BeforeConvertingToX>ก่อนแปลงเป็น {0}</BeforeConvertingToX>

--- a/src/Languages/tr-TR.xml
+++ b/src/Languages/tr-TR.xml
@@ -993,7 +993,7 @@ E-posta: mailto:nikse.dk@gmail.com</AboutText1>
     <SavedOriginalSubtitleX>Saved original subtitle {0}</SavedOriginalSubtitleX>
     <FileOnDiskModified>file on disk modified</FileOnDiskModified>
     <OverwriteModifiedFile>Overwrite the file {0} modified at {1} {2}{3} with current file loaded from disk at {4} {5}?</OverwriteModifiedFile>
-    <FileXIsReadOnly>Sadece okunabilir {0} dosya kaydedilemedi. </FileXIsReadOnly>
+    <FileXIsReadOnly>Sadece okunabilir {0} dosya kaydedilemedi.</FileXIsReadOnly>
     <UnableToSaveSubtitleX>Unable to save subtitle file {0}</UnableToSaveSubtitleX>
     <BeforeNew>Yeniden önce</BeforeNew>
     <New>Yeni</New>
@@ -1172,7 +1172,7 @@ Continue?</SubtitleAppendPrompt>
     <BeforeSetStartTimeAndOffsetTheRest>Başlangıç zamanı ayarlamadan önce</BeforeSetStartTimeAndOffsetTheRest>
     <BeforeSetEndTimeAndOffsetTheRest>Bitiş zamanı ayarlamadan önce</BeforeSetEndTimeAndOffsetTheRest>
     <BeforeSetEndAndVideoPosition>Görüntü pozisyonunda bitiş zamanı ayarlamadn önce</BeforeSetEndAndVideoPosition>
-    <ContinueWithCurrentSpellCheck>Geçerli hece kontrolü </ContinueWithCurrentSpellCheck>
+    <ContinueWithCurrentSpellCheck>Geçerli hece kontrolü</ContinueWithCurrentSpellCheck>
     <CharactersPerSecond>Krktr/san: {0:0.00}</CharactersPerSecond>
     <GetFrameRateFromVideoFile>Video dosyasından kare hızı al</GetFrameRateFromVideoFile>
     <NetworkMessage>Yeni mesaj: {0} ({1}): {2}</NetworkMessage>
@@ -1643,8 +1643,7 @@ Yeni oturum başlatın.</Information>
     <SwitchOriginalAndTranslation>Orijinal ve çeviri arasında geçiş yap</SwitchOriginalAndTranslation>
     <MergeOriginalAndTranslation>Orijinali ve çeviriyi birleştir</MergeOriginalAndTranslation>
     <ShortcutIsAlreadyDefinedX>Zaten tanımlanan kısayol:
-{0}
-</ShortcutIsAlreadyDefinedX>
+{0}</ShortcutIsAlreadyDefinedX>
     <ToggleTranslationAndOriginalInPreviews>Toggle translation and original in video/audio preview</ToggleTranslationAndOriginalInPreviews>
     <ListViewColumnDelete>Sütun, metni sil</ListViewColumnDelete>
     <ListViewColumnInsert>Sütun, metin ekle</ListViewColumnInsert>
@@ -1909,7 +1908,7 @@ Değişiklikler saklansın mı?</KeepChangesMessage>
     <Image>Görüntü</Image>
   </VobSubEditCharacters>
   <VobSubOcr>
-    <Title> VobSub (sub/idx) altyazı aktar</Title>
+    <Title>VobSub (sub/idx) altyazı aktar</Title>
     <TitleBluRay>Blu-ray (.sup) altyazı aktar</TitleBluRay>
     <OcrMethod>OCR method</OcrMethod>
     <OcrViaModi>OCR via Microsoft Office Document Imaging (MODI). Requires Microsoft Office</OcrViaModi>

--- a/src/Languages/vi-VN.xml
+++ b/src/Languages/vi-VN.xml
@@ -3,11 +3,9 @@
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.5</Version>
-    <TranslatedBy>
-    Dịch qua Tiếng Việt bởi by everytime
-    Mọi góp ý về bản dịch vui lòng gửi thư tới hộp thư: handes1990@gmail.com
-    Cảm ơn rất nhiều
-    </TranslatedBy>
+    <TranslatedBy>Dịch qua Tiếng Việt bởi by everytime
+Mọi góp ý về bản dịch vui lòng gửi thư tới hộp thư: handes1990@gmail.com
+Cảm ơn rất nhiều</TranslatedBy>
     <CultureName>vn-VN</CultureName>
     <HelpFile />
     <Ok>&amp;Đồng ý</Ok>
@@ -77,8 +75,7 @@
   </General>
   <About>
     <Title>Giới thiệu về Subtitle Edit</Title>
-    <AboutText1>
-Subtitle Edit là phần mềm mã nguồn mở miễn phí theo giấy phép của GNUic.
+    <AboutText1>Subtitle Edit là phần mềm mã nguồn mở miễn phí theo giấy phép của GNUic.
 
 Bạn có thể phân phối, sửa đổi và sử dụng một cách tự do.
 
@@ -88,7 +85,7 @@ Ghé thăm www.nikse.dk thường xuyên để biết thêm thông tin và tải
 
 Rất hân hạnh được chào đón.
 
-  Hộp thư: Gửi thư tới: nikse.dk@gmail.com</AboutText1>
+Hộp thư: Gửi thư tới: nikse.dk@gmail.com</AboutText1>
   </About>
   <AddToNames>
     <Title>Thêm tên tập tin/danh sách...</Title>
@@ -122,8 +119,7 @@ Rất hân hạnh được chào đón.
     <Percent>Phần trăm</Percent>
     <Recalculate>Tính toán lại</Recalculate>
     <AddSeconds>Thêm số giây</AddSeconds>
-    <SetAsPercent>Xác nhận giới hạn %
-</SetAsPercent>
+    <SetAsPercent>Xác nhận giới hạn %</SetAsPercent>
     <Note>Lưu ý: Thời gian hiển thị không trùng lên thời gian của văn bản tiếp theo</Note>
     <PleaseSelectAValueFromTheDropDownList>Vui lòng chọn giá trị từ danh sách xổ xuống</PleaseSelectAValueFromTheDropDownList>
     <PleaseChoose> -Vui lòng chọn- </PleaseChoose>
@@ -152,7 +148,7 @@ Rất hân hạnh được chào đón.
     <ConvertOptions>Cài đặt cách chuyển đổi</ConvertOptions>
     <AutoBreakLongLines>Tự động - ngắt các dòng dài</AutoBreakLongLines>
     <FixItalics>Sữa lỗi chữ in nghiêng</FixItalics>
-    <RemoveFormatting> Gỡ định dạng thẻ</RemoveFormatting>
+    <RemoveFormatting>Gỡ định dạng thẻ</RemoveFormatting>
     <RemoveTextForHI>Gỡ bỏ văn bản của HI</RemoveTextForHI>
     <RedoCasing>Quay lại cách hiển thị trước</RedoCasing>
     <Convert>Chuyển đổi</Convert>
@@ -272,7 +268,7 @@ Rất hân hạnh được chào đón.
     <SubtitleImage>Hình ảnh phụ đề</SubtitleImage>
   </DvdSubRipChooseLanguage>
   <EbuSaveOptions>
-    <Title> Lưu tùy chọn EBU</Title>
+    <Title>Lưu tùy chọn EBU</Title>
     <GeneralSubtitleInformation>Thông tin phụ đề</GeneralSubtitleInformation>
     <CodePageNumber>Mã hóa số trang</CodePageNumber>
     <DiskFormatCode>Mã hóa định dạng đĩa</DiskFormatCode>
@@ -297,8 +293,7 @@ Rất hân hạnh được chào đón.
     <ErrorsX>Lỗi: {0}</ErrorsX>
     <MaxLengthError>Số dòng {0} vượt quá chiều dài tối đa ({1}) bởi {2}: {3}</MaxLengthError>
     <TextUnchangedPresentation>Trình bày không thay đổi</TextUnchangedPresentation>
-    <TextLeftJustifiedText>Chứng minh văn bản bên trái
-</TextLeftJustifiedText>
+    <TextLeftJustifiedText>Chứng minh văn bản bên trái</TextLeftJustifiedText>
     <TextCenteredText>Văn bản ở giữa</TextCenteredText>
     <TextRightJustifiedText>Chứng minh văn bản bên phải</TextRightJustifiedText>
   </EbuSaveOptions>
@@ -346,13 +341,13 @@ Rất hân hạnh được chào đón.
     <MergeAllLines>Gộp tất cả các dòng</MergeAllLines>
     <UnbreakLines>Ngắt ở dòng</UnbreakLines>
     <RemoveStyling>Gỡ bỏ phong cách</RemoveStyling>
-    <ShowLineNumbers> Hiện dòng số</ShowLineNumbers>
+    <ShowLineNumbers>Hiện dòng số</ShowLineNumbers>
     <AddNewLineAfterLineNumber>Thêm dòng mới sau dòng số</AddNewLineAfterLineNumber>
     <ShowTimeCode>Mã hóa hiển thị thời gian</ShowTimeCode>
     <AddNewLineAfterTimeCode>Thêm dòng mới sau khi mã hóa thời gian</AddNewLineAfterTimeCode>
     <AddNewLineAfterTexts>Thêm dòng mới sau văn bản</AddNewLineAfterTexts>
     <AddNewLineBetweenSubtitles>Thêm dòng mới giữa các phụ đề</AddNewLineBetweenSubtitles>
-    <TimeCodeFormat> Mã hóa định dạng thời gian</TimeCodeFormat>
+    <TimeCodeFormat>Mã hóa định dạng thời gian</TimeCodeFormat>
     <Srt>srt</Srt>
     <Milliseconds>Milli giây</Milliseconds>
     <HHMMSSFF>HH:. MM: SS: FF</HHMMSSFF>
@@ -448,7 +443,7 @@ Rất hân hạnh được chào đón.
     <RemoveUnneededPeriodsExample>Hey you!. -&gt; Hey you!</RemoveUnneededPeriodsExample>
     <FixMissingSpacesExample>Hey.You. -&gt; Hey. You.</FixMissingSpacesExample>
     <FixUppercaseIInsindeLowercaseWordsExample>The earth is fIat. -&gt; The earth is flat.</FixUppercaseIInsindeLowercaseWordsExample>
-    <FixLowercaseIToUppercaseIExample> What do i care . -&gt; What do I care.</FixLowercaseIToUppercaseIExample>
+    <FixLowercaseIToUppercaseIExample>What do i care . -&gt; What do I care.</FixLowercaseIToUppercaseIExample>
     <StartTimeLaterThanEndTime>Số văn bản {0}: Thời gian bắt đầu ở sau thời gian kết thúc: {4} {1} -&gt; {2} {3}</StartTimeLaterThanEndTime>
     <UnableToFixStartTimeLaterThanEndTime>Không thể sửa lỗi văn bản số {0}: Thời gian bắt đầu ở sau thời gian kết thúc: {1}</UnableToFixStartTimeLaterThanEndTime>
     <XFixedToYZ>{0} Sửa lỗi tới: {1} {2}</XFixedToYZ>
@@ -598,7 +593,7 @@ Rất hân hạnh được chào đón.
         <ExportCapMakerPlus>CapMaker Plus...</ExportCapMakerPlus>
         <ExportCaptionsInc>Chú thích Inc ..</ExportCaptionsInc>
         <ExportCheetahCap>Cheetah CAP...</ExportCheetahCap>
-        <ExportUltech130> Chú thích Ultech130...</ExportUltech130>
+        <ExportUltech130>Chú thích Ultech130...</ExportUltech130>
         <Exit>Th&amp;oát</Exit>
       </File>
       <Edit>
@@ -704,7 +699,7 @@ Rất hân hạnh được chào đón.
         <SaveAs>Lưu với tên</SaveAs>
         <Find>Tìm</Find>
         <Replace>Thay thế</Replace>
-        <VisualSync> Đồng bộ khi xem</VisualSync>
+        <VisualSync>Đồng bộ khi xem</VisualSync>
         <SpellCheck>Kiểm tra chính tả</SpellCheck>
         <Settings>Cài đặt</Settings>
         <Help>Trợ giúp</Help>
@@ -963,7 +958,7 @@ Bạn có muốn bắt đầu từ phía trên cùng của tài liệu và tiế
     <BeforeCreateAdjustLines>Trước khi tạo/chỉnh dòng</BeforeCreateAdjustLines>
     <OpenAnsiSubtitle>Mở phụ đề...</OpenAnsiSubtitle>
     <BeforeChangeCasing>Trước khi thay đổi cách hiển thị</BeforeChangeCasing>
-    <CasingCompleteMessageNoNames> Hiển thị số dòng được thay đổi: {0}/{1}</CasingCompleteMessageNoNames>
+    <CasingCompleteMessageNoNames>Hiển thị số dòng được thay đổi: {0}/{1}</CasingCompleteMessageNoNames>
     <CasingCompleteMessageOnlyNames>Hiển thị số dòng với tên thay đổi: {0}/{1}</CasingCompleteMessageOnlyNames>
     <CasingCompleteMessage>Hiển thị số dòng được thay đổi: {0}/{1}, thay đổi cách hiển thị tên: {2}</CasingCompleteMessage>
     <BeforeChangeFrameRate>Trước khi thay đổi tỷ lệ khung hình</BeforeChangeFrameRate>
@@ -999,13 +994,13 @@ Bạn có muốn bắt đầu từ phía trên cùng của tài liệu và tiế
     <NameXNotAddedToNamesEtcList>Tên '{0}' KHÔNG thêm được vào tên tập tin/danh sách</NameXNotAddedToNamesEtcList>
     <WordXAddedToUserDic>Từ '{0}' đã được thêm vào từ điển người dùng</WordXAddedToUserDic>
     <WordXNotAddedToUserDic>Từ '{0}' KHÔNG thêm được vào từ điển người dùng</WordXNotAddedToUserDic>
-    <OcrReplacePairXAdded> Các orc thay thế cặp danh sách '{0} -&gt; {1}' đã được thêm vào danh sách thay thế orc</OcrReplacePairXAdded>
-    <OcrReplacePairXNotAdded> Các orc thay thế cặp danh sách '{0} -&gt; {1}' KHÔNG được thêm vào danh sách thay thế orc</OcrReplacePairXNotAdded>
+    <OcrReplacePairXAdded>Các orc thay thế cặp danh sách '{0} -&gt; {1}' đã được thêm vào danh sách thay thế orc</OcrReplacePairXAdded>
+    <OcrReplacePairXNotAdded>Các orc thay thế cặp danh sách '{0} -&gt; {1}' KHÔNG được thêm vào danh sách thay thế orc</OcrReplacePairXNotAdded>
     <XLinesSelected>{0} dòng được lựa chọn</XLinesSelected>
     <UnicodeMusicSymbolsAnsiWarning>Phụ đề chứa các ghi chú âm nhạc unicode. Sử dụng mã hóa tập tin ANSI để lưu sẽ bị mất. Tiếp tục với lưu?</UnicodeMusicSymbolsAnsiWarning>
     <NegativeTimeWarning>Phụ đề chứa mã hóa thời gian âm. Tiếp tục lưu?</NegativeTimeWarning>
     <BeforeMergeShortLines>Trước khi gộp các dòng quá ngắn</BeforeMergeShortLines>
-    <BeforeSplitLongLines> Trước khi chia các dòng quá dài</BeforeSplitLongLines>
+    <BeforeSplitLongLines>Trước khi chia các dòng quá dài</BeforeSplitLongLines>
     <MergedShortLinesX>Số dòng sáp nhập: {0}</MergedShortLinesX>
     <BeforeSetMinimumDisplayTimeBetweenParagraphs>Trước khi thiết lập hiển thị thời gian tối thiểu giữa các đoạn</BeforeSetMinimumDisplayTimeBetweenParagraphs>
     <XMinimumDisplayTimeBetweenParagraphsChanged>Số dòng với hiển thị thời gian tối thiểu giữa các đoạn thay đổi: {0}</XMinimumDisplayTimeBetweenParagraphsChanged>
@@ -1268,7 +1263,7 @@ có thể chỉnh sửa trong cùng một tập tin phụ đề (hợp tác vớ
     <DefaultVolume>Âm lượng mặc định</DefaultVolume>
     <VolumeNotes>0 là không có âm thanh, 100 là âm lượng cao nhất</VolumeNotes>
     <PreviewFontSize>Xem trước kích thước phông chữ</PreviewFontSize>
-    <MainWindowVideoControls> Cửa sổ chính điều khiển video</MainWindowVideoControls>
+    <MainWindowVideoControls>Cửa sổ chính điều khiển video</MainWindowVideoControls>
     <CustomSearchTextAndUrl>Tự chọn để tìm văn bản và URL</CustomSearchTextAndUrl>
     <WaveformAppearance>Xuất hiện dạng sóng</WaveformAppearance>
     <WaveformGridColor>Dạng lưới màu</WaveformGridColor>
@@ -1357,8 +1352,7 @@ có thể chỉnh sửa trong cùng một tập tin phụ đề (hợp tác vớ
     <GoForward100Milliseconds>100 ms phía trước</GoForward100Milliseconds>
     <GoBack500Milliseconds>500 ms trở lại</GoBack500Milliseconds>
     <GoForward500Milliseconds>500 ms phía trước</GoForward500Milliseconds>
-    <TogglePlayPause>Kích hoạt Phát/Tạm dừng
-</TogglePlayPause>
+    <TogglePlayPause>Kích hoạt Phát/Tạm dừng</TogglePlayPause>
     <Pause>Tạm dừng</Pause>
     <Fullscreen>Toàn màn hình</Fullscreen>
     <CustomSearch1>Dịch, tùy chọn tìm kiếm 1</CustomSearch1>
@@ -1480,7 +1474,7 @@ có thể chỉnh sửa trong cùng một tập tin phụ đề (hợp tác vớ
     <Title>Thống kê</Title>
     <TitleWithFileName>Thống kê - {0}</TitleWithFileName>
     <GeneralStatistics>Thống kê chung</GeneralStatistics>
-    <MostUsed> Dòng sử dụng nhiều nhất...</MostUsed>
+    <MostUsed>Dòng sử dụng nhiều nhất...</MostUsed>
     <MostUsedLines>DÙng tất cả các từ được sử dụng nhiều nhất</MostUsedLines>
     <MostUsedWords>Từ được sử dụng nhiều nhất</MostUsedWords>
     <NothingFound>Không tìm thấy gì</NothingFound>
@@ -1573,7 +1567,7 @@ có thể chỉnh sửa trong cùng một tập tin phụ đề (hợp tác vớ
     <SyncHelp>Thiết lập ít nhất hai thời điểm đồng bộ để thực hiện đồng bộ hóa thô</SyncHelp>
     <SetSyncPoint>Thiết lập thời điểm đồng bộ</SetSyncPoint>
     <RemoveSyncPoint>Gỡ bỏ thời điểm đồng bộ</RemoveSyncPoint>
-    <SyncPointsX> Đồng bộ chỉ: {0}</SyncPointsX>
+    <SyncPointsX>Đồng bộ chỉ: {0}</SyncPointsX>
     <Info>Khi đồng bộ một thời điểm sẽ điều chỉnh vị trí, tốc độ sẽ nhanh hơn khi đồng bộ hai hay nhiều hơn</Info>
     <ApplySync>Áp dụng</ApplySync>
   </PointSync>

--- a/src/Languages/zh-CHS.xml
+++ b/src/Languages/zh-CHS.xml
@@ -1644,8 +1644,7 @@ C# 源代码可从 https://github.com/SubtitleEdit/subtitleedit 获得。
     <SwitchOriginalAndTranslation>切换原文和翻译</SwitchOriginalAndTranslation>
     <MergeOriginalAndTranslation>合并原文和翻译</MergeOriginalAndTranslation>
     <ShortcutIsAlreadyDefinedX>快捷键已经定义:
-{0}
-</ShortcutIsAlreadyDefinedX>
+{0}</ShortcutIsAlreadyDefinedX>
     <ToggleTranslationAndOriginalInPreviews>在 视频/音频 预览中切换翻译和原文</ToggleTranslationAndOriginalInPreviews>
     <ListViewColumnDelete>列，删除文本</ListViewColumnDelete>
     <ListViewColumnInsert>列，插入文本</ListViewColumnInsert>

--- a/src/Logic/BmpReader.cs
+++ b/src/Logic/BmpReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Nikse.SubtitleEdit.Logic
 {

--- a/src/Logic/ColorChooser/ColorChangedEventArgs.cs
+++ b/src/Logic/ColorChooser/ColorChangedEventArgs.cs
@@ -1,4 +1,4 @@
-#region #Disclaimer
+﻿#region #Disclaimer
 
 // Author: Adalberto L. Simeone (Taranto, Italy)
 // E-Mail: avengerdragon@gmail.com

--- a/src/Logic/ColorChooser/ColorHandler.cs
+++ b/src/Logic/ColorChooser/ColorHandler.cs
@@ -1,4 +1,4 @@
-#region #Disclaimer
+﻿#region #Disclaimer
 
 // Author: Adalberto L. Simeone (Taranto, Italy)
 // E-Mail: avengerdragon@gmail.com

--- a/src/Logic/ColorChooser/ColorWheel.cs
+++ b/src/Logic/ColorChooser/ColorWheel.cs
@@ -1,4 +1,4 @@
-#region #Disclaimer
+﻿#region #Disclaimer
 
 // Author: Adalberto L. Simeone (Taranto, Italy)
 // E-Mail: avengerdragon@gmail.com

--- a/src/Logic/Language.cs
+++ b/src/Logic/Language.cs
@@ -1552,8 +1552,8 @@ namespace Nikse.SubtitleEdit.Logic
                 EndsWith = "Ends with",
                 NoContains = "Not contains",
                 RegEx = "Regular expression",
-                UnequalLines = "Unequal lines",
-                EqualLines = "Equal lines",
+                UnequalLines = "Odd-numbered lines",
+                EqualLines = "Even-numbered lines",
             };
 
             MultipleReplace = new LanguageStructure.MultipleReplace

--- a/src/Logic/LanguageDeserializer.cs
+++ b/src/Logic/LanguageDeserializer.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Xml;
 using Nikse.SubtitleEdit.Logic;
 

--- a/src/Logic/SubtitleFormats/Pac.cs
+++ b/src/Logic/SubtitleFormats/Pac.cs
@@ -626,7 +626,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             "(", //0x28
             ")", //0x29
             "+", //0x2b
-            "б", //",", //0x2c            
+            "б", //",", //0x2c
             "_", //0x2d
             "ю", //0x2e
             "Ж", //0x3a

--- a/src/Logic/VideoFormats/Matroska/MatroskaFile.cs
+++ b/src/Logic/VideoFormats/Matroska/MatroskaFile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Logic/VideoFormats/Matroska/MatroskaSubtitle.cs
+++ b/src/Logic/VideoFormats/Matroska/MatroskaSubtitle.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Nikse.SubtitleEdit.Logic.VideoFormats.Matroska
 {

--- a/src/Logic/VideoFormats/Matroska/MatroskaTrackInfo.cs
+++ b/src/Logic/VideoFormats/Matroska/MatroskaTrackInfo.cs
@@ -1,4 +1,4 @@
-namespace Nikse.SubtitleEdit.Logic.VideoFormats.Matroska
+﻿namespace Nikse.SubtitleEdit.Logic.VideoFormats.Matroska
 {
     internal class MatroskaTrackInfo
     {

--- a/src/Logic/VobSub/IdxParagraph.cs
+++ b/src/Logic/VobSub/IdxParagraph.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Nikse.SubtitleEdit.Logic.VobSub
 {


### PR DESCRIPTION
[2] BatchConvertOptions moved because the Dutch FixCommonErrors text needed one more pixel. Else, it ‘disturbs’ the [Settings] button to the right of it.