### PR TITLE
Added word list for Serbian-Cyrillic detection

### DIFF
--- a/src/Logic/Utilities.cs
+++ b/src/Logic/Utilities.cs
@@ -1205,6 +1205,7 @@ namespace Nikse.SubtitleEdit.Logic
                                                                    "razumem", "videla", "ceo", "svet", "porodica", "voleo", "srećan", "dođavola", "svetu", "htela",
                                                                    "videli", "negde", "želeo", "ponovo", "devojka", "umreti", "čoveka", "mesta", "deca", "osećam",
                                                                    "uopšte", "decu", "napred", "porodicu", "zaista", "mestu", "lepa", "takođe", "reč", "telo" };
+        public static readonly string[] AutoDetectWordsSerbian-Cyrl = { "сам", "али", "није", "само", "ово", "како", "добро", "све", "тако", "ће", "могу", "ћу", "зашто", "нешто", "за", "шта", "овде" };
 
         public static string AutoDetectGoogleLanguage(string text, int bestCount)
         {


### PR DESCRIPTION
Based on word frequency.

Now somebody just has to add detection logic (Hunspell's dictionary file is named "sr", without "-Cyrl").