### PR TITLE
Adjust default waveform colors

### DIFF
--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -669,8 +669,8 @@ namespace Nikse.SubtitleEdit.Core
             WaveformAllowOverlap = false;
             WaveformBorderHitMs = 15;
             WaveformGridColor = Color.FromArgb(255, 20, 20, 18);
-            WaveformColor = Color.GreenYellow;
-            WaveformSelectedColor = Color.Red;
+            WaveformColor = Color.FromArgb(255, 160, 240, 30);
+            WaveformSelectedColor = Color.FromArgb(255, 230, 0, 0);
             WaveformBackgroundColor = Color.Black;
             WaveformTextColor = Color.Gray;
             WaveformTextSize = 9;


### PR DESCRIPTION
The change is fairly subtle; you might not be able to see much difference depending on your monitor. To me it gets rid of some of the "harshness" while keeping the same general look. The images below are best viewed at full size in different browser tabs to compare.

Colors are quite subjective of course so feel free to close this if you don't like it or want to come up with your own colors. I won't be offended at all :bowtie:.

Before:
![color-before](https://cloud.githubusercontent.com/assets/6741660/10299755/30e30096-6bbc-11e5-922b-0d58d70ba506.png)

After:
![color-after](https://cloud.githubusercontent.com/assets/6741660/10299758/37c90acc-6bbc-11e5-9312-ad3e32035ea9.png)
