### PR TITLE
[Utilities/UIutil] - Move GetOpenDialogFilter to UIUtil.

### DIFF
--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -837,61 +837,6 @@ namespace Nikse.SubtitleEdit.Core
             }
         }
 
-        private static void AddExtension(StringBuilder sb, string extension)
-        {
-            if (!sb.ToString().Contains("*" + extension + ";", StringComparison.OrdinalIgnoreCase))
-            {
-                sb.Append('*');
-                sb.Append(extension.TrimStart('*'));
-                sb.Append(';');
-            }
-        }
-
-        public static string GetOpenDialogFilter()
-        {
-            var sb = new StringBuilder();
-            sb.Append(Configuration.Settings.Language.General.SubtitleFiles + "|");
-            foreach (SubtitleFormat s in SubtitleFormat.AllSubtitleFormats)
-            {
-                AddExtension(sb, s.Extension);
-                foreach (string ext in s.AlternateExtensions)
-                    AddExtension(sb, ext);
-            }
-            AddExtension(sb, new Pac().Extension);
-            AddExtension(sb, new Cavena890().Extension);
-            AddExtension(sb, new Spt().Extension);
-            AddExtension(sb, new Wsb().Extension);
-            AddExtension(sb, new CheetahCaption().Extension);
-            AddExtension(sb, ".chk");
-            AddExtension(sb, new CaptionsInc().Extension);
-            AddExtension(sb, new Ultech130().Extension);
-            AddExtension(sb, new ELRStudioClosedCaption().Extension);
-            AddExtension(sb, ".uld"); // Ultech drop frame
-            AddExtension(sb, new SonicScenaristBitmaps().Extension);
-            AddExtension(sb, ".mks");
-            AddExtension(sb, ".mxf");
-            AddExtension(sb, ".sup");
-            AddExtension(sb, ".dost");
-            AddExtension(sb, new Ayato().Extension);
-            AddExtension(sb, new PacUnicode().Extension);
-
-            if (!string.IsNullOrEmpty(Configuration.Settings.General.OpenSubtitleExtraExtensions))
-            {
-                var extraExtensions = Configuration.Settings.General.OpenSubtitleExtraExtensions.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (string ext in extraExtensions)
-                {
-                    if (ext.StartsWith("*.", StringComparison.Ordinal) && !sb.ToString().Contains(ext, StringComparison.OrdinalIgnoreCase))
-                        AddExtension(sb, ext);
-                }
-            }
-            AddExtension(sb, ".son");
-
-            sb.Append('|');
-            sb.Append(Configuration.Settings.Language.General.AllFiles);
-            sb.Append("|*.*");
-            return sb.ToString();
-        }
-
         public static bool IsValidRegex(string testPattern)
         {
             if (string.IsNullOrEmpty(testPattern))

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -216,7 +216,7 @@ namespace Nikse.SubtitleEdit.Forms
             buttonInputBrowse.Enabled = false;
             openFileDialog1.Title = Configuration.Settings.Language.General.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             openFileDialog1.Multiselect = true;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -216,7 +216,7 @@ namespace Nikse.SubtitleEdit.Forms
             buttonInputBrowse.Enabled = false;
             openFileDialog1.Title = Configuration.Settings.Language.General.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             openFileDialog1.Multiselect = true;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {

--- a/src/Forms/Compare.cs
+++ b/src/Forms/Compare.cs
@@ -44,7 +44,7 @@ namespace Nikse.SubtitleEdit.Forms
             UiUtil.FixLargeFonts(this, buttonOK);
             subtitleListView1.UseSyntaxColoring = false;
             subtitleListView2.UseSyntaxColoring = false;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             LoadConfigurations();
         }
 
@@ -928,7 +928,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             var listExt = new List<string>();
-            foreach (var s in UiUtil.GetOpenDialogFilter().Split(new[] { '*' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var s in UiUtil.SubtitleExtensionFilter.Value.Split(new[] { '*' }, StringSplitOptions.RemoveEmptyEntries))
             {
                 if (s.EndsWith(';'))
                     listExt.Add(s.Trim(';'));

--- a/src/Forms/Compare.cs
+++ b/src/Forms/Compare.cs
@@ -44,7 +44,7 @@ namespace Nikse.SubtitleEdit.Forms
             UiUtil.FixLargeFonts(this, buttonOK);
             subtitleListView1.UseSyntaxColoring = false;
             subtitleListView2.UseSyntaxColoring = false;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             LoadConfigurations();
         }
 
@@ -928,7 +928,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             var listExt = new List<string>();
-            foreach (var s in Utilities.GetOpenDialogFilter().Split(new[] { '*' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var s in UiUtil.GetOpenDialogFilter().Split(new[] { '*' }, StringSplitOptions.RemoveEmptyEntries))
             {
                 if (s.EndsWith(';'))
                     listExt.Add(s.Trim(';'));

--- a/src/Forms/JoinSubtitles.cs
+++ b/src/Forms/JoinSubtitles.cs
@@ -213,7 +213,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = Configuration.Settings.Language.General.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             openFileDialog1.Multiselect = true;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {

--- a/src/Forms/JoinSubtitles.cs
+++ b/src/Forms/JoinSubtitles.cs
@@ -213,7 +213,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = Configuration.Settings.Language.General.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             openFileDialog1.Multiselect = true;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -1714,7 +1714,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             openFileDialog1.Title = _languageGeneral.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 RemoveAlternate(true);
@@ -5258,7 +5258,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 openFileDialog1.Title = _language.OpenSubtitleToAppend;
                 openFileDialog1.FileName = string.Empty;
-                openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+                openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
                 if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
                 {
                     bool success = false;
@@ -10307,7 +10307,7 @@ namespace Nikse.SubtitleEdit.Forms
             ReloadFromSourceView();
             openFileDialog1.Title = _language.OpenAnsiSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 var chooseEncoding = new ChooseEncoding();
@@ -12860,7 +12860,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 openFileDialog1.Title = _language.OpenOtherSubtitle;
                 openFileDialog1.FileName = string.Empty;
-                openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+                openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
                 if (openFileDialog1.ShowDialog() == DialogResult.OK && File.Exists(openFileDialog1.FileName))
                 {
                     var file = new FileInfo(openFileDialog1.FileName);
@@ -13009,7 +13009,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             openFileDialog1.Title = _languageGeneral.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 Encoding encoding;
@@ -13093,7 +13093,7 @@ namespace Nikse.SubtitleEdit.Forms
                 SaveSubtitleListviewIndices();
                 openFileDialog1.Title = _languageGeneral.OpenOriginalSubtitleFile;
                 openFileDialog1.FileName = string.Empty;
-                openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+                openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
                 if (openFileDialog1.ShowDialog(this) != DialogResult.OK)
                     return;
 
@@ -16969,7 +16969,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = _languageGeneral.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 if (!File.Exists(openFileDialog1.FileName))
@@ -19382,7 +19382,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = _languageGeneral.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 if (!File.Exists(openFileDialog1.FileName))

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -1714,7 +1714,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             openFileDialog1.Title = _languageGeneral.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 RemoveAlternate(true);
@@ -5258,7 +5258,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 openFileDialog1.Title = _language.OpenSubtitleToAppend;
                 openFileDialog1.FileName = string.Empty;
-                openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+                openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
                 if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
                 {
                     bool success = false;
@@ -10307,7 +10307,7 @@ namespace Nikse.SubtitleEdit.Forms
             ReloadFromSourceView();
             openFileDialog1.Title = _language.OpenAnsiSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 var chooseEncoding = new ChooseEncoding();
@@ -12860,7 +12860,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 openFileDialog1.Title = _language.OpenOtherSubtitle;
                 openFileDialog1.FileName = string.Empty;
-                openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+                openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
                 if (openFileDialog1.ShowDialog() == DialogResult.OK && File.Exists(openFileDialog1.FileName))
                 {
                     var file = new FileInfo(openFileDialog1.FileName);
@@ -13009,7 +13009,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             openFileDialog1.Title = _languageGeneral.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 Encoding encoding;
@@ -13093,7 +13093,7 @@ namespace Nikse.SubtitleEdit.Forms
                 SaveSubtitleListviewIndices();
                 openFileDialog1.Title = _languageGeneral.OpenOriginalSubtitleFile;
                 openFileDialog1.FileName = string.Empty;
-                openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+                openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
                 if (openFileDialog1.ShowDialog(this) != DialogResult.OK)
                     return;
 
@@ -16969,7 +16969,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = _languageGeneral.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 if (!File.Exists(openFileDialog1.FileName))
@@ -19382,7 +19382,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = _languageGeneral.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 if (!File.Exists(openFileDialog1.FileName))

--- a/src/Forms/VobSubOcr.cs
+++ b/src/Forms/VobSubOcr.cs
@@ -7729,7 +7729,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = Configuration.Settings.Language.General.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 string fileName = openFileDialog1.FileName;
@@ -8816,7 +8816,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = Configuration.Settings.Language.General.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.SubtitleExtensionFilter.Value;
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 string fileName = openFileDialog1.FileName;

--- a/src/Forms/VobSubOcr.cs
+++ b/src/Forms/VobSubOcr.cs
@@ -7729,7 +7729,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = Configuration.Settings.Language.General.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 string fileName = openFileDialog1.FileName;
@@ -8816,7 +8816,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialog1.Title = Configuration.Settings.Language.General.OpenSubtitle;
             openFileDialog1.FileName = string.Empty;
-            openFileDialog1.Filter = Utilities.GetOpenDialogFilter();
+            openFileDialog1.Filter = UiUtil.GetOpenDialogFilter();
             if (openFileDialog1.ShowDialog(this) == DialogResult.OK)
             {
                 string fileName = openFileDialog1.FileName;

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -16,6 +16,8 @@ namespace Nikse.SubtitleEdit.Logic
 {
     internal static class UiUtil
     {
+        public static readonly Lazy<string> SubtitleExtensionFilter = new Lazy<string>(GetOpenDialogFilter);
+
         public static VideoInfo GetVideoInfo(string fileName)
         {
             VideoInfo info = Utilities.TryReadVideoInfoViaAviHeader(fileName);
@@ -606,7 +608,17 @@ namespace Nikse.SubtitleEdit.Logic
             return c == UnicodeCategory.SpaceSeparator || c == UnicodeCategory.Control || c == UnicodeCategory.LineSeparator || c == UnicodeCategory.ParagraphSeparator;
         }
 
-        public static string GetOpenDialogFilter()
+        private static void AddExtension(StringBuilder sb, string extension)
+        {
+            if (!sb.ToString().Contains("*" + extension + ";", StringComparison.OrdinalIgnoreCase))
+            {
+                sb.Append('*');
+                sb.Append(extension.TrimStart('*'));
+                sb.Append(';');
+            }
+        }
+
+        private static string GetOpenDialogFilter()
         {
             var sb = new StringBuilder();
             sb.Append(Configuration.Settings.Language.General.SubtitleFiles + "|");
@@ -649,16 +661,6 @@ namespace Nikse.SubtitleEdit.Logic
             sb.Append(Configuration.Settings.Language.General.AllFiles);
             sb.Append("|*.*");
             return sb.ToString();
-        }
-
-        private static void AddExtension(StringBuilder sb, string extension)
-        {
-            if (!sb.ToString().Contains("*" + extension + ";", StringComparison.OrdinalIgnoreCase))
-            {
-                sb.Append('*');
-                sb.Append(extension.TrimStart('*'));
-                sb.Append(';');
-            }
         }
 
     }

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -304,7 +304,7 @@ namespace Nikse.SubtitleEdit.Logic
             {
                 if (_helpKeys == Keys.None)
                     _helpKeys = GetKeys(Configuration.Settings.Shortcuts.GeneralHelp);
-                return _helpKeys;                 
+                return _helpKeys;
             }
             set { _helpKeys = value; }
         }
@@ -604,6 +604,61 @@ namespace Nikse.SubtitleEdit.Logic
         private static bool IsSpaceCategory(UnicodeCategory c)
         {
             return c == UnicodeCategory.SpaceSeparator || c == UnicodeCategory.Control || c == UnicodeCategory.LineSeparator || c == UnicodeCategory.ParagraphSeparator;
+        }
+
+        public static string GetOpenDialogFilter()
+        {
+            var sb = new StringBuilder();
+            sb.Append(Configuration.Settings.Language.General.SubtitleFiles + "|");
+            foreach (SubtitleFormat s in SubtitleFormat.AllSubtitleFormats)
+            {
+                AddExtension(sb, s.Extension);
+                foreach (string ext in s.AlternateExtensions)
+                    AddExtension(sb, ext);
+            }
+            AddExtension(sb, new Pac().Extension);
+            AddExtension(sb, new Cavena890().Extension);
+            AddExtension(sb, new Spt().Extension);
+            AddExtension(sb, new Wsb().Extension);
+            AddExtension(sb, new CheetahCaption().Extension);
+            AddExtension(sb, ".chk");
+            AddExtension(sb, new CaptionsInc().Extension);
+            AddExtension(sb, new Ultech130().Extension);
+            AddExtension(sb, new ELRStudioClosedCaption().Extension);
+            AddExtension(sb, ".uld"); // Ultech drop frame
+            AddExtension(sb, new SonicScenaristBitmaps().Extension);
+            AddExtension(sb, ".mks");
+            AddExtension(sb, ".mxf");
+            AddExtension(sb, ".sup");
+            AddExtension(sb, ".dost");
+            AddExtension(sb, new Ayato().Extension);
+            AddExtension(sb, new PacUnicode().Extension);
+
+            if (!string.IsNullOrEmpty(Configuration.Settings.General.OpenSubtitleExtraExtensions))
+            {
+                var extraExtensions = Configuration.Settings.General.OpenSubtitleExtraExtensions.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (string ext in extraExtensions)
+                {
+                    if (ext.StartsWith("*.", StringComparison.Ordinal) && !sb.ToString().Contains(ext, StringComparison.OrdinalIgnoreCase))
+                        AddExtension(sb, ext);
+                }
+            }
+            AddExtension(sb, ".son");
+
+            sb.Append('|');
+            sb.Append(Configuration.Settings.Language.General.AllFiles);
+            sb.Append("|*.*");
+            return sb.ToString();
+        }
+
+        private static void AddExtension(StringBuilder sb, string extension)
+        {
+            if (!sb.ToString().Contains("*" + extension + ";", StringComparison.OrdinalIgnoreCase))
+            {
+                sb.Append('*');
+                sb.Append(extension.TrimStart('*'));
+                sb.Append(';');
+            }
         }
 
     }


### PR DESCRIPTION
Calling GetOpenDialogFilters() is not efficient:

## Fixed:
- [x] New instance of StringBuilder every time this method is invoked.
- [x] New instance of subtitle format that aren't present in **SubtitleFormat.AllSubtitleFormats**;
- [x] Each one of these subtitle formats have their own non-static variables which will be initialized aswell.

``` c#
            AddExtension(sb, new Pac().Extension);
            AddExtension(sb, new Cavena890().Extension);
            AddExtension(sb, new Spt().Extension);
            AddExtension(sb, new Wsb().Extension);
            AddExtension(sb, new CheetahCaption().Extension);
            AddExtension(sb, ".chk");
            AddExtension(sb, new CaptionsInc().Extension);
            AddExtension(sb, new Ultech130().Extension);
            AddExtension(sb, new ELRStudioClosedCaption().Extension);
            AddExtension(sb, ".uld"); // Ultech drop frame
            AddExtension(sb, new SonicScenaristBitmaps().Extension);
            AddExtension(sb, ".mks");
            AddExtension(sb, ".mxf");
            AddExtension(sb, ".sup");
            AddExtension(sb, ".dost");
            AddExtension(sb, new Ayato().Extension);
            AddExtension(sb, new PacUnicode().Extension);
```