### PR TITLE
Refact Text.Encoding and encodingComboBox related stuff

### DIFF
--- a/libse/Configuration.cs
+++ b/libse/Configuration.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace Nikse.SubtitleEdit.Core
 {
@@ -13,11 +15,13 @@ namespace Nikse.SubtitleEdit.Core
         private readonly string _baseDir;
         private readonly string _dataDir;
         private readonly Lazy<Settings> _settings;
+        private readonly IEnumerable<Encoding> _encodings;
 
         private Configuration()
         {
             _baseDir = GetBaseDirectory();
             _dataDir = GetDataDirectory();
+            _encodings = GetAvailableEncodings();
             _settings = new Lazy<Settings>(Settings.GetSettings);
         }
 
@@ -165,6 +169,14 @@ namespace Nikse.SubtitleEdit.Core
             }
         }
 
+        public static IEnumerable<Encoding> AvailableEncodings
+        {
+            get
+            {
+                return Instance.Value._encodings;
+            }
+        }
+
         private static string GetInstallerPath()
         {
             const string valueName = "InstallLocation";
@@ -243,6 +255,23 @@ namespace Nikse.SubtitleEdit.Core
             {
                 throw new Exception("Please re-install Subtitle Edit (installer version)");
             }
+        }
+
+        private static IEnumerable<Encoding> GetAvailableEncodings()
+        {
+            var encodings = new List<Encoding>();
+            foreach (var ei in Encoding.GetEncodings())
+            {
+                try
+                {
+                    encodings.Add(Encoding.GetEncoding(ei.CodePage));
+                }
+                catch
+                {
+                    // though advertised, this code page is not supported
+                }
+            }
+            return encodings.ToArray();
         }
 
     }

--- a/libse/DetectEncoding/EncodingTools.cs
+++ b/libse/DetectEncoding/EncodingTools.cs
@@ -22,13 +22,13 @@ namespace Nikse.SubtitleEdit.Core.DetectEncoding
         /// </summary>
         static EncodingTools()
         {
-            List<int> streamEcodings = new List<int>();
+            List<int> streamEncodings = new List<int>();
             List<int> allEncodings = new List<int>();
-            List<int> mimeEcodings = new List<int>();
+            List<int> mimeEncodings = new List<int>();
 
             // asscii - most simple so put it in first place...
-            streamEcodings.Add(Encoding.ASCII.CodePage);
-            mimeEcodings.Add(Encoding.ASCII.CodePage);
+            streamEncodings.Add(Encoding.ASCII.CodePage);
+            mimeEncodings.Add(Encoding.ASCII.CodePage);
             allEncodings.Add(Encoding.ASCII.CodePage);
 
             // add default 2nd for all encodings
@@ -37,66 +37,61 @@ namespace Nikse.SubtitleEdit.Core.DetectEncoding
             if (Encoding.Default.IsSingleByte)
             {
                 // put it in second place
-                streamEcodings.Add(Encoding.Default.CodePage);
-                mimeEcodings.Add(Encoding.Default.CodePage);
+                streamEncodings.Add(Encoding.Default.CodePage);
+                mimeEncodings.Add(Encoding.Default.CodePage);
             }
 
             // prefer JIS over JIS-SHIFT (JIS is detected better than JIS-SHIFT)
             // this one does include cyrilic (strange but true)
             allEncodings.Add(50220);
-            mimeEcodings.Add(50220);
+            mimeEncodings.Add(50220);
 
             // always allow unicode flavours for streams (they all have a preamble)
-            streamEcodings.Add(Encoding.Unicode.CodePage);
-            foreach (EncodingInfo enc in Encoding.GetEncodings())
+            streamEncodings.Add(Encoding.Unicode.CodePage);
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (!streamEcodings.Contains(enc.CodePage))
+                if (!streamEncodings.Contains(encoding.CodePage))
                 {
-                    Encoding encoding = Encoding.GetEncoding(enc.CodePage);
                     if (encoding.GetPreamble().Length > 0)
-                        streamEcodings.Add(enc.CodePage);
+                        streamEncodings.Add(encoding.CodePage);
                 }
             }
 
             // stream is done here
-            PreferredEncodingsForStream = streamEcodings.ToArray();
+            PreferredEncodingsForStream = streamEncodings.ToArray();
 
             // all singlebyte encodings
