### PR TITLE
Fixed next/prev in Compare subtitles

### DIFF
--- a/src/Forms/Compare.cs
+++ b/src/Forms/Compare.cs
@@ -685,6 +685,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (subtitleListView1.SelectedItems.Count == 0)
                 {
+                    subtitleListView2.SelectIndexAndEnsureVisible(_differences[0]);
                     subtitleListView1.SelectIndexAndEnsureVisible(_differences[0]);
                 }
                 else
@@ -693,8 +694,11 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         if (_differences.Contains(i))
                         {
+                            subtitleListView2.SelectIndexAndEnsureVisible(i - 2);
                             subtitleListView1.SelectIndexAndEnsureVisible(i - 2);
+                            subtitleListView2.SelectIndexAndEnsureVisible(i + 2);
                             subtitleListView1.SelectIndexAndEnsureVisible(i + 2);
+                            subtitleListView2.SelectIndexAndEnsureVisible(i);
                             subtitleListView1.SelectIndexAndEnsureVisible(i);
                             break;
                         }
@@ -709,6 +713,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (subtitleListView1.SelectedItems.Count == 0)
                 {
+                    subtitleListView2.SelectIndexAndEnsureVisible(_differences[0]);
                     subtitleListView1.SelectIndexAndEnsureVisible(_differences[0]);
                 }
                 else
@@ -717,10 +722,12 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         if (_differences.Contains(i))
                         {
+                            subtitleListView2.SelectIndexAndEnsureVisible(i - 2);
                             subtitleListView1.SelectIndexAndEnsureVisible(i - 2);
+                            subtitleListView2.SelectIndexAndEnsureVisible(i + 2);
                             subtitleListView1.SelectIndexAndEnsureVisible(i + 2);
+                            subtitleListView2.SelectIndexAndEnsureVisible(i);
                             subtitleListView1.SelectIndexAndEnsureVisible(i);
-                            subtitleListView1.Focus();
                             break;
                         }
                     }


### PR DESCRIPTION
When you move the mouse cursor over the *right* side view the left/right arrow keys won't work. This patch will fix that, but it might not be the right solution.
