### PR TITLE
[timecode] - remove irrelevant method in TimeCode.cs

### DIFF
--- a/libse/TimeCode.cs
+++ b/libse/TimeCode.cs
@@ -172,11 +172,6 @@ namespace Nikse.SubtitleEdit.Core
             _totalMilliseconds += timeSpan.TotalMilliseconds;
         }
 
-        public void AddTime(double milliseconds)
-        {
-            _totalMilliseconds += milliseconds;
-        }
-
         public override string ToString()
         {
             return ToString(false);

--- a/src/Test/Logic/TimeCodeTest.cs
+++ b/src/Test/Logic/TimeCodeTest.cs
@@ -62,15 +62,6 @@ namespace Test.Logic
         }
 
         [TestMethod]
-        public void TimeCodeAddTime7()
-        {
-            var tc = new TimeCode(1000);
-            tc.AddTime(1000.0);
-
-            Assert.AreEqual(tc.TotalMilliseconds, 2000);
-        }
-
-        [TestMethod]
         public void TimeCodeDaysTest()
         {
             var tc = new TimeCode(24 * 3, 0, 0, 0)


### PR DESCRIPTION
this can be achieved with TimeCode.TotalMilliseconds