### PR TITLE
[bugfix] - only tries to add hyphen if one of the lines doesn't have one

### DIFF
--- a/libse/Forms/FixCommonErrors/Helper.cs
+++ b/libse/Forms/FixCommonErrors/Helper.cs
@@ -377,8 +377,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             Paragraph p = subtitle.Paragraphs[i];
             string text = p.Text;
-            var textCache = HtmlUtil.RemoveHtmlTags(text.TrimStart());
-            if (textCache.StartsWith('-') || textCache.Contains(Environment.NewLine + "-"))
+            var textCache = HtmlUtil.RemoveHtmlTags(text.TrimStart(), true);
+            if (textCache.StartsWith('-') ^ textCache.Contains(Environment.NewLine + "-"))
             {
                 Paragraph prev = subtitle.GetParagraphOrDefault(i - 1);
 


### PR DESCRIPTION
This will also fix bug e.g:

\{\an5\}\- At least I was going back to Hawaii.
\- Woody.

if you run FCE which text above and enable **Fix (add dash)** the text becomes:

{\an5}- At least I was going back to Hawaii.
**\- \-** Woody. _(add one more hyphen)_

Note: For two lines paragraphs only... PS: since the fix will only happen if paragraph contains 2 lines this is :+1: 