### PR TITLE
Illustration of an issue with StripableText [these unit tests fail]

### DIFF
--- a/src/Test/Logic/StripableTextTest.cs
+++ b/src/Test/Logic/StripableTextTest.cs
@@ -16,6 +16,24 @@ namespace Test.Logic
         }
 
         [TestMethod]
+        public void StripableTextItalic2()
+        {
+            var st = new StripableText("<i>O</i>");
+            Assert.AreEqual(st.Pre, "<i>");
+            Assert.AreEqual(st.Post, "</i>");
+            Assert.AreEqual(st.StrippedText, "O");
+        }
+
+        [TestMethod]
+        public void StripableTextItalic3()
+        {
+            var st = new StripableText("<i>Hi!");
+            Assert.AreEqual(st.Pre, "<i>");
+            Assert.AreEqual(st.Post, "!");
+            Assert.AreEqual(st.StrippedText, "Hi");
+        }
+
+        [TestMethod]
         public void StripableTextAss()
         {
             var st = new StripableText("{\\an9}Hi!");


### PR DESCRIPTION
I'm afraid, there is still an issue with StripableText, as shown by these unit tests. StripableTextItalic3() may not be a valid test (?), but I would expect StripableTextItalic2() to succeed.

Just one of many alternatives, as an illustration:
```
// tags like <i> or <font face="Segoe Print" color="#ff0000">
if (text.Length > 2 && text[0] == '<')
{
    int endIndex = text.IndexOf('>', 1);
    if (endIndex > 1 && text.LastIndexOf('<', endIndex - 1) == 0)
    {
        endIndex++;
        Pre += text.Substring(0, endIndex);
        text = text.Remove(0, endIndex);
    }
}
```
