### PR TITLE
[optimization] - Quick detect subtitle format

### DIFF
--- a/libse/SubtitleFormats/Csv2.cs
+++ b/libse/SubtitleFormats/Csv2.cs
@@ -32,14 +32,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             int fine = 0;
             int failed = 0;
             bool continuation = false;
-            foreach (string line in lines)
+            int count = lines.Count / 2 + 1;
+            for (int i = 0; i < count; i++)
             {
-                Match m = CsvLine.Match(line);
-                if (m.Success)
+                string line = lines[i];
+                Match match = CsvLine.Match(line);
+                if (match.Success)
                 {
                     fine++;
-                    string s = line.Remove(0, m.Length);
-                    continuation = s.StartsWith('"');
+                    continuation = line.StartsWith('"');
                 }
                 else if (!string.IsNullOrWhiteSpace(line))
                 {


### PR DESCRIPTION
I found out that almost all subtitle format loops until list.Count  to detect subtitle format which is not okay.
I think the better solution is to loop (Count /2 + 1)  since we are using two variables to track e.g:
`_fine` and `_failed` and return (_fine > _failed)

At the moment we hit (Count /2 + 1) we should probably be able to detect if "IsMine()"