### PR TITLE
[HtmlUtil] - Fix toggle/Untoggle if uppercase.

### DIFF
--- a/libse/HtmlUtil.cs
+++ b/libse/HtmlUtil.cs
@@ -675,8 +675,9 @@ namespace Nikse.SubtitleEdit.Core
 
         public static string ToogleTag(string text, string tag)
         {
-            if (text.Contains("<" + tag + ">"))
+            if (text.LastIndexOf(tag + '>', StringComparison.OrdinalIgnoreCase) > 0)
             {
+                text = FixUpperTags(text);
                 text = text.Replace("<" + tag + ">", string.Empty);
                 text = text.Replace("</" + tag + ">", string.Empty);
             }


### PR DESCRIPTION
Fixes toggle/untoggle if uppercase while in listview
also fixies if tag contains only one tag (e.g: <i> or </i>)

_Note: I have also found this same behavior in textbox. (patch on its way)_