-            foreach (EncodingInfo enc in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (!enc.GetEncoding().IsSingleByte)
-                    continue;
-
-                if (!allEncodings.Contains(enc.CodePage))
-                    allEncodings.Add(enc.CodePage);
-
-                // only add iso and IBM encodings to mime encodings
-                if (enc.CodePage <= 1258)
+                if (encoding.IsSingleByte)
                 {
-                    mimeEcodings.Add(enc.CodePage);
+                    if (!allEncodings.Contains(encoding.CodePage))
+                        allEncodings.Add(encoding.CodePage);
+
+                    // only add iso and IBM encodings to mime encodings
+                    if (encoding.CodePage <= 1258)
+                        mimeEncodings.Add(encoding.CodePage);
                 }
             }
 
             // add the rest (multibyte)
-            foreach (EncodingInfo enc in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (!enc.GetEncoding().IsSingleByte)
+                if (!encoding.IsSingleByte)
                 {
-                    if (!allEncodings.Contains(enc.CodePage))
-                        allEncodings.Add(enc.CodePage);
+                    if (!allEncodings.Contains(encoding.CodePage))
+                        allEncodings.Add(encoding.CodePage);
 
                     // only add iso and IBM encodings to mime encodings
-                    if (enc.CodePage <= 1258)
-                    {
-                        mimeEcodings.Add(enc.CodePage);
-                    }
+                    if (encoding.CodePage <= 1258)
+                        mimeEncodings.Add(encoding.CodePage);
                 }
             }
 
             // add unicodes
-            mimeEcodings.Add(Encoding.Unicode.CodePage);
+            mimeEncodings.Add(Encoding.Unicode.CodePage);
 
-            PreferredEncodings = mimeEcodings.ToArray();
+            PreferredEncodings = mimeEncodings.ToArray();
         }
 
         /// <summary>
@@ -338,7 +333,7 @@ namespace Nikse.SubtitleEdit.Core.DetectEncoding
         }
 
         /// <summary>
-        /// Rerurns up to maxEncodings codpages that are assumed to be apropriate
+        /// Returns up to maxEncodings codepages that are assumed to be apropriate
         /// </summary>
         /// <param name="input">array containing the raw data</param>
         /// <param name="maxEncodings">maxiumum number of encodings to detect</param>

