### PR TITLE
Updated  SETextBox Control

### DIFF
--- a/src/Controls/SETextBox.cs
+++ b/src/Controls/SETextBox.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Nikse.SubtitleEdit.Core;
+using System;
 using System.Drawing;
 using System.Windows.Forms;
-using Nikse.SubtitleEdit.Core;
 
 namespace Nikse.SubtitleEdit.Controls
 {
@@ -30,7 +30,12 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void SETextBox_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.Back)
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.A)
+            {
+                SelectAll();
+                e.SuppressKeyPress = true;
+            }
+            else if (e.Modifiers == Keys.Control && e.KeyCode == Keys.Back)
             {
                 int index = SelectionStart;
                 if (SelectionLength == 0)
@@ -265,5 +270,6 @@ namespace Nikse.SubtitleEdit.Controls
             }
             SelectionLength = selectionLength;
         }
+
     }
 }

--- a/src/Controls/SETextBox.cs
+++ b/src/Controls/SETextBox.cs
@@ -10,7 +10,7 @@ namespace Nikse.SubtitleEdit.Controls
     /// </summary>
     public class SETextBox : TextBox
     {
-        private const string BreakChars = " \".!?,)([]<>:;♪♫{}-/#*|¿¡\r\n\t";
+        private const string BreakChars = " \".!?,:;¿¡()[]{}<>♪♫-/#*|\t\r\n";
         private string _dragText = string.Empty;
         private int _dragStartFrom = 0;
         private long _dragStartTicks = 0;
@@ -37,11 +37,11 @@ namespace Nikse.SubtitleEdit.Controls
             }
             else if (e.Modifiers == Keys.Control && e.KeyCode == Keys.Back)
             {
-                int index = SelectionStart;
                 if (SelectionLength == 0)
                 {
-                    string s = Text;
-                    int deleteFrom = index - 1;
+                    var s = Text;
+                    var index = SelectionStart;
+                    var deleteFrom = index - 1;
 
                     if (deleteFrom > 0 && deleteFrom < s.Length)
                     {
@@ -61,8 +61,8 @@ namespace Nikse.SubtitleEdit.Controls
                         }
                         if (s[deleteFrom] == ' ')
                             deleteFrom++;
-                        Text = s.Remove(deleteFrom, index - deleteFrom);
-                        SelectionStart = deleteFrom;
+                        Select(deleteFrom, index - deleteFrom);
+                        Paste(string.Empty);
                     }
                 }
                 e.SuppressKeyPress = true;

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -6872,13 +6872,8 @@ namespace Nikse.SubtitleEdit.Forms
 
             //Utilities.CheckAutoWrap(textBoxListViewText, e, numberOfNewLines);
 
-            if (e.KeyCode == Keys.Enter && e.Modifiers == Keys.None && numberOfLines > Configuration.Settings.Tools.ListViewSyntaxMoreThanXLinesX)
+            if (e.Modifiers == Keys.None && e.KeyCode == Keys.Enter && numberOfLines > Configuration.Settings.Tools.ListViewSyntaxMoreThanXLinesX)
             {
-                e.SuppressKeyPress = true;
-            }
-            else if (e.Modifiers == Keys.Control && e.KeyCode == Keys.A)
-            {
-                textBoxListViewText.SelectAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyData == _mainTextBoxAutoBreak)
@@ -16687,7 +16682,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             //Utilities.CheckAutoWrap(textBoxListViewTextAlternate, e, numberOfNewLines);
 
-            if (e.KeyCode == Keys.Enter && e.Modifiers == Keys.None && numberOfLines > Configuration.Settings.Tools.ListViewSyntaxMoreThanXLinesX)
+            if (e.Modifiers == Keys.None && e.KeyCode == Keys.Enter && numberOfLines > Configuration.Settings.Tools.ListViewSyntaxMoreThanXLinesX)
             {
                 e.SuppressKeyPress = true;
             }


### PR DESCRIPTION
[1]
The `System.Windows.Forms.TextBox` Control ignores the `Ctl-A` shortcut when **Multiline** is enabled.

[2]
I think, `Ctl-Z` should revert a previous `Ctl-Backspace`: just like it reverts `Backspace` and `Delete`.
