### PR TITLE
Fix build.bat - use available Visual Studio

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -10,10 +10,18 @@ IF /I "%~1" == "-help"  GOTO SHOWHELP
 IF /I "%~1" == "--help" GOTO SHOWHELP
 IF /I "%~1" == "/?"     GOTO SHOWHELP
 
-IF NOT DEFINED VS120COMNTOOLS (
-  ECHO Visual Studio 2013 wasn't found
+IF DEFINED VS140COMNTOOLS (
+  SET VSVARS_BAT="%VS140COMNTOOLS%vsvars32.bat"
+) ELSE (
+IF DEFINED VS130COMNTOOLS (
+  SET VSVARS_BAT="%VS130COMNTOOLS%vsvars32.bat"
+) ELSE (
+IF DEFINED VS120COMNTOOLS (
+  SET VSVARS_BAT="%VS120COMNTOOLS%vsvars32.bat"
+) ELSE (
+  ECHO Cannot find Visual Studio
   GOTO EndWithError
-)
+)))
 
 IF "%~1" == "" (
   SET "BUILDTYPE=Build"
@@ -39,7 +47,7 @@ IF "%~1" == "" (
 :START
 PUSHD "src"
 
-CALL "%VS120COMNTOOLS%vsvars32.bat" x86
+CALL %VSVARS_BAT% x86
 TITLE %BUILDTYPE%ing SubtitleEdit - Release^|Any CPU...
 
 "MSBuild.exe" SubtitleEdit.sln /t:%BUILDTYPE% /p:Configuration=Release /p:Platform="Any CPU"^


### PR DESCRIPTION
Fixes ["*Visual Studio 2013 wasn't found*" problem.](https://github.com/SubtitleEdit/subtitleedit/commit/7883b28c264d93c26d7b6b53d95b0c2e422d709f#commitcomment-13478632)