### PR TITLE
[Utilities] - Change to native array init to avoid issue with unix platforms.

### DIFF
--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Core
         /// <summary>
         /// Cached environment new line characters for faster lookup.
         /// </summary>
-        public static readonly char[] NewLineChars = Environment.NewLine.ToCharArray();
+        public static readonly char[] NewLineChars = { '\r', '\n' };    
 
         public static VideoInfo TryReadVideoInfoViaMatroskaHeader(string fileName)
         {


### PR DESCRIPTION
The return value of **NewLine** can differ depending on the environment.
See: https://msdn.microsoft.com/en-us/library/system.environment.newline(v=vs.110).aspx