### PR TITLE
[SubtitleListView] - Remove extra column index from all lvi subitem

### DIFF
--- a/src/Controls/SubtitleListView.cs
+++ b/src/Controls/SubtitleListView.cs
@@ -765,9 +765,7 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     if (Items[i].SubItems.Count == ColumnIndexExtra + 1)
                     {
-                        Items[i].SubItems[ColumnIndexExtra].Text = string.Empty;
-                        Items[i].SubItems[ColumnIndexExtra].BackColor = BackColor;
-                        Items[i].SubItems[ColumnIndexExtra].ForeColor = ForeColor;
+                        Items[i].SubItems.RemoveAt(ColumnIndexExtra);
                     }
                 }
                 Columns.RemoveAt(ColumnIndexExtra);


### PR DESCRIPTION
`

    public void HideExtraColumn()
        {
            if (IsExtraColumnVisible)
            {
                IsExtraColumnVisible = false;

                if (IsAlternateTextColumnVisible)
                    ColumnIndexExtra = ColumnIndexTextAlternate + 1;
                else
                    ColumnIndexExtra = ColumnIndexTextAlternate;

                for (int i = 0; i < Items.Count; i++)
                {
                    if (Items[i].SubItems.Count == ColumnIndexExtra + 1)
                    {
                        Items[i].SubItems.RemoveAt(ColumnIndexExtra);
                    }
                }
                Columns.RemoveAt(ColumnIndexExtra);
                SubtitleListViewResize(null, null);
            }
        }
`
So far it's not causing any problem but let say in future we decide to use "Items[i].SubItems.Count" after exiting the loop it will return wrong value 