### PR TITLE
Descenders in PNGs, simplified line height calculation.

### DIFF
--- a/src/Forms/ExportPngXml.cs
+++ b/src/Forms/ExportPngXml.cs
@@ -2317,7 +2317,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                     bmp = new Bitmap(sizeX, sizeY);
                 }
 
-                // align lines with gjpqy, a bit lower
+                // align lines with descenders, a bit lower
                 var lines = text.SplitToLines();
                 int baseLinePadding = 13;
                 if (parameter.SubtitleFontSize < 30)
@@ -2326,20 +2326,8 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                     baseLinePadding = 9;
                 if (lines.Length > 0)
                 {
-                    var lastLine = lines[lines.Length - 1];
-					char [] specialChars = { 'g', 'j', 'p', 'q', 'y', ',', ';', 'ý', 'ę', 'ç', 'Ç', 'ș', 'ț', '(', ')', 'Ą', 'ą', 'Ę', 'ę', 'Ķ', 'ķ', 'Ņ', 'ņ', 'Ŗ', 'Ų', 'Ş', 'ų', 'Ɣ' };
-                    if (lastLine.Contains(specialChars))                    {
-                        var textNoBelow = lastLine;
-						foreach (char c in specialChars)
-						{
-							textNoBelow = textNoBelow.Replace(c, 'a');
-						}
-                        baseLinePadding -= (int)Math.Round((TextDraw.MeasureTextHeight(font, lastLine, parameter.SubtitleFontBold) - TextDraw.MeasureTextHeight(font, textNoBelow, parameter.SubtitleFontBold)));
-                    }
-                    else
-                    {
-                        baseLinePadding += 0;
-                    }
+        			var lastLine = lines[lines.Length - 1];
+                    baseLinePadding -= (int)Math.Floor((TextDraw.MeasureTextHeight(font, lastLine, parameter.SubtitleFontBold) - TextDraw.MeasureTextHeight(font, "a,", parameter.SubtitleFontBold)));
                     if (baseLinePadding < 0)
                         baseLinePadding = 0;
                 }

--- a/src/Forms/ExportPngXml.cs
+++ b/src/Forms/ExportPngXml.cs
@@ -2327,14 +2327,18 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                 if (lines.Length > 0)
                 {
                     var lastLine = lines[lines.Length - 1];
-                    if (lastLine.Contains(new[] { 'g', 'j', 'p', 'q', 'y', ',', 'ý', 'ę', 'ç', 'Ç' }))
-                    {
-                        var textNoBelow = lastLine.Replace('g', 'a').Replace('j', 'a').Replace('p', 'a').Replace('q', 'a').Replace('y', 'a').Replace(',', 'a').Replace('ý', 'a').Replace('ę', 'a').Replace('ç', 'a').Replace('Ç', 'a');
+					char [] specialChars = { 'g', 'j', 'p', 'q', 'y', ',', ';', 'ý', 'ę', 'ç', 'Ç', 'ș', 'ț', '(', ')', 'Ą', 'ą', 'Ę', 'ę', 'Ķ', 'ķ', 'Ņ', 'ņ', 'Ŗ', 'Ų', 'Ş', 'ų', 'Ɣ' };
+                    if (lastLine.Contains(specialChars))                    {
+                        var textNoBelow = lastLine;
+						foreach (char c in specialChars)
+						{
+							textNoBelow = textNoBelow.Replace(c, 'a');
+						}
                         baseLinePadding -= (int)Math.Round((TextDraw.MeasureTextHeight(font, lastLine, parameter.SubtitleFontBold) - TextDraw.MeasureTextHeight(font, textNoBelow, parameter.SubtitleFontBold)));
                     }
                     else
                     {
-                        baseLinePadding += 1;
+                        baseLinePadding += 0;
                     }
                     if (baseLinePadding < 0)
                         baseLinePadding = 0;


### PR DESCRIPTION
For an upcoming project with Romanian subtitles, I needed to improve the baseline calculation for PNG creation.

Instead of keeping a list with all possible characters and comparing line height to a line with these characters removed (textNoBelow), I just compare with a simple line "a,".

There is still an occasional difference of 1px in height for generated PNGs, this seems to be a rounding error somewhere. (Changing border width in 1px increments shows the offset on different lines).