### PR TITLE
Minor fix (Forms/VobSubOcr)

### DIFF
--- a/src/Forms/VobSubOcr.cs
+++ b/src/Forms/VobSubOcr.cs
@@ -7524,34 +7524,35 @@ namespace Nikse.SubtitleEdit.Forms
                 progressBar1.Value = 0;
                 progressBar1.Visible = true;
                 int imagesSavedCount = 0;
-                StringBuilder sb = new StringBuilder();
+                var sb = new StringBuilder();
                 sb.AppendLine("<html>");
                 sb.AppendLine("<head><title>Subtitle images</title></head>");
                 sb.AppendLine("<body>");
                 for (int i = 0; i < _subtitle.Paragraphs.Count; i++)
                 {
                     progressBar1.Value = i;
-                    Bitmap bmp = GetSubtitleBitmap(i);
-                    string numberString = string.Format("{0:0000}", i + 1);
+                    var bmp = GetSubtitleBitmap(i);
                     if (bmp != null)
                     {
-                        string fileName = Path.Combine(folderBrowserDialog1.SelectedPath, numberString + ".png");
-                        bmp.Save(fileName, System.Drawing.Imaging.ImageFormat.Png);
+                        var fileName = string.Format(CultureInfo.InvariantCulture, "{0:0000}.png", i + 1);
+                        var filePath = Path.Combine(folderBrowserDialog1.SelectedPath, fileName);
+                        bmp.Save(filePath, System.Drawing.Imaging.ImageFormat.Png);
                         imagesSavedCount++;
-                        Paragraph p = _subtitle.Paragraphs[i];
-                        string text = string.Empty;
+                        var p = _subtitle.Paragraphs[i];
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "#{3}:{0}->{1}<div style='text-align:center'><img src='{2}' />", p.StartTime.ToShortString(), p.EndTime.ToShortString(), fileName, i + 1);
                         if (!string.IsNullOrEmpty(p.Text))
                         {
-                            string backgroundColor = System.Drawing.ColorTranslator.ToHtml(subtitleListView1.GetBackgroundColor(i));
-                            text = "<br /><div style='font-size:22px; background-color:" + backgroundColor + "'>" + WebUtility.HtmlEncode(p.Text.Replace("<i>", "@1__").Replace("</i>", "@2__")).Replace("@1__", "<i>").Replace("@2__", "</i>").Replace(Environment.NewLine, "<br />") + "</div>";
+                            var backgroundColor = System.Drawing.ColorTranslator.ToHtml(subtitleListView1.GetBackgroundColor(i));
+                            var text = WebUtility.HtmlEncode(p.Text.Replace("<i>", "@1__").Replace("</i>", "@2__")).Replace("@1__", "<i>").Replace("@2__", "</i>").Replace(Environment.NewLine, "<br />");
+                            sb.Append("<br /><div style='font-size:22px; background-color:").Append(backgroundColor).Append("'>").Append(text).Append("</div>");
                         }
-                        sb.AppendLine(string.Format("#{3}:{0}->{1}<div style='text-align:center'><img src='{2}.png' />" + text + "</div><br /><hr />", p.StartTime.ToShortString(), p.EndTime.ToShortString(), numberString, i + 1));
+                        sb.AppendLine("</div><br /><hr />");
                         bmp.Dispose();
                     }
                 }
                 sb.AppendLine("</body>");
                 sb.AppendLine("</html>");
-                string htmlFileName = Path.Combine(folderBrowserDialog1.SelectedPath, "index.html");
+                var htmlFileName = Path.Combine(folderBrowserDialog1.SelectedPath, "index.html");
                 File.WriteAllText(htmlFileName, sb.ToString());
                 progressBar1.Visible = false;
                 MessageBox.Show(string.Format("{0} images saved in {1}", imagesSavedCount, folderBrowserDialog1.SelectedPath));


### PR DESCRIPTION
The subtitle paragraph text cannot be part of a composite
format string, because it might contain curly brackets.

Fixes [crash3](https://gist.github.com/heforfree/34938615ed7a11341275), reported in [issue 1433](https://github.com/SubtitleEdit/subtitleedit/issues/1433#issuecomment-163251071)