### PR TITLE
Make subtitle list use localized decimal separator

### DIFF
--- a/libse/TimeCode.cs
+++ b/libse/TimeCode.cs
@@ -228,5 +228,27 @@ namespace Nikse.SubtitleEdit.Core
             return string.Format("{0:00}:{1:00}:{2:00}.{3:00}", ts.Hours, ts.Minutes, ts.Seconds, SubtitleFormat.MillisecondsToFramesMaxFrameRate(ts.Milliseconds));
         }
 
+        public string ToDisplayString()
+        {
+            if (IsMaxTime)
+                return "-";
+
+            if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
+                return ToHHMMSSFF();
+
+            return ToString(true);
+        }
+
+        public string ToShortDisplayString()
+        {
+            if (IsMaxTime)
+                return "-";
+
+            if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
+                return ToShortStringHHMMSSFF();
+
+            return ToShortString(true);
+        }
+
     }
 }

--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -716,12 +716,7 @@ namespace Nikse.SubtitleEdit.Controls
                 pen = new Pen(new SolidBrush(Color.FromArgb(175, 110, 10, 10))) { DashStyle = System.Drawing.Drawing2D.DashStyle.Dash, Width = 2 };
                 e.Graphics.DrawLine(pen, currentRegionRight - 1, 0, currentRegionRight - 1, e.Graphics.VisibleClipBounds.Height);
 
