### PR TITLE
[addwaveform] Use consistent minutes:seconds format for extracting audio

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -113,7 +113,7 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <GeneratingPeakFile>Generating peak file...</GeneratingPeakFile>
     <GeneratingSpectrogram>Generating spectrogram...</GeneratingSpectrogram>
     <ExtractingSeconds>Extracting audio: {0:0.0} seconds</ExtractingSeconds>
-    <ExtractingMinutes>Extracting audio: {0}.{1:00} minutes</ExtractingMinutes>
+    <ExtractingMinutes>Extracting audio: {0}:{1:00} minutes</ExtractingMinutes>
     <WaveFileNotFound>Could not find extracted wave file!
 This feature requires VLC media player 1.1.x or newer ({0}-bit).
 


### PR DESCRIPTION
The rest of the interface shows a colon between minutes and seconds, rather than a period. A period makes it look like they are fractional minutes going from 0 to 100 rather than whole seconds going from 0 to 60.

This is how it looks after the change (circle for emphasis):
![image](https://user-images.githubusercontent.com/2448634/30002510-3faaf24e-90ab-11e7-9be3-6c1e30ad62b0.png)

Note that other languages may still use different characters here. Some of them do. Some of them already had a colon instead of a period.

I guess this is half a request and half a proposal, since this sort of thing is subjective.