### PR TITLE
Removed licence/license rule from eng_OCRFixReplaceList.xml

### DIFF
--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -813,7 +813,6 @@
     <Word from="lgive" to="I give" />
     <Word from="Li/0/Academy" to="Lilly Academy" />
     <Word from="li/lr." to="Mr." />
-    <Word from="licence" to="license" />
     <Word from="ligature___" to="ligature..." />
     <Word from="l'II" to="I'll" />
     <Word from="l'Il" to="I'll" />


### PR DESCRIPTION
In British English "licence" is a noun and "license" a verb.