### PR TITLE
[RemoveHi] - Only renumber if paragraphs were removed.

### DIFF
--- a/src/Forms/RemoveTextFromHearImpaired.cs
+++ b/src/Forms/RemoveTextFromHearImpaired.cs
@@ -15,7 +15,6 @@ namespace Nikse.SubtitleEdit.Forms
         private readonly LanguageStructure.RemoveTextFromHearImpaired _language;
         private readonly RemoveTextForHI _removeTextForHiLib;
         private Dictionary<Paragraph, string> _fixes;
-        private int _removeCount;
         private readonly Main _mainForm;
         private readonly List<Paragraph> _unchecked = new List<Paragraph>();
 
@@ -149,8 +148,11 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (Subtitle != null)
             {
-                RemoveTextFromHearImpaired();
-                Subtitle.Renumber();
+                int count = Subtitle.Paragraphs.Count;
+                if (RemoveTextFromHearImpaired() > 0 && count < Subtitle.Paragraphs.Count)
+                {
+                    Subtitle.Renumber();
+                }
                 if (_mainForm != null)
                 {
                     _mainForm.ReloadFromSubtitle(Subtitle);
@@ -162,6 +164,7 @@ namespace Nikse.SubtitleEdit.Forms
         public int RemoveTextFromHearImpaired()
         {
             _unchecked.Clear();
+            int removeCount = 0;
             for (int i = listViewFixes.Items.Count - 1; i >= 0; i--)
             {
                 var item = listViewFixes.Items[i];
@@ -177,14 +180,14 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         p.Text = newText;
                     }
-                    _removeCount++;
+                    removeCount++;
                 }
                 else
                 {
                     _unchecked.Add(p);
                 }
             }
-            return _removeCount;
+            return removeCount;
         }
 
         private void CheckBoxRemoveTextBetweenCheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
This patch will prevent Remove-HI from renumbering subtitle when OK is clicked even when no HI is present in text. /cc @niksedk 

To produce:
Renumber subtitle with any number >=2 (make sure subtitle does not contain any HI tags/notation)
Open Remove-HI and click OK. Subtitle will be renumbered.