### PR TITLE
Audio visualizer fixes

### DIFF
--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -522,9 +522,7 @@ namespace Nikse.SubtitleEdit.Controls
                         if (pos > 0 && pos < Width)
                         {
                             using (var p = new Pen(Color.AntiqueWhite))
-                            {
                                 graphics.DrawLine(p, pos, 0, pos, Height);
-                            }
                         }
                     }
                 }
@@ -536,9 +534,7 @@ namespace Nikse.SubtitleEdit.Controls
                     if (pos > 0 && pos < Width)
                     {
                         using (var p = new Pen(Color.Turquoise))
-                        {
                             graphics.DrawLine(p, pos, 0, pos, Height);
-                        }
                     }
                 }
 
@@ -554,19 +550,15 @@ namespace Nikse.SubtitleEdit.Controls
                     int currentRegionLeft = SecondsToXPosition(NewSelectionParagraph.StartTime.TotalSeconds - StartPositionSeconds);
                     int currentRegionRight = SecondsToXPosition(NewSelectionParagraph.EndTime.TotalSeconds - StartPositionSeconds);
                     int currentRegionWidth = currentRegionRight - currentRegionLeft;
-                    using (var brush = new SolidBrush(Color.FromArgb(128, 255, 255, 255)))
+                    if (currentRegionLeft >= 0 && currentRegionLeft <= Width)
                     {
-                        if (currentRegionLeft >= 0 && currentRegionLeft <= Width)
-                        {
+                        using (var brush = new SolidBrush(Color.FromArgb(128, 255, 255, 255)))
                             graphics.FillRectangle(brush, currentRegionLeft, 0, currentRegionWidth, graphics.VisibleClipBounds.Height);
 
-                            if (currentRegionWidth > 40)
-                            {
-                                using (var tBrush = new SolidBrush(Color.Turquoise))
-                                {
-                                    graphics.DrawString(string.Format("{0:0.###} {1}", ((double)currentRegionWidth / _wavePeaks.Header.SampleRate / _zoomFactor), Configuration.Settings.Language.Waveform.Seconds), Font, tBrush, new PointF(currentRegionLeft + 3, Height - 32));
-                                }
-                            }
+                        if (currentRegionWidth > 40)
+                        {
+                            using (var brush = new SolidBrush(Color.Turquoise))
+                                graphics.DrawString(string.Format("{0:0.###} {1}", ((double)currentRegionWidth / _wavePeaks.Header.SampleRate / _zoomFactor), Configuration.Settings.Language.Waveform.Seconds), Font, brush, new PointF(currentRegionLeft + 3, Height - 32));
                         }
                     }
                 }
@@ -581,30 +573,23 @@ namespace Nikse.SubtitleEdit.Controls
                 }
 
                 using (var textBrush = new SolidBrush(TextColor))
+                using (var textFont = new Font(Font.FontFamily, 8))
                 {
-                    using (var textFont = new Font(Font.FontFamily, 8))
+                    if (Width > 90)
                     {
-                        if (Width > 90)
-                        {
-                            graphics.DrawString(WaveformNotLoadedText, textFont, textBrush, new PointF(Width / 2 - 65, Height / 2 - 10));
-                        }
-                        else
-                        {
-                            using (var stringFormat = new StringFormat())
-                            {
-                                stringFormat.FormatFlags = StringFormatFlags.DirectionVertical;
-                                graphics.DrawString(WaveformNotLoadedText, textFont, textBrush, new PointF(1, 10), stringFormat);
-                            }
-                        }
+                        graphics.DrawString(WaveformNotLoadedText, textFont, textBrush, new PointF(Width / 2 - 65, Height / 2 - 10));
+                    }
+                    else
+                    {
+                        using (var stringFormat = new StringFormat(StringFormatFlags.DirectionVertical))
+                            graphics.DrawString(WaveformNotLoadedText, textFont, textBrush, new PointF(1, 10), stringFormat);
                     }
                 }
             }
             if (Focused)
             {
                 using (var p = new Pen(SelectedColor))
-                {
                     graphics.DrawRectangle(p, new Rectangle(0, 0, Width - 1, Height - 1));
-                }
             }
         }
 
@@ -652,30 +637,26 @@ namespace Nikse.SubtitleEdit.Controls
             double seconds = Math.Ceiling(StartPositionSeconds) - StartPositionSeconds;
             float position = SecondsToXPosition(seconds);
             using (var pen = new Pen(TextColor))
