### PR TITLE
[Installer] Fix missing language name

### DIFF
--- a/installer/Subtitle_Edit_installer.iss
+++ b/installer/Subtitle_Edit_installer.iss
@@ -104,47 +104,46 @@ DisableProgramGroupPage=auto
 CloseApplications=true
 SetupMutex='subtitle_edit_setup_mutex'
 
-
 [Languages]
-Name: en;   MessagesFile: compiler:Default.isl
+Name: "en"; MessagesFile: "compiler:Default.isl"
 #ifdef localize
-Name: ar;   MessagesFile: Languages\Arabic.isl
-Name: bg;   MessagesFile: Languages\Bulgarian.isl
-Name: ca;   MessagesFile: compiler:Languages\Catalan.isl
-Name: cs;   MessagesFile: compiler:Languages\Czech.isl
-Name: da;   MessagesFile: compiler:Languages\Danish.isl
-Name: de;   MessagesFile: compiler:Languages\German.isl
-Name: el;   MessagesFile: compiler:Languages\Greek.isl
-Name: es;   MessagesFile: compiler:Languages\Spanish.isl
-Name: eu;   MessagesFile: Languages\Basque.isl
-Name: fa;   MessagesFile: Languages\Farsi.isl
-Name: fi;   MessagesFile: compiler:Languages\Finnish.isl
-Name: fr;   MessagesFile: compiler:Languages\French.isl
-Name: hr;   MessagesFile: Languages\Croatian.isl
-Name: hu;   MessagesFile: compiler:Languages\Hungarian.isl
-Name: it;   MessagesFile: compiler:Languages\Italian.isl
-Name: ja;   MessagesFile: compiler:Languages\Japanese.isl
-Name: ko;   MessagesFile: Languages\Korean.isl
-Name: nl;   MessagesFile: compiler:Languages\Dutch.isl
-Name: pl;   MessagesFile: compiler:Languages\Polish.isl
-Name: pt;   MessagesFile: compiler:Languages\Portuguese.isl
-Name: ptBR; MessagesFile: compiler:Languages\BrazilianPortuguese.isl
-Name: ro;   MessagesFile: Languages\Romanian.isl
-Name: ru;   MessagesFile: compiler:Languages\Russian.isl
-Name: sl;   MessagesFile: compiler:Languages\Slovenian.isl
-Name: srC;  MessagesFile: compiler:Languages\SerbianCyrillic.isl
-Name: srL;  MessagesFile: compiler:Languages\SerbianLatin.isl
-Name: sv;   MessagesFile: Languages\Swedish.isl
-Name: th;   MessagesFile: Languages\Thai.isl
-Name: tr;   MessagesFile: compiler:Languages\Turkish.isl
-Name: vi;   MessagesFile: Languages\Vietnamese.isl
-Name: zh;   MessagesFile: Languages\ChineseSimplified.isl
-Name: zhTW; MessagesFile: Languages\ChineseTraditional.isl
+Name: "ar"; MessagesFile: "Languages\Arabic.isl"
+Name: "bg"; MessagesFile: "Languages\Bulgarian.isl"
+Name: "ca"; MessagesFile: "compiler:Languages\Catalan.isl"
+Name: "cs"; MessagesFile: "compiler:Languages\Czech.isl"
+Name: "da"; MessagesFile: "compiler:Languages\Danish.isl"
+Name: "de"; MessagesFile: "compiler:Languages\German.isl"
+Name: "el"; MessagesFile: "compiler:Languages\Greek.isl"
+Name: "es"; MessagesFile: "compiler:Languages\Spanish.isl"
+Name: "eu"; MessagesFile: "Languages\Basque.isl"
+Name: "fa"; MessagesFile: "Languages\Farsi.isl"
+Name: "fi"; MessagesFile: "compiler:Languages\Finnish.isl"
+Name: "fr"; MessagesFile: "compiler:Languages\French.isl"
+Name: "hr"; MessagesFile: "Languages\Croatian.isl"
+Name: "hu"; MessagesFile: "compiler:Languages\Hungarian.isl"
+Name: "it"; MessagesFile: "compiler:Languages\Italian.isl"
+Name: "ja"; MessagesFile: "compiler:Languages\Japanese.isl"
+Name: "ko"; MessagesFile: "Languages\Korean.isl"
+Name: "nl"; MessagesFile: "compiler:Languages\Dutch.isl"
+Name: "pl"; MessagesFile: "compiler:Languages\Polish.isl"
+Name: "pt"; MessagesFile: "compiler:Languages\Portuguese.isl"
+Name: "ptBR"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"
+Name: "ro"; MessagesFile: "Languages\Romanian.isl"
+Name: "ru"; MessagesFile: "compiler:Languages\Russian.isl"
+Name: "sl"; MessagesFile: "compiler:Languages\Slovenian.isl"
+Name: "srC"; MessagesFile: "compiler:Languages\SerbianCyrillic.isl"
+Name: "srL"; MessagesFile: "compiler:Languages\SerbianLatin.isl"
+Name: "sv"; MessagesFile: "Languages\Swedish.isl"
+Name: "th"; MessagesFile: "Languages\Thai.isl"
+Name: "tr"; MessagesFile: "compiler:Languages\Turkish.isl"
+Name: "uk"; MessagesFile: "compiler:Languages\Ukrainian.isl"
+Name: "vi"; MessagesFile: "Languages\Vietnamese.isl"
+Name: "zh"; MessagesFile: "Languages\ChineseSimplified.isl"
+Name: "zhTW"; MessagesFile: "Languages\ChineseTraditional.isl"
 #endif
 
 ; Include the installer's custom messages
 #include "Custom_Messages.iss"
-
 
 [Messages]
 BeveledLabel=Subtitle Edit {#app_ver} by Nikse


### PR DESCRIPTION
@niksedk  this patch will include `uk` to installer MessageFile.

Produced in this PR: https://github.com/SubtitleEdit/subtitleedit/commit/3039da378d05b7cf4c1b2ea3734525565b3ba150