### PR TITLE
Remove redundant function call

### DIFF
--- a/libse/HtmlUtil.cs
+++ b/libse/HtmlUtil.cs
@@ -363,10 +363,6 @@ namespace Nikse.SubtitleEdit.Core
 
             if (!s.Contains('<'))
                 return s;
-
-            if (s.Contains("< "))
-                s = FixInvalidItalicTags(s);
-
             return RemoveOpenCloseTags(s, TagItalic, TagBold, TagUnderline, TagParagraph, TagFont, TagCyrillicI);
         }
 


### PR DESCRIPTION
I think we don't need to call `FixInvalidItalicTags` anymore `RemoveOpenCloseTags` will handle if tag contains spaces inside