### PR TITLE
Some more wave visualizer enhancements

### DIFF
--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -133,8 +133,8 @@ namespace Nikse.SubtitleEdit.Controls
         }
 
         public const double VerticalZoomMinimum = 1.0;
-        public const double VerticalZoomMaximum = 20.0;
-        private double _verticalZoomFactor = 1.0; // 1.0=no zoom
+        public const double VerticalZoomMaximum = 40.0;
+        private double _verticalZoomFactor = 2.0; // 1.0=no zoom
         public double VerticalZoomFactor
         {
             get
@@ -404,7 +404,7 @@ namespace Nikse.SubtitleEdit.Controls
         private static int CalculateHeight(double value, int imageHeight, int maxHeight)
         {
             double percentage = value / maxHeight;
-            var result = (int)Math.Round((percentage * imageHeight) + (imageHeight / 2.0));
+            var result = (int)Math.Round((percentage / 2.0 + 0.5) * imageHeight);
             return imageHeight - result;
         }
 
@@ -1690,16 +1690,26 @@ namespace Nikse.SubtitleEdit.Controls
 
         public void ZoomIn()
         {
-            ZoomFactor = ZoomFactor + 0.1;
+            ZoomFactor += 0.1;
             if (OnZoomedChanged != null)
                 OnZoomedChanged.Invoke(this, null);
         }
 
         public void ZoomOut()
         {
-            ZoomFactor = ZoomFactor - 0.1;
+            ZoomFactor -= 0.1;
             if (OnZoomedChanged != null)
                 OnZoomedChanged.Invoke(this, null);
+        }
+
+        private void VerticalZoomIn()
+        {
+            VerticalZoomFactor *= 1.1;
+        }
+
+        private void VerticalZoomOut()
+        {
+            VerticalZoomFactor /= 1.1;
         }
 
         private void WaveformMouseWheel(object sender, MouseEventArgs e)
@@ -1716,6 +1726,16 @@ namespace Nikse.SubtitleEdit.Controls
                     ZoomIn();
                 else
                     ZoomOut();
+
+                return;
+            }
+
+            if (ModifierKeys == (Keys.Control | Keys.Shift))
+            {
+                if (e.Delta > 0)
+                    VerticalZoomIn();
+                else
+                    VerticalZoomOut();
 
                 return;
             }

--- a/src/Forms/AddWaveForm.Designer.cs
+++ b/src/Forms/AddWaveForm.Designer.cs
@@ -138,8 +138,8 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Generate waveform data";
-            this.Shown += new System.EventHandler(this.AddWareForm_Shown);
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AddWareForm_KeyDown);
+            this.Shown += new System.EventHandler(this.AddWaveform_Shown);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AddWaveform_KeyDown);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/src/Forms/AddWaveForm.cs
+++ b/src/Forms/AddWaveForm.cs
@@ -234,28 +234,24 @@ namespace Nikse.SubtitleEdit.Forms
             labelProgress.Text = Configuration.Settings.Language.AddWaveform.GeneratingPeakFile;
             Refresh();
 
-            var waveFile = new WavePeakGenerator(targetFile);
-
-            int sampleRate = Configuration.Settings.VideoControls.WaveformMinimumSampleRate; // Normally 128
-            while (waveFile.Header.SampleRate % sampleRate != 0 && sampleRate < 5000)
-                sampleRate++; // old sample-rate / new sample-rate must have rest = 0
-
-            waveFile.GeneratePeakSamples(sampleRate, delayInMilliseconds); // samples per second - SampleRate
-
-            if (Configuration.Settings.VideoControls.GenerateSpectrogram)
+            using (var waveFile = new WavePeakGenerator(targetFile))
             {
-                labelProgress.Text = Configuration.Settings.Language.AddWaveform.GeneratingSpectrogram;
-                Refresh();
-                Directory.CreateDirectory(_spectrogramDirectory);
-                SpectrogramBitmaps = waveFile.GenerateFourierData(256, _spectrogramDirectory, delayInMilliseconds); // image height = nfft / 2
+                waveFile.GeneratePeakSamples(delayInMilliseconds);
+
+                if (Configuration.Settings.VideoControls.GenerateSpectrogram)
+                {
+                    labelProgress.Text = Configuration.Settings.Language.AddWaveform.GeneratingSpectrogram;
+                    Refresh();
+                    SpectrogramBitmaps = waveFile.GenerateFourierData(256, _spectrogramDirectory, delayInMilliseconds); // image height = nfft / 2
+                }
+
+                WavePeak = waveFile;
             }
-            WavePeak = waveFile;
-            waveFile.Close();
 
             labelPleaseWait.Visible = false;
         }
 
-        private void AddWareForm_Shown(object sender, EventArgs e)
+        private void AddWaveform_Shown(object sender, EventArgs e)
         {
             Refresh();
             var audioTrackNames = new List<string>();
@@ -367,7 +363,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void AddWareForm_KeyDown(object sender, KeyEventArgs e)
+        private void AddWaveform_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Escape)
                 DialogResult = DialogResult.Cancel;

