### PR TITLE
[Bugfix] - Do not include '#' exporting to (SwiftInterchange2.cs)

### DIFF
--- a/libse/SubtitleFormats/SwiftInterchange2.cs
+++ b/libse/SubtitleFormats/SwiftInterchange2.cs
@@ -72,7 +72,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 string startTime = string.Format("{0:00}:{1:00}:{2:00}.{3:00}", p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, MillisecondsToFramesMaxFrameRate(p.StartTime.Milliseconds));
                 string duration = string.Format("{0:00}:{1:00}", p.Duration.Seconds, MillisecondsToFramesMaxFrameRate(p.Duration.Milliseconds));
-                sb.AppendLine(string.Format(paragraphWriteFormat, startTime, duration, HtmlUtil.RemoveHtmlTags(p.Text.Replace(Environment.NewLine, " ")), count));
+                sb.AppendLine(string.Format(paragraphWriteFormat, startTime, duration, HtmlUtil.RemoveHtmlTags(EncodeText(p.Text)), count));
                 sb.AppendLine();
                 sb.AppendLine();
                 count++;
@@ -154,6 +154,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 return false;
             }
+        }
+
+        private string EncodeText(string text)
+        {
+            text = text.Replace(Environment.NewLine, " ");
+            return text.Replace('#', '*');
         }
     }
 }

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -3308,8 +3308,11 @@ namespace Nikse.SubtitleEdit.Forms
 
             // Others
             text = text.Replace("…", "...");
-            text = text.Replace('♪', '#');
-            text = text.Replace('♫', '#');
+            char musicSymbol = '#';
+            if (GetCurrentSubtitleFormat().GetType() == typeof(SwiftInterchange2))
+                musicSymbol = '*';
+            text = text.Replace('♪', musicSymbol);
+            text = text.Replace('♫', musicSymbol);
             text = text.Replace("⇒", "=>");
 
             // Spaces


### PR DESCRIPTION
This patch will prevent  SwiftInterchange2 from exporting '#' when saving since SwiftInterchange2  exclude lines that starts with '#' if is not part for line-metadata.

PS: At first I thought it was a bug and I tried to remove [SwiftInterchange2.cs#L126 ](https://github.com/ivandrofly/subtitleedit/blob/sf-bf/libse/SubtitleFormats/SwiftInterchange2.cs#L126) but as stated in [SwiftInterchange2.cs#L38](https://github.com/ivandrofly/subtitleedit/blob/sf-bf/libse/SubtitleFormats/SwiftInterchange2.cs#L38) lines starting with '#' shouldn't be change