### PR TITLE
Removed 'hit' variable from GeneratePreview() (Forms/MultipleReplace)

### DIFF
--- a/src/Forms/MultipleReplace.cs
+++ b/src/Forms/MultipleReplace.cs
@@ -192,7 +192,6 @@ namespace Nikse.SubtitleEdit.Forms
             
             foreach (Paragraph p in _subtitle.Paragraphs)
             {
-                bool hit = false;
                 string newText = p.Text;
                 foreach (ReplaceExpression item in replaceExpressions)
                 {
@@ -200,7 +199,6 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         if (newText.Contains(item.FindWhat))
                         {
-                            hit = true;
                             newText = newText.Replace(item.FindWhat, item.ReplaceWith);
                         }
                     }
@@ -209,26 +207,20 @@ namespace Nikse.SubtitleEdit.Forms
                         Regex r = _compiledRegExList[item.FindWhat];
                         if (r.IsMatch(newText))
                         {
-                            hit = true;
                             newText = r.Replace(newText, item.ReplaceWith);
                         }
                     }
                     else
                     {
                         int index = newText.IndexOf(item.FindWhat, StringComparison.OrdinalIgnoreCase);
-                        if (index >= 0)
+                        while (index >= 0)
                         {
-                            hit = true;
-                            do
-                            {
-                                newText = newText.Remove(index, item.FindWhat.Length).Insert(index, item.ReplaceWith);
-                                index = newText.IndexOf(item.FindWhat, index + item.ReplaceWith.Length, StringComparison.OrdinalIgnoreCase);
-                            }
-                            while (index >= 0);
+                            newText = newText.Remove(index, item.FindWhat.Length).Insert(index, item.ReplaceWith);
+                            index = newText.IndexOf(item.FindWhat, index + item.ReplaceWith.Length, StringComparison.OrdinalIgnoreCase);
                         }
                     }
                 }
-                if (hit && newText != p.Text)
+                if (newText != p.Text)
                 {
                     FixCount++;
                     AddToPreviewListView(p, newText);


### PR DESCRIPTION
Removing the hit variable from GeneratePreview() will be slightly more efficient for paragraph texts that generate a hit, as the string comparison `newText != p.Text` is going to happen anyway. But, what about texts that don't generate a hit? Because `newText` and `p.Text` would still be the same reference pointer, the comparison should be fast, hence, the difference with using 'hit' might be negligible. I ran a test, and to my surprise, the NoHit version of GeneratePreview() appears to be slightly more efficient. However, my results might be a false positive, you should probably run your own test.

The test files I used [are in mrhittest.7z](https://www.dropbox.com/s/g6e898pg9cd5a5r/mrhittest.7z?dl=0),

- mrhittest.srt (60000 subtitle lines)
- mrhittest.template (6000 random replacement rules, not generating a hit)
- MultipleReplace.cs (with GeneratePreviewHit/GeneratePreviewNoHit)

Clicking OK will alternately invoke the Hit/NoHit preview, showing the result where normally the number of fixes is displayed. Cancel works as expected.
