### PR TITLE
Fixes for OS X (still not usable really)

### DIFF
--- a/libse/Configuration.cs
+++ b/libse/Configuration.cs
@@ -47,12 +47,17 @@ namespace Nikse.SubtitleEdit.Core
 
         public static bool IsRunningOnLinux()
         {
-            return Environment.OSVersion.Platform == PlatformID.Unix;
+            return Environment.OSVersion.Platform == PlatformID.Unix && !IsRunningOnMac();
         }
 
         public static bool IsRunningOnMac()
         {
-            return Environment.OSVersion.Platform == PlatformID.MacOSX;
+            // Current versions of Mono report the platform as Unix
+            return Environment.OSVersion.Platform == PlatformID.MacOSX ||
+                (Environment.OSVersion.Platform == PlatformID.Unix &&
+                 Directory.Exists("/Applications") &&
+                 Directory.Exists("/System") &&
+                 Directory.Exists("/Users"));
         }
 
         public static string TesseractDataFolder

--- a/src/Forms/AddWaveForm.cs
+++ b/src/Forms/AddWaveForm.cs
@@ -54,10 +54,14 @@ namespace Nikse.SubtitleEdit.Forms
             encoderName = "VLC";
             string parameters = "\"" + inputVideoFile + "\" -I dummy -vvv --no-sout-video --audio-track=" + audioTrackNumber + " --sout=\"#transcode{acodec=s16l,channels=1,ab=128}:std{access=file,mux=wav,dst=" + outWaveFile + "}\" vlc://quit";
             string exeFilePath;
-            if (Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnLinux())
             {
                 exeFilePath = "cvlc";
                 parameters = "-vvv --no-sout-video --audio-track=" + audioTrackNumber + " --sout '#transcode{" + encodeParamters + "}:std{mux=wav,access=file,dst=" + outWaveFile + "}' \"" + inputVideoFile + "\" vlc://quit";
+            }
+            else if (Configuration.IsRunningOnMac())
+            {
+                exeFilePath = "VLC.app/Contents/MacOS/VLC";
             }
             else // windows
             {

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -189,11 +189,15 @@ namespace Nikse.SubtitleEdit.Logic
         {
             GeneralSettings gs = Configuration.Settings.General;
 
-            if (Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnLinux())
                 return new MPlayer();
 
-            //if (Utilities.IsRunningOnMac())
-            //    return new LibVlcMono();
+            // Mono on OS X is 32 bit and thus requires 32 bit VLC. Place VLC in the same
+            // folder as Subtitle Edit and add this to the app.config inside the
+            // "configuration" element:
+            // <dllmap dll="libvlc" target="VLC.app/Contents/MacOS/lib/libvlc.dylib" />
+            if (Configuration.IsRunningOnMac())
+                return new LibVlcMono();
 
             if (gs.VideoPlayer == "VLC" && LibVlcDynamic.IsInstalled)
                 return new LibVlcDynamic();

--- a/src/Logic/VideoPlayers/LibVlcDynamic.cs
+++ b/src/Logic/VideoPlayers/LibVlcDynamic.cs
@@ -265,10 +265,17 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
         {
             get
             {
-                using (var vlc = new LibVlcDynamic())
+                try
                 {
-                    vlc.Initialize(null, null, null, null);
-                    return vlc.IsAllMethodsLoaded();
+                    using (var vlc = new LibVlcDynamic())
+                    {
+                        vlc.Initialize(null, null, null, null);
+                        return vlc.IsAllMethodsLoaded();
+                    }
+                }
+                catch
+                {
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
These are the fixes from when I got Subtitle Edit running on OS X. I didn't get video to display but it played the audio fine. Unfortunately Mono's WinForms is so bad (at least on OS X) that it's not really usable in my opinion. But I wanted to contribute these fixes in case someone else wants to play around with it or in hopes of Mono's WinForms improving in the future.