### PR TITLE
Audio visualizer fixes / enhancements

### DIFF
--- a/src/Forms/Main.Designer.cs
+++ b/src/Forms/Main.Designer.cs
@@ -2640,7 +2640,7 @@
             this.audioVisualizer.BackColor = System.Drawing.Color.Black;
             this.audioVisualizer.BackgroundColor = System.Drawing.Color.Black;
             this.audioVisualizer.Color = System.Drawing.Color.GreenYellow;
-            this.audioVisualizer.DrawGridLines = true;
+            this.audioVisualizer.ShowGridLines = true;
             this.audioVisualizer.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(20)))), ((int)(((byte)(20)))), ((int)(((byte)(18)))));
             this.audioVisualizer.Location = new System.Drawing.Point(472, 32);
             this.audioVisualizer.Margin = new System.Windows.Forms.Padding(0);

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -507,7 +507,7 @@ namespace Nikse.SubtitleEdit.Forms
                 audioVisualizer.OnTimeChangedAndOffsetRest += AudioWaveform_OnTimeChangedAndOffsetRest;
                 audioVisualizer.OnZoomedChanged += AudioWaveform_OnZoomedChanged;
                 audioVisualizer.InsertAtVideoPosition += audioVisualizer_InsertAtVideoPosition;
-                audioVisualizer.DrawGridLines = Configuration.Settings.VideoControls.WaveformDrawGrid;
+                audioVisualizer.ShowGridLines = Configuration.Settings.VideoControls.WaveformDrawGrid;
                 audioVisualizer.GridColor = Configuration.Settings.VideoControls.WaveformGridColor;
                 audioVisualizer.SelectedColor = Configuration.Settings.VideoControls.WaveformSelectedColor;
                 audioVisualizer.Color = Configuration.Settings.VideoControls.WaveformColor;
@@ -3520,7 +3520,7 @@ namespace Nikse.SubtitleEdit.Forms
             buttonCustomUrl2.Text = Configuration.Settings.VideoControls.CustomSearchText2;
             buttonCustomUrl2.Visible = Configuration.Settings.VideoControls.CustomSearchUrl2.Length > 1;
 
-            audioVisualizer.DrawGridLines = Configuration.Settings.VideoControls.WaveformDrawGrid;
+            audioVisualizer.ShowGridLines = Configuration.Settings.VideoControls.WaveformDrawGrid;
             audioVisualizer.GridColor = Configuration.Settings.VideoControls.WaveformGridColor;
             audioVisualizer.SelectedColor = Configuration.Settings.VideoControls.WaveformSelectedColor;
             audioVisualizer.Color = Configuration.Settings.VideoControls.WaveformColor;


### PR DESCRIPTION
I'm hoping this will fix the disappearing paragraph problem that was reported in LeonCheung's most recent comment in #1108.

* Workaround for non-sequential paragraphs or unusual overlapping situations.
* Fix for not showing all paragraphs when zoomed out far and with the video position near the end (StartPositionSeconds wasn't being validated early enough).
* Some small drawing optimizations when showing the spectrogram.
* Add some Invalidate calls where appropriate (will help in the future if we try to get rid of the forced Invalidate call in the timer).