### PR TITLE
Fixed Cyrillic _codePage init (Logic/SubtitleFormats/Pac)

### DIFF
--- a/src/Logic/SubtitleFormats/Pac.cs
+++ b/src/Logic/SubtitleFormats/Pac.cs
@@ -1340,7 +1340,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
                         if (allOk)
                             return 4; // Hebrew
 
-                        _codePage = 4;
+                        _codePage = 6;
                         index = start;
                         p = GetPacParagraph(ref index, buffer);
                         sb = new StringBuilder("(1234567890, .!?-\r\n'\"):;&");


### PR DESCRIPTION
Perhaps, it might be more convenient to use named codePage constants instead of integer literals?