### PR TITLE
Added MPV player support for mono

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ SubtitleEdit-*-setup.exe
 /src/SubtitleEdit.VC.opendb
 /src/SubtitleEdit.VC.VC.opendb
 /src/SubtitleEdit.VC.db
+/src/SubtitleEdit.userprefs

--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -668,7 +668,7 @@ namespace Nikse.SubtitleEdit.Core
             OpenSubtitleExtraExtensions = "*.mp4;*.m4v;*.mkv;*.ts"; // matroska/mp4/m4v files (can contain subtitles)
             ListViewColumnsRememberSize = true;
             VlcWaveTranscodeSettings = "acodec=s16l"; // "acodec=s16l,channels=1,ab=64,samplerate=8000";
-            MpvVideoOutput = "direct3d_shaders"; // mpv "vo" option
+            MpvVideoOutput = "vaapi"; // mpv "vo" option
             UseTimeFormatHHMMSSFF = false;
             ClearStatusBarAfterSeconds = 10;
             MoveVideo100Or500MsPlaySmallSample = false;

--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -668,7 +668,10 @@ namespace Nikse.SubtitleEdit.Core
             OpenSubtitleExtraExtensions = "*.mp4;*.m4v;*.mkv;*.ts"; // matroska/mp4/m4v files (can contain subtitles)
             ListViewColumnsRememberSize = true;
             VlcWaveTranscodeSettings = "acodec=s16l"; // "acodec=s16l,channels=1,ab=64,samplerate=8000";
