### PR TITLE
Fix build.bat - part 2

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -47,7 +47,7 @@ IF "%~1" == "" (
 :START
 PUSHD "src"
 
-CALL %VSVARS_BAT% x86
+CALL %VSVARS_BAT%
 TITLE %BUILDTYPE%ing SubtitleEdit - Release^|Any CPU...
 
 "MSBuild.exe" SubtitleEdit.sln /t:%BUILDTYPE% /p:Configuration=Release /p:Platform="Any CPU"^


### PR DESCRIPTION
VS 12.0 `vsvars32.bat` ignores command line arguments, VS 14.0 accepts only **store**.

I assume, the **x86** argument was required by older (no longer supported) versions.