--- a/libse/LanguageAutoDetect.cs
+++ b/libse/LanguageAutoDetect.cs
@@ -577,13 +577,13 @@ namespace Nikse.SubtitleEdit.Core
 
             try
             {
-                foreach (EncodingInfo ei in Encoding.GetEncodings())
+                foreach (var enc in Configuration.AvailableEncodings)
                 {
-                    if (ei.CodePage + ": " + ei.DisplayName == Configuration.Settings.General.DefaultEncoding &&
-                        ei.Name != Encoding.UTF8.BodyName &&
-                        ei.Name != Encoding.Unicode.BodyName)
+                    if (enc.CodePage + ": " + enc.EncodingName == Configuration.Settings.General.DefaultEncoding &&
+                        enc.WebName != Encoding.UTF8.WebName &&
+                        enc.WebName != Encoding.Unicode.WebName)
                     {
-                        encoding = ei.GetEncoding();
+                        encoding = enc;
                         break;
                     }
                 }

--- a/libse/LanguageAutoDetect.cs
+++ b/libse/LanguageAutoDetect.cs
@@ -579,9 +579,7 @@ namespace Nikse.SubtitleEdit.Core
             {
                 foreach (var enc in Configuration.AvailableEncodings)
                 {
-                    if (enc.CodePage + ": " + enc.EncodingName == Configuration.Settings.General.DefaultEncoding &&
-                        enc.WebName != Encoding.UTF8.WebName &&
-                        enc.WebName != Encoding.Unicode.WebName)
+                    if (enc.WebName == Configuration.Settings.General.DefaultEncoding && enc.WebName != Encoding.Unicode.WebName && enc.WebName != Encoding.UTF8.WebName)
                     {
                         encoding = enc;
                         break;
@@ -618,7 +616,7 @@ namespace Nikse.SubtitleEdit.Core
                         {
                             encoding = Encoding.UTF8;
                         }
-                        else if (couldBeUtf8 && Configuration.Settings.General.DefaultEncoding == Encoding.UTF8.BodyName)
+                        else if (couldBeUtf8 && Configuration.Settings.General.DefaultEncoding == Encoding.UTF8.WebName)
                         { // keep utf-8 encoding if it's default
                             encoding = Encoding.UTF8;
                         }

--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -596,7 +596,7 @@ namespace Nikse.SubtitleEdit.Core
             SubtitleBackgroundColor = Color.White;
             CenterSubtitleInTextBox = false;
             DefaultSubtitleFormat = "SubRip";
-            DefaultEncoding = Encoding.UTF8.EncodingName;
+            DefaultEncoding = Encoding.UTF8.WebName;
             AutoConvertToUtf8 = false;
             AutoGuessAnsiEncoding = false;
             ShowRecentFiles = true;
@@ -1140,7 +1140,7 @@ namespace Nikse.SubtitleEdit.Core
                     settings = CustomDeserialize(settingsFileName); //  15 msecs
 
                     if (settings.General.AutoConvertToUtf8)
-                        settings.General.DefaultEncoding = Encoding.UTF8.EncodingName;
+                        settings.General.DefaultEncoding = Encoding.UTF8.WebName;
                 }
                 catch
                 {

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -167,19 +167,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             comboBoxSubtitleFormats.SelectedIndex = selectedFormatIndex;
 
-            comboBoxEncoding.Items.Clear();
-            int encodingSelectedIndex = 0;
-            comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
-                {
-                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
-                    if (encoding.WebName == Configuration.Settings.General.DefaultEncoding)
-                        encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
-                }
-            }
-            comboBoxEncoding.SelectedIndex = encodingSelectedIndex;
+            UiUtil.InitializeTextEncodingComboBox(comboBoxEncoding);
 
             if (string.IsNullOrEmpty(Configuration.Settings.Tools.BatchConvertOutputFolder) || !Directory.Exists(Configuration.Settings.Tools.BatchConvertOutputFolder))
                 textBoxOutputFolder.Text = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
@@ -505,18 +493,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private Encoding GetCurrentEncoding()
         {
-            if (comboBoxEncoding.Text == Encoding.UTF8.BodyName || comboBoxEncoding.Text == Encoding.UTF8.EncodingName || comboBoxEncoding.Text == "utf-8")
-            {
-                return Encoding.UTF8;
-            }
-
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
-                    return encoding;
-            }
-
-            return Encoding.UTF8;
+            return UiUtil.GetTextEncodingComboBoxCurrentEncoding(comboBoxEncoding);
         }
 
         private SubtitleFormat GetCurrentSubtitleFormat()

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -170,12 +170,12 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxEncoding.Items.Clear();
             int encodingSelectedIndex = 0;
             comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.Name != Encoding.UTF8.BodyName && ei.CodePage >= 949 && !ei.DisplayName.Contains("EBCDIC") && ei.CodePage != 1047)
+                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
                 {
-                    comboBoxEncoding.Items.Add(ei.CodePage + ": " + ei.DisplayName);
-                    if (ei.Name == Configuration.Settings.General.DefaultEncoding)
+                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
+                    if (encoding.WebName == Configuration.Settings.General.DefaultEncoding)
                         encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
                 }
             }
@@ -510,10 +510,10 @@ namespace Nikse.SubtitleEdit.Forms
                 return Encoding.UTF8;
             }
 
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.CodePage + ": " + ei.DisplayName == comboBoxEncoding.Text)
-                    return ei.GetEncoding();
+                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
+                    return encoding;
             }
 
             return Encoding.UTF8;

--- a/src/Forms/ChooseEncoding.cs
+++ b/src/Forms/ChooseEncoding.cs
@@ -54,12 +54,12 @@ namespace Nikse.SubtitleEdit.Forms
                 _fileBuffer = new byte[0];
             }
 
-            Encoding encoding = LanguageAutoDetect.DetectAnsiEncoding(_fileBuffer);
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            var encoding = LanguageAutoDetect.DetectAnsiEncoding(_fileBuffer);
+            foreach (var enc in Configuration.AvailableEncodings)
             {
-                var item = new ListViewItem(new[] { ei.CodePage.ToString(), ei.Name, ei.DisplayName });
+                var item = new ListViewItem(new[] { enc.CodePage.ToString(), enc.WebName, enc.EncodingName });
                 listView1.Items.Add(item);
-                if (ei.CodePage == encoding.CodePage)
+                if (enc.CodePage == encoding.CodePage)
                     item.Selected = true;
             }
 

--- a/src/Forms/ExportCustomText.cs
+++ b/src/Forms/ExportCustomText.cs
@@ -33,16 +33,17 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxEncoding.Items.Clear();
             int encodingSelectedIndex = 0;
             comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.Name != Encoding.UTF8.BodyName && ei.CodePage >= 949 && !ei.DisplayName.Contains("EBCDIC") && ei.CodePage != 1047)
+                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
                 {
-                    comboBoxEncoding.Items.Add(ei.CodePage + ": " + ei.DisplayName);
-                    if (ei.Name == Configuration.Settings.General.DefaultEncoding)
+                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
+                    if (encoding.WebName == Configuration.Settings.General.DefaultEncoding)
                         encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
                 }
             }
             comboBoxEncoding.SelectedIndex = encodingSelectedIndex;
+
             if (string.IsNullOrEmpty(Configuration.Settings.Tools.ExportCustomTemplates))
             {
                 _templates.Add("SubRipÆÆ{number}\r\n{start} --> {end}\r\n{text}\r\n\r\nÆhh:mm:ss,zzzÆ[Do not modify]Æ");
@@ -187,10 +188,10 @@ namespace Nikse.SubtitleEdit.Forms
                 return Encoding.UTF8;
             }
 
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.CodePage + ": " + ei.DisplayName == comboBoxEncoding.Text)
-                    return ei.GetEncoding();
+                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
+                    return encoding;
             }
 
             return Encoding.UTF8;

--- a/src/Forms/ExportCustomText.cs
+++ b/src/Forms/ExportCustomText.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -30,19 +31,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             _title = title;
 
-            comboBoxEncoding.Items.Clear();
-            int encodingSelectedIndex = 0;
-            comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
-                {
-                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
-                    if (encoding.WebName == Configuration.Settings.General.DefaultEncoding)
-                        encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
-                }
-            }
-            comboBoxEncoding.SelectedIndex = encodingSelectedIndex;
+            UiUtil.InitializeTextEncodingComboBox(comboBoxEncoding);
 
             if (string.IsNullOrEmpty(Configuration.Settings.Tools.ExportCustomTemplates))
             {
@@ -183,18 +172,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private Encoding GetCurrentEncoding()
         {
-            if (comboBoxEncoding.Text == Encoding.UTF8.BodyName || comboBoxEncoding.Text == Encoding.UTF8.EncodingName || comboBoxEncoding.Text == "utf-8")
-            {
-                return Encoding.UTF8;
-            }
-
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
-                    return encoding;
-            }
-
-            return Encoding.UTF8;
+            return UiUtil.GetTextEncodingComboBoxCurrentEncoding(comboBoxEncoding);
         }
 
         private void buttonSave_Click(object sender, EventArgs e)

--- a/src/Forms/ExportText.cs
+++ b/src/Forms/ExportText.cs
@@ -50,12 +50,12 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxEncoding.Items.Clear();
             int encodingSelectedIndex = 0;
             comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.Name != Encoding.UTF8.BodyName && ei.CodePage >= 949 && !ei.DisplayName.Contains("EBCDIC") && ei.CodePage != 1047)
+                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
                 {
-                    comboBoxEncoding.Items.Add(ei.CodePage + ": " + ei.DisplayName);
-                    if (ei.Name == Configuration.Settings.General.DefaultEncoding)
+                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
+                    if (encoding.WebName == Configuration.Settings.General.DefaultEncoding)
                         encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
                 }
             }
@@ -142,10 +142,10 @@ namespace Nikse.SubtitleEdit.Forms
                 return Encoding.UTF8;
             }
 
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.CodePage + ": " + ei.DisplayName == comboBoxEncoding.Text)
-                    return ei.GetEncoding();
+                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
+                    return encoding;
             }
 
             return Encoding.UTF8;

--- a/src/Forms/ExportText.cs
+++ b/src/Forms/ExportText.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.IO;
 using System.Text;
@@ -47,19 +48,7 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxTimeCodeSeparator.SelectedIndex = 0;
             GeneratePreview();
 
-            comboBoxEncoding.Items.Clear();
-            int encodingSelectedIndex = 0;
-            comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
-                {
-                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
-                    if (encoding.WebName == Configuration.Settings.General.DefaultEncoding)
-                        encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
-                }
-            }
-            comboBoxEncoding.SelectedIndex = encodingSelectedIndex;
+            UiUtil.InitializeTextEncodingComboBox(comboBoxEncoding);
         }
 
         private void GeneratePreview()
@@ -137,18 +126,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private Encoding GetCurrentEncoding()
         {
-            if (comboBoxEncoding.Text == Encoding.UTF8.BodyName || comboBoxEncoding.Text == Encoding.UTF8.EncodingName || comboBoxEncoding.Text == "utf-8")
-            {
-                return Encoding.UTF8;
-            }
-
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
-                    return encoding;
-            }
-
-            return Encoding.UTF8;
+            return UiUtil.GetTextEncodingComboBoxCurrentEncoding(comboBoxEncoding);
         }
 
         private void buttonOK_Click(object sender, EventArgs e)

--- a/src/Forms/Main.Designer.cs
+++ b/src/Forms/Main.Designer.cs
@@ -792,7 +792,7 @@
             // 
             // comboBoxSubtitleFormats
             // 
-            this.comboBoxSubtitleFormats.DropDownHeight = 220;
+            this.comboBoxSubtitleFormats.DropDownHeight = 215;
             this.comboBoxSubtitleFormats.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxSubtitleFormats.DropDownWidth = 230;
             this.comboBoxSubtitleFormats.FlatStyle = System.Windows.Forms.FlatStyle.Standard;
@@ -817,11 +817,9 @@
             // 
             // comboBoxEncoding
             // 
-            this.comboBoxEncoding.DropDownHeight = 220;
+            this.comboBoxEncoding.DropDownHeight = 215;
             this.comboBoxEncoding.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBoxEncoding.DropDownWidth = 240;
             this.comboBoxEncoding.FlatStyle = System.Windows.Forms.FlatStyle.Standard;
-            this.comboBoxEncoding.IntegralHeight = false;
             this.comboBoxEncoding.Items.AddRange(new object[] {
             "ANSI",
             "UTF-7",
@@ -829,7 +827,7 @@
             "Unicode",
             "Unicode (big endian)"});
             this.comboBoxEncoding.Name = "comboBoxEncoding";
-            this.comboBoxEncoding.Size = new System.Drawing.Size(122, 40);
+            this.comboBoxEncoding.Size = new System.Drawing.Size(125, 40);
             this.comboBoxEncoding.DropDown += new System.EventHandler(this.MenuOpened);
             this.comboBoxEncoding.DropDownClosed += new System.EventHandler(this.MenuClosed);
             // 

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -334,17 +334,10 @@ namespace Nikse.SubtitleEdit.Forms
 
                 comboBoxEncoding.Items.Clear();
                 comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-                foreach (var ei in Encoding.GetEncodings())
+                foreach (var encoding in Configuration.AvailableEncodings)
                 {
-                    try
-                    {
-                        if (ei.Name != Encoding.UTF8.BodyName && ei.CodePage >= 949 && !ei.DisplayName.Contains("EBCDIC") && ei.CodePage != 1047) //Configuration.Settings.General.EncodingMinimumCodePage)
-                            comboBoxEncoding.Items.Add(ei.CodePage + ": " + ei.DisplayName);
-                    }
-                    catch
-                    {
-                        // Work-around for issue #1285
-                    }
+                    if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName)) //Configuration.Settings.General.EncodingMinimumCodePage
+                        comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
                 }
                 SetEncoding(Configuration.Settings.General.DefaultEncoding);
 
@@ -613,10 +606,10 @@ namespace Nikse.SubtitleEdit.Forms
                 return Encoding.UTF8;
             }
 
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.CodePage + ": " + ei.DisplayName == comboBoxEncoding.Text)
-                    return ei.GetEncoding();
+                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
+                    return encoding;
             }
 
             return Encoding.UTF8;

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -332,14 +332,7 @@ namespace Nikse.SubtitleEdit.Forms
                 if (Configuration.Settings.General.DefaultSubtitleFormat != "SubRip")
                     SetCurrentFormat(Configuration.Settings.General.DefaultSubtitleFormat);
 
-                comboBoxEncoding.Items.Clear();
-                comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-                foreach (var encoding in Configuration.AvailableEncodings)
-                {
-                    if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName)) //Configuration.Settings.General.EncodingMinimumCodePage
-                        comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
-                }
-                SetEncoding(Configuration.Settings.General.DefaultEncoding);
+                UiUtil.InitializeTextEncodingComboBox(comboBoxEncoding.ComboBox);
 
                 // set up UI interfaces / injections
                 YouTubeAnnotations.GetYouTubeAnnotationStyles = new UiGetYouTubeAnnotationStyles();
@@ -559,60 +552,33 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void SetEncoding(Encoding encoding)
         {
-            if (encoding.BodyName == Encoding.UTF8.BodyName)
+            foreach (TextEncodingListItem item in comboBoxEncoding.Items)
             {
-                comboBoxEncoding.SelectedIndex = 0;
-                return;
-            }
-
-            int i = 0;
-            foreach (string s in comboBoxEncoding.Items)
-            {
-                if (s == encoding.CodePage + ": " + encoding.EncodingName)
+                if (item.Equals(encoding))
                 {
-                    comboBoxEncoding.SelectedIndex = i;
+                    comboBoxEncoding.SelectedItem = item;
                     return;
                 }
-                i++;
             }
-            comboBoxEncoding.SelectedIndex = 0;
+            comboBoxEncoding.SelectedIndex = 0; // UTF-8
         }
 
         private void SetEncoding(string encodingName)
         {
-            if (encodingName == Encoding.UTF8.BodyName || encodingName == Encoding.UTF8.EncodingName || encodingName == "utf-8")
+            foreach (TextEncodingListItem item in comboBoxEncoding.Items)
             {
-                comboBoxEncoding.SelectedIndex = 0;
-                return;
-            }
-
-            int i = 0;
-            foreach (string s in comboBoxEncoding.Items)
-            {
-                if (s == encodingName || s.StartsWith(encodingName + ":", StringComparison.Ordinal))
+                if (item.Equals(encodingName))
                 {
-                    comboBoxEncoding.SelectedIndex = i;
+                    comboBoxEncoding.SelectedItem = item;
                     return;
                 }
-                i++;
             }
-            comboBoxEncoding.SelectedIndex = 0;
+            comboBoxEncoding.SelectedIndex = 0; // UTF-8
         }
 
         private Encoding GetCurrentEncoding()
         {
-            if (comboBoxEncoding.Text == Encoding.UTF8.BodyName || comboBoxEncoding.Text == Encoding.UTF8.EncodingName || comboBoxEncoding.Text == "utf-8")
-            {
-                return Encoding.UTF8;
-            }
-
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
-                    return encoding;
-            }
-
-            return Encoding.UTF8;
+            return UiUtil.GetTextEncodingComboBoxCurrentEncoding(comboBoxEncoding.ComboBox);
         }
 
         private void AudioWaveform_OnNonParagraphRightClicked(object sender, AudioVisualizer.ParagraphEventArgs e)

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -96,19 +96,7 @@ namespace Nikse.SubtitleEdit.Forms
             checkBoxShowFrameRate.Checked = gs.ShowFrameRate;
             comboBoxFrameRate.Text = gs.DefaultFrameRate.ToString(CultureInfo.CurrentCulture);
 
-            comboBoxEncoding.Items.Clear();
-            int encodingSelectedIndex = 0;
-            comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
-                {
-                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
-                    if (encoding.WebName == gs.DefaultEncoding || encoding.CodePage + ": " + encoding.EncodingName == gs.DefaultEncoding)
-                        encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
-                }
-            }
-            comboBoxEncoding.SelectedIndex = encodingSelectedIndex;
+            UiUtil.InitializeTextEncodingComboBox(comboBoxEncoding);
 
             checkBoxAutoDetectAnsiEncoding.Checked = gs.AutoGuessAnsiEncoding;
             comboBoxSubtitleFontSize.Text = gs.SubtitleFontSize.ToString(CultureInfo.InvariantCulture);
@@ -1065,12 +1053,7 @@ namespace Nikse.SubtitleEdit.Forms
             if (double.TryParse(comboBoxFrameRate.Text.Replace(',', '.').Replace(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, "."), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out outFrameRate))
                 gs.DefaultFrameRate = outFrameRate;
 
-            gs.DefaultEncoding = Encoding.UTF8.BodyName;
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
-                    gs.DefaultEncoding = comboBoxEncoding.Text;
-            }
+            gs.DefaultEncoding = UiUtil.GetTextEncodingComboBoxCurrentEncoding(comboBoxEncoding).WebName;
 
             gs.AutoGuessAnsiEncoding = checkBoxAutoDetectAnsiEncoding.Checked;
             gs.SubtitleFontSize = int.Parse(comboBoxSubtitleFontSize.Text);

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -99,12 +99,12 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxEncoding.Items.Clear();
             int encodingSelectedIndex = 0;
             comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (var ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.Name != Encoding.UTF8.BodyName && ei.CodePage >= 949 && !ei.DisplayName.Contains("EBCDIC") && ei.CodePage != 1047)
+                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
                 {
-                    comboBoxEncoding.Items.Add(ei.CodePage + ": " + ei.DisplayName);
-                    if (ei.Name == gs.DefaultEncoding || ei.CodePage + ": " + ei.DisplayName == gs.DefaultEncoding)
+                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
+                    if (encoding.WebName == gs.DefaultEncoding || encoding.CodePage + ": " + encoding.EncodingName == gs.DefaultEncoding)
                         encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
                 }
             }
@@ -1066,9 +1066,9 @@ namespace Nikse.SubtitleEdit.Forms
                 gs.DefaultFrameRate = outFrameRate;
 
             gs.DefaultEncoding = Encoding.UTF8.BodyName;
-            foreach (var ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.CodePage + ": " + ei.DisplayName == comboBoxEncoding.Text)
+                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
                     gs.DefaultEncoding = comboBoxEncoding.Text;
             }
 

--- a/src/Forms/Split.cs
+++ b/src/Forms/Split.cs
@@ -89,12 +89,12 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxEncoding.Items.Clear();
             int encodingSelectedIndex = 0;
             comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.Name != Encoding.UTF8.BodyName && ei.CodePage >= 949 && !ei.DisplayName.Contains("EBCDIC") && ei.CodePage != 1047)
+                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
                 {
-                    comboBoxEncoding.Items.Add(ei.CodePage + ": " + ei.DisplayName);
-                    if (ei.Name == Configuration.Settings.General.DefaultEncoding)
+                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
+                    if (encoding.WebName == Configuration.Settings.General.DefaultEncoding)
                         encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
                 }
             }
@@ -282,10 +282,10 @@ namespace Nikse.SubtitleEdit.Forms
                 return Encoding.UTF8;
             }
 
-            foreach (EncodingInfo ei in Encoding.GetEncodings())
+            foreach (var encoding in Configuration.AvailableEncodings)
             {
-                if (ei.CodePage + ": " + ei.DisplayName == comboBoxEncoding.Text)
-                    return ei.GetEncoding();
+                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
+                    return encoding;
             }
 
             return Encoding.UTF8;

--- a/src/Forms/Split.cs
+++ b/src/Forms/Split.cs
@@ -86,19 +86,7 @@ namespace Nikse.SubtitleEdit.Forms
                     comboBoxSubtitleFormats.SelectedIndex = comboBoxSubtitleFormats.Items.Count - 1;
             }
 
-            comboBoxEncoding.Items.Clear();
-            int encodingSelectedIndex = 0;
-            comboBoxEncoding.Items.Add(Encoding.UTF8.EncodingName);
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC") && !encoding.WebName.Equals(Encoding.UTF8.WebName))
-                {
-                    comboBoxEncoding.Items.Add(encoding.CodePage + ": " + encoding.EncodingName);
-                    if (encoding.WebName == Configuration.Settings.General.DefaultEncoding)
-                        encodingSelectedIndex = comboBoxEncoding.Items.Count - 1;
-                }
-            }
-            comboBoxEncoding.SelectedIndex = encodingSelectedIndex;
+            UiUtil.InitializeTextEncodingComboBox(comboBoxEncoding);
 
             if (numericUpDownParts.Maximum > _subtitle.Paragraphs.Count)
                 numericUpDownParts.Maximum = _subtitle.Paragraphs.Count / 2;
@@ -277,18 +265,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private Encoding GetCurrentEncoding()
         {
-            if (comboBoxEncoding.Text == Encoding.UTF8.BodyName || comboBoxEncoding.Text == Encoding.UTF8.EncodingName || comboBoxEncoding.Text == "utf-8")
-            {
-                return Encoding.UTF8;
-            }
-
-            foreach (var encoding in Configuration.AvailableEncodings)
-            {
-                if (encoding.CodePage + ": " + encoding.EncodingName == comboBoxEncoding.Text)
-                    return encoding;
-            }
-
-            return Encoding.UTF8;
+            return UiUtil.GetTextEncodingComboBoxCurrentEncoding(comboBoxEncoding);
         }
 
         private void Split_Shown(object sender, EventArgs e)