-            MpvVideoOutput = "vaapi"; // mpv "vo" option
+            if(Configuration.IsRunningOnLinux())
+                MpvVideoOutput = "vaapi"; // mpv "vo" option
+            else
+                MpvVideoOutput = "direct3d_shaders";
             UseTimeFormatHHMMSSFF = false;
             ClearStatusBarAfterSeconds = 10;
             MoveVideo100Or500MsPlaySmallSample = false;

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -25,11 +25,15 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Nikse.SubtitleEdit.Core.SpellCheck;
+using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Forms
 {
+    
     public sealed partial class Main : Form
     {
+        [DllImport("libc.so.6")]
+        private static extern IntPtr setlocale(int category,string locale);
 
         private class ComboBoxZoomItem
         {
@@ -311,6 +315,9 @@ namespace Nikse.SubtitleEdit.Forms
 
         public Main()
         {
+            const int LC_NUMERIC = 1;
+            if(Configuration.IsRunningOnLinux())
+                setlocale(LC_NUMERIC, "C");
             try
             {
                 InitializeComponent();

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -32,9 +32,6 @@ namespace Nikse.SubtitleEdit.Forms
     
     public sealed partial class Main : Form
     {
-        [DllImport("libc.so.6")]
-        private static extern IntPtr setlocale(int category,string locale);
-
         private class ComboBoxZoomItem
         {
             public string Text { get; set; }
@@ -315,9 +312,8 @@ namespace Nikse.SubtitleEdit.Forms
 
         public Main()
         {
-            const int LC_NUMERIC = 1;
             if(Configuration.IsRunningOnLinux())
-                setlocale(LC_NUMERIC, "C");
+                NativeMethods.setlocale(NativeMethods.LC_NUMERIC, "C");
             try
             {
                 InitializeComponent();

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -2380,6 +2380,5 @@ namespace Nikse.SubtitleEdit.Forms
         {
             checkBoxSyntaxColorTextMoreThanTwoLines.Text = string.Format(Configuration.Settings.Language.Settings.SyntaxColorTextMoreThanMaxLines, numericUpDownMaxNumberOfLines.Value);
         }
-
     }
 }

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -2327,7 +2327,10 @@ namespace Nikse.SubtitleEdit.Forms
         private void RefreshMpvSettings()
         {
             radioButtonVideoPlayerMPV.Enabled = LibMpvDynamic.IsInstalled;
-            labelMpvSettings.Text = "--vo=" + Configuration.Settings.General.MpvVideoOutput;
+            if (!Configuration.IsRunningOnLinux())
+                labelMpvSettings.Text = "--vo=" + Configuration.Settings.General.MpvVideoOutput;
+            else
+                labelMpvSettings.Text = "--vo=vaapi";
         }
 
         private void linkLabelBingSubscribe_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -2327,10 +2327,10 @@ namespace Nikse.SubtitleEdit.Forms
         private void RefreshMpvSettings()
         {
             radioButtonVideoPlayerMPV.Enabled = LibMpvDynamic.IsInstalled;
-            if (!Configuration.IsRunningOnLinux())
-                labelMpvSettings.Text = "--vo=" + Configuration.Settings.General.MpvVideoOutput;
-            else
+            if (Configuration.IsRunningOnLinux() && (Configuration.Settings.General.MpvVideoOutput == "direct3d_shaders"))
                 labelMpvSettings.Text = "--vo=vaapi";
+            else
+                labelMpvSettings.Text = "--vo=" + Configuration.Settings.General.MpvVideoOutput;
         }
 
         private void linkLabelBingSubscribe_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/src/Forms/SettingsMpv.Designer.cs
+++ b/src/Forms/SettingsMpv.Designer.cs
@@ -119,8 +119,7 @@
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.comboBoxVideoOutput);
-            if (!Configuration.IsRunningOnLinux())
-                this.Controls.Add(this.buttonDownload);
+            this.Controls.Add(this.buttonDownload);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
             this.MaximizeBox = false;

--- a/src/Forms/SettingsMpv.Designer.cs
+++ b/src/Forms/SettingsMpv.Designer.cs
@@ -1,5 +1,7 @@
 ﻿namespace Nikse.SubtitleEdit.Forms
 {
+    using Nikse.SubtitleEdit.Core;
+
     sealed partial class SettingsMpv
     {
         /// <summary>
@@ -38,23 +40,37 @@
             // 
             // buttonDownload
             // 
-            this.buttonDownload.Location = new System.Drawing.Point(12, 24);
-            this.buttonDownload.Name = "buttonDownload";
-            this.buttonDownload.Size = new System.Drawing.Size(186, 23);
-            this.buttonDownload.TabIndex = 0;
-            this.buttonDownload.Text = "Download mpv dll";
-            this.buttonDownload.UseVisualStyleBackColor = true;
-            this.buttonDownload.Click += new System.EventHandler(this.buttonDownload_Click_1);
+            if (!Configuration.IsRunningOnLinux())
+            {
+                this.buttonDownload.Location = new System.Drawing.Point(12, 24);
+                this.buttonDownload.Name = "buttonDownload";
+                this.buttonDownload.Size = new System.Drawing.Size(186, 23);
+                this.buttonDownload.TabIndex = 0;
+                this.buttonDownload.Text = "Download mpv dll";
+                this.buttonDownload.UseVisualStyleBackColor = true;
+                this.buttonDownload.Click += new System.EventHandler(this.buttonDownload_Click_1);
+            }
             // 
             // comboBoxVideoOutput
             // 
             this.comboBoxVideoOutput.FormattingEnabled = true;
-            this.comboBoxVideoOutput.Items.AddRange(new object[] {
-            "direct3d_shaders",
-            "direct3d ",
-            "sdl",
-            "vaapi",
-            "vdpau"});
+            if (Configuration.IsRunningOnLinux())
+            {
+                this.comboBoxVideoOutput.Items.AddRange(new object[] {
+                "sdl",
+                "vaapi",
+                "vdpau"});
+            }
+            else
+            {
+                this.comboBoxVideoOutput.Items.AddRange(new object[] {
+                "direct3d_shaders",
+                "direct3d ",
+                "sdl",
+                "vaapi",
+                "vdpau"});
+            }
+            
             this.comboBoxVideoOutput.Location = new System.Drawing.Point(12, 109);
             this.comboBoxVideoOutput.Name = "comboBoxVideoOutput";
             this.comboBoxVideoOutput.Size = new System.Drawing.Size(186, 21);
@@ -113,7 +129,8 @@
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.comboBoxVideoOutput);
-            this.Controls.Add(this.buttonDownload);
+            if (!Configuration.IsRunningOnLinux())
+                this.Controls.Add(this.buttonDownload);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
             this.MaximizeBox = false;

--- a/src/Forms/SettingsMpv.Designer.cs
+++ b/src/Forms/SettingsMpv.Designer.cs
@@ -40,36 +40,26 @@
             // 
             // buttonDownload
             // 
-            if (!Configuration.IsRunningOnLinux())
-            {
-                this.buttonDownload.Location = new System.Drawing.Point(12, 24);
-                this.buttonDownload.Name = "buttonDownload";
-                this.buttonDownload.Size = new System.Drawing.Size(186, 23);
-                this.buttonDownload.TabIndex = 0;
-                this.buttonDownload.Text = "Download mpv dll";
-                this.buttonDownload.UseVisualStyleBackColor = true;
-                this.buttonDownload.Click += new System.EventHandler(this.buttonDownload_Click_1);
-            }
+           
+            this.buttonDownload.Location = new System.Drawing.Point(12, 24);
+            this.buttonDownload.Name = "buttonDownload";
+            this.buttonDownload.Size = new System.Drawing.Size(186, 23);
+            this.buttonDownload.TabIndex = 0;
+            this.buttonDownload.Text = "Download mpv dll";
+            this.buttonDownload.UseVisualStyleBackColor = true;
+            this.buttonDownload.Click += new System.EventHandler(this.buttonDownload_Click_1);
+            
+            
             // 
             // comboBoxVideoOutput
             // 
             this.comboBoxVideoOutput.FormattingEnabled = true;
-            if (Configuration.IsRunningOnLinux())
-            {
-                this.comboBoxVideoOutput.Items.AddRange(new object[] {
-                "sdl",
-                "vaapi",
-                "vdpau"});
-            }
-            else
-            {
-                this.comboBoxVideoOutput.Items.AddRange(new object[] {
-                "direct3d_shaders",
-                "direct3d ",
-                "sdl",
-                "vaapi",
-                "vdpau"});
-            }
+            this.comboBoxVideoOutput.Items.AddRange(new object[] {
+            "direct3d_shaders",
+            "direct3d ",
+            "sdl",
+            "vaapi",
+            "vdpau"});
             
             this.comboBoxVideoOutput.Location = new System.Drawing.Point(12, 109);
             this.comboBoxVideoOutput.Name = "comboBoxVideoOutput";

--- a/src/Forms/SettingsMpv.cs
+++ b/src/Forms/SettingsMpv.cs
@@ -31,6 +31,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 comboBoxVideoOutput.Items.Clear();
                 comboBoxVideoOutput.Items.AddRange(new object[] { "direct3d ", "sdl", "vaapi", "vdpau" });
+                Controls.Remove(this.buttonDownload);
             }
         }
 

--- a/src/Forms/SettingsMpv.cs
+++ b/src/Forms/SettingsMpv.cs
@@ -9,19 +9,29 @@ namespace Nikse.SubtitleEdit.Forms
 {
     public sealed partial class SettingsMpv : Form
     {
+
         public SettingsMpv()
         {
+           
+
             InitializeComponent();
             labelPleaseWait.Text = string.Empty;
-            if (!Configuration.IsRunningOnLinux())
-                comboBoxVideoOutput.Text = Configuration.Settings.General.MpvVideoOutput;
-            else
+            if (Configuration.IsRunningOnLinux() && (Configuration.Settings.General.MpvVideoOutput == "direct3d_shaders"))
                 comboBoxVideoOutput.Text = "vaapi";
+            
+            else
+                comboBoxVideoOutput.Text = Configuration.Settings.General.MpvVideoOutput;
             buttonCancel.Text = Configuration.Settings.Language.General.Cancel;
             buttonOK.Text = Configuration.Settings.Language.General.Ok;
             Text = Configuration.Settings.Language.SettingsMpv.Title;
             if (!Configuration.IsRunningOnLinux())
                 buttonDownload.Text = Configuration.Settings.Language.SettingsMpv.DownloadMpv;
+
+            if (Configuration.IsRunningOnLinux())
+            {
+                comboBoxVideoOutput.Items.Clear();
+                comboBoxVideoOutput.Items.AddRange(new object[] { "direct3d ", "sdl", "vaapi", "vdpau" });
+            }
         }
 
         private void wc_DownloadDataCompleted(object sender, DownloadDataCompletedEventArgs e)
@@ -33,6 +43,8 @@ namespace Nikse.SubtitleEdit.Forms
                 buttonOK.Enabled = true;
                 if (!Configuration.IsRunningOnLinux())
                     buttonDownload.Enabled = true;
+                else
+                    buttonDownload.Enabled = false;
                 Cursor = Cursors.Default;
                 return;
             }
@@ -60,6 +72,8 @@ namespace Nikse.SubtitleEdit.Forms
             buttonOK.Enabled = true;
             if (!Configuration.IsRunningOnLinux())
                 buttonDownload.Enabled = true;
+            else
+                buttonDownload.Enabled = false;
             MessageBox.Show(Configuration.Settings.Language.SettingsMpv.DownloadMpvOk);
         }
 
@@ -69,8 +83,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 labelPleaseWait.Text = Configuration.Settings.Language.General.PleaseWait;
                 buttonOK.Enabled = false;
-                if (!Configuration.IsRunningOnLinux())
-                    buttonDownload.Enabled = false;
+                buttonDownload.Enabled = false;
                 Refresh();
                 Cursor = Cursors.WaitCursor;
 
@@ -89,6 +102,8 @@ namespace Nikse.SubtitleEdit.Forms
                 buttonOK.Enabled = true;
                 if (!Configuration.IsRunningOnLinux())
                     buttonDownload.Enabled = true;
+                else
+                    buttonDownload.Enabled = false;
                 Cursor = Cursors.Default;
                 MessageBox.Show(exception.Message + Environment.NewLine + Environment.NewLine + exception.StackTrace);
             }

--- a/src/Forms/SettingsMpv.cs
+++ b/src/Forms/SettingsMpv.cs
@@ -13,11 +13,15 @@ namespace Nikse.SubtitleEdit.Forms
         {
             InitializeComponent();
             labelPleaseWait.Text = string.Empty;
-            comboBoxVideoOutput.Text = Configuration.Settings.General.MpvVideoOutput;
+            if (!Configuration.IsRunningOnLinux())
+                comboBoxVideoOutput.Text = Configuration.Settings.General.MpvVideoOutput;
+            else
+                comboBoxVideoOutput.Text = "vaapi";
             buttonCancel.Text = Configuration.Settings.Language.General.Cancel;
             buttonOK.Text = Configuration.Settings.Language.General.Ok;
             Text = Configuration.Settings.Language.SettingsMpv.Title;
-            buttonDownload.Text = Configuration.Settings.Language.SettingsMpv.DownloadMpv;
+            if (!Configuration.IsRunningOnLinux())
+                buttonDownload.Text = Configuration.Settings.Language.SettingsMpv.DownloadMpv;
         }
 
         private void wc_DownloadDataCompleted(object sender, DownloadDataCompletedEventArgs e)
@@ -27,7 +31,8 @@ namespace Nikse.SubtitleEdit.Forms
                 MessageBox.Show(Configuration.Settings.Language.SettingsMpv.DownloadMpvFailed);
                 labelPleaseWait.Text = string.Empty;
                 buttonOK.Enabled = true;
-                buttonDownload.Enabled = true;
+                if (!Configuration.IsRunningOnLinux())
+                    buttonDownload.Enabled = true;
                 Cursor = Cursors.Default;
                 return;
             }
@@ -53,7 +58,8 @@ namespace Nikse.SubtitleEdit.Forms
             Cursor = Cursors.Default;
             labelPleaseWait.Text = string.Empty;
             buttonOK.Enabled = true;
-            buttonDownload.Enabled = true;
+            if (!Configuration.IsRunningOnLinux())
+                buttonDownload.Enabled = true;
             MessageBox.Show(Configuration.Settings.Language.SettingsMpv.DownloadMpvOk);
         }
 
@@ -63,7 +69,8 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 labelPleaseWait.Text = Configuration.Settings.Language.General.PleaseWait;
                 buttonOK.Enabled = false;
-                buttonDownload.Enabled = false;
+                if (!Configuration.IsRunningOnLinux())
+                    buttonDownload.Enabled = false;
                 Refresh();
                 Cursor = Cursors.WaitCursor;
 
@@ -80,7 +87,8 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 labelPleaseWait.Text = string.Empty;
                 buttonOK.Enabled = true;
-                buttonDownload.Enabled = true;
+                if (!Configuration.IsRunningOnLinux())
+                    buttonDownload.Enabled = true;
                 Cursor = Cursors.Default;
                 MessageBox.Show(exception.Message + Environment.NewLine + Environment.NewLine + exception.StackTrace);
             }

--- a/src/Logic/NativeMethods.cs
+++ b/src/Logic/NativeMethods.cs
@@ -126,6 +126,67 @@ namespace Nikse.SubtitleEdit.Logic
 
         #endregion VLC
 
+        #region MPV
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr mpv_create();
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int mpv_initialize(IntPtr mpvHandle);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int mpv_command(IntPtr mpvHandle, IntPtr utf8Strings);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int mpv_terminate_destroy(IntPtr mpvHandle);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr mpv_wait_event(IntPtr mpvHandle, double wait);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int mpv_set_option(IntPtr mpvHandle, byte[] name, int format, ref long data);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int mpv_set_option_string(IntPtr mpvHandle, byte[] name, byte[] value);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr mpv_get_property_string(IntPtr mpvHandle, byte[] name);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int mpv_get_property(IntPtr mpvHandle, byte[] name, int format, ref double data);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int mpv_set_property(IntPtr mpvHandle, byte[] name, int format, ref byte[] data);
+
+
+        [DllImport("mpv", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int mpv_free(IntPtr data);
+
+        #endregion MPV
+
+        #region System
+
+        internal const int LC_NUMERIC = 1;
+
+        [DllImport("libc.so.6")]
+        internal static extern IntPtr setlocale(int category, string locale);
+
+        [DllImport("libdl.so")]
+        internal static extern IntPtr dlopen(string filename, int flags);
+
+        [DllImport("libdl.so")]
+        internal static extern IntPtr dlclose(IntPtr handle);
+
+        #endregion
     }
+
 
 }

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -174,7 +174,7 @@ namespace Nikse.SubtitleEdit.Logic
             GeneralSettings gs = Configuration.Settings.General;
 
             if (Configuration.IsRunningOnLinux())
-                return new MPlayer();
+				return new LibMpvMono();
 
             // Mono on OS X is 32 bit and thus requires 32 bit VLC. Place VLC in the same
             // folder as Subtitle Edit and add this to the app.config inside the

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -174,7 +174,7 @@ namespace Nikse.SubtitleEdit.Logic
             GeneralSettings gs = Configuration.Settings.General;
 
             if (Configuration.IsRunningOnLinux())
-				return new LibMpvMono();
+                return new LibMpvMono();
 
             // Mono on OS X is 32 bit and thus requires 32 bit VLC. Place VLC in the same
             // folder as Subtitle Edit and add this to the app.config inside the

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -17,12 +17,6 @@ namespace Nikse.SubtitleEdit.Logic
 {
     internal static class UiUtil
     {
-
-        [DllImport("libdl.so")]
-        static extern IntPtr dlopen(string filename, int flags);
-
-        [DllImport("libdl.so")]
-        static extern IntPtr dlclose(IntPtr handle);
         public static readonly Lazy<string> SubtitleExtensionFilter = new Lazy<string>(GetOpenDialogFilter);
 
         public static VideoInfo GetVideoInfo(string fileName)
@@ -185,10 +179,10 @@ namespace Nikse.SubtitleEdit.Logic
 
             if (Configuration.IsRunningOnLinux())
             {
-                handle = dlopen("libmpv.so", RTLD_NOW|RTLD_GLOBAL);
+                handle = NativeMethods.dlopen("libmpv.so", RTLD_NOW|RTLD_GLOBAL);
                 if (handle != IntPtr.Zero)
                 { 
-					dlclose(handle);
+                    NativeMethods.dlclose(handle);
                     return new LibMpvMono();
                 }
                 else

--- a/src/Logic/VideoPlayers/libMpvDynamic.cs
+++ b/src/Logic/VideoPlayers/libMpvDynamic.cs
@@ -378,7 +378,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
             {
                 _mpvInitialize.Invoke(_mpvHandle);
 
-                string videoOutput = "vaapi";
+                string videoOutput = "direct3d_shaders";
                 if (!string.IsNullOrWhiteSpace(Configuration.Settings.General.MpvVideoOutput))
                     videoOutput = Configuration.Settings.General.MpvVideoOutput;
                 _mpvSetOptionString(_mpvHandle, GetUtf8Bytes("vo"), GetUtf8Bytes(videoOutput)); // "direct3d_shaders" is default, "direct3d" could be used for compabality with old systems

--- a/src/SubtitleEdit.csproj
+++ b/src/SubtitleEdit.csproj
@@ -866,6 +866,7 @@
     <Compile Include="Logic\UiGetPacEncoding.cs" />
     <Compile Include="Logic\UiGetYouTubeAnnotationStyles.cs" />
     <Compile Include="Logic\UiUtil.cs" />
+    <Compile Include="Logic\VideoPlayers\LibMpvMono.cs" />
     <Compile Include="Logic\VideoPlayers\LibMpvDynamic.cs" />
     <Compile Include="Logic\VideoPlayers\LibVlcDynamic.cs" />
     <Compile Include="Logic\VideoPlayers\LibVlcMono.cs" />


### PR DESCRIPTION
If libmpv.so is found in the system then it will be used instead of MPlayer. 
MPV player works many times better then MPlayer fallback.
tested with: direct3d, sdi, vaapi, vdpau.