### PR TITLE
Fixed hrv_OCRFixReplaceList.xml

### DIFF
--- a/Dictionaries/hrv_OCRFixReplaceList.xml
+++ b/Dictionaries/hrv_OCRFixReplaceList.xml
@@ -1,1115 +1,1318 @@
-<OCRFixReplaceList>
-<WholeWords>
-<Word from="advokatski" to="odvjetnički" />
-<Word from="aluminijum" to="aluminij" />
-<Word from="Američki" to="američki" />
-<Word from="bedni" to="bijedni" />
-<Word from="bednog" to="bijednog" />
-<Word from="bejah" to="bijah" />
-<Word from="beleg" to="biljeg" />
-<Word from="belešci" to="bilješci" />
-<Word from="bezbjedna" to="sigurna" />
-<Word from="bežati" to="bježati" />
-<Word from="bićemo" to="bit ćemo" />
-<Word from="bioskop" to="kino" />
-<Word from="bitci" to="bitki" />
-<Word from="blijeđi" to="bljeđi" />
-<Word from="beg" to="bijeg" />
-<Word from="begu" to="bijegu" />
-<Word from="bekstvo" to="bijeg" />
-<Word from="besan" to="bijesan" />
-<Word from="beše" to="bješe" />
-<Word from="bolesan" to="bolestan" />
-<Word from="boleti" to="boljeti" />
-<Word from="braon" to="smeđa" />
-<Word from="bukvalni" to="doslovni" />	<Word from="bukvalno" to="doslovno" />
-<Word from="bukvalnom" to="doslovnom" />
-<Word from="ceo" to="cijeli" />
-<Word from="cjeli" to="cijeli" />
-<Word from="cena" to="cijena" />
-<Word from="ceni" to="cijeni" />
-<Word from="cjelog" to="cijelog" />
-<Word from="čas " to="sat " />
-<Word from="čemo" to="ćemo" />
-<Word from="ču" to="ću" />
-<Word from="češ" to="ćeš" />
-<Word from="če" to="će" />
-<Word from="ćale" to="tata" />
-<Word from="ćorsokak" to="slijepa ulica" />
-<Word from="ćorsokaku" to="slijepoj ulici" />
-<Word from="ćošku" to="uglu" />
-<Word from="ćerka" to="kći" />
-<Word from="kćerka" to="kći" />
-<Word from="ćerke" to="kćeri" />
-<Word from="ćutao" to="šutio" />
-<Word from="ćutala" to="šutjela" />
-<Word from="ćuteći" to="šuteći" />
-<Word from="daćeš" to="dat ćeš" />
-<Word from="daće" to="dat će" />
-<Word from="daga" to="da ga" />
-<Word from="dali si" to="da li si" />
-<Word from="Dali si" to="Da li si" />
-<Word from="dedom" to="djedom" />
-<Word from="dejstvo" to="djelovanje" />
-<Word from="dela" to="djela" />
-<Word from="delo" to="djelo" />
-<Word from="deli" to="dijeli" />
-<Word from="delu" to="djelu" />
-<Word from="deluju" to="djeluju" />
-<Word from="djete" to="dijete" />               <Word from="Djete" to="Dijete" />
-<Word from="diskutujem" to="raspravljam" />     <!--nisu za regex-->
-<Word from="diskutuješ" to="raspravljaš" />  	<Word from="diskutuje" to="raspravlja" />
-<Word from="diskutujemo" to="raspravljamo" />   <Word from="diskutuju" to="raspravljaju" />
-<Word from="delovala" to="djelovala" />
-<Word from="delovanje" to="djelovanje" />
-<Word from="deo" to="dio" />
-<Word from="desiti" to="dogoditi" />
-<Word from="desiće se" to="dogodit će se" />
-<Word from="dešava" to="događa" />
-<Word from="dete" to="dijete" />
-<Word from="detektuje" to="detektira" />
-<Word from="detetu" to="djetetu" />
-<Word from="deteta" to="djeteta" />
-<Word from="dječiji" to="dječji" />
-<Word from="dijetetom" to="djetetom" />
-<Word from="dobo" to="dobro" />
-<Word from="dobićeš" to="dobit ćeš" />
-<Word from="doćiću" to="doći ću" />
-<Word from="dole" to="dolje" />  
-<Word from="dolnji" to="donji" />      <Word from="doljnji" to="donji" />
-<Word from="doneo" to="donio" />       <Word from="Doneo" to="Donio" />
-<Word from="doneso" to="donio" />
-<Word from="donesti" to="donijeti" />  <Word from="donjeti" to="donijeti" />
-<Word from="dospeo" to="dospio" /> <!-- nije za regex -->
-<Word from="dospeju" to="dospiju" />
-<Word from="do đavola" to="do vraga" />
-<Word from="dođavola" to="dovraga" />
-<Word from="drug" to="prijatelj" />
-<Word from="drugarica" to="prijateljica" />
-<Word from="dve" to="dvije" />
-<Word from="đavo" to="vrag" />
-<Word from="đavola" to="vraga" />
-<Word from="đemper" to="džemper" />  
-<Word from="džanki" to="ovisnik" />
-<Word from="džigerica" to="jetra" />
-<Word from="džigericu" to="jetru" />
-<Word from="džin" to="div" />
-<Word from="džinovski" to="divovski" />
-<Word from="evro" to="euro" />
-<Word from="evra" to="eura" />                      <Word from="evrom" to="eurom" />   
-<Word from="fabriku" to="tvornicu" />
-<Word from="falsifikujem" to="falsificiram" />    	<Word from="falsifikuješ" to="falsificiraš" />
-<Word from="falsifikuje" to="falsificira" />        <Word from="falsifikujemo" to="falsificiramo" />
-<Word from="falsifikujete" to="falsificirate" />    <Word from="falsifikuju" to="falsificiraju" />
-<Word from="foka" to="tuljan" />                    <Word from="foku" to="tuljana" /> 
-<Word from="foke" to="tuljani" />                   <Word from="fokama" to="tuljanina" />
-<Word from="funkcioniše" to="funkcionira" />
-<Word from="gde" to="gdje" />
-<Word from="Gde" to="Gdje" />
-<Word from="greški" to="grešci" />
-<Word from="gidošnja" to="godišnja" />
-<Word from="hiljade" to="tisuće" />
-<Word from="iči" to="ići" />
-<Word from="iko" to="itko" />
-<Word from="izleteo" to="izletio" />
-<Word from="ivica" to="rub" />   			<Word from="ivice" to="ruba" />
-<Word from="ivici" to="rubu" />         	<Word from="ivicu" to="rub" />
-<Word from="hoču" to="hoću"/>  				<Word from="hočeš" to="hoćeš"/>  	<Word from="hoče" to="hoće"/>  
-<Word from="hočemo" to="hoćemo"/>  <Word from="hočete" to="hoćete"/>  
-<Word from="holesterol" to="kolesterol" />
-<Word from="Hteo" to="Htio"/>   			<Word from="hteo" to="htio" />
-<Word from="htjeo" to="htio" />
-<Word from="htela" to="htjela" />
-<Word from="hrišćanin" to="kršćanin" />
-<Word from="hrišćanski" to="kršćanski" />
-<Word from="hrvatki" to="hrvatski" />
-<Word from="hrvatkog" to="hrvatskog" />
-<Word from="ignoriši" to="ignoriraj" />    <Word from="ignorišem" to="ignoriram" />
-<Word from="ignoriše" to="ignorira" />     <Word from="ignoriši" to="ignoriraj" />   <Word from="ignorišeš" to="ignoriraš" />
-<Word from="informacioni" to="informacijski" />
-<Word from="ispričaći" to="ispričati ću" />
-<Word from="isuviše" to="previše" />
-<Word from="i te kako" to="itekako" />
-<Word from="jedamput" to="jedanput" />
-<Word from="jelda" to="jel' da" />
-<Word from="juče" to="jučer" />  			<Word from="Juče" to="Jučer" /> 
-<Word from="kancelarija" to="ured" />      	<Word from="kancelariji" to="uredu" />
-<Word from="kancera" to="raka" />
-<Word from="ker" to="pas" />
-<Word from="kera" to="psa" />
-<Word from="keru" to="psu" />
-<Word from="ko" to="tko" />					<Word from="Ko" to="Tko" />
-<Word from="kolena" to="koljena" />
-<Word from="komandni" to="zapovjedni" />
-<Word from="kompanija" to="tvrtka" />
-<Word from="komplikovan" to="kompliciran" />
-<Word from="komplikovano" to="komplicirano" />
-<Word from="komplikuješ" to="kompliciraš" />
-<Word from="komplikuju" to="kompliciraju" />
-<Word from="konfor" to="komfor" />
-<Word from="konkurišem" to="konkuriram" />	<Word from="konkuriše" to="konkurira" />
-<Word from="kolevka" to="kolijevka" />
-<Word from="kolevki" to="kolijevci" />
-<Word from="koa" to="kao" />
-<Word from="komitet" to="odbor" /> 			<Word from="komitetu" to="odboru" />
-<Word from="komitetom" to="odborom" />  	<Word from="komitetima" to="odborima" />
-<Word from="korjenu" to="korijenu" />
-<Word from="krstovima" to="križevima" />
-<Word from="križom" to="križem" />
-<Word from="kupatilo" to="kupaona" />
-<Word from="kupatilu" to="kupaoni" />
-<Word from="kučka" to="kuja" />
-<Word from="lažeju" to="lažu" />
-<Word from="lažov" to="lažljivac" />
-<Word from="lek" to="lijek" />    
-<Word from="lenji" to="lijeni" />    
-<Word from="letela" to="letjela" />
-<Word from="leva" to="lijeva" />
-<Word from="levi" to="lijevi" />
-<Word from="Levo" to="Lijevo" />
-<Word from="lepota" to="lepota" />  
-<Word from="lepša" to="ljepša" />             	
-<Word from="lepšu" to="ljepšu" />           
-<Word from="leto" to="ljeto" />         
-<Word from="leto" to="ljeto" />         <Word from="leta" to="ljeta" />
-<Word from="loži" to="pali" />
-<Word from="ludački" to="luđački" /> 	<Word from="ludačka" to="luđačka" />
-<Word from="ludak" to="luđak" />        <Word from="ludaci" to="luđaci" /> 
-<Word from="malopre" to="malo prije" />
-<Word from="maloprije" to="malo prije" />
-<Word from="manifestuje" to="manifestira" />
-<Word from="mator" to="star" />    	<Word from="matori" to="stari" />
-<Word from="menja" to="mijenja" />  <Word from="Menja" to="Mijenja" /> <!-- nije za regex! -->
-<Word from="merač" to="mjerač" />
-<Word from="mere" to="mjere" />
-<Word from="mesečnik" to="mjesečnik" />
-<Word from="mesečno" to="mjesečno" />
-<Word from="meša" to="miješa" />
-<Word from="milion" to="milijun" />
-<Word from="miliona" to="milijuna" />
-<Word from="misliće" to="mislit će" />
-<Word from="mlečna" to="mliječna" />
-<Word from="mlečni" to="mliječni" />
-<Word from="mleveno" to="mljeveno" />
-<Word from="moč" to="moć" />
-<Word from="moraću" to="morat ću" />
-<Word from="moraćeš" to="morat ćeš" />
-<Word from="muzejem" to="muzejom" />
-<Word from="muzici" to="glazbi" />
-<Word from="naduvan" to="napušen" />
-<Word from="nagoveštaj" to="nagovještaj" />
-<Word from="najzad" to="napokon" />
-<Word from="nameštaj" to="namještaj" />
-<Word from="nameste" to="namjeste" />
-<Word from="namešteno" to="namješteno" />
-<Word from="namena" to="namjena" />
-<Word from="napolje" to="van" />
-<Word from="napolju" to="vani" />
-<Word from="natera" to="natjera" /> <Word from="naterali" to="natjerali" />
-<Word from="nauka" to="znanost" />
-<Word from="nazad" to="natrag" />  <Word from="Nazad" to="Natrag" />
-<Word from="napraviću" to="napravit ću" />
-<Word from="napred" to="naprijed" />
-<Word from="naprimjer" to="na primjer" />
-<Word from="nasreću" to="na sreću" />
-<Word from="nauka" to="znanost" />
-<Word from="nebih" to="ne bi" />
-<Word from="negde" to="negdje" />
-<Word from="nemrem" to="ne mogu" />
-<Word from="nemogu" to="ne mogu" />
-<Word from="nene" to="njene" />
-<Word from="nigde" to="nigdje" />
-<Word from="niko" to="nitko" />     <Word from="Niko" to="Nitko" />
-<Word from="nejde" to="ne ide" />
-<Word from="nesrećnica" to="nesretnica" />
-<Word from="nervi" to="živci" />
-<Word from="nervira" to="živcira" />
-<Word from="nervni" to="živčani" />
-<Word from="neču" to="neću" /> 		<Word from="nečeš" to="nećeš" /> <Word from="neče" to="neće" /> 
-<Word from="nečemo" to="nećemo" />  <Word from="nečete" to="nećete" /> 
-<Word from="neda" to="ne da" />             <Word from="nedam" to="ne dam" /> 
-<Word from="neznam" to="ne znam" />         <Word from="nezna" to="ne zna" />     
-<Word from="Neznam" to="Ne znam" />         <Word from="Nezna" to="Ne zna" />
-<Word from="neznajući" to="ne znajući" />
-<Word from="new yorški" to="njujorški" />   <Word from="nju jorški" to="njujorški" />
-<Word from="nežan" to="nježan" />
-<Word from="neželi" to="ne želi" />
-<Word from="niej" to="nije" />
-<Word from="niije" to="nije" />
-<Word from="njem" to="nijem" />
-<Word from="nesvijest" to="nesvjest" />
-<Word from="obe" to="obje" />
-<Word from="obeležava" to="obilježava" />
-<Word from="obeležavanje" to="obilježavanje" />	   <Word from="obeležavanjem" to="obilježavanjem" />
-<Word from="obelodanjen" to="objelodanjen" />	   <Word from="obelodanjeno" to="objelodanjeno" />
-<Word from="obezbediti" to="osigurati" />
-<Word from="obezbeđivanje" to="osiguravanje" />  <Word from="obezbeđivanja" to="osiguranja" />
-<Word from="obezbeđivanju" to="osiguravanju" />
-<Word from="obožavalac" to="obožavatelj" />
-<Word from="obuhvata" to="obuhvaća" />
-<Word from="oceni" to="ocijeni" />
-<Word from="odandje" to="odande" />             <Word from="odavdje" to="odavde" />
-<Word from="odbrana" to="obrana" />     		<Word from="odbranim" to="obranim" />
-<Word from="odkad" to="otkad" />
-<Word from="odma" to="odmah" />
-<Word from="odneti" to="odnijeti" />             <Word from="odnjeti" to="odnijeti" />
-<Word from="odupreti" to="oduprijeti" />
-<Word from="odprilike" to="otprilike" />
-<Word from="oduvek" to="oduvijek" />             <Word from="oduvjek" to="oduvijek" /> 
-<Word from="oprostiće" to="oprostit će" />       <Word from="Oprostiće" to="Oprostit će" />
-<Word from="organizuju" to="organiziraju" /> 
-<Word from="ovde" to="ovdje" />
-<Word from="Ovde" to="Ovdje" />
-<Word from="ovdije" to="ovdje" />
-<Word from="pantalone" to="hlače" />
-<Word from="parčence" to="komadić" />
-<Word from="paramparčad" to="komadići" />
-<Word from="pemzija" to="penzija" /> 
-<Word from="pemziju" to="penziju" />
-<Word from="pertle" to="žnirance" />
-<Word from="pesama" to="pjesama" />
-<Word from="peškirima" to="ručnicima" />
-<Word from="pitaću" to="pitat ću" />
-<Word from="plata" to="plaća" />	<Word from="plača" to="plaća" />
-<Word from="platu" to="plaću" />
-<Word from="plačanje" to="plaćanje" />   <Word from="plačanjem" to="plaćanjem" />
-<Word from="plaćeš" to="plačeš" />
-<Word from="podpisati" to="potpisati" />
-<Word from="podretlo" to="porijeklo" />
-<Word from="pogrješiti" to="pogriješiti" />
-<Word from="pomen" to="spomen" />
-<Word from="poreklo" to="porijeklo" />   <Word from="poreklu" to="porijeklu" />
-<Word from="prenos" to="prijenos" />
-<Word from="prenosa" to="prijenosa" /> 	
-<Word from="prenosu" to="prijenosu" />
-<Word from="preterao" to="pretjerao" />
-<Word from="preteruj" to="pretjeruj" /> <Word from="preteruje" to="pretjeruje" />
-<Word from="pridonjeti" to="pridonijeti" />
-<Word from="prijatan" to="ugodan" />
-<Word from="proleteo" to="proletio" />
-<Word from="podneo" to="podnio" />
-<Word from="podnesti" to="podnijeti" />
-<Word from="podnjeti" to="podnijeti" />
-<Word from="podstrekač" to="poticatelj" />
-<Word from="pomaći" to="pomaknuti" /> 
-<Word from="poen" to="bod" /> <!-- nije za regex -->
-<Word from="poena" to="boda" />
-<Word from="poeni" to="bodovi" />
-<Word from="poludeo" to="poludio" />     <Word from="poludela" to="poludjela" />
-<Word from="ponaosob" to="osobno" />
-<Word from="poneo" to="ponio" />    <!-- nije za regex!!-->
-<Word from="ponesla" to="ponijela" />
-<Word from="ponela" to="ponijela" />
-<Word from="ponjeli" to="ponijeli" />
-<Word from="ponjeti" to="ponijeti" />
-<Word from="pomoč" to="pomoć" />
-<Word from="poređenje" to="usporedba" />
-<Word from="poređenju" to="usporedbi" />
-<Word from="poseta" to="posjet" />
-<Word from="posle" to="poslije" />       <Word from="Posle" to="Poslije" />
-<Word from="posledično" to="posljedično" />    
-<Word from="poslje" to="poslije" />
-<Word from="pozadi" to="iza" />
-<Word from="poželeo" to="poželio" />
-<Word from="praktikuju" to="prakticiraju" />
-<Word from="pre" to="prije" />   <Word from="Pre" to="Prije" />
-<Word from="predame" to="preda me" />
-<Word from="preporuča" to="preporučuje" />
-<Word from="preti" to="prijeti" /> <!-- nije za regex -->
-<Word from="predsednik" to="predsjednik" />
-<Word from="precednik" to="predsjednik" />
-<Word from="precijednik" to="predsjednik" />
-<Word from="precjednik" to="predsjednik" />
-<Word from="preduzeli" to="poduzeli" />
-<Word from="prevod" to="prijevod" />
-<Word from="prihvata" to="prihvaća" />
-<Word from="prihvatam" to="prihvaćam" />
-<Word from="prihvatanje" to="prihvaćanje" />
-<Word from="priije" to="prije" />
-<Word from="prijtelj" to="prijatelj" />
-<Word from="prijtelji" to="prijatelji" />
-<Word from="primjete" to="primijete" />
-<Word from="primjetila" to="primijetila" />
-<Word from="primjetio" to="primijetio" />
-<Word from="prodato" to="prodano" />
-<Word from="promeniti" to="promijeniti" />
-<Word from="promenilo" to="promijenilo" />
-<Word from="promjenilo" to="promijenilo" />
-<Word from="promijena" to="promjena" />
-<Word from="protivrečne" to="proturječne" />
-<Word from="psihićki" to="psihički" />
-<Word from="radijo" to="radio" />
-<Word from="rađe" to="radije" />
-<Word from="raspust" to="odmor" />
-<Word from="razgovrati" to="razgovarati" />
-<Word from="reč" to="riječ" />
-<Word from="rećiću" to="reći ću" />
-<Word from="redosljed" to="redoslijed" />
-<Word from="reko" to="rekao" />
-<Word from="reka" to="rijeka" />   	     <Word from="rjeka" to="rijeka" />
-<Word from="reke" to="rijeke" />   	     <Word from="rjeke" to="rijeke" />
-<Word from="riješenje" to="rješenje" />  <Word from="Riješenje" to="Rješenje" />
-<Word from="rješe" to="riješe" />        <Word from="Rješe" to="Riješe" />
-<Word from="reku" to="rijeku" />         <Word from="rekom" to="rijekom" />
-<Word from="rengen" to="rendgen" />
-<Word from="reagovati" to="reagirati" />   <Word from="reaguje" to="reagira" />
-<Word from="retka" to="rijetka" />         <Word from="retko" to="rijetko" /> 	
-<Word from="retkost" to="rijetkost" />     <Word from="rjetkost" to="rijetkost" />
-<Word from="rijeđi" to="rjeđi" />
-<Word from="ronioc" to="ronilac" />
-<Word from="samoubistava" to="samoubojstava" />
-<Word from="sedela" to="sjedila" />
-<Word from="sedišta" to="sjedala" />
-<Word from="sedište" to="sjedalo" />
-<Word from="sedni" to="sjedni" /> 		<Word from="Sedni" to="Sjedni" />
-<Word from="sedi" to="sjedi" /> 		<Word from="sednem" to="sjednem" />
-<Word from="sedite" to="sjedite" />    	<Word from="sedite" to="sjedite" />
-<Word from="sertan" to="sretan" />
-<Word from="siguan" to="siguran" />
-<Word from="sirće" to="ocat" />
-<Word from="sirćetu" to="octu" />
-<Word from="slijedbenik" to="sljedbenik" />
-<Word from="sma" to="sam" />
-<Word from="smao" to="samo" />
-<Word from="sme" to="smije" />   		<Word from="Sme" to="Smije" />
-<Word from="smešak" to="smješak" />
-<Word from="smešno" to="smiješno" /> 	<Word from="smješno" to="smiješno" />
-<Word from="sem" to="osim" />
-<Word from="sam sam" to="sam sâm" />
-<Word from="s menom" to="sa mnom" />
-<Word from="samnom" to="sa mnom" />
-<Word from="savest" to="savjest" />
-<Word from="savesti" to="savjesti" />
-<Word from="savijest" to="savjest" />
-<Word from="saviješću" to="savješću" />
-<Word from="savešću" to="savješću" />
-<Word from="seti" to="sjeti" />        <Word from="setim" to="sjetim"/>
-<Word from="sintersajzer" to="synthesizer" />
-<Word from="sitnisajzer" to="synthesizer" />
-<Word from="skuvati" to="skuhati" />
-<Word from="smao" to="samo" />
-<Word from="smestila" to="smjestila" />
-<Word from="smestio" to="smjestio" />
-<Word from="smešten" to="smješten" />
-<Word from="srečom" to="srećom" />
-<Word from="sveštenik" to="svećenik" />
-<Word from="svjet" to="svijet" />
-<Word from="sneg" to="snijeg" />
-<Word from="sočiva" to="leće" />
-<Word from="sočivo" to="leća" />
-<Word from="spasao" to="spasio" />
-<Word from="spolja" to="izvana" />
-<Word from="spoljašnji" to="vanjski" />
-<Word from="sprat" to="kat" />
-<Word from="sprata" to="kata" />
-<Word from="sta" to="što" />
-<Word from="stepen" to="stupanj" />
-<Word from="stepeni" to="stupnjeva" />
-<Word from="sticati" to="stjecati" />
-<Word from="sudija" to="sudac" />
-<Word from="sudijo" to="suče" />
-<Word from="sudijskog" to="sudskog" />
-<Word from="suština" to="bit" />    <Word from="suštinski" to="bitni" />
-<Word from="svideo" to="svidio" />
-<Word from="svest" to="svijest" />   <Word from="Svest" to="Svijest" />
-<!-- u korist svijeta koji se češće pojavljuje ostat će ovako-->
-<Word from="svet" to="svijet" /> 	 <Word from="Svet" to="Svijet" />
-<Word from="svetom" to="svijetom" />     <Word from="sveta" to="svijeta" />
-<Word from="svetu" to="svijetu" />
-<Word from="svjest" to="svijest" />
-<Word from="nesvest" to="nesvijest" />
-<Word from="nesvjest" to="nesvijest" />
-<Word from="nesvesti" to="nesvijesti" />
-<Word from="nesvjesti" to="nesvijesti" />
-<Word from="svestan" to="svjestan" />
-<Word from="šagarepa" to="mrkva" />
-<Word from="šečer" to="šećer" />
-<Word from="šolja" to="šalica" />        	
-<Word from="šolju" to="šalicu" />
-<Word from="španski" to="španjolski" />
-<Word from="Šta" to="Što" />
-<Word from="štab" to="stožer" />	
-<Word from="štabu" to="stožeru" />
-<Word from="štampa" to="tisak" />
-<Word from="šta" to="što" />
-<Word from="štp" to="što" />
-<Word from="tačno" to="točno" />
-<Word from="tačnije" to="točnije" />
-<Word from="tačna" to="točna" />
-<Word from="tačnija" to="točnija" />
-<Word from="talas" to="val" />
-<Word from="tačka" to="točka" />
-<Word from="tačkama" to="točkama" />
-<Word from="tačke" to="točke" />
-<Word from="takođe" to="također" />
-<Word from="teraj" to="tjeraj" />
-<Word from="tržni" to="trgovački" />
-<Word from="testera" to="pila" />
-<Word from="tržnom" to="trgovačkom" />
-<Word from="tugi" to="tuzi" />
-<Word from="tvrtci" to="tvrtki" />
-<Word from="ubediti" to="uvjeriti" />
-<Word from="ubedio" to="uvjerio" />
-<Word from="ubeđuju" to="uvjeravaju" />
-<Word from="ubijediti" to="uvjeriti" />
-<Word from="ubjediti" to="uvjeriti" />
-<Word from="ubiću" to="ubit ću" />
-<Word from="ubiće" to="ubit će" />
-<Word from="ubistava" to="ubojstava" />
-<Word from="učestvuju" to="sudjeluju" />
-<Word from="udavit" to="utopit" />
-<Word from="udaviti" to="utopiti" />
-<Word from="uglom" to="kutom" />
-<Word from="uljeva" to="ulijeva" />
-<Word from="u jutro" to="ujutro" />      <Word from="ujutru" to="ujutro" />
-<Word from="umem" to="umijem" />
-<Word from="umeš" to="umiješ" />
-<Word from="umesto" to="umjesto" />
-<Word from="umetnost" to="umjetnost" />
-<Word from="umetnosti" to="umjetnosti" />
-<Word from="umetnošću" to="umjetnošću" />
-<Word from="umreti" to="umrijeti" />
-<Word from="univerzitet" to="sveučilište" />
-<Word from="unapred" to="unaprijed" />
-<Word from="uopšte" to="uopće" />
-<Word from="upašću" to="upast ću" />
-<Word from="uprkos" to="usprkos" />  	<Word from="Uprkos" to="Usprkos" />
-<Word from="uradio" to="učinio" />
-<Word from="uradiću" to="učinit ću" />
-<Word from="uspeo" to="uspio" />
-<Word from="Uspeo" to="Uspio" /> <Word from="uspela" to="uspjela" /> <Word from="uspelo" to="uspjelo" />
-<Word from="uspe" to="uspije" />		
-<Word from="uspeju" to="uspiju" />
-<Word from="uspem" to="uspijem" />
-<Word from="usredsrede" to="usredotoče" />
-<Word from="utičem" to="utječem" />
-<Word from="uvek" to="uvijek" /> <Word from="uvjek" to="uvijek" />
-<Word from="Uvek" to="Uvijek" /> <Word from="Uvjek" to="Uvijek" />
-<Word from="uvijet" to="uvjet" />
-<Word from="uvo" to="uho" />
-<Word from="važi" to="vrijedi" />
-<Word from="večan" to="vječan" />  <Word from="večna" to="vječna" /> <Word from="večno" to="vječno" />
-<Word from="venca" to="vijenca" />
-<Word from="veoma" to="vrlo" />
-<Word from="verovati" to="vjerovati" /> <!-- nije za regex -->
-<Word from="verovanje" to="vjerovanje" />
-<Word from="vetar" to="vjetar" />
-<Word from="vetra" to="vjetra" />
-<Word from="več" to="već" />
-<Word from="veče" to="večer" />
-<Word from="večnost" to="vječnost" />
-<Word from="večno" to="vječno" />
-<Word from="vešt" to="vješt" />
-<Word from="veštine" to="vještine" />
-<Word from="vežba" to="vježba" />
-<Word from="vizuelne" to="vizualne" />
-<Word from="vrede" to="vrijede" />
-<Word from="vredan" to="vrijedan" /> 		 <Word from="vredna" to="vrijedna" /> <Word from="vredno" to="vrijedno" />
-<Word from="vrednost" to="vrijednost" />     <Word from="vrednosti" to="vrijednosti" />
-<Word from="vrednošću" to="vrijednošću" />
-<Word from="vreme" to="vrijeme" />
-<Word from="Vreme" to="Vrijeme" />
-<Word from="voliti" to="voljeti" />
-<Word from="voleo" to="volio" /> 			<Word from="Voleo" to="Volio" />
-<Word from="voleće" to="voljet će" />
-<Word from="voz" to="vlak" />              <Word from="Voz" to="Vlak" /> 
-<Word from="vjetru" to="vetru" />
-<Word from="vratiće" to="vratit će" />
-<Word from="vređanje" to="vrijeđanje" />  	<Word from="vređa" to="vrijeđa" />
-<Word from="whiskey" to="viski" />
-<Word from="zamena" to="zamjena" />
-<Word from="zamnom" to="za mnom" />
-<Word from="zanm" to="znam" />
-<Word from="zanma" to="zanima" />
-<Word from="zaspem" to="zaspim" />
-<Word from="zauvek" to="zauvijek" />
-<Word from="za uvijek" to="zauvijek" />
-<Word from="zavredili" to="zavrijedili" />
-<Word from="zdrvo" to="zdravo" />
-<Word from="Zdrvo" to="Zdravo" />
-<Word from="zvaničan" to="služben" />
-<Word from="zver" to="zvijer" />                <Word from="zvjer" to="zvijer" />
-<Word from="zveri" to="zvijeri" />              <Word from="zvjeri" to="zvijeri" />
-<Word from="želela" to="željela" />
-<Word from="želeo" to="želio" />                <Word from="Želeo" to="Želio" />
-<Word from="željeo" to="želio" />
-<Word from="želeli" to="željeli" />
-<Word from="živeo" to="živio" />
-
-<!-- NISU ZA REGEX!!! osim ako netko zna bolje, naravno :) -->
-<Word from="bićemo" to="bit ćemo" />        <Word from="Bićemo" to="Bit ćemo" />
-<Word from="bićete" to="bit ćete" />        <Word from="Bićete" to="Bit ćete" />
-<Word from="bićeš" to="bit ćeš" />          <Word from="Bićeš"  to="Bit ćeš" />
-<Word from="definiše" to="definira" />      <Word from="definišem" to="definiram" />                    
-<Word from="definiši" to="definiraj" />     <Word from="definišu" to="definiraju" />  
-<Word from="eksperimentišem" to="eksperimentiram" />     <Word from="eksperimentišu" to="eksperimentiraju" />  
-<Word from="eksperimentišeš" to="eksperimentiraš" />     <Word from="eksperimentišete" to="eksperimentirate" />           
-<Word from="eksperimentiše" to="eksperimentira" />       <Word from="eksperimentišemo" to="eksperimentiramo" />           
-<Word from="historija" to="povijest" /> 	<Word from="historije" to="povijesti" />
-<Word from="historiji" to="povijesti" /> 	<Word from="istoriji" to="povijesti" />
-<Word from="historiju" to="povijest" /> 	<Word from="istorija" to="povijest" />   <Word from="Istorija" to="Povijest" />
-<Word from="istorije" to="povijesti" /> 	<Word from="istoriju" to="povijest" />
-<Word from="interesujem" to="zanimam" /> 	<Word from="interesuješ" to="zanimaš" />
-<Word from="interesuje" to="zanima" />  	<Word from="Interesuje" to="Zanima" />
-<Word from="interesuju" to="zanimaju" />
-<Word from="interesovanje" to="zanimanje" />
-<Word from="izvini" to="oprosti" />    	    <Word from="Izvini" to="Oprosti" />        
-<Word from="izvinite" to="oprostite" />     <Word from="Izvinite" to="Oprostite" />     
-<Word from="izvinjavam" to="ispričavam" />  <Word from="Izvinjavam" to="Ispričavam" />
-<Word from="kola" to="auto" />              <Word from="kolima" to="autom" />
-<Word from="komšija" to="susjed" />  	    <Word from="komšiji" to="susjedu" />
-<Word from="komšiluk" to="susjedstvo" />  	<Word from="komšiluku" to="susjedstvu" />
-<Word from="komšije" to="susjedi" />        <Word from="komšijama" to="susjedima" /> 
-<Word from="komšijski" to="susjedni" />     <Word from="komšijskog" to="susjednog" />
-<Word from="kontrolišem" to="kontroliram" />    <Word from="kontrolišeš" to="kontroliraš" />
-<Word from="kontrolišemo" to="kontroliramo" /> 	<Word from="kontrolišete" to="kontrolirate" /> 
-<Word from="kontrolišu" to="kontroliraju" />	<Word from="kontrolisati" to="kontrolirati" />
-<Word from="izgladneo" to="izgladnio" />
-<Word from="odeljenje" to="odjel" />
-<Word from="odeljenjem" to="odjelom" />
-<Word from="ogladneo" to="ogladnio" />
-<Word from="obezbeđujem" to="osiguravam" />      <Word from="obezbeđuješ" to="osiguravaš" />
-<Word from="obezbeđuje" to="osigurava" />        <Word from="obezbeđujemo" to="osiguravamo" />
-<Word from="obezbeđuju" to="osiguravaju" /> 
-<Word from="oblast" to="područje" />        <Word from="oblastima" to="područjima" />
-<Word from="oblasti" to="područj " /><!--ostaje ovako jer je prijevod u raznim padežima različit-->                      
-<Word from="prićaću" to="pričat ću" />      <Word from="Prićaću" to="Pričat ću" />
-<Word from="prićaćeš" to="pričat ćeš" />    <Word from="Prićaćeš" to="Pričat ćeš" />
-<Word from="prićaćemo" to="pričat ćemo" />  <Word from="Prićaćemo" to="Pričat ćemo" />
-<Word from="pomera" to="miče" />         	<Word from="pomeraj" to="miči" />
-<Word from="pomjeraj" to="miči" />          <Word from="pomeraju" to="miču" /> 
-<Word from="pomeri" to="pomakni" />         <Word from="Pomeri" to="Pomakni" /> 
-<Word from="pomeriš" to="pomakneš" />  	
-<Word from="pomerati" to="micati" />
-<Word from="poneo" to="ponio" />             
-<Word from="porodica" to="obitelj" /> 
-<Word from="porodice" to="obitelji" />
-<Word from="porodici" to="obitelji" />
-<Word from="porodicu" to="obitelj" />
-<Word from="porodični" to="obiteljski" />
-<Word from="porodičnu" to="obiteljsku" />
-<Word from="porodičnog" to="obiteljskog" />
-<Word from="postaćeš" to="postat ćeš" />    <Word from="Postaćeš" to="Postat ćeš" />
-<Word from="postačeš" to="postat ćeš" />    <Word from="Postačeš" to="Postat ćeš" />
-<Word from="postaramo" to="pobrinemo" />
-<Word from="postaraj" to="pobrini" />
-<Word from="postaraju" to="pobrinu" />
-<Word from="postarajmo" to="pobrinimo" />
-<Word from="postara" to="pobrine" />
-<Word from="postaraš" to="pobrineš" />
-<Word from="povinujem" to="pokoravam" />    <Word from="povinuje" to="pokorava" />
-<Word from="povinujete" to="pokoravate" />  <Word from="povinuju" to="pokoravaju" />
-<Word from="procenat" to="postotak" />    	<Word from="procenata" to="postotaka" />
-<Word from="procentu" to="postotku" />	    <Word from="procenti" to="postoci" />
-<Word from="procentima" to="postocima" />
-<Word from="razumela" to="razumjela" />  <Word from="razumeli" to="razumjeli" />
-<Word from="razumijeo" to="razumio" />   <Word from="Razumijeo" to="Razumio" />
-<Word from="razumjeo" to="razumio" />    <Word from="Razumjeo" to="Razumio" />  <Word from="Razumeo" to="Razumio" />
-<Word from="razumeću" to="razumjet ću" />
-<Word from="sistem" to="sustav" /> <Word from="sistemi" to="sustavi" /> <Word from="sistemu" to="sustavu" />
-<Word from="sistemima" to="sustavima" /> <Word from="sisteme" to="sustave" /> 
-<Word from="Sistem" to="Sustav" /> <Word from="Sistemi" to="Sustavi" /> <Word from="Sistemu" to="Sustavu" />
-<Word from="Sistemima" to="Sustavima" /> <Word from="Sisteme" to="Sustave" /> 
-<Word from="spreče" to="spriječe" />        <Word from="sprječe" to="spriječe" /> 
-<Word from="Spreče" to="Spriječe" />        <Word from="Sprječe" to="Spriječe" /> 
-<Word from="štampa" to="tisak" /> 			<Word from="štampu" to="tisak" /> 
-<Word from="štampom" to="tiskom" />         <Word from="štampi" to="tisku" />
-<Word from="štamparska" to="tiskovna" /> <Word from="štamparski" to="tiskovni" />
-<Word from="štampati" to="tiskati" />
-
-<Word from="tolerišem" to="toleriram" /> 
-<Word from="toleriše" to="tolerira" /> 	    <Word from="tolerišeš" to="toleriraš" />
-<Word from="tolerišu" to="toleriraju" />
-<Word from="video" to="vidio" /> 
-<Word from="Video" to="Vidio" /> 
-<Word from="videćemo" to="vidjet ćemo" /> 
-<Word from="videćeš" to="vidjet ćeš" />
-<Word from="vratiću" to="vratit ću" />
-<Word from="vratiće" to="vratit će" />
-<Word from="vratit ćeš" to="vratit ćeš" />
-
-<!--pridjevi optimalan, minimalan i maksimalan nemaju komparativ i superlativ.-->
-<Word from="najoptimalnije" to="optimalno" /> <Word from="najoptimalnija" to="optimalna" /> 
-<Word from="najminimalniji" to="minimalni" /> <Word from="najminimalnija" to="minimalna" /> 
-<Word from="najmaksimalniji" to="maksimalan" /> <Word from="najmaksimalnija" to="maksimalna" /> 
-
-<!--sasvim rijetko se pojavljuje biće kao imenica, tako da  je ovo u korist češće riječi-->
-<Word from="biće" to="bit će" />  <Word from="Biće" to="Bit će" />
-<Word from="biću" to="bit ću" />  <Word from="Biće" to="Bit će" />
-
-<!--imena mjeseci -->
-<Word from="januar" to="siječanj" />   <Word from="januara" to="siječnja" />  <Word from="januaru" to="siječnju" />
-<Word from="februar" to="veljača" />   <Word from="februara" to="veljače" />  <Word from="februaru" to="veljači" />
-<Word from="mart" to="ožujak" />       <Word from="marta" to="ožujka" />      <Word from="martu" to="ožujku" />
-<Word from="april" to="travanj" />     <Word from="aprila" to="travnja" />    <Word from="aprilu" to="travnju" />
-<Word from="maj" to="svibanj" />       <Word from="maja" to="svibnja" />      <Word from="maju" to="svibnju" />
-<Word from="majem" to="svibnjem" />    <Word from="svibnjom" to="svibnjem" />
-<Word from="jun" to="lipanj" />        <Word from="junu" to="lipnju" />       <Word from="juna" to="lipnja" /> 
-<Word from="juli" to="srpanj" />       <Word from="jula" to="srpnja" />       <Word from="julu" to="srpnju" />
-<Word from="august" to="kolovoz" />    <Word from="augusta" to="kolovoza" />  <Word from="augustu" to="kolovozu" />
-<Word from="septembar" to="rujan" />   <Word from="septembra" to="rujna" />   <Word from="septembru" to="rujnu" />
-<Word from="oktobar" to="listopad" />  <Word from="oktobru" to="listopadu" />
-<Word from="novembar" to="studeni" />  <Word from="novembra" to="studenog" /> <Word from="novembru" to="studenom" />
-<Word from="decembar" to="prosinac" /> <Word from="decembra" to="prosinca" /> <Word from="decembru" to="prosincu" /> 
-<Word from="sreda" to="srijeda" />     <Word from="sredu" to="srijedu" />     <Word from="sredom" to="srijedom" />
-
-<!-- osobna imena i imena gradova/država itd.-->
-<Word from="Afghanistan" to="Afganistan" />
-<Word from="Bil " to="Bill" /> <!-- ne dirati razmak -->
-<Word from="Bruklin" to="Brooklyn" />           <Word from="Bruklinu" to="Brooklynu" />
-<Word from="Brajan" to="Brian" />
-<Word from="Braun" to="Brown" />
-<Word from="Brussels" to="Bruxelles" />
-<Word from="California" to="Kalifornija" /> <Word from="Californija" to="Kalifornija" />
-<Word from="Californii" to="Kaliforniji" /> <Word from="Californiji" to="Kaliforniji" /> 
-<Word from="Californiu" to="Kaliforniju" /> <Word from="Californiju" to="Kaliforniju" />
-<Word from="Džakobi" to="Jacobi" />
-<Word from="Džejn" to="Jane" />
-<Word from="Džejms" to="James" />
-<Word from="Džes" to="Jess" />
-<Word from="Džesika" to="Jessica" />
-<Word from="Džim" to="Jim" />
-<Word from="Džime" to="Jime" />
-<Word from="Džon" to="John" />
-<Word from="Džoni" to="Johnny" />
-<Word from="Džonson" to="Johnson" />
-<Word from="Ejmi" to="Amy" />
-<Word from="Endi" to="Andy" />
-<Word from="Filadelfija" to="Philadelphia" /> 	
-<Word from="Filadelfiju" to="Philadelphiju" /> 	<Word from="Filadelfiji" to="Philadelphiji" />
-<Word from="Holivud" to="Hollywood" />
-<Word from="Holivuda" to="Hollywooda" />		<Word from="Holivudu" to="Hollywoodu" />
-<Word from="Hitrou" to="Heathrow" />
-<Word from="Iraq" to="Irak" /> 					<Word from="in Iraq" to="u Iraku" />
-<Word from="Lusi" to="Lucy" />
-<Word from="Mexico" to="Meksiko" /> 			<Word from="in Mexico" to="u Meksiku" />
-<Word from="Mocart" to="Mozart" />
-<Word from="Nensi" to="Nancy" />
-<Word from="Pol" to="Paul" />
-<Word from="Rajan" to="Ryan" />
-<Word from="Ričard" to="Richard" />
-<Word from="Ričmond" to="Richmond" />
-<Word from="Sajmon" to="Simon" />
-<Word from="Stiv" to="Steve" />
-<Word from="Stiven" to="Stephen" />
-<Word from="Sančez" to="Sanchez" />
-<Word from="Vinsent" to="Vincent" />
-<Word from="Švajcarska" to="Švicarska" />       <Word from="Švajcarskoj" to="Švicarskoj" />
-<Word from="Holandija" to="Nizozemska" />       <Word from="Holandijom" to="Nizozemskom" /> 
-<Word from="Holandiju" to="Nizozemsku" />       <Word from="Holandiji" to="Nizozemskoj" /> 
-<Word from="Losanđeles" to="Los Angeles" />     <Word from="Losanđelesu" to="Los Angelesu" />
-<Word from="Los Anđeles" to="Los Angeles" />	<Word from="Los Anđelesu" to="Los Angelesu" />
-<Word from="Los Anđelesom" to="Los Angelesom" />
-<Word from="Njujork" to="New York" />        
-<Word from="Njujorka" to="New Yorka" />         <Word from="Njujorku" to="New Yorku" />
-
-</WholeWords>
-<PartialWords/>
-<PartialLines>
-<LinePart from="Dobro veče" to="Dobra večer" />
-<LinePart from="Dobro večer" to="Dobra večer" />
-<LinePart from="Dobar večer" to="Dobra večer" />
-<LinePart from="gdje ideš" to="kamo ideš" />      <LinePart from="Gdje ideš" to="Kamo ideš" />
-<LinePart from="moje saučešće" to="moja sućut" /> 
-<LinePart from="Moram da idem" to="Moram ići" />  <LinePart from="moraš da ideš" to="moraš ići" />
-<LinePart from="na večer" to="navečer" /> 		  <LinePart from="Na večer" to="Navečer" />
-<LinePart from="Ne mogu da verujem" to="Ne mogu vjerovati" />
-<LinePart from="od kako" to="otkako" /> 
-<LinePart from="tamo je natrag" to="tamo je iza" /> <LinePart from="Tamo je natrag" to="Tamo je iza" />
-</PartialLines>
-<BeginLines />
-<EndLines />
-<WholeLines />
-<RegularExpressions>
-<!--  deklinacije imenica i konjugacije glagola -->  
-<RegEx find="(jeda|dva|tri|četr|pet|šes|sedam|osam|devet)(najst)(a|e|i|o|u|im|om|og|oj|ima)*" replaceWith="$1naest$3"/>
-<RegEx find="([aA])(bsorbira)(m|š|mo|te|ju|li|le|la|lo|ti|jući)*" replaceWith="$1psorbira$3"/>
-<RegEx find="([aA])(bstraktn)(a|e|i|o|u|oj|om|og|im|ima)*" replaceWith="$1pstraktn$3"/>
-<RegEx find="\b(advokat)(a|e|u)*" replaceWith="odvjetnik$2"/> <RegEx find="\b(advokat)(i|ima)" replaceWith="odvjetnic$2"/>
-<RegEx find="(akcion)(i|a|e|u)" replaceWith="akcijsk$2"/>
-<RegEx find="(aktuel)(an|ni|na|ne|no|nom|nu|nim|nima)" replaceWith="aktual$2"/>
-<RegEx find="(Alas)(ka|ku|ki|ci)" replaceWith="Aljas$2"/>
-<RegEx find="(asvalt)(a|u|om|ira|irati|iranje|iran|iranog|irano|iranu|iranoj|iranom|na|ni|noj|nom)*" replaceWith="asfalt$2"/>
-<RegEx find="(avijon)(i|a|e|u|ima)" replaceWith="avion$2"/>
-<RegEx find="(bezbed)(an|na|no|ni|nima|nu|ne|nog|nom|noj)" replaceWith="sigur$2"/>
-<RegEx find="(bezbedno)(st|stima|šću|snu|snog|snom|sni)*" replaceWith="sigurno$2"/>
-<RegEx find="(bakcil)(i|a|e|u|ima)*" replaceWith="bacil$2"/>
-<RegEx find="(biro)\b(a|i|u|om|ima)*" replaceWith="ured$2"/>
-<RegEx find="([bB])(elešk)(a|e|u|om|ama)*" replaceWith="$1ilješk$3"/>
-<RegEx find="([bB])(esn)(i|o|u|om|og|om|oj)" replaceWith="$1ijesn$3"/>
-<RegEx find="([bB])(eznadež)(an|na|no|nom|noj|nim|nima)" replaceWith="$1eznad$3"/>
-<RegEx find="([bB])(ež)(i|imo|e|ao|ala|ali|anje|anjem|anju)" replaceWith="$1jež$3"/>
-<RegEx find="([bB])(ijež)(i|imo|e|ao|ala|ali)" replaceWith="$1jež$3"/>
-<RegEx find="([bB])(ožiji)(a|i|u|om|ima)*" replaceWith="$1ožji$3"/>
-<RegEx find="(Božićn)(a|e|i|o|u|om|im)*" replaceWith="božićn$2"/> 
-<RegEx find="(Božičn)(a|e|i|o|u|om|im)*" replaceWith="božićn$2"/>
-<RegEx find="(Hrist)(a|e|u|om)*" replaceWith="Krist$2"/>
-<RegEx find="\b([cC])(en)(a|e|i|o|u|om|ama|iti|ila|ilo|io|im|iš|imo|ite|iše)" replaceWith="$1ijen$3"/>
-<RegEx find="([cC])(enjen)(a|e|i|im|ima|o|u|om|oj)*" replaceWith="$1ijenjen$3"/>
-<RegEx find="([cC])(jenjen)(a|e|i|im|ima|o|u|om|oj)*" replaceWith="$1ijenjen$3"/>
-<RegEx find="(čas)(a|u|om|ovi|ovima|ove|ova)" replaceWith="sat$2"/>
-<RegEx find="([čČ])(ove)(k|ka|ku|kom|kove|če|čanstvo|čanstva|čanstvu|čanstvom|čni|čna|čno)" replaceWith="$1ovje$3"/>
-<RegEx find="([čČ])(ovije)(k|ka|ku|kom|kov|kovog|kovoj|kovom|če|čanstva|čanstvu|čanstvom|čni|čna|čno)" replaceWith="$1ovje$3"/>
-<RegEx find="([bB])(ekstv)(a|u|om)" replaceWith="$1bijeg$3"/>
-<RegEx find="(bioskop)(a|u|om)" replaceWith="kin$2"/>
-<RegEx find="\b([cC])(el)(a|e|i|o|u|og|om|oj|ima|og|osti)\b" replaceWith="$1ijel$3"/>
-<RegEx find="\b([cC])(jel)(a|e|i|o|u|om|oj|ima|og|osti)\b" replaceWith="$1ijel$3"/>
-<RegEx find="(ćut)(im|iš|i|imo|ite|e)" replaceWith="šut$2"/>   <RegEx find="(Ćut)(im|iš|i|imo|ite|e)" replaceWith="Šut$2"/>
-<RegEx find="(del)(ić|ića|iće|ićem|ići|ićima)" replaceWith="djel$2"/>
-<RegEx find="([dD])(eli)\b(m|š|mo|te|li|le|la|ti)" replaceWith="$1ijel$3"/> 
-<RegEx find="([dD])(jeli)\b(m|š|mo|te|li|le|la|ti)" replaceWith="$1ijel$3"/>
-<RegEx find="(delikvent)(a|e|i|u|ima|om|na|no|ni|nim|nom|noj|ica|ici
-	   |icu|ice|cija|ciji|ciju|cije|cijama)*" replaceWith="delinkvent$2"/>
-<RegEx find="([dD])(eluje)(m|š|mo|te|mo)*" replaceWith="$1jeluje$3"/>
-<RegEx find="([dD])(ete)(tom|tov|tovog|tovu|tove)" replaceWith="$1jete$3"/>
-<RegEx find="([dD])(ec)(a|i|o|u|e|om)*" replaceWith="$1jec$3"/>
-<RegEx find="([dD])(efinisan)(a|i|o|u|e|om|og)*" replaceWith="$1efiniran$3"/>
-<RegEx find="\b([dD])(elov)(a|e|i|ima)" replaceWith="$1ijelov$3"/>
-<RegEx find="([dD])(evoj)(ka|ke|ki|ko|ku|kom|kama|ci|čica|čice|čici|činu|čine)" replaceWith="$1jevoj$3"/>
-<RegEx find="([dD])(eča)(ka|ku|ke|kom|ci|cima)" replaceWith="$1ječa$3"/>
-<RegEx find="([dD])(ijec)(a|i|o|u|e|om)" replaceWith="$1jec$3"/>
-<RegEx find="([dD])(ragocen)(a|i|o|u|e|om|og|oj|ima)" replaceWith="$1ragocjen$3"/>
-<RegEx find="([dD])(obija)(m|š|mo|te|ju|la|le|li|ti)*" replaceWith="$1obiva$3"/>
-<RegEx find="(dopada)(m|š|mo|te|ju|la|le|li|ti)*" replaceWith="sviđa$2"/>
-<RegEx find="(dosije)(a|e|i|u|ima)" replaceWith="dosje$2"/>
-<RegEx find="(dospe)(li|la|ti)" replaceWith="dospje$2"/>
-<RegEx find="(dospe)(m|š|e|mo|te)" replaceWith="dospije$2"/>
-<RegEx find="(dušek)(a|u|i|e|ima)*" replaceWith="madrac$2"/>
-<RegEx find="\b(đep)(a|u|ovi|ove|ova|ima|na|ne|ni|no|noj|nom|nima)*" replaceWith="džep$2"/>
-<RegEx find="(evrop)(ski|ska|sko|sku|skom)" replaceWith="europ$2"/>
-<RegEx find="(Evrop)(a|e|i|o|u|om)" replaceWith="Europ$2"/>
-<RegEx find="(farba)(m|š|mo|te|ju|li|še|nje)*" replaceWith="boja$2"/>
-<RegEx find="(fudbal)(a|u|om)*" replaceWith="nogomet$2"/>
-<RegEx find="([gG])(luv)(a|e|o|u|oj|om)*" replaceWith="$1luh$3"/>
-<RegEx find="\b([gG])(reh)(a|e|u|om)*" replaceWith="$1rijeh$3"/>
-<RegEx find="\b([gG])(rjeh)(a|e|u|om)*" replaceWith="$1rijeh$3"/>
-<RegEx find="\b([gG])(res)(i|ima)" replaceWith="$1rijes$3"/>
-<RegEx find="([gG])(rejanj)(e|u|a|em|ima)" replaceWith="$1rijanj$3" />
-<RegEx find="([gG])(reši)(o|m|š|mo|te|la|li|ti)" replaceWith="$1riješi$3"/>
-<RegEx find="([gG])(rješi)(o|m|š|mo|te|la|li|ti)" replaceWith="$1riješi$3"/>
-<RegEx find="(haos)(a|i|e|u|ima|na|no|ni|om)*" replaceWith="kaos$2"/>
-<RegEx find="(Holand)(ska|sku|skom|skoj)" replaceWith="Nizozems$3"/>
-	    <RegEx find="(Nizuzem)(ska|sku|skom|skoj)" replaceWith="Nizozems$3"/>
-<RegEx find="(historijsk)(e|i|a|o|u|om|oj)" replaceWith="povijesn$2"/> 
-<RegEx find="(Historijsk)(e|i|a|o|u|om|oj)" replaceWith="Povijesn$2"/>
-  	   <RegEx find="(istorijsk)(e|i|a|o|u|om|oj)*" replaceWith="povijesn$2"/>
-  	   <RegEx find="(Istorijsk)(e|i|a|o|u|om|oj)*" replaceWith="Povijesn$2"/>
-<RegEx find="(hiljad)(a|e|i|u|om|ama)" replaceWith="tisuć$2"/>
-<RegEx find="(hleb)(a|u|om)*" replaceWith="kruh$2"/>
-<RegEx find="([iI])(migracion)(a|i|u|e|om|og)*" replaceWith="$1migracijsk$3"/>
-       <RegEx find="(migracion)(a|i|u|e|om|og)*" replaceWith="migracijsk$2"/>
-<RegEx find="([iI])(nostranstv)(a|u|o|om|ima)" replaceWith="$1nozemstv$3"/>
-<RegEx find="(interesantn)(a|e|i|o|u|om)*" replaceWith="zanimljiv$2"/>
-<RegEx find="([iI])(spoljava)(m|š|mo|te|ju|li|nje)*" replaceWith="$1zražava$3"/>
-<RegEx find="([iI])(zbe)(ći|gava|gavaš|gavamo|gavate|gavaju|gavanje|gavali|gao|gla|gli|glo)" replaceWith="$1zbje$3"/>
-<RegEx find="([iIz])(bled)(ela|elo|ele|eli|io|elom|elima|jele)" replaceWith="$1blijedj$3"/>
-<RegEx find="([iI])(sčeznu)(o|la|le|li|lu|lom|lima|lima|ti|uše|uvši)" replaceWith="$1ščeznu$3"/>
-<RegEx find="([iI])(sčezn)(em|eš|e|emo|ete|u)" replaceWith="$1ščezn$3"/>
-<RegEx find="([iI])(skorišć)(en|ena|eni|enu|enoj|enom|enima|avam|avaš|ava|avamo|avate|avaju|avajte)" replaceWith="$1skorišt$3"/>
-<RegEx find="([iI])(zmen)(a|e|i|u|om|ama)" replaceWith="$1zmjen$3"/>
-<RegEx find="(ispresecan)(a|e|i|u|om)*" replaceWith="ispresijecan$2"/>
-<RegEx find="([iI])(zgladne)(la|le|li|lo|lu|lima|lom)" replaceWith="$1zgladnje$3"/>
-<RegEx find="([iI])(zvešta)(j|ji|ja|je|ju|vam|vaš|va|vamo|vate|vaju|vanje)*" replaceWith="$1zvješta$3"/>
-<RegEx find="\b([kK])(af)(a|e|i|u|om|ama|ana|ane|ani|anu|anom|anama|anska|anski|ansku|anskom)\b" replaceWith="$1av$3"/>
-<RegEx find="(kancelarij)(u|om)*" replaceWith="ured$2"/>
-<RegEx find="(kirij)(a|e|i|o|u|om)" replaceWith="stanarin$2"/>
-<RegEx find="([kK])(elner)(a|e|i|u|ima)*" replaceWith="$1onobar$3"/>
-<RegEx find="\b([kK])(olen)(a|o|u|ima)" replaceWith="$1oljen$3"/>
-<RegEx find="([kK])(ombinovanj)(e|a|u|em|ima)" replaceWith="$1ombiniranj$3"/>
-<RegEx find="(kompjuter)(a|e|i|u|om|ima)*" replaceWith="kompjutor$2"/>
-<RegEx find="(konkurs)(a|e|i|u|om|ima)*" replaceWith="natječaj$2"/>
-<RegEx find="(konkuris)(ati|ali|ale|alo)" replaceWith="konkurir$2"/>
-<RegEx find="(kontrolisan)(o|i|a|oj|om|ima)*" replaceWith="kontroliran$2"/>
-<RegEx find="(nekontrolisan)(o|i|a|oj|om|ima)*" replaceWith="nekontroliran$2"/>
-<RegEx find="([kK])(orišćenj)(a|e|u|em|ima)*" replaceWith="$1orištenj$3"/>
-<RegEx find="([kK])(oriščenj)(a|e|u|em|ima)*" replaceWith="$1orištenj$3"/>
-<RegEx find="([kK])(učk)(a|e|i|o|u|om)*" replaceWith="$1uj$3"/>
-<RegEx find="([kK])(uvan)(a|e|i|o|u|ima|og|om|oj|im)*" replaceWith="$1uhan$3"/>
-<RegEx find="([kK])(uvar)(a|e|i|u|ima)*" replaceWith="$1uhar$3"/>
-<RegEx find="\b(krst)(a|u|em)*" replaceWith="križ$2"/>
-<RegEx find="([lL])(eči)(o|la|le|li|ti|še)*" replaceWith="$1iječi$3"/>
-<RegEx find="([lL])(ječi)(o|la|le|li|ti|še)*" replaceWith="$1iječi$3"/>
-<RegEx find="([lL])(ečni)(k|ka|ku|ca|cu|ci|ce|cima|cama)*" replaceWith="$1iječni$3"/>
-<RegEx find="([lL])(ječni)(k|ka|ku|ca|cu|ci|ce|cima|cama)*" replaceWith="$1iječni$3"/>
-<RegEx find="([lL])(ekar)(a|e|u|om)*" replaceWith="$1iječnik$3"/>
-<RegEx find="\b(len)(a|e|i|o|u|om|ima|čina|čino|čine)" replaceWith="lijen$2"/>
-<RegEx find="\b(Len)(a|e|i|o|u|om|ima|čina|čino|čine)" replaceWith="Lijen$2"/>
-<RegEx find="([lL])(ep)(a|i|o|u|e|im|om|ima|og|om)*\b" replaceWith="$1ijep$3"/>
-<RegEx find="\b(lev)(a|i|o|u|om|oj|ima)" replaceWith="lijev$2"/>
-<RegEx find="\b(ličn)(a|e|i|o|u|im|om|oj)*" replaceWith="osobn$2"/>
-<RegEx find="\b(Ličn)(a|e|i|o|u|im|om|oj)*" replaceWith="Osobn$2"/>
-<RegEx find="(lobanj)(a|e|i|u|om|aima)*" replaceWith="lubanj$2"/>
-<RegEx find="(Lobanj)(a|e|i|u|om|aima)*" replaceWith="Lubanj$2"/>
-<RegEx find="\b(ljep)(a|e|i|o|u|om|oj|ima)\b" replaceWith="lijep$2"/>
-<RegEx find="\b(Ljep)(a|e|i|o|u|om|oj|ima)\b" replaceWith="Lijep$2"/>
-<RegEx find="([mM])(esec)(a|e|i|u|om|ima)*" replaceWith="$1jesec$3"/>
-<RegEx find="(meša)(m|n|ni|na|no|nom|noj|nima|š|mo|te|ju|njem|nju|li|lica|licu|lici|lice|licama|ti)" replaceWith="miješa$2"/>
-<RegEx find="(mješa)(m|n|ni|na|no|nom|noj|nima|š|mo|te|ju|njem|nju|li|ti)" replaceWith="miješa$2"/>
-<RegEx find="([mM])(edve)(da|de|di|du|dom|dima|đa|đu|đom|đoj|đi|đeg)" replaceWith="$1edvje$3"/>
-<RegEx find="([mM])(enja)(m|š|mo|te|ju|li|ti)" replaceWith="$1ijenja$3"/>
-<RegEx find="([mM])(jenja)(m|š|mo|te|ju|li|ti)*" replaceWith="$1ijenja$3"/>
-<RegEx find="([mM])(est)(a|o|u|om|ima)" replaceWith="$1jest$3"/>
-<RegEx find="([mM])(jenja)(m|š|mo|te|ju|li)*" replaceWith="$1ijenja$3"/>
-<RegEx find="([mM])(lek)(a|o|u|om)" replaceWith="$1lijek$3"/> <RegEx find="([mM])(ljek)(a|o|u|om)" replaceWith="$1lijek$3"/>
-<RegEx find="([mM])(oč)(i|u|ni|nim|noj)" replaceWith="$1oć$3"/>
-<RegEx find="([mM])(ogučnost)(i|ima)*" replaceWith="$1ogućnost$3"/>
-<RegEx find="([mM])(uva)(o|j|š|mo|te|ju|vši|li|ti|lo|la|le)" replaceWith="$1ota$3"/>
-<RegEx find="(muzik)(a|u|om)\b" replaceWith="glazb$2"/>
-<RegEx find="([nN])(amer)(a|e|i|u|om|na|no|noj|nom|nim)" replaceWith="$1amjer$3"/>
-<RegEx find="([nN])(ameni)(m|š|mo|o|te|ti|o|la|le|li|še)*" replaceWith="$1amijeni$3"/>
-<RegEx find="([nN])(amjeni)(m|š|mo|o|te|ti|o|la|le|li|še)*" replaceWith="$1amijeni$3"/>
-<RegEx find="([nN])(amesti)(m|š|mo|te|ti|o|la|le|li|še)*" replaceWith="$1amjesti$3"/>
-<RegEx find="([nN])(arandž)(a|e|i|u|om|ama)" replaceWith="$aranč$3"/> 
-<RegEx find="([nN])(aranđ)(a|e|i|u|om|ama)" replaceWith="$aranč$3"/>
-<RegEx find="([nN])(asljeđ)(a|e|i|u|em|ima)" replaceWith="$1aslijeđ$3"/>
-<RegEx find="([nN])(asmej)(em|eš|e|emo|ete|u|ani|ane|anima|anoj|anom
-|ano|ava|avaš|an|ana|anu|anog|alo|ala|ao)" replaceWith="$1asmij$3"/>
-<RegEx find="([nN])(ečove)(k|ka|ku|kom|kove|če|čanstvo|čanstva|čanstvu|čanstvom|čni|čna|čno)" replaceWith="$1ečovje$3"/>
-<RegEx find="(nedelj)(a)*" replaceWith="nedjelj$2"/>
-<RegEx find="([nN])(eprijatn)(a|e|i|u|om|no|noj|nom|nim)*" replaceWith="$1eugodn$3"/>
-<RegEx find="([nN])(eprimet)(an|na|no|ne|ljiv|ljiva|ljivo|ljivost|ljivošću|ljivosti|nost)" replaceWith="$1eprimjet$3"/>
-<RegEx find="([nN])(epobediv)(a|o|om|oj|e|i|u|ost|ošću|osti)" replaceWith="$1epobjediv$3"/>
-<RegEx find="(nevaspitan)(a|e|i|o|u|oj|om|im|ima|je|ju|jem)" replaceWith="neobrazovan$2"/>
-<RegEx find="(nevaspitan)(a|e|i|o|u|oj|om|im|ima|je|ju|jem)" replaceWith="Neobrazovan$2"/>
-<RegEx find="([nN])(everojat)(an|na|ne|ni|no|nom|nog|nu|noj|nim)*" replaceWith="$1evjerojat$3"/> <!-- vrijedi i za vjerojatno-->
-<RegEx find="([nN])(everovat)(an|na|ne|ni|no|nom|nog|nu|noj|nim)*" replaceWith="$1evjerojat$3"/> <!-- -||- -->
-<RegEx find="([nN])(esreć)(an|na|ni|nik|nika|nikom|nica|nicu|nicom|no|nom|noj|niji|nijeg|nijem|nija|niju|nijom|nijoj)" replaceWith="$1esret$3"/>
-<RegEx find="(nesmij)(em|eš|e|emo|ete|u)*" replaceWith="ne smij$2"/>
-<RegEx find="([nN])(ežn)(a|e|i|u|om|og|oj|ima|iji|ije|ija)" replaceWith="$1ježn$3"/>
-<RegEx find="([nN])(oč)(i|u|ni|na|noj|nim)*" replaceWith="$1oć$3"/>
-<RegEx find="(naučn)(i|a|o|og|u|oj|om|ik|im|ici)*" replaceWith="znanstven$2"/>
-<RegEx find="([oO])(bavest)(io|ila|ile|ili|iti|iše)*" replaceWith="$1bavijest$3"/>
-<RegEx find="([oO])(bavjest)(io|ila|ile|ili|iti|iše)*" replaceWith="$1bavijest$3"/>
-<RegEx find="(obezbeđenj)(a|e|u|ima)" replaceWith="osiguranj$2"/>
-<RegEx find="([oO])(brača)(m|o|š|mo|te|ju|jući|vši|la|le|li|lo|ti)*" replaceWith="$1braća$3"/>
-<RegEx find="\b(odeć)(a|u|i|om)" replaceWith="odjeć$2"/>
-<RegEx find="([oO])(deljenj)(a|u)" replaceWith="$1djel$3"/>
-<RegEx find="([oO])(dgaji)(la|le|li|še)*" replaceWith="$1dgoji$3"/>
-<RegEx find="([oO])(gladne)(la|le|li|lo|lu|lima|lom)" replaceWith="$1gladnje$3"/>
-<RegEx find="([oO])(kean)(a|e|i|u|ima)*" replaceWith="$1cean$3"/>
-<RegEx find="([oO])(psednut)(a|e|i|u|om|im|ima)*" replaceWith="$1psjednut$3"/>
-<RegEx find="([oO])(pšt)(a|e|i|u|em|om|im)" replaceWith="$1pć$3"/>
-<RegEx find="([oO])(rganizuje)(m|mo|š|te)*" replaceWith="$1rganizira$3"/>
-<RegEx find="([oO])(rganizov)(an|ana|ano|ani|anom|anoj|anima|anim)" replaceWith="$1rganizir$3"/>
-<RegEx find="([oO])(seti)(o|m|š|la|li|le|ti)" replaceWith="$1sjeti$3"/>
-<RegEx find="([oO])(setljiv)(a|i|e|o|om|im|ima|oj)*" replaceWith="$1sjetljiv$3"/>
-<RegEx find="([oO])(seća)(m|š|mo|te|ju|j|ja|ji|je|jem|ju|jima)*" replaceWith="$1sjeća$3"/>
-<RegEx find="([oO])(strv)(a|u|om|ima)" replaceWith="$1tok$3"/>
-<RegEx find="\b([oO])(ter)(a|am|amo|ate|aju)" replaceWith="$1tjer$3"/>
-<RegEx find="([oO])(zled)(a|e|i|u|om|ama)" replaceWith="$1zljed$3"/>
-<RegEx find="([oO])(zlijed)\b(a|e|i|u|om|ama)" replaceWith="$1zljed$3"/>
-<RegEx find="([oO])(zledi)(m|š|mo|te|ti|o|la|lo|še)*" replaceWith="$1zlijedi$3"/>
-<RegEx find="([oO])(zleđen)(a|am|amo|ate|aju|om|oj|ima)" replaceWith="$1zlijeđen$3"/>
-<RegEx find="([oO])(zljeđen)(a|am|amo|ate|aju|om|oj|ima)" replaceWith="$1zlijeđen$3"/>
-<RegEx find="(pacov)(a|i|u|om|ima)*" replaceWith="štakor$2"/>
-<RegEx find="([pP])(eva)(č|m|š|mo|te|ju|li|čica|či|čice)*" replaceWith="$1jeva$3"/>
-<RegEx find="([pP])(esm)(a|e|i|o|u|om)" replaceWith="$1jesm$3"/>  
-<RegEx find="([pP])(eša)(k|ka|ku|kom|kinja|kinjom|cima|čim|čiš|čimo|čite|če|čili)" replaceWith="$1ješa$3"/>
-<RegEx find="(peškir)(a|e|i|u|om)*" replaceWith="ručnik$2"/>
-<RegEx find="([pP])(obed)(a|e|i|o|u|om|ama|nik|nika|niku|nica|nici|nicu)" replaceWith="$1objed$3"/>
-<RegEx find="([pP])(odstica)(j|ja|ju|ti|jima|je|li|še)" replaceWith="$1otic$3"/>
-<RegEx find="([pP])(odstič)(em|eš|e|emo|ete|u)" replaceWith="$1otič$3"/>
-<RegEx find="([pP])(otcenjen)(a|e|i|o|u|om|oj|om|ima)*" replaceWith="$1odcijenjen$3"/>
-<RegEx find="([pP])(ridik)(a|e|i|o|u|om|ama)" replaceWith="$1rodik$3"/>
-<RegEx find="([pP])(roleć)(a|e|u|em|ima)*" replaceWith="$1roljeć$3"/>
-<RegEx find="([pP])(oseduj)(e|em|eš|emo|ete|u)" replaceWith="$1osjeduj$3"/>
-<RegEx find="([pP])(oseti)\b(o|m|š|la|li|le|lo|ti)*" replaceWith="$1osjeti$3"/>
-<RegEx find="([pP])(odseti)(o|m|š|la|li|le|lo|ti)*" replaceWith="$1odsjeti$3"/>
-    <RegEx find="([pP])(otseti)(o|m|š|la|li|le|lo|ti)*" replaceWith="$1odsjeti$3"/>
-    <RegEx find="([pP])(otsjeti)(o|m|š|la|li|le|lo|ti)*" replaceWith="$1odsjeti$3"/>
-<RegEx find="([pP])(osledic)(a|e|i|o|u|om)" replaceWith="$1osljedic$3"/>
-<RegEx find="([pP])(oslednj)(a|e|i|u|em|oj|om|ima)" replaceWith="$1osljednj$3"/>
-<RegEx find="([pP])(osed)(a|e|i|o|u|om)" replaceWith="$1osjed$3"/>
-<RegEx find="([pP])(osmatra)(č|j|m|š|mo|te|ju|či|ču|ča|če|čice)*" replaceWith="$1romatra$3"/>
-<RegEx find="([pP])(oter)(a|e|i|u|om|ama|aš|amo|ate|aju|nica|nicama|nicu|nice)*" replaceWith="$1otjer$3"/>
-<RegEx find="([pP])(ovred)(io|ila|ili|ile|iti|iše|ilo)" replaceWith="$1ovrijed$3"/>
-<RegEx find="([pP])(ovrjed)(io|ila|ili|ile|iti)" replaceWith="$1ovrijed$3"/>
-<RegEx find="([pP])(ovređen)(a|am|amo|ate|aju|om|oj|ima)" replaceWith="$1ovrijeđen$3"/>
-<RegEx find="([pP])(ovređen)(a|am|amo|ate|aju|om|oj|ima)" replaceWith="$1ovrijeđen$3"/>
-<RegEx find="(pozorišt)(a|e|u|ima)*" replaceWith="kazališt$2"/>
-<RegEx find="([pP])(redlog)(a|u|om)*" replaceWith="$1rijedlog$3"/>     
-<RegEx find="([pP])(rjedlog)(a|u|om)*" replaceWith="$1rijedlog$3"/>
-<RegEx find="([pP])(redloz)(i|ima)" replaceWith="$1rijedloz$3"/>
-<RegEx find="([pP])(rjedloz)(i|ima)" replaceWith="$1rijedloz$3"/>
-<RegEx find="([pP])(restupnik)(a|u|om)*" replaceWith="$1rijestupnik$3"/>
-<RegEx find="([pP])(rjestupnik)(a|u|om)*" replaceWith="$1rijestupnik$3"/>
-<RegEx find="([pP])(reteriva)(o|la|lo|nje|nja|u|em|njima)*" replaceWith="$1retjeriva$3"/>
-<RegEx find="([pP])(rolet)(no|nom|na|noj|nim)*" replaceWith="$1ljet$3"/>
-<RegEx find="([pP])(rolet)(ele|ela|elim|elima)*" replaceWith="$1letj$3"/>
-<RegEx find="([pP])(romen)(a|e|i|u|om|ama)" replaceWith="$1romjen$3"/>
-<RegEx find="(promen)(im|iš|imo|ite|ili|ile)" replaceWith="promijen$2"/>
-<RegEx find="(promjen)(im|iš|imo|ite|ili|ile)" replaceWith="promijen$2"/>
-<RegEx find="([pP])(esnik)(a|u|ov|ovu|om)*" replaceWith="#1jesnik$3"/>
-<RegEx find="\b([pP])(obed)(a|i|e|u|o|om|ama)" replaceWith="$1objed$3"/>
-<RegEx find="\b([pP])(obed)(im|iš|i|imo|ite|e|iti|ili|ivši)" replaceWith="$1obijed$3"/>
-<RegEx find="([pP])(obeg)(ao|la|li|le|lo|avši)" replaceWith="$1objeg$3"/>
-<RegEx find="([pP])(oent)(a|e|u|i|o|om|ama)" replaceWith="$1oant$3"/>
-<RegEx find="([pP])(ogreš)(io|ila|ili)" replaceWith="$1ogriješ$3"/> 
-<RegEx find="([pP])(ogrješ)(io|ila|ili)" replaceWith="$1ogriješ$3"/>
-<RegEx find="([pP])(oslednj)(i|im|e|em|eg|ima)" replaceWith="$1osljed$3"/>  
-<RegEx find="(pomera)(m|š|mo|te)" replaceWith="miče$2"/>
-<RegEx find="([pP])(one)(la|le|li|lo|ti)" replaceWith="$1onije$3"/>
-<RegEx find="([pP])(onje)(la|le|li|lo|ti)" replaceWith="$1onije$3"/>
-<RegEx find="([pP])(overenj)(e|a|u|em)" replaceWith="$1ovjerenj$3"/>
-<RegEx find="([pP])(overljiv)(a|e|i|o|u|ima|ima|om|og|oj)*" replaceWith="$1ovjerljiv$3"/>
-<RegEx find="([pP])(revoz)\b(a|u|om|ovi|ovima)*" replaceWith="$1rijevoz$3"/>
-<RegEx find="([pP])(retnj)(a|e|i|o|u|om|ama)*" replaceWith="$1rijetnj$3"/>
-<RegEx find="([pP])(rimećuj)(em|eš|e|emo|ete|u)" replaceWith="$1rimjećuj$3"/>
-<RegEx find="([pP])(rimijećuj)(em|eš|e|emo|ete|u)" replaceWith="$1rimjećuj$3"/>
-<RegEx find="([pP])(rimer)(ak|en|ena|eno|enog|enu|enim|ku|kom|ci|cima)*" replaceWith="$1rimjer$3"/>
-       <RegEx find="([nN])(eprimer)(en|ena|eno|enog|enu|enim)" replaceWith="$1rimjer$3"/>
-<RegEx find="\b([pP])(rimet)(an|na|no|ljiv|ljiva|ljivo|ljivost|ljivošću|ljivosti|nost)" replaceWith="$1rimjet$3"/>
-<RegEx find="\b([pP])(rimen)(a|e|i|o|u|om|jena|jene|jenoj|jenim|jiv|jiva|jivo|jivog|jivom|jivu)*" replaceWith="$1rimjen$3"/>
-<RegEx find="\b([pP])(rimeni)(m|š|imo|ite|ti|li|la|le|lo)" replaceWith="$1rimijeni$3"/>
-<RegEx find="\b([pP])(rimeti)(o|la|le|lo|li)*" replaceWith="$1rimijeti$3"/>
-<RegEx find="([pP])(rosečn)(a|e|i|o|u|om|oj|im|ima)*" replaceWith="$1rosječn$3"/>
-<RegEx find="([pP])(over)(im|iš|i|imo|ite|e|ili|ile|ilo|iše)" replaceWith="$1ovjer$3"/>
-<RegEx find="([pP])(rover)(a|e|i|o|u|om|im|ama|im|iš|i|imo|ite|iti|e|ili|ile|ilo|iše)" replaceWith="$1rovjer$3"/>
-<RegEx find="([pP])(rjedlo)(g|ga|ge|gu|gom|zi|zima)" replaceWith="$1rijedlo$3"/> 
-<RegEx find="([pP])(reti)(o|š|mo|te|la|li|lo|le)" replaceWith="$1rijeti$3"/>
-<RegEx find="([pP])(reter)(ao|am|aš|amo|ate|aju|ala|ali|alo|ale|ivanje|ivanja|ivali|ivale|ujem|uješ|uje|ujemo|ujete|uju)" replaceWith="$1retjer$3"/>
-<RegEx find="(prevazi)(đen|đeno|đena|ći|laženje|laženja|laženju|laženjem)" replaceWith="nadi$2"/>
-<RegEx find="([rR])(azmen)(a|e|u|i|ama)*" replaceWith="$1azmjen$3"/>
-<RegEx find="([rR])(azume)(m|š|mo|te|va)" replaceWith="$1azumije$3"/>
-<RegEx find="([rR])(ešava)(m|š|mo|te|ju|nje|li)*" replaceWith="$1ješava$3"/>
-<RegEx find="([rR])(ešenj)(e|em|u|a|ima)*" replaceWith="$1ješenj$3"/>
-<RegEx find="\b([rR])(eč)(i|ima)" replaceWith="$1iječ$3"/>
-<RegEx find="\b([rR])(eš)(io|ila|ili|ile|iti|im|iš|i|imo|ite|e)" replaceWith="$1iješ$3"/> 
-<RegEx find="\b([rR])(ješi)(o|la|li|le|ti|m|š|mo|te)" replaceWith="$1iješi$3"/> 
-<RegEx find="\b([rR])(eš)(avati|avala|avao|avali|avam|avaš|ava|avamo|avate|avaju|avanje)" replaceWith="$1ješ$3"/>
-<RegEx find="\b([rR])(iješ)(avati|avala|avao|avali|avam|avaš|ava|avamo|avate|avaju|avanje)" replaceWith="$1ješ$3"/> 
-<RegEx find="(sačeka)(j|te|š|mo|te|ju|li|še|te|jte)*" replaceWith="pričeka$2"/>
-<RegEx find="(Sačeka)(j|te|š|mo|te|ju|li|še|te|jte)*" replaceWith="Pričeka$2"/>
-<RegEx find="(saobraćaj)(na|nu|ni|nom|nima)*" replaceWith="promet$2"/>
-<RegEx find="(Saobraćaj)(na|nu|ni|nom|nima)*" replaceWith="Promet$2"/>
-<RegEx find="([sS])(aradni)(ka|ku|kom|ca|ce|ci|cu|co|cima|cama)" replaceWith="$1uradni$3"/>
-<RegEx find="([sS])(arađ)(ivam|ivaš|iva|ivamo|ivate|ivaju|ivati|ujem|uješ|uje|ujemo|ujete|uju|ujući|ujuća|ivanje|ivanjem)*" replaceWith="$1urađ$3"/>
-<RegEx find="([sS])(amoubistv)(a|o|u|om|ima)" replaceWith="$1amoubojstv$3"/>
-<RegEx find="\b([sS])(avet)(a|u|om|ima|nik|nica|nica|nicu|nici|nicima|nicama|nice|ovanje|ovanju)*" replaceWith="$1avjet$3"/>
-<RegEx find="([sS])(ažaleva)(m|š|mo|te|ju|ti|li|le|la|lo|jući|juća|juće|nje)" replaceWith="$1ažalijeva$3"/>
-<RegEx find="([sS])(ažaljeva)(m|š|mo|te|ju|ti|li|le|la|lo|jući|juća|juće|nje)" replaceWith="$1ažalijeva$3"/>
-<RegEx find="\b([sS])(edi)(m|š|i|imo|ite|e|eći|ili|ile|ilo|iše)" replaceWith="$1jedi$3"/>
-<RegEx find="\b(sme)(m|š|mo|te|šna|šne|šni|šno|šnom|šnoj|šnu)\b" replaceWith="smije$2"/>
-<RegEx find="\b(Sme)(m|š|mo|te|šna|šne|šni|šno|šnom|šnoj|šnu)\b" replaceWith="Smije$2"/>
-<RegEx find="\b([sS])(mej)(u|e|em|eš|emo|ete|anje|anju|ati|ali|ale|ao|ala|alo)" replaceWith="$1mij$3"/>
-<RegEx find="([sS])(pasava)(m|š|mo|te|ju|li|nje|nju|nja)*" replaceWith="$1pašava$3"/>
-<RegEx find="([sS])(prečava)(m|š|mo|te|ju|li|še|nje)*" replaceWith="$1prječava$3"/>
-<RegEx find="([sS])(priječava)(m|š|mo|te|ju|li|še)*" replaceWith="$1prječava$3"/>
-<RegEx find="([sS])(preči)(m|š|mo|te|li|še|o|la|li|le|lo|ti)*" replaceWith="$1priječi$3"/>
-<RegEx find="([sS])(prječi)(m|š|mo|te|li|še|o|la|li|le|lo|ti)*" replaceWith="$1priječi$3"/>
-<RegEx find="([sS])(umlja)(m|š|še|mo|te|ti|ju|jući|li|le|lo)*" replaceWith="$1umnja$3"/>
-<RegEx find="([sS])(eti)\b(t|o|m|š|la|li|le|ti)" replaceWith="$1jeti$3"/>
-<RegEx find="([sS])(ever)(a|u|om|ni|nom|ac)*" replaceWith="$1jever$3"/>
-<RegEx find="([sS])(eća)(m|š|mo|te|ju|li|nje)*" replaceWith="$1jeća$3"/>
-<RegEx find="(shvata)(m|š|mo|te|ju|li|ti|nje)" replaceWith="shvaća$2"/>
-<RegEx find="([sS])(led)(eće|ećeg|eća|eću|ećom|ećoj|ećem|eći|ećom|ećima|ećim|ećih)*" replaceWith="$1ljed$3"/>
-<RegEx find="([sS])(ljed)\b(a|e|i|u|om|im|iš|imo|ite|e|ili)" replaceWith="$1lijed$3"/>	
-	    <RegEx find="([rR])(edosljed)(a|e|u|om)" replaceWith="$1edoslijed$3"/>	
-<RegEx find="([sS])(meh)(a|u|om)*" replaceWith="$1mijeh$3"/>
-<RegEx find="([sS])(mešn)(a|e|i|o|u|om|oj|ima)*" replaceWith="$1miješn$3"/>
-<RegEx find="(sopstven)(a|e|i|o|u|om|oj|im|og|ima)*" replaceWith="vlastit$2"/>
-<RegEx find="(spakuje)(m|eš|mo|te)*" replaceWith="spakira$2"/>
-<RegEx find="([sS])(reč)(a|e|i|u|om|ama)" replaceWith="$1reć$3"/>
-<RegEx find="([sS])(reč)(an|na|ni|nik|nika|nikom|nica|nicu|nicom
-|no|nom|noj|niji|nijeg|nijem|nija|niju|nijom|nijoj)" replaceWith="$1ret$3"/>
-<RegEx find="([sS])(reć)(an|na|ni|nik|nika|nikom|nica|nicu|nicom
-|no|nom|noj|niji|nijeg|nijem|nija|niju|nijom|nijoj)" replaceWith="$1ret$3"/>
-<RegEx find="(stomak)(u|om)*" replaceWith="trbuh$2"/>  
-<RegEx find="(stomač)(na|ne|ni|no|nu|noj|nom|nima)" replaceWith="trbuš$2"/> 
-<RegEx find="\b([sS])(trel)(a|e|i|u|o|om|ac|cu|ci|cima|ama)" replaceWith="$1trijel$3"/>
-<RegEx find="\b([sS])(trjel)(a|e|i|u|o|om|ac|cu|ci|cima|ama)" replaceWith="$1trijel$3"/>
-<RegEx find="([sS])(used)(a|e|i|o|u|ama|ima|ski|skim|ima)*" replaceWith="$1usjed$3"/>
-<RegEx find="(suštin)(e|i|om)" replaceWith="biti"/> 
-<RegEx find="([sS])(vat)(am|aš|a|amo|ate|aju|ajući|ali|ale|alo|aše)" replaceWith="$1hvać$3"/>
-<RegEx find="([sS])(vedo)(k|ke|ka|ku|kom|ci|cima|kinja|kinju|kinji
-|čanstvo|čanstva|čili|čio|čila|čiti)" replaceWith="$1vjedo$3"/>
-<RegEx find="([sS])(vesn)(a|e|i|o|u|om|oj|ima|ost|ošću)" replaceWith="$1vjesn$3"/>
+﻿<OCRFixReplaceList>
+  <WholeWords>
+    <Word from="advokatski" to="odvjetnički" />
+    <Word from="aluminijum" to="aluminij" />
+    <Word from="Američki" to="američki" />
+    <Word from="bedni" to="bijedni" />
+    <Word from="bednog" to="bijednog" />
+    <Word from="bejah" to="bijah" />
+    <Word from="beleg" to="biljeg" />
+    <Word from="belešci" to="bilješci" />
+    <Word from="bezbjedna" to="sigurna" />
+    <Word from="bežati" to="bježati" />
+    <Word from="bićemo" to="bit ćemo" />
+    <Word from="bioskop" to="kino" />
+    <Word from="bitci" to="bitki" />
+    <Word from="blijeđi" to="bljeđi" />
+    <Word from="beg" to="bijeg" />
+    <Word from="begu" to="bijegu" />
+    <Word from="bekstvo" to="bijeg" />
+    <Word from="besan" to="bijesan" />
+    <Word from="beše" to="bješe" />
+    <Word from="bolesan" to="bolestan" />
+    <Word from="boleti" to="boljeti" />
+    <Word from="braon" to="smeđa" />
+    <Word from="bukvalni" to="doslovni" />
+    <Word from="bukvalno" to="doslovno" />
+    <Word from="bukvalnom" to="doslovnom" />
+    <Word from="ceo" to="cijeli" />
+    <Word from="cjeli" to="cijeli" />
+    <Word from="cena" to="cijena" />
+    <Word from="ceni" to="cijeni" />
+    <Word from="cjelog" to="cijelog" />
+    <Word from="čas " to="sat " />
+    <Word from="čemo" to="ćemo" />
+    <Word from="ču" to="ću" />
+    <Word from="češ" to="ćeš" />
+    <Word from="če" to="će" />
+    <Word from="ćale" to="tata" />
+    <Word from="ćorsokak" to="slijepa ulica" />
+    <Word from="ćorsokaku" to="slijepoj ulici" />
+    <Word from="ćošku" to="uglu" />
+    <Word from="ćerka" to="kći" />
+    <Word from="kćerka" to="kći" />
+    <Word from="ćerke" to="kćeri" />
+    <Word from="ćutao" to="šutio" />
+    <Word from="ćutala" to="šutjela" />
+    <Word from="ćuteći" to="šuteći" />
+    <Word from="daćeš" to="dat ćeš" />
+    <Word from="daće" to="dat će" />
+    <Word from="daga" to="da ga" />
+    <Word from="dali si" to="da li si" />
+    <Word from="Dali si" to="Da li si" />
+    <Word from="dedom" to="djedom" />
+    <Word from="dejstvo" to="djelovanje" />
+    <Word from="dela" to="djela" />
+    <Word from="delo" to="djelo" />
+    <Word from="deli" to="dijeli" />
+    <Word from="delu" to="djelu" />
+    <Word from="deluju" to="djeluju" />
+    <Word from="djete" to="dijete" />
+    <Word from="Djete" to="Dijete" />
+    <!-- nisu za regex -->
+    <Word from="diskutujem" to="raspravljam" />
+    <Word from="diskutuješ" to="raspravljaš" />
+    <Word from="diskutuje" to="raspravlja" />
+    <Word from="diskutujemo" to="raspravljamo" />
+    <Word from="diskutuju" to="raspravljaju" />
+    <Word from="delovala" to="djelovala" />
+    <Word from="delovanje" to="djelovanje" />
+    <Word from="deo" to="dio" />
+    <Word from="desiti" to="dogoditi" />
+    <Word from="desiće se" to="dogodit će se" />
+    <Word from="dešava" to="događa" />
+    <Word from="dete" to="dijete" />
+    <Word from="detektuje" to="detektira" />
+    <Word from="detetu" to="djetetu" />
+    <Word from="deteta" to="djeteta" />
+    <Word from="dječiji" to="dječji" />
+    <Word from="dijetetom" to="djetetom" />
+    <Word from="dobo" to="dobro" />
+    <Word from="dobićeš" to="dobit ćeš" />
+    <Word from="doćiću" to="doći ću" />
+    <Word from="dole" to="dolje" />
+    <Word from="dolnji" to="donji" />
+    <Word from="doljnji" to="donji" />
+    <Word from="doneo" to="donio" />
+    <Word from="Doneo" to="Donio" />
+    <Word from="doneso" to="donio" />
+    <Word from="donesti" to="donijeti" />
+    <Word from="donjeti" to="donijeti" />
+    <!-- nije za regex -->
+    <Word from="dospeo" to="dospio" />
+    <Word from="dospeju" to="dospiju" />
+    <Word from="do đavola" to="do vraga" />
+    <Word from="dođavola" to="dovraga" />
+    <Word from="drug" to="prijatelj" />
+    <Word from="drugarica" to="prijateljica" />
+    <Word from="dve" to="dvije" />
+    <Word from="đavo" to="vrag" />
+    <Word from="đavola" to="vraga" />
+    <Word from="đemper" to="džemper" />
+    <Word from="džanki" to="ovisnik" />
+    <Word from="džigerica" to="jetra" />
+    <Word from="džigericu" to="jetru" />
+    <Word from="džin" to="div" />
+    <Word from="džinovski" to="divovski" />
+    <Word from="evro" to="euro" />
+    <Word from="evra" to="eura" />
+    <Word from="evrom" to="eurom" />
+    <Word from="fabriku" to="tvornicu" />
+    <Word from="falsifikujem" to="falsificiram" />
+    <Word from="falsifikuješ" to="falsificiraš" />
+    <Word from="falsifikuje" to="falsificira" />
+    <Word from="falsifikujemo" to="falsificiramo" />
+    <Word from="falsifikujete" to="falsificirate" />
+    <Word from="falsifikuju" to="falsificiraju" />
+    <Word from="foka" to="tuljan" />
+    <Word from="foku" to="tuljana" />
+    <Word from="foke" to="tuljani" />
+    <Word from="fokama" to="tuljanina" />
+    <Word from="funkcioniše" to="funkcionira" />
+    <Word from="gde" to="gdje" />
+    <Word from="Gde" to="Gdje" />
+    <Word from="greški" to="grešci" />
+    <Word from="gidošnja" to="godišnja" />
+    <Word from="hiljade" to="tisuće" />
+    <Word from="iči" to="ići" />
+    <Word from="iko" to="itko" />
+    <Word from="izleteo" to="izletio" />
+    <Word from="ivica" to="rub" />
+    <Word from="ivice" to="ruba" />
+    <Word from="ivici" to="rubu" />
+    <Word from="ivicu" to="rub" />
+    <Word from="hoču" to="hoću" />
+    <Word from="hočeš" to="hoćeš" />
+    <Word from="hoče" to="hoće" />
+    <Word from="hočemo" to="hoćemo" />
+    <Word from="hočete" to="hoćete" />
+    <Word from="holesterol" to="kolesterol" />
+    <Word from="Hteo" to="Htio" />
+    <Word from="hteo" to="htio" />
+    <Word from="htjeo" to="htio" />
+    <Word from="htela" to="htjela" />
+    <Word from="hrišćanin" to="kršćanin" />
+    <Word from="hrišćanski" to="kršćanski" />
+    <Word from="hrvatki" to="hrvatski" />
+    <Word from="hrvatkog" to="hrvatskog" />
+    <Word from="ignoriši" to="ignoriraj" />
+    <Word from="ignorišem" to="ignoriram" />
+    <Word from="ignoriše" to="ignorira" />
+    <Word from="ignoriši" to="ignoriraj" />
+    <Word from="ignorišeš" to="ignoriraš" />
+    <Word from="informacioni" to="informacijski" />
+    <Word from="ispričaći" to="ispričati ću" />
+    <Word from="isuviše" to="previše" />
+    <Word from="i te kako" to="itekako" />
+    <Word from="jedamput" to="jedanput" />
+    <Word from="jelda" to="jel' da" />
+    <Word from="juče" to="jučer" />
+    <Word from="Juče" to="Jučer" />
+    <Word from="kancelarija" to="ured" />
+    <Word from="kancelariji" to="uredu" />
+    <Word from="kancera" to="raka" />
+    <Word from="ker" to="pas" />
+    <Word from="kera" to="psa" />
+    <Word from="keru" to="psu" />
+    <Word from="ko" to="tko" />
+    <Word from="Ko" to="Tko" />
+    <Word from="kolena" to="koljena" />
+    <Word from="komandni" to="zapovjedni" />
+    <Word from="kompanija" to="tvrtka" />
+    <Word from="komplikovan" to="kompliciran" />
+    <Word from="komplikovano" to="komplicirano" />
+    <Word from="komplikuješ" to="kompliciraš" />
+    <Word from="komplikuju" to="kompliciraju" />
+    <Word from="konfor" to="komfor" />
+    <Word from="konkurišem" to="konkuriram" />
+    <Word from="konkuriše" to="konkurira" />
+    <Word from="kolevka" to="kolijevka" />
+    <Word from="kolevki" to="kolijevci" />
+    <Word from="koa" to="kao" />
+    <Word from="komitet" to="odbor" />
+    <Word from="komitetu" to="odboru" />
+    <Word from="komitetom" to="odborom" />
+    <Word from="komitetima" to="odborima" />
+    <Word from="korjenu" to="korijenu" />
+    <Word from="krstovima" to="križevima" />
+    <Word from="križom" to="križem" />
+    <Word from="kupatilo" to="kupaona" />
+    <Word from="kupatilu" to="kupaoni" />
+    <Word from="kučka" to="kuja" />
+    <Word from="lažeju" to="lažu" />
+    <Word from="lažov" to="lažljivac" />
+    <Word from="lek" to="lijek" />
+    <Word from="lenji" to="lijeni" />
+    <Word from="letela" to="letjela" />
+    <Word from="leva" to="lijeva" />
+    <Word from="levi" to="lijevi" />
+    <Word from="Levo" to="Lijevo" />
+    <Word from="lepota" to="lepota" />
+    <Word from="lepša" to="ljepša" />
+    <Word from="lepšu" to="ljepšu" />
+    <Word from="leto" to="ljeto" />
+    <Word from="leto" to="ljeto" />
+    <Word from="leta" to="ljeta" />
+    <Word from="loži" to="pali" />
+    <Word from="ludački" to="luđački" />
+    <Word from="ludačka" to="luđačka" />
+    <Word from="ludak" to="luđak" />
+    <Word from="ludaci" to="luđaci" />
+    <Word from="malopre" to="malo prije" />
+    <Word from="maloprije" to="malo prije" />
+    <Word from="manifestuje" to="manifestira" />
+    <Word from="mator" to="star" />
+    <Word from="matori" to="stari" />
+    <!-- nije za regex! -->
+    <Word from="menja" to="mijenja" />
+    <Word from="Menja" to="Mijenja" />
+    <Word from="merač" to="mjerač" />
+    <Word from="mere" to="mjere" />
+    <Word from="mesečnik" to="mjesečnik" />
+    <Word from="mesečno" to="mjesečno" />
+    <Word from="meša" to="miješa" />
+    <Word from="milion" to="milijun" />
+    <Word from="miliona" to="milijuna" />
+    <Word from="misliće" to="mislit će" />
+    <Word from="mlečna" to="mliječna" />
+    <Word from="mlečni" to="mliječni" />
+    <Word from="mleveno" to="mljeveno" />
+    <Word from="moč" to="moć" />
+    <Word from="moraću" to="morat ću" />
+    <Word from="moraćeš" to="morat ćeš" />
+    <Word from="muzejem" to="muzejom" />
+    <Word from="muzici" to="glazbi" />
+    <Word from="naduvan" to="napušen" />
+    <Word from="nagoveštaj" to="nagovještaj" />
+    <Word from="najzad" to="napokon" />
+    <Word from="nameštaj" to="namještaj" />
+    <Word from="nameste" to="namjeste" />
+    <Word from="namešteno" to="namješteno" />
+    <Word from="namena" to="namjena" />
+    <Word from="napolje" to="van" />
+    <Word from="napolju" to="vani" />
+    <Word from="natera" to="natjera" />
+    <Word from="naterali" to="natjerali" />
+    <Word from="nauka" to="znanost" />
+    <Word from="nazad" to="natrag" />
+    <Word from="Nazad" to="Natrag" />
+    <Word from="napraviću" to="napravit ću" />
+    <Word from="napred" to="naprijed" />
+    <Word from="naprimjer" to="na primjer" />
+    <Word from="nasreću" to="na sreću" />
+    <Word from="nauka" to="znanost" />
+    <Word from="nebih" to="ne bi" />
+    <Word from="negde" to="negdje" />
+    <Word from="nemrem" to="ne mogu" />
+    <Word from="nemogu" to="ne mogu" />
+    <Word from="nene" to="njene" />
+    <Word from="nigde" to="nigdje" />
+    <Word from="niko" to="nitko" />
+    <Word from="Niko" to="Nitko" />
+    <Word from="nejde" to="ne ide" />
+    <Word from="nesrećnica" to="nesretnica" />
+    <Word from="nervi" to="živci" />
+    <Word from="nervira" to="živcira" />
+    <Word from="nervni" to="živčani" />
+    <Word from="neču" to="neću" />
+    <Word from="nečeš" to="nećeš" />
+    <Word from="neče" to="neće" />
+    <Word from="nečemo" to="nećemo" />
+    <Word from="nečete" to="nećete" />
+    <Word from="neda" to="ne da" />
+    <Word from="nedam" to="ne dam" />
+    <Word from="neznam" to="ne znam" />
+    <Word from="nezna" to="ne zna" />
+    <Word from="Neznam" to="Ne znam" />
+    <Word from="Nezna" to="Ne zna" />
+    <Word from="neznajući" to="ne znajući" />
+    <Word from="new yorški" to="njujorški" />
+    <Word from="nju jorški" to="njujorški" />
+    <Word from="nežan" to="nježan" />
+    <Word from="neželi" to="ne želi" />
+    <Word from="niej" to="nije" />
+    <Word from="niije" to="nije" />
+    <Word from="njem" to="nijem" />
+    <Word from="nesvijest" to="nesvjest" />
+    <Word from="obe" to="obje" />
+    <Word from="obeležava" to="obilježava" />
+    <Word from="obeležavanje" to="obilježavanje" />
+    <Word from="obeležavanjem" to="obilježavanjem" />
+    <Word from="obelodanjen" to="objelodanjen" />
+    <Word from="obelodanjeno" to="objelodanjeno" />
+    <Word from="obezbediti" to="osigurati" />
+    <Word from="obezbeđivanje" to="osiguravanje" />
+    <Word from="obezbeđivanja" to="osiguranja" />
+    <Word from="obezbeđivanju" to="osiguravanju" />
+    <Word from="obožavalac" to="obožavatelj" />
+    <Word from="obuhvata" to="obuhvaća" />
+    <Word from="oceni" to="ocijeni" />
+    <Word from="odandje" to="odande" />
+    <Word from="odavdje" to="odavde" />
+    <Word from="odbrana" to="obrana" />
+    <Word from="odbranim" to="obranim" />
+    <Word from="odkad" to="otkad" />
+    <Word from="odma" to="odmah" />
+    <Word from="odneti" to="odnijeti" />
+    <Word from="odnjeti" to="odnijeti" />
+    <Word from="odupreti" to="oduprijeti" />
+    <Word from="odprilike" to="otprilike" />
+    <Word from="oduvek" to="oduvijek" />
+    <Word from="oduvjek" to="oduvijek" />
+    <Word from="oprostiće" to="oprostit će" />
+    <Word from="Oprostiće" to="Oprostit će" />
+    <Word from="organizuju" to="organiziraju" />
+    <Word from="ovde" to="ovdje" />
+    <Word from="Ovde" to="Ovdje" />
+    <Word from="ovdije" to="ovdje" />
+    <Word from="pantalone" to="hlače" />
+    <Word from="parčence" to="komadić" />
+    <Word from="paramparčad" to="komadići" />
+    <Word from="pemzija" to="penzija" />
+    <Word from="pemziju" to="penziju" />
+    <Word from="pertle" to="žnirance" />
+    <Word from="pesama" to="pjesama" />
+    <Word from="peškirima" to="ručnicima" />
+    <Word from="pitaću" to="pitat ću" />
+    <Word from="plata" to="plaća" />
+    <Word from="plača" to="plaća" />
+    <Word from="platu" to="plaću" />
+    <Word from="plačanje" to="plaćanje" />
+    <Word from="plačanjem" to="plaćanjem" />
+    <Word from="plaćeš" to="plačeš" />
+    <Word from="podpisati" to="potpisati" />
+    <Word from="podretlo" to="porijeklo" />
+    <Word from="pogrješiti" to="pogriješiti" />
+    <Word from="pomen" to="spomen" />
+    <Word from="poreklo" to="porijeklo" />
+    <Word from="poreklu" to="porijeklu" />
+    <Word from="prenos" to="prijenos" />
+    <Word from="prenosa" to="prijenosa" />
+    <Word from="prenosu" to="prijenosu" />
+    <Word from="preterao" to="pretjerao" />
+    <Word from="preteruj" to="pretjeruj" />
+    <Word from="preteruje" to="pretjeruje" />
+    <Word from="pridonjeti" to="pridonijeti" />
+    <Word from="prijatan" to="ugodan" />
+    <Word from="proleteo" to="proletio" />
+    <Word from="podneo" to="podnio" />
+    <Word from="podnesti" to="podnijeti" />
+    <Word from="podnjeti" to="podnijeti" />
+    <Word from="podstrekač" to="poticatelj" />
+    <Word from="pomaći" to="pomaknuti" />
+    <!-- nije za regex -->
+    <Word from="poen" to="bod" />
+    <Word from="poena" to="boda" />
+    <Word from="poeni" to="bodovi" />
+    <Word from="poludeo" to="poludio" />
+    <Word from="poludela" to="poludjela" />
+    <Word from="ponaosob" to="osobno" />
+    <!-- nije za regex! -->
+    <Word from="poneo" to="ponio" />
+    <Word from="ponesla" to="ponijela" />
+    <Word from="ponela" to="ponijela" />
+    <Word from="ponjeli" to="ponijeli" />
+    <Word from="ponjeti" to="ponijeti" />
+    <Word from="pomoč" to="pomoć" />
+    <Word from="poređenje" to="usporedba" />
+    <Word from="poređenju" to="usporedbi" />
+    <Word from="poseta" to="posjet" />
+    <Word from="posle" to="poslije" />
+    <Word from="Posle" to="Poslije" />
+    <Word from="posledično" to="posljedično" />
+    <Word from="poslje" to="poslije" />
+    <Word from="pozadi" to="iza" />
+    <Word from="poželeo" to="poželio" />
+    <Word from="praktikuju" to="prakticiraju" />
+    <Word from="pre" to="prije" />
+    <Word from="Pre" to="Prije" />
+    <Word from="predame" to="preda me" />
+    <Word from="preporuča" to="preporučuje" />
+    <!-- nije za regex -->
+    <Word from="preti" to="prijeti" />
+    <Word from="predsednik" to="predsjednik" />
+    <Word from="precednik" to="predsjednik" />
+    <Word from="precijednik" to="predsjednik" />
+    <Word from="precjednik" to="predsjednik" />
+    <Word from="preduzeli" to="poduzeli" />
+    <Word from="prevod" to="prijevod" />
+    <Word from="prihvata" to="prihvaća" />
+    <Word from="prihvatam" to="prihvaćam" />
+    <Word from="prihvatanje" to="prihvaćanje" />
+    <Word from="priije" to="prije" />
+    <Word from="prijtelj" to="prijatelj" />
+    <Word from="prijtelji" to="prijatelji" />
+    <Word from="primjete" to="primijete" />
+    <Word from="primjetila" to="primijetila" />
+    <Word from="primjetio" to="primijetio" />
+    <Word from="prodato" to="prodano" />
+    <Word from="promeniti" to="promijeniti" />
+    <Word from="promenilo" to="promijenilo" />
+    <Word from="promjenilo" to="promijenilo" />
+    <Word from="promijena" to="promjena" />
+    <Word from="protivrečne" to="proturječne" />
+    <Word from="psihićki" to="psihički" />
+    <Word from="radijo" to="radio" />
+    <Word from="rađe" to="radije" />
+    <Word from="raspust" to="odmor" />
+    <Word from="razgovrati" to="razgovarati" />
+    <Word from="reč" to="riječ" />
+    <Word from="rećiću" to="reći ću" />
+    <Word from="redosljed" to="redoslijed" />
+    <Word from="reko" to="rekao" />
+    <Word from="reka" to="rijeka" />
+    <Word from="rjeka" to="rijeka" />
+    <Word from="reke" to="rijeke" />
+    <Word from="rjeke" to="rijeke" />
+    <Word from="riješenje" to="rješenje" />
+    <Word from="Riješenje" to="Rješenje" />
+    <Word from="rješe" to="riješe" />
+    <Word from="Rješe" to="Riješe" />
+    <Word from="reku" to="rijeku" />
+    <Word from="rekom" to="rijekom" />
+    <Word from="rengen" to="rendgen" />
+    <Word from="reagovati" to="reagirati" />
+    <Word from="reaguje" to="reagira" />
+    <Word from="retka" to="rijetka" />
+    <Word from="retko" to="rijetko" />
+    <Word from="retkost" to="rijetkost" />
+    <Word from="rjetkost" to="rijetkost" />
+    <Word from="rijeđi" to="rjeđi" />
+    <Word from="ronioc" to="ronilac" />
+    <Word from="samoubistava" to="samoubojstava" />
+    <Word from="sedela" to="sjedila" />
+    <Word from="sedišta" to="sjedala" />
+    <Word from="sedište" to="sjedalo" />
+    <Word from="sedni" to="sjedni" />
+    <Word from="Sedni" to="Sjedni" />
+    <Word from="sedi" to="sjedi" />
+    <Word from="sednem" to="sjednem" />
+    <Word from="sedite" to="sjedite" />
+    <Word from="sedite" to="sjedite" />
+    <Word from="sertan" to="sretan" />
+    <Word from="siguan" to="siguran" />
+    <Word from="sirće" to="ocat" />
+    <Word from="sirćetu" to="octu" />
+    <Word from="slijedbenik" to="sljedbenik" />
+    <Word from="sma" to="sam" />
+    <Word from="smao" to="samo" />
+    <Word from="sme" to="smije" />
+    <Word from="Sme" to="Smije" />
+    <Word from="smešak" to="smješak" />
+    <Word from="smešno" to="smiješno" />
+    <Word from="smješno" to="smiješno" />
+    <Word from="sem" to="osim" />
+    <Word from="sam sam" to="sam sâm" />
+    <Word from="s menom" to="sa mnom" />
+    <Word from="samnom" to="sa mnom" />
+    <Word from="savest" to="savjest" />
+    <Word from="savesti" to="savjesti" />
+    <Word from="savijest" to="savjest" />
+    <Word from="saviješću" to="savješću" />
+    <Word from="savešću" to="savješću" />
+    <Word from="seti" to="sjeti" />
+    <Word from="setim" to="sjetim" />
+    <Word from="sintersajzer" to="synthesizer" />
+    <Word from="sitnisajzer" to="synthesizer" />
+    <Word from="skuvati" to="skuhati" />
+    <Word from="smao" to="samo" />
+    <Word from="smestila" to="smjestila" />
+    <Word from="smestio" to="smjestio" />
+    <Word from="smešten" to="smješten" />
+    <Word from="srečom" to="srećom" />
+    <Word from="sveštenik" to="svećenik" />
+    <Word from="svjet" to="svijet" />
+    <Word from="sneg" to="snijeg" />
+    <Word from="sočiva" to="leće" />
+    <Word from="sočivo" to="leća" />
+    <Word from="spasao" to="spasio" />
+    <Word from="spolja" to="izvana" />
+    <Word from="spoljašnji" to="vanjski" />
+    <Word from="sprat" to="kat" />
+    <Word from="sprata" to="kata" />
+    <Word from="sta" to="što" />
+    <Word from="stepen" to="stupanj" />
+    <Word from="stepeni" to="stupnjeva" />
+    <Word from="sticati" to="stjecati" />
+    <Word from="sudija" to="sudac" />
+    <Word from="sudijo" to="suče" />
+    <Word from="sudijskog" to="sudskog" />
+    <Word from="suština" to="bit" />
+    <Word from="suštinski" to="bitni" />
+    <Word from="svideo" to="svidio" />
+    <Word from="svest" to="svijest" />
+    <Word from="Svest" to="Svijest" />
+    <!-- u korist svijeta koji se češće pojavljuje ostat će ovako -->
+    <Word from="svet" to="svijet" />
+    <Word from="Svet" to="Svijet" />
+    <Word from="svetom" to="svijetom" />
+    <Word from="sveta" to="svijeta" />
+    <Word from="svetu" to="svijetu" />
+    <Word from="svjest" to="svijest" />
+    <Word from="nesvest" to="nesvijest" />
+    <Word from="nesvjest" to="nesvijest" />
+    <Word from="nesvesti" to="nesvijesti" />
+    <Word from="nesvjesti" to="nesvijesti" />
+    <Word from="svestan" to="svjestan" />
+    <Word from="šagarepa" to="mrkva" />
+    <Word from="šečer" to="šećer" />
+    <Word from="šolja" to="šalica" />
+    <Word from="šolju" to="šalicu" />
+    <Word from="španski" to="španjolski" />
+    <Word from="Šta" to="Što" />
+    <Word from="štab" to="stožer" />
+    <Word from="štabu" to="stožeru" />
+    <Word from="štampa" to="tisak" />
+    <Word from="šta" to="što" />
+    <Word from="štp" to="što" />
+    <Word from="tačno" to="točno" />
+    <Word from="tačnije" to="točnije" />
+    <Word from="tačna" to="točna" />
+    <Word from="tačnija" to="točnija" />
+    <Word from="talas" to="val" />
+    <Word from="tačka" to="točka" />
+    <Word from="tačkama" to="točkama" />
+    <Word from="tačke" to="točke" />
+    <Word from="takođe" to="također" />
+    <Word from="teraj" to="tjeraj" />
+    <Word from="tržni" to="trgovački" />
+    <Word from="testera" to="pila" />
+    <Word from="tržnom" to="trgovačkom" />
+    <Word from="tugi" to="tuzi" />
+    <Word from="tvrtci" to="tvrtki" />
+    <Word from="ubediti" to="uvjeriti" />
+    <Word from="ubedio" to="uvjerio" />
+    <Word from="ubeđuju" to="uvjeravaju" />
+    <Word from="ubijediti" to="uvjeriti" />
+    <Word from="ubjediti" to="uvjeriti" />
+    <Word from="ubiću" to="ubit ću" />
+    <Word from="ubiće" to="ubit će" />
+    <Word from="ubistava" to="ubojstava" />
+    <Word from="učestvuju" to="sudjeluju" />
+    <Word from="udavit" to="utopit" />
+    <Word from="udaviti" to="utopiti" />
+    <Word from="uglom" to="kutom" />
+    <Word from="uljeva" to="ulijeva" />
+    <Word from="u jutro" to="ujutro" />
+    <Word from="ujutru" to="ujutro" />
+    <Word from="umem" to="umijem" />
+    <Word from="umeš" to="umiješ" />
+    <Word from="umesto" to="umjesto" />
+    <Word from="umetnost" to="umjetnost" />
+    <Word from="umetnosti" to="umjetnosti" />
+    <Word from="umetnošću" to="umjetnošću" />
+    <Word from="umreti" to="umrijeti" />
+    <Word from="univerzitet" to="sveučilište" />
+    <Word from="unapred" to="unaprijed" />
+    <Word from="uopšte" to="uopće" />
+    <Word from="upašću" to="upast ću" />
+    <Word from="uprkos" to="usprkos" />
+    <Word from="Uprkos" to="Usprkos" />
+    <Word from="uradio" to="učinio" />
+    <Word from="uradiću" to="učinit ću" />
+    <Word from="uspeo" to="uspio" />
+    <Word from="Uspeo" to="Uspio" />
+    <Word from="uspela" to="uspjela" />
+    <Word from="uspelo" to="uspjelo" />
+    <Word from="uspe" to="uspije" />
+    <Word from="uspeju" to="uspiju" />
+    <Word from="uspem" to="uspijem" />
+    <Word from="usredsrede" to="usredotoče" />
+    <Word from="utičem" to="utječem" />
+    <Word from="uvek" to="uvijek" />
+    <Word from="uvjek" to="uvijek" />
+    <Word from="Uvek" to="Uvijek" />
+    <Word from="Uvjek" to="Uvijek" />
+    <Word from="uvijet" to="uvjet" />
+    <Word from="uvo" to="uho" />
+    <Word from="važi" to="vrijedi" />
+    <Word from="večan" to="vječan" />
+    <Word from="večna" to="vječna" />
+    <Word from="večno" to="vječno" />
+    <Word from="venca" to="vijenca" />
+    <Word from="veoma" to="vrlo" />
+    <!-- nije za regex -->
+    <Word from="verovati" to="vjerovati" />
+    <Word from="verovanje" to="vjerovanje" />
+    <Word from="vetar" to="vjetar" />
+    <Word from="vetra" to="vjetra" />
+    <Word from="več" to="već" />
+    <Word from="veče" to="večer" />
+    <Word from="večnost" to="vječnost" />
+    <Word from="večno" to="vječno" />
+    <Word from="vešt" to="vješt" />
+    <Word from="veštine" to="vještine" />
+    <Word from="vežba" to="vježba" />
+    <Word from="vizuelne" to="vizualne" />
+    <Word from="vrede" to="vrijede" />
+    <Word from="vredan" to="vrijedan" />
+    <Word from="vredna" to="vrijedna" />
+    <Word from="vredno" to="vrijedno" />
+    <Word from="vrednost" to="vrijednost" />
+    <Word from="vrednosti" to="vrijednosti" />
+    <Word from="vrednošću" to="vrijednošću" />
+    <Word from="vreme" to="vrijeme" />
+    <Word from="Vreme" to="Vrijeme" />
+    <Word from="voliti" to="voljeti" />
+    <Word from="voleo" to="volio" />
+    <Word from="Voleo" to="Volio" />
+    <Word from="voleće" to="voljet će" />
+    <Word from="voz" to="vlak" />
+    <Word from="Voz" to="Vlak" />
+    <Word from="vjetru" to="vetru" />
+    <Word from="vratiće" to="vratit će" />
+    <Word from="vređanje" to="vrijeđanje" />
+    <Word from="vređa" to="vrijeđa" />
+    <Word from="whiskey" to="viski" />
+    <Word from="zamena" to="zamjena" />
+    <Word from="zamnom" to="za mnom" />
+    <Word from="zanm" to="znam" />
+    <Word from="zanma" to="zanima" />
+    <Word from="zaspem" to="zaspim" />
+    <Word from="zauvek" to="zauvijek" />
+    <Word from="za uvijek" to="zauvijek" />
+    <Word from="zavredili" to="zavrijedili" />
+    <Word from="zdrvo" to="zdravo" />
+    <Word from="Zdrvo" to="Zdravo" />
+    <Word from="zvaničan" to="služben" />
+    <Word from="zver" to="zvijer" />
+    <Word from="zvjer" to="zvijer" />
+    <Word from="zveri" to="zvijeri" />
+    <Word from="zvjeri" to="zvijeri" />
+    <Word from="želela" to="željela" />
+    <Word from="želeo" to="želio" />
+    <Word from="Želeo" to="Želio" />
+    <Word from="željeo" to="želio" />
+    <Word from="želeli" to="željeli" />
+    <Word from="živeo" to="živio" />
+    <!-- NISU ZA REGEX!!! osim ako netko zna bolje, naravno :) -->
+    <Word from="bićemo" to="bit ćemo" />
+    <Word from="Bićemo" to="Bit ćemo" />
+    <Word from="bićete" to="bit ćete" />
+    <Word from="Bićete" to="Bit ćete" />
+    <Word from="bićeš" to="bit ćeš" />
+    <Word from="Bićeš" to="Bit ćeš" />
+    <Word from="definiše" to="definira" />
+    <Word from="definišem" to="definiram" />
+    <Word from="definiši" to="definiraj" />
+    <Word from="definišu" to="definiraju" />
+    <Word from="eksperimentišem" to="eksperimentiram" />
+    <Word from="eksperimentišu" to="eksperimentiraju" />
+    <Word from="eksperimentišeš" to="eksperimentiraš" />
+    <Word from="eksperimentišete" to="eksperimentirate" />
+    <Word from="eksperimentiše" to="eksperimentira" />
+    <Word from="eksperimentišemo" to="eksperimentiramo" />
+    <Word from="historija" to="povijest" />
+    <Word from="historije" to="povijesti" />
+    <Word from="historiji" to="povijesti" />
+    <Word from="istoriji" to="povijesti" />
+    <Word from="historiju" to="povijest" />
+    <Word from="istorija" to="povijest" />
+    <Word from="Istorija" to="Povijest" />
+    <Word from="istorije" to="povijesti" />
+    <Word from="istoriju" to="povijest" />
+    <Word from="interesujem" to="zanimam" />
+    <Word from="interesuješ" to="zanimaš" />
+    <Word from="interesuje" to="zanima" />
+    <Word from="Interesuje" to="Zanima" />
+    <Word from="interesuju" to="zanimaju" />
+    <Word from="interesovanje" to="zanimanje" />
+    <Word from="izvini" to="oprosti" />
+    <Word from="Izvini" to="Oprosti" />
+    <Word from="izvinite" to="oprostite" />
+    <Word from="Izvinite" to="Oprostite" />
+    <Word from="izvinjavam" to="ispričavam" />
+    <Word from="Izvinjavam" to="Ispričavam" />
+    <Word from="kola" to="auto" />
+    <Word from="kolima" to="autom" />
+    <Word from="komšija" to="susjed" />
+    <Word from="komšiji" to="susjedu" />
+    <Word from="komšiluk" to="susjedstvo" />
+    <Word from="komšiluku" to="susjedstvu" />
+    <Word from="komšije" to="susjedi" />
+    <Word from="komšijama" to="susjedima" />
+    <Word from="komšijski" to="susjedni" />
+    <Word from="komšijskog" to="susjednog" />
+    <Word from="kontrolišem" to="kontroliram" />
+    <Word from="kontrolišeš" to="kontroliraš" />
+    <Word from="kontrolišemo" to="kontroliramo" />
+    <Word from="kontrolišete" to="kontrolirate" />
+    <Word from="kontrolišu" to="kontroliraju" />
+    <Word from="kontrolisati" to="kontrolirati" />
+    <Word from="izgladneo" to="izgladnio" />
+    <Word from="odeljenje" to="odjel" />
+    <Word from="odeljenjem" to="odjelom" />
+    <Word from="ogladneo" to="ogladnio" />
+    <Word from="obezbeđujem" to="osiguravam" />
+    <Word from="obezbeđuješ" to="osiguravaš" />
+    <Word from="obezbeđuje" to="osigurava" />
+    <Word from="obezbeđujemo" to="osiguravamo" />
+    <Word from="obezbeđuju" to="osiguravaju" />
+    <Word from="oblast" to="područje" />
+    <Word from="oblastima" to="područjima" />
+    <!-- ostaje ovako jer je prijevod u raznim padežima različit -->
+    <Word from="oblasti" to="područj " />
+    <Word from="prićaću" to="pričat ću" />
+    <Word from="Prićaću" to="Pričat ću" />
+    <Word from="prićaćeš" to="pričat ćeš" />
+    <Word from="Prićaćeš" to="Pričat ćeš" />
+    <Word from="prićaćemo" to="pričat ćemo" />
+    <Word from="Prićaćemo" to="Pričat ćemo" />
+    <Word from="pomera" to="miče" />
+    <Word from="pomeraj" to="miči" />
+    <Word from="pomjeraj" to="miči" />
+    <Word from="pomeraju" to="miču" />
+    <Word from="pomeri" to="pomakni" />
+    <Word from="Pomeri" to="Pomakni" />
+    <Word from="pomeriš" to="pomakneš" />
+    <Word from="pomerati" to="micati" />
+    <Word from="poneo" to="ponio" />
+    <Word from="porodica" to="obitelj" />
+    <Word from="porodice" to="obitelji" />
+    <Word from="porodici" to="obitelji" />
+    <Word from="porodicu" to="obitelj" />
+    <Word from="porodični" to="obiteljski" />
+    <Word from="porodičnu" to="obiteljsku" />
+    <Word from="porodičnog" to="obiteljskog" />
+    <Word from="postaćeš" to="postat ćeš" />
+    <Word from="Postaćeš" to="Postat ćeš" />
+    <Word from="postačeš" to="postat ćeš" />
+    <Word from="Postačeš" to="Postat ćeš" />
+    <Word from="postaramo" to="pobrinemo" />
+    <Word from="postaraj" to="pobrini" />
+    <Word from="postaraju" to="pobrinu" />
+    <Word from="postarajmo" to="pobrinimo" />
+    <Word from="postara" to="pobrine" />
+    <Word from="postaraš" to="pobrineš" />
+    <Word from="povinujem" to="pokoravam" />
+    <Word from="povinuje" to="pokorava" />
+    <Word from="povinujete" to="pokoravate" />
+    <Word from="povinuju" to="pokoravaju" />
+    <Word from="procenat" to="postotak" />
+    <Word from="procenata" to="postotaka" />
+    <Word from="procentu" to="postotku" />
+    <Word from="procenti" to="postoci" />
+    <Word from="procentima" to="postocima" />
+    <Word from="razumela" to="razumjela" />
+    <Word from="razumeli" to="razumjeli" />
+    <Word from="razumijeo" to="razumio" />
+    <Word from="Razumijeo" to="Razumio" />
+    <Word from="razumjeo" to="razumio" />
+    <Word from="Razumjeo" to="Razumio" />
+    <Word from="Razumeo" to="Razumio" />
+    <Word from="razumeću" to="razumjet ću" />
+    <Word from="sistem" to="sustav" />
+    <Word from="sistemi" to="sustavi" />
+    <Word from="sistemu" to="sustavu" />
+    <Word from="sistemima" to="sustavima" />
+    <Word from="sisteme" to="sustave" />
+    <Word from="Sistem" to="Sustav" />
+    <Word from="Sistemi" to="Sustavi" />
+    <Word from="Sistemu" to="Sustavu" />
+    <Word from="Sistemima" to="Sustavima" />
+    <Word from="Sisteme" to="Sustave" />
+    <Word from="spreče" to="spriječe" />
+    <Word from="sprječe" to="spriječe" />
+    <Word from="Spreče" to="Spriječe" />
+    <Word from="Sprječe" to="Spriječe" />
+    <Word from="štampa" to="tisak" />
+    <Word from="štampu" to="tisak" />
+    <Word from="štampom" to="tiskom" />
+    <Word from="štampi" to="tisku" />
+    <Word from="štamparska" to="tiskovna" />
+    <Word from="štamparski" to="tiskovni" />
+    <Word from="štampati" to="tiskati" />
+    <Word from="tolerišem" to="toleriram" />
+    <Word from="toleriše" to="tolerira" />
+    <Word from="tolerišeš" to="toleriraš" />
+    <Word from="tolerišu" to="toleriraju" />
+    <Word from="video" to="vidio" />
+    <Word from="Video" to="Vidio" />
+    <Word from="videćemo" to="vidjet ćemo" />
+    <Word from="videćeš" to="vidjet ćeš" />
+    <Word from="vratiću" to="vratit ću" />
+    <Word from="vratiće" to="vratit će" />
+    <Word from="vratit ćeš" to="vratit ćeš" />
+    <!-- pridjevi optimalan, minimalan i maksimalan nemaju komparativ i superlativ. -->
+    <Word from="najoptimalnije" to="optimalno" />
+    <Word from="najoptimalnija" to="optimalna" />
+    <Word from="najminimalniji" to="minimalni" />
+    <Word from="najminimalnija" to="minimalna" />
+    <Word from="najmaksimalniji" to="maksimalan" />
+    <Word from="najmaksimalnija" to="maksimalna" />
+    <!-- sasvim rijetko se pojavljuje biće kao imenica, tako da  je ovo u korist češće riječi -->
+    <Word from="biće" to="bit će" />
+    <Word from="Biće" to="Bit će" />
+    <Word from="biću" to="bit ću" />
+    <Word from="Biće" to="Bit će" />
+    <!-- imena mjeseci -->
+    <Word from="januar" to="siječanj" />
+    <Word from="januara" to="siječnja" />
+    <Word from="januaru" to="siječnju" />
+    <Word from="februar" to="veljača" />
+    <Word from="februara" to="veljače" />
+    <Word from="februaru" to="veljači" />
+    <Word from="mart" to="ožujak" />
+    <Word from="marta" to="ožujka" />
+    <Word from="martu" to="ožujku" />
+    <Word from="april" to="travanj" />
+    <Word from="aprila" to="travnja" />
+    <Word from="aprilu" to="travnju" />
+    <Word from="maj" to="svibanj" />
+    <Word from="maja" to="svibnja" />
+    <Word from="maju" to="svibnju" />
+    <Word from="majem" to="svibnjem" />
+    <Word from="svibnjom" to="svibnjem" />
+    <Word from="jun" to="lipanj" />
+    <Word from="junu" to="lipnju" />
+    <Word from="juna" to="lipnja" />
+    <Word from="juli" to="srpanj" />
+    <Word from="jula" to="srpnja" />
+    <Word from="julu" to="srpnju" />
+    <Word from="august" to="kolovoz" />
+    <Word from="augusta" to="kolovoza" />
+    <Word from="augustu" to="kolovozu" />
+    <Word from="septembar" to="rujan" />
+    <Word from="septembra" to="rujna" />
+    <Word from="septembru" to="rujnu" />
+    <Word from="oktobar" to="listopad" />
+    <Word from="oktobru" to="listopadu" />
+    <Word from="novembar" to="studeni" />
+    <Word from="novembra" to="studenog" />
+    <Word from="novembru" to="studenom" />
+    <Word from="decembar" to="prosinac" />
+    <Word from="decembra" to="prosinca" />
+    <Word from="decembru" to="prosincu" />
+    <Word from="sreda" to="srijeda" />
+    <Word from="sredu" to="srijedu" />
+    <Word from="sredom" to="srijedom" />
+    <!-- osobna imena i imena gradova/država itd. -->
+    <Word from="Afghanistan" to="Afganistan" />
+    <!-- ne dirati razmak -->
+    <Word from="Bil " to="Bill" />
+    <Word from="Bruklin" to="Brooklyn" />
+    <Word from="Bruklinu" to="Brooklynu" />
+    <Word from="Brajan" to="Brian" />
+    <Word from="Braun" to="Brown" />
+    <Word from="Brussels" to="Bruxelles" />
+    <Word from="California" to="Kalifornija" />
+    <Word from="Californija" to="Kalifornija" />
+    <Word from="Californii" to="Kaliforniji" />
+    <Word from="Californiji" to="Kaliforniji" />
+    <Word from="Californiu" to="Kaliforniju" />
+    <Word from="Californiju" to="Kaliforniju" />
+    <Word from="Džakobi" to="Jacobi" />
+    <Word from="Džejn" to="Jane" />
+    <Word from="Džejms" to="James" />
+    <Word from="Džes" to="Jess" />
+    <Word from="Džesika" to="Jessica" />
+    <Word from="Džim" to="Jim" />
+    <Word from="Džime" to="Jime" />
+    <Word from="Džon" to="John" />
+    <Word from="Džoni" to="Johnny" />
+    <Word from="Džonson" to="Johnson" />
+    <Word from="Ejmi" to="Amy" />
+    <Word from="Endi" to="Andy" />
+    <Word from="Filadelfija" to="Philadelphia" />
+    <Word from="Filadelfiju" to="Philadelphiju" />
+    <Word from="Filadelfiji" to="Philadelphiji" />
+    <Word from="Holivud" to="Hollywood" />
+    <Word from="Holivuda" to="Hollywooda" />
+    <Word from="Holivudu" to="Hollywoodu" />
+    <Word from="Hitrou" to="Heathrow" />
+    <Word from="Iraq" to="Irak" />
+    <Word from="in Iraq" to="u Iraku" />
+    <Word from="Lusi" to="Lucy" />
+    <Word from="Mexico" to="Meksiko" />
+    <Word from="in Mexico" to="u Meksiku" />
+    <Word from="Mocart" to="Mozart" />
+    <Word from="Nensi" to="Nancy" />
+    <Word from="Pol" to="Paul" />
+    <Word from="Rajan" to="Ryan" />
+    <Word from="Ričard" to="Richard" />
+    <Word from="Ričmond" to="Richmond" />
+    <Word from="Sajmon" to="Simon" />
+    <Word from="Stiv" to="Steve" />
+    <Word from="Stiven" to="Stephen" />
+    <Word from="Sančez" to="Sanchez" />
+    <Word from="Vinsent" to="Vincent" />
+    <Word from="Švajcarska" to="Švicarska" />
+    <Word from="Švajcarskoj" to="Švicarskoj" />
+    <Word from="Holandija" to="Nizozemska" />
+    <Word from="Holandijom" to="Nizozemskom" />
+    <Word from="Holandiju" to="Nizozemsku" />
+    <Word from="Holandiji" to="Nizozemskoj" />
+    <Word from="Losanđeles" to="Los Angeles" />
+    <Word from="Losanđelesu" to="Los Angelesu" />
+    <Word from="Los Anđeles" to="Los Angeles" />
+    <Word from="Los Anđelesu" to="Los Angelesu" />
+    <Word from="Los Anđelesom" to="Los Angelesom" />
+    <Word from="Njujork" to="New York" />
+    <Word from="Njujorka" to="New Yorka" />
+    <Word from="Njujorku" to="New Yorku" />
+  </WholeWords>
+  <PartialWords />
+  <PartialLines>
+    <LinePart from="Dobro veče" to="Dobra večer" />
+    <LinePart from="Dobro večer" to="Dobra večer" />
+    <LinePart from="Dobar večer" to="Dobra večer" />
+    <LinePart from="gdje ideš" to="kamo ideš" />
+    <LinePart from="Gdje ideš" to="Kamo ideš" />
+    <LinePart from="moje saučešće" to="moja sućut" />
+    <LinePart from="Moram da idem" to="Moram ići" />
+    <LinePart from="moraš da ideš" to="moraš ići" />
+    <LinePart from="na večer" to="navečer" />
+    <LinePart from="Na večer" to="Navečer" />
+    <LinePart from="Ne mogu da verujem" to="Ne mogu vjerovati" />
+    <LinePart from="od kako" to="otkako" />
+    <LinePart from="tamo je natrag" to="tamo je iza" />
+    <LinePart from="Tamo je natrag" to="Tamo je iza" />
+  </PartialLines>
+  <BeginLines />
+  <EndLines />
+  <WholeLines />
+  <RegularExpressions>
+    <!-- deklinacije imenica i konjugacije glagola -->
+    <RegEx find="(jeda|dva|tri|četr|pet|šes|sedam|osam|devet)(najst)(a|e|i|o|u|im|om|og|oj|ima)*" replaceWith="$1naest$3" />
+    <RegEx find="([aA])(bsorbira)(m|š|mo|te|ju|li|le|la|lo|ti|jući)*" replaceWith="$1psorbira$3" />
+    <RegEx find="([aA])(bstraktn)(a|e|i|o|u|oj|om|og|im|ima)*" replaceWith="$1pstraktn$3" />
+    <RegEx find="\b(advokat)(a|e|u)*" replaceWith="odvjetnik$2" />
+    <RegEx find="\b(advokat)(i|ima)" replaceWith="odvjetnic$2" />
+    <RegEx find="(akcion)(i|a|e|u)" replaceWith="akcijsk$2" />
+    <RegEx find="(aktuel)(an|ni|na|ne|no|nom|nu|nim|nima)" replaceWith="aktual$2" />
+    <RegEx find="(Alas)(ka|ku|ki|ci)" replaceWith="Aljas$2" />
+    <RegEx find="(asvalt)(a|u|om|ira|irati|iranje|iran|iranog|irano|iranu|iranoj|iranom|na|ni|noj|nom)*" replaceWith="asfalt$2" />
+    <RegEx find="(avijon)(i|a|e|u|ima)" replaceWith="avion$2" />
+    <RegEx find="(bezbed)(an|na|no|ni|nima|nu|ne|nog|nom|noj)" replaceWith="sigur$2" />
+    <RegEx find="(bezbedno)(st|stima|šću|snu|snog|snom|sni)*" replaceWith="sigurno$2" />
+    <RegEx find="(bakcil)(i|a|e|u|ima)*" replaceWith="bacil$2" />
+    <RegEx find="(biro)\b(a|i|u|om|ima)*" replaceWith="ured$2" />
+    <RegEx find="([bB])(elešk)(a|e|u|om|ama)*" replaceWith="$1ilješk$3" />
+    <RegEx find="([bB])(esn)(i|o|u|om|og|om|oj)" replaceWith="$1ijesn$3" />
+    <RegEx find="([bB])(eznadež)(an|na|no|nom|noj|nim|nima)" replaceWith="$1eznad$3" />
+    <RegEx find="([bB])(ež)(i|imo|e|ao|ala|ali|anje|anjem|anju)" replaceWith="$1jež$3" />
+    <RegEx find="([bB])(ijež)(i|imo|e|ao|ala|ali)" replaceWith="$1jež$3" />
+    <RegEx find="([bB])(ožiji)(a|i|u|om|ima)*" replaceWith="$1ožji$3" />
+    <RegEx find="(Božićn)(a|e|i|o|u|om|im)*" replaceWith="božićn$2" />
+    <RegEx find="(Božičn)(a|e|i|o|u|om|im)*" replaceWith="božićn$2" />
+    <RegEx find="(Hrist)(a|e|u|om)*" replaceWith="Krist$2" />
+    <RegEx find="\b([cC])(en)(a|e|i|o|u|om|ama|iti|ila|ilo|io|im|iš|imo|ite|iše)" replaceWith="$1ijen$3" />
+    <RegEx find="([cC])(enjen)(a|e|i|im|ima|o|u|om|oj)*" replaceWith="$1ijenjen$3" />
+    <RegEx find="([cC])(jenjen)(a|e|i|im|ima|o|u|om|oj)*" replaceWith="$1ijenjen$3" />
+    <RegEx find="(čas)(a|u|om|ovi|ovima|ove|ova)" replaceWith="sat$2" />
+    <RegEx find="([čČ])(ove)(k|ka|ku|kom|kove|če|čanstvo|čanstva|čanstvu|čanstvom|čni|čna|čno)" replaceWith="$1ovje$3" />
+    <RegEx find="([čČ])(ovije)(k|ka|ku|kom|kov|kovog|kovoj|kovom|če|čanstva|čanstvu|čanstvom|čni|čna|čno)" replaceWith="$1ovje$3" />
+    <RegEx find="([bB])(ekstv)(a|u|om)" replaceWith="$1bijeg$3" />
+    <RegEx find="(bioskop)(a|u|om)" replaceWith="kin$2" />
+    <RegEx find="\b([cC])(el)(a|e|i|o|u|og|om|oj|ima|og|osti)\b" replaceWith="$1ijel$3" />
+    <RegEx find="\b([cC])(jel)(a|e|i|o|u|om|oj|ima|og|osti)\b" replaceWith="$1ijel$3" />
+    <RegEx find="(ćut)(im|iš|i|imo|ite|e)" replaceWith="šut$2" />
+    <RegEx find="(Ćut)(im|iš|i|imo|ite|e)" replaceWith="Šut$2" />
+    <RegEx find="(del)(ić|ića|iće|ićem|ići|ićima)" replaceWith="djel$2" />
+    <RegEx find="([dD])(eli)\b(m|š|mo|te|li|le|la|ti)" replaceWith="$1ijel$3" />
+    <RegEx find="([dD])(jeli)\b(m|š|mo|te|li|le|la|ti)" replaceWith="$1ijel$3" />
+    <RegEx find="(delikvent)(a|e|i|u|ima|om|na|no|ni|nim|nom|noj|ica|ici     |icu|ice|cija|ciji|ciju|cije|cijama)*" replaceWith="delinkvent$2" />
+    <RegEx find="([dD])(eluje)(m|š|mo|te|mo)*" replaceWith="$1jeluje$3" />
+    <RegEx find="([dD])(ete)(tom|tov|tovog|tovu|tove)" replaceWith="$1jete$3" />
+    <RegEx find="([dD])(ec)(a|i|o|u|e|om)*" replaceWith="$1jec$3" />
+    <RegEx find="([dD])(efinisan)(a|i|o|u|e|om|og)*" replaceWith="$1efiniran$3" />
+    <RegEx find="\b([dD])(elov)(a|e|i|ima)" replaceWith="$1ijelov$3" />
+    <RegEx find="([dD])(evoj)(ka|ke|ki|ko|ku|kom|kama|ci|čica|čice|čici|činu|čine)" replaceWith="$1jevoj$3" />
+    <RegEx find="([dD])(eča)(ka|ku|ke|kom|ci|cima)" replaceWith="$1ječa$3" />
+    <RegEx find="([dD])(ijec)(a|i|o|u|e|om)" replaceWith="$1jec$3" />
+    <RegEx find="([dD])(ragocen)(a|i|o|u|e|om|og|oj|ima)" replaceWith="$1ragocjen$3" />
+    <RegEx find="([dD])(obija)(m|š|mo|te|ju|la|le|li|ti)*" replaceWith="$1obiva$3" />
+    <RegEx find="(dopada)(m|š|mo|te|ju|la|le|li|ti)*" replaceWith="sviđa$2" />
+    <RegEx find="(dosije)(a|e|i|u|ima)" replaceWith="dosje$2" />
+    <RegEx find="(dospe)(li|la|ti)" replaceWith="dospje$2" />
+    <RegEx find="(dospe)(m|š|e|mo|te)" replaceWith="dospije$2" />
+    <RegEx find="(dušek)(a|u|i|e|ima)*" replaceWith="madrac$2" />
+    <RegEx find="\b(đep)(a|u|ovi|ove|ova|ima|na|ne|ni|no|noj|nom|nima)*" replaceWith="džep$2" />
+    <RegEx find="(evrop)(ski|ska|sko|sku|skom)" replaceWith="europ$2" />
+    <RegEx find="(Evrop)(a|e|i|o|u|om)" replaceWith="Europ$2" />
+    <RegEx find="(farba)(m|š|mo|te|ju|li|še|nje)*" replaceWith="boja$2" />
+    <RegEx find="(fudbal)(a|u|om)*" replaceWith="nogomet$2" />
+    <RegEx find="([gG])(luv)(a|e|o|u|oj|om)*" replaceWith="$1luh$3" />
+    <RegEx find="\b([gG])(reh)(a|e|u|om)*" replaceWith="$1rijeh$3" />
+    <RegEx find="\b([gG])(rjeh)(a|e|u|om)*" replaceWith="$1rijeh$3" />
+    <RegEx find="\b([gG])(res)(i|ima)" replaceWith="$1rijes$3" />
+    <RegEx find="([gG])(rejanj)(e|u|a|em|ima)" replaceWith="$1rijanj$3" />
+    <RegEx find="([gG])(reši)(o|m|š|mo|te|la|li|ti)" replaceWith="$1riješi$3" />
+    <RegEx find="([gG])(rješi)(o|m|š|mo|te|la|li|ti)" replaceWith="$1riješi$3" />
+    <RegEx find="(haos)(a|i|e|u|ima|na|no|ni|om)*" replaceWith="kaos$2" />
+    <RegEx find="(Holand)(ska|sku|skom|skoj)" replaceWith="Nizozems$3" />
+    <RegEx find="(Nizuzem)(ska|sku|skom|skoj)" replaceWith="Nizozems$3" />
+    <RegEx find="(historijsk)(e|i|a|o|u|om|oj)" replaceWith="povijesn$2" />
+    <RegEx find="(Historijsk)(e|i|a|o|u|om|oj)" replaceWith="Povijesn$2" />
+    <RegEx find="(istorijsk)(e|i|a|o|u|om|oj)*" replaceWith="povijesn$2" />
+    <RegEx find="(Istorijsk)(e|i|a|o|u|om|oj)*" replaceWith="Povijesn$2" />
+    <RegEx find="(hiljad)(a|e|i|u|om|ama)" replaceWith="tisuć$2" />
+    <RegEx find="(hleb)(a|u|om)*" replaceWith="kruh$2" />
+    <RegEx find="([iI])(migracion)(a|i|u|e|om|og)*" replaceWith="$1migracijsk$3" />
+    <RegEx find="(migracion)(a|i|u|e|om|og)*" replaceWith="migracijsk$2" />
+    <RegEx find="([iI])(nostranstv)(a|u|o|om|ima)" replaceWith="$1nozemstv$3" />
+    <RegEx find="(interesantn)(a|e|i|o|u|om)*" replaceWith="zanimljiv$2" />
+    <RegEx find="([iI])(spoljava)(m|š|mo|te|ju|li|nje)*" replaceWith="$1zražava$3" />
+    <RegEx find="([iI])(zbe)(ći|gava|gavaš|gavamo|gavate|gavaju|gavanje|gavali|gao|gla|gli|glo)" replaceWith="$1zbje$3" />
+    <RegEx find="([iIz])(bled)(ela|elo|ele|eli|io|elom|elima|jele)" replaceWith="$1blijedj$3" />
+    <RegEx find="([iI])(sčeznu)(o|la|le|li|lu|lom|lima|lima|ti|uše|uvši)" replaceWith="$1ščeznu$3" />
+    <RegEx find="([iI])(sčezn)(em|eš|e|emo|ete|u)" replaceWith="$1ščezn$3" />
+    <RegEx find="([iI])(skorišć)(en|ena|eni|enu|enoj|enom|enima|avam|avaš|ava|avamo|avate|avaju|avajte)" replaceWith="$1skorišt$3" />
+    <RegEx find="([iI])(zmen)(a|e|i|u|om|ama)" replaceWith="$1zmjen$3" />
+    <RegEx find="(ispresecan)(a|e|i|u|om)*" replaceWith="ispresijecan$2" />
+    <RegEx find="([iI])(zgladne)(la|le|li|lo|lu|lima|lom)" replaceWith="$1zgladnje$3" />
+    <RegEx find="([iI])(zvešta)(j|ji|ja|je|ju|vam|vaš|va|vamo|vate|vaju|vanje)*" replaceWith="$1zvješta$3" />
+    <RegEx find="\b([kK])(af)(a|e|i|u|om|ama|ana|ane|ani|anu|anom|anama|anska|anski|ansku|anskom)\b" replaceWith="$1av$3" />
+    <RegEx find="(kancelarij)(u|om)*" replaceWith="ured$2" />
+    <RegEx find="(kirij)(a|e|i|o|u|om)" replaceWith="stanarin$2" />
+    <RegEx find="([kK])(elner)(a|e|i|u|ima)*" replaceWith="$1onobar$3" />
+    <RegEx find="\b([kK])(olen)(a|o|u|ima)" replaceWith="$1oljen$3" />
+    <RegEx find="([kK])(ombinovanj)(e|a|u|em|ima)" replaceWith="$1ombiniranj$3" />
+    <RegEx find="(kompjuter)(a|e|i|u|om|ima)*" replaceWith="kompjutor$2" />
+    <RegEx find="(konkurs)(a|e|i|u|om|ima)*" replaceWith="natječaj$2" />
+    <RegEx find="(konkuris)(ati|ali|ale|alo)" replaceWith="konkurir$2" />
+    <RegEx find="(kontrolisan)(o|i|a|oj|om|ima)*" replaceWith="kontroliran$2" />
+    <RegEx find="(nekontrolisan)(o|i|a|oj|om|ima)*" replaceWith="nekontroliran$2" />
+    <RegEx find="([kK])(orišćenj)(a|e|u|em|ima)*" replaceWith="$1orištenj$3" />
+    <RegEx find="([kK])(oriščenj)(a|e|u|em|ima)*" replaceWith="$1orištenj$3" />
+    <RegEx find="([kK])(učk)(a|e|i|o|u|om)*" replaceWith="$1uj$3" />
+    <RegEx find="([kK])(uvan)(a|e|i|o|u|ima|og|om|oj|im)*" replaceWith="$1uhan$3" />
+    <RegEx find="([kK])(uvar)(a|e|i|u|ima)*" replaceWith="$1uhar$3" />
+    <RegEx find="\b(krst)(a|u|em)*" replaceWith="križ$2" />
+    <RegEx find="([lL])(eči)(o|la|le|li|ti|še)*" replaceWith="$1iječi$3" />
+    <RegEx find="([lL])(ječi)(o|la|le|li|ti|še)*" replaceWith="$1iječi$3" />
+    <RegEx find="([lL])(ečni)(k|ka|ku|ca|cu|ci|ce|cima|cama)*" replaceWith="$1iječni$3" />
+    <RegEx find="([lL])(ječni)(k|ka|ku|ca|cu|ci|ce|cima|cama)*" replaceWith="$1iječni$3" />
+    <RegEx find="([lL])(ekar)(a|e|u|om)*" replaceWith="$1iječnik$3" />
+    <RegEx find="\b(len)(a|e|i|o|u|om|ima|čina|čino|čine)" replaceWith="lijen$2" />
+    <RegEx find="\b(Len)(a|e|i|o|u|om|ima|čina|čino|čine)" replaceWith="Lijen$2" />
+    <RegEx find="([lL])(ep)(a|i|o|u|e|im|om|ima|og|om)*\b" replaceWith="$1ijep$3" />
+    <RegEx find="\b(lev)(a|i|o|u|om|oj|ima)" replaceWith="lijev$2" />
+    <RegEx find="\b(ličn)(a|e|i|o|u|im|om|oj)*" replaceWith="osobn$2" />
+    <RegEx find="\b(Ličn)(a|e|i|o|u|im|om|oj)*" replaceWith="Osobn$2" />
+    <RegEx find="(lobanj)(a|e|i|u|om|aima)*" replaceWith="lubanj$2" />
+    <RegEx find="(Lobanj)(a|e|i|u|om|aima)*" replaceWith="Lubanj$2" />
+    <RegEx find="\b(ljep)(a|e|i|o|u|om|oj|ima)\b" replaceWith="lijep$2" />
+    <RegEx find="\b(Ljep)(a|e|i|o|u|om|oj|ima)\b" replaceWith="Lijep$2" />
+    <RegEx find="([mM])(esec)(a|e|i|u|om|ima)*" replaceWith="$1jesec$3" />
+    <RegEx find="(meša)(m|n|ni|na|no|nom|noj|nima|š|mo|te|ju|njem|nju|li|lica|licu|lici|lice|licama|ti)" replaceWith="miješa$2" />
+    <RegEx find="(mješa)(m|n|ni|na|no|nom|noj|nima|š|mo|te|ju|njem|nju|li|ti)" replaceWith="miješa$2" />
+    <RegEx find="([mM])(edve)(da|de|di|du|dom|dima|đa|đu|đom|đoj|đi|đeg)" replaceWith="$1edvje$3" />
+    <RegEx find="([mM])(enja)(m|š|mo|te|ju|li|ti)" replaceWith="$1ijenja$3" />
+    <RegEx find="([mM])(jenja)(m|š|mo|te|ju|li|ti)*" replaceWith="$1ijenja$3" />
+    <RegEx find="([mM])(est)(a|o|u|om|ima)" replaceWith="$1jest$3" />
+    <RegEx find="([mM])(jenja)(m|š|mo|te|ju|li)*" replaceWith="$1ijenja$3" />
+    <RegEx find="([mM])(lek)(a|o|u|om)" replaceWith="$1lijek$3" />
+    <RegEx find="([mM])(ljek)(a|o|u|om)" replaceWith="$1lijek$3" />
+    <RegEx find="([mM])(oč)(i|u|ni|nim|noj)" replaceWith="$1oć$3" />
+    <RegEx find="([mM])(ogučnost)(i|ima)*" replaceWith="$1ogućnost$3" />
+    <RegEx find="([mM])(uva)(o|j|š|mo|te|ju|vši|li|ti|lo|la|le)" replaceWith="$1ota$3" />
+    <RegEx find="(muzik)(a|u|om)\b" replaceWith="glazb$2" />
+    <RegEx find="([nN])(amer)(a|e|i|u|om|na|no|noj|nom|nim)" replaceWith="$1amjer$3" />
+    <RegEx find="([nN])(ameni)(m|š|mo|o|te|ti|o|la|le|li|še)*" replaceWith="$1amijeni$3" />
+    <RegEx find="([nN])(amjeni)(m|š|mo|o|te|ti|o|la|le|li|še)*" replaceWith="$1amijeni$3" />
+    <RegEx find="([nN])(amesti)(m|š|mo|te|ti|o|la|le|li|še)*" replaceWith="$1amjesti$3" />
+    <RegEx find="([nN])(arandž)(a|e|i|u|om|ama)" replaceWith="$aranč$3" />
+    <RegEx find="([nN])(aranđ)(a|e|i|u|om|ama)" replaceWith="$aranč$3" />
+    <RegEx find="([nN])(asljeđ)(a|e|i|u|em|ima)" replaceWith="$1aslijeđ$3" />
+    <RegEx find="([nN])(asmej)(em|eš|e|emo|ete|u|ani|ane|anima|anoj|anom|ano|ava|avaš|an|ana|anu|anog|alo|ala|ao)" replaceWith="$1asmij$3" />
+    <RegEx find="([nN])(ečove)(k|ka|ku|kom|kove|če|čanstvo|čanstva|čanstvu|čanstvom|čni|čna|čno)" replaceWith="$1ečovje$3" />
+    <RegEx find="(nedelj)(a)*" replaceWith="nedjelj$2" />
+    <RegEx find="([nN])(eprijatn)(a|e|i|u|om|no|noj|nom|nim)*" replaceWith="$1eugodn$3" />
+    <RegEx find="([nN])(eprimet)(an|na|no|ne|ljiv|ljiva|ljivo|ljivost|ljivošću|ljivosti|nost)" replaceWith="$1eprimjet$3" />
+    <RegEx find="([nN])(epobediv)(a|o|om|oj|e|i|u|ost|ošću|osti)" replaceWith="$1epobjediv$3" />
+    <RegEx find="(nevaspitan)(a|e|i|o|u|oj|om|im|ima|je|ju|jem)" replaceWith="neobrazovan$2" />
+    <RegEx find="(nevaspitan)(a|e|i|o|u|oj|om|im|ima|je|ju|jem)" replaceWith="Neobrazovan$2" />
+    <!-- vrijedi i za vjerojatno -->
+    <RegEx find="([nN])(everojat)(an|na|ne|ni|no|nom|nog|nu|noj|nim)*" replaceWith="$1evjerojat$3" />
+    <!-- -||- -->
+    <RegEx find="([nN])(everovat)(an|na|ne|ni|no|nom|nog|nu|noj|nim)*" replaceWith="$1evjerojat$3" />
+    <RegEx find="([nN])(esreć)(an|na|ni|nik|nika|nikom|nica|nicu|nicom|no|nom|noj|niji|nijeg|nijem|nija|niju|nijom|nijoj)" replaceWith="$1esret$3" />
+    <RegEx find="(nesmij)(em|eš|e|emo|ete|u)*" replaceWith="ne smij$2" />
+    <RegEx find="([nN])(ežn)(a|e|i|u|om|og|oj|ima|iji|ije|ija)" replaceWith="$1ježn$3" />
+    <RegEx find="([nN])(oč)(i|u|ni|na|noj|nim)*" replaceWith="$1oć$3" />
+    <RegEx find="(naučn)(i|a|o|og|u|oj|om|ik|im|ici)*" replaceWith="znanstven$2" />
+    <RegEx find="([oO])(bavest)(io|ila|ile|ili|iti|iše)*" replaceWith="$1bavijest$3" />
+    <RegEx find="([oO])(bavjest)(io|ila|ile|ili|iti|iše)*" replaceWith="$1bavijest$3" />
+    <RegEx find="(obezbeđenj)(a|e|u|ima)" replaceWith="osiguranj$2" />
+    <RegEx find="([oO])(brača)(m|o|š|mo|te|ju|jući|vši|la|le|li|lo|ti)*" replaceWith="$1braća$3" />
+    <RegEx find="\b(odeć)(a|u|i|om)" replaceWith="odjeć$2" />
+    <RegEx find="([oO])(deljenj)(a|u)" replaceWith="$1djel$3" />
+    <RegEx find="([oO])(dgaji)(la|le|li|še)*" replaceWith="$1dgoji$3" />
+    <RegEx find="([oO])(gladne)(la|le|li|lo|lu|lima|lom)" replaceWith="$1gladnje$3" />
+    <RegEx find="([oO])(kean)(a|e|i|u|ima)*" replaceWith="$1cean$3" />
+    <RegEx find="([oO])(psednut)(a|e|i|u|om|im|ima)*" replaceWith="$1psjednut$3" />
+    <RegEx find="([oO])(pšt)(a|e|i|u|em|om|im)" replaceWith="$1pć$3" />
+    <RegEx find="([oO])(rganizuje)(m|mo|š|te)*" replaceWith="$1rganizira$3" />
+    <RegEx find="([oO])(rganizov)(an|ana|ano|ani|anom|anoj|anima|anim)" replaceWith="$1rganizir$3" />
+    <RegEx find="([oO])(seti)(o|m|š|la|li|le|ti)" replaceWith="$1sjeti$3" />
+    <RegEx find="([oO])(setljiv)(a|i|e|o|om|im|ima|oj)*" replaceWith="$1sjetljiv$3" />
+    <RegEx find="([oO])(seća)(m|š|mo|te|ju|j|ja|ji|je|jem|ju|jima)*" replaceWith="$1sjeća$3" />
+    <RegEx find="([oO])(strv)(a|u|om|ima)" replaceWith="$1tok$3" />
+    <RegEx find="\b([oO])(ter)(a|am|amo|ate|aju)" replaceWith="$1tjer$3" />
+    <RegEx find="([oO])(zled)(a|e|i|u|om|ama)" replaceWith="$1zljed$3" />
+    <RegEx find="([oO])(zlijed)\b(a|e|i|u|om|ama)" replaceWith="$1zljed$3" />
+    <RegEx find="([oO])(zledi)(m|š|mo|te|ti|o|la|lo|še)*" replaceWith="$1zlijedi$3" />
+    <RegEx find="([oO])(zleđen)(a|am|amo|ate|aju|om|oj|ima)" replaceWith="$1zlijeđen$3" />
+    <RegEx find="([oO])(zljeđen)(a|am|amo|ate|aju|om|oj|ima)" replaceWith="$1zlijeđen$3" />
+    <RegEx find="(pacov)(a|i|u|om|ima)*" replaceWith="štakor$2" />
+    <RegEx find="([pP])(eva)(č|m|š|mo|te|ju|li|čica|či|čice)*" replaceWith="$1jeva$3" />
+    <RegEx find="([pP])(esm)(a|e|i|o|u|om)" replaceWith="$1jesm$3" />
+    <RegEx find="([pP])(eša)(k|ka|ku|kom|kinja|kinjom|cima|čim|čiš|čimo|čite|če|čili)" replaceWith="$1ješa$3" />
+    <RegEx find="(peškir)(a|e|i|u|om)*" replaceWith="ručnik$2" />
+    <RegEx find="([pP])(obed)(a|e|i|o|u|om|ama|nik|nika|niku|nica|nici|nicu)" replaceWith="$1objed$3" />
+    <RegEx find="([pP])(odstica)(j|ja|ju|ti|jima|je|li|še)" replaceWith="$1otic$3" />
+    <RegEx find="([pP])(odstič)(em|eš|e|emo|ete|u)" replaceWith="$1otič$3" />
+    <RegEx find="([pP])(otcenjen)(a|e|i|o|u|om|oj|om|ima)*" replaceWith="$1odcijenjen$3" />
+    <RegEx find="([pP])(ridik)(a|e|i|o|u|om|ama)" replaceWith="$1rodik$3" />
+    <RegEx find="([pP])(roleć)(a|e|u|em|ima)*" replaceWith="$1roljeć$3" />
+    <RegEx find="([pP])(oseduj)(e|em|eš|emo|ete|u)" replaceWith="$1osjeduj$3" />
+    <RegEx find="([pP])(oseti)\b(o|m|š|la|li|le|lo|ti)*" replaceWith="$1osjeti$3" />
+    <RegEx find="([pP])(odseti)(o|m|š|la|li|le|lo|ti)*" replaceWith="$1odsjeti$3" />
+    <RegEx find="([pP])(otseti)(o|m|š|la|li|le|lo|ti)*" replaceWith="$1odsjeti$3" />
+    <RegEx find="([pP])(otsjeti)(o|m|š|la|li|le|lo|ti)*" replaceWith="$1odsjeti$3" />
+    <RegEx find="([pP])(osledic)(a|e|i|o|u|om)" replaceWith="$1osljedic$3" />
+    <RegEx find="([pP])(oslednj)(a|e|i|u|em|oj|om|ima)" replaceWith="$1osljednj$3" />
+    <RegEx find="([pP])(osed)(a|e|i|o|u|om)" replaceWith="$1osjed$3" />
+    <RegEx find="([pP])(osmatra)(č|j|m|š|mo|te|ju|či|ču|ča|če|čice)*" replaceWith="$1romatra$3" />
+    <RegEx find="([pP])(oter)(a|e|i|u|om|ama|aš|amo|ate|aju|nica|nicama|nicu|nice)*" replaceWith="$1otjer$3" />
+    <RegEx find="([pP])(ovred)(io|ila|ili|ile|iti|iše|ilo)" replaceWith="$1ovrijed$3" />
+    <RegEx find="([pP])(ovrjed)(io|ila|ili|ile|iti)" replaceWith="$1ovrijed$3" />
+    <RegEx find="([pP])(ovređen)(a|am|amo|ate|aju|om|oj|ima)" replaceWith="$1ovrijeđen$3" />
+    <RegEx find="([pP])(ovređen)(a|am|amo|ate|aju|om|oj|ima)" replaceWith="$1ovrijeđen$3" />
+    <RegEx find="(pozorišt)(a|e|u|ima)*" replaceWith="kazališt$2" />
+    <RegEx find="([pP])(redlog)(a|u|om)*" replaceWith="$1rijedlog$3" />
+    <RegEx find="([pP])(rjedlog)(a|u|om)*" replaceWith="$1rijedlog$3" />
+    <RegEx find="([pP])(redloz)(i|ima)" replaceWith="$1rijedloz$3" />
+    <RegEx find="([pP])(rjedloz)(i|ima)" replaceWith="$1rijedloz$3" />
+    <RegEx find="([pP])(restupnik)(a|u|om)*" replaceWith="$1rijestupnik$3" />
+    <RegEx find="([pP])(rjestupnik)(a|u|om)*" replaceWith="$1rijestupnik$3" />
+    <RegEx find="([pP])(reteriva)(o|la|lo|nje|nja|u|em|njima)*" replaceWith="$1retjeriva$3" />
+    <RegEx find="([pP])(rolet)(no|nom|na|noj|nim)*" replaceWith="$1ljet$3" />
+    <RegEx find="([pP])(rolet)(ele|ela|elim|elima)*" replaceWith="$1letj$3" />
+    <RegEx find="([pP])(romen)(a|e|i|u|om|ama)" replaceWith="$1romjen$3" />
+    <RegEx find="(promen)(im|iš|imo|ite|ili|ile)" replaceWith="promijen$2" />
+    <RegEx find="(promjen)(im|iš|imo|ite|ili|ile)" replaceWith="promijen$2" />
+    <RegEx find="([pP])(esnik)(a|u|ov|ovu|om)*" replaceWith="#1jesnik$3" />
+    <RegEx find="\b([pP])(obed)(a|i|e|u|o|om|ama)" replaceWith="$1objed$3" />
+    <RegEx find="\b([pP])(obed)(im|iš|i|imo|ite|e|iti|ili|ivši)" replaceWith="$1obijed$3" />
+    <RegEx find="([pP])(obeg)(ao|la|li|le|lo|avši)" replaceWith="$1objeg$3" />
+    <RegEx find="([pP])(oent)(a|e|u|i|o|om|ama)" replaceWith="$1oant$3" />
+    <RegEx find="([pP])(ogreš)(io|ila|ili)" replaceWith="$1ogriješ$3" />
+    <RegEx find="([pP])(ogrješ)(io|ila|ili)" replaceWith="$1ogriješ$3" />
+    <RegEx find="([pP])(oslednj)(i|im|e|em|eg|ima)" replaceWith="$1osljed$3" />
+    <RegEx find="(pomera)(m|š|mo|te)" replaceWith="miče$2" />
+    <RegEx find="([pP])(one)(la|le|li|lo|ti)" replaceWith="$1onije$3" />
+    <RegEx find="([pP])(onje)(la|le|li|lo|ti)" replaceWith="$1onije$3" />
+    <RegEx find="([pP])(overenj)(e|a|u|em)" replaceWith="$1ovjerenj$3" />
+    <RegEx find="([pP])(overljiv)(a|e|i|o|u|ima|ima|om|og|oj)*" replaceWith="$1ovjerljiv$3" />
+    <RegEx find="([pP])(revoz)\b(a|u|om|ovi|ovima)*" replaceWith="$1rijevoz$3" />
+    <RegEx find="([pP])(retnj)(a|e|i|o|u|om|ama)*" replaceWith="$1rijetnj$3" />
+    <RegEx find="([pP])(rimećuj)(em|eš|e|emo|ete|u)" replaceWith="$1rimjećuj$3" />
+    <RegEx find="([pP])(rimijećuj)(em|eš|e|emo|ete|u)" replaceWith="$1rimjećuj$3" />
+    <RegEx find="([pP])(rimer)(ak|en|ena|eno|enog|enu|enim|ku|kom|ci|cima)*" replaceWith="$1rimjer$3" />
+    <RegEx find="([nN])(eprimer)(en|ena|eno|enog|enu|enim)" replaceWith="$1rimjer$3" />
+    <RegEx find="\b([pP])(rimet)(an|na|no|ljiv|ljiva|ljivo|ljivost|ljivošću|ljivosti|nost)" replaceWith="$1rimjet$3" />
+    <RegEx find="\b([pP])(rimen)(a|e|i|o|u|om|jena|jene|jenoj|jenim|jiv|jiva|jivo|jivog|jivom|jivu)*" replaceWith="$1rimjen$3" />
+    <RegEx find="\b([pP])(rimeni)(m|š|imo|ite|ti|li|la|le|lo)" replaceWith="$1rimijeni$3" />
+    <RegEx find="\b([pP])(rimeti)(o|la|le|lo|li)*" replaceWith="$1rimijeti$3" />
+    <RegEx find="([pP])(rosečn)(a|e|i|o|u|om|oj|im|ima)*" replaceWith="$1rosječn$3" />
+    <RegEx find="([pP])(over)(im|iš|i|imo|ite|e|ili|ile|ilo|iše)" replaceWith="$1ovjer$3" />
+    <RegEx find="([pP])(rover)(a|e|i|o|u|om|im|ama|im|iš|i|imo|ite|iti|e|ili|ile|ilo|iše)" replaceWith="$1rovjer$3" />
+    <RegEx find="([pP])(rjedlo)(g|ga|ge|gu|gom|zi|zima)" replaceWith="$1rijedlo$3" />
+    <RegEx find="([pP])(reti)(o|š|mo|te|la|li|lo|le)" replaceWith="$1rijeti$3" />
+    <RegEx find="([pP])(reter)(ao|am|aš|amo|ate|aju|ala|ali|alo|ale|ivanje|ivanja|ivali|ivale|ujem|uješ|uje|ujemo|ujete|uju)" replaceWith="$1retjer$3" />
+    <RegEx find="(prevazi)(đen|đeno|đena|ći|laženje|laženja|laženju|laženjem)" replaceWith="nadi$2" />
+    <RegEx find="([rR])(azmen)(a|e|u|i|ama)*" replaceWith="$1azmjen$3" />
+    <RegEx find="([rR])(azume)(m|š|mo|te|va)" replaceWith="$1azumije$3" />
+    <RegEx find="([rR])(ešava)(m|š|mo|te|ju|nje|li)*" replaceWith="$1ješava$3" />
+    <RegEx find="([rR])(ešenj)(e|em|u|a|ima)*" replaceWith="$1ješenj$3" />
+    <RegEx find="\b([rR])(eč)(i|ima)" replaceWith="$1iječ$3" />
+    <RegEx find="\b([rR])(eš)(io|ila|ili|ile|iti|im|iš|i|imo|ite|e)" replaceWith="$1iješ$3" />
+    <RegEx find="\b([rR])(ješi)(o|la|li|le|ti|m|š|mo|te)" replaceWith="$1iješi$3" />
+    <RegEx find="\b([rR])(eš)(avati|avala|avao|avali|avam|avaš|ava|avamo|avate|avaju|avanje)" replaceWith="$1ješ$3" />
+    <RegEx find="\b([rR])(iješ)(avati|avala|avao|avali|avam|avaš|ava|avamo|avate|avaju|avanje)" replaceWith="$1ješ$3" />
+    <RegEx find="(sačeka)(j|te|š|mo|te|ju|li|še|te|jte)*" replaceWith="pričeka$2" />
+    <RegEx find="(Sačeka)(j|te|š|mo|te|ju|li|še|te|jte)*" replaceWith="Pričeka$2" />
+    <RegEx find="(saobraćaj)(na|nu|ni|nom|nima)*" replaceWith="promet$2" />
+    <RegEx find="(Saobraćaj)(na|nu|ni|nom|nima)*" replaceWith="Promet$2" />
+    <RegEx find="([sS])(aradni)(ka|ku|kom|ca|ce|ci|cu|co|cima|cama)" replaceWith="$1uradni$3" />
+    <RegEx find="([sS])(arađ)(ivam|ivaš|iva|ivamo|ivate|ivaju|ivati|ujem|uješ|uje|ujemo|ujete|uju|ujući|ujuća|ivanje|ivanjem)*" replaceWith="$1urađ$3" />
+    <RegEx find="([sS])(amoubistv)(a|o|u|om|ima)" replaceWith="$1amoubojstv$3" />
+    <RegEx find="\b([sS])(avet)(a|u|om|ima|nik|nica|nica|nicu|nici|nicima|nicama|nice|ovanje|ovanju)*" replaceWith="$1avjet$3" />
+    <RegEx find="([sS])(ažaleva)(m|š|mo|te|ju|ti|li|le|la|lo|jući|juća|juće|nje)" replaceWith="$1ažalijeva$3" />
+    <RegEx find="([sS])(ažaljeva)(m|š|mo|te|ju|ti|li|le|la|lo|jući|juća|juće|nje)" replaceWith="$1ažalijeva$3" />
+    <RegEx find="\b([sS])(edi)(m|š|i|imo|ite|e|eći|ili|ile|ilo|iše)" replaceWith="$1jedi$3" />
+    <RegEx find="\b(sme)(m|š|mo|te|šna|šne|šni|šno|šnom|šnoj|šnu)\b" replaceWith="smije$2" />
+    <RegEx find="\b(Sme)(m|š|mo|te|šna|šne|šni|šno|šnom|šnoj|šnu)\b" replaceWith="Smije$2" />
+    <RegEx find="\b([sS])(mej)(u|e|em|eš|emo|ete|anje|anju|ati|ali|ale|ao|ala|alo)" replaceWith="$1mij$3" />
+    <RegEx find="([sS])(pasava)(m|š|mo|te|ju|li|nje|nju|nja)*" replaceWith="$1pašava$3" />
+    <RegEx find="([sS])(prečava)(m|š|mo|te|ju|li|še|nje)*" replaceWith="$1prječava$3" />
+    <RegEx find="([sS])(priječava)(m|š|mo|te|ju|li|še)*" replaceWith="$1prječava$3" />
+    <RegEx find="([sS])(preči)(m|š|mo|te|li|še|o|la|li|le|lo|ti)*" replaceWith="$1priječi$3" />
+    <RegEx find="([sS])(prječi)(m|š|mo|te|li|še|o|la|li|le|lo|ti)*" replaceWith="$1priječi$3" />
+    <RegEx find="([sS])(umlja)(m|š|še|mo|te|ti|ju|jući|li|le|lo)*" replaceWith="$1umnja$3" />
+    <RegEx find="([sS])(eti)\b(t|o|m|š|la|li|le|ti)" replaceWith="$1jeti$3" />
+    <RegEx find="([sS])(ever)(a|u|om|ni|nom|ac)*" replaceWith="$1jever$3" />
+    <RegEx find="([sS])(eća)(m|š|mo|te|ju|li|nje)*" replaceWith="$1jeća$3" />
+    <RegEx find="(shvata)(m|š|mo|te|ju|li|ti|nje)" replaceWith="shvaća$2" />
+    <RegEx find="([sS])(led)(eće|ećeg|eća|eću|ećom|ećoj|ećem|eći|ećom|ećima|ećim|ećih)*" replaceWith="$1ljed$3" />
+    <RegEx find="([sS])(ljed)\b(a|e|i|u|om|im|iš|imo|ite|e|ili)" replaceWith="$1lijed$3" />
+    <RegEx find="([rR])(edosljed)(a|e|u|om)" replaceWith="$1edoslijed$3" />
+    <RegEx find="([sS])(meh)(a|u|om)*" replaceWith="$1mijeh$3" />
+    <RegEx find="([sS])(mešn)(a|e|i|o|u|om|oj|ima)*" replaceWith="$1miješn$3" />
+    <RegEx find="(sopstven)(a|e|i|o|u|om|oj|im|og|ima)*" replaceWith="vlastit$2" />
+    <RegEx find="(spakuje)(m|eš|mo|te)*" replaceWith="spakira$2" />
+    <RegEx find="([sS])(reč)(a|e|i|u|om|ama)" replaceWith="$1reć$3" />
+    <RegEx find="([sS])(reč)(an|na|ni|nik|nika|nikom|nica|nicu|nicom|no|nom|noj|niji|nijeg|nijem|nija|niju|nijom|nijoj)" replaceWith="$1ret$3" />
+    <RegEx find="([sS])(reć)(an|na|ni|nik|nika|nikom|nica|nicu|nicom|no|nom|noj|niji|nijeg|nijem|nija|niju|nijom|nijoj)" replaceWith="$1ret$3" />
+    <RegEx find="(stomak)(u|om)*" replaceWith="trbuh$2" />
+    <RegEx find="(stomač)(na|ne|ni|no|nu|noj|nom|nima)" replaceWith="trbuš$2" />
+    <RegEx find="\b([sS])(trel)(a|e|i|u|o|om|ac|cu|ci|cima|ama)" replaceWith="$1trijel$3" />
+    <RegEx find="\b([sS])(trjel)(a|e|i|u|o|om|ac|cu|ci|cima|ama)" replaceWith="$1trijel$3" />
+    <RegEx find="([sS])(used)(a|e|i|o|u|ama|ima|ski|skim|ima)*" replaceWith="$1usjed$3" />
+    <RegEx find="(suštin)(e|i|om)" replaceWith="biti" />
+    <RegEx find="([sS])(vat)(am|aš|a|amo|ate|aju|ajući|ali|ale|alo|aše)" replaceWith="$1hvać$3" />
+    <RegEx find="([sS])(vedo)(k|ke|ka|ku|kom|ci|cima|kinja|kinju|kinji|čanstvo|čanstva|čili|čio|čila|čiti)" replaceWith="$1vjedo$3" />
+    <RegEx find="([sS])(vesn)(a|e|i|o|u|om|oj|ima|ost|ošću)" replaceWith="$1vjesn$3" />
     <!-- razlikuju se svjetlo i svijetlo no tu automatske pomoći nema, već je na korisnicima da dodaju i gdje je potrebno! -->
