### PR TITLE
[SubtitleFormat] - Filter by extension when checking subs.

### DIFF
--- a/libse/SubtitleFormats/AQTitle.cs
+++ b/libse/SubtitleFormats/AQTitle.cs
@@ -31,6 +31,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > _errorCount;

--- a/libse/SubtitleFormats/AbcIViewer.cs
+++ b/libse/SubtitleFormats/AbcIViewer.cs
@@ -24,6 +24,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/AdobeAfterEffectsFTME.cs
+++ b/libse/SubtitleFormats/AdobeAfterEffectsFTME.cs
@@ -25,6 +25,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/AdobeEncore.cs
+++ b/libse/SubtitleFormats/AdobeEncore.cs
@@ -27,8 +27,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
-
             var sb = new StringBuilder();
             foreach (string line in lines)
                 sb.AppendLine(line);

--- a/libse/SubtitleFormats/AdobeEncoreLineTabNewLine.cs
+++ b/libse/SubtitleFormats/AdobeEncoreLineTabNewLine.cs
@@ -26,8 +26,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
-
             var sb = new StringBuilder();
             foreach (string line in lines)
                 sb.AppendLine(line);

--- a/libse/SubtitleFormats/AdobeEncoreLineTabs.cs
+++ b/libse/SubtitleFormats/AdobeEncoreLineTabs.cs
@@ -26,8 +26,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
-
             var sb = new StringBuilder();
             foreach (string line in lines)
                 sb.AppendLine(line);

--- a/libse/SubtitleFormats/AdobeEncoreTabs.cs
+++ b/libse/SubtitleFormats/AdobeEncoreTabs.cs
@@ -26,8 +26,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
-
             var sb = new StringBuilder();
             foreach (string line in lines)
                 sb.AppendLine(line);

--- a/libse/SubtitleFormats/AdobeEncoreWithLineNumbers.cs
+++ b/libse/SubtitleFormats/AdobeEncoreWithLineNumbers.cs
@@ -26,8 +26,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
-
             var sb = new StringBuilder();
             foreach (string line in lines)
                 sb.AppendLine(line);

--- a/libse/SubtitleFormats/AdobeEncoreWithLineNumbersNtsc.cs
+++ b/libse/SubtitleFormats/AdobeEncoreWithLineNumbersNtsc.cs
@@ -26,8 +26,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
-
             var sb = new StringBuilder();
             foreach (string line in lines)
                 sb.AppendLine(line);

--- a/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -67,8 +67,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
-
             var sb = new StringBuilder();
             lines.ForEach(line => sb.AppendLine(line));
             string all = sb.ToString();

