### PR TITLE
[StatusLog] - Minor update

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -20762,19 +20762,13 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void labelStatus_Click(object sender, EventArgs e)
         {
-            if (_statusLog.Count == 0)
-            {
-                return;
-            }
-
             if (_statusLogForm == null || _statusLogForm.IsDisposed)
             {
                 _statusLogForm = new StatusLog(_statusLog);
-                _statusLogForm.Show(this);
             }
-            else
+            if (!_statusLogForm.Visible)
             {
-                _statusLogForm.Show();
+                _statusLogForm.Show(this);
             }
         }
 

--- a/src/Forms/StatusLog.cs
+++ b/src/Forms/StatusLog.cs
@@ -10,6 +10,7 @@ namespace Nikse.SubtitleEdit.Forms
     {
         private readonly List<string> _log;
         private int _logCount = -1;
+        private readonly StringBuilder Sb = new StringBuilder();
 
         public StatusLog(List<string> log)
         {
@@ -37,18 +38,21 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void timer1_Tick(object sender, System.EventArgs e)
         {
-            timer1.Stop();
-            if (_logCount != _log.Count)
+            if (_logCount == _log.Count)
             {
-                _logCount = _log.Count;
-                var sb = new StringBuilder();
-                for (int i = _logCount - 1; i >= 0; i--)
-                {
-                    sb.AppendLine(_log[i]);
-                }
-                textBoxStatusLog.Text = sb.ToString();
+                return;
             }
-            timer1.Start();
+            _logCount = _log.Count;
+            for (int i = _logCount - 1; i >= 0; i--)
+            {
+                Sb.AppendLine(_log[i]);
+            }
+            textBoxStatusLog.Text = Sb.ToString();
+            Sb.Clear();
+            if (!timer1.Enabled)
+            {
+                timer1.Start();
+            }
         }
 
         private void buttonOK_Click(object sender, System.EventArgs e)


### PR DESCRIPTION
- Cache stringbuilder  used to build log
- Remove redundant call to timer.Stop() / timer.Start() (since timer will be called in main-thread to it's not necessary to call timer.stop())