### PR TITLE
Minor refact (Logic/Utilities)

### DIFF
--- a/src/Logic/Utilities.cs
+++ b/src/Logic/Utilities.cs
@@ -1178,7 +1178,7 @@ namespace Nikse.SubtitleEdit.Logic
             if (count > bestCount)
             {
                 int norwegianCount = GetCount(text, "ut", "deg", "meg", "merkelig", "mye", "spørre");
-                int dutchCount = GetCount(text, "van", "het", "een", "Het", "m(ij|ĳ)", "z(ij|ĳ)n");
+                int dutchCount = GetCount(text, "van", "een", "[Hh]et", "m(ij|ĳ)", "z(ij|ĳ)n");
                 if (norwegianCount < 2 && dutchCount < count)
                     return "da";
             }
@@ -1187,7 +1187,7 @@ namespace Nikse.SubtitleEdit.Logic
             if (count > bestCount)
             {
                 int danishCount = GetCount(text, "siger", "dig", "mig", "mærkelig", "tilbage", "spørge");
-                int dutchCount = GetCount(text, "van", "het", "een", "Het", "m(ij|ĳ)", "z(ij|ĳ)n");
+                int dutchCount = GetCount(text, "van", "een", "[Hh]et", "m(ij|ĳ)", "z(ij|ĳ)n");
                 if (danishCount < 2 && dutchCount < count)
                     return "no";
             }
@@ -1199,7 +1199,7 @@ namespace Nikse.SubtitleEdit.Logic
             count = GetCount(text, "el", "bien", "Vamos", "Hola", "casa", "con");
             if (count > bestCount)
             {
-                int frenchCount = GetCount(text, "C'est", "c'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
+                int frenchCount = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
                 if (frenchCount < 2)
                     return "es";
             }
@@ -1218,7 +1218,7 @@ namespace Nikse.SubtitleEdit.Logic
             if (count > bestCount)
                 return "de";
 
-            count = GetCount(text, "van", "het", "een", "Het", "m(ij|ĳ)", "z(ij|ĳ)n");
+            count = GetCount(text, "van", "een", "[Hh]et", "m(ij|ĳ)", "z(ij|ĳ)n");
             if (count > bestCount)
                 return "nl";
 
@@ -1230,7 +1230,7 @@ namespace Nikse.SubtitleEdit.Logic
                                    "giorno", "faccio", "davvero", "negativo", "essere", "vuole", "sensitivo", "venire");
             if (count > bestCount)
             {
-                int frenchCount = GetCount(text, "C'est", "c'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
+                int frenchCount = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
                 int spanishCount = GetCount(text, "Hola", "nada", "Vamos", "pasa", "los", "como"); // not french words
                 if (frenchCount < 2 && spanishCount < 2)
                     return "it";
@@ -1417,7 +1417,7 @@ namespace Nikse.SubtitleEdit.Logic
                         if (count > bestCount)
                         {
                             int danishCount = GetCount(text, "siger", "dig", "mig", "mærkelig", "tilbage", "spørge");
-                            int dutchCount = GetCount(text, "van", "het", "een", "Het", "m(ij|ĳ)", "z(ij|ĳ)n");
+                            int dutchCount = GetCount(text, "van", "een", "[Hh]et", "m(ij|ĳ)", "z(ij|ĳ)n");
                             if (danishCount < 2 && dutchCount < count)
                                 languageName = shortName;
                         }
@@ -1465,7 +1465,7 @@ namespace Nikse.SubtitleEdit.Logic
                         count = GetCount(text, "el", "bien", "Vamos", "Hola", "casa", "con");
                         if (count > bestCount)
                         {
-                            int frenchWords = GetCount(text, "C'est", "c'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
+                            int frenchWords = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
                             if (frenchWords < 2)
                                 languageName = shortName;
                         }
@@ -1484,7 +1484,7 @@ namespace Nikse.SubtitleEdit.Logic
                         count = GetCount(text, "Cosa", "sono", "Grazie", "Buongiorno", "bene", "questo");
                         if (count > bestCount)
                         {
-                            int frenchWords = GetCount(text, "C'est", "c'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
+                            int frenchWords = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
                             int spanishWords = GetCount(text, "Hola", "nada", "Vamos", "pasa", "los", "como"); // not french words
                             if (frenchWords < 2 && spanishWords < 2)
                                 languageName = shortName;
@@ -1496,7 +1496,7 @@ namespace Nikse.SubtitleEdit.Logic
                             languageName = shortName;
                         break;
                     case "nl_NL":
-                        count = GetCount(text, "van", "het", "een", "Het", "m(ij|ĳ)", "z(ij|ĳ)n");
+                        count = GetCount(text, "van", "een", "[Hh]et", "m(ij|ĳ)", "z(ij|ĳ)n");
                         if (count > bestCount)
                             languageName = shortName;
                         break;


### PR DESCRIPTION
Matching `[Hh]et` seems to be more efficient than matching `Het` and `het` separately.
Same for `[Cc]'est` vs. `C'est` and `c'est`.