--- a/libse/SubtitleFormats/AribB36.cs
+++ b/libse/SubtitleFormats/AribB36.cs
@@ -348,6 +348,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
             {
                 var fi = new FileInfo(fileName);

--- a/libse/SubtitleFormats/AvidCaption.cs
+++ b/libse/SubtitleFormats/AvidCaption.cs
@@ -26,6 +26,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > _errorCount;

--- a/libse/SubtitleFormats/AvidDvd.cs
+++ b/libse/SubtitleFormats/AvidDvd.cs
@@ -35,7 +35,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             if (fileName != null && fileName.EndsWith(".dost", StringComparison.OrdinalIgnoreCase))
                 return false;
-
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > _errorCount;

--- a/libse/SubtitleFormats/AvidStl.cs
+++ b/libse/SubtitleFormats/AvidStl.cs
@@ -121,7 +121,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (File.Exists(fileName))
             {
                 try
                 {

--- a/libse/SubtitleFormats/Ayato.cs
+++ b/libse/SubtitleFormats/Ayato.cs
@@ -24,7 +24,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (File.Exists(fileName))
             {
                 var fi = new FileInfo(fileName);
                 if (fi.Length >= 3000 && fi.Length < 1024000) // not too small or too big

--- a/libse/SubtitleFormats/BdnXml.cs
+++ b/libse/SubtitleFormats/BdnXml.cs
@@ -26,6 +26,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/BelleNuitSubtitler.cs
+++ b/libse/SubtitleFormats/BelleNuitSubtitler.cs
@@ -29,6 +29,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > _errorCount;

--- a/libse/SubtitleFormats/CapMakerPlus.cs
+++ b/libse/SubtitleFormats/CapMakerPlus.cs
@@ -144,7 +144,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (File.Exists(fileName))
             {
                 var fi = new FileInfo(fileName);
                 if (fi.Length >= 640 && fi.Length < 1024000) // not too small or too big

--- a/libse/SubtitleFormats/Cappella.cs
+++ b/libse/SubtitleFormats/Cappella.cs
@@ -24,6 +24,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/CaptionAssistant.cs
+++ b/libse/SubtitleFormats/CaptionAssistant.cs
@@ -24,6 +24,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/Captionate.cs
+++ b/libse/SubtitleFormats/Captionate.cs
@@ -27,6 +27,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/CaptionateMs.cs
+++ b/libse/SubtitleFormats/CaptionateMs.cs
@@ -25,6 +25,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/CaptionsInc.cs
+++ b/libse/SubtitleFormats/CaptionsInc.cs
@@ -101,7 +101,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (File.Exists(fileName))
             {
                 if (!fileName.EndsWith(".cin", StringComparison.OrdinalIgnoreCase))
                     return false;

--- a/libse/SubtitleFormats/CaraokeXml.cs
+++ b/libse/SubtitleFormats/CaraokeXml.cs
@@ -24,6 +24,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/Cavena890.cs
+++ b/libse/SubtitleFormats/Cavena890.cs
@@ -863,7 +863,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (File.Exists(fileName))
             {
                 var fi = new FileInfo(fileName);
                 if (fi.Length >= 640 && fi.Length < 1024000) // not too small or too big

--- a/libse/SubtitleFormats/CheetahCaption.cs
+++ b/libse/SubtitleFormats/CheetahCaption.cs
@@ -239,7 +239,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (File.Exists(fileName))
             {
                 var fi = new FileInfo(fileName);
                 if (fi.Length >= 200 && fi.Length < 1024000) // not too small or too big

--- a/libse/SubtitleFormats/PListCaption.cs
+++ b/libse/SubtitleFormats/PListCaption.cs
@@ -42,6 +42,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var sb = new StringBuilder();
             lines.ForEach(line => sb.AppendLine(line));
             string xmlAsString = sb.ToString().Trim();

--- a/libse/SubtitleFormats/PhoenixSubtitle.cs
+++ b/libse/SubtitleFormats/PhoenixSubtitle.cs
@@ -45,7 +45,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            if (fileName?.EndsWith(".pjs", StringComparison.OrdinalIgnoreCase) == false)
+            if (fileName?.EndsWith(Extension, StringComparison.OrdinalIgnoreCase) == false)
             {
                 return false;
             }

--- a/libse/SubtitleFormats/PinnacleImpression.cs
+++ b/libse/SubtitleFormats/PinnacleImpression.cs
@@ -26,6 +26,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             StringBuilder sb = new StringBuilder();
             foreach (string line in lines)

--- a/libse/SubtitleFormats/UnknownSubtitle27.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle27.cs
@@ -26,12 +26,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
-
             var sb = new StringBuilder();
             foreach (string line in lines)
                 sb.AppendLine(line);
-
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > _errorCount;
         }

--- a/libse/SubtitleFormats/UnknownSubtitle28.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle28.cs
@@ -25,6 +25,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;

--- a/libse/SubtitleFormats/UnknownSubtitle41.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle41.cs
@@ -26,6 +26,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
             Subtitle subtitle = new Subtitle();
             var oldFrameRate = Configuration.Settings.General.CurrentFrameRate;
             LoadSubtitle(subtitle, lines, fileName);

--- a/libse/SubtitleFormats/UnknownSubtitle67.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle67.cs
@@ -25,6 +25,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            if (fileName == null || !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+                return false;
+
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             return subtitle.Paragraphs.Count > 0;


### PR DESCRIPTION
Part 1

Will prevent loading xml/json/.txt/... using subtitle format which has nothing to do with them.
Let me know if it's okay to do this if not (FREE TO CLOSE).
Note: fileName param (required).