### PR TITLE
Fix for issue #1108

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -8016,15 +8016,15 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void UpdateOverlapErrors(TimeCode startTime)
         {
-            labelStartTimeWarning.Text = string.Empty;
-            labelDurationWarning.Text = string.Empty;
+            string startTimeWarning = string.Empty;
+            string durationWarning = string.Empty;
             if (_subtitle.Paragraphs.Count > 0 && SubtitleListview1.SelectedItems.Count > 0 && startTime != null)
             {
                 int firstSelectedIndex = SubtitleListview1.SelectedItems[0].Index;
 
                 var prevParagraph = _subtitle.GetParagraphOrDefault(firstSelectedIndex - 1);
                 if (prevParagraph != null && prevParagraph.EndTime.TotalMilliseconds > startTime.TotalMilliseconds && Configuration.Settings.Tools.ListViewSyntaxColorOverlap)
-                    labelStartTimeWarning.Text = string.Format(_languageGeneral.OverlapPreviousLineX, prevParagraph.EndTime.TotalSeconds - startTime.TotalSeconds);
+                    startTimeWarning = string.Format(_languageGeneral.OverlapPreviousLineX, prevParagraph.EndTime.TotalSeconds - startTime.TotalSeconds);
 
                 var nextParagraph = _subtitle.GetParagraphOrDefault(firstSelectedIndex + 1);
                 if (nextParagraph != null)
@@ -8032,21 +8032,23 @@ namespace Nikse.SubtitleEdit.Forms
                     double durationMilliSeconds = GetDurationInMilliseconds();
                     if (startTime.TotalMilliseconds + durationMilliSeconds > nextParagraph.StartTime.TotalMilliseconds && Configuration.Settings.Tools.ListViewSyntaxColorOverlap)
                     {
-                        labelDurationWarning.Text = string.Format(_languageGeneral.OverlapX, ((startTime.TotalMilliseconds + durationMilliSeconds) - nextParagraph.StartTime.TotalMilliseconds) / TimeCode.BaseUnit);
+                        durationWarning = string.Format(_languageGeneral.OverlapX, ((startTime.TotalMilliseconds + durationMilliSeconds) - nextParagraph.StartTime.TotalMilliseconds) / TimeCode.BaseUnit);
                     }
 
-                    if (labelStartTimeWarning.Text.Length == 0 &&
+                    if (startTimeWarning.Length == 0 &&
                         startTime.TotalMilliseconds > nextParagraph.StartTime.TotalMilliseconds && Configuration.Settings.Tools.ListViewSyntaxColorOverlap)
                     {
                         double di = (startTime.TotalMilliseconds - nextParagraph.StartTime.TotalMilliseconds) / TimeCode.BaseUnit;
-                        labelStartTimeWarning.Text = string.Format(_languageGeneral.OverlapNextX, di);
+                        startTimeWarning = string.Format(_languageGeneral.OverlapNextX, di);
                     }
                     else if (numericUpDownDuration.Value < 0)
                     {
-                        labelDurationWarning.Text = _languageGeneral.Negative;
+                        durationWarning = _languageGeneral.Negative;
                     }
                 }
             }
+            labelStartTimeWarning.Text = startTimeWarning;
+            labelDurationWarning.Text = durationWarning;
         }
 
         private double GetDurationInMilliseconds()
@@ -11064,7 +11066,6 @@ namespace Nikse.SubtitleEdit.Forms
                 }
 
                 checkBoxSyncListViewWithVideoWhilePlaying.Checked = oldSync;
-                numericUpDownDuration.ValueChanged += NumericUpDownDurationValueChanged;
 
                 if (goToNext)
                 {


### PR DESCRIPTION
The main fix is just removing one line that causes the NumericUpDownDurationValueChanged event to get wired up multiple times.

Before I found that problem, I noticed that it seemed to be masked by avoiding changing the text in the warning labels so frequently.  Basically it was an optimization that reduced the symptoms of the problem.  Since it is more efficient, I decided to include it in the patch as well. (EDIT: I figured out why it works. In Control's Text property setter there's logic like "if (value == Text) return;". By setting the text to string.Empty and then the actual value later, it effectively bypassed that logic.)