### PR TITLE
Improved Arabic language handling in PAC files

### DIFF
--- a/libse/SubtitleFormats/Pac.cs
+++ b/libse/SubtitleFormats/Pac.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
@@ -42,763 +43,387 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         /// <summary>
         /// Contains Swedish, Danish, German, Spanish, and French letters
         /// </summary>
-        private static readonly List<int> LatinCodes = new List<int> {
-            0xe041, // Ã
-            0xe04e, // Ñ
-            0xe04f, // Õ
-            0xe061, // ã
-            0xe06e, // ñ
-            0xe06f, // õ
-            0xe161, // å
-            0xe141, // Å
+        private static readonly Dictionary<int, SpecialCharacter> LatinCodes = new Dictionary<int, SpecialCharacter> {
+            { 0xe041, new SpecialCharacter("Ã")},
+            { 0xe04e, new SpecialCharacter("Ñ")},
+            { 0xe04f, new SpecialCharacter("Õ")},
+            { 0xe061, new SpecialCharacter("ã")},
+            { 0xe06e, new SpecialCharacter("ñ")},
+            { 0xe06f, new SpecialCharacter("õ")},
+            { 0xe161, new SpecialCharacter("å")},
+            { 0xe141, new SpecialCharacter("Å")},
 
-            0x618a, // ā
-            0x418a, // Ā
-            0x458a, // Ē
-            0x658a, // ē
-            0x498a, // Ī
-            0x698a, // ī
-            0x4f8a, // Ō
-            0x6f8a, // ō
-            0x558a, // Ū
-            0x758a, // ū
+            { 0x618a, new SpecialCharacter("ā")},
+            { 0x418a, new SpecialCharacter("Ā")},
+            { 0x458a, new SpecialCharacter("Ē")},
+            { 0x658a, new SpecialCharacter("ē")},
+            { 0x498a, new SpecialCharacter("Ī")},
+            { 0x698a, new SpecialCharacter("ī")},
+            { 0x4f8a, new SpecialCharacter("Ō")},
+            { 0x6f8a, new SpecialCharacter("ō")},
+            { 0x558a, new SpecialCharacter("Ū")},
+            { 0x758a, new SpecialCharacter("ū")},
 
-            0x23, // £
-            0x7c, // æ
-            0x7d, // ø
-            0x7e, // §
-            0x80, // #
-            0x5c, // Æ
-            0x5d, // Ø
-            0x5e, // ÷
-            0x2d, // -
-            0x5f, // –
-            0xE54f, // Ö
-            0xE56f, // ö
-            0xe541, // Ä
-            0xe561, // ä
-            0xe555, // Ü
-            0xe575, // ü
-            0x81,   // ß
-            0x82,   // ²
-            0xe241, // Á
-            0xe249, // Í
-            0xe255, // Ú
-            0xe259, // Ý
-            0xe261, // á
-            0xe265, // é
-            0xe269, // í
-            0xe245, // É
-            0xe275, // ú
-            0xe279, // ý
-            0xe361, // à
-            0xe365, // è
-            0xe36f, // ò
-            0xe345, // È
-            0xe349, // Ì
-            0xe34f, // Ò
-            0xe369, // ì
-            0xe443, // Ĉ
-            0xe447, // Ĝ
-            0xe448, // Ĥ
-            0xe44A, // Ĵ
-            0xe453, // Ŝ
-            0xeA55, // Ŭ
-            0xe463, // ĉ
-            0xe467, // ĝ
-            0xe468, // ĥ
-            0xe46A, // ĵ
-            0xe473, // ŝ
-            0xeA75, // ŭ
-            0xe341, // À
-            0xe361, // à
-            0xe441, // Â
-            0xe461, // â
-            0xe643, // Ç
-            0xe663, // ç
-            0xe445, // Ê
-            0xe465, // ê
-            0xe545, // Ë
-            0xe565, // ë
-            0xe56f, // ö
-            0xe449, // Î
-            0xe469, // î
-            0xe549, // Ï
-            0xe569, // ï
-            0xe44F, // Ô
-            0xe46F, // ô
-            0xe355, // Ù
-            0xe375, // ù
-            0xe455, // Û
-            0xe475, // û
-            0xe559, // Ÿ
-            0xe579, // ÿ
-            0xeb41, // Ą
-            0xeb61, // ą
-            0xe243, // Ć
-            0xe263, // ć
-            0xeB45, // Ę
-            0xeB65, // ę
-            0x9c,   // Ł
-            0xbc,   // ł
-            0xe24e, // Ń
-            0xe26e, // ń
-            0xe24f, // Ó
-            0xe26f, // ó
-            0xe253, // Ś
-            0xe273, // ś
-            0xe25a, // Ź
-            0xe27a, // ź
-            0xe85a, // Ż
-            0xe87a, // ż
-            135, // þ
-            137, // ð
-            136, // Þ
-            140, // Ð
+            { 0x23, new SpecialCharacter("£")},
+            { 0x7c, new SpecialCharacter("æ")},
+            { 0x7d, new SpecialCharacter("ø")},
+            { 0x7e, new SpecialCharacter("§")},
+            { 0x80, new SpecialCharacter("#")},
+            { 0x5c, new SpecialCharacter("Æ")},
+            { 0x5d, new SpecialCharacter("Ø")},
+            { 0x5e, new SpecialCharacter("÷")},
+            { 0x2d, new SpecialCharacter("-")},
+            { 0x5f, new SpecialCharacter("–")},
+            { 0xE54f, new SpecialCharacter("Ö")},
+            { 0xE56f, new SpecialCharacter("ö")},
+            { 0xe541, new SpecialCharacter("Ä")},
+            { 0xe561, new SpecialCharacter("ä")},
+            { 0xe555, new SpecialCharacter("Ü")},
+            { 0xe575, new SpecialCharacter("ü")},
+            { 0x81,   new SpecialCharacter("ß")},
+            { 0x82,   new SpecialCharacter("²")},
+            { 0xe241, new SpecialCharacter("Á")},
+            { 0xe249, new SpecialCharacter("Í")},
+            { 0xe255, new SpecialCharacter("Ú")},
+            { 0xe259, new SpecialCharacter("Ý")},
+            { 0xe261, new SpecialCharacter("á")},
+            { 0xe265, new SpecialCharacter("é")},
+            { 0xe269, new SpecialCharacter("í")},
+            { 0xe245, new SpecialCharacter("É")},
+            { 0xe275, new SpecialCharacter("ú")}, // or "ѓ" !?
+            { 0xe279, new SpecialCharacter("ý")},
+            { 0xe361, new SpecialCharacter("à")},
+            { 0xe365, new SpecialCharacter("è")},
+            { 0xe36f, new SpecialCharacter("ò")},
+            { 0xe345, new SpecialCharacter("È")},
+            { 0xe349, new SpecialCharacter("Ì")},
+            { 0xe34f, new SpecialCharacter("Ò")},
+            { 0xe369, new SpecialCharacter("ì")},
+            { 0xe443, new SpecialCharacter("Ĉ")},
+            { 0xe447, new SpecialCharacter("Ĝ")},
+            { 0xe448, new SpecialCharacter("Ĥ")},
+            { 0xe44A, new SpecialCharacter("Ĵ")},
+            { 0xe453, new SpecialCharacter("Ŝ")},
+            { 0xeA55, new SpecialCharacter("Ŭ")},
+            { 0xe463, new SpecialCharacter("ĉ")},
+            { 0xe467, new SpecialCharacter("ĝ")},
+            { 0xe468, new SpecialCharacter("ĥ")},
+            { 0xe46A, new SpecialCharacter("ĵ")},
+            { 0xe473, new SpecialCharacter("ŝ")},
+            { 0xeA75, new SpecialCharacter("ŭ")},
+            { 0xe341, new SpecialCharacter("À")},
+            { 0xe441, new SpecialCharacter("Â")},
+            { 0xe461, new SpecialCharacter("â")},
+            { 0xe643, new SpecialCharacter("Ç")},
+            { 0xe663, new SpecialCharacter("ç")},
+            { 0xe445, new SpecialCharacter("Ê")},
+            { 0xe465, new SpecialCharacter("ê")},
+            { 0xe545, new SpecialCharacter("Ë")},
+            { 0xe565, new SpecialCharacter("ë")},
+            { 0xe449, new SpecialCharacter("Î")},
+            { 0xe469, new SpecialCharacter("î")},
+            { 0xe549, new SpecialCharacter("Ï")},
+            { 0xe569, new SpecialCharacter("ï")},
+            { 0xe44F, new SpecialCharacter("Ô")},
+            { 0xe46F, new SpecialCharacter("ô")},
+            { 0xe355, new SpecialCharacter("Ù")},
+            { 0xe375, new SpecialCharacter("ù")},
+            { 0xe455, new SpecialCharacter("Û")},
+            { 0xe475, new SpecialCharacter("û")},
+            { 0xe559, new SpecialCharacter("Ÿ")},
+            { 0xe579, new SpecialCharacter("ÿ")},
+            { 0xeb41, new SpecialCharacter("Ą")},
+            { 0xeb61, new SpecialCharacter("ą")},
+            { 0xe243, new SpecialCharacter("Ć")},
+            { 0xe263, new SpecialCharacter("ć")},
+            { 0xeB45, new SpecialCharacter("Ę")},
+            { 0xeB65, new SpecialCharacter("ę")},
+            { 0x9c,   new SpecialCharacter("Ł")},
+            { 0xbc,   new SpecialCharacter("ł")},
+            { 0xe24e, new SpecialCharacter("Ń")},
+            { 0xe26e, new SpecialCharacter("ń")},
+            { 0xe24f, new SpecialCharacter("Ó")},
+            { 0xe26f, new SpecialCharacter("ó")},
+            { 0xe253, new SpecialCharacter("Ś")},
+            { 0xe273, new SpecialCharacter("ś")},
+            { 0xe25a, new SpecialCharacter("Ź")},
+            { 0xe27a, new SpecialCharacter("ź")},
+            { 0xe85a, new SpecialCharacter("Ż")},
+            { 0xe87a, new SpecialCharacter("ż")},
+            { 0x87, new SpecialCharacter("þ")},
+            { 0x89, new SpecialCharacter("ð")},
+            { 0x88, new SpecialCharacter("Þ")},
+            { 0x8c, new SpecialCharacter("Ð")},
 
-            0xe653, // Ş
-            0xe673, // ş
-            0xe663, // ç
-            0x7b,   // ı
-            0xe56f, // ö
-            0xe575, // ü
-            0xeA67, // ğ
-            0xeA47, // Ğ
-            0xe849, // İ
+            { 0xe653, new SpecialCharacter("Ş")},
+            { 0xe673, new SpecialCharacter("ş")},
+            { 0x7b,   new SpecialCharacter("ı")},
+            { 0xeA67, new SpecialCharacter("ğ")},
+            { 0xeA47, new SpecialCharacter("Ğ")},
+            { 0xe849, new SpecialCharacter("İ")},
 
-            0xE75A, // Ž
-            0xE753, // Š
-            0xE743, // Č
-            0x8C, // Đ
+            { 0xE75A, new SpecialCharacter("Ž")},
+            { 0xE753, new SpecialCharacter("Š")},
+            { 0xE743, new SpecialCharacter("Č")},
 
-            0xE77A, // ž
-            0xE773, // š
-            0xE763, // č
-            0xAE, // đ
+            { 0xE77A, new SpecialCharacter("ž")},
+            { 0xE773, new SpecialCharacter("š")},
+            { 0xE763, new SpecialCharacter("č")},
+            { 0xAE, new SpecialCharacter("đ")},
 
-            0xA8,  // ¿
-            0xAD,  // ¡
-            0xA6,  // ª
-            0xA7,  // º
+            { 0xA8,  new SpecialCharacter("¿")},
+            { 0xAD,  new SpecialCharacter("¡")},
+            { 0xA6,  new SpecialCharacter("ª")},
+            { 0xA7,  new SpecialCharacter("º")},
 
-            0xAB, // "«"
-            0xBB, // "»"
-            0xB3, // "³"
-            0x1C, // "“"
-            0x1D, // "”"
-            0x18, // "‘"
-            0x19, // "’"
-            0x13, // "–"
-            0x14, // "—"
+            { 0xAB, new SpecialCharacter("«")},
+            { 0xBB, new SpecialCharacter("»")},
+            { 0xB3, new SpecialCharacter("³")},
+            { 0x1C, new SpecialCharacter("“")},
+            { 0x1D, new SpecialCharacter("”")},
+            { 0x18, new SpecialCharacter("‘")},
+            { 0x19, new SpecialCharacter("’")},
+            { 0x13, new SpecialCharacter("–")},
+            { 0x14, new SpecialCharacter("—")}
         };
 
-        private static readonly List<string> LatinLetters = new List<string> {
-            "Ã",
-            "Ñ",
-            "Õ",
-            "ã",
-            "ñ",
-            "õ",
-            "å",
-            "Å",
-
-            "ā",
-            "Ā",
-            "Ē",
-            "ē",
-            "Ī",
-            "ī",
-            "Ō",
-            "ō",
-            "Ū",
-            "ū",
-
-            "£",
-            "æ",
-            "ø",
-            "§",
-            "#",
-            "Æ",
-            "Ø",
-            "÷",
-            "-",
-            "–",
-            "Ö",
-            "ö",
-            "Ä",
-            "ä",
-            "Ü",
-            "ü",
-            "ß",
-            "²",
-            "Á",
-            "Í",
-            "Ú",
-            "Ý",
-            "á",
-            "é",
-            "í",
-            "É",
-            "ú",
-            "ý",
-            "à",
-            "è",
-            "ò",
-            "È",
-            "Ì",
-            "Ò",
-            "ì",
-            "Ĉ",
-            "Ĝ",
-            "Ĥ",
-            "Ĵ",
-            "Ŝ",
-            "Ŭ",
-            "ĉ",
-            "ĝ",
-            "ĥ",
-            "ĵ",
-            "ŝ",
-            "ŭ",
-            "À",
-            "à",
-            "Â",
-            "â",
-            "Ç",
-            "ç",
-            "Ê",
-            "ê",
-            "Ë",
-            "ë",
-            "ö",
-            "Î",
-            "î",
-            "Ï",
-            "ï",
-            "Ô",
-            "ô",
-            "Ù",
-            "ù",
-            "Û",
-            "û",
-            "Ÿ",
-            "ÿ",
-            "Ą",
-            "ą",
-            "Ć",
-            "ć",
-            "Ę",
-            "ę",
-            "Ł",
-            "ł",
-            "Ń",
-            "ń",
-            "Ó",
-            "ó",
-            "Ś",
-            "ś",
-            "Ź",
-            "ź",
-            "Ż",
-            "ż",
-            "þ",
-            "ð",
-            "Þ",
-            "Ð",
-
-            "Ş", // 0xe653
-            "ş", // 0xe673
-            "ç", // 0xe663
-            "ı", // 0x7b
-            "ö", // 0xe56f
-            "ü",
-            "ğ",
-            "Ğ",
-            "İ",
-
-            "Ž", // 0xE75A
-            "Š", // 0xE753
-            "Č", // 0xE743
-            "Đ", // 0xE744
-            "ž", // 0xE77A
-            "š", // 0xE773
-            "č", // 0xE763
-            "đ", // 0xE764
-
-            "¿", // 0xA8
-            "¡", // 0xAD
-            "ª", // 0xA6
-            "º", // 0xA7
-
-            "«", // 0xAB
-            "»", // 0xBB
-            "³", // 0xB3
-            "“", // 0x1C
-            "”", // 0x1D
-            "‘", // 0x18
-            "’", // 0x19
-            "–", // 0x13
-            "—", // 0x14
-        };
-
-        private static readonly List<int> HebrewCodes = new List<int>
+        private static readonly Dictionary<int, SpecialCharacter> HebrewCodes = new Dictionary<int, SpecialCharacter>
         {
-            0xa0, // א
-            0xa1, // ב
-            0xa2, // ג
-            0xa3, // ד
-            0xa4, // ה
-            0xa5, // ו
-            0xa6, // ז
-            0xa7, // ח
-            0xa8, // ט
-            0xa9, // י
-            0xaa, // ך
-            0xab, // כ
-            0xac, // ל
-            0xad, // ם
-            0xae, // מ
-            0xaf, // ן
-            0xb0, // נ
-            0xb1, // ס
-            0xb2, // ע
-            0xb3, // ף
-            0xb4, // פ
-            0xb5, // ץ
-            0xb6, // צ
-            0xb7, // ק
-            0xb8, // ר
-            0xb9, // ש
-            0xba, // ת
-            44, // ،
+            { 0xa0, new SpecialCharacter("א")},
+            { 0xa1, new SpecialCharacter("ב")},
+            { 0xa2, new SpecialCharacter("ג")},
+            { 0xa3, new SpecialCharacter("ד")},
+            { 0xa4, new SpecialCharacter("ה")},
+            { 0xa5, new SpecialCharacter("ו")},
+            { 0xa6, new SpecialCharacter("ז")},
+            { 0xa7, new SpecialCharacter("ח")},
+            { 0xa8, new SpecialCharacter("ט")},
+            { 0xa9, new SpecialCharacter("י")},
+            { 0xaa, new SpecialCharacter("ך")},
+            { 0xab, new SpecialCharacter("כ")},
+            { 0xac, new SpecialCharacter("ל")},
+            { 0xad, new SpecialCharacter("ם")},
+            { 0xae, new SpecialCharacter("מ")},
+            { 0xaf, new SpecialCharacter("ן")},
+            { 0xb0, new SpecialCharacter("נ")},
+            { 0xb1, new SpecialCharacter("ס")},
+            { 0xb2, new SpecialCharacter("ע")},
+            { 0xb3, new SpecialCharacter("ף")},
+            { 0xb4, new SpecialCharacter("פ")},
+            { 0xb5, new SpecialCharacter("ץ")},
+            { 0xb6, new SpecialCharacter("צ")},
+            { 0xb7, new SpecialCharacter("ק")},
+            { 0xb8, new SpecialCharacter("ר")},
+            { 0xb9, new SpecialCharacter("ש")},
+            { 0xba, new SpecialCharacter("ת")},
+            { 0x2c, new SpecialCharacter("،")}
+        };
+        
+        private static readonly Dictionary<int, SpecialCharacter> ArabicCodes = new Dictionary<int, SpecialCharacter> {
+            { 0xe081, new SpecialCharacter("أ")},
+            { 0xe09b, new SpecialCharacter("ؤ")},
+            { 0xe09c, new SpecialCharacter("ئ")},
+            { 0xe09f, new SpecialCharacter("ي")},
+            { 0xe181, new SpecialCharacter("إ")},
+            { 0xe281, new SpecialCharacter("آ")},
+            { 0xe781, new SpecialCharacter("اً")},
+            { 0x80, new SpecialCharacter("ـ")},
+            { 0x81, new SpecialCharacter("ا")},
+            { 0x82, new SpecialCharacter("ب")},
+            { 0x83, new SpecialCharacter("ت")},
+            { 0x84, new SpecialCharacter("ث")},
+            { 0x85, new SpecialCharacter("ج")},
+            { 0x86, new SpecialCharacter("ح")},
+            { 0x87, new SpecialCharacter("خ")},
+            { 0x88, new SpecialCharacter("د")},
+            { 0x89, new SpecialCharacter("ذ")},
+            { 0x8A, new SpecialCharacter("ر")},
+            { 0x8b, new SpecialCharacter("ز")},
+            { 0x8c, new SpecialCharacter("س")},
+            { 0x8d, new SpecialCharacter("ش")},
+            { 0x8e, new SpecialCharacter("ص")},
+            { 0x8f, new SpecialCharacter("ض")},
+            { 0x90, new SpecialCharacter("ظ")},
+            { 0x91, new SpecialCharacter("ط")},
+            { 0x92, new SpecialCharacter("ع")},
+            { 0x93, new SpecialCharacter("غ")},
+            { 0x94, new SpecialCharacter("ف")},
+            { 0x95, new SpecialCharacter("ق")},
+            { 0x96, new SpecialCharacter("ك")},
+            { 0x97, new SpecialCharacter("ل")},
+            { 0x98, new SpecialCharacter("م")},
+            { 0x99, new SpecialCharacter("ن")},
+            { 0x9A, new SpecialCharacter("ه")},
+            { 0x9b, new SpecialCharacter("و")},
+            { 0x9c, new SpecialCharacter("ى")},
+            { 0x9d, new SpecialCharacter("ة")},
+            { 0x9f, new SpecialCharacter("ي")},
+            { 0xa0, new SpecialCharacter("ء")},
+
+            { 231, new SpecialCharacter("\u064B", true)},
+            { 232, new SpecialCharacter("\u064D", true)},
+            { 229, new SpecialCharacter("\u064E", true)},
+            { 228, new SpecialCharacter("\u064F", true)},
+            { 230, new SpecialCharacter("\u0650", true)},
+            { 227, new SpecialCharacter("\u0651", true)},
+            { 226, new SpecialCharacter("\u0653", true)},
+            { 224, new SpecialCharacter("\u0654", true)},
+            { 225, new SpecialCharacter("\u0655", true)}
         };
 
-        private static readonly List<string> HebrewLetters = new List<string>
-        {
-            "א", // 0xa0
-            "ב", // 0xa1
-            "ג", // 0xa2
-            "ד", // 0xa3
-            "ה", // 0xa4
-            "ו", // 0xa5
-            "ז", // 0xa6
-            "ח", // 0xa7
-            "ט", // 0xa8
-            "י", // 0xa9
-            "ך", // 0xaa
-            "כ", // 0xab
-            "ל", // 0xac
-            "ם", // 0xad
-            "מ", // 0xae
-            "ן", // 0xaf
-            "נ", // 0xb0
-            "ס", // 0xb1
-            "ע", // 0xb2
-            "ף", // 0xb3
-            "פ", // 0xb4
-            "ץ", // 0xb5
-            "צ", // 0xb6
-            "ק", // 0xb7
-            "ר", // 0xb8
-            "ש", // 0xb9
-            "ת", // 0xba
-            "،", // 44
-        };
-
-        private static readonly List<int> ArabicCodes = new List<int> {
-            0xe081, //=أ
-            0xe09b, //=ؤ
-            0xe09c, //=ئ
-            0xe09f, //=ي
-            0xe181, //=إ
-            0xe281, //=آ
-            0xe781, //=اً
-            0x80,
-            0x81, //=ا
-            0x82, //=ب
-            0x83, //=ت
-            0x84, //=ث
-            0x85, //=ج
-            0x86, //=ح
-            0x87, //=خ
-            0x88, //=د
-            0x89, //=ذ
-            0x8A, //=ر
-            0x8b, //=ز
-            0x8c, //=س
-            0x8d, //=ش
-            0x8e, //=ص
-            0x8f, //=ض
-            0x90, //=ظ
-            0x91, //=ط
-            0x92, //=ع
-            0x93, //=غ
-            0x94, //=ف
-            0x95, //=ق
-            0x96, //=ك
-            0x97, //=ل
-            0x98, //=م
-            0x99, //=ن
-            0x9A, //=ه
-            0x9b, //=و
-            0x9c, //=ى
-            0x9d, //=ة
-            0x9f, //=ي
-            0xa0, //=ء
-        };
-
-        private static readonly List<string> ArabicLetters = new List<string> {
-            "أ",
-            "ؤ",
-            "ئ",
-            "ي", // 0xe09f
-            "إ",
-            "آ",
-            "اً",
-            "ـ",
-            "ا",
-            "ب",
-            "ت",
-            "ث",
-            "ج",
-            "ح",
-            "خ",
-            "د",
-            "ذ",
-            "ر",
-            "ز",
-            "س",
-            "ش",
-            "ص",
-            "ض",
-            "ظ",
-            "ط",
-            "ع",
-            "غ",
-            "ف",
-            "ق",
-            "ك",
-            "ل",
-            "م",
-            "ن",
-            "ه",
-            "و",
-            "ى",
-            "ة",
-            "ي",
-            "ء",
-        };
-
-        private static readonly List<int> CyrillicCodes = new List<int> {
-            0x20, //space
-            0x21, //!
-            0x22, //Э
-            0x23, // /
-            0x24, //?
-            0x25, //:
-            0x26, //.
-            0x27, //э
-            0x28, //(
-            0x29, //)
-            0x2b, //+
-            0x2c, //,
-            0x2d, //_
-            0x2e, //ю
-            0x3a, //Ж
-            0x3b, //Ж
-            0x3c, //>
-            0x41, //Ф
-            0x42, //И
-            0x43, //C
-            0x44, //В
-            0x45, //У
-            0x46, //A
-            0x47, //П
-            0x48, //Р
-            0x49, //Ш
-            0x4a, //О
-            0x4b, //Л
-            0x4c, //Д
-            0x4d, //Ь
-            0x4e, //Т
-            0x4f, //Щ
-            0x50, //З
-            0x52, //К
-            0x53, //Ы
-            0x54, //Е
-            0x55, //Г
-            0x56, //М
-            0x57, //Ц
-            0x58, //Ч
-            0x59, //Н
-            0x5a, //Я
-            0x5b, //х
-            0x5d, //ъ
-            0x5e, //,
-            0x5f, //-
-            0x61, //ф
-            0x62, //и
-            0x63, //c
-            0x64, //в
-            0x65, //у
-            0x66, //a
-            0x67, //п
-            0x68, //p
-            0x69, //ш
-            0x6a, //о
-            0x6b, //л
-            0x6c, //д
-            0x6d, //ь
-            0x6e, //т
-            0x6f, //щ
-            0x70, //з
-            0x72, //к
-            0x73, //ы
-            0x74, //e
-            0x75, //г
-            0x76, //м
-            0x77, //ц
-            0x78, //ч
-            0x79, //н
-            0x7a, //я
-            0x7b, //Х
-            0x7d, //Ъ
-            0x80, //Б
-            0x81, //Ю
-            0x88, //Ј
-            0x8a, //Њ
-            0x8f, //Џ
-            0x92, //ђ
-            0x94, //,
-            0x95, //-
-            0x96, //і
-            0x98, //ј
-            0x99, //љ
-            0x9a, //њ
-            0x9b, //ћ
-            0x9d, //§
-            0x9f, //џ
-            0xa2, //%
-            0xac, //C
-            0xad, //D
-            0xae, //E
-            0xaf, //F
-            0xb0, //G
-            0xb1, //H
-            0xb2, //'
-            0xb3, //"
-            0xb4, //I
-            0xb5, //J
-            0xb6, //K
-            0xb7, //L
-            0xb8, //M
-            0xb9, //N
-            0xba, //P
-            0xbb, //Q
-            0xbc, //R
-            0xbd, //S
-            0xbe, //T
-            0xbf, //U
-            0xc0, //V
-            0xc2, //W
-            0xc3, //X
-            0xc4, //Y
-            0xc5, //Z
-            0xc6, //b
-            0xc7, //c
-            0xc8, //d
-            0xc9, //e
-            0xca, //f
-            0xcb, //g
-            0xcc, //h
-            0xcd, //i
-            0xce, //j
-            0xcf, //k
-            0xd0, // (blank)
-            0xd1, //l
-            0xd2, //m
-            0xd3, //n
-            0xd4, //o
-            0xd5, //p
-            0xd6, //q
-            0xd7, //r
-            0xd8, //s
-            0xd9, //t
-            0xda, //u
-            0xdb, //v
-            0xdc, //w
-            0xdd, //э
-            0xde, //ю
-            0xdf, //z
-            0xe3, //ѐ
-            0xe065, //ў
-            0xe574, //ё
-            0xe252, //Ќ
-            0xe272, //ќ
-            0xe275, //ѓ
-            0xe596, //ї
-            0x6938, //ш
+        private static readonly Dictionary<int, SpecialCharacter> CyrillicCodes = new Dictionary<int, SpecialCharacter> {
+            { 0x20, new SpecialCharacter(" ")},
+            { 0x21, new SpecialCharacter("!")},
+            { 0x22, new SpecialCharacter("Э")},
+            { 0x23, new SpecialCharacter(" /")},
+            { 0x24, new SpecialCharacter("?")},
+            { 0x25, new SpecialCharacter(":")},
+            { 0x26, new SpecialCharacter(".")},
+            { 0x27, new SpecialCharacter("э")},
+            { 0x28, new SpecialCharacter("(")},
+            { 0x29, new SpecialCharacter(")")},
+            { 0x2b, new SpecialCharacter("+")},
+            { 0x2c, new SpecialCharacter(",")},
+            { 0x2d, new SpecialCharacter("_")},
+            { 0x2e, new SpecialCharacter("ю")},
+            { 0x3a, new SpecialCharacter("Ж")},
+            { 0x3b, new SpecialCharacter("Ж")},
+            { 0x3c, new SpecialCharacter(">")},
+            { 0x41, new SpecialCharacter("Ф")},
+            { 0x42, new SpecialCharacter("И")},
+            { 0x43, new SpecialCharacter("C")},
+            { 0x44, new SpecialCharacter("В")},
+            { 0x45, new SpecialCharacter("У")},
+            { 0x46, new SpecialCharacter("A")},
+            { 0x47, new SpecialCharacter("П")},
+            { 0x48, new SpecialCharacter("Р")},
+            { 0x49, new SpecialCharacter("Ш")},
+            { 0x4a, new SpecialCharacter("О")},
+            { 0x4b, new SpecialCharacter("Л")},
+            { 0x4c, new SpecialCharacter("Д")},
+            { 0x4d, new SpecialCharacter("Ь")},
+            { 0x4e, new SpecialCharacter("Т")},
+            { 0x4f, new SpecialCharacter("Щ")},
+            { 0x50, new SpecialCharacter("З")},
+            { 0x52, new SpecialCharacter("К")},
+            { 0x53, new SpecialCharacter("Ы")},
+            { 0x54, new SpecialCharacter("Е")},
+            { 0x55, new SpecialCharacter("Г")},
+            { 0x56, new SpecialCharacter("М")},
+            { 0x57, new SpecialCharacter("Ц")},
+            { 0x58, new SpecialCharacter("Ч")},
+            { 0x59, new SpecialCharacter("Н")},
+            { 0x5a, new SpecialCharacter("Я")},
+            { 0x5b, new SpecialCharacter("х")},
+            { 0x5d, new SpecialCharacter("ъ")},
+            { 0x5e, new SpecialCharacter(",")},
+            { 0x5f, new SpecialCharacter("-")},
+            { 0x61, new SpecialCharacter("ф")},
+            { 0x62, new SpecialCharacter("и")},
+            { 0x63, new SpecialCharacter("c")},
+            { 0x64, new SpecialCharacter("в")},
+            { 0x65, new SpecialCharacter("у")},
+            { 0x66, new SpecialCharacter("a")},
+            { 0x67, new SpecialCharacter("п")},
+            { 0x68, new SpecialCharacter("p")},
+            { 0x69, new SpecialCharacter("ш")},
+            { 0x6a, new SpecialCharacter("о")},
+            { 0x6b, new SpecialCharacter("л")},
+            { 0x6c, new SpecialCharacter("д")},
+            { 0x6d, new SpecialCharacter("ь")},
+            { 0x6e, new SpecialCharacter("т")},
+            { 0x6f, new SpecialCharacter("щ")},
+            { 0x70, new SpecialCharacter("з")},
+            { 0x72, new SpecialCharacter("к")},
+            { 0x73, new SpecialCharacter("ы")},
+            { 0x74, new SpecialCharacter("e")},
+            { 0x75, new SpecialCharacter("г")},
+            { 0x76, new SpecialCharacter("м")},
+            { 0x77, new SpecialCharacter("ц")},
+            { 0x78, new SpecialCharacter("ч")},
+            { 0x79, new SpecialCharacter("н")},
+            { 0x7a, new SpecialCharacter("я")},
+            { 0x7b, new SpecialCharacter("Х")},
+            { 0x7d, new SpecialCharacter("Ъ")},
+            { 0x80, new SpecialCharacter("Б")},
+            { 0x81, new SpecialCharacter("Ю")},
+            { 0x88, new SpecialCharacter("Ј")},
+            { 0x8a, new SpecialCharacter("Њ")},
+            { 0x8f, new SpecialCharacter("Џ")},
+            { 0x92, new SpecialCharacter("ђ")},
+            { 0x94, new SpecialCharacter(",")},
+            { 0x95, new SpecialCharacter("-")},
+            { 0x96, new SpecialCharacter("і")},
+            { 0x98, new SpecialCharacter("ј")},
+            { 0x99, new SpecialCharacter("љ")},
+            { 0x9a, new SpecialCharacter("њ")},
+            { 0x9b, new SpecialCharacter("ћ")},
+            { 0x9d, new SpecialCharacter("§")},
+            { 0x9f, new SpecialCharacter("џ")},
+            { 0xa2, new SpecialCharacter("%")},
+            { 0xac, new SpecialCharacter("C")},
+            { 0xad, new SpecialCharacter("D")},
+            { 0xae, new SpecialCharacter("E")},
+            { 0xaf, new SpecialCharacter("F")},
+            { 0xb0, new SpecialCharacter("G")},
+            { 0xb1, new SpecialCharacter("H")},
+            { 0xb2, new SpecialCharacter("'")},
+            { 0xb3, new SpecialCharacter("")},
+            { 0xb4, new SpecialCharacter("I")},
+            { 0xb5, new SpecialCharacter("J")},
+            { 0xb6, new SpecialCharacter("K")},
+            { 0xb7, new SpecialCharacter("L")},
+            { 0xb8, new SpecialCharacter("M")},
+            { 0xb9, new SpecialCharacter("N")},
+            { 0xba, new SpecialCharacter("P")},
+            { 0xbb, new SpecialCharacter("Q")},
+            { 0xbc, new SpecialCharacter("R")},
+            { 0xbd, new SpecialCharacter("S")},
+            { 0xbe, new SpecialCharacter("T")},
+            { 0xbf, new SpecialCharacter("U")},
+            { 0xc0, new SpecialCharacter("V")},
+            { 0xc2, new SpecialCharacter("W")},
+            { 0xc3, new SpecialCharacter("X")},
+            { 0xc4, new SpecialCharacter("Y")},
+            { 0xc5, new SpecialCharacter("Z")},
+            { 0xc6, new SpecialCharacter("b")},
+            { 0xc7, new SpecialCharacter("c")},
+            { 0xc8, new SpecialCharacter("d")},
+            { 0xc9, new SpecialCharacter("e")},
+            { 0xca, new SpecialCharacter("f")},
+            { 0xcb, new SpecialCharacter("g")},
+            { 0xcc, new SpecialCharacter("h")},
+            { 0xcd, new SpecialCharacter("i")},
+            { 0xce, new SpecialCharacter("j")},
+            { 0xcf, new SpecialCharacter("k")},
+            { 0xd0, new SpecialCharacter("")},
+            { 0xd1, new SpecialCharacter("l")},
+            { 0xd2, new SpecialCharacter("m")},
+            { 0xd3, new SpecialCharacter("n")},
+            { 0xd4, new SpecialCharacter("o")},
+            { 0xd5, new SpecialCharacter("p")},
+            { 0xd6, new SpecialCharacter("q")},
+            { 0xd7, new SpecialCharacter("r")},
+            { 0xd8, new SpecialCharacter("s")},
+            { 0xd9, new SpecialCharacter("t")},
+            { 0xda, new SpecialCharacter("u")},
+            { 0xdb, new SpecialCharacter("v")},
+            { 0xdc, new SpecialCharacter("w")},
+            { 0xdd, new SpecialCharacter("э")},
+            { 0xde, new SpecialCharacter("ю")},
+            { 0xdf, new SpecialCharacter("z")},
+            { 0xe3, new SpecialCharacter("ѐ")},
+            { 0xe065, new SpecialCharacter("ў")},
+            { 0xe574, new SpecialCharacter("ё")},
+            { 0xe252, new SpecialCharacter("Ќ")},
+            { 0xe272, new SpecialCharacter("ќ")},
+            { 0xe596, new SpecialCharacter("ї")},
+            { 0x6938, new SpecialCharacter("ш")}
 
         };
-
-        private static readonly List<string> CyrillicLetters = new List<string> {
-            " ", //0x20
-            "!", //0x21
-            "Э", //0x22
-            "/", //0x23
-            "?", //0x24
-            ":", //0x25
-            ".", //0x26
-            "э", //0x27
-            "(", //0x28
-            ")", //0x29
-            "+", //0x2b
-            "б", //",", //0x2c
-            "_", //0x2d
-            "ю", //0x2e
-            "Ж", //0x3a
-            "Ж", //0x3b
-            ">", //0x3c
-            "Ф", //0x41
-            "И", //0x42
-            "C", //0x43
-            "B", //0x44
-            "У", //0x45
-            "A", //0x46
-            "П", //0x47
-            "Р", //0x48
-            "Ш", //0x49
-            "О", //0x4a
-            "Л", //0x4b
-            "Д", //0x4c
-            "Ь", //0x4d
-            "Т", //0x4e
-            "Щ", //0x4f
-            "З", //0x50
-            "К", //0x52
-            "Ы", //0x53
-            "Е", //0x54
-            "Г", //0x55
-            "М", //0x56
-            "Ц", //0x57
-            "Ч", //0x58
-            "Н", //0x59
-            "Я", //0x5a
-            "х", //0x5b
-            "ъ", //0x5d
-            ",", //0x5e
-            "-", //0x5f
-            "ф", //0x61
-            "и", //0x62
-            "с", //0x63
-            "в", //0x64
-            "у", //0x65
-            "a", //0x66
-            "п", //0x67
-            "p", //0x68
-            "ш", //0x69
-            "о", //0x6a
-            "л", //0x6b
-            "д", //0x6c
-            "ь", //0x6d
-            "т", //0x6e
-            "щ", //0x6f
-            "з", //0x70
-            "к", //0x72
-            "ы", //0x73
-            "e", //0x74
-            "г", //0x75
-            "м", //0x76
-            "ц", //0x77
-            "ч", //0x78
-            "н", //0x79
-            "я", //0x7a
-            "Х", //0x7b
-            "Ъ", //0x7d
-            "Б", //0x80
-            "Ю", //0x81
-            "Ј", //0x88
-            "Њ", //0x8a
-            "Џ", //0x8f
-            "ђ", //0x92
-            ",", //0x94
-            "-", //0x95
-            "і", //0x96
-            "ј", //0x98
-            "љ", //0x99
-            "ћ", //0x9b
-            "њ", //0x9a
-            "§", //0x9d
-            "џ", //0x9f
-            "%", //0xa2
-            "C", //0xac
-            "D", //0xad
-            "E", //0xae
-            "F", //0xaf
-            "G", //0xb0
-            "H", //0xb1
-            "'", //0xb2
-            "\"", //0xb3
-            "I", //0xb4
-            "J", //0xb5
-            "K", //0xb6
-            "L", //0xb7
-            "M", //0xb8
-            "N", //0xb9
-            "P", //0xba
-            "Q", //0xbb
-            "R", //0xbc
-            "S", //0xbd
-            "T", //0xbe
-            "U", //0xbf
-            "V", //0xc0
-            "W", //0xc2
-            "X", //0xc3
-            "Y", //0xc4
-            "Z", //0xc5
-            "b", //0xc6
-            "c", //0xc7
-            "d", //0xc8
-            "e", //0xc9
-            "f", //0xca
-            "g", //0xcb
-            "h", //0xcc
-            "i", //0xcd
-            "j", //0xce
-            "k", //0xcf
-            "", //0xd0
-            "l", //0xd1
-            "m", //0xd2
-            "n", //0xd3
-            "o", //0xd4
-            "p", //0xd5
-            "q", //0xd6
-            "r", //0xd7
-            "s", //0xd8
-            "t", //0xd9
-            "u", //0xda
-            "v", //0xdb
-            "w", //0xdc
-            "э", //0xdd
-            "ю", //0xde
-            "z", //0xdf
-            "ѐ", //0xe3
-            "ў", //0xe065
-            "ё", //0xe574
-            "Ќ", //0xe252
-            "ќ", //0xe272
-            "ѓ", //0xe275
-            "ї", //0xe596
-            "ш", //0x6938
-        };
-
-        private static readonly List<int> KoreanCodes = new List<int> {
-            0x20, //space
-        };
-
-        private static readonly List<string> KoreanLetters = new List<string> {
-            " ", //0x20
-
+        
+        private static readonly Dictionary<int, SpecialCharacter> KoreanCodes = new Dictionary<int, SpecialCharacter> {
+            { 0x20, new SpecialCharacter(" ")}
         };
 
         private string _fileName = string.Empty;
@@ -1324,8 +949,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         _codePage = CodePageLatin;
                         var sb = new StringBuilder("ABCDEFGHIJKLMNOPPQRSTUVWXYZÆØÅÄÖÜabcdefghijklmnopqrstuvwxyzæøäåü(1234567890, .!?-\r\n'\"):;&");
-                        foreach (string s in LatinLetters)
-                            sb.Append(s);
+                        foreach (var code in LatinCodes.Values)
+                            sb.Append(code.Character);
                         var codePageLetters = sb.ToString();
                         var allOk = true;
                         foreach (char ch in HtmlUtil.RemoveHtmlTags(p.Text, true))
@@ -1359,8 +984,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         index = start;
                         p = GetPacParagraph(ref index, buffer);
                         sb = new StringBuilder("(1234567890, .!?-\r\n'\"):;&");
-                        foreach (string s in ArabicLetters)
-                            sb.Append(s);
+                        foreach (var code in ArabicCodes.Values)
+                            sb.Append(code.Character);
                         codePageLetters = sb.ToString();
                         allOk = true;
                         foreach (char ch in HtmlUtil.RemoveHtmlTags(p.Text, true))
@@ -1378,8 +1003,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         index = start;
                         p = GetPacParagraph(ref index, buffer);
                         sb = new StringBuilder("(1234567890, .!?-\r\n'\"):;&");
-                        foreach (string s in HebrewLetters)
-                            sb.Append(s);
+                        foreach (var code in HebrewCodes.Values)
+                            sb.Append(code.Character);
                         codePageLetters = sb.ToString();
                         allOk = true;
                         foreach (char ch in HtmlUtil.RemoveHtmlTags(p.Text, true))
@@ -1397,8 +1022,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         index = start;
                         p = GetPacParagraph(ref index, buffer);
                         sb = new StringBuilder("(1234567890, .!?-\r\n'\"):;&");
-                        foreach (string s in CyrillicLetters)
-                            sb.Append(s);
+                        foreach (var code in CyrillicCodes.Values)
+                            sb.Append(code.Character);
                         codePageLetters = sb.ToString();
                         allOk = true;
                         foreach (char ch in HtmlUtil.RemoveHtmlTags(p.Text, true))
@@ -1495,10 +1120,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else
                 {
                     string letter = text.Substring(i, 1);
-                    int idx = LatinLetters.IndexOf(letter);
-                    if (idx >= 0)
+                    var code = Find(LatinCodes, letter);
+                    if (code != null)
                     {
-                        int byteValue = LatinCodes[idx];
+                        int byteValue = code.Value.Key;
                         if (byteValue < 256)
                         {
                             buffer[i + extra] = (byte)byteValue;
@@ -1536,20 +1161,20 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static byte[] GetArabicBytes(string text, byte alignment)
         {
-            return GetBytesViaLists(text, ArabicLetters, ArabicCodes, alignment);
+            return GetBytesViaLists(text, ArabicCodes, alignment);
         }
 
         private static byte[] GetHebrewBytes(string text, byte alignment)
         {
-            return GetBytesViaLists(text, HebrewLetters, HebrewCodes, alignment);
+            return GetBytesViaLists(text, HebrewCodes, alignment);
         }
 
         private static byte[] GetCyrillicBytes(string text, byte alignment)
         {
-            return GetBytesViaLists(text, CyrillicLetters, CyrillicCodes, alignment);
+            return GetBytesViaLists(text, CyrillicCodes, alignment);
         }
 
-        private static byte[] GetBytesViaLists(string text, List<string> letters, List<int> codes, byte alignment)
+        private static byte[] GetBytesViaLists(string text, Dictionary<int,SpecialCharacter> codes, byte alignment)
         {
             int i = 0;
             var buffer = new byte[text.Length * 2];
@@ -1568,22 +1193,22 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     bool doubleCharacter = false;
                     string letter = string.Empty;
-                    int idx = -1;
+                    KeyValuePair<int, SpecialCharacter>? character = null;
                     if (i + 1 < text.Length)
                     {
                         letter = text.Substring(i, 2);
-                        idx = letters.IndexOf(letter);
-                        if (idx >= 0)
+                        character = Find(codes, letter);
+                        if (character != null)
                             doubleCharacter = true;
                     }
-                    if (idx < 0)
+                    if (character == null)
                     {
                         letter = text.Substring(i, 1);
-                        idx = letters.IndexOf(letter);
+                        character = Find(codes, letter);
                     }
-                    if (idx >= 0)
+                    if (character.HasValue)
                     {
-                        int byteValue = codes[idx];
+                        int byteValue = character.Value.Key;
                         if (byteValue < 256)
                         {
                             buffer[i + extra] = (byte)byteValue;
@@ -1683,21 +1308,20 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (b >= 0x20 && b < 0x70)
                 return Encoding.ASCII.GetString(buffer, index, 1);
 
-            int idx = ArabicCodes.IndexOf(b);
-            if (idx >= 0)
-                return ArabicLetters[idx];
+            if (ArabicCodes.ContainsKey(b))
+                return ArabicCodes[b].Character;
 
             if (buffer.Length > index + 1)
             {
-                idx = ArabicCodes.IndexOf(b * 256 + buffer[index + 1]);
-                if (idx >= 0)
+                var code = b * 256 + buffer[index + 1];
+                if (ArabicCodes.ContainsKey(code))
                 {
                     index++;
-                    return ArabicLetters[idx];
+                    return ArabicCodes[code].Character;
                 }
             }
 
-            return string.Format("({0})", b);
+            return string.Empty;// string.Format("({0})", b);
         }
 
         public static string GetHebrewString(byte[] buffer, ref int index)
@@ -1706,28 +1330,26 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (b >= 0x20 && b < 0x70 && b != 44)
                 return Encoding.ASCII.GetString(buffer, index, 1);
 
-            int idx = HebrewCodes.IndexOf(b);
-            if (idx >= 0)
-                return HebrewLetters[idx];
+            if (HebrewCodes.ContainsKey(b))
+                return HebrewCodes[b].Character;
 
-            return string.Format("({0})", b);
+            return string.Empty;//string.Format("({0})", b);
         }
 
         public static string GetLatinString(Encoding encoding, byte[] buffer, ref int index)
         {
             byte b = buffer[index];
 
-            int idx = LatinCodes.IndexOf(b);
-            if (idx >= 0)
-                return LatinLetters[idx];
+            if (LatinCodes.ContainsKey(b))
+                return LatinCodes[b].Character;
 
             if (buffer.Length > index + 1)
             {
-                idx = LatinCodes.IndexOf(b * 256 + buffer[index + 1]);
-                if (idx >= 0)
+                var code = b * 256 + buffer[index + 1];
+                if (LatinCodes.ContainsKey(code))
                 {
                     index++;
-                    return LatinLetters[idx];
+                    return LatinCodes[code].Character;
                 }
             }
 
@@ -1743,21 +1365,20 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (b >= 0x30 && b <= 0x39) // decimal digits
                 return Encoding.ASCII.GetString(buffer, index, 1);
 
-            int idx = CyrillicCodes.IndexOf(b);
-            if (idx >= 0)
-                return CyrillicLetters[idx];
+            if (CyrillicCodes.ContainsKey(b))
+                return CyrillicCodes[b].Character;
 
             if (buffer.Length > index + 1)
             {
-                idx = CyrillicCodes.IndexOf(b * 256 + buffer[index + 1]);
-                if (idx >= 0)
+                var code = b * 256 + buffer[index + 1];
+                if (CyrillicCodes.ContainsKey(code))
                 {
                     index++;
-                    return CyrillicLetters[idx];
+                    return CyrillicCodes[code].Character;
                 }
             }
 
-            return string.Format("({0})", b);
+            return string.Empty;//string.Format("({0})", b);
         }
 
         public static string GetKoreanString(byte[] buffer, ref int index)
@@ -1767,21 +1388,20 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (b >= 0x30 && b <= 0x39) // decimal digits
                 return Encoding.ASCII.GetString(buffer, index, 1);
 
-            int idx = KoreanCodes.IndexOf(b);
-            if (idx >= 0)
-                return KoreanLetters[idx];
+            if (KoreanCodes.ContainsKey(b))
+                return KoreanCodes[b].Character;
 
             if (buffer.Length > index + 1)
             {
-                idx = KoreanCodes.IndexOf(b * 256 + buffer[index + 1]);
-                if (idx >= 0)
+                var code = b * 256 + buffer[index + 1];
+                if (KoreanCodes.ContainsKey(code))
                 {
                     index++;
-                    return CyrillicLetters[idx];
+                    return KoreanCodes[code].Character;
                 }
             }
 
-            return string.Format("({0})", b);
+            return string.Empty;//string.Format("({0})", b);
         }
 
         internal static TimeCode GetTimeCode(int timeCodeIndex, byte[] buffer)
@@ -1801,5 +1421,21 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return new TimeCode();
         }
 
+        private static KeyValuePair<int, SpecialCharacter>? Find(Dictionary<int, SpecialCharacter> list, string letter)
+        {
+            return list.Where(c => c.Value.Character == letter).Cast<KeyValuePair<int, SpecialCharacter>?>().FirstOrDefault();
+        }
+
+        internal struct SpecialCharacter
+        {
+            internal SpecialCharacter(string character, bool switchOrder = false)
+            {
+                Character = character;
+                SwitchOrder = switchOrder;
+            }
+
+            internal string Character { get; set; }
+            internal bool SwitchOrder { get; set; }
+        }
     }
 }


### PR DESCRIPTION
The current PAC implementation for the Arabic language was using only "basic" characters and the "accent" ones were added to the wrong side.

Original:

![image](https://cloud.githubusercontent.com/assets/9946441/26636821/1e5606ec-461e-11e7-91c2-afbe260a2b4f.png)

After the change the "accent" symbols are correctly assigned to the letters:

![image](https://cloud.githubusercontent.com/assets/9946441/26636869/39597bf4-461e-11e7-80ba-3b17095502a1.png)

