### PR TITLE
[BUG] Google/Microsoft translate original line crash, fixes #1405

### DIFF
--- a/src/Forms/GoogleTranslate.cs
+++ b/src/Forms/GoogleTranslate.cs
@@ -152,6 +152,8 @@ namespace Nikse.SubtitleEdit.Forms
             GoogleTranslate_Resize(null, null);
 
             _googleApiNotWorking = !Configuration.Settings.Tools.UseGooleApiPaidService; // google has closed their free api service :(
+
+            this._formattingTypes = new FormattingType[this._subtitle.Paragraphs.Count];
         }
 
         private void buttonTranslate_Click(object sender, EventArgs e)
@@ -176,8 +178,6 @@ namespace Nikse.SubtitleEdit.Forms
                 DoMicrosoftTranslate(from, to);
                 return;
             }
-
-            _formattingTypes = new FormattingType[_subtitle.Paragraphs.Count];
 
             buttonOK.Enabled = false;
             buttonCancel.Enabled = false;


### PR DESCRIPTION
Since the Initialize method is called no matter what, moved the instantiation of FormattingType array there and out of the click event of translate. 

Now will work the same for Google Translate and Google/Microsoft Translate