--- a/src/Logic/TextEncodingListItem.cs
+++ b/src/Logic/TextEncodingListItem.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Logic
+{
+    internal class TextEncodingListItem : IEquatable<Encoding>, IEquatable<string>
+    {
+        private readonly Encoding _encoding;
+        private readonly string _displayName;
+
+        public Encoding Encoding
+        {
+            get
+            {
+                return _encoding;
+            }
+        }
+
+        public string DisplayName
+        {
+            get
+            {
+                return _displayName;
+            }
+        }
+
+        public TextEncodingListItem(Encoding encoding)
+        {
+            if (encoding.CodePage.Equals(Encoding.UTF8.CodePage))
+            {
+                _encoding = Encoding.UTF8;
+                _displayName = _encoding.EncodingName;
+            }
+            else
+            {
+                _encoding = encoding;
+                _displayName = encoding.CodePage + ": " + encoding.EncodingName;
+            }
+        }
+
+        public override string ToString()
+        {
+            return _displayName;
+        }
+
+        public bool Equals(string name)
+        {
+            return !ReferenceEquals(name, null) && (
+                   _encoding.WebName.Equals(name, StringComparison.OrdinalIgnoreCase) ||
+                   _encoding.EncodingName.Equals(name, StringComparison.OrdinalIgnoreCase) ||
+                   _displayName.Equals(name, StringComparison.OrdinalIgnoreCase) ||
+                   _encoding.CodePage.ToString().Equals(name));
+        }
+
+        public bool Equals(Encoding encoding)
+        {
+            return !ReferenceEquals(encoding, null) && _encoding.CodePage.Equals(encoding.CodePage);
+        }
+
+        public override bool Equals(object obj)
+        {
+            var item = obj as TextEncodingListItem;
+            return !ReferenceEquals(item, null) && Equals(item.Encoding);
+        }
+
+        public override int GetHashCode()
+        {
+            return _encoding.CodePage.GetHashCode();
+        }
+    }
+}

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -393,6 +393,50 @@ namespace Nikse.SubtitleEdit.Logic
             label.Text = sb.ToString();
         }
 
+        public static void InitializeTextEncodingComboBox(ComboBox comboBox)
+        {
+            var defaultEncoding = Configuration.Settings.General.DefaultEncoding;
+            var selectedItem = (TextEncodingListItem)null;
+            comboBox.BeginUpdate();
+            comboBox.Items.Clear();
+            using (var graphics = comboBox.CreateGraphics())
+            {
+                var maxWidth = 0.0F;
+                foreach (var encoding in Configuration.AvailableEncodings)
+                {
+                    if (encoding.CodePage >= 949 && encoding.CodePage != 1047 && !encoding.EncodingName.Contains("EBCDIC"))
+                    {
+                        var item = new TextEncodingListItem(encoding);
+                        if (selectedItem == null && item.Equals(defaultEncoding))
+                            selectedItem = item;
+                        var width = graphics.MeasureString(item.DisplayName, comboBox.Font).Width;
+                        if (width > maxWidth)
+                            maxWidth = width;
+                        if (encoding.CodePage.Equals(Encoding.UTF8.CodePage))
+                            comboBox.Items.Insert(0, item);
+                        else
+                            comboBox.Items.Add(item);
+                    }
+                }
+                comboBox.DropDownWidth = (int)Math.Round(maxWidth + 7.5);
+            }
+            if (selectedItem == null)
+                comboBox.SelectedIndex = 0; // UTF-8 if DefaultEncoding is not found
+            else
+                comboBox.SelectedItem = selectedItem;
+            comboBox.EndUpdate();
+            Configuration.Settings.General.DefaultEncoding = (comboBox.SelectedItem as TextEncodingListItem).Encoding.WebName;
+        }
+
+        public static Encoding GetTextEncodingComboBoxCurrentEncoding(ComboBox comboBox)
+        {
+            if (comboBox.SelectedIndex > 0)
+            {
+                return (comboBox.SelectedItem as TextEncodingListItem).Encoding;
+            }
+            return Encoding.UTF8;
+        }
+
         private const string BreakChars = "\",:;.¡!¿?()[]{}<>♪♫-–—/#*|";
 
         public static void ApplyControlBackspace(TextBox textBox)

--- a/src/SubtitleEdit.csproj
+++ b/src/SubtitleEdit.csproj
@@ -850,6 +850,7 @@
     <Compile Include="Logic\SpellCheck\MacHunspell.cs" />
     <Compile Include="Logic\SpellCheck\VoikkoSpellCheck.cs" />
     <Compile Include="Logic\SpellCheck\WindowsHunspell.cs" />
+    <Compile Include="Logic\TextEncodingListItem.cs" />
     <Compile Include="Logic\UiEbuSaveHelper.cs" />
     <Compile Include="Logic\UiGetPacEncoding.cs" />
     <Compile Include="Logic\UiGetYouTubeAnnotationStyles.cs" />


### PR DESCRIPTION
- Replaces replicated `encodingComboBox` code with shared UiUtil methods
- Sets `DropDownWith` appropriately while initialising the `encodingComboBox`
- Sets `Settings.General.DefaultEncoding` consistently to platform and locale independent IANA registered encoding name
