### PR TITLE
[Pac/Utilities] - Optimize checking for ascci letter/digit.

### DIFF
--- a/libse/CharUtils.cs
+++ b/libse/CharUtils.cs
@@ -11,5 +11,11 @@
         {
             return (ch >= '0') && (ch <= '9');
         }
+
+        public static bool IsAsciiLetterOrDigit(char ch)
+        {
+            return IsDigit(ch) || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
+        }
+
     }
 }

--- a/libse/SubtitleFormats/Pac.cs
+++ b/libse/SubtitleFormats/Pac.cs
@@ -905,9 +905,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             byte[] textBuffer;
 
             if (_codePage == CodePageArabic)
-                textBuffer = GetArabicBytes(Utilities.FixEnglishTextInRightToLeftLanguage(text, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), alignment);
+                textBuffer = GetArabicBytes(Utilities.FixEnglishTextInRightToLeftLanguage(text, ch => CharUtils.IsAsciiLetterOrDigit(ch)), alignment);
             else if (_codePage == CodePageHebrew)
-                textBuffer = GetHebrewBytes(Utilities.FixEnglishTextInRightToLeftLanguage(text, "0123456789abcdefghijklmnopqrstuvwxyz"), alignment);
+                textBuffer = GetHebrewBytes(Utilities.FixEnglishTextInRightToLeftLanguage(text, ch => CharUtils.IsDigit(ch) || (ch >= 'a' && ch <= 'z')), alignment);
             else if (_codePage == CodePageLatin)
                 textBuffer = GetLatinBytes(encoding, text, alignment);
             else if (_codePage == CodePageCyrillic)
@@ -1212,7 +1212,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             p.Text = p.Text.Replace("\0", string.Empty);
             p.Text = FixItalics(p.Text);
             if (_codePage == CodePageArabic)
-                p.Text = Utilities.FixEnglishTextInRightToLeftLanguage(p.Text, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+                p.Text = Utilities.FixEnglishTextInRightToLeftLanguage(p.Text, ch => CharUtils.IsAsciiLetterOrDigit(ch));
 
             if (verticalAlignment < 5)
             {

--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -1246,7 +1246,7 @@ namespace Nikse.SubtitleEdit.Core
             return new string(chars);
         }
 
-        public static string FixEnglishTextInRightToLeftLanguage(string text, string reverseChars)
+        public static string FixEnglishTextInRightToLeftLanguage(string text, Predicate<char> charChecker)
         {
             var sb = new StringBuilder();
             var lines = text.SplitToLines();
@@ -1265,7 +1265,7 @@ namespace Nikse.SubtitleEdit.Core
                 string numbers = string.Empty;
                 for (int i = 0; i < s.Length; i++)
                 {
-                    if (numbersOn && reverseChars.Contains(s[i]))
+                    if (numbersOn && charChecker(s[i]))
                     {
                         numbers = s[i] + numbers;
                     }
@@ -1275,7 +1275,7 @@ namespace Nikse.SubtitleEdit.Core
                         s = s.Remove(i - numbers.Length, numbers.Length).Insert(i - numbers.Length, numbers);
                         numbers = string.Empty;
                     }
-                    else if (reverseChars.Contains(s[i]))
+                    else if (charChecker(s[i]))
                     {
                         numbers = s[i] + numbers;
                         numbersOn = true;

--- a/src/Forms/PacEncoding.cs
+++ b/src/Forms/PacEncoding.cs
@@ -10,7 +10,6 @@ namespace Nikse.SubtitleEdit.Forms
 
     public sealed partial class PacEncoding : Form
     {
-        private const string PreviewChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
         public int CodePageIndex { get; set; }
 
         private readonly byte[] _previewBuffer;
@@ -74,7 +73,7 @@ namespace Nikse.SubtitleEdit.Forms
                         index++;
                     }
                     if (CodePageIndex == Pac.CodePageArabic)
-                        textBoxPreview.Text = Utilities.FixEnglishTextInRightToLeftLanguage(sb.ToString(), PreviewChars);
+                        textBoxPreview.Text = Utilities.FixEnglishTextInRightToLeftLanguage(sb.ToString(), ch => CharUtils.IsAsciiLetterOrDigit(ch));
                     else
                         textBoxPreview.Text = sb.ToString();
                 }


### PR DESCRIPTION
Reduced operation ~**2n+10** to **~2** where **n** is the length of English alphabet