### PR TITLE
Improve accuracy of spectrogram

### DIFF
--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -493,11 +493,10 @@ namespace Nikse.SubtitleEdit.Core
 
                 // save image
                 string imagePath = Path.Combine(spectrogramDirectory, iChunk + ".gif");
-                saveImageTask = new Task(() =>
+                saveImageTask = Task.Factory.StartNew(() =>
                 {
                     bmp.Save(imagePath, System.Drawing.Imaging.ImageFormat.Gif);
                 });
-                saveImageTask.Start();
             }
 
             // wait for last image to finish saving

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -556,25 +556,10 @@ namespace Nikse.SubtitleEdit.Core
                 bmp.LockImage();
                 for (int x = 0; x < width; x++)
                 {
-                    Action<int, double[]> processSegment = (offset, magnitude) =>
-                    {
-                        // read a segment of the recorded signal
-                        for (int i = 0; i < _nfft; i++)
-                        {
-                            _segment[i] = samples[x * _nfft + offset + i] * _window[i];
-                        }
-
-                        // transform to the frequency domain
-                        _fft.ComputeForward(_segment);
-
-                        // compute the magnitude of the spectrum
-                        MagnitudeSpectrum(_segment, magnitude);
-                    };
-
                     // process 2 segments offset by -1/4 and 1/4 fft size, resulting in 1/2 fft size
                     // window spacing (the minimum overlap to avoid discarding parts of the signal)
-                    processSegment(x > 0 ? -_nfft / 4 : 0, _magnitude1);
-                    processSegment(x < width - 1 ? _nfft / 4 : 0, _magnitude2);
+                    ProcessSegment(samples, (x * _nfft) + (x > 0 ? -_nfft / 4 : 0), _magnitude1);
+                    ProcessSegment(samples, (x * _nfft) + (x < width - 1 ? _nfft / 4 : 0), _magnitude2);
 
                     // draw
                     for (int y = 0; y < height; y++)
@@ -585,6 +570,19 @@ namespace Nikse.SubtitleEdit.Core
                 }
                 bmp.UnlockImage();
                 return bmp.GetBitmap();
+            }
+
+            private void ProcessSegment(double[] samples, int offset, double[] magnitude)
+            {
+                // read a segment of the recorded signal
+                for (int i = 0; i < _nfft; i++)
+                    _segment[i] = samples[offset + i] * _window[i];
+
+                // transform to the frequency domain
+                _fft.ComputeForward(_segment);
+
+                // compute the magnitude of the spectrum
+                MagnitudeSpectrum(_segment, magnitude);
             }
 
             private static double[] CreateRaisedCosineWindow(int n)

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -506,10 +506,11 @@ namespace Nikse.SubtitleEdit.Core
 
             var doc = new XmlDocument();
             var culture = CultureInfo.InvariantCulture;
-            doc.LoadXml("<SpectrogramInfo><SampleDuration/><NFFT/><ImageWidth/></SpectrogramInfo>");
+            doc.LoadXml("<SpectrogramInfo><SampleDuration/><NFFT/><ImageWidth/><SecondsPerImage/></SpectrogramInfo>");
             doc.DocumentElement.SelectSingleNode("SampleDuration").InnerText = ((double)nfft / Header.SampleRate).ToString(culture);
             doc.DocumentElement.SelectSingleNode("NFFT").InnerText = nfft.ToString(culture);
             doc.DocumentElement.SelectSingleNode("ImageWidth").InnerText = bitmapWidth.ToString(culture);
