### PR TITLE
Minor fixes and refact

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -26,7 +26,7 @@
    * Better handling of some zero width Unicode spaces - thx Krystian
    * Spell check issue with multiple occurrences of same word in one subtitle - thx Krystian
    * Rounding issue in formats with duration in output - thx Victor/Jamakmake
-   * Fixed possible crash in setting regarding VLC path - thx xylographe 
+   * Fixed possible crash in setting regarding VLC path - thx xylographe
    * Fixed shortcut key in French replace dialog - thx Claude
    * Go to first empty line now also focuses it - thx Jamakmake
    * + Many minor fixes from Ivandrofly and xylographe
@@ -42,11 +42,11 @@
    * Updated Croatian OCR fix replace list - thx diomed & xylographe
    * Remove text for HI - "Remove if text contains" now allows multiple items separated by comma or semicolon - thx Jesper
    * Added fix for invalid time codes in Avid (bug in Avid) - thx Xenophon
-   * All Google urls now uses https
+   * All Google urls now use https
 * FIXED:
    * Fixed "Discard" message in OCR when pressing "OK" (regression from 3.4.7) - thx Music Fan
    * Fixed Blu-ray sup export with frame rate 23.976 (regression from 3.4.7) - thx Arjan
-   * Fixed remebered value from Tools -> Adjust all times (regression from 3.4.7) - thx GH
+   * Fixed remembered value from Tools -> Adjust all times (regression from 3.4.7) - thx GH
    * Fixed GT by using https - thx Sopor
    * Fixed crash after using "Split" - thx Krystian
    * Fix for large data inside "Sami" files - thx hhgyu
@@ -128,13 +128,13 @@
    * Updated German/French translations - thx xylographe
    * Updated Polish translation - thx admas
    * Updated Portuguese translation - thx moob
-   * Taskbar icon progress info for batch-convert/dvd-rip/matroska+TS-import  
+   * Taskbar icon progress info for batch-convert/dvd-rip/matroska+TS-import
    * Improved speed for "Auto-balance/unbreak lines" - thx Ivandrofly
-   * Improved speed for "Multiple replace"   
+   * Improved speed for "Multiple replace"
 * FIXED:
    * Fixed bugs in ASS/SSA loading - thx kotuwa
    * Fixed bug in spell check with auto change casing of http -  thx Ivandrofly
-   * Change language in "Spell check" dialog now loads correct language lists - thx Sami 
+   * Change language in "Spell check" dialog now loads correct language lists - thx Sami
    * Fixed missing rule for "Fix invalid italic tags" - thx Ivandrofly
    * Fixed possible freeze in video player text - thx Mafu
    * Fixed crash in "Merge lines with same time code" - thx Miguel
@@ -503,7 +503,7 @@
    * Added "File -> Import images"
    * Added "Tools -> Merge lines with same text"
    * Importing from plain text file,  "One line is one subtitle" now has a 
-     "Line break" option - thx Adrian   
+     "Line break" option - thx Adrian
    * Added XML subtitle format "FLVCoreCuePoints" - thx Jon
    * Added some support for fxpxml 1.3
    * Added link to Sinhala spell check dictionary
@@ -651,7 +651,7 @@
    * Added Hungarian translation - thx Zityi
    * Added a few new subtitle formats
    * Added "Tools -> Sort by -> Style" - thx Mike
-   * When moving start/end in waveform and holding down the ALT key will now
+   * When moving start/end in waveform and holding down the ALT key will now 
      move border if the closest subtitle is less than 500 ms away - thx Leon
 * IMPROVED:
    * Updated Spanish translation - thx pakitonaranjo
@@ -800,7 +800,7 @@
    * Fixed export to 3D Side-by-side to working 3D Half-side-by-side - thx r0lZ
    * If no "Find" has been made, F3 will show "Find" window - thx fox
 * FIXED:
-   * After closing "SSA/ASS style designer", first style was applied
+   * After closing "SSA/ASS style designer", first style was applied 
      to all lines - thx vicgol/Xabier/Mike
    * "Set start time" (F11) now does not adjust the endtime - thx fox
    * Fix overlapping display times now checks minimum duration 
