### PR TITLE
paragraph: make calles go to one main constructor

### DIFF
--- a/libse/Paragraph.cs
+++ b/libse/Paragraph.cs
@@ -58,12 +58,8 @@ namespace Nikse.SubtitleEdit.Core
             return Guid.NewGuid().ToString();
         }
 
-        public Paragraph()
+        public Paragraph() : this(new TimeCode(), new TimeCode(), string.Empty)
         {
-            StartTime = TimeCode.FromSeconds(0);
-            EndTime = TimeCode.FromSeconds(0);
-            Text = string.Empty;
-            ID = GenerateId();
         }
 
         public Paragraph(TimeCode startTime, TimeCode endTime, string text)
@@ -99,22 +95,16 @@ namespace Nikse.SubtitleEdit.Core
             Bookmark = paragraph.Bookmark;
         }
 
-        public Paragraph(int startFrame, int endFrame, string text)
+        public Paragraph(int startFrame, int endFrame, string text) :
+            this(new TimeCode(), new TimeCode(), text)
         {
-            StartTime = new TimeCode();
-            EndTime = new TimeCode();
             StartFrame = startFrame;
             EndFrame = endFrame;
-            Text = text;
-            ID = GenerateId();
         }
 
         public Paragraph(string text, double startTotalMilliseconds, double endTotalMilliseconds)
+            : this(new TimeCode(startTotalMilliseconds), new TimeCode(endTotalMilliseconds), text)
         {
-            StartTime = new TimeCode(startTotalMilliseconds);
-            EndTime = new TimeCode(endTotalMilliseconds);
-            Text = text;
-            ID = GenerateId();
         }
 
         public void Adjust(double factor, double adjustmentInSeconds)


### PR DESCRIPTION
remove redundant code and make all the calls go through on main constructor when instantiating paragraph