### PR TITLE
[Fix] - Fix 'Button Ok' (src/Forms/ChangeFrameRate.cs)

### DIFF
--- a/src/Forms/ChangeFrameRate.cs
+++ b/src/Forms/ChangeFrameRate.cs
@@ -71,15 +71,16 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void ButtonOkClick(object sender, EventArgs e)
         {
-            double d;
-            if (double.TryParse(comboBoxFrameRateFrom.Text, out d) &&
-                double.TryParse(comboBoxFrameRateTo.Text, out d))
-            {
-                DialogResult = DialogResult.OK;
-            }
-            else if (comboBoxFrameRateFrom.Text.Trim() == comboBoxFrameRateTo.Text.Trim())
+            if (comboBoxFrameRateFrom.Text.Trim() == comboBoxFrameRateTo.Text.Trim())
             {
                 MessageBox.Show(Configuration.Settings.Language.ChangeFrameRate.FrameRateNotChanged);
+                return;
+            }
+
+            double d;
+            if (double.TryParse(comboBoxFrameRateFrom.Text, out d) && double.TryParse(comboBoxFrameRateTo.Text, out d))
+            {
+                DialogResult = DialogResult.OK;
             }
             else
             {


### PR DESCRIPTION
* The message will not be displayed to the user if same frame if selected

I think we should prevent user from input characters other then **numeric & ,**