### PR TITLE
Fix missing context menu items on new selection

### DIFF
--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -813,13 +813,13 @@ namespace Nikse.SubtitleEdit.Controls
                         _mouseDownParagraph.StartTime.TotalMilliseconds = milliseconds;
                         NewSelectionParagraph.StartTime.TotalMilliseconds = milliseconds;
                         _mouseMoveStartX = e.X;
-                        _mouseMoveEndX = SecondsToXPosition(NewSelectionParagraph.EndTime.TotalSeconds);
+                        _mouseMoveEndX = SecondsToXPosition(NewSelectionParagraph.EndTime.TotalSeconds - StartPositionSeconds);
                     }
                     else
                     {
                         _mouseDownParagraph.EndTime.TotalMilliseconds = milliseconds;
                         NewSelectionParagraph.EndTime.TotalMilliseconds = milliseconds;
-                        _mouseMoveStartX = SecondsToXPosition(NewSelectionParagraph.StartTime.TotalSeconds);
+                        _mouseMoveStartX = SecondsToXPosition(NewSelectionParagraph.StartTime.TotalSeconds - StartPositionSeconds);
                         _mouseMoveEndX = e.X;
                     }
                     SetMinMaxViaSeconds(seconds);


### PR DESCRIPTION
This fixes the following bug: Create a new selection in the audio visualizer. Then move your mouse to the edge of that selection and drag the edge to resize it. Then right click inside the selection and notice that context menu items such as "Add text here" are missing.