### PR TITLE
[Main] - Remove duplicated BeginUpdate call.

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -3138,8 +3138,11 @@ namespace Nikse.SubtitleEdit.Forms
                 RecentFileEntry rfe = null;
                 foreach (var file in Configuration.Settings.RecentFiles.Files)
                 {
-                    if (file.FileName == item.Text)
+                    if (file.FileName.Equals(item.Text, StringComparison.OrdinalIgnoreCase))
+                    {
                         rfe = file;
+                        break;
+                    }
                 }
                 if (rfe == null)
                 {

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -3141,7 +3141,6 @@ namespace Nikse.SubtitleEdit.Forms
                     if (file.FileName == item.Text)
                         rfe = file;
                 }
-                SubtitleListview1.BeginUpdate();
                 if (rfe == null)
                 {
                     OpenSubtitle(item.Text, null);
@@ -3159,7 +3158,6 @@ namespace Nikse.SubtitleEdit.Forms
                 }
                 GotoSubPosAndPause();
                 SetRecentIndices(item.Text);
-                SubtitleListview1.EndUpdate();
                 if (rfe != null && !string.IsNullOrEmpty(rfe.VideoFileName))
                 {
                     var p = _subtitle.GetParagraphOrDefault(rfe.FirstSelectedIndex);


### PR DESCRIPTION
- SubtitleListview.Fill(...) always calls BeginUpdate
- Exit the loop as soon the file is found in **Recent File Entry**. (will save us from 25 loops in case file is in position 1)
- Compare names using **OrdinalIgnoreCase** rule.
