### PR TITLE
Adjusted Move to (Top|Bottom) (Forms/MultipleReplace)

### DIFF
--- a/src/Forms/MultipleReplace.cs
+++ b/src/Forms/MultipleReplace.cs
@@ -491,7 +491,12 @@ namespace Nikse.SubtitleEdit.Forms
             int index = listViewReplaceList.SelectedIndices[0];
             if (index == 0)
                 return;
-            SwapReplaceList(index, 0);
+
+            var item = listViewReplaceList.Items[index];
+            listViewReplaceList.Items.RemoveAt(index);
+            listViewReplaceList.Items.Insert(0, item);
+            GeneratePreview();
+            SaveReplaceList(false);
         }
 
         private void moveBottomToolStripMenuItem_Click(object sender, EventArgs e)
@@ -500,7 +505,12 @@ namespace Nikse.SubtitleEdit.Forms
             int bottomIndex = listViewReplaceList.Items.Count - 1;
             if (index == bottomIndex)
                 return;
-            SwapReplaceList(index, bottomIndex);
+
+            var item = listViewReplaceList.Items[index];
+            listViewReplaceList.Items.RemoveAt(index);
+            listViewReplaceList.Items.Add(item);
+            GeneratePreview();
+            SaveReplaceList(false);
         }
 
         private void ExportClick(object sender, EventArgs e)


### PR DESCRIPTION
The Move to Top/Bottom behaviour in MultipleReplace deviates from customary practice. Instead of placing the selected item at the top/bottom without changing the order of other items, the selected item and the top/bottom item are swapped.

This patch implements the customary behaviour.
