### PR TITLE
Fixed "zh-CHT" ==> "zh-tw" (Forms/ChooseLanguage)

### DIFF
--- a/src/Forms/ChooseLanguage.cs
+++ b/src/Forms/ChooseLanguage.cs
@@ -75,9 +75,9 @@ namespace Nikse.SubtitleEdit.Forms
                 try
                 {
                     if (cultureName.Equals("zh-CHS", StringComparison.OrdinalIgnoreCase))
-                        comboBoxLanguages.Items.Add(new CultureListItem(new CultureInfo(0x4)));
-                    else if (cultureName.Equals("zh-CHT", StringComparison.OrdinalIgnoreCase))
-                        comboBoxLanguages.Items.Add(new CultureListItem(new CultureInfo(0x7C04)));
+                        comboBoxLanguages.Items.Add(new CultureListItem(new CultureInfo(0x0004)));  // zh-Hans
+                    else if (cultureName.Equals("zh-tw", StringComparison.OrdinalIgnoreCase))
+                        comboBoxLanguages.Items.Add(new CultureListItem(new CultureInfo(0x7C04)));  // zh-Hant
                     else
                         comboBoxLanguages.Items.Add(new CultureListItem(CultureInfo.CreateSpecificCulture(cultureName)));
                 }


### PR DESCRIPTION
The translation file is named `zh-tw.xml`, not `zh-CHT.xml`.