-                string durationStr;
-                if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
-                    durationStr = paragraph.Duration.ToShortStringHHMMSSFF();
-                else
-                    durationStr = paragraph.Duration.ToShortString(true);
-
+                string durationStr = paragraph.Duration.ToShortDisplayString();
                 var n = _zoomFactor * _wavePeaks.Header.SampleRate;
                 if (n > 80)
                 {

--- a/src/Controls/SubtitleListView.cs
+++ b/src/Controls/SubtitleListView.cs
@@ -113,7 +113,7 @@ namespace Nikse.SubtitleEdit.Controls
             {
                 using (var graphics = parentForm.CreateGraphics())
                 {
-                    var timestampSizeF = graphics.MeasureString("00:00:33,527", Font);
+                    var timestampSizeF = graphics.MeasureString(new TimeCode(0, 0, 33, 527).ToDisplayString(), Font);
                     var timestampWidth = (int)(timestampSizeF.Width + 0.5) + 11;
                     Columns[ColumnIndexStart].Width = timestampWidth;
                     Columns[ColumnIndexEnd].Width = timestampWidth;
@@ -600,51 +600,22 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void Add(Paragraph paragraph)
         {
-            var item = new ListViewItem(paragraph.Number.ToString(CultureInfo.InvariantCulture)) { Tag = paragraph };
+            var item = new ListViewItem(paragraph.Number.ToString(CultureInfo.InvariantCulture)) { Tag = paragraph, UseItemStyleForSubItems = false };
             ListViewItem.ListViewSubItem subItem;
 
-            if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
-            {
-                if (paragraph.StartTime.IsMaxTime)
-                    subItem = new ListViewItem.ListViewSubItem(item, "-");
-                else
-                    subItem = new ListViewItem.ListViewSubItem(item, paragraph.StartTime.ToHHMMSSFF());
-                item.SubItems.Add(subItem);
+            subItem = new ListViewItem.ListViewSubItem(item, paragraph.StartTime.ToDisplayString());
+            item.SubItems.Add(subItem);
 
-                if (paragraph.EndTime.IsMaxTime)
-                    subItem = new ListViewItem.ListViewSubItem(item, "-");
-                else
-                    subItem = new ListViewItem.ListViewSubItem(item, paragraph.EndTime.ToHHMMSSFF());
-                item.SubItems.Add(subItem);
+            subItem = new ListViewItem.ListViewSubItem(item, paragraph.EndTime.ToDisplayString());
+            item.SubItems.Add(subItem);
 
-                subItem = new ListViewItem.ListViewSubItem(item, string.Format("{0},{1:00}", paragraph.Duration.Seconds, Core.SubtitleFormats.SubtitleFormat.MillisecondsToFramesMaxFrameRate(paragraph.Duration.Milliseconds)));
-                item.SubItems.Add(subItem);
-            }
-            else
-            {
-                if (paragraph.StartTime.IsMaxTime)
-                    subItem = new ListViewItem.ListViewSubItem(item, "-");
-                else
-                    subItem = new ListViewItem.ListViewSubItem(item, paragraph.StartTime.ToString());
-                item.SubItems.Add(subItem);
-
-                if (paragraph.EndTime.IsMaxTime)
-                    subItem = new ListViewItem.ListViewSubItem(item, "-");
-                else
-                    subItem = new ListViewItem.ListViewSubItem(item, paragraph.EndTime.ToString());
-                item.SubItems.Add(subItem);
-
-                subItem = new ListViewItem.ListViewSubItem(item, string.Format("{0},{1:000}", paragraph.Duration.Seconds, paragraph.Duration.Milliseconds));
-                item.SubItems.Add(subItem);
-            }
+            subItem = new ListViewItem.ListViewSubItem(item, paragraph.Duration.ToShortDisplayString());
+            item.SubItems.Add(subItem);
 
             subItem = new ListViewItem.ListViewSubItem(item, paragraph.Text.Replace(Environment.NewLine, _lineSeparatorString));
-            if (SubtitleFontBold)
-                subItem.Font = new Font(_subtitleFontName, SubtitleFontSize, FontStyle.Bold);
-            else
-                subItem.Font = new Font(_subtitleFontName, SubtitleFontSize);
-
-            item.UseItemStyleForSubItems = false;
+            subItem.Font = SubtitleFontBold ?
+                new Font(_subtitleFontName, SubtitleFontSize, FontStyle.Bold) :
+                new Font(_subtitleFontName, SubtitleFontSize);
             item.SubItems.Add(subItem);
 
             Items.Add(item);
@@ -710,8 +681,8 @@ namespace Nikse.SubtitleEdit.Controls
             foreach (ListViewItem item in Items)
             {
                 if (item.Text == p.Number.ToString(CultureInfo.InvariantCulture) &&
-                    item.SubItems[ColumnIndexStart].Text == p.StartTime.ToString() &&
-                    item.SubItems[ColumnIndexEnd].Text == p.EndTime.ToString() &&
+                    item.SubItems[ColumnIndexStart].Text == p.StartTime.ToDisplayString() &&
+                    item.SubItems[ColumnIndexEnd].Text == p.EndTime.ToDisplayString() &&
                     item.SubItems[ColumnIndexText].Text == p.Text)
                 {
                     RestoreFirstVisibleIndex();
@@ -754,36 +725,10 @@ namespace Nikse.SubtitleEdit.Controls
             if (IsValidIndex(index))
             {
                 ListViewItem item = Items[index];
-
-                if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
-                {
-                    if (paragraph.StartTime.IsMaxTime)
-                        item.SubItems[ColumnIndexStart].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexStart].Text = paragraph.StartTime.ToHHMMSSFF();
-
-                    if (paragraph.EndTime.IsMaxTime)
-                        item.SubItems[ColumnIndexEnd].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToHHMMSSFF();
-
-                    item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:00}", paragraph.Duration.Seconds, Core.SubtitleFormats.SubtitleFormat.MillisecondsToFramesMaxFrameRate(paragraph.Duration.Milliseconds));
-                }
-                else
-                {
-                    if (paragraph.StartTime.IsMaxTime)
-                        item.SubItems[ColumnIndexStart].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexStart].Text = paragraph.StartTime.ToString();
-
-                    if (paragraph.EndTime.IsMaxTime)
-                        item.SubItems[ColumnIndexEnd].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToString();
-
-                    item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:000}", paragraph.Duration.Seconds, paragraph.Duration.Milliseconds);
-                }
-                Items[index].SubItems[ColumnIndexText].Text = paragraph.Text.Replace(Environment.NewLine, _lineSeparatorString);
+                item.SubItems[ColumnIndexStart].Text = paragraph.StartTime.ToDisplayString();
+                item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToDisplayString();
+                item.SubItems[ColumnIndexDuration].Text = paragraph.Duration.ToShortDisplayString();
+                item.SubItems[ColumnIndexText].Text = paragraph.Text.Replace(Environment.NewLine, _lineSeparatorString);
             }
         }
 
@@ -887,22 +832,8 @@ namespace Nikse.SubtitleEdit.Controls
             if (IsValidIndex(index))
             {
                 ListViewItem item = Items[index];
-                if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
-                {
-                    item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:00}", paragraph.Duration.Seconds, Core.SubtitleFormats.SubtitleFormat.MillisecondsToFramesMaxFrameRate(paragraph.Duration.Milliseconds));
-                    if (paragraph.EndTime.IsMaxTime)
-                        item.SubItems[ColumnIndexEnd].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToHHMMSSFF();
-                }
-                else
-                {
-                    item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:000}", paragraph.Duration.Seconds, paragraph.Duration.Milliseconds);
-                    if (paragraph.EndTime.IsMaxTime)
-                        item.SubItems[ColumnIndexEnd].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToString();
-                }
+                item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToDisplayString();
+                item.SubItems[ColumnIndexDuration].Text = paragraph.Duration.ToShortDisplayString();
             }
         }
 
