### PR TITLE
[StatusLog] - Several fixes from prev pr and #2558

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -330,7 +330,7 @@ namespace Nikse.SubtitleEdit.Forms
             try
             {
                 InitializeComponent();
-                Icon = Properties.Resources.SubtitleEditFormIcon;                
+                Icon = Properties.Resources.SubtitleEditFormIcon;
 
                 textBoxListViewTextAlternate.Visible = false;
                 labelAlternateText.Visible = false;
@@ -19942,16 +19942,11 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 return;
             }
-
             if (_statusLogForm == null || _statusLogForm.IsDisposed)
             {
                 _statusLogForm = new StatusLog(_statusLog);
-                _statusLogForm.Show(this);
             }
-            else
-            {
-                _statusLogForm.Show();
-            }
+            _statusLogForm.Show();
         }
 
         private void toolStripMenuItemStatistics_Click(object sender, EventArgs e)

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -5143,6 +5143,10 @@ namespace Nikse.SubtitleEdit.Forms
             if (!string.IsNullOrEmpty(message))
             {
                 _timerClearStatus.Stop();
+                if (_statusLog.Count == 100)
+                {
+                    _statusLog.RemoveAt(0);
+                }
                 _statusLog.Add(string.Format("{0:0000}-{1:00}-{2:00} {3}: {4}", DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day, DateTime.Now.ToLongTimeString(), message));
                 _timerClearStatus.Start();
             }

--- a/src/Forms/StatusLog.Designer.cs
+++ b/src/Forms/StatusLog.Designer.cs
@@ -78,7 +78,6 @@
             this.Name = "StatusLog";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Status messages";
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.StatusLog_KeyDown);
             this.ResumeLayout(false);

--- a/src/Forms/StatusLog.cs
+++ b/src/Forms/StatusLog.cs
@@ -11,7 +11,7 @@ namespace Nikse.SubtitleEdit.Forms
         private readonly IList<string> _log;
         private int _logCount = -1;
 
-        public StatusLog(List<string> log)
+        public StatusLog(IList<string> log)
         {
             InitializeComponent();
             Text = Configuration.Settings.Language.Main.StatusLog;

--- a/src/Forms/StatusLog.cs
+++ b/src/Forms/StatusLog.cs
@@ -6,9 +6,9 @@ using System.Windows.Forms;
 
 namespace Nikse.SubtitleEdit.Forms
 {
-    public sealed partial class StatusLog : PositionAndSizeForm
+    public partial class StatusLog : PositionAndSizeForm
     {
-        private readonly List<string> _log;
+        private readonly IList<string> _log;
         private int _logCount = -1;
 
         public StatusLog(List<string> log)
@@ -18,6 +18,10 @@ namespace Nikse.SubtitleEdit.Forms
             buttonOK.Text = Configuration.Settings.Language.General.Ok;
             _log = log;
             timer1_Tick(null, null);
+
+            // Handle timer when the form is active/inactive
+            Shown += delegate { timer1?.Start(); };
+            FormClosed += delegate { timer1?.Stop(); };
         }
 
         private void StatusLog_KeyDown(object sender, KeyEventArgs e)
@@ -32,13 +36,14 @@ namespace Nikse.SubtitleEdit.Forms
             if (_logCount != _log.Count)
             {
                 var sb = new StringBuilder();
-                foreach (var logEntry in _log.AsEnumerable().Reverse())
+                for (int i = _log.Count - 1; i >= 0; i--)
                 {
-                    sb.AppendLine(logEntry);
+                    // Start from the most recent log
+                    sb.AppendLine(_log[i]);
                 }
                 textBoxStatusLog.Text = sb.ToString();
+                _logCount = _log.Count;
             }
-            _logCount = _log.Count;
             timer1.Start();
         }
 


### PR DESCRIPTION
- Use reverse looping in order to display the most recent log at the top
- Stop timer when the form is closed
- Use non-modal form to allow Status log to be non-topmost
- Minor refact
- Set maximum log entry to 100