### PR TITLE
[SETextBox] - Use DateTime.UtcNow instead time-zoned one.

### DIFF
--- a/src/Controls/SETextBox.cs
+++ b/src/Controls/SETextBox.cs
@@ -101,7 +101,7 @@ namespace Nikse.SubtitleEdit.Controls
                 if (_dragFromThis)
                 {
                     _dragFromThis = false;
-                    long milliseconds = (DateTime.Now.Ticks - _dragStartTicks) / 10000;
+                    long milliseconds = (DateTime.UtcNow.Ticks - _dragStartTicks) / 10000;
                     if (milliseconds < 400)
                     {
                         SelectionLength = 0;
@@ -217,7 +217,7 @@ namespace Nikse.SubtitleEdit.Controls
             {
                 _dragText = SelectedText;
                 _dragStartFrom = SelectionStart;
-                _dragStartTicks = DateTime.Now.Ticks;
+                _dragStartTicks = DateTime.UtcNow.Ticks;
             }
             base.WndProc(ref m);
         }


### PR DESCRIPTION
Interanally **DataTime.Now.Ticks** will create instance of **DateTime.UtcNow** and try to figure out the Time-zone using **DateTime.UtcNow** which is futile in this scenario.