-<RegEx find="([sS])(vetl)(a|e|i|o|u|om|ost|osti|ošću)" replaceWith="$1vjetl$3"/> 
-<RegEx find="([sS])(vetsk)(a|e|i|o|u|om|og|oj)" replaceWith="$1vjetsk$3"/>
-<RegEx find="([sS])(vež)(a|e|u|om|oj)*" replaceWith="$1vjež$3"/>
-<RegEx find="([sS])(vide)(la|li|lo)" replaceWith="$1vidje$3"/>
-<RegEx find="([sS])(vjet)(a|u|om)" replaceWith="$1vijet$3"/>
-<RegEx find="([sS])(vijet)(ski|skim|sku|skog|skom)" replaceWith="$1vjet$3"/>
-<RegEx find="(Špansk)(a|e|i|o|u|oj|om|im)*" replaceWith="Španjolsk$2"/>
-<RegEx find="(takmičenj)(a|e|u|ima|em)" replaceWith="natjecanj$2"/>
-<RegEx find="\b([tT])(ač)(an|na|no|nom|noj|nog|nima|niji|nijim|nije|nijem|niju|nijoj)*" replaceWith="$1oč$3"/>
-<RegEx find="(talentov)(an|ana|ani|ano|anom|anoj|anima)" replaceWith="talentir$2"/>
-<RegEx find="\b(tel)(o|a|u|om|ima)" replaceWith="tijel$2"/>
-<RegEx find="\b(Tel)(o|a|u|om|ima)" replaceWith="Tijel$2"/>
-<RegEx find="\b([tT])(esn)(a|e|i|o|u|om|oj|og|ima)" replaceWith="$1ijesn$3"/>
-<RegEx find="\b([tT])(oleris)(ao|ala|ale|ali|ati)" replaceWith="$1olerir$3"/>
-<RegEx find="([uU])(bedljivo)(st|šću)*" replaceWith="$1vjerljivo$3"/>
-<RegEx find="([uU])(beđen)(a|e|i|o|u|oj|om|ima|ost|ošću)*" replaceWith="$1vjeren$3"/>
-<RegEx find="\b([uU])(bic)(a|e|i|o|u|om|ima)" replaceWith="$1bojic$3"/>
-<RegEx find="\b([uU])(bistv)(a|o|u|om|ima)" replaceWith="$1bojstv$3"/>
-<RegEx find="(učestvuje)(m|š|mo|te)*" replaceWith="sudjeluje$2"/>
-<RegEx find="([uU])(cen)(a|e|i|u|om|ama|nu|om)" replaceWith="$1cjen$3"/>
-<RegEx find="(učestvo)(vala|vao|valo|vali|vale|vati|vanje|vanjem)*" replaceWith="sudjelo$2"/>
-<RegEx find="\b(ulepša)(vam|vaš|vamo|vate|vaju|vati|vaše|nom|nim|noj|nima)" replaceWith="uljepša$2"/>
-<RegEx find="([uU])(metni)(k|ka|ku|kom|ca|cu|ce|ci|ma|čka|čke|čki|čkim|čko|čkom)" replaceWith="$1mjetni$3"/>
-<RegEx find="([uU])(propašćava)(m|š|mo|nje|te|ju|li)*" replaceWith="$1propaštava$3"/>
-<RegEx find="([uU])(propaščava)(m|š|mo|nje|te|ju|li)*" replaceWith="$1propaštava$3"/>
-<RegEx find="([uU])(slov)(a|e|i|u|om|ima)*" replaceWith="$1vjet$3"/>
-<RegEx find="([uU])(speh)(a|e|u|om)*" replaceWith="$1spjeh$3"/>
-<RegEx find="([uU])(spesi)(ma)*" replaceWith="$1spjesi$3"/>
-<RegEx find="([uU])(speš)(an|na|ne|ni|no|nu|nom|noj|nim|nima)*" replaceWith="$1spješ$3"/>
-<RegEx find="([uU])(sredsred)(im|iš|i|imo|ite|ili|io|ila|ilo)*" replaceWith="$1sredotoč$3"/>
-<RegEx find="([uU])(sredsređen)(a|e|i|im|ima|o|oj|u|om|ost|ošću)*" replaceWith="$1sredotočen$3"/>
-<RegEx find="\b([uU])(spev)(am|aš|a|amo|ate|aju|ale|alo|ali|aše)" replaceWith="$1spijev$3"/>
-<RegEx find="\b([uU])(spjev)(am|aš|a|amo|ate|aju|ale|alo|ali|aše)" replaceWith="$1spijev$3"/>
-<RegEx find="([uU])(sredsredi)(m|š|mo|te|la|lo|o|li|še)*" replaceWith="$1sredotoči$3"/>
-<RegEx find="(ućut)(im|iš|i|imo|ite|e)" replaceWith="ušut$2"/> 
-<RegEx find="(Ućut)(im|iš|i|imo|ite|e)" replaceWith="Ućut$2"/>
-<RegEx find="(univerzum)(a|e|i|u|om|ima)*" replaceWith="svemir$2"/>
-<RegEx find="([uU])(ticaj)(a|e|i|u|em|ima|ni|nu|nima|noj|nom)*" replaceWith="$1tjecaj$3"/>
-<RegEx find="([uU])(verav)(am|aš|a|amo|ate|aju|ati|ala|ao|ali|aše)" replaceWith="$1vjerav$3"/>
-<RegEx find="([uU])(verljiv)(a|e|i|o|u|ima|ima|om|og|oj)*" replaceWith="$1vjerljiv$3"/>
-<RegEx find="([uU])(vet)(a|e|i|u|om|ima|nu|nima|noj|nom)*" replaceWith="$1vjet$3"/>
-<RegEx find="(uzok)(ujem|uješ|uje|ujemo|ujete|uju|ovan|ovani|ovali|ovale|ovalo)*" replaceWith="uzrok$2"/>
-<RegEx find="\b(varvar)(a|e|i|u|ima|skom|skim|skoj|skima|ski)" replaceWith="barbar$2"/>
-<RegEx find="\b(Varvar)(a|e|i|u|ima)" replaceWith="Barbar$2"/>
-<RegEx find="(vazduh)(a|u|om)*" replaceWith="zrak$2"/>
-<RegEx find="(vazduš)(ni|na|nu|no|nom|nog)*" replaceWith="zrač$2"/>
-<RegEx find="(vaspitan)(a|e|i|o|u|oj|om|im|ima|je|ju|jem)" replaceWith="obrazovan$2"/>
-<RegEx find="(Vaspitan)(a|e|i|o|u|oj|om|im|ima|je|ju|jem)" replaceWith="Obrazovan$2"/>
-<RegEx find="(vaspitn)(a|e|i|o|u|oj|om|im|ima)" replaceWith="obrazovn$2"/>
-<RegEx find="(Vaspitn)(a|e|i|o|u|oj|om|im|ima)" replaceWith="Obrazovn$2"/>
-<RegEx find="([vV])(eoma)" replaceWith="$1rlo"/>
-<RegEx find="([vV])(erova)(o|la|li|le|lo|še)" replaceWith="$1jerova$3"/>
-<RegEx find="([vV])(erovat)(an|na|ne|ni|no|nom|nog|nu|noj|nim)" replaceWith="$1jerojat$3"/>
-<RegEx find="([vV])(eruj)(e|u|em|eš|ete|emo|te)*" replaceWith="$1jeruj$3"/>
-<RegEx find="\b(vest)(i|ima)*" replaceWith="vijest$2"/>   <RegEx find="\b(Vest)(i|ima)*" replaceWith="Vijest$2"/>      
-<RegEx find="\b(vjest)(i|ima)*" replaceWith="vijest$2"/>    <RegEx find="\b(Vjest)(i|ima)*" replaceWith="Vijest$2"/>    
-<RegEx find="([vV])(eštic)(a|e|i|u|om|ama)" replaceWith="$1ještic$3"/>  
-<RegEx find="([vV])(enčanj)(e|a|u|em|ima)" replaceWith="$1jenčanj$3"/>
-<RegEx find="(veštačk)(a|e|i|o|u|og|om|oj|im|ima)" replaceWith="umjetn$2"/>
-<RegEx find="(Veštačk)(a|e|i|o|u|og|om|oj|im|ima)" replaceWith="Umjetn$2"/>
-<RegEx find="([vV])(et)(ar|ra|ru|rom|rovi|rovito|rovima)" replaceWith="$1jet$3"/>
-<RegEx find="([vV])(ide)(la|le|li|ti)" replaceWith="$1idje$3"/>
-<RegEx find="\b([vV])(išlj)(a|e|i|u|eg|em|oj|om)" replaceWith="$1iš$3"/>
-<RegEx find="\b([vV])(odk)(a|e|i|u|ama)" replaceWith="$1otk$3"/>
-<RegEx find="([vV])(ole)(n|na|no|ti|nu|nog|la|le|li)" replaceWith="$1olje$3"/>
-<RegEx find="([vV])(redi)(m|š|mo|te|li)*" replaceWith="$1rijedi$3"/>
-<RegEx find="([zZ])(ainteresova)(n|ni|ne|la|le|li|lo|ti|na|no|noj)" replaceWith="$1ainteresira$3"/>
-<RegEx find="([zZ])(ahtev)(am|aš|amo|ate|aju|ali|ati|ajmo|ajte|aju)" replaceWith="$1ahtijev$3"/> 
-<RegEx find="([zZ])(ahtjev)(am|aš|amo|ate|aju|ali|ati|ajmo|ajte|aju)" replaceWith="$1ahtijev$3"/> 
-<RegEx find="([zZ])(ahtev)(a|u|i|e|om|ima)" replaceWith="$1ahtjev$3"/>
-<RegEx find="([zZ])(amenjiv)(a|u|i|e|o|ima|og|ov)*" replaceWith="$1amjenjiv$3"/>
-       <RegEx find="([nN])(ezamenjiv)(a|u|i|e|o|ima|og|ov)*" replaceWith="$1ezamjenjiv$3"/>
-<RegEx find="([zZ])(ameni)(m|š|mo|o|te|ti|o|la|le|li|še)*" replaceWith="$1amijeni$3"/>
-<RegEx find="([zZ])(amjeni)(m|š|mo|o|te|ti|o|la|le|li|še)*" replaceWith="$1amijeni$3"/>
-<RegEx find="(zavis)(im|iš|i|imo|ite|ni|ne|nima|nim|nom|nik|nica|nošću)" replaceWith="ovis$2"/>
-<RegEx find="(Zavis)(im|iš|i|imo|ite|ni|ne|nima|nim|nom|nik|nica|nošću)" replaceWith="Ovis$2"/>
-<RegEx find="([zZ])(avređ)(ujem|uješ|uje|ujemo|ujete|uju)" replaceWith="$1avrjeđ$3"/>
-<RegEx find="(zvaničn)(a|e|i|o|u|ima)" replaceWith="služben$2"/> 
-<RegEx find="([zZ])(vezd)(a|e|i|o|u|ama)\b" replaceWith="$1vijezd$3"/>
-<RegEx find="([zZ])(vezd)(ana|ano|anom|anoj|ice|icama)" replaceWith="$1vjezd$3"/>
-<RegEx find="([žŽ])(ive)(li|la|le|lu|lima|ti)" replaceWith="$1ivje$3"/>
-<RegEx find="([žŽ])(lezd)(a|e|i|o|u|ama)" replaceWith="$1lijezd$3"/>
-<RegEx find="([žŽ])(ljezd)(a|e|i|o|u|ama)" replaceWith="$1lijezd$3"/>
- <!--experimental-->
-<RegEx find="(oćeju)" replaceWith="oće"/> 
-<RegEx find="(tćeš)" replaceWith="t ćeš"/> 
-</RegularExpressions>
+    <RegEx find="([sS])(vetl)(a|e|i|o|u|om|ost|osti|ošću)" replaceWith="$1vjetl$3" />
+    <RegEx find="([sS])(vetsk)(a|e|i|o|u|om|og|oj)" replaceWith="$1vjetsk$3" />
+    <RegEx find="([sS])(vež)(a|e|u|om|oj)*" replaceWith="$1vjež$3" />
+    <RegEx find="([sS])(vide)(la|li|lo)" replaceWith="$1vidje$3" />
+    <RegEx find="([sS])(vjet)(a|u|om)" replaceWith="$1vijet$3" />
+    <RegEx find="([sS])(vijet)(ski|skim|sku|skog|skom)" replaceWith="$1vjet$3" />
+    <RegEx find="(Špansk)(a|e|i|o|u|oj|om|im)*" replaceWith="Španjolsk$2" />
+    <RegEx find="(takmičenj)(a|e|u|ima|em)" replaceWith="natjecanj$2" />
+    <RegEx find="\b([tT])(ač)(an|na|no|nom|noj|nog|nima|niji|nijim|nije|nijem|niju|nijoj)*" replaceWith="$1oč$3" />
+    <RegEx find="(talentov)(an|ana|ani|ano|anom|anoj|anima)" replaceWith="talentir$2" />
+    <RegEx find="\b(tel)(o|a|u|om|ima)" replaceWith="tijel$2" />
+    <RegEx find="\b(Tel)(o|a|u|om|ima)" replaceWith="Tijel$2" />
+    <RegEx find="\b([tT])(esn)(a|e|i|o|u|om|oj|og|ima)" replaceWith="$1ijesn$3" />
+    <RegEx find="\b([tT])(oleris)(ao|ala|ale|ali|ati)" replaceWith="$1olerir$3" />
+    <RegEx find="([uU])(bedljivo)(st|šću)*" replaceWith="$1vjerljivo$3" />
+    <RegEx find="([uU])(beđen)(a|e|i|o|u|oj|om|ima|ost|ošću)*" replaceWith="$1vjeren$3" />
+    <RegEx find="\b([uU])(bic)(a|e|i|o|u|om|ima)" replaceWith="$1bojic$3" />
+    <RegEx find="\b([uU])(bistv)(a|o|u|om|ima)" replaceWith="$1bojstv$3" />
+    <RegEx find="(učestvuje)(m|š|mo|te)*" replaceWith="sudjeluje$2" />
+    <RegEx find="([uU])(cen)(a|e|i|u|om|ama|nu|om)" replaceWith="$1cjen$3" />
+    <RegEx find="(učestvo)(vala|vao|valo|vali|vale|vati|vanje|vanjem)*" replaceWith="sudjelo$2" />
+    <RegEx find="\b(ulepša)(vam|vaš|vamo|vate|vaju|vati|vaše|nom|nim|noj|nima)" replaceWith="uljepša$2" />
+    <RegEx find="([uU])(metni)(k|ka|ku|kom|ca|cu|ce|ci|ma|čka|čke|čki|čkim|čko|čkom)" replaceWith="$1mjetni$3" />
+    <RegEx find="([uU])(propašćava)(m|š|mo|nje|te|ju|li)*" replaceWith="$1propaštava$3" />
+    <RegEx find="([uU])(propaščava)(m|š|mo|nje|te|ju|li)*" replaceWith="$1propaštava$3" />
+    <RegEx find="([uU])(slov)(a|e|i|u|om|ima)*" replaceWith="$1vjet$3" />
+    <RegEx find="([uU])(speh)(a|e|u|om)*" replaceWith="$1spjeh$3" />
+    <RegEx find="([uU])(spesi)(ma)*" replaceWith="$1spjesi$3" />
+    <RegEx find="([uU])(speš)(an|na|ne|ni|no|nu|nom|noj|nim|nima)*" replaceWith="$1spješ$3" />
+    <RegEx find="([uU])(sredsred)(im|iš|i|imo|ite|ili|io|ila|ilo)*" replaceWith="$1sredotoč$3" />
+    <RegEx find="([uU])(sredsređen)(a|e|i|im|ima|o|oj|u|om|ost|ošću)*" replaceWith="$1sredotočen$3" />
+    <RegEx find="\b([uU])(spev)(am|aš|a|amo|ate|aju|ale|alo|ali|aše)" replaceWith="$1spijev$3" />
+    <RegEx find="\b([uU])(spjev)(am|aš|a|amo|ate|aju|ale|alo|ali|aše)" replaceWith="$1spijev$3" />
+    <RegEx find="([uU])(sredsredi)(m|š|mo|te|la|lo|o|li|še)*" replaceWith="$1sredotoči$3" />
+    <RegEx find="(ućut)(im|iš|i|imo|ite|e)" replaceWith="ušut$2" />
+    <RegEx find="(Ućut)(im|iš|i|imo|ite|e)" replaceWith="Ućut$2" />
+    <RegEx find="(univerzum)(a|e|i|u|om|ima)*" replaceWith="svemir$2" />
+    <RegEx find="([uU])(ticaj)(a|e|i|u|em|ima|ni|nu|nima|noj|nom)*" replaceWith="$1tjecaj$3" />
+    <RegEx find="([uU])(verav)(am|aš|a|amo|ate|aju|ati|ala|ao|ali|aše)" replaceWith="$1vjerav$3" />
+    <RegEx find="([uU])(verljiv)(a|e|i|o|u|ima|ima|om|og|oj)*" replaceWith="$1vjerljiv$3" />
+    <RegEx find="([uU])(vet)(a|e|i|u|om|ima|nu|nima|noj|nom)*" replaceWith="$1vjet$3" />
+    <RegEx find="(uzok)(ujem|uješ|uje|ujemo|ujete|uju|ovan|ovani|ovali|ovale|ovalo)*" replaceWith="uzrok$2" />
+    <RegEx find="\b(varvar)(a|e|i|u|ima|skom|skim|skoj|skima|ski)" replaceWith="barbar$2" />
+    <RegEx find="\b(Varvar)(a|e|i|u|ima)" replaceWith="Barbar$2" />
+    <RegEx find="(vazduh)(a|u|om)*" replaceWith="zrak$2" />
+    <RegEx find="(vazduš)(ni|na|nu|no|nom|nog)*" replaceWith="zrač$2" />
+    <RegEx find="(vaspitan)(a|e|i|o|u|oj|om|im|ima|je|ju|jem)" replaceWith="obrazovan$2" />
+    <RegEx find="(Vaspitan)(a|e|i|o|u|oj|om|im|ima|je|ju|jem)" replaceWith="Obrazovan$2" />
+    <RegEx find="(vaspitn)(a|e|i|o|u|oj|om|im|ima)" replaceWith="obrazovn$2" />
+    <RegEx find="(Vaspitn)(a|e|i|o|u|oj|om|im|ima)" replaceWith="Obrazovn$2" />
+    <RegEx find="([vV])(eoma)" replaceWith="$1rlo" />
+    <RegEx find="([vV])(erova)(o|la|li|le|lo|še)" replaceWith="$1jerova$3" />
+    <RegEx find="([vV])(erovat)(an|na|ne|ni|no|nom|nog|nu|noj|nim)" replaceWith="$1jerojat$3" />
+    <RegEx find="([vV])(eruj)(e|u|em|eš|ete|emo|te)*" replaceWith="$1jeruj$3" />
+    <RegEx find="\b(vest)(i|ima)*" replaceWith="vijest$2" />
+    <RegEx find="\b(Vest)(i|ima)*" replaceWith="Vijest$2" />
+    <RegEx find="\b(vjest)(i|ima)*" replaceWith="vijest$2" />
+    <RegEx find="\b(Vjest)(i|ima)*" replaceWith="Vijest$2" />
+    <RegEx find="([vV])(eštic)(a|e|i|u|om|ama)" replaceWith="$1ještic$3" />
+    <RegEx find="([vV])(enčanj)(e|a|u|em|ima)" replaceWith="$1jenčanj$3" />
+    <RegEx find="(veštačk)(a|e|i|o|u|og|om|oj|im|ima)" replaceWith="umjetn$2" />
+    <RegEx find="(Veštačk)(a|e|i|o|u|og|om|oj|im|ima)" replaceWith="Umjetn$2" />
+    <RegEx find="([vV])(et)(ar|ra|ru|rom|rovi|rovito|rovima)" replaceWith="$1jet$3" />
+    <RegEx find="([vV])(ide)(la|le|li|ti)" replaceWith="$1idje$3" />
+    <RegEx find="\b([vV])(išlj)(a|e|i|u|eg|em|oj|om)" replaceWith="$1iš$3" />
+    <RegEx find="\b([vV])(odk)(a|e|i|u|ama)" replaceWith="$1otk$3" />
+    <RegEx find="([vV])(ole)(n|na|no|ti|nu|nog|la|le|li)" replaceWith="$1olje$3" />
+    <RegEx find="([vV])(redi)(m|š|mo|te|li)*" replaceWith="$1rijedi$3" />
+    <RegEx find="([zZ])(ainteresova)(n|ni|ne|la|le|li|lo|ti|na|no|noj)" replaceWith="$1ainteresira$3" />
+    <RegEx find="([zZ])(ahtev)(am|aš|amo|ate|aju|ali|ati|ajmo|ajte|aju)" replaceWith="$1ahtijev$3" />
+    <RegEx find="([zZ])(ahtjev)(am|aš|amo|ate|aju|ali|ati|ajmo|ajte|aju)" replaceWith="$1ahtijev$3" />
+    <RegEx find="([zZ])(ahtev)(a|u|i|e|om|ima)" replaceWith="$1ahtjev$3" />
+    <RegEx find="([zZ])(amenjiv)(a|u|i|e|o|ima|og|ov)*" replaceWith="$1amjenjiv$3" />
+    <RegEx find="([nN])(ezamenjiv)(a|u|i|e|o|ima|og|ov)*" replaceWith="$1ezamjenjiv$3" />
+    <RegEx find="([zZ])(ameni)(m|š|mo|o|te|ti|o|la|le|li|še)*" replaceWith="$1amijeni$3" />
+    <RegEx find="([zZ])(amjeni)(m|š|mo|o|te|ti|o|la|le|li|še)*" replaceWith="$1amijeni$3" />
+    <RegEx find="(zavis)(im|iš|i|imo|ite|ni|ne|nima|nim|nom|nik|nica|nošću)" replaceWith="ovis$2" />
+    <RegEx find="(Zavis)(im|iš|i|imo|ite|ni|ne|nima|nim|nom|nik|nica|nošću)" replaceWith="Ovis$2" />
+    <RegEx find="([zZ])(avređ)(ujem|uješ|uje|ujemo|ujete|uju)" replaceWith="$1avrjeđ$3" />
+    <RegEx find="(zvaničn)(a|e|i|o|u|ima)" replaceWith="služben$2" />
+    <RegEx find="([zZ])(vezd)(a|e|i|o|u|ama)\b" replaceWith="$1vijezd$3" />
+    <RegEx find="([zZ])(vezd)(ana|ano|anom|anoj|ice|icama)" replaceWith="$1vjezd$3" />
+    <RegEx find="([žŽ])(ive)(li|la|le|lu|lima|ti)" replaceWith="$1ivje$3" />
+    <RegEx find="([žŽ])(lezd)(a|e|i|o|u|ama)" replaceWith="$1lijezd$3" />
+    <RegEx find="([žŽ])(ljezd)(a|e|i|o|u|ama)" replaceWith="$1lijezd$3" />
+    <!-- experimental -->
+    <RegEx find="(oćeju)" replaceWith="oće" />
+    <RegEx find="(tćeš)" replaceWith="t ćeš" />
+  </RegularExpressions>
 </OCRFixReplaceList>


### PR DESCRIPTION
Removed four line breaks inside attribute values.

Due to TAB expansion and XML indentation, there are to many changed
lines for GitHub. A --ignore-space diff is available at [Gist](https://gist.github.com/xylographe/0a497dcf53e9ab2a900d) for review.
