### PR TITLE
Waveform - show actual peak values

### DIFF
--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -1539,6 +1539,12 @@ namespace Nikse.SubtitleEdit.Controls
             {
                 ZoomOut();
             }
+            else if (e.Modifiers == Keys.Control && e.KeyCode == Keys.D0)
+            {
+                ZoomFactor = 1.0;
+                if (OnZoomedChanged != null)
+                    OnZoomedChanged.Invoke(this, null);
+            }
             else if (e.Modifiers == Keys.None && e.KeyCode == Keys.Z)
             {
                 if (StartPositionSeconds > 0.1)

--- a/src/Controls/AudioVisualizer.cs
+++ b/src/Controls/AudioVisualizer.cs
@@ -503,7 +503,7 @@ namespace Nikse.SubtitleEdit.Controls
                             if (pos1 >= _wavePeaks.Peaks.Count)
                                 break;
                             float pos1Weight = pos - pos0;
-                            float pos0Weight = 1 - pos1Weight;
+                            float pos0Weight = 1F - pos1Weight;
                             var peak0 = _wavePeaks.Peaks[pos0];
                             var peak1 = _wavePeaks.Peaks[pos1];
                             float max = peak0.Max * pos0Weight + peak1.Max * pos1Weight;

--- a/src/Forms/AddWaveForm.cs
+++ b/src/Forms/AddWaveForm.cs
@@ -242,7 +242,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     labelProgress.Text = Configuration.Settings.Language.AddWaveform.GeneratingSpectrogram;
                     Refresh();
-                    SpectrogramBitmaps = waveFile.GenerateFourierData(256, _spectrogramDirectory, delayInMilliseconds); // image height = nfft / 2
+                    SpectrogramBitmaps = waveFile.GenerateSpectrogram(_spectrogramDirectory, delayInMilliseconds);
                 }
             }
 

--- a/src/Forms/AddWaveForm.cs
+++ b/src/Forms/AddWaveForm.cs
@@ -18,7 +18,8 @@ namespace Nikse.SubtitleEdit.Forms
         private string _peakWaveFileName;
         private string _wavFileName;
         private string _spectrogramDirectory;
-        public List<Bitmap> SpectrogramBitmaps { get; private set; }
+        public WavePeakData Peaks { get; private set; }
+        public SpectrogramData Spectrogram { get; private set; }
         private string _encodeParamters;
         private const string RetryEncodeParameters = "acodec=s16l";
         private int _audioTrackNumber = -1;
@@ -236,13 +237,13 @@ namespace Nikse.SubtitleEdit.Forms
 
             using (var waveFile = new WavePeakGenerator(targetFile))
             {
-                waveFile.GeneratePeaks(delayInMilliseconds, _peakWaveFileName);
+                Peaks = waveFile.GeneratePeaks(delayInMilliseconds, _peakWaveFileName);
 
                 if (Configuration.Settings.VideoControls.GenerateSpectrogram)
                 {
                     labelProgress.Text = Configuration.Settings.Language.AddWaveform.GeneratingSpectrogram;
                     Refresh();
-                    SpectrogramBitmaps = waveFile.GenerateSpectrogram(_spectrogramDirectory, delayInMilliseconds);
+                    Spectrogram = waveFile.GenerateSpectrogram(delayInMilliseconds, _spectrogramDirectory);
                 }
             }
 

--- a/src/Forms/AddWaveForm.cs
+++ b/src/Forms/AddWaveForm.cs
@@ -15,6 +15,7 @@ namespace Nikse.SubtitleEdit.Forms
     {
         public string SourceVideoFileName { get; private set; }
         private bool _cancel;
+        private string _peakWaveFileName;
         private string _wavFileName;
         private string _spectrogramDirectory;
         public List<Bitmap> SpectrogramBitmaps { get; private set; }
@@ -31,10 +32,9 @@ namespace Nikse.SubtitleEdit.Forms
             labelInfo.Text = string.Empty;
         }
 
