### PR TITLE
[Bugfix] - Only allow 'Fix all' if merge short lines allows

### DIFF
--- a/libse/Forms/FixCommonErrors/EmptyFixCallbackNotAllowFix.cs
+++ b/libse/Forms/FixCommonErrors/EmptyFixCallbackNotAllowFix.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
+{
+    class EmptyFixCallbackNotAllowFix : EmptyFixCallback, IFixCallbacks
+    {
+        private readonly HashSet<string> _notAllowedFixes = new HashSet<string>();
+
+        public HashSet<string> NotAllowedFix
+        {
+            get
+            {
+                return _notAllowedFixes;
+            }
+        }
+
+        public new bool AllowFix(Paragraph p, string action)
+        {
+            return !_notAllowedFixes.Contains(p.Number.ToString(System.Globalization.CultureInfo.InvariantCulture) + "|" + action);
+        }
+    }
+}

--- a/libse/Forms/FixCommonErrors/FixShortLinesAll.cs
+++ b/libse/Forms/FixCommonErrors/FixShortLinesAll.cs
@@ -12,7 +12,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 Paragraph p = subtitle.Paragraphs[i];
-                if (callbacks.AllowFix(p, fixAction))
+                if (callbacks.AllowFix(p, fixAction) && callbacks.AllowFix(p, language.MergeShortLine))
                 {
                     string s = HtmlUtil.RemoveHtmlTags(p.Text, true);
                     if (s.Replace(Environment.NewLine, " ").Replace("  ", " ").Length < Configuration.Settings.Tools.MergeLinesShorterThan && p.Text.Contains(Environment.NewLine))

--- a/libse/LibSE.csproj
+++ b/libse/LibSE.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Forms\CheckForUpdatesHelper.cs" />
     <Compile Include="Forms\FixCommonErrors\AddMissingQuotes.cs" />
     <Compile Include="Forms\FixCommonErrors\EmptyFixCallback.cs" />
+    <Compile Include="Forms\FixCommonErrors\EmptyFixCallbackNotAllowFix.cs" />
     <Compile Include="Forms\FixCommonErrors\Fix3PlusLines.cs" />
     <Compile Include="Forms\FixCommonErrors\FixAloneLowercaseIToUppercaseI.cs" />
     <Compile Include="Forms\FixCommonErrors\FixDanishLetterI.cs" />

--- a/src/Test/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrorsTest.cs
@@ -136,6 +136,37 @@ namespace Test
 
         [TestMethod]
         [DeploymentItem("SubtitleEdit.exe")]
+        public void FixShortLinesAllNormal()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "HILDEBRAND" + Environment.NewLine + "IMPRESSOS & RARIDADES");
+                new FixShortLinesAll().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual(_subtitle.Paragraphs[0].Text, "HILDEBRAND IMPRESSOS & RARIDADES");
+            }
+        }
+
+        [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
+        public void FixShortLinesAllNormal2()
+        {
+            const string expected = "Obrigado\r\nJ.";
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, expected);
+                var fixSetting = new EmptyFixCallbackNotAllowFix();
+                fixSetting.NotAllowedFix.Add(_subtitle.Paragraphs[0].Number + "|" + Configuration.Settings.Language.FixCommonErrors.MergeShortLine);
+
+                new FixShortLines().Fix(_subtitle, fixSetting);
+                Assert.AreEqual(expected, _subtitle.Paragraphs[0].Text);
+
+                new FixShortLinesAll().Fix(_subtitle, fixSetting);
+                Assert.AreEqual(expected, _subtitle.Paragraphs[0].Text);
+            }
+        }
+
+        [TestMethod]
+        [DeploymentItem("SubtitleEdit.exe")]
         public void FixShortLinesLong()
         {
             using (var target = GetFixCommonErrorsLib())


### PR DESCRIPTION
If you checked both `Remove lines break in short text with only one sentence` and `Remove lines break in short text with only one sentence (all except dialogue)`.  to see the problem Uncheck all checked items in listviewFixes and hit Apply, the `Remove lines break in short text with only one sentence (all except dialogue)` will automatically fix even though all the fix option are unchecked

Test text: **Obrigado\<br/ >J.** 