### PR TITLE
Fix Autobreak fuction

### DIFF
--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -620,9 +620,19 @@ namespace Nikse.SubtitleEdit.Core
                 s = s.Substring(0, splitPos) + Environment.NewLine + s.Substring(splitPos);
 
             s = ReInsertHtmlTags(s, htmlTags);
+            var idx = s.IndexOf(Environment.NewLine + "</");
+            if (idx > 2)
+            {
+                var endIdx = s.IndexOf('>', idx + 2);
+                if (endIdx > idx)
+                {
+                    var tag = s.Substring(idx + Environment.NewLine.Length, endIdx - (idx + Environment.NewLine.Length) + 1);
+                    s = s.Insert(idx, tag);
+                    s = s.Remove(idx + tag.Length + Environment.NewLine.Length, tag.Length);
+                }
+            }
             s = s.Replace(" " + Environment.NewLine, Environment.NewLine);
             s = s.Replace(Environment.NewLine + " ", Environment.NewLine);
-
             return s.TrimEnd();
         }
 

--- a/src/Test/Logic/UtilitiesTest.cs
+++ b/src/Test/Logic/UtilitiesTest.cs
@@ -50,6 +50,17 @@ namespace Test.Logic
 
         [TestMethod]
         [DeploymentItem("SubtitleEdit.exe")]
+        public void AutoBreakLine5()
+        {
+            Configuration.Settings.General.SubtitleLineMaximumLength = 43;
+            const string s1 = "<i>30 years ago I'd found</i> The Book of the Dead.";
+            var s2 = Utilities.AutoBreakLine(s1);
+            var Expected = "<i>30 years ago I'd found</i>" + Environment.NewLine + "The Book of the Dead.";
+            Assert.AreEqual(Expected, s2);
+        }
+
+        [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
         public void AutoBreakLine5DoNoBreakAtPeriod()
         {
             Configuration.Settings.General.SubtitleLineMaximumLength = 43;


### PR DESCRIPTION
If you try to Autobreak:
`<i>30 years ago I'd found</i> The Book of the Dead.`
it ends up like:

*\<i>30 years ago I'd found
\</i> The Book of the Dead.*