@@ -876,7 +876,7 @@
    * Advanced Substation Alpha style viewer/creator (right click in list view)
    * Timed Text style view/creator (right click in list view)
    * File -> D-Cinema properties (for both SMTPE and interop)
-   * Can now display frames instead of milliseconds in main window
+   * Can now display frames instead of milliseconds in main window 
      (see Options -> Settings)
    * New setting in Options: "Max. chars/second"
    * New settings in Options regarding "Min. duration" + "Max. duration"
@@ -899,7 +899,7 @@
    * Added Sync -> Adjust in percent - thx Ralf
    * Subtitle beamer - thx Ralf
    * Many new shortcuts
-   * Added "Remove line if all uppercase" to "Remove text for HI" 
+   * Added "Remove line if all uppercase" to "Remove text for HI"
 * IMPROVED:
    * Improved support for Advanced Substation Alpha (+ Substation Alpha)
    * Improved support for SAMI (now two different formats + font color support)
@@ -907,7 +907,7 @@
    * Added extra options for export as text
    * Added many new possible shortcut keys
    * Find and replace, better undo, faster + a little UI - thx Adem
-   * Fix common errors -> Start with uppercase letter after colon/semicolon moved
+   * Fix common errors -> Start with uppercase letter after colon/semicolon moved 
      to separate fix item (no longer in "Start with uppercase after paragraph/period")
    * Can now read Ulead format with positions - thx Steve
    * Can now convert text subtitles in mkv/mks files via command line - thx the hulk
@@ -981,7 +981,7 @@
    * Added Finnish translation - thx Veikko
    * Can now import binary Cheetah Caption subtitle format
  * IMPROVED:
-   * VLC audio extraction now generates smaller wave file - thx utocne
+   * VLC audio extraction now generates smaller wave file - thx utocne 
      (transcoding parameters now in settings.xml)
    * Added "Find text" to Point Sync + Set Sync Point - thx eMWu
    * Unbreak/auto-break buttons now also work on selected lines - thx XhmikosR
@@ -1030,7 +1030,7 @@
    * Wrong positioning of some texts (mostly at startup) - thx Trottel
    * Fix crash in image export (due to blank lines) - thx Mahdi
    * Line-breaking now works better with font tags - thx Trottel/XhmikosR
-   * Moving subtitles in timeline (waveform/spectrogram) with mouse
+   * Moving subtitles in timeline (waveform/spectrogram) with mouse 
      is now fast again
 
 
@@ -1058,7 +1058,7 @@
  * FIXED:
    * Export to Blu-ray sup timestamps
    * Crash in Visual Sync - thx XhmikosR
-   * Incorrect timestamps in MicroDVD format after using
+   * Incorrect timestamps in MicroDVD format after using 
      "Set start time and offset the rest" + a few more buttons - thx whuras
    * Bug in replace when showing original subtitle - thx Krystian
    * Bug in auto break lines regarding italic tags - thx Majid
@@ -1084,8 +1084,8 @@
    * Support for F4 subtitle formats - thx Fred
    * Export to Blu-ray sup format
  * IMPROVED:
-   * Updated Tesseract to 3.01
-     Now includes (some) italic detection + adds support for
+   * Updated Tesseract to 3.01 
+     Now includes (some) italic detection + adds support for 
      Arabic, Hebrew, Hindi and Thai
    * Undo improved so it also works for textbox + redo (Ctrl+Y)
    * Many new configurable shortcuts (e.g. for fullscreen video player)
@@ -1145,7 +1145,7 @@
    * Added "Point sync via other subtitle" - thx ioannis
    * Tools -> Make empty translation from current subtitle - thx vmb
    * Tools -> Show original text in audio/video previews - thx vmb
-   * Command line conversion between subtitle formats
+   * Command line conversion between subtitle formats 
      (Example: subtitleedit /convert *.srt MicroDVD - thx Carl)
    * Subtitle preview font size (below video player) is now available in 
      Options -> Settings
