### PR TITLE
[TimeCode] - Fix bug when converting to HHMMSSFF.

### DIFF
--- a/libse/TimeCode.cs
+++ b/libse/TimeCode.cs
@@ -212,14 +212,15 @@ namespace Nikse.SubtitleEdit.Core
 
         public string ToShortStringHHMMSSFF()
         {
+            // Expected return format: 00:00:00:00
             string s = ToHHMMSSFF();
             int j = 0;
-            if (s.StartsWith("0:00:", StringComparison.Ordinal))
-                j = 5;
-            if (s.StartsWith("00:", StringComparison.Ordinal))
+            int len = s.Length;
+            // Keep jumping 00: if any in 's'.
+            while (j + 2 < len && s[j] == '0' && s[j + 1] == '0' && s[j + 2] == ':')
+            {
                 j += 3;
-            if (s.StartsWith("00:", StringComparison.Ordinal))
-                j += 3;
+            }
             return j > 0 ? s.Substring(j) : s;
         }
 


### PR DESCRIPTION
This patch contains two fixes for TimeCode.cs
1. In commit => https://github.com/SubtitleEdit/subtitleedit/commit/eb508249b625a3e1da50c9c3fe611a489726bb54#diff-94d56fd78956a1f792beafd07344beb4 variable **s** was never changed/removed after checking if it starts with "0:00" and "00:" we were just incrementing **j**

2. We call `string s = ToHHMMSSFF();` to give of the formatted time-code in https://github.com/SubtitleEdit/subtitleedit/commit/eb508249b625a3e1da50c9c3fe611a489726bb54#diff-94d56fd78956a1f792beafd07344beb4R217 we checked if s start with "0:00", that check will always return false because even if _totalMilliseconds is 0 `ToHHMMSSFF()` will always two zeros ("00") at beginning.

Here is an example how string is formatted with 0 and #.
`${0:00} => 00`
`${0:#0} => 0`
`${0:##} => ""`