-        public WavePeakGenerator WavePeak { get; private set; }
-
-        public void Initialize(string videoFile, string spectrogramDirectory, int audioTrackNumber)
+        public void Initialize(string videoFile, string peakWaveFileName, string spectrogramDirectory, int audioTrackNumber)
         {
+            _peakWaveFileName = peakWaveFileName;
             _audioTrackNumber = audioTrackNumber;
             if (_audioTrackNumber < 0)
                 _audioTrackNumber = 0;
@@ -236,7 +236,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             using (var waveFile = new WavePeakGenerator(targetFile))
             {
-                waveFile.GeneratePeakSamples(delayInMilliseconds);
+                waveFile.GeneratePeaks(delayInMilliseconds, _peakWaveFileName);
 
                 if (Configuration.Settings.VideoControls.GenerateSpectrogram)
                 {
@@ -244,8 +244,6 @@ namespace Nikse.SubtitleEdit.Forms
                     Refresh();
                     SpectrogramBitmaps = waveFile.GenerateFourierData(256, _spectrogramDirectory, delayInMilliseconds); // image height = nfft / 2
                 }
-
-                WavePeak = waveFile;
             }
 
             labelPleaseWait.Visible = false;
@@ -379,8 +377,9 @@ namespace Nikse.SubtitleEdit.Forms
             _cancel = true;
         }
 
-        internal void InitializeViaWaveFile(string fileName, string spectrogramFolder)
+        internal void InitializeViaWaveFile(string fileName, string peakWaveFileName, string spectrogramFolder)
         {
+            _peakWaveFileName = peakWaveFileName;
             _wavFileName = fileName;
             _spectrogramDirectory = spectrogramFolder;
         }

--- a/src/Forms/AddWaveformBatch.cs
+++ b/src/Forms/AddWaveformBatch.cs
@@ -333,7 +333,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 if (Configuration.Settings.VideoControls.GenerateSpectrogram)
                 {
-                    waveFile.GenerateSpectrogram(Main.GetSpectrogramFolder(videoFileName), delayInMilliseconds);
+                    waveFile.GenerateSpectrogram(delayInMilliseconds, Main.GetSpectrogramFolder(videoFileName));
                 }
             }
         }

--- a/src/Forms/AddWaveformBatch.cs
+++ b/src/Forms/AddWaveformBatch.cs
@@ -333,7 +333,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 if (Configuration.Settings.VideoControls.GenerateSpectrogram)
                 {
-                    waveFile.GenerateFourierData(256, Main.GetSpectrogramFolder(videoFileName), delayInMilliseconds); // image height = nfft / 2
+                    waveFile.GenerateSpectrogram(Main.GetSpectrogramFolder(videoFileName), delayInMilliseconds);
                 }
             }
         }