@@ -1192,7 +1192,7 @@
    * Auto-backup (never, every minute, every 5th minute or every 15th minute) - thx swedelandster
    * Video player/controls/waveform can now be un-docked (e.g. for people with multiple monitors)
    * Spell check via Word (Options -> Settings:General -> Spell checker)
-   * Edit original subtitle
+   * Edit original subtitle 
      (Options -> Settings:General:Allow edit of original subtitle - thx Luis for testing)
    * Waveform control can adjust play rate (slow, normal, fast and very fast - VLC player only)
    * Ability to remember the last selected line when re-opening subtitles - thx Frederic
@@ -1200,17 +1200,17 @@
    * Support for the subtitle "QuickTime text" format (two variations) + Scenarist + Adobe Encore
    * Added "Chars/sec" info to textbox in main window - thx Kerensky
    * Options to choose font color and background color (for list view/text-boxes)
-   * Can now import VobSub subtitles embedded in Matroska (.mkv) files
+   * Can now import VobSub subtitles embedded in Matroska (.mkv) files 
      (thx mosu for mkv info + thx hawk for testing)
    * Waveform position can be locked at center via new "Center" button - thx Krystian
    * Can insert (a whole) subtitle after a line in the list view via context menu
    * Auto-suggest line splitting with button while typing - thx DrJackson
    * Auto-wrap text while typing option - thx swedelandster
-   * Video menu will now have a "Choose audio track" if more than one audio track exists
+   * Video menu will now have a "Choose audio track" if more than one audio track exists 
      (only when using VLC as video player)
    * Bulgarian translation - thx Ivo Ivanov
  * IMPROVED:
-   * Main window: Video player will now automatically move up beside subtitle if waveform is
+   * Main window: Video player will now automatically move up beside subtitle if waveform is 
      displayed + some resizing of controls allowed via splitters
    * Context menu for subtitle textbox now has italic, bold, underline, font name, and color
    * Updated NHunspell (spell check component) to latest version (0.9.6)
@@ -1220,7 +1220,7 @@
    * Fix common OCR errors improved - thx aMvEL, sialivi, Alberto
    * Remove text for HI can now also remove interjections - thx DrJackson
    * Start/display time changes are now undo-able - thx Luis
-   * Subtitle preview on video player is more precise now (thx hawk), uses the font from Settings
+   * Subtitle preview on video player is more precise now (thx hawk), uses the font from Settings 
      and bold (thx Leszek)
    * "Point sync" can now also sync using only one sync point - thx tttoan
    * VLC media player - mouse click now toggles play/pause
@@ -1241,7 +1241,7 @@
 
 3.0 (18th November 2010)
  * NEW:
-   * Waveform control with many sync/replay/creation commands
+   * Waveform control with many sync/replay/creation commands 
      (thx Kerensky for the feedback)
    * Translator mode (Edit -> Show original subtitle) - thx DrJackson
    * Added Microsoft translate
@@ -1252,29 +1252,29 @@
    * New cool installer - thx XhmikosR
  * IMPROVED:
    * Layout changed - Translation helper + Create/adjust lines moved to main window
-   * Ripping subtitles from DVD should now have correct time codes
+   * Ripping subtitles from DVD should now have correct time codes 
      - thx JeanlDvd/DvdSubEdit + gioni666
-   * Ripping subtitles from DVD/VobSub files now has a an option to only OCR
+   * Ripping subtitles from DVD/VobSub files now has a an option to only OCR 
      "forced subtitles" - thx Rolf
-   * Ripping subtitles from VobSub files now has an option to use time codes
+   * Ripping subtitles from VobSub files now has an option to use time codes 
      from idx file (now default)
    * Updated Tesseract 2.x to 3.0
-   * Can now retrieve and install spell check dictionaries from the internet
+   * Can now retrieve and install spell check dictionaries from the internet 
      (thx DrJackson for the idea, Jaime Olivares for zip unpack code & Pierre for testing)
    * "Compare subtitle" color high-lighting is now more like other compare programs
