### PR TITLE
Added fixed for \t in: Fix Unneeded Spaces

### DIFF
--- a/src/Forms/FixCommonErrors.cs
+++ b/src/Forms/FixCommonErrors.cs
@@ -1218,7 +1218,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     var oldText = p.Text;
                     var text = Utilities.RemoveUnneededSpaces(p.Text, Language);
-                    if (text.Length != oldText.Length && Utilities.CountTagInText(text, ' ') < Utilities.CountTagInText(oldText, ' ') + Utilities.CountTagInText(oldText, '\u00A0'))
+                    if (text.Length != oldText.Length && (Utilities.CountTagInText(text, ' ') + Utilities.CountTagInText(text, '\t')) < ((Utilities.CountTagInText(oldText, ' ') + Utilities.CountTagInText(oldText, '\u00A0') + Utilities.CountTagInText(oldText, '\t'))))
                     {
                         doubleSpaces++;
                         p.Text = text;

--- a/src/Logic/Utilities.cs
+++ b/src/Logic/Utilities.cs
@@ -2987,7 +2987,8 @@ namespace Nikse.SubtitleEdit.Logic
             text = text.Replace(ZeroWidthSpace, string.Empty);
             text = text.Replace(zeroWidthNoBreakSpace, string.Empty);
             text = text.Replace(noBreakSpace, " ");
-            text = text.Replace(operatingSystemCommand, string.Empty); // some kind of hidden space!!!
+            text = text.Replace(operatingSystemCommand, string.Empty);
+            text = text.Replace('\t', ' ');
 
             while (text.Contains("  "))
                 text = text.Replace("  ", " ");

--- a/src/Test/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrorsTest.cs
@@ -736,6 +736,8 @@ namespace Test
             }
         }
 
+        [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
         public void FixUnneededSpaces2()
         {
             using (var target = GetFixCommonErrorsLib())
@@ -746,6 +748,8 @@ namespace Test
             }
         }
 
+        [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
         public void FixUnneededSpaces3()
         {
             using (var target = GetFixCommonErrorsLib())
@@ -756,6 +760,8 @@ namespace Test
             }
         }
 
+        [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
         public void FixUnneededSpaces4()
         {
             using (var target = GetFixCommonErrorsLib())
@@ -767,6 +773,7 @@ namespace Test
         }
 
         [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
         public void FixUneededSpaces5()
         {
             using (var target = GetFixCommonErrorsLib())
@@ -776,6 +783,19 @@ namespace Test
                 target.FixUnneededSpaces();
                 Assert.AreEqual(target.Subtitle.Paragraphs[0].Text, expected);
                 Assert.AreEqual(target.Subtitle.Paragraphs[1].Text, expected);
+            }
+        }
+
+        [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
+        public void FixUneededSpaces6()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                const string expected = "Foo bar.";
+                InitializeFixCommonErrorsLine(target, "Foo \t\tbar.");
+                target.FixUnneededSpaces();
+                Assert.AreEqual(target.Subtitle.Paragraphs[0].Text, expected);
             }
         }
 


### PR DESCRIPTION
Some method test weren't working missing ```[TestMethod]``` attributes... now  fixed :)