@@ -924,50 +855,14 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     if (IsValidIndex(i))
                     {
-                        ListViewItem item = Items[i];
                         Paragraph p = subtitle.Paragraphs[i];
-                        item.SubItems[ColumnIndexStart].Text = p.StartTime.ToHHMMSSFF();
-                        item.SubItems[ColumnIndexEnd].Text = p.EndTime.ToHHMMSSFF();
-                        item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:00}", p.Duration.Seconds, Core.SubtitleFormats.SubtitleFormat.MillisecondsToFramesMaxFrameRate(p.Duration.Milliseconds));
+                        ListViewItem item = Items[i];
+                        item.SubItems[ColumnIndexStart].Text = p.StartTime.ToDisplayString();
+                        item.SubItems[ColumnIndexEnd].Text = p.EndTime.ToDisplayString();
+                        item.SubItems[ColumnIndexDuration].Text = p.Duration.ToShortDisplayString();
                     }
                 }
                 EndUpdate();
-            }
-        }
-
-        public void SetStartTime(int index, Paragraph paragraph)
-        {
-            if (IsValidIndex(index))
-            {
-                ListViewItem item = Items[index];
-                if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
-                {
-                    if (paragraph.StartTime.IsMaxTime)
-                        item.SubItems[ColumnIndexStart].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexStart].Text = paragraph.StartTime.ToHHMMSSFF();
-
-                    if (paragraph.EndTime.IsMaxTime)
-                        item.SubItems[ColumnIndexEnd].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToHHMMSSFF();
-
-                    item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:00}", paragraph.Duration.Seconds, Core.SubtitleFormats.SubtitleFormat.MillisecondsToFramesMaxFrameRate(paragraph.Duration.Milliseconds));
-                }
-                else
-                {
-                    if (paragraph.StartTime.IsMaxTime)
-                        item.SubItems[ColumnIndexStart].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexStart].Text = paragraph.StartTime.ToString();
-
-                    if (paragraph.EndTime.IsMaxTime)
-                        item.SubItems[ColumnIndexEnd].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToString();
-
-                    item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:000}", paragraph.Duration.Seconds, paragraph.Duration.Milliseconds);
-                }
             }
         }
 
@@ -976,34 +871,9 @@ namespace Nikse.SubtitleEdit.Controls
             if (IsValidIndex(index))
             {
                 ListViewItem item = Items[index];
-                if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
-                {
-                    if (paragraph.StartTime.IsMaxTime)
-                        item.SubItems[ColumnIndexStart].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexStart].Text = paragraph.StartTime.ToHHMMSSFF();
-
-                    if (paragraph.EndTime.IsMaxTime)
-                        item.SubItems[ColumnIndexEnd].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToHHMMSSFF();
-
-                    item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:00}", paragraph.Duration.Seconds, Core.SubtitleFormats.SubtitleFormat.MillisecondsToFramesMaxFrameRate(paragraph.Duration.Milliseconds));
-                }
-                else
-                {
-                    if (paragraph.StartTime.IsMaxTime)
-                        item.SubItems[ColumnIndexStart].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexStart].Text = paragraph.StartTime.ToString();
-
-                    if (paragraph.EndTime.IsMaxTime)
-                        item.SubItems[ColumnIndexEnd].Text = "-";
-                    else
-                        item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToString();
-
-                    item.SubItems[ColumnIndexDuration].Text = string.Format("{0},{1:000}", paragraph.Duration.Seconds, paragraph.Duration.Milliseconds);
-                }
+                item.SubItems[ColumnIndexStart].Text = paragraph.StartTime.ToDisplayString();
+                item.SubItems[ColumnIndexEnd].Text = paragraph.EndTime.ToDisplayString();
+                item.SubItems[ColumnIndexDuration].Text = paragraph.Duration.ToShortDisplayString();
             }
         }
 

