### PR TITLE
Increase efficiency with XmlReaderSettings (LanguageDeserializer)

### DIFF
--- a/src/Logic/LanguageDeserializer.cs
+++ b/src/Logic/LanguageDeserializer.cs
@@ -19,7 +19,9 @@ namespace Nikse.SubtitleEdit.Logic
             var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             var language = new Language();
 
-            using (XmlReader reader = XmlReader.Create(stream))
+            using (XmlReader reader = XmlReader.Create(stream, new XmlReaderSettings {
+                   IgnoreWhitespace = true, IgnoreProcessingInstructions = true, IgnoreComments = true,
+                   DtdProcessing = DtdProcessing.Ignore, CheckCharacters = false, CloseInput = true }))
             {
                 while (reader.Read())
                 {

--- a/src/UpdateLanguageFiles/LanguageDeserializerGenerator.cs
+++ b/src/UpdateLanguageFiles/LanguageDeserializerGenerator.cs
@@ -29,7 +29,9 @@ namespace Nikse.SubtitleEdit.Logic
             var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             var language = new Language();
 
-            using (XmlReader reader = XmlReader.Create(stream))
+            using (XmlReader reader = XmlReader.Create(stream, new XmlReaderSettings {
+                   IgnoreWhitespace = true, IgnoreProcessingInstructions = true, IgnoreComments = true,
+                   DtdProcessing = DtdProcessing.Ignore, CheckCharacters = false, CloseInput = true }))
             {
                 while (reader.Read())
                 {


### PR DESCRIPTION
According to [this test](https://gist.github.com/xylographe/1f8d736ff311365a8ef6), ignoring whitespace nodes in the reader would be _slightly_ more efficient than ignoring them in the while-loop. But, perhaps, not enough to justify the extra ‘clutter’?