### PR TITLE
[Main/Plugin] - Use EnumerateFiles for more efficiency.

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -15062,7 +15062,6 @@ namespace Nikse.SubtitleEdit.Forms
             var path = Configuration.PluginsDirectory;
             if (!Directory.Exists(path))
                 return;
-            var pluginFiles = Directory.GetFiles(path, "*.DLL");
 
             int filePluginCount = 0;
             int toolsPluginCount = 0;
@@ -15099,7 +15098,7 @@ namespace Nikse.SubtitleEdit.Forms
                     toolStripMenuItemAutoTranslate.DropDownItems.Remove(x);
             }
 
-            foreach (var pluginFileName in pluginFiles)
+            foreach (var pluginFileName in Directory.EnumerateFiles(path, "*.DLL"))
             {
                 try
                 {


### PR DESCRIPTION
When working with many files **EnumerateFiles** can be more efficient than **GetFiles()**. (Stated in [MSDN](https://msdn.microsoft.com/en-us/library/dd383458(v=vs.110).aspx))