### PR TITLE
Avoid throwing exceptions when trying to open an AVI

### DIFF
--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -76,12 +76,11 @@ namespace Nikse.SubtitleEdit.Core
             {
                 using (var rp = new RiffParser())
                 {
-                    var dh = new RiffDecodeHeader(rp);
-                    rp.OpenFile(fileName);
-                    info.FileType = RiffParser.FromFourCC(rp.FileType);
-                    if (RiffParser.ckidAVI == rp.FileType)
+                    if (rp.TryOpenFile(fileName) && rp.FileType == RiffParser.ckidAVI)
                     {
+                        var dh = new RiffDecodeHeader(rp);
                         dh.ProcessMainAVI();
+                        info.FileType = RiffParser.FromFourCC(rp.FileType);
                         info.Width = dh.Width;
                         info.Height = dh.Height;
                         info.FramesPerSecond = dh.FrameRate;


### PR DESCRIPTION
When debugging and Visual Studio set to break on exceptions, it always breaks into this code when something other than AVI is opened. That gets annoying after a while, hence this patch.