-   * Fix common errors - Fix alone lowercase "i" to "I" now works better close to
+   * Fix common errors - Fix alone lowercase "i" to "I" now works better close to 
      HTML tags (thx chamallow)
    * Updated names list - thx chamallow
    * "Google translate" window is now resizable - thx Kerensky
    * Bold/italic/font tags now work better in SSA/ASS subtitles
-   * Icons are now external in the "Icons" folder - you can change them easily yourself
+   * Icons are now external in the "Icons" folder - you can change them easily yourself 
      without re-compiling (thx 6205)
    * New toolbar icons from gnome-look.org with some customization - thx 6205
  * FIXED:
    * Merge short lines now works with italic tags - thx honeybunny
-   * Importing subtitles from Matroska files will now correctly change the current
+   * Importing subtitles from Matroska files will now correctly change the current 
      encoding to UTF-8 (thx Jonathan)
-   * Numerous fixes in "Remove text for hearing impaired"
+   * Numerous fixes in "Remove text for hearing impaired" 
      - thx sialivi, eMWu, honeybunny, aMvEL
    * Tools -> Append subtitle without synchronizing - thx Les
    * Bug in "Spell check -> Add to names/etc list" - thx dny238

--- a/libse/Forms/RemoveTextForHI.cs
+++ b/libse/Forms/RemoveTextForHI.cs
@@ -266,8 +266,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     string arr1 = new StripableText(arr[1]).StrippedText;
 
                     //line continuation?
-                    if (arr0.Length > 0 && arr1.Length > 1 && (Utilities.LowercaseLetters + ",").Contains(arr0.Substring(arr0.Length - 1), StringComparison.Ordinal) &&
-                        Utilities.LowercaseLetters.Contains(arr1[0]))
+                    if (arr0.Length > 0 && arr1.Length > 1 && (Utilities.LowercaseLetters + ",").Contains(arr0.Substring(arr0.Length - 1)) && Utilities.LowercaseLetters.Contains(arr1[0]))
                     {
                         if (new StripableText(arr[1]).Pre.Contains("...") == false)
                             insertDash = false;
@@ -325,7 +324,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                         newText = newText.Replace(Environment.NewLine, Environment.NewLine + "- ");
                 }
             }
-            if (text.Contains("<i>", StringComparison.Ordinal) && !newText.Contains("<i>", StringComparison.Ordinal) && newText.EndsWith("</i>", StringComparison.Ordinal))
+            if (text.Contains("<i>") && !newText.Contains("<i>") && newText.EndsWith("</i>", StringComparison.Ordinal))
                 newText = "<i>" + newText;
 
             if (string.IsNullOrWhiteSpace(newText))
