### PR TITLE
[AdjustSelectedLines] - Always adjust selection if greater than 1.

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -4806,7 +4806,7 @@ namespace Nikse.SubtitleEdit.Forms
             using (var adjustDisplayTime = new AdjustDisplayDuration())
             {
                 List<int> selectedIndices = null;
-                if (onlySelectedLines)
+                if (onlySelectedLines || SubtitleListview1.SelectedIndices.Count > 1)
                 {
                     adjustDisplayTime.Text += " - " + _language.SelectedLines;
                     selectedIndices = new List<int>();


### PR DESCRIPTION
If user select more than one item from subtitle-listview and click `Tools\Adjust durations` the intention is always to adjust selected line right?

(I know it can also be done by selecting lines from subtitle-listview and right click `Adjust duration for selected lines..`) but it's also useful to do it from Tools.
I also think it's quicker to do adjustment from `Tools` (Mouse).
