### PR TITLE
Filter popular video format

### DIFF
--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -1167,7 +1167,8 @@ namespace Nikse.SubtitleEdit.Forms
                 try
                 {
                     string ext = Path.GetExtension(fileName).ToLowerInvariant();
-                    if (ext != ".png" && ext != ".jpg" && ext != ".dll" && ext != ".exe" && ext != ".zip")
+                    if (ext != ".mp4" && ext != ".avi" && ext != ".mkv" && ext != ".flv" &&
+                        ext != ".png" && ext != ".jpg" && ext != ".dll" && ext != ".exe" && ext != ".zip")
                     {
                         var fi = new FileInfo(fileName);
                         if (ext == ".sub" && FileUtil.IsVobSub(fileName))


### PR DESCRIPTION
In most of the case there will the a video file in same directory as subtitle, so why waste time checking if it's subtitle file or not