### PR TITLE
Use Utilities.FixLargeFonts in DCinema forms

### DIFF
--- a/src/Forms/DCinema/DCinemaPropertiesForm.cs
+++ b/src/Forms/DCinema/DCinemaPropertiesForm.cs
@@ -5,17 +5,6 @@ namespace Nikse.SubtitleEdit.Forms.DCinema
 {
     public /* abstract */ class DCinemaPropertiesForm : PositionAndSizeForm
     {
-        protected void FixLargeFonts(Button referenceButton)
-        {
-            using (var graphics = CreateGraphics())
-            {
-                var textSize = graphics.MeasureString(referenceButton.Text, Font);
-                if (textSize.Height > referenceButton.Height - 4)
-                {
-                    var newButtonHeight = (int)(textSize.Height + 7.5f);
-                    Utilities.SetButtonHeight(this, newButtonHeight, 1);
-                }
-            }
-        }
+
     }
 }

--- a/src/Forms/DCinema/DCinemaPropertiesInterop.cs
+++ b/src/Forms/DCinema/DCinemaPropertiesInterop.cs
@@ -86,7 +86,7 @@ namespace Nikse.SubtitleEdit.Forms.DCinema
                 else
                     numericUpDownZPosition.Value = 0;
             }
-            FixLargeFonts(buttonCancel);
+            Utilities.FixLargeFonts(this, buttonCancel);
         }
 
         private void buttonGenerateID_Click(object sender, EventArgs e)

--- a/src/Forms/DCinema/DCinemaPropertiesSmpte.cs
+++ b/src/Forms/DCinema/DCinemaPropertiesSmpte.cs
@@ -78,7 +78,7 @@ namespace Nikse.SubtitleEdit.Forms.DCinema
                     numericUpDownTopBottomMargin.Value = 8;
 
             }
-            FixLargeFonts(buttonCancel);
+            Utilities.FixLargeFonts(this, buttonCancel);
         }
 
         private void buttonFontColor_Click(object sender, EventArgs e)

--- a/src/Logic/Utilities.cs
+++ b/src/Logic/Utilities.cs
@@ -2089,7 +2089,7 @@ namespace Nikse.SubtitleEdit.Logic
                 foreach (Control subControl in control.Controls)
                 {
                     if (subControl.HasChildren)
-                        SetButtonHeight(subControl, newHeight, level++);
+                        SetButtonHeight(subControl, newHeight, level + 1);
                     else if (subControl is Button)
                         subControl.Height = newHeight;
                 }


### PR DESCRIPTION
[1]
Although the abstract class `DCinemaPropertiesForm` is now empty, it is still used in Forms/Main.

[2]
I think, the idea is to limit the `SetButtonHeight()` recursion depth.