### PR TITLE
Return if text doesn't contain '<'

### DIFF
--- a/src/Core/HtmlUtil.cs
+++ b/src/Core/HtmlUtil.cs
@@ -402,7 +402,7 @@ namespace Nikse.SubtitleEdit.Core
 
         internal static string FixUpperTags(string text)
         {
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(text) || !text.Contains('<'))
                 return text;
             var tags = new string[] { "<I>", "<U>", "<B>", "<FONT", "</I>", "</U>", "</B>", "</FONT>" };
             var idx = text.IndexOfAny(tags, StringComparison.Ordinal);


### PR DESCRIPTION
`text.IndexOfAny(tags, StringComparison.Ordinal);` is little bit expensive