### PR TITLE
[UpdateAssemblyInfo] Update General/Version in XML translation files

### DIFF
--- a/src/UpdateAssemblyInfo/UpdateAssemblyInfo.csproj
+++ b/src/UpdateAssemblyInfo/UpdateAssemblyInfo.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLineRunner.cs" />


### PR DESCRIPTION
In addition to updating the short version (major.minor.maintenance) in `AssemblyInfo.cs.template`, also update `<General><Version>` in the XML translation files when preparing a new release.

Convenient side effect: ensures that all translation files contain syntactically valid XML, because a malformed translation file would throw an exception (`XmlDocument.Load()`).

New release would go smth like this:
- Update `Changelog.txt`
- Increase version to 3.4.13 in SubtitleEdit project properties "Assembly Information" in Visual Studio
- Rebuild solution (updates AssemblyInfo templates, translations, and LanguageMaster)
- `git commit -am "Release 3.4.13"`
- `git tag 3.4.13`
- Rebuild solution (set full version and hash from new git tag)
- `git push --tags origin master`
