### PR TITLE
Fixed: Autobreak problem when line contains Narrator in sec line

### DIFF
--- a/src/Forms/AutoBreakUnbreakLines.cs
+++ b/src/Forms/AutoBreakUnbreakLines.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 using System.Drawing;
+using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -69,7 +70,7 @@ namespace Nikse.SubtitleEdit.Forms
                 for (int i = start; i <= max; i++)
                     comboBoxConditions.Items.Add(i.ToString(CultureInfo.InvariantCulture));
 
-                int index = Configuration.Settings.Tools.MergeLinesShorterThan - (start + 1);
+                int index = Configuration.Settings.Tools.MergeLinesShorterThan - 11;
                 if (index > 0 && index < max)
                     comboBoxConditions.SelectedIndex = index;
                 else
@@ -120,7 +121,7 @@ namespace Nikse.SubtitleEdit.Forms
             listViewFixes.Items.Clear();
             foreach (Paragraph p in _paragraphs)
             {
-                if (p.Text.Length > minLength || p.Text.Contains(Environment.NewLine))
+                if (p.Text.Length > minLength || p.Text.Contains(Environment.NewLine, StringComparison.Ordinal))
                 {
                     string text = Utilities.AutoBreakLine(p.Text, 5, MergeLinesShorterThan, language);
                     if (text != p.Text)

--- a/src/Logic/Utilities.cs
+++ b/src/Logic/Utilities.cs
@@ -545,13 +545,17 @@ namespace Nikse.SubtitleEdit.Logic
                 return text;
 
             // do not autobreak dialogs
-            if (text.Contains('-') && text.Contains(Environment.NewLine, StringComparison.Ordinal))
+            if ((text.Contains('-') || text.Contains(':')) && text.Contains(Environment.NewLine, StringComparison.Ordinal))
             {
+                const string endLineChars = ".?!)]";
                 var noTagLines = HtmlUtil.RemoveHtmlTags(text).SplitToLines();
                 if (noTagLines.Length == 2)
                 {
                     var arr0 = noTagLines[0].Trim().TrimEnd('"').TrimEnd('\'').TrimEnd();
-                    if (arr0.StartsWith('-') && noTagLines[1].TrimStart().StartsWith('-') && arr0.Length > 1 && ".?!)]".Contains(arr0[arr0.Length - 1]) || arr0.EndsWith("--", StringComparison.Ordinal) || arr0.EndsWith('–'))
+                    if (arr0.StartsWith('-') && noTagLines[1].TrimStart().StartsWith('-') && arr0.Length > 1 && endLineChars.Contains(arr0[arr0.Length - 1]) || arr0.EndsWith("--", StringComparison.Ordinal) || arr0.EndsWith('–'))
+                        return text;
+                    var idx = noTagLines[1].IndexOf(':');
+                    if (arr0.Length > 1 && (endLineChars.Contains(arr0[arr0.Length - 1]) || arr0.EndsWith("--", StringComparison.Ordinal) || arr0.EndsWith('–')) && !Utilities.IsBetweenNumbers(noTagLines[1], idx))
                         return text;
                 }
             }

--- a/src/Test/UtilitiesTest.cs
+++ b/src/Test/UtilitiesTest.cs
@@ -48,6 +48,17 @@ namespace Test
 
         [TestMethod]
         [DeploymentItem("SubtitleEdit.exe")]
+        public void AutoBreakLine5()
+        {
+            Configuration.Settings.General.SubtitleLineMaximumLength = 43;
+            string s1 = "Housing reform!\r\nWoman: <i>Yeah!</i>";
+            string s2 = Utilities.AutoBreakLine(s1);
+            string target = s1;
+            Assert.AreEqual(target, s2);
+        }
+
+        [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
         public void AutoBreakLine5DoNoBreakAtPeriod()
         {
             Configuration.Settings.General.SubtitleLineMaximumLength = 43;


### PR DESCRIPTION
```
1
00:00:01,000 --> 00:00:03,000
Housing reform!
Woman: <i>Yeah!</i>

```
Becames: 
```
1
00:00:01,000 --> 00:00:03,000
Housing reform! Woman: <i>Yeah!</i>

```
/cc @niksedk, @xylographe