### PR TITLE
Corrected misspelled word in Language.cs

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -1846,7 +1846,7 @@ can edit in same subtitle file (collaboration)</Information>
   <StartNumberingFrom>
     <Title>Renumber</Title>
     <StartFromNumber>Start from number:</StartFromNumber>
-    <PleaseEnterAValidNumber>Ups, please enter a valid number</PleaseEnterAValidNumber>
+    <PleaseEnterAValidNumber>Oops, please enter a valid number</PleaseEnterAValidNumber>
   </StartNumberingFrom>
   <Statistics>
     <Title>Statistics</Title>

--- a/libse/Language.cs
+++ b/libse/Language.cs
@@ -2142,7 +2142,7 @@ can edit in same subtitle file (collaboration)",
             {
                 Title = "Renumber",
                 StartFromNumber = "Start from number:",
-                PleaseEnterAValidNumber = "Ups, please enter a valid number",
+                PleaseEnterAValidNumber = "Oops, please enter a valid number",
             };
 
             Statistics = new LanguageStructure.Statistics


### PR DESCRIPTION
[Oops,](https://www.oxforddictionaries.com/definition/learner/oops) "ups" is the plural of "up" – as in ["ups and downs"](https://www.oxforddictionaries.com/definition/american_english/ups-and-downs?q=ups+and+downs). :smile: