### PR TITLE
Updated OcrFixReplaceList.cs

### DIFF
--- a/libse/Dictionaries/OcrFixReplaceList.cs
+++ b/libse/Dictionaries/OcrFixReplaceList.cs
@@ -281,10 +281,18 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
         {
             if (Configuration.Settings.Tools.OcrFixUseHardcodedRules)
             {
+                // common Latin ligatures from legacy encodings;
+                // Unicode includes them only for compatibility and discourages their use
+                word = word.Replace("ﬀ", "ff");
                 word = word.Replace("ﬁ", "fi");
+                word = word.Replace("ﬂ", "fl");
+                word = word.Replace("ﬃ", "ffi");
+                word = word.Replace("ﬄ", "ffl");
+
                 word = word.Replace('ν', 'v'); // NOTE: first 'v' is a special unicode character!!!!
                 word = word.Replace('’', '\'');
                 word = word.Replace('`', '\'');
+                word = word.Replace('´', '\'');
                 word = word.Replace('‘', '\'');
                 word = word.Replace('—', '-');
                 while(word.Contains("--"))


### PR DESCRIPTION
Added other common Latin ligatures present in Unicode.

Also added the acute accent, which I've often seen used instead of the
apostrophe, either as an OCR error or because people mistake it for the
curly apostrophe.