### PR TITLE
Minor refact

### DIFF
--- a/src/Forms/DvdSubRipChooseLanguage.cs
+++ b/src/Forms/DvdSubRipChooseLanguage.cs
@@ -172,15 +172,17 @@ namespace Nikse.SubtitleEdit.Forms
                 subs.Add((x as SubListBoxItem).SubPack);
             }
 
-            var formSubOcr = new VobSubOcr();
-            formSubOcr.InitializeQuick(subs, _palette, Configuration.Settings.VobSubOcr, SelectedLanguageString);
-            var subtitle = formSubOcr.ReadyVobSubRip();
-            formSubOcr.Dispose();
+            using (var formSubOcr = new VobSubOcr())
+            {
+                formSubOcr.InitializeQuick(subs, _palette, Configuration.Settings.VobSubOcr, SelectedLanguageString);
+                var subtitle = formSubOcr.ReadyVobSubRip();
 
-            var exportBdnXmlPng = new ExportPngXml();
-            exportBdnXmlPng.InitializeFromVobSubOcr(subtitle, new Logic.SubtitleFormats.SubRip(), "VOBSUB", "DVD", formSubOcr, SelectedLanguageString);
-            exportBdnXmlPng.ShowDialog(this);
-            exportBdnXmlPng.Dispose();
+                using (var exportBdnXmlPng = new ExportPngXml())
+                {
+                    exportBdnXmlPng.InitializeFromVobSubOcr(subtitle, new Logic.SubtitleFormats.SubRip(), "VOBSUB", "DVD", formSubOcr, SelectedLanguageString);
+                    exportBdnXmlPng.ShowDialog(this);
+                }
+            }
         }
 
     }

--- a/src/Forms/FindDialog.Designer.cs
+++ b/src/Forms/FindDialog.Designer.cs
@@ -43,7 +43,7 @@
             this.textBoxFind.Name = "textBoxFind";
             this.textBoxFind.Size = new System.Drawing.Size(189, 21);
             this.textBoxFind.TabIndex = 0;
-            this.textBoxFind.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextBoxFindKeyDown);
+            this.textBoxFind.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextBoxFind_KeyDown);
             // 
             // buttonFind
             // 
@@ -53,7 +53,7 @@
             this.buttonFind.TabIndex = 1;
             this.buttonFind.Text = "Find";
             this.buttonFind.UseVisualStyleBackColor = true;
-            this.buttonFind.Click += new System.EventHandler(this.ButtonFindClick);
+            this.buttonFind.Click += new System.EventHandler(this.ButtonFind_Click);
             // 
             // buttonCancel
             // 
@@ -76,7 +76,7 @@
             this.radioButtonNormal.TabStop = true;
             this.radioButtonNormal.Text = "Normal";
             this.radioButtonNormal.UseVisualStyleBackColor = true;
-            this.radioButtonNormal.CheckedChanged += new System.EventHandler(this.RadioButtonCheckedChanged);
+            this.radioButtonNormal.CheckedChanged += new System.EventHandler(this.RadioButton_CheckedChanged);
             // 
             // radioButtonCaseSensitive
             // 
@@ -87,7 +87,7 @@
             this.radioButtonCaseSensitive.TabIndex = 7;
             this.radioButtonCaseSensitive.Text = "Case sensitive";
             this.radioButtonCaseSensitive.UseVisualStyleBackColor = true;
-            this.radioButtonCaseSensitive.CheckedChanged += new System.EventHandler(this.RadioButtonCheckedChanged);
+            this.radioButtonCaseSensitive.CheckedChanged += new System.EventHandler(this.RadioButton_CheckedChanged);
             // 
             // radioButtonRegEx
             // 
@@ -98,7 +98,7 @@
             this.radioButtonRegEx.TabIndex = 9;
             this.radioButtonRegEx.Text = "RegEx";
             this.radioButtonRegEx.UseVisualStyleBackColor = true;
