### PR TITLE
Fix for neutral cultures (Forms/ChooseLanguage)

### DIFF
--- a/src/Forms/ChooseLanguage.cs
+++ b/src/Forms/ChooseLanguage.cs
@@ -74,12 +74,10 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 try
                 {
-                    if (cultureName.Equals("zh-CHS", StringComparison.OrdinalIgnoreCase))
-                        comboBoxLanguages.Items.Add(new CultureListItem(new CultureInfo(0x0004)));  // zh-Hans
-                    else if (cultureName.Equals("zh-tw", StringComparison.OrdinalIgnoreCase))
-                        comboBoxLanguages.Items.Add(new CultureListItem(new CultureInfo(0x7C04)));  // zh-Hant
-                    else
-                        comboBoxLanguages.Items.Add(new CultureListItem(CultureInfo.CreateSpecificCulture(cultureName)));
+                    var ci = CultureInfo.CreateSpecificCulture(cultureName);
+                    if (!ci.Name.Equals(cultureName, StringComparison.OrdinalIgnoreCase))
+                        ci = CultureInfo.GetCultureInfo(cultureName);
+                    comboBoxLanguages.Items.Add(new CultureListItem(ci));
                 }
                 catch (ArgumentException)
                 {


### PR DESCRIPTION
A generally applicable way to deal with neutral culture translations, instead of making a separate exception for each translation concerned.
Currently, only affects (and fixes) `zh-Hans` and `zh-TW`.
