### PR TITLE
Strip control characters before trimming white space

### DIFF
--- a/libse/Dictionaries/NamesList.cs
+++ b/libse/Dictionaries/NamesList.cs
@@ -200,7 +200,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
 
         public bool Add(string name)
         {
-            name = name.Trim().RemoveControlCharacters();
+            name = name.RemoveControlCharacters().Trim();
             if (name.Length > 1 && name.ContainsLetter())
             {
                 if (name.Contains(' '))

--- a/libse/LanguageStructure.cs
+++ b/libse/LanguageStructure.cs
@@ -1053,7 +1053,7 @@
             public string BeforeMergeLinesWithSameText { get; set; }
             public string ImportTimeCodesDifferentNumberOfLinesWarning { get; set; }
             public string ParsingTransportStream { get; set; }
-            public string XPercentCompleted { get; set; }            
+            public string XPercentCompleted { get; set; }
             public string ErrorLoadIdx { get; set; }
             public string ErrorLoadRar { get; set; }
             public string ErrorLoadZip { get; set; }

--- a/libse/SubtitleFormats/Cavena890.cs
+++ b/libse/SubtitleFormats/Cavena890.cs
@@ -235,7 +235,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     _languageIdLine1 = LanguageIdDanish;
                     _languageIdLine2 = LanguageIdDanish;
-                }               
+                }
 
                 // prompt???
                 //if (Configuration.Settings.SubtitleSettings.CurrentCavena890LanguageIdLine1 >= 0)
@@ -707,7 +707,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (_languageIdLine1 == LanguageIdHebrew || fontNameLine1 == "HEBNOA" || fontNameLine2 == "HEBNOA")
             {
                 _languageIdLine1 = LanguageIdHebrew;
-                _languageIdLine2 = LanguageIdHebrew;                
+                _languageIdLine2 = LanguageIdHebrew;
             }
 
             // Russian
@@ -727,7 +727,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             else if (_languageIdLine1 == LanguageIdChineseTraditional || fontNameLine1 == "CCKM44" || fontNameLine2 == "CCKM44")
             {
                 _languageIdLine1 = LanguageIdChineseTraditional;
-                _languageIdLine2 = LanguageIdChineseTraditional;                
+                _languageIdLine2 = LanguageIdChineseTraditional;
             }
 
 

--- a/libse/SubtitleFormats/NciTimedRollUpCaptions.cs
+++ b/libse/SubtitleFormats/NciTimedRollUpCaptions.cs
@@ -73,7 +73,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
-
             var paragraph = new Paragraph();
             var expecting = ExpectingLine.TimeCodes;
             _errorCount = 0;

--- a/libse/SubtitleFormats/Pac.cs
+++ b/libse/SubtitleFormats/Pac.cs
@@ -1139,7 +1139,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             }
                             else
                             {
-                                sb.Append(Encoding.GetEncoding(950).GetString(buffer, index, 2));                                
+                                sb.Append(Encoding.GetEncoding(950).GetString(buffer, index, 2));
                             }
                         }
                         index++;

--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -179,7 +179,7 @@ namespace Nikse.SubtitleEdit.Core
             return string.Format("{0:0.0} gb", (float)fileSize / (1024 * 1024 * 1024));
         }
 
-        
+
 
         /// <summary>
         /// Downloads the requested resource as a <see cref="String"/> using the configured <see cref="WebProxy"/>.

--- a/src/Forms/AddToNames.cs
+++ b/src/Forms/AddToNames.cs
@@ -79,7 +79,7 @@ namespace Nikse.SubtitleEdit.Forms
                 return;
             }
 
-            NewName = textBoxAddName.Text.Trim().RemoveControlCharacters();
+            NewName = textBoxAddName.Text.RemoveControlCharacters().Trim();
             string languageName = null;
             _language = Configuration.Settings.Language.Main;
 