-            this.radioButtonRegEx.CheckedChanged += new System.EventHandler(this.RadioButtonCheckedChanged);
+            this.radioButtonRegEx.CheckedChanged += new System.EventHandler(this.RadioButton_CheckedChanged);
             // 
             // comboBoxFind
             // 
@@ -107,7 +107,7 @@
             this.comboBoxFind.Name = "comboBoxFind";
             this.comboBoxFind.Size = new System.Drawing.Size(189, 21);
             this.comboBoxFind.TabIndex = 0;
-            this.comboBoxFind.KeyDown += new System.Windows.Forms.KeyEventHandler(this.comboBoxFind_KeyDown);
+            this.comboBoxFind.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ComboBoxFind_KeyDown);
             // 
             // FindDialog
             // 

--- a/src/Forms/FindDialog.cs
+++ b/src/Forms/FindDialog.cs
@@ -28,13 +28,25 @@ namespace Nikse.SubtitleEdit.Forms
             Utilities.FixLargeFonts(this, buttonCancel);
         }
 
-        private FindType GetFindType()
+        private FindType FindType
         {
-            if (radioButtonNormal.Checked)
-                return FindType.Normal;
-            if (radioButtonCaseSensitive.Checked)
-                return FindType.CaseSensitive;
-            return FindType.RegEx;
+            get
+            {
+                if (radioButtonNormal.Checked)
+                    return FindType.Normal;
+                if (radioButtonCaseSensitive.Checked)
+                    return FindType.CaseSensitive;
+                return FindType.RegEx;
+            }
+            set
+            {
+                if (value == FindType.CaseSensitive)
+                    radioButtonCaseSensitive.Checked = true;
+                if (value == FindType.Normal)
+                    radioButtonNormal.Checked = true;
+                if (value == FindType.RegEx)
+                    radioButtonRegEx.Checked = true;
+            }
         }
 
         private string FindText
@@ -49,7 +61,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         public FindReplaceDialogHelper GetFindDialogHelper(int startLineIndex)
         {
-            return new FindReplaceDialogHelper(GetFindType(), FindText, _regEx, string.Empty, 200, 300, startLineIndex);
+            return new FindReplaceDialogHelper(FindType, FindText, _regEx, string.Empty, 200, 300, startLineIndex);
         }
 
         private void FormFindDialog_KeyDown(object sender, KeyEventArgs e)
@@ -60,7 +72,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void ButtonFindClick(object sender, EventArgs e)
+        private void ButtonFind_Click(object sender, EventArgs e)
         {
             string searchText = FindText;
             textBoxFind.Text = searchText;
@@ -92,19 +104,19 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void TextBoxFindKeyDown(object sender, KeyEventArgs e)
+        private void TextBoxFind_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter)
-                ButtonFindClick(null, null);
+                ButtonFind_Click(null, null);
         }
 
-        private void comboBoxFind_KeyDown(object sender, KeyEventArgs e)
+        private void ComboBoxFind_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter)
-                ButtonFindClick(null, null);
+                ButtonFind_Click(null, null);
         }
 
