### PR TITLE
Refact ToUtf8XmlString (Logic/SubtitleFormats/SubtitleFormat)

### DIFF
--- a/src/Logic/SubtitleFormats/SubtitleFormat.cs
+++ b/src/Logic/SubtitleFormats/SubtitleFormat.cs
@@ -371,19 +371,25 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
 
         public static string ToUtf8XmlString(XmlDocument xml, bool omitXmlDeclaration = false)
         {
+            var encoding = new UTF8Encoding(false, false); // no BOM, no exception
             var settings = new XmlWriterSettings
             {
+                Encoding = encoding,
                 Indent = true,
                 OmitXmlDeclaration = omitXmlDeclaration,
             };
-            var result = new StringBuilder();
+            var stream = new MemoryStream();
 
-            using (var xmlWriter = XmlWriter.Create(result, settings))
+            using (var xmlWriter = XmlWriter.Create(stream, settings))
             {
                 xml.Save(xmlWriter);
             }
+            stream.Position = 0; // rewind
 
-            return result.ToString().Replace(" encoding=\"utf-16\"", " encoding=\"utf-8\"").Trim();
+            using (var textReader = new StreamReader(stream, encoding, false))
+            {
+                return textReader.ReadToEnd().Trim();
+            }
         }
 
         public virtual bool IsTextBased


### PR DESCRIPTION
I spoke too soon. This is a _clean_ `ToUtf8XmlString()` implementation, and it happens to be more efficient than its predecessors.

See [ToUtf8XmlString-Efficiency-Test](https://gist.github.com/xylographe/b1b65f1a5f53c5440c99) and [ToUtf8XmlString-Validity-Test](https://gist.github.com/xylographe/dbb8eab90877b8f2c96f) on Gist.
