### PR TITLE
Added missing SaveReplaceList() (Forms/MultipleReplace)

### DIFF
--- a/src/Forms/MultipleReplace.cs
+++ b/src/Forms/MultipleReplace.cs
@@ -330,6 +330,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void ListViewReplaceListItemChecked(object sender, ItemCheckedEventArgs e)
         {
             GeneratePreview();
+            SaveReplaceList(false);
         }
 
         private void DeleteToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
This makes a difference when you check/uncheck replace items, and then add more replace items via import.
