### PR TITLE
Attempting to fix FixExtraSpaces()

### DIFF
--- a/src/Core/StringExtensions.cs
+++ b/src/Core/StringExtensions.cs
@@ -145,13 +145,14 @@ namespace Nikse.SubtitleEdit.Core
 
         public static string FixExtraSpaces(this string s)
         {
-            if (string.IsNullOrWhiteSpace(s))
-                return string.Empty;
+            if (string.IsNullOrEmpty(s))
+                return s;
 
             while (s.Contains("  "))
                 s = s.Replace("  ", " ");
             s = s.Replace(" " + Environment.NewLine, Environment.NewLine);
-            return s.Replace(Environment.NewLine + " ", Environment.NewLine);
+            s = s.Replace(Environment.NewLine + " ", Environment.NewLine);
+            return s.Trim(' ');
         }
 
         public static bool ContainsLetter(this string s)


### PR DESCRIPTION
Having had a closer look at `FixExtraSpaces()`, I think this would be the correct behaviour:

1. Every NewLine is preserved (empty lines too)
2. Leading spaces are removed instead of squashed to one space
3. Trailing spaces are removed instead of squashed to one space

Not 100% sure about [1], though.

Examples:  (underscore is space, vbar is NewLine)
```
"_Sous_____le___ciel___de__Paris____"
 ==> "Sous_le_ciel_de_Paris"

"__S'envole___une_chanson_|____Elle_est___née__d'aujourd'hui_"
 ==> "S'envole_une_chanson|Elle_est_née_d'aujourd'hui"
 
"___|Dans____le__coeur__|d'un_garçon_||_"
 ==> "|Dans_le_coeur|d'un_garçon||"

"|__|Sous_le__ciel_de____Paris__|_Marchent_____des__amoureux|_______|__||"
 ==> "||Sous_le_ciel_de_Paris|Marchent_des_amoureux||||"
```
