### PR TITLE
WebVTT generation was missing a space before "-->"

### DIFF
--- a/libse/SubtitleFormats/WebVTT.cs
+++ b/libse/SubtitleFormats/WebVTT.cs
@@ -40,7 +40,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override string ToText(Subtitle subtitle, string title)
         {
             const string timeCodeFormatHours = "{0:00}:{1:00}:{2:00}.{3:000}"; // hh:mm:ss.mmm
-            const string paragraphWriteFormat = "{0}--> {1}{2}{5}{3}{4}{5}";
+            const string paragraphWriteFormat = "{0} --> {1}{2}{5}{3}{4}{5}";
 
             var sb = new StringBuilder();
             sb.AppendLine("WEBVTT");


### PR DESCRIPTION
According to w3c at least one space (or tab) must exist before the "-->" sign:
https://w3c.github.io/webvtt/#webvtt-cue-timings

One or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
The string "-->" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
One or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.