### PR TITLE
Call paragraph's frame/time calculate method to convert from frame/frame

### DIFF
--- a/libse/Subtitle.cs
+++ b/libse/Subtitle.cs
@@ -299,11 +299,8 @@ namespace Nikse.SubtitleEdit.Core
         {
             foreach (Paragraph p in Paragraphs)
             {
-                double startFrame = p.StartTime.TotalMilliseconds / TimeCode.BaseUnit * oldFrameRate;
-                double endFrame = p.EndTime.TotalMilliseconds / TimeCode.BaseUnit * oldFrameRate;
-                p.StartTime.TotalMilliseconds = startFrame * (TimeCode.BaseUnit / newFrameRate);
-                p.EndTime.TotalMilliseconds = endFrame * (TimeCode.BaseUnit / newFrameRate);
-                p.CalculateFrameNumbersFromTimeCodes(newFrameRate);
+                p.CalculateFrameNumbersFromTimeCodes(oldFrameRate);
+                p.CalculateTimeCodesFromFrameNumbers(newFrameRate);
             }
         }
 


### PR DESCRIPTION
There is one thing we should consider if we use this the time will be rounded, if its okay to round the time code :+1: otherwise some check need to be added before merging this PR /CC @niksedk 

Note: If we convert from `23.976 => 25` and we try to go back to `23.976` by converting from `25 => 23.976` time wont be fully restored