### PR TITLE
[HtmlUtil] - Make sure text contains '<'.

### DIFF
--- a/libse/HtmlUtil.cs
+++ b/libse/HtmlUtil.cs
@@ -403,7 +403,7 @@ namespace Nikse.SubtitleEdit.Core
 
         public static string FixUpperTags(string text)
         {
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(text) || !text.Contains('<'))
                 return text;
             var idx = text.IndexOfAny(UppercaseTags, StringComparison.Ordinal);
             while (idx >= 0)


### PR DESCRIPTION
To avoid looping entire `{ "<I>", "<U>", "<B>", "<FONT", "</I>", "</U>", "</B>", "</FONT>" }`
in case text doesn't contain any HTML tags.