--- a/src/Controls/VideoPlayerContainer.cs
+++ b/src/Controls/VideoPlayerContainer.cs
@@ -1217,10 +1217,7 @@ namespace Nikse.SubtitleEdit.Controls
                 var span = TimeCode.FromSeconds(pos);
                 var dur = TimeCode.FromSeconds(Duration);
 
-                if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
-                    _labelTimeCode.Text = string.Format("{0} / {1}", span.ToHHMMSSFF(), dur.ToHHMMSSFF());
-                else
-                    _labelTimeCode.Text = string.Format("{0:00}:{1:00}:{2:00},{3:000} / {4:00}:{5:00}:{6:00},{7:000}", span.Hours, span.Minutes, span.Seconds, span.Milliseconds, dur.Hours, dur.Minutes, dur.Seconds, dur.Milliseconds);
+                _labelTimeCode.Text = string.Format("{0} / {1}", span.ToDisplayString(), dur.ToDisplayString());
 
                 RefreshPlayPauseButtons();
             }

--- a/src/Forms/ExportPngXml.cs
+++ b/src/Forms/ExportPngXml.cs
@@ -3796,7 +3796,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 
         private void SubtitleListView1Add(Paragraph paragraph)
         {
-            var item = new ListViewItem(paragraph.Number.ToString(CultureInfo.InvariantCulture)) { Tag = paragraph };
+            var item = new ListViewItem(paragraph.Number.ToString(CultureInfo.InvariantCulture)) { Tag = paragraph, UseItemStyleForSubItems = false };
             ListViewItem.ListViewSubItem subItem;
 
             if (subtitleListView1.CheckBoxes)
@@ -3806,45 +3806,17 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                 item.SubItems.Add(subItem);
             }
 
-            if (Configuration.Settings != null && Configuration.Settings.General.UseTimeFormatHHMMSSFF)
-            {
-                if (paragraph.StartTime.IsMaxTime)
-                    subItem = new ListViewItem.ListViewSubItem(item, "-");
-                else
-                    subItem = new ListViewItem.ListViewSubItem(item, paragraph.StartTime.ToHHMMSSFF());
-                item.SubItems.Add(subItem);
+            subItem = new ListViewItem.ListViewSubItem(item, paragraph.StartTime.ToDisplayString());
+            item.SubItems.Add(subItem);
 
-                if (paragraph.EndTime.IsMaxTime)
-                    subItem = new ListViewItem.ListViewSubItem(item, "-");
-                else
-                    subItem = new ListViewItem.ListViewSubItem(item, paragraph.EndTime.ToHHMMSSFF());
-                item.SubItems.Add(subItem);
+            subItem = new ListViewItem.ListViewSubItem(item, paragraph.EndTime.ToDisplayString());
+            item.SubItems.Add(subItem);
 
-                subItem = new ListViewItem.ListViewSubItem(item, string.Format("{0},{1:00}", paragraph.Duration.Seconds, SubtitleFormat.MillisecondsToFramesMaxFrameRate(paragraph.Duration.Milliseconds)));
-                item.SubItems.Add(subItem);
-            }
-            else
-            {
-                if (paragraph.StartTime.IsMaxTime)
-                    subItem = new ListViewItem.ListViewSubItem(item, "-");
-                else
-                    subItem = new ListViewItem.ListViewSubItem(item, paragraph.StartTime.ToString());
-                item.SubItems.Add(subItem);
-
-                if (paragraph.EndTime.IsMaxTime)
-                    subItem = new ListViewItem.ListViewSubItem(item, "-");
-                else
-                    subItem = new ListViewItem.ListViewSubItem(item, paragraph.EndTime.ToString());
-                item.SubItems.Add(subItem);
-
-                subItem = new ListViewItem.ListViewSubItem(item, string.Format("{0},{1:000}", paragraph.Duration.Seconds, paragraph.Duration.Milliseconds));
-                item.SubItems.Add(subItem);
-            }
+            subItem = new ListViewItem.ListViewSubItem(item, paragraph.Duration.ToShortDisplayString());
+            item.SubItems.Add(subItem);
 
             subItem = new ListViewItem.ListViewSubItem(item, paragraph.Text.Replace(Environment.NewLine, Configuration.Settings.General.ListViewLineSeparatorString));
             subItem.Font = new Font(_subtitleFontName, Font.Size);
-
-            item.UseItemStyleForSubItems = false;
             item.SubItems.Add(subItem);
 
             subtitleListView1.Items.Add(item);

