### PR TITLE
Spectrogram optimization, round 2

### DIFF
--- a/libse/FastBitmap.cs
+++ b/libse/FastBitmap.cs
@@ -8,12 +8,20 @@ namespace Nikse.SubtitleEdit.Core
 {
     unsafe public class FastBitmap
     {
-        private struct PixelData
+        public struct PixelData
         {
             public byte Blue;
             public byte Green;
             public byte Red;
             public byte Alpha;
+
+            public PixelData(Color c)
+            {
+                Alpha = c.A;
+                Red = c.R;
+                Green = c.G;
+                Blue = c.B;
+            }
 
             public override string ToString()
             {
@@ -80,6 +88,12 @@ namespace Nikse.SubtitleEdit.Core
             data->Red = color.R;
             data->Green = color.G;
             data->Blue = color.B;
+        }
+
+        public void SetPixel(int x, int y, PixelData color)
+        {
+            var data = (PixelData*)(_pBase + y * _width + x * sizeof(PixelData));
+            *data = color;
         }
 
         public void SetPixel(int x, int y, Color color, int length)

--- a/libse/RealFFT.cs
+++ b/libse/RealFFT.cs
@@ -8,9 +8,9 @@ namespace Nikse.SubtitleEdit.Core
 {
     public class RealFFT
     {
-        private int _length;
-        private int[] _ip;
-        private double[] _w;
+        private readonly int _length;
+        private readonly int[] _ip;
+        private readonly double[] _w;
 
         public readonly double ForwardScaleFactor;
         public readonly double ReverseScaleFactor;

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -689,7 +689,7 @@ namespace Nikse.SubtitleEdit.Core
 
                 public int Map(double magnitude)
                 {
-                    return magnitude >= _minMagnitude ? (int)(_multiplier * Math.Log10(magnitude) + _addend) : 0;
+                    return magnitude >= _minMagnitude ? (int)(Math.Log10(magnitude) * _multiplier + _addend) : 0;
                 }
 
                 // Less optimized but readable version of the above

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -227,7 +227,7 @@ namespace Nikse.SubtitleEdit.Core
         {
             PeaksPerSecond = peaksPerSecond;
 
-            ReadSampleDataValueDelegate readSampleDataValue = GetSampleDataRerader();
+            ReadSampleDataValueDelegate readSampleDataValue = GetSampleDataReader();
             DataMinValue = int.MaxValue;
             DataMaxValue = int.MinValue;
             PeakSamples = new List<int>();
@@ -266,7 +266,7 @@ namespace Nikse.SubtitleEdit.Core
         public void GenerateAllSamples()
         {
             // determine how to read sample values
-            ReadSampleDataValueDelegate readSampleDataValue = GetSampleDataRerader();
+            ReadSampleDataValueDelegate readSampleDataValue = GetSampleDataReader();
 
             // load data
             _data = new byte[Header.DataChunkSize];
@@ -333,7 +333,9 @@ namespace Nikse.SubtitleEdit.Core
 
         private int ReadValue16Bit(ref int index)
         {
-            int result = BitConverter.ToInt16(_data, index);
+            int result = (short)(
+                (_data[index    ]     ) |
+                (_data[index + 1] << 8));
             index += 2;
             return result;
         }
@@ -361,7 +363,7 @@ namespace Nikse.SubtitleEdit.Core
         /// Determine how to read sample values
         /// </summary>
         /// <returns>Sample data reader that matches bits per sample</returns>
-        private ReadSampleDataValueDelegate GetSampleDataRerader()
+        private ReadSampleDataValueDelegate GetSampleDataReader()
         {
             ReadSampleDataValueDelegate readSampleDataValue;
             switch (Header.BitsPerSample)
@@ -403,8 +405,8 @@ namespace Nikse.SubtitleEdit.Core
 
             List<Bitmap> bitmaps = new List<Bitmap>();
             SpectrogramDrawer drawer = new SpectrogramDrawer(nfft);
-            ReadSampleDataValueDelegate readSampleDataValue = GetSampleDataRerader();
-            double sampleScale = 1.0 / Math.Pow(2.0, Header.BitsPerSample - 1);
+            ReadSampleDataValueDelegate readSampleDataValue = GetSampleDataReader();
+            double sampleScale = 1.0 / (Math.Pow(2.0, Header.BitsPerSample - 1) * Header.NumberOfChannels);
 
             int delaySampleCount = (int)(Header.SampleRate * (delayInMilliseconds / TimeCode.BaseUnit));
 
@@ -467,9 +469,6 @@ namespace Nikse.SubtitleEdit.Core
                         {
                             value += readSampleDataValue(ref dataByteOffset);
                         }
-                        value /= Header.NumberOfChannels;
-                        if (value < DataMinValue) DataMinValue = value;
-                        if (value > DataMaxValue) DataMaxValue = value;
                         chunkSamples[chunkSampleOffset] = value * sampleScale;
                         chunkSampleOffset += 1;
                     }
@@ -504,10 +503,12 @@ namespace Nikse.SubtitleEdit.Core
 
         private class SpectrogramDrawer
         {
+            private const double raisedCosineWindowScale = 0.5;
+
             private int _nfft;
             private MagnitudeToIndexMapper _mapper;
             private RealFFT _fft;
-            private Color[] _palette;
+            private FastBitmap.PixelData[] _palette;
             private double[] _segment;
             private double[] _window;
             private double[] _magnitude;
@@ -521,43 +522,39 @@ namespace Nikse.SubtitleEdit.Core
                 _segment = new double[nfft];
                 _window = CreateRaisedCosineWindow(nfft);
                 _magnitude = new double[nfft / 2];
+
+                double scaleCorrection = 1.0 / (raisedCosineWindowScale * _fft.ForwardScaleFactor);
+                for (int i = 0; i < _window.Length; i++)
+                {
+                    _window[i] *= scaleCorrection;
+                }
             }
 
             public Bitmap Draw(double[] samples)
             {
-                const int overlap = 0;
-                int numSamples = samples.Length;
-                int colIncrement = _nfft * (1 - overlap);
-
-                int numcols = numSamples / colIncrement;
-                // make sure we don't step beyond the end of the recording
-                while ((numcols - 1) * colIncrement + _nfft > numSamples)
-                    numcols--;
-
-                const double raisedCosineWindowScale = 0.5;
-
-                double scaleCorrection = 1.0 / (raisedCosineWindowScale * _fft.ForwardScaleFactor);
-                var bmp = new FastBitmap(new Bitmap(numcols, _nfft / 2));
+                int width = samples.Length / _nfft;
+                int height = _nfft / 2;
+                var bmp = new FastBitmap(new Bitmap(width, height));
                 bmp.LockImage();
-                for (int col = 0; col < numcols; col++)
+                for (int x = 0; x < width; x++)
                 {
                     // read a segment of the recorded signal
-                    for (int c = 0; c < _nfft; c++)
+                    for (int i = 0; i < _nfft; i++)
                     {
-                        _segment[c] = samples[col * colIncrement + c] * _window[c] * scaleCorrection;
+                        _segment[i] = samples[x * _nfft + i] * _window[i];
                     }
 
                     // transform to the frequency domain
                     _fft.ComputeForward(_segment);
 
-                    // and compute the magnitude spectrum
+                    // compute the magnitude of the spectrum
                     MagnitudeSpectrum(_segment, _magnitude);
 
-                    // Draw
-                    for (int newY = 0; newY < _nfft / 2 - 1; newY++)
+                    // draw
+                    for (int y = 0; y < height; y++)
                     {
-                        int colorIndex = _mapper.Map(_magnitude[newY]);
-                        bmp.SetPixel(col, (_nfft / 2 - 1) - newY, _palette[colorIndex]);
+                        int colorIndex = _mapper.Map(_magnitude[y]);
+                        bmp.SetPixel(x, height - y - 1, _palette[colorIndex]);
                     }
                 }
                 bmp.UnlockImage();
@@ -585,13 +582,13 @@ namespace Nikse.SubtitleEdit.Core
                 return a * a + b * b;
             }
 
-            private static Color[] GeneratePalette(int nfft)
+            private static FastBitmap.PixelData[] GeneratePalette(int nfft)
             {
-                Color[] palette = new Color[nfft];
+                var palette = new FastBitmap.PixelData[nfft];
                 if (Configuration.Settings.VideoControls.SpectrogramAppearance == "Classic")
                 {
                     for (int colorIndex = 0; colorIndex < nfft; colorIndex++)
-                        palette[colorIndex] = PaletteValue(colorIndex, nfft);
+                        palette[colorIndex] = new FastBitmap.PixelData(PaletteValue(colorIndex, nfft));
                 }
                 else
                 {
@@ -599,7 +596,7 @@ namespace Nikse.SubtitleEdit.Core
                                                      Configuration.Settings.VideoControls.WaveformColor.G,
                                                      Configuration.Settings.VideoControls.WaveformColor.B, nfft);
                     for (int i = 0; i < nfft; i++)
-                        palette[i] = list[i];
+                        palette[i] = new FastBitmap.PixelData(list[i]);
                 }
                 return palette;
             }

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -535,7 +535,8 @@ namespace Nikse.SubtitleEdit.Core
                 const double raisedCosineWindowScale = 0.5;
 
                 double scaleCorrection = 1.0 / (raisedCosineWindowScale * _fft.ForwardScaleFactor);
-                var bmp = new Bitmap(numcols, _nfft / 2);
+                var bmp = new FastBitmap(new Bitmap(numcols, _nfft / 2));
+                bmp.LockImage();
                 for (int col = 0; col < numcols; col++)
                 {
                     // read a segment of the recorded signal
@@ -551,16 +552,14 @@ namespace Nikse.SubtitleEdit.Core
                     MagnitudeSpectrum(_segment, _magnitude);
 
                     // Draw
-                    var fbmp = new FastBitmap(bmp);
-                    fbmp.LockImage();
                     for (int newY = 0; newY < _nfft / 2 - 1; newY++)
                     {
                         int colorIndex = MapToPixelIndex(_magnitude[newY], 100, 255);
-                        fbmp.SetPixel(col, (_nfft / 2 - 1) - newY, _palette[colorIndex]);
+                        bmp.SetPixel(col, (_nfft / 2 - 1) - newY, _palette[colorIndex]);
                     }
-                    fbmp.UnlockImage();
                 }
-                return bmp;
+                bmp.UnlockImage();
+                return bmp.GetBitmap();
             }
 
             private static double[] CreateRaisedCosineWindow(int n)

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -505,13 +505,13 @@ namespace Nikse.SubtitleEdit.Core
         {
             private const double raisedCosineWindowScale = 0.5;
 
-            private int _nfft;
-            private MagnitudeToIndexMapper _mapper;
-            private RealFFT _fft;
-            private FastBitmap.PixelData[] _palette;
-            private double[] _segment;
-            private double[] _window;
-            private double[] _magnitude;
+            private readonly int _nfft;
+            private readonly MagnitudeToIndexMapper _mapper;
+            private readonly RealFFT _fft;
+            private readonly FastBitmap.PixelData[] _palette;
+            private readonly double[] _segment;
+            private readonly double[] _window;
+            private readonly double[] _magnitude;
 
             public SpectrogramDrawer(int nfft)
             {


### PR DESCRIPTION
Using my same test (~10 minute video) that took 2.7 seconds after the first round of optimization, I now have it down to 1.8 seconds.

This should be my last pull request for spectrogram optimizations; it's about as good as it's going to get.

The timing breakdown is now 54% in Bitmap.Save (saving the GIF), 35% in SpectrogramDrawer.Draw (including the FFT stuff), and 11% for other overhead (e.g. converting the audio bytes to double).