### PR TITLE
Added /multiplereplace:<list> to command line convert

### DIFF
--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -1077,11 +1077,11 @@ namespace Nikse.SubtitleEdit.Forms
                 bool success;
                 if (checkBoxOverwriteOriginalFiles.Checked)
                 {
-                    success = CommandLineConvert.BatchConvertSave(p.ToFormat, null, GetCurrentEncoding(), Path.GetDirectoryName(p.FileName), _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, true, -1, null, false, false, false, false);
+                    success = CommandLineConvert.BatchConvertSave(p.ToFormat, null, GetCurrentEncoding(), Path.GetDirectoryName(p.FileName), _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, true, -1, null, null, false, false, false);
                 }
                 else
                 {
-                    success = CommandLineConvert.BatchConvertSave(p.ToFormat, null, GetCurrentEncoding(), textBoxOutputFolder.Text, _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, checkBoxOverwrite.Checked, -1, null, false, false, false, false);
+                    success = CommandLineConvert.BatchConvertSave(p.ToFormat, null, GetCurrentEncoding(), textBoxOutputFolder.Text, _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, checkBoxOverwrite.Checked, -1, null, null, false, false, false);
                 }
                 if (success)
                 {

--- a/src/Forms/MultipleReplace.cs
+++ b/src/Forms/MultipleReplace.cs
@@ -127,18 +127,9 @@ namespace Nikse.SubtitleEdit.Forms
                 foreach (var fileName in importFileNames)
                 {
                     if (fileName.Equals("."))
-                    {
                         Configuration.Settings.MultipleSearchAndReplaceList.AddRange(savedList);
-                        continue;
-                    }
-                    try
-                    {
+                    else
                         ImportRulesFile(fileName);
-                    }
-                    catch (Exception exception)
-                    {
-                        Console.WriteLine(exception.Message);
-                    }
                 }
                 RunFromBatch(subtitle);
             }


### PR DESCRIPTION
Where \<list\> is a comma separated file name list
The name "." represents replace rules from Settings.xml

The `/multiplereplace` switch is equivalent to `/multiplereplace:.`

Also added `/overwrite` switch to the usage message (overlooked in previous PR).
