### PR TITLE
[Main/HistoryItem] - Fix bug when button-new is been clicked continually

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -3411,7 +3411,9 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void ResetSubtitle()
         {
+            comboBoxSubtitleFormats.SelectedIndexChanged -= ComboBoxSubtitleFormatsSelectedIndexChanged;
             SetCurrentFormat(Configuration.Settings.General.DefaultSubtitleFormat);
+            comboBoxSubtitleFormats.SelectedIndexChanged += ComboBoxSubtitleFormatsSelectedIndexChanged;
 
             labelStartTimeWarning.Text = string.Empty;
             labelDurationWarning.Text = string.Empty;
@@ -3433,9 +3435,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             SubtitleListview1.HideExtraColumn();
             SubtitleListview1.DisplayExtraFromExtra = false;
-
-            ComboBoxSubtitleFormatsSelectedIndexChanged(null, null);
-
+            
             toolStripComboBoxFrameRate.Text = Configuration.Settings.General.DefaultFrameRate.ToString();
 
             SetEncoding(Configuration.Settings.General.DefaultEncoding);
@@ -3499,7 +3499,8 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (ContinueNewOrExit())
             {
-                MakeHistoryForUndo(_language.BeforeNew);
+                if(IsSubtitleLoaded)
+                    MakeHistoryForUndo(_language.BeforeNew);
                 ResetSubtitle();
             }
         }


### PR DESCRIPTION
You can see the issue by clicking BUTTON NEW multiply time and open **Show history (for undo)/History Item**.