--- a/src/Forms/AddWaveformBatch.cs
+++ b/src/Forms/AddWaveformBatch.cs
@@ -329,8 +329,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             using (var waveFile = new WavePeakGenerator(targetFile))
             {
-                waveFile.GeneratePeakSamples(delayInMilliseconds);
-                waveFile.WritePeakSamples(Main.GetPeakWaveFileName(videoFileName));
+                waveFile.GeneratePeaks(delayInMilliseconds, Main.GetPeakWaveFileName(videoFileName));
 
                 if (Configuration.Settings.VideoControls.GenerateSpectrogram)
                 {

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -18438,9 +18438,9 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     MakeHistoryForUndoOnlyIfNotResent(string.Format(_language.BeforeGuessingTimeCodes));
 
-                    double startFrom = 0;
+                    double startFromSeconds = 0;
                     if (form.StartFromVideoPosition)
-                        startFrom = mediaPlayer.CurrentPosition;
+                        startFromSeconds = mediaPlayer.CurrentPosition;
 
                     if (form.DeleteAll)
                     {
@@ -18450,11 +18450,11 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         for (int i = _subtitle.Paragraphs.Count - 1; i > 0; i--)
                         {
-                            if (_subtitle.Paragraphs[i].EndTime.TotalSeconds + 1 > startFrom)
+                            if (_subtitle.Paragraphs[i].EndTime.TotalSeconds + 1 > startFromSeconds)
                                 _subtitle.Paragraphs.RemoveAt(i);
                         }
                     }
-                    audioVisualizer.GenerateTimeCodes(form.BlockSize, form.VolumeMinimum, form.VolumeMaximum, form.DefaultMilliseconds);
+                    audioVisualizer.GenerateTimeCodes(_subtitle, startFromSeconds, form.BlockSize, form.VolumeMinimum, form.VolumeMaximum, form.DefaultMilliseconds);
                     if (IsFramesRelevant && CurrentFrameRate > 0)
                         _subtitle.CalculateFrameNumbersFromTimeCodesNoCheck(CurrentFrameRate);
                     SubtitleListview1.Fill(_subtitle, _subtitleAlternate);

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -2552,8 +2552,7 @@ namespace Nikse.SubtitleEdit.Forms
                         _videoAudioTrackNumber = -1;
                         labelVideoInfo.Text = _languageGeneral.NoVideoLoaded;
                         audioVisualizer.WavePeaks = null;
-                        audioVisualizer.ResetSpectrogram();
-                        audioVisualizer.Invalidate();
+                        audioVisualizer.Spectrogram = null;
                     }
 
                     if (Configuration.Settings.General.ShowVideoPlayer || Configuration.Settings.General.ShowAudioVisualizer)
@@ -2643,8 +2642,7 @@ namespace Nikse.SubtitleEdit.Forms
                         _videoAudioTrackNumber = -1;
                         labelVideoInfo.Text = _languageGeneral.NoVideoLoaded;
                         audioVisualizer.WavePeaks = null;
-                        audioVisualizer.ResetSpectrogram();
-                        audioVisualizer.Invalidate();
+                        audioVisualizer.Spectrogram = null;
 
                         Configuration.Settings.RecentFiles.Add(fileName, FirstVisibleIndex, FirstSelectedIndex, _videoFileName, _subtitleAlternateFileName);
                         Configuration.Settings.Save();
@@ -3301,8 +3299,7 @@ namespace Nikse.SubtitleEdit.Forms
             _videoAudioTrackNumber = -1;
             labelVideoInfo.Text = _languageGeneral.NoVideoLoaded;
             audioVisualizer.WavePeaks = null;
-            audioVisualizer.ResetSpectrogram();
-            audioVisualizer.Invalidate();
+            audioVisualizer.Spectrogram = null;
 
             _sourceViewChange = false;
 
@@ -12678,10 +12675,8 @@ namespace Nikse.SubtitleEdit.Forms
                 string spectrogramFolder = GetSpectrogramFolder(fileName);
                 if (File.Exists(peakWaveFileName))
                 {
-                    using (var peakGenerator = new WavePeakGenerator(peakWaveFileName))
-                        audioVisualizer.WavePeaks = peakGenerator.LoadPeaks();
-                    audioVisualizer.ResetSpectrogram();
-                    audioVisualizer.InitializeSpectrogram(spectrogramFolder);
+                    audioVisualizer.WavePeaks = WavePeakData.FromDisk(peakWaveFileName);
+                    audioVisualizer.Spectrogram = SpectrogramData.FromDisk(spectrogramFolder);
                     toolStripComboBoxWaveform_SelectedIndexChanged(null, null);
                     SetWaveformPosition(0, 0, 0);
                     timerWaveform.Start();
@@ -13424,8 +13419,7 @@ namespace Nikse.SubtitleEdit.Forms
                 if (audioVisualizer.WavePeaks != null)
                 {
                     audioVisualizer.WavePeaks = null;
-                    audioVisualizer.ResetSpectrogram();
-                    audioVisualizer.Invalidate();
+                    audioVisualizer.Spectrogram = null;
                 }
                 openFileDialog1.InitialDirectory = Path.GetDirectoryName(openFileDialog1.FileName);
                 if (!panelVideoPlayer.Visible)
@@ -14825,10 +14819,8 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     if (addWaveform.ShowDialog() == DialogResult.OK)
                     {
-                        using (var peakGenerator = new WavePeakGenerator(peakWaveFileName))
-                            audioVisualizer.WavePeaks = peakGenerator.LoadPeaks();
-                        if (addWaveform.SpectrogramBitmaps != null)
-                            audioVisualizer.InitializeSpectrogram(addWaveform.SpectrogramBitmaps, spectrogramFolder);
+                        audioVisualizer.WavePeaks = addWaveform.Peaks;
+                        audioVisualizer.Spectrogram = addWaveform.Spectrogram;
                         timerWaveform.Start();
                     }
                 }
@@ -15199,17 +15191,20 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             if (_videoFileName == null)
+            {
                 OpenVideo(fileName);
+                return;
+            }
 
             using (var addWaveform = new AddWaveform())
             {
-                string spectrogramFolder = GetSpectrogramFolder(_videoFileName);
                 string peakWaveFileName = GetPeakWaveFileName(_videoFileName);
+                string spectrogramFolder = GetSpectrogramFolder(_videoFileName);
                 addWaveform.InitializeViaWaveFile(fileName, peakWaveFileName, spectrogramFolder);
                 if (addWaveform.ShowDialog() == DialogResult.OK)
                 {
-                    using (var peakGenerator = new WavePeakGenerator(peakWaveFileName))
-                        audioVisualizer.WavePeaks = peakGenerator.LoadPeaks();
+                    audioVisualizer.WavePeaks = addWaveform.Peaks;
+                    audioVisualizer.Spectrogram = addWaveform.Spectrogram;
                     timerWaveform.Start();
                 }
             }
@@ -16494,8 +16489,7 @@ namespace Nikse.SubtitleEdit.Forms
             _videoAudioTrackNumber = -1;
             labelVideoInfo.Text = _languageGeneral.NoVideoLoaded;
             audioVisualizer.WavePeaks = null;
-            audioVisualizer.ResetSpectrogram();
-            audioVisualizer.Invalidate();
+            audioVisualizer.Spectrogram = null;
         }
 
         private void ToolStripMenuItemVideoDropDownOpening(object sender, EventArgs e)


