### PR TITLE
Fixed ShowTip method (Forms/Compare)

### DIFF
--- a/src/Forms/Compare.Designer.cs
+++ b/src/Forms/Compare.Designer.cs
@@ -309,8 +309,8 @@ namespace Nikse.SubtitleEdit.Forms
             this.Controls.Add(this.buttonOpenSubtitle2);
             this.Controls.Add(this.buttonOpenSubtitle1);
             this.Controls.Add(this.buttonOK);
-            this.Controls.Add(this.labelSubtitle2);
             this.Controls.Add(this.subtitleListView2);
+            this.Controls.Add(this.labelSubtitle2);
             this.Controls.Add(this.subtitleListView1);
             this.Controls.Add(this.labelSubtitle1);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));

--- a/src/Forms/Compare.cs
+++ b/src/Forms/Compare.cs
@@ -827,10 +827,18 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void ShowTip(Control control)
         {
-            string sub1Path = control.Text;
-            if (!string.IsNullOrEmpty(sub1Path))
+            var text = control.Text;
+            if (!string.IsNullOrEmpty(text))
             {
-                toolTip1.Show(Path.GetFileName(sub1Path), control);
+                try
+                {
+                    text = Path.GetFileName(text);
+                }
+                catch
+                {
+                    // not a path
+                }
+                toolTip1.Show(text, control);
             }
         }
 


### PR DESCRIPTION
\[1]
When the label text is not a file path, `Path.GetFileName()` will throw an exception.

\[2]
A multi-line label text would hide the top of the corresponding subtitle ListView.