### PR TITLE
[Optimization] - Do renumbering only if no paragraphs were removed

### DIFF
--- a/libse/SubtitleFormats/DvdSubtitle.cs
+++ b/libse/SubtitleFormats/DvdSubtitle.cs
@@ -140,9 +140,8 @@ LICENSE=
                 index++;
             }
 
-            subtitle.RemoveEmptyLines();
-
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
     }
 }

--- a/libse/SubtitleFormats/ImageLogicAutocaption.cs
+++ b/libse/SubtitleFormats/ImageLogicAutocaption.cs
@@ -121,8 +121,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 p = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/JsonType5.cs
+++ b/libse/SubtitleFormats/JsonType5.cs
@@ -158,8 +158,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     _errorCount++;
                 }
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/JsonType6.cs
+++ b/libse/SubtitleFormats/JsonType6.cs
@@ -177,8 +177,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 p.Text = Utilities.AutoBreakLine(p.Text);
                 subtitle.Paragraphs.Add(new Paragraph(p));
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/Lrc.cs
+++ b/libse/SubtitleFormats/Lrc.cs
@@ -214,8 +214,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 index++;
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
         private static string GetTextAfterTimeCodes(string s)

--- a/libse/SubtitleFormats/NciCaption.cs
+++ b/libse/SubtitleFormats/NciCaption.cs
@@ -247,11 +247,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - 1;
             }
 
-            subtitle.RemoveEmptyLines();
+            var totalRemoved = subtitle.RemoveEmptyLines();
             Paragraph last = subtitle.GetParagraphOrDefault(subtitle.Paragraphs.Count - 1);
             if (last != null)
                 last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(last.Text);
-            subtitle.Renumber();
+            if (totalRemoved == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/NciTimedRollUpCaptions.cs
+++ b/libse/SubtitleFormats/NciTimedRollUpCaptions.cs
@@ -130,8 +130,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);
                 }
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
         private static string FixText(string text)

--- a/libse/SubtitleFormats/Oresme.cs
+++ b/libse/SubtitleFormats/Oresme.cs
@@ -100,8 +100,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].EndTime.TotalMilliseconds = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].StartTime.TotalMilliseconds +
                          Utilities.GetOptimalDisplayMilliseconds(subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].Text);
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
         private static string GetText(string s)

--- a/libse/SubtitleFormats/OresmeDocXDocument.cs
+++ b/libse/SubtitleFormats/OresmeDocXDocument.cs
@@ -269,13 +269,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 subtitle.Paragraphs[i].EndTime.TotalMilliseconds = subtitle.Paragraphs[i + 1].StartTime.TotalMilliseconds;
             }
             subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].EndTime.TotalMilliseconds = 2500;
-            subtitle.RemoveEmptyLines();
+            var totalRemoved = subtitle.RemoveEmptyLines();
             for (int i = 0; i < subtitle.Paragraphs.Count - 1; i++)
             {
                 if (subtitle.Paragraphs[i].EndTime.TotalMilliseconds == subtitle.Paragraphs[i + 1].StartTime.TotalMilliseconds)
                     subtitle.Paragraphs[i].EndTime.TotalMilliseconds = subtitle.Paragraphs[i + 1].StartTime.TotalMilliseconds - 1;
             }
-            subtitle.Renumber();
+            if (totalRemoved == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/QubeMasterImport.cs
+++ b/libse/SubtitleFormats/QubeMasterImport.cs
@@ -131,8 +131,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (allNullEndTime)
                 subtitle.Paragraphs.Clear();
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber(); ;
         }
 
     }

--- a/libse/SubtitleFormats/SwiftInterchange2.cs
+++ b/libse/SubtitleFormats/SwiftInterchange2.cs
@@ -135,8 +135,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             if (p != null)
                 subtitle.Paragraphs.Add(p);
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
         private static bool GetTimeCode(TimeCode timeCode, string timeString)

--- a/libse/SubtitleFormats/TSB4.cs
+++ b/libse/SubtitleFormats/TSB4.cs
@@ -84,8 +84,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     i += endOfText + 5;
                 }
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle21.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle21.cs
@@ -121,8 +121,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 p = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle33.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle33.cs
@@ -147,8 +147,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 index++;
             }
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle44.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle44.cs
@@ -132,8 +132,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (current.Duration.TotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                     current.EndTime.TotalMilliseconds = current.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle46.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle46.cs
@@ -98,8 +98,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 index++;
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle52.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle52.cs
@@ -132,8 +132,8 @@ FILE_INFO_END";
             if (p != null)
                 p.Text = text.ToString().Trim();
             subtitle.Header = header.ToString();
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle54.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle54.cs
@@ -131,8 +131,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (allNullEndTime)
                 subtitle.Paragraphs.Clear();
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle55.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle55.cs
@@ -125,8 +125,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!string.IsNullOrEmpty(p.Text))
                 subtitle.Paragraphs.Add(p);
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle56.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle56.cs
@@ -117,8 +117,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             foreach (Paragraph temp in subtitle.Paragraphs)
                 temp.Text = temp.Text.Replace("<", "@ITALIC_START").Replace(">", "</i>").Replace("@ITALIC_START", "<i>");
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle58.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle58.cs
@@ -118,8 +118,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!string.IsNullOrEmpty(p.Text))
                 subtitle.Paragraphs.Add(p);
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle60.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle60.cs
@@ -143,8 +143,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!allNullEndTime)
                 subtitle.Paragraphs.Clear();
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle61.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle61.cs
@@ -137,8 +137,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!allNullEndTime)
                 subtitle.Paragraphs.Clear();
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
         private static TimeCode DecodeTimeCode(string[] parts)

--- a/libse/SubtitleFormats/UnknownSubtitle62.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle62.cs
@@ -114,8 +114,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!string.IsNullOrEmpty(p.Text))
                 subtitle.Paragraphs.Add(p);
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle63.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle63.cs
@@ -123,8 +123,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!string.IsNullOrEmpty(p.Text))
                 subtitle.Paragraphs.Add(p);
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle66.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle66.cs
@@ -127,8 +127,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!string.IsNullOrEmpty(p.Text))
                 subtitle.Paragraphs.Add(p);
 
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
     }

--- a/libse/SubtitleFormats/UnknownSubtitle80.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle80.cs
@@ -116,8 +116,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 paragraph.Text = text.ToString().Trim();
             }
-            subtitle.RemoveEmptyLines();
-            subtitle.Renumber();
+            if (subtitle.RemoveEmptyLines() == 0)
+                subtitle.Renumber();
         }
 
         private static string EncodeTimeCode(TimeCode time)


### PR DESCRIPTION
Once a paragraph is removed the RemoveEmptyLines will call Renumber so its redundant to re-run Renumber again