+            using (var textBrush = new SolidBrush(TextColor))
+            using (var textFont = new Font(Font.FontFamily, 7))
             {
-                using (var textBrush = new SolidBrush(TextColor))
+                while (position < Width)
                 {
-                    using (var textFont = new Font(Font.FontFamily, 7))
+                    var n = _zoomFactor * _wavePeaks.Header.SampleRate;
+                    if (n > 38 || (int)Math.Round(StartPositionSeconds + seconds) % 5 == 0)
                     {
-                        while (position < Width)
-                        {
-                            var n = _zoomFactor * _wavePeaks.Header.SampleRate;
-                            if (n > 38 || (int)Math.Round(StartPositionSeconds + seconds) % 5 == 0)
-                            {
-                                graphics.DrawLine(pen, position, imageHeight, position, imageHeight - 10);
-                                graphics.DrawString(GetDisplayTime(StartPositionSeconds + seconds), textFont, textBrush, new PointF(position + 2, imageHeight - 13));
-                            }
-
-                            seconds += 0.5;
-                            position = SecondsToXPosition(seconds);
-
-                            if (n > 64)
-                                graphics.DrawLine(pen, position, imageHeight, position, imageHeight - 5);
-
-                            seconds += 0.5;
-                            position = SecondsToXPosition(seconds);
-                        }
+                        graphics.DrawLine(pen, position, imageHeight, position, imageHeight - 10);
+                        graphics.DrawString(GetDisplayTime(StartPositionSeconds + seconds), textFont, textBrush, new PointF(position + 2, imageHeight - 13));
                     }
+
+                    seconds += 0.5;
+                    position = SecondsToXPosition(seconds);
+
+                    if (n > 64)
+                        graphics.DrawLine(pen, position, imageHeight, position, imageHeight - 5);
+
+                    seconds += 0.5;
+                    position = SecondsToXPosition(seconds);
                 }
             }
         }

--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -696,7 +696,7 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void DrawParagraph(Paragraph paragraph, Graphics graphics)
         {
-            if (paragraph == null)
+            if (paragraph == null || paragraph.EndTime.TotalSeconds < StartPositionSeconds || paragraph.StartTime.TotalSeconds > EndPositionSeconds)
                 return;
 
             int currentRegionLeft = SecondsToXPosition(paragraph.StartTime.TotalSeconds - StartPositionSeconds);

--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -541,7 +541,10 @@ namespace Nikse.SubtitleEdit.Controls
                 // paragraphs
                 foreach (Paragraph p in _displayableParagraphs)
                 {
-                    DrawParagraph(p, graphics);
+                    if (p.EndTime.TotalSeconds >= StartPositionSeconds && p.StartTime.TotalSeconds <= EndPositionSeconds)
+                    {
+                        DrawParagraph(p, graphics);
+                    }
                 }
 
                 // current selection
@@ -550,7 +553,7 @@ namespace Nikse.SubtitleEdit.Controls
                     int currentRegionLeft = SecondsToXPosition(NewSelectionParagraph.StartTime.TotalSeconds - StartPositionSeconds);
                     int currentRegionRight = SecondsToXPosition(NewSelectionParagraph.EndTime.TotalSeconds - StartPositionSeconds);
                     int currentRegionWidth = currentRegionRight - currentRegionLeft;
-                    if (currentRegionLeft >= 0 && currentRegionLeft <= Width)
+                    if (currentRegionRight >= 0 && currentRegionLeft <= Width)
                     {
                         using (var brush = new SolidBrush(Color.FromArgb(128, 255, 255, 255)))
                             graphics.FillRectangle(brush, currentRegionLeft, 0, currentRegionWidth, graphics.VisibleClipBounds.Height);
@@ -673,9 +676,6 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void DrawParagraph(Paragraph paragraph, Graphics graphics)
         {
-            if (paragraph == null || paragraph.EndTime.TotalSeconds < StartPositionSeconds || paragraph.StartTime.TotalSeconds > EndPositionSeconds)
-                return;
-
             int currentRegionLeft = SecondsToXPosition(paragraph.StartTime.TotalSeconds - StartPositionSeconds);
             int currentRegionRight = SecondsToXPosition(paragraph.EndTime.TotalSeconds - StartPositionSeconds);
             int currentRegionWidth = currentRegionRight - currentRegionLeft;


### PR DESCRIPTION
* Fix crash when waveform isn't loaded (this one was my fault, sorry! NearestSubtitles referenced EndPositionSeconds and therefore _wavePeaks even if no waveform was loaded).
* Fix wrong paragraph being shown as selected if any preceding paragraphs have an empty start time.
* Fix vertical grid lines moving when scrolling.
* Improve the look of paragraph numbering when zoomed out.
* Fix paragraph text not getting shortened enough in some cases and slightly overlapping the end.
* Fix new selection disappearing if part of it gets scrolled out of the left.

I finally realized that all the stuff going on in NearestSubtitles to avoid simply iterating through the full paragraph list was kind of pointless from a performance perspective, because the full paragraph list already gets fully iterated anyway when populating _subtitle.Paragraphs on every call to SetPosition.  With that in mind, and knowing that the distinction between current and previous/next paragraphs is not important, I was able to greatly simplify that code.

I also found some problems in the way the selected indexes were being handled.  First, _selectedIndices referenced the always-up-to-date selected index collection, whereas the corresponding paragraphs in _subtitle are cached at each SetPosition call.  So in theory they could get out of synch for a small period of time while editing.  Second, the cached paragraphs in _subtitle were actually filtered to remove the ones with no start time (StartTime.IsMaxTime), which could really mess things up :).  That also explains the try/catch in the original code - to prevent out of bounds exceptions if the paragraphs and selected indexes got out of synch.