### PR TITLE
Do not entry FixInvalidItalicTags if text doesn't contain '<'

### DIFF
--- a/src/Logic/Utilities.cs
+++ b/src/Logic/Utilities.cs
@@ -2129,6 +2129,9 @@ namespace Nikse.SubtitleEdit.Logic
 
         public static string FixInvalidItalicTags(string text)
         {
+            if (text == null || !text.Contains('<'))
+                return text;
+
             const string beginTag = "<i>";
             const string endTag = "</i>";
 


### PR DESCRIPTION
@niksedk This patch is safe and will provide some optimization... instead of running 10+ step without fixing anything why not exit the method if there is no `<`