--- a/src/Forms/AddWaveformBatch.cs
+++ b/src/Forms/AddWaveformBatch.cs
@@ -211,7 +211,12 @@ namespace Nikse.SubtitleEdit.Forms
             while (index < listViewInputFiles.Items.Count && _abort == false)
             {
                 var item = listViewInputFiles.Items[index];
-                item.SubItems[3].Text = Configuration.Settings.Language.AddWaveformBatch.ExtractingAudio;
+                Action<string> updateStatus = status =>
+                {
+                    item.SubItems[3].Text = status;
+                    Refresh();
+                };
+                updateStatus(Configuration.Settings.Language.AddWaveformBatch.ExtractingAudio);
                 string fileName = item.Text;
                 try
                 {
@@ -285,7 +290,7 @@ namespace Nikse.SubtitleEdit.Forms
                         }
                     }
 
-                    item.SubItems[3].Text = Configuration.Settings.Language.AddWaveformBatch.Calculating;
+                    updateStatus(Configuration.Settings.Language.AddWaveformBatch.Calculating);
                     MakeWaveformAndSpectrogram(fileName, targetFile, _delayInMilliseconds);
 
                     // cleanup
@@ -300,13 +305,13 @@ namespace Nikse.SubtitleEdit.Forms
 
                     IncrementAndShowProgress();
 
-                    item.SubItems[3].Text = Configuration.Settings.Language.AddWaveformBatch.Done;
+                    updateStatus(Configuration.Settings.Language.AddWaveformBatch.Done);
                 }
                 catch
                 {
                     IncrementAndShowProgress();
 
-                    item.SubItems[3].Text = Configuration.Settings.Language.AddWaveformBatch.Error;
+                    updateStatus(Configuration.Settings.Language.AddWaveformBatch.Error);
                 }
                 index++;
             }
@@ -322,21 +327,16 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void MakeWaveformAndSpectrogram(string videoFileName, string targetFile, int delayInMilliseconds)
         {
-            var waveFile = new WavePeakGenerator(targetFile);
+            using (var waveFile = new WavePeakGenerator(targetFile))
+            {
+                waveFile.GeneratePeakSamples(delayInMilliseconds);
+                waveFile.WritePeakSamples(Main.GetPeakWaveFileName(videoFileName));
 
-            int sampleRate = Configuration.Settings.VideoControls.WaveformMinimumSampleRate; // Normally 128
-            while (waveFile.Header.SampleRate % sampleRate != 0 && sampleRate < 5000)
-                sampleRate++; // old sample-rate / new sample-rate must have rest = 0
-
-            waveFile.GeneratePeakSamples(sampleRate, delayInMilliseconds); // samples per second - SampleRate
-
-            //if (Configuration.Settings.VideoControls.GenerateSpectrogram)
-            //{
-            //    //Directory.CreateDirectory(_spectrogramDirectory);
-            //    //SpectrogramBitmaps = waveFile.GenerateFourierData(256, _spectrogramDirectory, delayInMilliseconds); // image height = nfft / 2
-            //}
-            waveFile.WritePeakSamples(Main.GetPeakWaveFileName(videoFileName));
-            waveFile.Close();
+                if (Configuration.Settings.VideoControls.GenerateSpectrogram)
+                {
+                    waveFile.GenerateFourierData(256, Main.GetSpectrogramFolder(videoFileName), delayInMilliseconds); // image height = nfft / 2
+                }
+            }
         }
 
         private void IncrementAndShowProgress()

--- a/src/Forms/Main.Designer.cs
+++ b/src/Forms/Main.Designer.cs
@@ -4450,7 +4450,7 @@
             this.audioVisualizer.TextBold = true;
             this.audioVisualizer.TextColor = System.Drawing.Color.Gray;
             this.audioVisualizer.TextSize = 9F;
-            this.audioVisualizer.VerticalZoomFactor = 1D;
+            this.audioVisualizer.VerticalZoomFactor = 2D;
             this.audioVisualizer.WaveformNotLoadedText = "Click to add waveform";
             this.audioVisualizer.WavePeaks = null;
             this.audioVisualizer.ZoomFactor = 1D;

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -14803,7 +14803,7 @@ namespace Nikse.SubtitleEdit.Forms
             return wavePeakName;
         }
 
-        private static string GetSpectrogramFolder(string videoFileName)
+        public static string GetSpectrogramFolder(string videoFileName)
         {
             var dir = Configuration.SpectrogramsFolder.TrimEnd(Path.DirectorySeparatorChar);
             if (!Directory.Exists(dir))


### PR DESCRIPTION
* WaveToVisualizer: Fix peak generation skipping the last fractional second of audio.
* Add waveform batch: Generate spectrogram (if respective setting is enabled).
* Add waveform batch: Fix status not showing the "calculating..." part.
* Small code cleanups (e.g. fix typo, make constant match naming convention, factor out some redundant code).

EDIT: Added some more:
* Audio visualizer: Fix waveform height calculation being 2x too high (but set default vertical zoom to 2.0 to keep the same effective look). Now you can zoom out vertically to 1.0 to see the correct height.
* Audio visualizer: Allow vertical zoom to be changed with control + shift + scroll wheel.