--- a/src/Forms/FixCommonErrors.cs
+++ b/src/Forms/FixCommonErrors.cs
@@ -4563,7 +4563,7 @@ namespace Nikse.SubtitleEdit.Forms
                 _originalSubtitle.Paragraphs[_subtitleListViewIndex].EndTime.TotalMilliseconds +=
                     (startTime.TotalMilliseconds - _originalSubtitle.Paragraphs[_subtitleListViewIndex].StartTime.TotalMilliseconds);
                 _originalSubtitle.Paragraphs[_subtitleListViewIndex].StartTime = startTime;
-                subtitleListView1.SetStartTime(_subtitleListViewIndex, _originalSubtitle.Paragraphs[_subtitleListViewIndex]);
+                subtitleListView1.SetStartTimeAndDuration(_subtitleListViewIndex, _originalSubtitle.Paragraphs[_subtitleListViewIndex]);
             }
         }
 

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -6469,7 +6469,7 @@ namespace Nikse.SubtitleEdit.Forms
                             double dur = last.Duration.TotalMilliseconds;
                             last.StartTime.TotalMilliseconds = startTime.TotalMilliseconds;
                             last.EndTime.TotalMilliseconds = startTime.TotalMilliseconds + dur;
-                            SubtitleListview1.SetStartTime(_subtitleListViewIndex, last);
+                            SubtitleListview1.SetStartTimeAndDuration(_subtitleListViewIndex, last);
                             showSource = true;
                         }
                     }
@@ -8009,7 +8009,7 @@ namespace Nikse.SubtitleEdit.Forms
                 var p = _subtitle.Paragraphs[_subtitleListViewIndex];
                 p.EndTime.TotalMilliseconds += (startTime.TotalMilliseconds - p.StartTime.TotalMilliseconds);
                 p.StartTime = startTime;
-                SubtitleListview1.SetStartTime(_subtitleListViewIndex, p);
+                SubtitleListview1.SetStartTimeAndDuration(_subtitleListViewIndex, p);
                 if (GetCurrentSubtitleFormat().IsFrameBased)
                 {
                     p.CalculateFrameNumbersFromTimeCodes(CurrentFrameRate);
@@ -13271,7 +13271,7 @@ namespace Nikse.SubtitleEdit.Forms
                     if (_subtitle.Paragraphs[index].StartTime.TotalMilliseconds < 0)
                         _subtitle.Paragraphs[index].StartTime.TotalMilliseconds = 0;
                     timeUpDownStartTime.TimeCode = _subtitle.Paragraphs[index].StartTime;
-                    SubtitleListview1.SetStartTime(index, _subtitle.Paragraphs[index]);
+                    SubtitleListview1.SetStartTimeAndDuration(index, _subtitle.Paragraphs[index]);
                     timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
                 }
                 else
@@ -13568,7 +13568,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 p.StartTime.TotalMilliseconds += adjustMilliseconds;
                 p.EndTime.TotalMilliseconds += adjustMilliseconds;
-                SubtitleListview1.SetStartTime(i, p);
+                SubtitleListview1.SetStartTimeAndDuration(i, p);
             }
         }
 
@@ -13952,7 +13952,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     _subtitle.Paragraphs[index].StartTime.TotalSeconds = videoPosition;
                     _subtitle.Paragraphs[index].EndTime.TotalMilliseconds = _subtitle.Paragraphs[index].StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(_subtitle.Paragraphs[index].Text);
-                    SubtitleListview1.SetStartTime(index, _subtitle.Paragraphs[index]);
+                    SubtitleListview1.SetStartTimeAndDuration(index, _subtitle.Paragraphs[index]);
                     checkBoxSyncListViewWithVideoWhilePlaying.Checked = oldSync;
                     timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
                     return;
@@ -13960,7 +13960,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 _subtitle.Paragraphs[index].StartTime = new TimeCode(_subtitle.Paragraphs[index].StartTime.TotalMilliseconds - offset);
                 _subtitle.Paragraphs[index].EndTime = new TimeCode(_subtitle.Paragraphs[index].EndTime.TotalMilliseconds - offset);
