### PR TITLE
Updated Croatian/Serbian language detection (word frequency)

### DIFF
--- a/src/Logic/Utilities.cs
+++ b/src/Logic/Utilities.cs
@@ -1189,10 +1189,21 @@ namespace Nikse.SubtitleEdit.Logic
         public static readonly string[] AutoDetectWordsRomanian = { "Какво", "тук", "може", "Как", "Ваше", "какво" };
         public static readonly string[] AutoDetectWordsArabic = { "Какво", "тук", "може", "Как", "Ваше", "какво" };
         public static readonly string[] AutoDetectWordsHebrew = { "אתה", "אולי", "הוא", "בסדר", "יודע", "טוב" };
-        public static readonly string[] AutoDetectWordsSerbian = { "sam", "što", "öto", "äto", "ovo", "vas", "nije", "Šta", "ovde", "za" };
+        public static readonly string[] AutoDetectWordsCroatianAndSerbian = { "sam", "ali", "nije", "samo", "ovo", "kako", "dobro", "sve", "tako", "će", "mogu", "ću", "zašto", "nešto", "za" };
+        public static readonly string[] AutoDetectWordsCroatian = { "što", "ovdje", "gdje", "kamo", "tko", "prije", "uvijek", "vrijeme", "vidjeti", "netko",
+                                                                    "vidio", "nitko", "bok", "lijepo", "oprosti", "htio", "mjesto", "oprostite", "čovjek", "dolje",
+                                                                    "čovječe", "dvije", "dijete", "dio", "poslije", "događa", "vjerovati", "vjerojatno", "vjerujem", "točno",
+                                                                    "razumijem", "vidjela", "cijeli", "svijet", "obitelj", "volio", "sretan", "dovraga", "svijetu", "htjela",
+                                                                    "vidjeli", "negdje", "želio", "ponovno", "djevojka", "umrijeti", "čovjeka", "mjesta", "djeca", "osjećam",
+                                                                    "uopće", "djecu", "naprijed", "obitelji", "doista", "mjestu", "lijepa", "također", "riječ", "tijelo" };
+        public static readonly string[] AutoDetectWordsSerbian = { "šta", "ovde", "gde", "ko", "pre", "uvek", "vreme", "videti", "neko",
+                                                                   "video", "niko", "ćao", "lepo", "izvini", "hteo", "mesto", "izvinite", "čovek", "dole",
+                                                                   "čoveče", "dve", "dete", "deo", "posle", "dešava", "verovati", "verovatno", "verujem", "tačno",
+                                                                   "razumem", "videla", "ceo", "svet", "porodica", "voleo", "srećan", "dođavola", "svetu", "htela",
+                                                                   "videli", "negde", "želeo", "ponovo", "devojka", "umreti", "čoveka", "mesta", "deca", "osećam",
+                                                                   "uopšte", "decu", "napred", "porodicu", "zaista", "mestu", "lepa", "takođe", "reč", "telo" };
         public static readonly string[] AutoDetectWordsVietnamese = { "không", "tôi", "anh", "đó", "Tôi", "ông" };
         public static readonly string[] AutoDetectWordsHungarian = { "hogy", "lesz", "tudom", "vagy", "mondtam", "még" };
-        public static readonly string[] AutoDetectWordsCroatian = { "sam", "öto", "äto", "ovo", "vas", "što" };
         public static readonly string[] AutoDetectWordsTurkish = { "için", "Tamam", "Hayır", "benim", "daha", "deðil", "önce", "lazým", "benim", "çalýþýyor", "burada", "efendim" };
 
         public static string AutoDetectGoogleLanguage(string text, int bestCount)
@@ -1301,15 +1312,11 @@ namespace Nikse.SubtitleEdit.Logic
             if (count > bestCount)
                 return "he"; // Hebrew
 
-            count = GetCount(text, AutoDetectWordsSerbian);
+            count = GetCount(text, AutoDetectWordsCroatianAndSerbian);
             if (count > bestCount)
             {
-                int croatianCount = GetCount(text, "sigurnošću", "ubojstvo", "službeni", "nedjelja", "izražava", "dogodilo", "svjetlo", "sigurno", "shvaćam",
-                                                   "obitelj", "vijest", "svijet", "sjećam", "lijepa", "dijete", "cijeli", "bijeli", "smije", "smije", "ured",
-                                                   "otok", "opći", "križ", "htio", "gdje", "auto", "sat", "kći");
-                int serbianCount = GetCount(text, "ispoljava", "porodica", "ponaosob", "bukvalno", "ubistvo", "ubediti", "suštini", "komitet", "dejstvo",
-                                                  "uopšte", "štampa", "ostrvo", "naučni", "kiriju", "kćerke", "nauka", "ivica", "čovek", "lepa", "krst",
-                                                  "kola", "hteo", "drug", "dete", "celi", "sme", "sem", "gde", "čas");
+                int croatianCount = GetCount(text, AutoDetectWordsCroatian);
+                int serbianCount = GetCount(text, AutoDetectWordsSerbian);
                 if (croatianCount > serbianCount)
                     return "hr"; // Croatian
 
@@ -1559,7 +1566,7 @@ namespace Nikse.SubtitleEdit.Logic
                         }
                         break;
                     case "hr_HR": // Croatian
-                        count = GetCount(text, AutoDetectWordsCroatian);
+                        count = GetCount(text, AutoDetectWordsCroatianAndSerbian);
                         if (count > bestCount)
                             languageName = shortName;
                         break;


### PR DESCRIPTION
Replaced the word lists for Croatian and Serbian with new lists consisting of the most frequent words that have both Croatian and Serbian variant. This should hopefully stop wrong detections of one as the other.

I used the frequency list created from opensubtitles.org dump (2012), available here: https://invokeit.wordpress.com/frequency-word-lists/