### PR TITLE
Let ChooseLanguage not depend on installed Windows cultures

### DIFF
--- a/src/Forms/ChooseLanguage.cs
+++ b/src/Forms/ChooseLanguage.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using Nikse.SubtitleEdit.Logic;
 using System.Xml;
@@ -10,35 +11,64 @@ namespace Nikse.SubtitleEdit.Forms
 {
     public sealed partial class ChooseLanguage : PositionAndSizeForm
     {
-        public class CultureListItem
+        private class TranslationInfo : IEquatable<TranslationInfo>
         {
-            private CultureInfo _cultureInfo;
-
-            public CultureListItem(CultureInfo cultureInfo)
+            private readonly string _cultureName;
+            public string CultureName
             {
-                _cultureInfo = cultureInfo;
+                get { return _cultureName; }
+            }
+
+            private readonly string _displayName;
+            public string DisplayName
+            {
+                get { return _displayName; }
+            }
+
+            public TranslationInfo(string cultureName, string displayName)
+            {
+                _cultureName = cultureName;
+                try
+                {
+                    var ci = CultureInfo.GetCultureInfo(cultureName);
+                    _displayName = char.ToUpper(displayName[0], ci) + displayName.Substring(1);
+                }
+                catch
+                {
+                    _displayName = char.ToUpperInvariant(displayName[0]) + displayName.Substring(1);
+                }
+            }
+
+            public bool Equals(TranslationInfo ti)
+            {
+                return (ti != null) ? CultureName.Equals(ti.CultureName, StringComparison.OrdinalIgnoreCase) : false;
+            }
+
+            public override bool Equals(Object obj)
+            {
+                return Equals(obj as TranslationInfo);
+            }
+
+            public override int GetHashCode()
+            {
+                return CultureName.ToUpperInvariant().GetHashCode();
             }
 
             public override string ToString()
             {
-                return char.ToUpper(_cultureInfo.NativeName[0]) + _cultureInfo.NativeName.Substring(1);
-            }
-
-            public string Name
-            {
-                get { return _cultureInfo.Name; }
+                return DisplayName;
             }
         }
+
+        private readonly TranslationInfo DefaultTranslation;
+        private readonly TranslationInfo CurrentTranslation;
 
         public string CultureName
         {
             get
             {
-                int index = comboBoxLanguages.SelectedIndex;
-                if (index == -1)
-                    return "en-US";
-                else
-                    return (comboBoxLanguages.Items[index] as CultureListItem).Name;
+                var translation = comboBoxLanguages.SelectedItem as TranslationInfo;
+                return (translation == null) ? DefaultTranslation.CultureName : translation.CultureName;
             }
         }
 
@@ -46,50 +76,51 @@ namespace Nikse.SubtitleEdit.Forms
         {
             InitializeComponent();
 
-            List<string> list = new List<string>();
+            var defaultLanguage = new Language();
+            DefaultTranslation = new TranslationInfo(defaultLanguage.General.CultureName, defaultLanguage.Name);
+            var currentLanguage = Configuration.Settings.Language;
+            if (currentLanguage == null)
+            {
+                CurrentTranslation = new TranslationInfo(CultureInfo.CurrentUICulture.Name, CultureInfo.CurrentUICulture.NativeName);
+            }
+            else
+            {
+                CurrentTranslation = new TranslationInfo(currentLanguage.General.CultureName, currentLanguage.Name);
+            }
+
+            var translations = new HashSet<TranslationInfo>();
+            translations.Add(DefaultTranslation);
             if (Directory.Exists(Path.Combine(Configuration.BaseDirectory, "Languages")))
             {
-                string[] versionInfo = Utilities.AssemblyVersion.Split('.');
-                string currentVersion = String.Format("{0}.{1}.{2}", versionInfo[0], versionInfo[1], versionInfo[2]);
+                var versionInfo = Utilities.AssemblyVersion.Split('.');
+                var currentVersion = string.Format("{0}.{1}.{2}", versionInfo[0], versionInfo[1], versionInfo[2]);
+                var document = new XmlDocument { XmlResolver = null };
 
-                foreach (string fileName in Directory.GetFiles(Path.Combine(Configuration.BaseDirectory, "Languages"), "*.xml"))
+                foreach (var fileName in Directory.GetFiles(Path.Combine(Configuration.BaseDirectory, "Languages"), "*.xml"))
                 {
-                    string cultureName = Path.GetFileNameWithoutExtension(fileName);
-                    XmlDocument doc = new XmlDocument();
-                    doc.Load(fileName);
+                    document.Load(fileName);
                     try
                     {
-                        string version = doc.DocumentElement.SelectSingleNode("General/Version").InnerText;
+                        var version = document.DocumentElement.SelectSingleNode("General/Version").InnerText.Trim();
                         if (version == currentVersion)
-                            list.Add(cultureName);
+                        {
+                            var cultureName = document.DocumentElement.SelectSingleNode("General/CultureName").InnerText.Trim();
+                            var displayName = document.DocumentElement.Attributes["Name"].Value.Trim();
+                            if (!string.IsNullOrEmpty(cultureName) && !string.IsNullOrEmpty(displayName))
+                                translations.Add(new TranslationInfo(cultureName, displayName));
+                        }
                     }
                     catch
                     {
                     }
                 }
             }
-            list.Sort();
-            comboBoxLanguages.Items.Add(new CultureListItem(CultureInfo.CreateSpecificCulture("en-US")));
-            foreach (string cultureName in list)
-            {
-                try
-                {
-                    var ci = CultureInfo.CreateSpecificCulture(cultureName);
-                    if (!ci.Name.Equals(cultureName, StringComparison.OrdinalIgnoreCase))
-                        ci = CultureInfo.GetCultureInfo(cultureName);
-                    comboBoxLanguages.Items.Add(new CultureListItem(ci));
-                }
-                catch (ArgumentException)
-                {
-                    System.Diagnostics.Debug.WriteLine(cultureName + " is not a valid culture");
-                }
-            }
 
-            int index = 0;
-            for (int i = 0; i < comboBoxLanguages.Items.Count; i++)
+            int index = -1;
+            foreach (var translation in translations.OrderBy(ti => ti.DisplayName, StringComparer.CurrentCultureIgnoreCase).ThenBy(ti => ti.CultureName, StringComparer.Ordinal))
             {
-                var item = (CultureListItem)comboBoxLanguages.Items[i];
-                if (item.Name == Configuration.Settings.Language.General.CultureName)
+                int i = comboBoxLanguages.Items.Add(translation);
+                if (translation.Equals(CurrentTranslation) || (index < 0 && translation.Equals(DefaultTranslation)))
                     index = i;
             }
             comboBoxLanguages.SelectedIndex = index;

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -1153,15 +1153,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             optionsToolStripMenuItem.Text = _language.Menu.Options.Title;
             settingsToolStripMenuItem.Text = _language.Menu.Options.Settings;
-            changeLanguageToolStripMenuItem.Text = _language.Menu.Options.ChooseLanguage;
-            try
-            {
-                var ci = System.Globalization.CultureInfo.GetCultureInfo(_languageGeneral.CultureName);
-                changeLanguageToolStripMenuItem.Text += " [" + ci.NativeName + "]";
-            }
-            catch
-            {
-            }
+            changeLanguageToolStripMenuItem.Text = _language.Menu.Options.ChooseLanguage + " [" + Configuration.Settings.Language.Name + "]";
 
             toolStripMenuItemNetworking.Text = _language.Menu.Networking.Title;
             startServerToolStripMenuItem.Text = _language.Menu.Networking.StartNewSession;
@@ -2581,7 +2573,7 @@ namespace Nikse.SubtitleEdit.Forms
                             MessageBox.Show(this, errors, Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                         errors = (format as AdvancedSubStationAlpha).Errors;
                         if (!string.IsNullOrEmpty(errors))
-                            MessageBox.Show(errors, Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            MessageBox.Show(this, errors, Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     }
                     else if (format.GetType() == typeof(SubRip))
                     {
@@ -9100,7 +9092,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (noOfErrors > 0)
             {
-                MessageBox.Show(string.Format("{0} error(s) occured during extraction of bdsup\r\n\r\n{1}", noOfErrors, lastError));
+                MessageBox.Show(string.Format("{0} error(s) occurred during extraction of bdsup\r\n\r\n{1}", noOfErrors, lastError));
             }
 
             using (var formSubOcr = new VobSubOcr())
@@ -11760,11 +11752,13 @@ namespace Nikse.SubtitleEdit.Forms
                 _language = Configuration.Settings.Language.Main;
                 InitializeLanguage();
             }
-            catch (Exception exception)
+            catch (Exception ex)
             {
-                MessageBox.Show(exception.Message + Environment.NewLine +
-                                Environment.NewLine +
-                                exception.StackTrace, "Error loading language file");
+                var cap = "Language file load error";
+                var msg = "Could not load language file " + cultureName + ".xml" +
+                          "\n\nError Message:\n" + ex.Message +
+                          "\n\nStack Trace:\n" + ex.StackTrace;
+                MessageBox.Show(this, msg, cap);
                 Configuration.Settings.Language = new Language(); // default is en-US
                 Configuration.Settings.General.Language = null;
                 _languageGeneral = Configuration.Settings.Language.General;

--- a/src/Languages/bg-BG.xml
+++ b/src/Languages/bg-BG.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Bulgarian">
+<Language Name="български">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/ca-ES.xml
+++ b/src/Languages/ca-ES.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Catalan">
+<Language Name="català">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/cs-CZ.xml
+++ b/src/Languages/cs-CZ.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Čeština">
+<Language Name="čeština">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/da-DK.xml
+++ b/src/Languages/da-DK.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Dansk">
+<Language Name="dansk">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/el-GR.xml
+++ b/src/Languages/el-GR.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Greek">
+<Language Name="Ελληνικά">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/es-AR.xml
+++ b/src/Languages/es-AR.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Español">
+<Language Name="Español (Argentina)">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/es-ES.xml
+++ b/src/Languages/es-ES.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Español">
+<Language Name="Español (España)">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.2</Version>

--- a/src/Languages/es-MX.xml
+++ b/src/Languages/es-MX.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Español">
+<Language Name="Español (México)">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/eu-ES.xml
+++ b/src/Languages/eu-ES.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Euskara">
+<Language Name="euskara">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/fa-IR.xml
+++ b/src/Languages/fa-IR.xml
@@ -4,7 +4,7 @@
     <Title>شادوساب</Title>
     <Version>3.2.8</Version>
     <TranslatedBy>ترجمه توسط:برنامه نويس جوان</TranslatedBy>
-    <CultureName>Fa-IR</CultureName>
+    <CultureName>fa-IR</CultureName>
     <HelpFile>فایل راهنما</HelpFile>
     <Ok>تائید</Ok>
     <Cancel>لغو</Cancel>

--- a/src/Languages/fi-FI.xml
+++ b/src/Languages/fi-FI.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Finnish">
+<Language Name="suomi">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/fr-FR.xml
+++ b/src/Languages/fr-FR.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Français">
+<Language Name="français">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/hr-HR.xml
+++ b/src/Languages/hr-HR.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Hrvatski">
+<Language Name="hrvatski">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/hu-HU.xml
+++ b/src/Languages/hu-HU.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Hungarian">
+<Language Name="magyar">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>
@@ -440,7 +440,7 @@ Megjegyzés: Ellenőrizze a szabad merevlemez területet.</WaveFileMalformed>
     <Right>Jobbra</Right>
     <Center>Középre</Center>
     <BottomMargin>Alsó margó</BottomMargin>
-   <LeftRightMargin>Bal/jobb margó</LeftRightMargin>
+    <LeftRightMargin>Bal/jobb margó</LeftRightMargin>
     <SaveBluRraySupAs>Válassza ki a Blu-ray sup fájl nevét</SaveBluRraySupAs>
     <SaveVobSubAs>Válassza ki a VobSub fájl nevét</SaveVobSubAs>
     <SaveFabImageScriptAs>Válassza ki a FAB képszkript fájl nevét</SaveFabImageScriptAs>
@@ -1658,7 +1658,7 @@ szerkesztheti ugyanazt a feliratfájlt</Information>
     <ToggleDockUndockOfVideoControls>Videóvezérlő dokkolás/leválasztás kapcsoló</ToggleDockUndockOfVideoControls>
     <CreateSetEndAddNewAndGoToNew>Befejezés beállítása, új hozzáadása és ugrás az újra</CreateSetEndAddNewAndGoToNew>
     <AdjustViaEndAutoStartAndGoToNext>Beállítás a végpozíción keresztül és ugrás a következőre</AdjustViaEndAutoStartAndGoToNext>
-    <AdjustSetEndTimeAndGoToNext>Befejezés beállítása és ugrás a következőre</AdjustSetEndTimeAndGoToNext> 
+    <AdjustSetEndTimeAndGoToNext>Befejezés beállítása és ugrás a következőre</AdjustSetEndTimeAndGoToNext>
     <AdjustSetStartAutoDurationAndGoToNext>Indítás beállítása, automatikus időtartam és ugrás a következőre</AdjustSetStartAutoDurationAndGoToNext>
     <AdjustSetEndNextStartAndGoToNext>Befejezés beállítása, következő indítás és ugrás a következőre</AdjustSetEndNextStartAndGoToNext>
     <AdjustStartDownEndUpAndGoToNext>Le gomb=indítás beállítása, Fel gomb=befejezés beállítása és ugrás a következőre</AdjustStartDownEndUpAndGoToNext>

--- a/src/Languages/it-IT.xml
+++ b/src/Languages/it-IT.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Italiano">
+<Language Name="italiano">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/pl-PL.xml
+++ b/src/Languages/pl-PL.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Polish">
+<Language Name="polski">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/pt-BR.xml
+++ b/src/Languages/pt-BR.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Brazilian Portuguese">
+<Language Name="Português (Brasil)">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/pt-PT.xml
+++ b/src/Languages/pt-PT.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Portuguese - Portugal">
+<Language Name="português (Portugal)">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/ro-RO.xml
+++ b/src/Languages/ro-RO.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Română">
+<Language Name="română">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/ru-RU.xml
+++ b/src/Languages/ru-RU.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Russian">
+<Language Name="русский">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/sl-SI.xml
+++ b/src/Languages/sl-SI.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Slovenian">
+<Language Name="slovenski">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/sr-Cyrl-RS.xml
+++ b/src/Languages/sr-Cyrl-RS.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Српски">
+<Language Name="српски">
   <General>
     <Title>Сабтајтл едит</Title>
     <Version>3.2</Version>

--- a/src/Languages/sr-Latn-RS.xml
+++ b/src/Languages/sr-Latn-RS.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Srpski">
+<Language Name="srpski">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/sv-SE.xml
+++ b/src/Languages/sv-SE.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Swedish">
+<Language Name="svenska">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>
     <TranslatedBy>Översätt av Ted</TranslatedBy>
-    <CultureName>sv-Subtitle Edit</CultureName>
+    <CultureName>sv-SE</CultureName>
     <HelpFile />
     <Ok>OK</Ok>
     <Cancel>Avbryt</Cancel>

--- a/src/Languages/tr-TR.xml
+++ b/src/Languages/tr-TR.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Turkish">
+<Language Name="Türkçe">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/uk-UA.xml
+++ b/src/Languages/uk-UA.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Ukrainian">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Language Name="українська">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>
     <TranslatedBy>Переклад: Максим Кобєлєв http://mazepa-studio.com</TranslatedBy>
     <CultureName>uk-UA</CultureName>
-    <HelpFile></HelpFile>
+    <HelpFile />
     <Ok>&amp;Гаразд</Ok>
     <Cancel>&amp;Скасувати</Cancel>
     <Apply>Застосувати</Apply>
@@ -76,19 +76,17 @@
   </General>
   <About>
     <Title>Про програму Subtitle Edit</Title>
-    <AboutText1>
-      Subtitle Edit - це вільне програмне забезпечення під ліцензією
-      GNU Public License. Ви можете вільно поширювати, редагувати
-      та використовувати його.
+    <AboutText1>Subtitle Edit - це вільне програмне забезпечення під ліцензією
+GNU Public License. Ви можете вільно поширювати, редагувати
+та використовувати його.
 
-      Сирцевий код на C# доступний тут https://github.com/SubtitleEdit/subtitleedit
+Сирцевий код на C# доступний тут https://github.com/SubtitleEdit/subtitleedit
 
-      Відвідайте www.nikse.dk, щоб отримати останню версію.
+Відвідайте www.nikse.dk, щоб отримати останню версію.
 
-      Пропозиції дуже радо вітаються.
+Пропозиції дуже радо вітаються.
 
-      Email: mailto:nikse.dk@gmail.com
-    </AboutText1>
+Email: mailto:nikse.dk@gmail.com</AboutText1>
   </About>
   <AddToNames>
     <Title>Додати до списку імен/шумів і т. п.</Title>
@@ -114,19 +112,15 @@
     <GeneratingSpectrogram>Створення спектрограми...</GeneratingSpectrogram>
     <ExtractingSeconds>Виокремлення аудіо: {0:0.0} секунд</ExtractingSeconds>
     <ExtractingMinutes>Виокремлення аудіо: {0}.{1:00} хвилин</ExtractingMinutes>
-    <WaveFileNotFound>
-      Не вдалося знайти виокремлений wav-файл!
-      Цей функціонал потребує медіапрогравача VLC версії 1.1.x або новішої ({0}-bit).
+    <WaveFileNotFound>Не вдалося знайти виокремлений wav-файл!
+Цей функціонал потребує медіапрогравача VLC версії 1.1.x або новішої ({0}-bit).
 
-      Командний рядок: {1} {2}
-    </WaveFileNotFound>
-    <WaveFileMalformed>
-      {0} не вдалося виокремити аудіодані до wav-файлу!
+Командний рядок: {1} {2}</WaveFileNotFound>
+    <WaveFileMalformed>{0} не вдалося виокремити аудіодані до wav-файлу!
 
-      Командний рядок: {1} {2}
+Командний рядок: {1} {2}
 
-      Примітка: Перевірте наявність вільного місця на диску.
-    </WaveFileMalformed>
+Примітка: Перевірте наявність вільного місця на диску.</WaveFileMalformed>
     <LowDiskSpace>НИЗЬКИЙ РІВЕНЬ ВІЛЬНОГО МІСЦЯ НА ДИСКУ!</LowDiskSpace>
     <FreeDiskSpace>Вільно {0}</FreeDiskSpace>
   </AddWaveform>
@@ -456,10 +450,8 @@
     <SavePremiereEdlAs>Оберіть ім'я для файлу Premiere EDL</SavePremiereEdlAs>
     <SaveFcpAs>Оберіть ім'я для xml-файлу Final Cut Pro</SaveFcpAs>
     <SaveDostAs>Оберіть ім'я для файлу DoStudio dost</SaveDostAs>
-    <SomeLinesWereTooLongX>
-      Деякі рядки були надто довгими:
-      {0}
-    </SomeLinesWereTooLongX>
+    <SomeLinesWereTooLongX>Деякі рядки були надто довгими:
+{0}</SomeLinesWereTooLongX>
     <LineHeight>Висота рядка</LineHeight>
     <BoxSingleLine>Рамка на рядок</BoxSingleLine>
     <BoxMultiLine>Рамка на всі рядки</BoxMultiLine>
@@ -1054,15 +1046,11 @@
     <SavedOriginalSubtitleX>Збережено оригінальний субтитр {0}</SavedOriginalSubtitleX>
     <FileOnDiskModified>Файл на диску змінено</FileOnDiskModified>
     <OverwriteModifiedFile>Перезаписати файл {0}, змінений {1} о {2}{3}, поточним файлом, завантаженим з диску {4} о {5}?</OverwriteModifiedFile>
-    <FileXIsReadOnly>
-      Неможливо зберегти {0}
+    <FileXIsReadOnly>Неможливо зберегти {0}
 
-      Файл тільки для читання!
-    </FileXIsReadOnly>
-    <UnableToSaveSubtitleX>
-      Неможливо зберегти файл субтитрів {0}
-      Субтитри видаються порожніми - спробуйте зберегти ще раз, якщо ви працюєте над коректними субтитрами!
-    </UnableToSaveSubtitleX>
+Файл тільки для читання!</FileXIsReadOnly>
+    <UnableToSaveSubtitleX>Неможливо зберегти файл субтитрів {0}
+Субтитри видаються порожніми - спробуйте зберегти ще раз, якщо ви працюєте над коректними субтитрами!</UnableToSaveSubtitleX>
     <BeforeNew>Перед створенням нового файлу</BeforeNew>
     <New>Новий</New>
     <BeforeConvertingToX>Перед конвертацією в {0}</BeforeConvertingToX>
@@ -1073,19 +1061,13 @@
     <OpenVideoFile>Відкрити відеофайл...</OpenVideoFile>
     <NewFrameRateUsedToCalculateTimeCodes>Нову частоту кадрів ({0}) було використано для обрахунку часових міток початку/кінця</NewFrameRateUsedToCalculateTimeCodes>
     <NewFrameRateUsedToCalculateFrameNumbers>Нову частоту кадрів ({0}) було використано для обрахунку номерів кадрів початку/кінця</NewFrameRateUsedToCalculateFrameNumbers>
-    <FindContinue>
-      Об'єкт пошуку не знайдено.
-      Бажаєте розпочати з початку документу і шукати ще раз?
-    </FindContinue>
+    <FindContinue>Об'єкт пошуку не знайдено.
+Бажаєте розпочати з початку документу і шукати ще раз?</FindContinue>
     <FindContinueTitle>Продовжити пошук?</FindContinueTitle>
-    <ReplaceContinueNotFound>
-      Об'єкт пошуку не знайдено.
-      Бажаєте розпочати з початку документу і продовжити пошук та заміну?
-    </ReplaceContinueNotFound>
-    <ReplaceXContinue>
-      Об'єкт пошуку було замінено {0} раз(ів).
-      Ви хотіли б розпочати з початку документу і продовжити пошук та заміну?
-    </ReplaceXContinue>
+    <ReplaceContinueNotFound>Об'єкт пошуку не знайдено.
+Бажаєте розпочати з початку документу і продовжити пошук та заміну?</ReplaceContinueNotFound>
+    <ReplaceXContinue>Об'єкт пошуку було замінено {0} раз(ів).
+Ви хотіли б розпочати з початку документу і продовжити пошук та заміну?</ReplaceXContinue>
     <ReplaceContinueTitle>Продовжити заміну?</ReplaceContinueTitle>
     <SearchingForXFromLineY>Пошук '{0}', починаючи з рядка {1}...</SearchingForXFromLineY>
     <XFoundAtLineNumberY>'{0}' знайдено в рядку номер {1}</XFoundAtLineNumberY>
@@ -1115,11 +1097,9 @@
     <TextingForHearingImpairedRemovedOneLine>Текст для людей із вадами слуху видалено: Один рядок</TextingForHearingImpairedRemovedOneLine>
     <TextingForHearingImpairedRemovedXLines>Текст для людей із вадами слуху видалено: {0} рядків</TextingForHearingImpairedRemovedXLines>
     <SubtitleSplitted>Субтитр було розділено</SubtitleSplitted>
-    <SubtitleAppendPrompt>
-      Ви приєднаєте файл субтитрів до субтитрів, які зараз завантажені і які повинні бути вже синхронізовані з відеофайлом.
+    <SubtitleAppendPrompt>Ви приєднаєте файл субтитрів до субтитрів, які зараз завантажені і які повинні бути вже синхронізовані з відеофайлом.
 
-      Продовжити?
-    </SubtitleAppendPrompt>
+Продовжити?</SubtitleAppendPrompt>
     <SubtitleAppendPromptTitle>Приєднати субтитри</SubtitleAppendPromptTitle>
     <OpenSubtitleToAppend>Відкрити субтитри, які слід приєднати...</OpenSubtitleToAppend>
     <AppendViaVisualSyncTitle>Візуальна синхронізація - приєднання другої частини субтитрів</AppendViaVisualSyncTitle>
@@ -1302,11 +1282,9 @@
     <ErrorLoadJpg>Здається, цей файл - файл зображення JPG. Subtitle Edit не відкриває файли JPG.</ErrorLoadJpg>
     <ErrorLoadSrr>Здається, цей файл - файл ReScene .srr - не є файлом субтитрів.</ErrorLoadSrr>
     <ErrorLoadTorrent>Здається, цей файл - файл BitTorrent - не є файлом субтитрів.</ErrorLoadTorrent>
-    <ErrorLoadBinaryZeroes>
-      Даруйте, цей файл містить тільки бінарні нулі!
+    <ErrorLoadBinaryZeroes>Даруйте, цей файл містить тільки бінарні нулі!
 
-      Якщо ви редагували цей файл за допомогою Subtitle Edit, ймовірно ви зможете знайти резервну копію через пункт меню Файл -&gt; Відновити автоматичну резервну копію...
-    </ErrorLoadBinaryZeroes>
+Якщо ви редагували цей файл за допомогою Subtitle Edit, ймовірно ви зможете знайти резервну копію через пункт меню Файл -&gt; Відновити автоматичну резервну копію...</ErrorLoadBinaryZeroes>
     <ErrorDirectoryDropNotAllowed>Перетягування тек тут не підтримується.</ErrorDirectoryDropNotAllowed>
     <NoSupportEncryptedVobSub>Зашифрований вміст VobSub не підтримується.</NoSupportEncryptedVobSub>
     <NoSupportHereBluRaySup>Файли blu-ray sup тут не підтримуються.</NoSupportHereBluRaySup>
@@ -1401,10 +1379,8 @@
   </NetworkChat>
   <NetworkJoin>
     <Title>Приєднатися до сесії</Title>
-    <Information>
-      Приєднатися до наявної сесії, де кілька осіб
-      можуть спільно редагувати один файл субтитрів (співпрацювати)
-    </Information>
+    <Information>Приєднатися до наявної сесії, де кілька осіб
+можуть спільно редагувати один файл субтитрів (співпрацювати)</Information>
     <Join>Приєднатися</Join>
   </NetworkJoin>
   <NetworkLogAndInfo>
@@ -1414,10 +1390,8 @@
   <NetworkStart>
     <Title>Розпочати нову сесію</Title>
     <ConnectionTo>З'єднуємося з {0}...</ConnectionTo>
-    <Information>
-      Розпочати нову сесію, де кілька осіб зможуть
-      спільно редагувати один файл субтитрів (співпрацювати)
-    </Information>
+    <Information>Розпочати нову сесію, де кілька осіб зможуть
+спільно редагувати один файл субтитрів (співпрацювати)</Information>
     <Start>Розпочати</Start>
   </NetworkStart>
   <OpenVideoDvd>
@@ -1993,11 +1967,9 @@
     <FindText>Знайти текст</FindText>
     <GoToSubPosition>Поз. субтитру</GoToSubPosition>
     <KeepChangesTitle>Зберегти зміни?</KeepChangesTitle>
-    <KeepChangesMessage>
-      В режимі "візуальної синхронізації" до субтитрів було внесено зміни.
+    <KeepChangesMessage>В режимі "візуальної синхронізації" до субтитрів було внесено зміни.
 
-      Зберегти ці зміни?
-    </KeepChangesMessage>
+Зберегти ці зміни?</KeepChangesMessage>
     <SynchronizationDone>Синхронізацію виконано!</SynchronizationDone>
     <StartSceneMustComeBeforeEndScene>Початкова сцена має бути раніше за кінцеву сцену!</StartSceneMustComeBeforeEndScene>
     <Tip>Порада: Використовуйте клавіші &lt;ctrl+←/→&gt;, щоб просунутися на 100 мс назад/вперед</Tip>

--- a/src/Languages/vi-VN.xml
+++ b/src/Languages/vi-VN.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="Viet Nam">
+<Language Name="Tiếng Việt">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>
     <TranslatedBy>Dịch qua Tiếng Việt bởi by everytime
 Mọi góp ý về bản dịch vui lòng gửi thư tới hộp thư: handes1990@gmail.com
 Cảm ơn rất nhiều</TranslatedBy>
-    <CultureName>vn-VN</CultureName>
+    <CultureName>vi-VN</CultureName>
     <HelpFile />
     <Ok>&amp;Đồng ý</Ok>
     <Cancel>H&amp;ủy bỏ</Cancel>

--- a/src/Languages/zh-Hans.xml
+++ b/src/Languages/zh-Hans.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="简体中文">
+<Language Name="中文(简体)">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Languages/zh-tw.xml
+++ b/src/Languages/zh-tw.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="繁體中文">
+<Language Name="中文(繁體)">
   <General>
     <Title>Subtitle Edit</Title>
     <Version>3.4.8</Version>

--- a/src/Logic/LanguageDeserializer.cs
+++ b/src/Logic/LanguageDeserializer.cs
@@ -29,6 +29,8 @@ namespace Nikse.SubtitleEdit.Logic
                     {
                         if (!reader.IsEmptyElement && reader.Depth > 0)
                             name.Append('/').Append(reader.Name);
+                        else if (reader.Depth == 0)
+                            language.Name = reader["Name"];
                     }
                     else if (reader.NodeType == XmlNodeType.EndElement)
                     {

--- a/src/UpdateLanguageFiles/LanguageDeserializerGenerator.cs
+++ b/src/UpdateLanguageFiles/LanguageDeserializerGenerator.cs
@@ -39,6 +39,8 @@ namespace Nikse.SubtitleEdit.Logic
                     {
                         if (!reader.IsEmptyElement && reader.Depth > 0)
                             name.Append('/').Append(reader.Name);
+                        else if (reader.Depth == 0)
+                            language.Name = reader[""Name""];
                     }
                     else if (reader.NodeType == XmlNodeType.EndElement)
                     {


### PR DESCRIPTION
Because not every Windows system has all cultures installed, it would be better not to depend on them just to select a language. The information is also available in the xml translation files.

[1]
Fix CultureName and Language Name attribute values in translations, where necessary.
[2]
Language.Name is a special case (attribute) in the LanguageDeserializer.
[3]
Replace unnecessary use of (possibly missing) CultureInfo in Main.
[4]
Use custom TranslationInfo class instead of CultureInfo in ChooseLanguage.
