### PR TITLE
Fix not all paragraphs showing in the audio visualizer when zoomed out

### DIFF
--- a/libse/WaveToVisualizer.cs
+++ b/libse/WaveToVisualizer.cs
@@ -260,7 +260,7 @@ namespace Nikse.SubtitleEdit.Core
 
             PeaksPerSecond = Math.Min(Configuration.Settings.VideoControls.WaveformMinimumSampleRate, Header.SampleRate);
 
-            // Ensure that peaks per second is a multiple of the sample rate
+            // Ensure that peaks per second is a factor of the sample rate
             while (Header.SampleRate % PeaksPerSecond != 0)
                 PeaksPerSecond++;
 

--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -308,80 +308,43 @@ namespace Nikse.SubtitleEdit.Controls
             InsertAtVideoPositionShortcut = Utilities.GetKeys(Configuration.Settings.Shortcuts.MainWaveformInsertAtCurrentPosition);
         }
 
-        public void NearestSubtitles(Subtitle subtitle, double currentVideoPositionSeconds, int subtitleIndex)
+        private void NearestSubtitles(Subtitle subtitle, double currentVideoPositionSeconds, int subtitleIndex)
         {
-            _previousAndNextParagraphs.Clear();
             _currentParagraph = null;
+            _previousAndNextParagraphs.Clear();
 
-            var positionMilliseconds = (int)Math.Round(currentVideoPositionSeconds * TimeCode.BaseUnit);
-            if (_selectedParagraph != null && _selectedParagraph.StartTime.TotalMilliseconds < positionMilliseconds && _selectedParagraph.EndTime.TotalMilliseconds > positionMilliseconds)
+            if (subtitle.Paragraphs.Count == 0)
+                return;
+
+            // Locate the current paragraph, which is the paragraph ending soonest after the
+            // current video position, or if none such exist, the last paragraph. There's a
+            // good chance this will end up being the selected paragraph, so we'll check it
+            // first as an optimization.
+            bool isPositionInsideSelection = _selectedParagraph != null &&
+                _selectedParagraph.StartTime.TotalSeconds <= currentVideoPositionSeconds &&
+                _selectedParagraph.EndTime.TotalSeconds > currentVideoPositionSeconds;
+            int currentParagraphIndex = isPositionInsideSelection ? subtitleIndex :
+                subtitle.Paragraphs.FindIndex(p => p.EndTime.TotalSeconds > currentVideoPositionSeconds);
+            if (currentParagraphIndex == -1)
+                currentParagraphIndex = subtitle.Paragraphs.Count - 1;
+
+            _currentParagraph = subtitle.Paragraphs[currentParagraphIndex];
+
+            // Locate the other paragraphs inside the visible time range, as well as one extra
+            // on either side (helps when scrolling).
+            for (int i = currentParagraphIndex + 1; i < subtitle.Paragraphs.Count; i++)
             {
-                _currentParagraph = _selectedParagraph;
-                for (int j = 1; j < 12; j++)
-                {
-                    Paragraph nextParagraph = subtitle.GetParagraphOrDefault(subtitleIndex - j);
-                    _previousAndNextParagraphs.Add(nextParagraph);
-                }
-                for (int j = 1; j < 10; j++)
-                {
-                    Paragraph nextParagraph = subtitle.GetParagraphOrDefault(subtitleIndex + j);
-                    _previousAndNextParagraphs.Add(nextParagraph);
-                }
+                Paragraph p = subtitle.Paragraphs[i];
+                _previousAndNextParagraphs.Add(p);
+                if (p.StartTime.TotalSeconds >= EndPositionSeconds)
+                    break;
             }
-            else
+            for (int i = currentParagraphIndex - 1; i >= 0; i--)
             {
-                for (int i = 0; i < subtitle.Paragraphs.Count; i++)
-                {
-                    Paragraph p = subtitle.Paragraphs[i];
-                    if (p.EndTime.TotalMilliseconds > positionMilliseconds)
-                    {
-                        _currentParagraph = p;
-                        for (int j = 1; j < 10; j++)
-                        {
-                            Paragraph nextParagraph = subtitle.GetParagraphOrDefault(i - j);
-                            _previousAndNextParagraphs.Add(nextParagraph);
-                        }
-                        for (int j = 1; j < 10; j++)
-                        {
-                            Paragraph nextParagraph = subtitle.GetParagraphOrDefault(i + j);
-                            _previousAndNextParagraphs.Add(nextParagraph);
-                        }
-
-                        break;
-                    }
-                }
-                if (_previousAndNextParagraphs.Count == 0)
-                {
-                    for (int i = 0; i < subtitle.Paragraphs.Count; i++)
-                    {
-                        Paragraph p = subtitle.Paragraphs[i];
-                        if (p.EndTime.TotalMilliseconds > StartPositionSeconds * 1000)
-                        {
-                            _currentParagraph = p;
-                            for (int j = 1; j < 10; j++)
-                            {
-                                Paragraph nextParagraph = subtitle.GetParagraphOrDefault(i - j);
-                                _previousAndNextParagraphs.Add(nextParagraph);
-                            }
-                            for (int j = 1; j < 10; j++)
-                            {
-                                Paragraph nextParagraph = subtitle.GetParagraphOrDefault(i + j);
-                                _previousAndNextParagraphs.Add(nextParagraph);
-                            }
-
-                            break;
-                        }
-                    }
-                    if (_previousAndNextParagraphs.Count == 0 && _subtitle.Paragraphs.Count > 0)
-                    {
-                        int i = _subtitle.Paragraphs.Count;
-                        for (int j = 1; j < 10; j++)
-                        {
-                            Paragraph nextParagraph = subtitle.GetParagraphOrDefault(i - j);
-                            _previousAndNextParagraphs.Add(nextParagraph);
-                        }
-                    }
-                }
+                Paragraph p = subtitle.Paragraphs[i];
+                _previousAndNextParagraphs.Add(p);
+                if (p.EndTime.TotalSeconds <= StartPositionSeconds)
+                    break;
             }
         }
 

--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -1417,24 +1417,7 @@ namespace Nikse.SubtitleEdit.Controls
                 double seconds = XPositionToSeconds(e.X);
                 var milliseconds = (int)(seconds * TimeCode.BaseUnit);
 
-                Paragraph p = null;
-                if (IsParagrapHit(milliseconds, _selectedParagraph))
-                    p = _selectedParagraph;
-                else if (IsParagrapHit(milliseconds, _currentParagraph))
-                    p = _currentParagraph;
-
-                if (p == null)
-                {
-                    foreach (Paragraph p2 in _previousAndNextParagraphs)
-                    {
-                        if (IsParagrapHit(milliseconds, p2))
-                        {
-                            p = p2;
-                            break;
-                        }
-                    }
-                }
-
+                Paragraph p = GetParagraphAtMilliseconds(milliseconds);
                 if (p != null)
                 {
                     seconds = p.StartTime.TotalSeconds;


### PR DESCRIPTION
The previous code always loaded about 9 paragraphs before/after the "current" paragraph (i.e. the one at the current video position), which was usually sufficient except when zoomed out too much.

The new code figures out which paragraphs are needed to fill the whole displayed time range.

The logic for determining the "current" paragraph has been cleaned up but is pretty much the same as before. The only difference is that when no more subtitles exist after the current video position, the old code would default to the first displayed one, if present, before defaulting to the last subtitle. This didn't seem to serve any purpose so I just default to the last one. In fact, as far as I can tell, the rest of the code in the visualizer makes no distinction between current and previous/next paragraphs. It could probably all just be combined into one "displayable paragraphs" list, unless it was separated out for some other reason (optimization?).