-                SubtitleListview1.SetStartTime(index, _subtitle.Paragraphs[index]);
+                SubtitleListview1.SetStartTimeAndDuration(index, _subtitle.Paragraphs[index]);
 
                 for (int i = index + 1; i < SubtitleListview1.Items.Count; i++)
                 {
@@ -13968,7 +13968,7 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         _subtitle.Paragraphs[i].StartTime = new TimeCode(_subtitle.Paragraphs[i].StartTime.TotalMilliseconds - offset);
                         _subtitle.Paragraphs[i].EndTime = new TimeCode(_subtitle.Paragraphs[i].EndTime.TotalMilliseconds - offset);
-                        SubtitleListview1.SetStartTime(i, _subtitle.Paragraphs[i]);
+                        SubtitleListview1.SetStartTimeAndDuration(i, _subtitle.Paragraphs[i]);
                     }
                 }
 
@@ -14023,7 +14023,7 @@ namespace Nikse.SubtitleEdit.Forms
                     if (_subtitle.Paragraphs[index].StartTime.TotalMilliseconds < 0)
                         _subtitle.Paragraphs[index].StartTime.TotalMilliseconds = 0;
                     timeUpDownStartTime.TimeCode = _subtitle.Paragraphs[index].StartTime;
-                    SubtitleListview1.SetStartTime(index, _subtitle.Paragraphs[index]);
+                    SubtitleListview1.SetStartTimeAndDuration(index, _subtitle.Paragraphs[index]);
                     timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
                 }
                 else
@@ -14047,7 +14047,7 @@ namespace Nikse.SubtitleEdit.Forms
                             ShowSource();
                     }
                     if (!_subtitle.Paragraphs[index + 1].StartTime.IsMaxTime)
-                        SubtitleListview1.SetStartTime(index + 1, _subtitle.Paragraphs[index + 1]);
+                        SubtitleListview1.SetStartTimeAndDuration(index + 1, _subtitle.Paragraphs[index + 1]);
                     SubtitleListview1.SelectIndexAndEnsureVisible(index + 1, true);
                 }
                 _makeHistoryPaused = false;
@@ -16972,7 +16972,7 @@ namespace Nikse.SubtitleEdit.Forms
                 if (p.StartTime.TotalMilliseconds < 0)
                     p.StartTime.TotalMilliseconds = 0;
                 timeUpDownStartTime.TimeCode = p.StartTime;
-                SubtitleListview1.SetStartTime(index, p);
+                SubtitleListview1.SetStartTimeAndDuration(index, p);
                 timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
             }
             if (p.Duration.TotalSeconds < 0 || p.Duration.TotalSeconds > 10)

--- a/src/Forms/SyncPointsSync.cs
+++ b/src/Forms/SyncPointsSync.cs
@@ -148,7 +148,7 @@ namespace Nikse.SubtitleEdit.Forms
                     var p = new Paragraph();
                     p.StartTime.TotalMilliseconds = _synchronizationPoints[i].TotalMilliseconds;
                     p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + _subtitle.Paragraphs[i].Duration.TotalMilliseconds;
-                    SubtitleListview1.SetStartTime(i, p);
+                    SubtitleListview1.SetStartTimeAndDuration(i, p);
 
                     var item = new ListBoxSyncPoint { Index = i, Text = _subtitle.Paragraphs[i].Number + " - " + p.StartTime };
                     listBoxSyncPoints.Items.Add(item);
@@ -159,7 +159,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     SubtitleListview1.SetBackgroundColor(i, SubtitleListview1.BackColor);
                     SubtitleListview1.SetNumber(i, (i + 1).ToString(CultureInfo.InvariantCulture));
-                    SubtitleListview1.SetStartTime(i, _subtitle.Paragraphs[i]);
+                    SubtitleListview1.SetStartTimeAndDuration(i, _subtitle.Paragraphs[i]);
                 }
             }
         }

--- a/src/Forms/VobSubOcr.cs
+++ b/src/Forms/VobSubOcr.cs
@@ -8479,7 +8479,7 @@ namespace Nikse.SubtitleEdit.Forms
                         Paragraph currentP = _subtitle.Paragraphs[index];
                         currentP.StartTime.TotalMilliseconds = p.StartTime.TotalMilliseconds;
                         currentP.EndTime.TotalMilliseconds = p.EndTime.TotalMilliseconds;
-                        subtitleListView1.SetStartTime(index, currentP);
+                        subtitleListView1.SetStartTimeAndDuration(index, currentP);
                     }
                     index++;
                 }


### PR DESCRIPTION
This makes the subtitle list use the localized decimal separator character. I also reduced some of the redundancy with some new methods in TimeCode: ToDisplayString and ToShortDisplayString.

I noticed that SubtitleListView's SetStartTime and SetStartTimeAndDuration methods were completely identical as well (they both updated the start time, end time, and duration), so I combined them.