-        private void RadioButtonCheckedChanged(object sender, EventArgs e)
+        private void RadioButton_CheckedChanged(object sender, EventArgs e)
         {
             if (sender == radioButtonRegEx)
             {
@@ -151,12 +163,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (findHelper != null)
             {
-                if (findHelper.FindType == FindType.RegEx)
-                    radioButtonRegEx.Checked = true;
-                else if (findHelper.FindType == FindType.CaseSensitive)
-                    radioButtonCaseSensitive.Checked = true;
-                else
-                    radioButtonNormal.Checked = true;
+                FindType = findHelper.FindType;
             }
         }
 

--- a/src/Languages/pl-PL.xml
+++ b/src/Languages/pl-PL.xml
@@ -111,11 +111,13 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <GeneratingSpectrogram>Generowanie spektrogramu...</GeneratingSpectrogram>
     <ExtractingSeconds>Wyodrębnione audio: {0:0.0} sek.</ExtractingSeconds>
     <ExtractingMinutes>Wyodrębnione audio: {0:0.0} min.</ExtractingMinutes>
-    <WaveFileNotFound>Nie można znaleźć wyodrębnionego pliku wave! 
-Ta funkcja wymaga VLC media player 1.1.x lub nowszego ({0}-bit). Wiersz poleceń: {1} {2}</WaveFileNotFound>
-    <WaveFileMalformed>{0} nie był w stanie wyodrębnić danych audio do pliku wave! 
+    <WaveFileNotFound>Nie można znaleźć wyodrębnionego pliku wave!
+Ta funkcja wymaga VLC media player 1.1.x lub nowszego ({0}-bit).
 
-Wiersz poleceń: {1} {2} 
+Wiersz poleceń: {1} {2}</WaveFileNotFound>
+    <WaveFileMalformed>{0} nie był w stanie wyodrębnić danych audio do pliku wave!
+
+Wiersz poleceń: {1} {2}
 
 Uwaga: Sprawdź wolne miejsce na dysku.</WaveFileMalformed>
     <LowDiskSpace>MAŁO MIEJSCA NA DYSKU!</LowDiskSpace>
@@ -340,7 +342,7 @@ Uwaga: Sprawdź wolne miejsce na dysku.</WaveFileMalformed>
     <Title>Wybierz języka</Title>
     <ChooseLanguageStreamId>Wybierz język (stream-id)</ChooseLanguageStreamId>
     <UnknownLanguage>Nieznany język</UnknownLanguage>
-    <SubtitleImageXofYAndWidthXHeight>Obraz napisów {0}/{1}  -  {2}x{3} </SubtitleImageXofYAndWidthXHeight>
+    <SubtitleImageXofYAndWidthXHeight>Obraz napisów {0}/{1}  -  {2}x{3}</SubtitleImageXofYAndWidthXHeight>
     <SubtitleImage>Obraz napisów</SubtitleImage>
   </DvdSubRipChooseLanguage>
   <EbuSaveOptions>
@@ -1276,7 +1278,7 @@ Kontynuować?</SubtitleAppendPrompt>
     <ErrorLoadPng>Ten plik wydaje się być plikiem PNG. W Subtitle Edit nie można otworzyć plików PNG.</ErrorLoadPng>
     <ErrorLoadSrr>Ten plik wydaje się być plikiem ReScene .srr - to nie jest plik z napisami.</ErrorLoadSrr>
     <ErrorLoadTorrent>Ten plik wydaje się być plikiem BitTorrent - to nie jest plik z napisami.</ErrorLoadTorrent>
-    <ErrorLoadBinaryZeroes>Przepraszamy, ten plik zawiera tylko zera binarne! 
+    <ErrorLoadBinaryZeroes>Przepraszamy, ten plik zawiera tylko zera binarne!
 
 Jeśli edytowałeś ten plik w Subtitle Edit, to możesz odszukać kopię zapasową poprzez pozycję menu Plik -&gt; Przywróć automatycznie zapisaną kopię zapasową...</ErrorLoadBinaryZeroes>
     <NoSupportEncryptedVobSub>Zaszyfrowana zawartość VobSub nie jest obsługiwana.</NoSupportEncryptedVobSub>
@@ -1288,7 +1290,7 @@ Jeśli edytowałeś ten plik w Subtitle Edit, to możesz odszukać kopię zapaso
   <MatroskaSubtitleChooser>
     <Title>Wybierz napisy z pliku Matroska</Title>
     <PleaseChoose>Znaleziono klika napisów - proszę wybrać</PleaseChoose>
-    <TrackXLanguageYTypeZ>Ścieżka {0} - {1} - język: {2} - typ: {3}</TrackXLanguageYTypeZ>
+    <TrackXLanguageYTypeZ>Ścieżka {0} - język: {1} - typ: {2}</TrackXLanguageYTypeZ>
   </MatroskaSubtitleChooser>
   <MeasurementConverter>
     <Title>Konwerter miar</Title>
@@ -1373,7 +1375,7 @@ Jeśli edytowałeś ten plik w Subtitle Edit, to możesz odszukać kopię zapaso
   <NetworkJoin>
     <Title>Dołącz do sesji sieciowej</Title>
     <Information>Dołącz do istniejącej sesji, w której wiele osób
- może edytować ten sam plik z napisami (współpracować)</Information>
+może edytować ten sam plik z napisami (współpracować)</Information>
     <Join>Dołącz</Join>
   </NetworkJoin>
   <NetworkLogAndInfo>
@@ -1384,7 +1386,7 @@ Jeśli edytowałeś ten plik w Subtitle Edit, to możesz odszukać kopię zapaso
     <Title>Uruchom sesję sieciową</Title>
     <ConnectionTo>Łączenie się z {0}...</ConnectionTo>
     <Information>Rozpocznij nową sesję, w której wiele osób
- może edytować ten sam plik z napisami (współpracować)</Information>
+może edytować ten sam plik z napisami (współpracować)</Information>
     <Start>Start</Start>
   </NetworkStart>
   <OpenVideoDvd>
@@ -1638,7 +1640,7 @@ Jeśli edytowałeś ten plik w Subtitle Edit, to możesz odszukać kopię zapaso
     <MusicSymbolsToReplace>Symbole muzyczne do zastąpienia (oddzielone spacją)</MusicSymbolsToReplace>
     <FixCommonOcrErrorsUseHardcodedRules>Popraw częste błędy OCR - także z użyciem sztywnych reguł</FixCommonOcrErrorsUseHardcodedRules>
     <FixCommonerrorsFixShortDisplayTimesAllowMoveStartTime>Popraw krótki czas wyświetlania
-	(z możliwym przesunięciem czasu rozpoczęcia)</FixCommonerrorsFixShortDisplayTimesAllowMoveStartTime>
+(z możliwym przesunięciem czasu rozpoczęcia)</FixCommonerrorsFixShortDisplayTimesAllowMoveStartTime>
     <Shortcuts>Skróty klawiszowe</Shortcuts>
     <Shortcut>Skrót</Shortcut>
     <Control>Ctrl</Control>
@@ -1805,8 +1807,8 @@ Jeśli edytowałeś ten plik w Subtitle Edit, to możesz odszukać kopię zapaso
     <LineMaximumLength>Maksymalna długość linii</LineMaximumLength>
     <LineContinuationBeginEndStrings>Znak kontynuacji na początku/końcu linii</LineContinuationBeginEndStrings>
     <NumberOfSplits>Ilość podzielonych: {0}</NumberOfSplits>
-    <LongestSingleLineIsXAtY>Najdłuższą pojedynczą linią jest linia o nr {1} - zawiera {0} znaków </LongestSingleLineIsXAtY>
-    <LongestLineIsXAtY>Ogólnie najdłuższą linią jest linia o nr {1} - zawiera {0} znaków </LongestLineIsXAtY>
+    <LongestSingleLineIsXAtY>Najdłuższą pojedynczą linią jest linia o nr {1} - zawiera {0} znaków</LongestSingleLineIsXAtY>
+    <LongestLineIsXAtY>Ogólnie najdłuższą linią jest linia o nr {1} - zawiera {0} znaków</LongestLineIsXAtY>
   </SplitLongLines>
   <SplitSubtitle>
     <Title>Podziel napisy</Title>


### PR DESCRIPTION
[1]
Release XmlWriter resources.
Using StringBuilder increases efficiency.

[2]
formSubOcr was used after being disposed.

[3]
A FindType property seems more natural than a GetFindType method, and consistent with the existing FindText property.
Some event handler names changed for consistency (ControlName_EventName).
