### PR TITLE
Minor refact

### DIFF
--- a/src/Core/StringExtensions.cs
+++ b/src/Core/StringExtensions.cs
@@ -145,8 +145,8 @@ namespace Nikse.SubtitleEdit.Core
 
         public static string FixExtraSpaces(this string s)
         {
-            if (string.IsNullOrEmpty(s) || s.Trim().Length == 0)
-                return s;
+            if (string.IsNullOrWhiteSpace(s))
+                return string.Empty;
 
             while (s.Contains("  "))
                 s = s.Replace("  ", " ");

--- a/src/Forms/Compare.cs
+++ b/src/Forms/Compare.cs
@@ -904,7 +904,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private static void CopyTextToClipboard(RichTextBox sender)
         {
-            if (sender.Text.Trim().Length == 0)
+            if (string.IsNullOrWhiteSpace(sender.Text))
                 return;
             if (sender.SelectedText.Length > 0)
             {

--- a/src/Logic/Forms/RemoveTextForHI.cs
+++ b/src/Logic/Forms/RemoveTextForHI.cs
@@ -857,12 +857,12 @@ namespace Nikse.SubtitleEdit.Logic.Forms
                     return lines[0];
                 }
             }
-            if (lines.Length == 2 && lines[1].Replace(".", string.Empty).Replace("?", string.Empty).Replace("!", string.Empty).Replace("-", string.Empty).Replace("—", string.Empty).Trim().Length == 0)
+            if (lines.Length == 2 && string.IsNullOrWhiteSpace(lines[1].Replace(".", string.Empty).Replace("?", string.Empty).Replace("!", string.Empty).Replace("-", string.Empty).Replace("—", string.Empty)))
             {
                 text = lines[0];
                 lines = text.SplitToLines();
             }
-            else if (lines.Length == 2 && lines[0].Replace(".", string.Empty).Replace("?", string.Empty).Replace("!", string.Empty).Replace("-", string.Empty).Replace("—", string.Empty).Trim().Length == 0)
+            else if (lines.Length == 2 && string.IsNullOrWhiteSpace(lines[0].Replace(".", string.Empty).Replace("?", string.Empty).Replace("!", string.Empty).Replace("-", string.Empty).Replace("—", string.Empty)))
             {
                 text = lines[1];
                 lines = text.SplitToLines();

--- a/src/Logic/Settings.cs
+++ b/src/Logic/Settings.cs
@@ -1072,7 +1072,7 @@ namespace Nikse.SubtitleEdit.Logic
 
         public void Save()
         {
-            //this is too slow: Serialize(Configuration.BaseDirectory + "Settings.xml", this);
+            //this is too slow: Serialize(Configuration.SettingsFileName, this);
 
             CustomSerialize(Configuration.SettingsFileName, this);
         }
@@ -1088,16 +1088,16 @@ namespace Nikse.SubtitleEdit.Logic
         public static Settings GetSettings()
         {
             var settings = new Settings();
-            string settingsFileName = Configuration.SettingsFileName;
+            var settingsFileName = Configuration.SettingsFileName;
             if (File.Exists(settingsFileName))
             {
                 try
                 {
+                    //too slow... :(  - settings = Deserialize(settingsFileName); // 688 msecs
                     settings = CustomDeserialize(settingsFileName); //  15 msecs
 
                     if (settings.General.AutoConvertToUtf8)
                         settings.General.DefaultEncoding = Encoding.UTF8.EncodingName;
-                    //too slow... :(  - settings = Deserialize(Configuration.BaseDirectory + "Settings.xml"); // 688 msecs
                 }
                 catch
                 {
@@ -2641,8 +2641,9 @@ namespace Nikse.SubtitleEdit.Logic
 
         private static void CustomSerialize(string fileName, Settings settings)
         {
-            var sw = new StringWriter();
-            using (var textWriter = new XmlTextWriter(sw) { Formatting = Formatting.Indented })
+            var xws = new XmlWriterSettings { Indent = true };
+            var sb = new StringBuilder();
+            using (var textWriter = XmlWriter.Create(sb, xws))
             {
                 textWriter.WriteStartDocument();
 
@@ -3187,7 +3188,7 @@ namespace Nikse.SubtitleEdit.Logic
 
                 try
                 {
-                    File.WriteAllText(fileName, sw.ToString().Replace("encoding=\"utf-16\"", "encoding=\"utf-8\""), Encoding.UTF8);
+                    File.WriteAllText(fileName, sb.ToString().Replace("encoding=\"utf-16\"", "encoding=\"utf-8\""), Encoding.UTF8);
                 }
                 catch
                 {

--- a/src/Logic/SubtitleFormats/Chk.cs
+++ b/src/Logic/SubtitleFormats/Chk.cs
@@ -249,7 +249,7 @@ namespace Nikse.SubtitleEdit.Logic.SubtitleFormats
             }
 
             text = sb + post;
-            if (HtmlUtil.RemoveHtmlTags(text).Trim().Length == 0)
+            if (string.IsNullOrWhiteSpace(HtmlUtil.RemoveHtmlTags(text)))
                 return string.Empty;
             return text;
         }


### PR DESCRIPTION
[1] "new XmlTextWriter" ==> "XmlWriter.Create"

MSDN: “Starting with the .NET Framework 2.0, we recommend that you create XmlWriter instances by using the XmlWriter.Create method and the XmlWriterSettings class to take advantage of new functionality.”

Using a StringBuilder as output medium avoids the undisposed StringWriter issue. The StringWriter will now be created and disposed internally.

[2] "s.Text.Trim().Length == 0" ==> "string.IsNullOrWhiteSpace(s)"

IsNullOrWhiteSpace is slightly more efficient.