@@ -400,7 +399,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     tempStrippedtext += "?";
                 if (!StartAndEndsWithHearImpariedTags(tempStrippedtext))
                 {
-                    if (removedDialogInFirstLine && stSub.Pre.Contains("- ", StringComparison.Ordinal))
+                    if (removedDialogInFirstLine && stSub.Pre.Contains("- "))
                         stSub.Pre = stSub.Pre.Replace("- ", string.Empty);
 
                     string newText = stSub.StrippedText;
@@ -513,43 +512,43 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 text = st.Pre + text + st.Post;
 
             if (oldText.TrimStart().StartsWith("- ", StringComparison.Ordinal) && text != null && !text.Contains(Environment.NewLine) &&
-                (oldText.Contains(Environment.NewLine + "- ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + " - ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + "<i>- ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + "<i> - ", StringComparison.Ordinal)))
+                (oldText.Contains(Environment.NewLine + "- ") ||
+                 oldText.Contains(Environment.NewLine + " - ") ||
+                 oldText.Contains(Environment.NewLine + "<i>- ") ||
+                 oldText.Contains(Environment.NewLine + "<i> - ")))
             {
                 text = text.TrimStart().TrimStart('-').TrimStart();
             }
             if (oldText.TrimStart().StartsWith("-", StringComparison.Ordinal) &&
                 !oldText.TrimStart().StartsWith("--", StringComparison.Ordinal) &&
                 text != null && !text.Contains(Environment.NewLine) &&
-                (oldText.Contains(Environment.NewLine + "-", StringComparison.Ordinal) && !oldText.Contains(Environment.NewLine + "--", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + " - ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + "<i>- ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + "<i> - ", StringComparison.Ordinal)))
+                (oldText.Contains(Environment.NewLine + "-") && !oldText.Contains(Environment.NewLine + "--") ||
+                 oldText.Contains(Environment.NewLine + " - ") ||
+                 oldText.Contains(Environment.NewLine + "<i>- ") ||
+                 oldText.Contains(Environment.NewLine + "<i> - ")))
             {
                 text = text.TrimStart().TrimStart('-').TrimStart();
             }
 
             if (oldText.TrimStart().StartsWith("<i>- ", StringComparison.Ordinal) &&
-                text != null && text.StartsWith("<i>- ", StringComparison.Ordinal) && !text.Contains(Environment.NewLine, StringComparison.Ordinal) &&
-                (oldText.Contains(Environment.NewLine + "- ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + " - ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + "<i>- ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + "<i> - ", StringComparison.Ordinal)))
+                text != null && text.StartsWith("<i>- ", StringComparison.Ordinal) && !text.Contains(Environment.NewLine) &&
+                (oldText.Contains(Environment.NewLine + "- ") ||
+                 oldText.Contains(Environment.NewLine + " - ") ||
+                 oldText.Contains(Environment.NewLine + "<i>- ") ||
+                 oldText.Contains(Environment.NewLine + "<i> - ")))
             {
                 text = text.Remove(3, 2);
             }
 
-            if (text != null && !text.Contains(Environment.NewLine, StringComparison.Ordinal) &&
+            if (text != null && !text.Contains(Environment.NewLine) &&
                 (oldText.Contains(':') && !text.Contains(':') ||
                  oldText.Contains('[') && !text.Contains('[') ||
                  oldText.Contains('(') && !text.Contains('(') ||
                  oldText.Contains('{') && !text.Contains('{')) &&
-                (oldText.Contains(Environment.NewLine + "- ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + " - ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + "<i>- ", StringComparison.Ordinal) ||
-                 oldText.Contains(Environment.NewLine + "<i> - ", StringComparison.Ordinal)))
+                (oldText.Contains(Environment.NewLine + "- ") ||
+                 oldText.Contains(Environment.NewLine + " - ") ||
+                 oldText.Contains(Environment.NewLine + "<i>- ") ||
+                 oldText.Contains(Environment.NewLine + "<i> - ")))
             {
                 text = text.TrimStart().TrimStart('-').TrimStart();
             }
@@ -563,13 +562,13 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     text = text.Insert(1, " ");
                 if (text.StartsWith("<i>-", StringComparison.Ordinal) && text.Length > 5 && text[4] != ' ' && text[4] != '-')
                     text = text.Insert(4, " ");
-                if (text.Contains(Environment.NewLine + "-", StringComparison.Ordinal))
+                if (text.Contains(Environment.NewLine + "-"))
                 {
                     int index = text.IndexOf(Environment.NewLine + "-", StringComparison.Ordinal);
                     if (index + 4 < text.Length && text[index + Environment.NewLine.Length + 1] != ' ' && text[index + Environment.NewLine.Length + 1] != '-')
                         text = text.Insert(index + Environment.NewLine.Length + 1, " ");
                 }
-                if (text.Contains(Environment.NewLine + "<i>-", StringComparison.Ordinal))
+                if (text.Contains(Environment.NewLine + "<i>-"))
                 {
                     int index = text.IndexOf(Environment.NewLine + "<i>-", StringComparison.Ordinal);
                     if (index + 5 < text.Length && text[index + Environment.NewLine.Length + 4] != ' ' && text[index + Environment.NewLine.Length + 4] != '-')
@@ -717,16 +716,16 @@ namespace Nikse.SubtitleEdit.Core.Forms
                         {
                             int index = match.Index;
                             string temp = text.Remove(index, s.Length);
-                            if (temp.Remove(0, index) == " —" && temp.EndsWith("—  —"))
+                            if (temp.Remove(0, index) == " —" && temp.EndsWith("—  —", StringComparison.Ordinal))
                             {
                                 temp = temp.TrimEnd('—').TrimEnd();
-                                if (temp.TrimEnd().EndsWith(Environment.NewLine + "—"))
+                                if (temp.TrimEnd().EndsWith(Environment.NewLine + "—", StringComparison.Ordinal))
                                     temp = temp.TrimEnd().TrimEnd('—').TrimEnd();
                             }
-                            else if (temp.Remove(0, index) == " —" && temp.EndsWith("-  —"))
+                            else if (temp.Remove(0, index) == " —" && temp.EndsWith("-  —", StringComparison.Ordinal))
                             {
                                 temp = temp.TrimEnd('—').TrimEnd();
-                                if (temp.TrimEnd().EndsWith(Environment.NewLine + "-"))
+                                if (temp.TrimEnd().EndsWith(Environment.NewLine + "-", StringComparison.Ordinal))
                                     temp = temp.TrimEnd().TrimEnd('-').TrimEnd();
                             }
                             else if (index == 2 && temp.StartsWith("-  —", StringComparison.Ordinal))
@@ -786,12 +785,12 @@ namespace Nikse.SubtitleEdit.Core.Forms
                                     temp = temp.Remove(index - s.Length, 2);
                                     removeAfter = false;
                                 }
-                                else if (index > 0 && temp.Substring(index - s.Length).StartsWith(", -—"))
+                                else if (index > 0 && temp.Substring(index - s.Length).StartsWith(", -—", StringComparison.Ordinal))
                                 {
                                     temp = temp.Remove(index - s.Length, 3);
                                     removeAfter = false;
                                 }
-                                else if (index > 0 && temp.Substring(index - s.Length).StartsWith(", --"))
+                                else if (index > 0 && temp.Substring(index - s.Length).StartsWith(", --", StringComparison.Ordinal))
                                 {
                                     temp = temp.Remove(index - s.Length, 2);
                                     removeAfter = false;
@@ -844,7 +843,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                                     temp = temp.Remove(0, index);
                                     if (pre.EndsWith('-') && temp.StartsWith('-'))
                                         temp = temp.Remove(0, 1);
-                                    if (pre.EndsWith("- ") && temp.StartsWith('-'))
+                                    if (pre.EndsWith("- ", StringComparison.Ordinal) && temp.StartsWith('-'))
                                         temp = temp.Remove(0, 1);
                                 }
 
@@ -867,7 +866,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                                 temp = pre + temp;
                             }
 
-                            if (temp.EndsWith(Environment.NewLine + "- "))
+                            if (temp.EndsWith(Environment.NewLine + "- ", StringComparison.Ordinal))
                                 temp = temp.Remove(temp.Length - 4, 4);
 
                             var st = new StripableText(temp);
@@ -937,7 +936,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                      oldText.Contains("!" + Environment.NewLine) || oldText.Contains("!</i>" + Environment.NewLine) ||
                      oldText.Contains("?" + Environment.NewLine) || oldText.Contains("?</i>" + Environment.NewLine)))
                 {
-                    if (text.StartsWith("<i>-"))
+                    if (text.StartsWith("<i>-", StringComparison.Ordinal))
                         text = "<i>" + text.Remove(0, 4).TrimStart();
                     else
                         text = text.TrimStart('-').TrimStart();
@@ -947,7 +946,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                      oldText.Contains("!" + Environment.NewLine) || oldText.Contains("!</i>" + Environment.NewLine) ||
                      oldText.Contains("?" + Environment.NewLine) || oldText.Contains("?</i>" + Environment.NewLine)))
                 {
-                    if (text.StartsWith("<i>-"))
+                    if (text.StartsWith("<i>-", StringComparison.Ordinal))
                         text = "<i>" + text.Remove(0, 4).TrimStart();
                     else
                         text = text.TrimStart('-').TrimStart();
@@ -960,25 +959,25 @@ namespace Nikse.SubtitleEdit.Core.Forms
         {
             string newText = text;
             string s = text;
-            if (s.StartsWith('[') && s.IndexOf(']') > 0 && Settings.RemoveTextBetweenSquares)
-                newText = s.Remove(0, s.IndexOf(']') + 1);
-            else if (s.StartsWith('{') && s.IndexOf('}') > 0 && Settings.RemoveTextBetweenBrackets)
-                newText = s.Remove(0, s.IndexOf('}') + 1);
-            else if (s.StartsWith('?') && s.IndexOf('?', 1) > 0 && Settings.RemoveTextBetweenQuestionMarks)
-                newText = s.Remove(0, s.IndexOf('?', 1) + 1);
-            else if (s.StartsWith('(') && s.IndexOf(')') > 0 && Settings.RemoveTextBetweenParentheses)
-                newText = s.Remove(0, s.IndexOf(')') + 1);
-            else if (s.StartsWith('[') && s.IndexOf("]:", StringComparison.Ordinal) > 0 && Settings.RemoveTextBetweenSquares)
+            if (Settings.RemoveTextBetweenSquares && s.StartsWith('[') && s.IndexOf("]:", StringComparison.Ordinal) > 0)
                 newText = s.Remove(0, s.IndexOf("]:", StringComparison.Ordinal) + 2);
-            else if (s.StartsWith('{') && s.IndexOf("}:", StringComparison.Ordinal) > 0 && Settings.RemoveTextBetweenBrackets)
+            else if (Settings.RemoveTextBetweenBrackets && s.StartsWith('{') && s.IndexOf("}:", StringComparison.Ordinal) > 0)
                 newText = s.Remove(0, s.IndexOf("}:", StringComparison.Ordinal) + 2);
-            else if (s.StartsWith('?') && s.IndexOf("?:", 1, StringComparison.Ordinal) > 0 && Settings.RemoveTextBetweenQuestionMarks)
-                newText = s.Remove(0, s.IndexOf("?:", StringComparison.Ordinal) + 2);
-            else if (s.StartsWith('(') && s.IndexOf("):", StringComparison.Ordinal) > 0 && Settings.RemoveTextBetweenParentheses)
+            else if (Settings.RemoveTextBetweenParentheses && s.StartsWith('(') && s.IndexOf("):", StringComparison.Ordinal) > 0)
                 newText = s.Remove(0, s.IndexOf("):", StringComparison.Ordinal) + 2);
+            else if (Settings.RemoveTextBetweenQuestionMarks && s.StartsWith('?') && s.IndexOf("?:", 1, StringComparison.Ordinal) > 0)
+                newText = s.Remove(0, s.IndexOf("?:", StringComparison.Ordinal) + 2);
+            else if (Settings.RemoveTextBetweenSquares && s.StartsWith('[') && s.IndexOf(']') > 0)
+                newText = s.Remove(0, s.IndexOf(']') + 1);
+            else if (Settings.RemoveTextBetweenBrackets && s.StartsWith('{') && s.IndexOf('}') > 0)
+                newText = s.Remove(0, s.IndexOf('}') + 1);
+            else if (Settings.RemoveTextBetweenParentheses && s.StartsWith('(') && s.IndexOf(')') > 0)
+                newText = s.Remove(0, s.IndexOf(')') + 1);
+            else if (Settings.RemoveTextBetweenQuestionMarks && s.StartsWith('?') && s.IndexOf('?', 1) > 0)
+                newText = s.Remove(0, s.IndexOf('?', 1) + 1);
             else if (Settings.RemoveTextBetweenCustomTags &&
                      s.Length > 0 && Settings.CustomEnd.Length > 0 && Settings.CustomStart.Length > 0 &&
-                     s.StartsWith(Settings.CustomStart) && s.LastIndexOf(Settings.CustomEnd, StringComparison.Ordinal) > 0)
+                     s.StartsWith(Settings.CustomStart, StringComparison.Ordinal) && s.LastIndexOf(Settings.CustomEnd, StringComparison.Ordinal) > 0)
                 newText = s.Remove(0, s.LastIndexOf(Settings.CustomEnd, StringComparison.Ordinal) + Settings.CustomEnd.Length);
             if (newText != text)
                 newText = newText.TrimStart(' ');
@@ -1044,14 +1043,14 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
         private bool StartAndEndsWithHearImpariedTags(string text)
         {
-            return (text.StartsWith('[') && text.EndsWith(']') && !text.Trim('[').Contains('[') && Settings.RemoveTextBetweenSquares) ||
-                   (text.StartsWith('{') && text.EndsWith('}') && !text.Trim('{').Contains('{') && Settings.RemoveTextBetweenBrackets) ||
-                   (text.StartsWith('?') && text.EndsWith('?') && !text.Trim('?').Contains('?') && Settings.RemoveTextBetweenQuestionMarks) ||
-                   (text.StartsWith('(') && text.EndsWith(')') && !text.Trim('(').Contains('(') && Settings.RemoveTextBetweenParentheses) ||
-                   (text.StartsWith('[') && text.EndsWith("]:", StringComparison.Ordinal) && !text.Trim('[').Contains('[') && Settings.RemoveTextBetweenSquares) ||
-                   (text.StartsWith('{') && text.EndsWith("}:", StringComparison.Ordinal) && !text.Trim('{').Contains('{') && Settings.RemoveTextBetweenBrackets) ||
-                   (text.StartsWith('?') && text.EndsWith("?:", StringComparison.Ordinal) && !text.Trim('?').Contains('?') && Settings.RemoveTextBetweenQuestionMarks) ||
-                   (text.StartsWith('(') && text.EndsWith("):", StringComparison.Ordinal) && !text.Trim('(').Contains('(') && Settings.RemoveTextBetweenParentheses) ||
+            return (Settings.RemoveTextBetweenSquares && text.StartsWith('[') && text.EndsWith(']') && !text.Trim('[').Contains('[')) ||
+                   (Settings.RemoveTextBetweenBrackets && text.StartsWith('{') && text.EndsWith('}') && !text.Trim('{').Contains('{')) ||
+                   (Settings.RemoveTextBetweenParentheses && text.StartsWith('(') && text.EndsWith(')') && !text.Trim('(').Contains('(')) ||
+                   (Settings.RemoveTextBetweenQuestionMarks && text.StartsWith('?') && text.EndsWith('?') && !text.Trim('?').Contains('?')) ||
+                   (Settings.RemoveTextBetweenSquares && text.StartsWith('[') && text.EndsWith("]:", StringComparison.Ordinal) && !text.Trim('[').Contains('[')) ||
+                   (Settings.RemoveTextBetweenBrackets && text.StartsWith('{') && text.EndsWith("}:", StringComparison.Ordinal) && !text.Trim('{').Contains('{')) ||
+                   (Settings.RemoveTextBetweenParentheses && text.StartsWith('(') && text.EndsWith("):", StringComparison.Ordinal) && !text.Trim('(').Contains('(')) ||
+                   (Settings.RemoveTextBetweenQuestionMarks && text.StartsWith('?') && text.EndsWith("?:", StringComparison.Ordinal) && !text.Trim('?').Contains('?')) ||
                    (Settings.RemoveTextBetweenCustomTags &&
                     Settings.CustomStart.Length > 0 && Settings.CustomEnd.Length > 0 &&
                     text.StartsWith(Settings.CustomStart, StringComparison.Ordinal) && text.EndsWith(Settings.CustomEnd, StringComparison.Ordinal));
@@ -1062,7 +1061,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             text = text.Trim();
             if (startTag == "?" || endTag == "?")
             {
-                if (text.StartsWith(startTag) && text.EndsWith(endTag))
+                if (text.StartsWith(startTag, StringComparison.Ordinal) && text.EndsWith(endTag, StringComparison.Ordinal))
                     return string.Empty;
                 return text;
             }


### PR DESCRIPTION
[2]
Reversed search order in `RemoveStartEndTags()`.
If you look for `[...]` first, you'll never find `[...]:`.
