### PR TITLE
Minor fix (IfoParser.InterpretLanguageCode)

### DIFF
--- a/libse/IfoParser.cs
+++ b/libse/IfoParser.cs
@@ -283,12 +283,8 @@ namespace Nikse.SubtitleEdit.Core
 
         private static string InterpretLanguageCode(string code)
         {
-            int i = 0;
-            while (LanguageCodes[i] != code && i < 143)
-            {
-                i++;
-            }
-            return LanguageNames[i];
+            int i = LanguageCodes.IndexOf(code);
+            return i < 0 ? "Unknown (" + code + ")" : LanguageNames[i];
         }
 
         private void ParseVtsPgci()


### PR DESCRIPTION
With the modified language lists the literal integer `143` has become incorrect.

An unknown language code **`xx`** will now result in **`Unknown (xx)`** instead of  **`???`**.