+            doc.DocumentElement.SelectSingleNode("SecondsPerImage").InnerText = ((double)chunkSampleCount / Header.SampleRate).ToString(culture); // currently unused; for backwards compatibility
             doc.Save(Path.Combine(spectrogramDirectory, "Info.xml"));
 
             return bitmaps;

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -558,7 +558,7 @@ namespace Nikse.SubtitleEdit.Core
                 {
                     // process 2 segments offset by -1/4 and 1/4 fft size, resulting in 1/2 fft size
                     // window spacing (the minimum overlap to avoid discarding parts of the signal)
-                    ProcessSegment(samples, (x * _nfft) + (x > 0 ? -_nfft / 4 : 0), _magnitude1);
+                    ProcessSegment(samples, (x * _nfft) - (x > 0 ? _nfft / 4 : 0), _magnitude1);
                     ProcessSegment(samples, (x * _nfft) + (x < width - 1 ? _nfft / 4 : 0), _magnitude2);
 
                     // draw

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -489,7 +489,7 @@ namespace Nikse.SubtitleEdit.Core
 
                 // wait for previous image to finish saving
                 if (saveImageTask != null)
-                    Task.WaitAll(saveImageTask);
+                    saveImageTask.Wait();
 
                 // save image
                 string imagePath = Path.Combine(spectrogramDirectory, iChunk + ".gif");
@@ -501,7 +501,7 @@ namespace Nikse.SubtitleEdit.Core
 
             // wait for last image to finish saving
             if (saveImageTask != null)
-                Task.WaitAll(saveImageTask);
+                saveImageTask.Wait();
 
             var doc = new XmlDocument();
             var culture = CultureInfo.InvariantCulture;

--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -505,14 +505,11 @@ namespace Nikse.SubtitleEdit.Core
                 Task.WaitAll(saveImageTask);
 
             var doc = new XmlDocument();
-            doc.LoadXml("<SpectrogramInfo><SampleDuration/><TotalDuration/><AudioFormat /><AudioFormat /><ChunkId /><SecondsPerImage /><ImageWidth /><NFFT /></SpectrogramInfo>");
-            doc.DocumentElement.SelectSingleNode("SampleDuration").InnerText = ((double)nfft / Header.SampleRate).ToString(CultureInfo.InvariantCulture);
-            doc.DocumentElement.SelectSingleNode("TotalDuration").InnerText = Header.LengthInSeconds.ToString(CultureInfo.InvariantCulture);
-            doc.DocumentElement.SelectSingleNode("AudioFormat").InnerText = Header.AudioFormat.ToString(CultureInfo.InvariantCulture);
-            doc.DocumentElement.SelectSingleNode("ChunkId").InnerText = Header.ChunkId.ToString(CultureInfo.InvariantCulture);
-            doc.DocumentElement.SelectSingleNode("SecondsPerImage").InnerText = ((double)chunkSampleCount / Header.SampleRate).ToString(CultureInfo.InvariantCulture);
-            doc.DocumentElement.SelectSingleNode("ImageWidth").InnerText = bitmapWidth.ToString(CultureInfo.InvariantCulture);
-            doc.DocumentElement.SelectSingleNode("NFFT").InnerText = nfft.ToString(CultureInfo.InvariantCulture);
+            var culture = CultureInfo.InvariantCulture;
+            doc.LoadXml("<SpectrogramInfo><SampleDuration/><NFFT/><ImageWidth/></SpectrogramInfo>");
+            doc.DocumentElement.SelectSingleNode("SampleDuration").InnerText = ((double)nfft / Header.SampleRate).ToString(culture);
+            doc.DocumentElement.SelectSingleNode("NFFT").InnerText = nfft.ToString(culture);
+            doc.DocumentElement.SelectSingleNode("ImageWidth").InnerText = bitmapWidth.ToString(culture);
             doc.Save(Path.Combine(spectrogramDirectory, "Info.xml"));
 
             return bitmaps;

--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -89,7 +89,6 @@ namespace Nikse.SubtitleEdit.Controls
         private double _sampleDuration;
         private double _imageWidth;
         private int _nfft;
-        private double _secondsPerImage;
 
         public delegate void ParagraphEventHandler(object sender, ParagraphEventArgs e);
         public event ParagraphEventHandler OnNewSelectionRightClicked;
@@ -1815,7 +1814,6 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     doc.Load(xmlInfoFileName);
                     _sampleDuration = Convert.ToDouble(doc.DocumentElement.SelectSingleNode("SampleDuration").InnerText, CultureInfo.InvariantCulture);
-                    _secondsPerImage = Convert.ToDouble(doc.DocumentElement.SelectSingleNode("SecondsPerImage").InnerText, CultureInfo.InvariantCulture);
                     _nfft = Convert.ToInt32(doc.DocumentElement.SelectSingleNode("NFFT").InnerText, CultureInfo.InvariantCulture);
                     _imageWidth = Convert.ToInt32(doc.DocumentElement.SelectSingleNode("ImageWidth").InnerText, CultureInfo.InvariantCulture);
                     ShowSpectrogram = true;
@@ -1839,7 +1837,7 @@ namespace Nikse.SubtitleEdit.Controls
             var bmpDestination = new Bitmap(width, _nfft / 2); //calculate width
             var gfx = Graphics.FromImage(bmpDestination);
 
-            double startRow = seconds / _secondsPerImage;
+            double startRow = seconds / (_sampleDuration * _imageWidth);
             var bitmapIndex = (int)startRow;
             var subtractValue = (int)Math.Round((startRow - bitmapIndex) * _imageWidth);
 

--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -85,6 +85,7 @@ namespace Nikse.SubtitleEdit.Controls
 
         private List<Bitmap> _spectrogramBitmaps = new List<Bitmap>();
         private string _spectrogramDirectory;
+        private const int SpectrogramDisplayHeight = 128;
         private double _sampleDuration;
         private double _imageWidth;
         private int _nfft;
@@ -481,7 +482,7 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     DrawSpectrogramBitmap(StartPositionSeconds, graphics);
                     if (ShowWaveform)
-                        imageHeight -= _nfft / 2;
+                        imageHeight -= SpectrogramDisplayHeight;
                 }
 
                 //                using (var penOther = new Pen(ParagraphColor))
@@ -1835,7 +1836,7 @@ namespace Nikse.SubtitleEdit.Controls
             double duration = EndPositionSeconds - StartPositionSeconds;
             var width = (int)(duration / _sampleDuration);
 
-            var bmpDestination = new Bitmap(width, 128); //calculate width
+            var bmpDestination = new Bitmap(width, _nfft / 2); //calculate width
             var gfx = Graphics.FromImage(bmpDestination);
 
             double startRow = seconds / _secondsPerImage;
@@ -1857,7 +1858,7 @@ namespace Nikse.SubtitleEdit.Controls
             gfx.Dispose();
 
             if (ShowWaveform)
-                graphics.DrawImage(bmpDestination, new Rectangle(0, Height - bmpDestination.Height, Width, bmpDestination.Height));
+                graphics.DrawImage(bmpDestination, new Rectangle(0, Height - SpectrogramDisplayHeight, Width, SpectrogramDisplayHeight));
             else
                 graphics.DrawImage(bmpDestination, new Rectangle(0, 0, Width, Height));
             bmpDestination.Dispose();


### PR DESCRIPTION
The original spectrogram code applied a window function to each segment, but didn't do any overlapping to compensate for the signal loss near the edges. I've fixed that and the result is more peasant/accurate looking spectrogram images.

Also includes:
* Clean up some unused fields in Info.xml (I did leave one unnecessary field however so that older versions can still read files generated by the new version).
* Fixes to allow for FFT sizes other than 256 (not that it will actually be used, but just for the sake of correctness).
* Save out GIF in a separate thread. For this reason, the code is yet again faster even though it's doing a bit more work with the overlapping.