### PR TITLE
Improve detection of portable MPC-HC

### DIFF
--- a/src/Logic/VideoPlayers/MpcHC/MpcHc.cs
+++ b/src/Logic/VideoPlayers/MpcHC/MpcHc.cs
@@ -286,7 +286,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.MpcHC
 
                 if (!string.IsNullOrEmpty(Configuration.Settings.General.MpcHcLocation))
                 {
-                    path = Path.GetDirectoryName(Configuration.Settings.General.MpcHcLocation);
+                    path = Configuration.Settings.General.MpcHcLocation;
                     if (path != null && (File.Exists(path) && path.EndsWith("mpc-hc64.exe", StringComparison.OrdinalIgnoreCase)))
                         return path;
                     if (Directory.Exists(Configuration.Settings.General.MpcHcLocation))
@@ -340,7 +340,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.MpcHC
 
                 if (!string.IsNullOrEmpty(Configuration.Settings.General.MpcHcLocation))
                 {
-                    path = Path.GetDirectoryName(Configuration.Settings.General.MpcHcLocation);
+                    path = Configuration.Settings.General.MpcHcLocation;
                     if (path != null && File.Exists(path) && path.EndsWith("mpc-hc.exe", StringComparison.OrdinalIgnoreCase))
                         return path;
                     if (Directory.Exists(Configuration.Settings.General.MpcHcLocation))


### PR DESCRIPTION
The old code only retained the directory information from the MPC-HC path given in the settings and then went on to check whether there is a file at this place that ends with "mpc-hc.exe" or "mpc-hc64.exe" which of course doesn't work because the path now belongs to a directory.