--- a/src/Forms/AddToOcrReplaceList.cs
+++ b/src/Forms/AddToOcrReplaceList.cs
@@ -22,8 +22,8 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void buttonOK_Click(object sender, EventArgs e)
         {
-            string key = textBoxOcrFixKey.Text.Trim().RemoveControlCharacters();
-            string value = textBoxOcrFixValue.Text.Trim().RemoveControlCharacters();
+            string key = textBoxOcrFixKey.Text.RemoveControlCharacters().Trim();
+            string value = textBoxOcrFixValue.Text.RemoveControlCharacters().Trim();
             if (key.Length == 0 || value.Length == 0 || key == value)
                 return;
 

--- a/src/Forms/AddToUserDic.cs
+++ b/src/Forms/AddToUserDic.cs
@@ -30,7 +30,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void buttonOK_Click(object sender, EventArgs e)
         {
-            NewWord = textBoxAddName.Text.Trim().ToLower().RemoveControlCharacters();
+            NewWord = textBoxAddName.Text.RemoveControlCharacters().Trim().ToLower();
             if (NewWord.Length == 0)
             {
                 DialogResult = DialogResult.Cancel;

--- a/src/Forms/ExportPngXml.cs
+++ b/src/Forms/ExportPngXml.cs
@@ -118,7 +118,7 @@ namespace Nikse.SubtitleEdit.Forms
                     return d;
                 return 25;
             }
-        }       
+        }
 
         private int MillisecondsToFramesMaxFrameRate(double milliseconds)
         {

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -32,7 +32,6 @@ namespace Nikse.SubtitleEdit.Forms
 
         private class ComboBoxZoomItem
         {
-
             public string Text { get; set; }
             public double ZoomFactor { get; set; }
 
@@ -40,7 +39,6 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 return Text;
             }
-
         }
 
         private const int TabControlListView = 0;

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -1797,7 +1797,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void ButtonAddNamesEtcClick(object sender, EventArgs e)
         {
             string language = GetCurrentWordListLanguage();
-            string text = textBoxNameEtc.Text.Trim().RemoveControlCharacters();
+            string text = textBoxNameEtc.Text.RemoveControlCharacters().Trim();
             if (!string.IsNullOrEmpty(language) && text.Length > 1 && !_wordListNamesEtc.Contains(text))
             {
                 var namesList = new NamesList(Configuration.DictionariesFolder, language, Configuration.Settings.WordLists.UseOnlineNamesEtc, Configuration.Settings.WordLists.NamesEtcUrl);
@@ -1897,7 +1897,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void ButtonAddUserWordClick(object sender, EventArgs e)
         {
             string language = GetCurrentWordListLanguage();
-            string text = textBoxUserWord.Text.Trim().ToLower().RemoveControlCharacters();
+            string text = textBoxUserWord.Text.RemoveControlCharacters().Trim().ToLower();
             if (!string.IsNullOrEmpty(language) && text.Length > 0 && !_userWordList.Contains(text))
             {
                 Utilities.AddToUserDictionary(text, language);
@@ -2006,8 +2006,8 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void ButtonAddOcrFixClick(object sender, EventArgs e)
         {
-            string key = textBoxOcrFixKey.Text.Trim().RemoveControlCharacters();
-            string value = textBoxOcrFixValue.Text.Trim().RemoveControlCharacters();
+            string key = textBoxOcrFixKey.Text.RemoveControlCharacters().Trim();
+            string value = textBoxOcrFixValue.Text.RemoveControlCharacters().Trim();
             if (key.Length == 0 || value.Length == 0 || key == value || Utilities.IsInteger(key))
                 return;
 

--- a/src/Logic/UiEbuSaveHelper.cs
+++ b/src/Logic/UiEbuSaveHelper.cs
@@ -18,7 +18,7 @@ namespace Nikse.SubtitleEdit.Logic
             _header = header;
             _justificationCode = justificationCode;
             _fileName = fileName;
-            _subtitle = subtitle;            
+            _subtitle = subtitle;
         }
 
         public bool ShowDialogOk()
@@ -32,7 +32,7 @@ namespace Nikse.SubtitleEdit.Logic
 
         public byte JustificationCode
         {
-            get { return _justificationCode; } 
+            get { return _justificationCode; }
             set { _justificationCode = value; }
         }
 

--- a/src/UpdateAssemblyInfo/Program.cs
+++ b/src/UpdateAssemblyInfo/Program.cs
@@ -172,7 +172,7 @@ namespace UpdateAssemblyInfo
                     }
                     else
                     {
-                        Console.WriteLine("updating version number to " + newVersionInfo.Version + " " + newVersionInfo.RevisionGuid);                        
+                        Console.WriteLine("updating version number to " + newVersionInfo.Version + " " + newVersionInfo.RevisionGuid);
                     }
                     UpdateAssemblyInfo(seTemplateFileName, newVersionInfo);
                     UpdateAssemblyInfo(libSeTmplateFileName, newVersionInfo);


### PR DESCRIPTION
For example, `"a <SYN> "` ==> `"a"`  (where \<SYN> represents a literal synchronous idle character).