### PR TITLE
Update start with uppercase after a symbol

### DIFF
--- a/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
+++ b/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
@@ -24,9 +24,9 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     if (lastText.EndsWith(':') || lastText.EndsWith(';'))
                     {
                         var st = new StrippableText(p.Text);
-                        if (st.StrippedText.Length > 0 && st.StrippedText[0] != char.ToUpper(st.StrippedText[0]))
+                        if (ShouldCapitalize(st.StrippedText))
                         {
-                            p.Text = st.Pre + char.ToUpper(st.StrippedText[0]) + st.StrippedText.Substring(1) + st.Post;
+                            p.Text = st.CombineWithPrePost(st.StrippedText.CapitalizeFirstLetter());
                         }
                     }
                 }
@@ -76,7 +76,9 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                                 }
                                 if (change)
                                 {
-                                    p.Text = p.Text.Remove(j, 1).Insert(j, char.ToUpper(s).ToString(CultureInfo.InvariantCulture));
+                                    string textFromIdx = p.Text.Substring(j).CapitalizeFirstLetter();
+                                    p.Text = p.Text.Remove(j);
+                                    p.Text = p.Text.Insert(j, textFromIdx);
                                 }
 
                                 lastWasColon = false;
@@ -106,5 +108,27 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             callbacks.UpdateFixStatus(noOfFixes, language.StartWithUppercaseLetterAfterColon, noOfFixes.ToString(CultureInfo.InvariantCulture));
         }
 
+        protected static bool ShouldCapitalize(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return false;
+            }
+
+            char firstChar = input[0];
+            // not a letter or already uppercase
+            if (char.IsLetter(firstChar) == false || char.IsUpper(firstChar))
+            {
+                return false;
+            }
+
+            // ignore: iPhone, iPad...
+            if (input.Length > 1 && input[0] == 'i' && char.IsUpper(input[1]))
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
+++ b/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
@@ -42,38 +42,38 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     bool lastWasColon = false;
                     for (int j = 0; j < text.Length; j++)
                     {
-                        var s = text[j];
-                        if (s == ':' || s == ';')
+                        char ch = text[j];
+                        if (ch == ':' || ch == ';')
                         {
                             lastWasColon = true;
                         }
                         else if (lastWasColon)
                         {
                             // skip whitespace index
-                            if (j + 2 < text.Length && text[j] == ' ')
+                            if (j + 2 < text.Length && ch == ' ')
                             {
-                                s = text[++j];
+                                ch = text[++j];
                             }
 
-                            var startFromJ = text.Substring(j);
-                            if (startFromJ.Length > 3 && startFromJ[0] == '<' && startFromJ[2] == '>' && (startFromJ[1] == 'i' || startFromJ[1] == 'b' || startFromJ[1] == 'u'))
+                            var textFromJ = text.Substring(j);
+                            if (textFromJ.Length > 3 && textFromJ[0] == '<' && textFromJ[2] == '>' && (textFromJ[1] == 'i' || textFromJ[1] == 'b' || textFromJ[1] == 'u'))
                             {
                                 skipCount = 2;
                             }
-                            else if (startFromJ.StartsWith("<font ", StringComparison.OrdinalIgnoreCase) && text.Substring(j).Contains('>'))
+                            else if (textFromJ.StartsWith("<font ", StringComparison.OrdinalIgnoreCase) && text.Substring(j).Contains('>'))
                             {
-                                skipCount = (j + startFromJ.IndexOf('>', 6)) - j;
+                                skipCount = (j + textFromJ.IndexOf('>', 6)) - j;
                             }
-                            else if (Helper.IsTurkishLittleI(s, callbacks.Encoding, callbacks.Language))
+                            else if (Helper.IsTurkishLittleI(ch, callbacks.Encoding, callbacks.Language))
                             {
-                                text = text.Remove(j, 1).Insert(j, Helper.GetTurkishUppercaseLetter(s, callbacks.Encoding).ToString(CultureInfo.InvariantCulture));
+                                text = text.Remove(j, 1).Insert(j, Helper.GetTurkishUppercaseLetter(ch, callbacks.Encoding).ToString(CultureInfo.InvariantCulture));
                                 lastWasColon = false;
                             }
-                            else if (char.IsLower(s))
+                            else if (char.IsLower(ch))
                             {
                                 // iPhone
                                 bool change = true;
-                                if (s == 'i' && text.Length > j + 1)
+                                if (ch == 'i' && text.Length > j + 1)
                                 {
                                     if (text[j + 1] == char.ToUpper(text[j + 1]))
                                     {
@@ -82,14 +82,14 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                                 }
                                 if (change)
                                 {
-                                    string textFromIdx = text.Substring(j).CapitalizeFirstLetter();
+                                    textFromJ = textFromJ.CapitalizeFirstLetter();
                                     text = text.Remove(j);
-                                    text = text.Insert(j, textFromIdx);
+                                    text = text.Insert(j, textFromJ);
                                 }
 
                                 lastWasColon = false;
                             }
-                            else if (!(" " + Environment.NewLine).Contains(s))
+                            else if (!(" " + Environment.NewLine).Contains(ch))
                             {
                                 lastWasColon = false;
                             }

--- a/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
+++ b/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
@@ -46,7 +46,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     {
                         char charAtPosition = text[start];
                         // Allow fixing lowercase letter after recursive ??? or !!!.
-                        if (charAtPosition != '.') // Dot is not include 'cause I don't capitalize word after the ellipses (...), right?
+                        if (charAtPosition != '.') // Dot is not include 'cause we don't capitalize word after the ellipses (...), right?
                         {
                             while (start + 1 < text.Length && text[start + 1] == charAtPosition)
                             {
@@ -57,7 +57,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         // Try to reach the last dot if char at *start is '.'.
                         if (charAtPosition == '.')
                         {
-                            while (start + 1 < text.Length && text[start + 1] == '.')
+                            while (start + 1 < text.Length && text[start + 1] == charAtPosition)
                             {
                                 start++;
                             }
@@ -97,18 +97,15 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
             if (textBefore != null && textBefore.EndsWith("...", System.StringComparison.Ordinal))
             {
-                if (callbacks.Language == "en" && text.StartsWith("i "))
-                {
-                }
-                else
+                if (!(callbacks.Language == "en" && text.StartsWith("i ", System.StringComparison.Ordinal)))
                 {
                     return text; // too hard to say if uppercase after "..."
                 }
-            }                
+            }
 
             if (textBefore != null && textBefore.EndsWith(" - ", System.StringComparison.Ordinal) && !textBefore.EndsWith(". - ", System.StringComparison.Ordinal))
             {
-                return text; 
+                return text;
             }
 
             // Skip words like iPhone, iPad...
@@ -122,8 +119,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 return Helper.GetTurkishUppercaseLetter(text[0], callbacks.Encoding) + text.Substring(1);
             }
 
-            text = char.ToUpper(text[0]) + text.Substring(1);
-            return text;
+            return text.CapitalizeFirstLetter();
         }
 
     }


### PR DESCRIPTION
## TODO 👷 
- [x] FixStartWithUppercaseLetterAfterColon
- [x] FixStartWithUppercaseLetterAfterPeriodInsideParagraph
- [ ] FixStartWithUppercaseLetterAfterParagraph