### PR DESCRIPTION
I was playing with another subtitle editor program and noticed that in its waveform display it was much easier to notice where the quiet/loud parts were. Curious how it worked, I read through the source code and found that for each "column" (1 pixel wide area) it displays, it scans through a range of audio samples corresponding to that time slice, finds the minimum and maximum samples, and then draws a vertical line from a point representing the minimum to a point representing the maximum.

And then of course I had to implement it in Subtitle Edit :smile:.

Notes:
* Although it is backwards compatible with the peak files written by previous versions, you will not get the full benefit of the new code unless you re-generate the peaks. **So please clear your old waveforms folder before trying it out!**
* There is some performance impact when generating the peaks, since it now has to scan through all the samples. That said, it's still quite fast, and I think it's worth it for the improved usefulness of the waveform. To give you an example, it took ~450 ms to scan through 10 minutes of audio, vs. the old code's ~40 ms. That's still not much compared to the ~10 seconds it took to extract the audio or the spectrogram generation time.

Other changes:
* Rounding fix to the spectrogram drawing code (results in slightly better alignment).
* Ctrl+0 shortcut key in the audio visualizer to reset to 100% zoom.
* Some code cleanups (e.g. spectrogram drawing / loading).

Before:
![before2](https://cloud.githubusercontent.com/assets/6741660/10266045/ddfe1244-6a17-11e5-9914-95d4bf00aa43.png)

After:
![after2](https://cloud.githubusercontent.com/assets/6741660/10266046/e2a9a0b0-6a17-11e5-9728-8f129435eec3.png)