### PR TITLE
Refact CommandLineConvert

### DIFF
--- a/libse/Configuration.cs
+++ b/libse/Configuration.cs
@@ -40,21 +40,56 @@ namespace Nikse.SubtitleEdit.Core
             _settings = new Lazy<Settings>(Settings.GetSettings);
         }
 
-        public static bool IsRunningOnLinux()
+        private const int _platformWindows = 1;
+        private const int _platformLinux = 2;
+        private const int _platformMac = 3;
+        private static int _platform;
+
+        public static bool IsRunningOnWindows
         {
-            return Environment.OSVersion.Platform == PlatformID.Unix && !IsRunningOnMac();
+            get
+            {
+                if (_platform == 0)
+                {
+                    _platform = GetPlatform();
+                }
+                return _platform == _platformWindows;
+            }
         }
 
-        public static bool IsRunningOnMac()
+        public static bool IsRunningOnLinux
+        {
+            get
+            {
+                if (_platform == 0)
+                {
+                    _platform = GetPlatform();
+                }
+                return _platform == _platformLinux;
+            }
+        }
+
+        public static bool IsRunningOnMac
+        {
+            get
+            {
+                if (_platform == 0)
+                {
+                    _platform = GetPlatform();
+                }
+                return _platform == _platformMac;
+            }
+        }
+
+        private static int GetPlatform()
         {
             // Current versions of Mono report the platform as Unix
-            return Environment.OSVersion.Platform == PlatformID.MacOSX ||
-                (Environment.OSVersion.Platform == PlatformID.Unix &&
-                 Directory.Exists("/Applications") &&
-                 Directory.Exists("/System") &&
-                 Directory.Exists("/Users"));
+            return Environment.OSVersion.Platform == PlatformID.MacOSX || (Environment.OSVersion.Platform == PlatformID.Unix && Directory.Exists("/Applications") && Directory.Exists("/System") && Directory.Exists("/Users"))
+                 ? _platformMac
+                 : Environment.OSVersion.Platform == PlatformID.Unix
+                 ? _platformLinux
+                 : _platformWindows;
         }
-
 
         public static Settings Settings => Instance.Value._settings.Value;
 
@@ -94,7 +129,7 @@ namespace Nikse.SubtitleEdit.Core
         {
             var appDataRoamingPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Subtitle Edit");
 
-            if (IsRunningOnLinux() || IsRunningOnMac())
+            if (IsRunningOnLinux || IsRunningOnMac)
             {
                 if (!Directory.Exists(appDataRoamingPath) && !File.Exists(Path.Combine(BaseDirectory, ".PACKAGE-MANAGER")))
                 {
@@ -143,7 +178,7 @@ namespace Nikse.SubtitleEdit.Core
 
         private static string GetTesseractDataDirectory()
         {
-            if (IsRunningOnLinux() || IsRunningOnMac())
+            if (IsRunningOnLinux || IsRunningOnMac)
             {
                 if (Directory.Exists("/usr/share/tesseract-ocr/tessdata"))
                 {
@@ -165,7 +200,7 @@ namespace Nikse.SubtitleEdit.Core
 
         private static string GetTesseract302DataDirectory()
         {
-            if (IsRunningOnLinux() || IsRunningOnMac())
+            if (IsRunningOnLinux || IsRunningOnMac)
             {
                 if (Directory.Exists("/usr/share/tesseract-ocr/tessdata"))
                 {

--- a/libse/FilePathComparer.cs
+++ b/libse/FilePathComparer.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Core
+{
+    public abstract class FilePathComparer : IEqualityComparer<string>, IComparer<string>
+    {
+        private sealed class WindowsFilePathComparer: FilePathComparer
+        {
+            public override int Compare(string path1, string path2)
+            {
+                return ReferenceEquals(path1, path2)
+                     ? 0
+                     : ReferenceEquals(path2, null)
+                     ? 1
+                     : ReferenceEquals(path1, null)
+                     ? -1
+                     : string.Compare(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase);
+            }
+
+            public override bool Equals(string path1, string path2)
+            {
+                return ReferenceEquals(path1, path2) ||
+                       (!(ReferenceEquals(path1, null) || ReferenceEquals(path2, null)) &&
+                        string.Equals(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase));
+            }
+
+            public override int GetHashCode(string path)
+            {
+                return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).ToUpperInvariant().GetHashCode();
+            }
+        }
+
+        private sealed class UnixFilePathComparer : FilePathComparer
+        {
+            public override int Compare(string path1, string path2)
+            {
+                return ReferenceEquals(path1, path2)
+                     ? 0
+                     : ReferenceEquals(path2, null)
+                     ? 1
+                     : ReferenceEquals(path1, null)
+                     ? -1
+                     : string.Compare(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), StringComparison.Ordinal);
+            }
+
+            public override bool Equals(string path1, string path2)
+            {
+                return ReferenceEquals(path1, path2) ||
+                       (!(ReferenceEquals(path1, null) || ReferenceEquals(path2, null)) &&
+                        string.Equals(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), StringComparison.Ordinal));
+            }
+
+            public override int GetHashCode(string path)
+            {
+                return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).GetHashCode();
+            }
+        }
+
+        public static FilePathComparer Native => Configuration.IsRunningOnWindows ? Windows : Unix;
+        public static FilePathComparer Windows => new WindowsFilePathComparer();
+        public static FilePathComparer Unix => new UnixFilePathComparer();
+
+        public abstract int Compare(string path1, string path2);
+        public abstract bool Equals(string path1, string path2);
+        public abstract int GetHashCode(string path);
+    }
+}

--- a/libse/LibSE.csproj
+++ b/libse/LibSE.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Enums\SubtitleSortCriteria.cs" />
     <Compile Include="FastBitmap.cs" />
     <Compile Include="FastFileStream.cs" />
+    <Compile Include="FilePathComparer.cs" />
     <Compile Include="FileUtil.cs" />
     <Compile Include="FixCasing.cs" />
     <Compile Include="Forms\CheckForUpdatesHelper.cs" />

--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -838,7 +838,7 @@ $HorzAlign          =   Center
             OpenSubtitleExtraExtensions = "*.mp4;*.m4v;*.mkv;*.ts"; // matroska/mp4/m4v files (can contain subtitles)
             ListViewColumnsRememberSize = true;
             VlcWaveTranscodeSettings = "acodec=s16l"; // "acodec=s16l,channels=1,ab=64,samplerate=8000";
-            MpvVideoOutput = Configuration.IsRunningOnLinux() ? "vaapi" : "direct3d";
+            MpvVideoOutput = Configuration.IsRunningOnLinux ? "vaapi" : "direct3d";
             MpvHandlesPreviewText = true;
             FFmpegSceneThreshold = "0.4"; // thresshold for generating scene changes - 0.2 is sensitive (more scene change), 0.6 is less sensitive (fewer scene changes)
             UseTimeFormatHHMMSSFF = false;
@@ -1626,7 +1626,7 @@ $HorzAlign          =   Center
             // General
             node = doc.DocumentElement.SelectSingleNode("General");
 
-            // Profiles            
+            // Profiles
             int profileCount = 0;
             foreach (XmlNode listNode in node.SelectNodes("Profiles/Profile"))
             {

--- a/src/Forms/AddWaveForm.cs
+++ b/src/Forms/AddWaveForm.cs
@@ -61,12 +61,12 @@ namespace Nikse.SubtitleEdit.Forms
             encoderName = "VLC";
             string parameters = "\"" + inputVideoFile + "\" -I dummy -vvv --no-random --no-repeat --no-loop --no-sout-video --audio-track=" + audioTrackNumber + " --sout=\"#transcode{acodec=s16l,channels=1,ab=128}:std{access=file,mux=wav,dst=" + outWaveFile + "}\" vlc://quit";
             string exeFilePath;
-            if (Configuration.IsRunningOnLinux())
+            if (Configuration.IsRunningOnLinux)
             {
                 exeFilePath = "cvlc";
                 parameters = "-vvv --no-random --no-repeat --no-loop --no-sout-video --audio-track=" + audioTrackNumber + " --sout '#transcode{" + encodeParamters + "}:std{mux=wav,access=file,dst=" + outWaveFile + "}' \"" + inputVideoFile + "\" vlc://quit";
             }
-            else if (Configuration.IsRunningOnMac())
+            else if (Configuration.IsRunningOnMac)
             {
                 exeFilePath = "VLC.app/Contents/MacOS/VLC";
             }
@@ -118,7 +118,7 @@ namespace Nikse.SubtitleEdit.Forms
             SourceVideoFileName = labelVideoFileName.Text;
             string targetFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".wav");
             string targetDriveLetter = null;
-            if (!(Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac()))
+            if (Configuration.IsRunningOnWindows)
             {
                 var root = Path.GetPathRoot(targetFile);
                 if (root.Length > 1 && root[1] == ':')

--- a/src/Forms/AudioToText.cs
+++ b/src/Forms/AudioToText.cs
@@ -63,12 +63,12 @@ namespace Nikse.SubtitleEdit.Forms
                 encoderName = "VLC";
                 string parameters = "\"" + inputVideoFile + "\" -I dummy -vvv --no-random --no-repeat --no-loop --no-sout-video --audio-track=" + audioTrackNumber + " --sout=\"#transcode{acodec=s16l,channels=1,ab=128,samplerate=16000}:std{access=file,mux=wav,dst=" + outWaveFile + "}\" vlc://quit";
                 string exeFilePath;
-                if (Configuration.IsRunningOnLinux())
+                if (Configuration.IsRunningOnLinux)
                 {
                     exeFilePath = "cvlc";
                     parameters = "-vvv --no-random --no-repeat --no-loop --no-sout-video --audio-track=" + audioTrackNumber + " --sout '#transcode{" + encodeParamters + "}:std{mux=wav,access=file,dst=" + outWaveFile + "}' \"" + inputVideoFile + "\" vlc://quit";
                 }
-                else if (Configuration.IsRunningOnMac())
+                else if (Configuration.IsRunningOnMac)
                 {
                     exeFilePath = "VLC.app/Contents/MacOS/VLC";
                 }

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -1219,11 +1219,11 @@ namespace Nikse.SubtitleEdit.Forms
                     bool success;
                     if (checkBoxOverwriteOriginalFiles.Checked)
                     {
-                        success = CommandLineConvert.BatchConvertSave(targetFormat, null, GetCurrentEncoding(), Path.GetDirectoryName(p.FileName), _count, ref _converted, ref _errors, _allFormats.ToList(), p.FileName, p.Subtitle, p.SourceFormat, true, -1, null, null, null);
+                        success = CommandLineConvert.BatchConvertSave(targetFormat, null, GetCurrentEncoding(), Path.GetDirectoryName(p.FileName), _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, true, -1, null, null);
                     }
                     else
                     {
-                        success = CommandLineConvert.BatchConvertSave(targetFormat, null, GetCurrentEncoding(), textBoxOutputFolder.Text, _count, ref _converted, ref _errors, _allFormats.ToList(), p.FileName, p.Subtitle, p.SourceFormat, checkBoxOverwrite.Checked, -1, null, null, null);
+                        success = CommandLineConvert.BatchConvertSave(targetFormat, null, GetCurrentEncoding(), textBoxOutputFolder.Text, _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, checkBoxOverwrite.Checked, -1, null, null);
                     }
                     p.Item.SubItems[3].Text = success ? Configuration.Settings.Language.BatchConvert.Converted : Configuration.Settings.Language.BatchConvert.NotConverted;
                 }

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -1219,11 +1219,11 @@ namespace Nikse.SubtitleEdit.Forms
                     bool success;
                     if (checkBoxOverwriteOriginalFiles.Checked)
                     {
-                        success = CommandLineConvert.BatchConvertSave(targetFormat, null, GetCurrentEncoding(), Path.GetDirectoryName(p.FileName), _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, true, -1, null, null);
+                        success = CommandLineConvert.BatchConvertSave(targetFormat, TimeSpan.Zero, GetCurrentEncoding(), Path.GetDirectoryName(p.FileName), _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, true, -1, null, null);
                     }
                     else
                     {
-                        success = CommandLineConvert.BatchConvertSave(targetFormat, null, GetCurrentEncoding(), textBoxOutputFolder.Text, _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, checkBoxOverwrite.Checked, -1, null, null);
+                        success = CommandLineConvert.BatchConvertSave(targetFormat, TimeSpan.Zero, GetCurrentEncoding(), textBoxOutputFolder.Text, _count, ref _converted, ref _errors, _allFormats, p.FileName, p.Subtitle, p.SourceFormat, checkBoxOverwrite.Checked, -1, null, null);
                     }
                     p.Item.SubItems[3].Text = success ? Configuration.Settings.Language.BatchConvert.Converted : Configuration.Settings.Language.BatchConvert.NotConverted;
                 }

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -394,7 +394,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         public Main()
         {
-            if (Configuration.IsRunningOnLinux())
+            if (Configuration.IsRunningOnLinux)
             {
                 NativeMethods.setlocale(NativeMethods.LC_NUMERIC, "C");
             }
@@ -18715,7 +18715,7 @@ namespace Nikse.SubtitleEdit.Forms
                 timerAlternateTextUndo.Start();
             }
 
-            if (Configuration.IsRunningOnLinux())
+            if (Configuration.IsRunningOnLinux)
             {
                 numericUpDownDuration.Left = timeUpDownStartTime.Left + timeUpDownStartTime.Width + 10;
                 numericUpDownDuration.Width += 10;

--- a/src/Forms/Ocr/VobSubOcr.cs
+++ b/src/Forms/Ocr/VobSubOcr.cs
@@ -6398,8 +6398,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
         private void InitializeTesseract(string chosenLanguage = null)
         {
-            if (!Directory.Exists(Configuration.Tesseract302Directory) &&
-                !Configuration.IsRunningOnLinux() && !Configuration.IsRunningOnMac() &&
+            if (Configuration.IsRunningOnWindows &&
+                !Directory.Exists(Configuration.Tesseract302Directory) &&
                 Directory.Exists(Configuration.TesseractOriginalDirectory))
             {
                 foreach (string dirPath in Directory.GetDirectories(Configuration.TesseractOriginalDirectory, "*", SearchOption.AllDirectories))

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -522,7 +522,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             checkBoxUseFFmpeg.Text = language.WaveformUseFFmpeg;
             buttonDownloadFfmpeg.Text = language.DownloadFFmpeg;
-            if (Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnLinux || Configuration.IsRunningOnMac)
             {
                 buttonDownloadFfmpeg.Visible = false;
             }
@@ -690,7 +690,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             comboBoxSpellChecker.SelectedIndex = gs.SpellChecker.Contains("word", StringComparison.OrdinalIgnoreCase) ? 1 : 0;
 
-            if (Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnLinux || Configuration.IsRunningOnMac)
             {
                 comboBoxSpellChecker.SelectedIndex = 0;
                 comboBoxSpellChecker.Enabled = false;
@@ -2710,9 +2710,9 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialogFFmpeg.FileName = string.Empty;
             openFileDialogFFmpeg.Title = Configuration.Settings.Language.Settings.WaveformBrowseToFFmpeg;
-            if (!Configuration.IsRunningOnLinux() && !Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnWindows)
             {
-                openFileDialogFFmpeg.Filter = "FFmpeg.exe|FFmpeg.exe";
+                openFileDialogFFmpeg.Filter = "FFmpeg (ffmpeg.exe)|ffmpeg.exe";
             }
             if (openFileDialogFFmpeg.ShowDialog(this) == DialogResult.OK)
             {
@@ -2729,9 +2729,9 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialogFFmpeg.FileName = string.Empty;
             openFileDialogFFmpeg.Title = Configuration.Settings.Language.Settings.WaveformBrowseToVLC;
-            if (!Configuration.IsRunningOnLinux() && !Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnWindows)
             {
-                openFileDialogFFmpeg.Filter = "vlc.exe|vlc.exe";
+                openFileDialogFFmpeg.Filter = $"{Configuration.Settings.Language.Settings.VlcMediaPlayer} (vlc.exe)|vlc.exe";
             }
             if (openFileDialogFFmpeg.ShowDialog(this) == DialogResult.OK)
             {
@@ -2796,7 +2796,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             openFileDialogFFmpeg.FileName = string.Empty;
             openFileDialogFFmpeg.Title = Configuration.Settings.Language.Settings.WaveformBrowseToFFmpeg;
-            openFileDialogFFmpeg.Filter = Configuration.Settings.Language.General.AudioFiles + "|*.wav";
+            openFileDialogFFmpeg.Filter = $"{Configuration.Settings.Language.General.AudioFiles} (*.wav)|*.wav";
             if (openFileDialogFFmpeg.ShowDialog(this) == DialogResult.OK)
             {
                 textBoxNetworkSessionNewMessageSound.Text = openFileDialogFFmpeg.FileName;
@@ -2870,7 +2870,7 @@ namespace Nikse.SubtitleEdit.Forms
                 buttonMpvSettings.Font = new Font(buttonMpvSettings.Font.FontFamily, buttonMpvSettings.Font.Size, FontStyle.Bold);
             }
 
-            if (Configuration.IsRunningOnLinux() && Configuration.Settings.General.MpvVideoOutput.StartsWith("direct3d"))
+            if (Configuration.IsRunningOnLinux && Configuration.Settings.General.MpvVideoOutput.StartsWith("direct3d"))
             {
                 labelMpvSettings.Text = "--vo=vaapi";
             }

--- a/src/Forms/SettingsMpv.cs
+++ b/src/Forms/SettingsMpv.cs
@@ -17,7 +17,7 @@ namespace Nikse.SubtitleEdit.Forms
             InitializeComponent();
             UiUtil.FixFonts(this);
             labelPleaseWait.Text = string.Empty;
-            if (Configuration.IsRunningOnLinux() && Configuration.Settings.General.MpvVideoOutput == "direct3d")
+            if (Configuration.IsRunningOnLinux && Configuration.Settings.General.MpvVideoOutput == "direct3d")
             {
                 comboBoxVideoOutput.Text = "vaapi";
             }
@@ -29,12 +29,12 @@ namespace Nikse.SubtitleEdit.Forms
             buttonCancel.Text = Configuration.Settings.Language.General.Cancel;
             buttonOK.Text = Configuration.Settings.Language.General.Ok;
             Text = Configuration.Settings.Language.SettingsMpv.Title;
-            if (!Configuration.IsRunningOnLinux())
+            if (!Configuration.IsRunningOnLinux)
             {
                 buttonDownload.Text = Configuration.Settings.Language.SettingsMpv.DownloadMpv;
             }
 
-            if (Configuration.IsRunningOnLinux())
+            if (Configuration.IsRunningOnLinux)
             {
                 comboBoxVideoOutput.Items.Clear();
                 comboBoxVideoOutput.Items.AddRange(new object[] { "vaapi", "opengl", "sdl", "vdpau" });
@@ -52,7 +52,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 e.Error.Message);
                 labelPleaseWait.Text = string.Empty;
                 buttonOK.Enabled = true;
-                buttonDownload.Enabled = !Configuration.IsRunningOnLinux();
+                buttonDownload.Enabled = !Configuration.IsRunningOnLinux;
                 Cursor = Cursors.Default;
                 return;
             }
@@ -81,14 +81,7 @@ namespace Nikse.SubtitleEdit.Forms
             Cursor = Cursors.Default;
             labelPleaseWait.Text = string.Empty;
             buttonOK.Enabled = true;
-            if (!Configuration.IsRunningOnLinux())
-            {
-                buttonDownload.Enabled = true;
-            }
-            else
-            {
-                buttonDownload.Enabled = false;
-            }
+            buttonDownload.Enabled = !Configuration.IsRunningOnLinux;
 
             MessageBox.Show(Configuration.Settings.Language.SettingsMpv.DownloadMpvOk);
         }
@@ -104,7 +97,7 @@ namespace Nikse.SubtitleEdit.Forms
                 Refresh();
                 Cursor = Cursors.WaitCursor;
                 string url = "https://github.com/SubtitleEdit/support-files/blob/master/mpv/libmpv" + IntPtr.Size * 8 + ".zip?raw=true";
-                var wc = new WebClient { Proxy = Utilities.GetProxy() };                
+                var wc = new WebClient { Proxy = Utilities.GetProxy() };
 
                 wc.DownloadDataCompleted += wc_DownloadDataCompleted;
                 wc.DownloadProgressChanged += (o, args) =>
@@ -117,7 +110,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 labelPleaseWait.Text = string.Empty;
                 buttonOK.Enabled = true;
-                buttonDownload.Enabled = !Configuration.IsRunningOnLinux();
+                buttonDownload.Enabled = !Configuration.IsRunningOnLinux;
                 Cursor = Cursors.Default;
                 MessageBox.Show(exception.Message + Environment.NewLine + Environment.NewLine + exception.StackTrace);
             }

--- a/src/Logic/CommandLineConvert.cs
+++ b/src/Logic/CommandLineConvert.cs
@@ -774,6 +774,51 @@ namespace Nikse.SubtitleEdit.Logic
         }
 
         /// <summary>
+        /// Gets an offset argument from the command line
+        /// </summary>
+        /// <param name="commandLineArguments">All unresolved arguments from the command line</param>
+        private static TimeSpan GetOffset(IList<string> commandLineArguments)
+        {
+            var offset = GetArgument(commandLineArguments, "offset:", "0");
+            if (int.TryParse(offset, NumberStyles.AllowLeadingSign, CultureInfo.CurrentCulture, out var number) || int.TryParse(offset, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out number))
+            {
+                return TimeSpan.FromMilliseconds(number);
+            }
+
+            var parts = offset.Split(new[] { ':', ',', '.' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            if (parts.Count > 1)
+            {
+                var result = TimeSpan.Zero;
+                if (parts.Count == 4 && (int.TryParse(parts[0], NumberStyles.AllowLeadingSign, CultureInfo.CurrentCulture, out number) || int.TryParse(parts[0], NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out number)))
+                {
+                    result = result.Add(TimeSpan.FromHours(number));
+                    parts.RemoveAt(0);
+                }
+                if (parts.Count == 3 && (int.TryParse(parts[0], NumberStyles.None, CultureInfo.CurrentCulture, out number) || int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out number)))
+                {
+                    result = result.Add(TimeSpan.FromMinutes(number));
+                    parts.RemoveAt(0);
+                }
+                if (parts.Count == 2 && (int.TryParse(parts[0], NumberStyles.None, CultureInfo.CurrentCulture, out number) || int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out number)))
+                {
+                    result = result.Add(TimeSpan.FromSeconds(number));
+                    parts.RemoveAt(0);
+                }
+                if (parts.Count == 1 && (int.TryParse(parts[0], NumberStyles.None, CultureInfo.CurrentCulture, out number) || int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out number)))
+                {
+                    result = result.Add(TimeSpan.FromMilliseconds(number));
+                    parts.RemoveAt(0);
+                }
+                if (parts.Count == 0)
+                {
+                    return result;
+                }
+            }
+
+            throw new FormatException($"The /offset value '{offset}' is invalid.");
+        }
+
+        /// <summary>
         /// Gets a resolution argument from the command line
         /// </summary>
         /// <param name="commandLineArguments">All unresolved arguments from the command line</param>

--- a/src/Logic/CommandLineConvert.cs
+++ b/src/Logic/CommandLineConvert.cs
@@ -220,7 +220,7 @@ namespace Nikse.SubtitleEdit.Logic
                         }
                         else
                         {
-                            throw new Exception($"The /outputfolder '{folder}' does not exist.");
+                            throw new DirectoryNotFoundException($"The /outputfolder '{folder}' does not exist.");
                         }
                     }
                 }
@@ -236,7 +236,7 @@ namespace Nikse.SubtitleEdit.Logic
                         }
                         else
                         {
-                            throw new Exception($"The /inputfolder '{folder}' does not exist.");
+                            throw new DirectoryNotFoundException($"The /inputfolder '{folder}' does not exist.");
                         }
                     }
                 }
@@ -292,7 +292,7 @@ namespace Nikse.SubtitleEdit.Logic
                         }
                         else if (!int.TryParse(pcp, out pacCodePage) || !Pac.IsValidCodePage(pacCodePage))
                         {
-                            throw new Exception($"The /pac-codepage value '{pcp}' is invalid.");
+                            throw new FormatException($"The /pac-codepage value '{pcp}' is invalid.");
                         }
                     }
                 }
@@ -761,7 +761,7 @@ namespace Nikse.SubtitleEdit.Logic
                         return d;
                     }
                 }
-                throw new Exception($"The /{requestedFrameRateName} value '{fps}' is invalid - number between {minimumFrameRate} and {maximumFrameRate} expected.");
+                throw new FormatException($"The /{requestedFrameRateName} value '{fps}' is invalid - number between {minimumFrameRate} and {maximumFrameRate} expected.");
             }
             return null;
         }
@@ -788,7 +788,7 @@ namespace Nikse.SubtitleEdit.Logic
                         return new Point(w, h);
                     }
                 }
-                throw new Exception($"The /resolution value '{res}' is invalid - <width>x<height> or <width>,<height> expected.");
+                throw new FormatException($"The /resolution value '{res}' is invalid - <width>x<height> or <width>,<height> expected.");
             }
             return null;
         }

--- a/src/Logic/CommandLineConvert.cs
+++ b/src/Logic/CommandLineConvert.cs
@@ -295,7 +295,7 @@ namespace Nikse.SubtitleEdit.Logic
                     }
                 }
 
-                var multipleReplaceImportFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var multipleReplaceImportFiles = new HashSet<string>(FilePathComparer.Native);
                 {
                     var mra = GetArgument(unconsumedArguments, "multiplereplace:");
                     if (mra.Length > 0)
@@ -347,7 +347,7 @@ namespace Nikse.SubtitleEdit.Logic
                     patterns.Add(pattern);
                 }
 
-                var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var files = new HashSet<string>(FilePathComparer.Native);
 
                 foreach (var p in patterns)
                 {
@@ -402,7 +402,7 @@ namespace Nikse.SubtitleEdit.Logic
                             {
                                 if (matroska.IsValid)
                                 {
-                                    var mkvFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                                    var mkvFileNames = new HashSet<string>(FilePathComparer.Native);
                                     var tracks = matroska.GetTracks(true);
                                     if (tracks.Count > 0)
                                     {

--- a/src/Logic/CommandLineConvert.cs
+++ b/src/Logic/CommandLineConvert.cs
@@ -186,7 +186,6 @@ namespace Nikse.SubtitleEdit.Logic
 
                 var unconsumedArguments = arguments.Skip(4).Select(s => s.Trim()).Where(s => s.Length > 0).ToList();
                 var offset = GetArgument(unconsumedArguments, "offset:");
-                var trackNumber = GetArgument(unconsumedArguments, "track-number:");
                 var resolution = GetResolution(unconsumedArguments);
                 var targetFrameRate = GetFrameRate(unconsumedArguments, "targetfps");
                 var frameRate = GetFrameRate(unconsumedArguments, "fps");
@@ -324,6 +323,15 @@ namespace Nikse.SubtitleEdit.Logic
                     }
                 }
 
+                var trackNumbers = new HashSet<string>(GetArgument(unconsumedArguments, "track-number:").Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(tn => tn.Trim()).Where(tn => tn.Length > 0));
+                foreach (var trackNumber in trackNumbers)
+                {
+                    if (!int.TryParse(trackNumber, out _))
+                    {
+                        throw new FormatException($"The track number '{trackNumber}' is invalid.");
+                    }
+                }
+
                 var actions = GetArgumentActions(unconsumedArguments);
 
                 bool overwrite = GetArgument(unconsumedArguments, "overwrite").Equals("overwrite");
@@ -401,7 +409,7 @@ namespace Nikse.SubtitleEdit.Logic
                                     {
                                         foreach (var track in tracks)
                                         {
-                                            if (string.IsNullOrEmpty(trackNumber) || track.TrackNumber.ToString(CultureInfo.InvariantCulture) == trackNumber)
+                                            if (trackNumbers.Count == 0 || trackNumbers.Contains(track.TrackNumber.ToString(CultureInfo.InvariantCulture)))
                                             {
                                                 var lang = track.Language.RemoveChar('?').RemoveChar('!').RemoveChar('*').RemoveChar(',').RemoveChar('/').Trim();
                                                 if (track.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase))
@@ -515,7 +523,7 @@ namespace Nikse.SubtitleEdit.Logic
                             var mp4SubtitleTracks = mp4Parser.GetSubtitleTracks();
                             foreach (var track in mp4SubtitleTracks)
                             {
-                                if (string.IsNullOrEmpty(trackNumber) || track.Tkhd.TrackId.ToString(CultureInfo.InvariantCulture) == trackNumber)
+                                if (trackNumbers.Count == 0 || trackNumbers.Contains(track.Tkhd.TrackId.ToString(CultureInfo.InvariantCulture)))
                                 {
                                     if (track.Mdia.IsVobSubSubtitle)
                                     {

--- a/src/Logic/CommandLineConvert.cs
+++ b/src/Logic/CommandLineConvert.cs
@@ -18,7 +18,6 @@ namespace Nikse.SubtitleEdit.Logic
 {
     public static class CommandLineConvert
     {
-        private static readonly bool IsWindows = !(Configuration.IsRunningOnMac() || Configuration.IsRunningOnLinux());
         private static StreamWriter _stdOutWriter;
         private static string _currentFolder;
         private static bool _consoleAttached;
@@ -884,7 +883,7 @@ namespace Nikse.SubtitleEdit.Logic
         private static void AttachConsole()
         {
             var stdout = Console.OpenStandardOutput();
-            if (IsWindows && stdout == Stream.Null)
+            if (Configuration.IsRunningOnWindows && stdout == Stream.Null)
             {
                 // only attach if output is not being redirected
                 _consoleAttached = NativeMethods.AttachConsole(NativeMethods.ATTACH_PARENT_PROCESS);

--- a/src/Logic/NativeMethods.cs
+++ b/src/Logic/NativeMethods.cs
@@ -44,6 +44,7 @@ namespace Nikse.SubtitleEdit.Logic
         [DllImport("kernel32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool AttachConsole(int dwProcessId);
+        internal const int ATTACH_PARENT_PROCESS = -1;
 
         [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/Logic/OCR/Tesseract/TesseractMultiRunner.cs
+++ b/src/Logic/OCR/Tesseract/TesseractMultiRunner.cs
@@ -19,7 +19,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr.Tesseract
         public TesseractMultiRunner()
         {
             TesseractErrors = new List<string>();
-            _runningOnWindows = !Configuration.IsRunningOnMac() && !Configuration.IsRunningOnLinux();
+            _runningOnWindows = Configuration.IsRunningOnWindows;
         }
 
         private void TesseractErrorReceived(object sender, DataReceivedEventArgs e)

--- a/src/Logic/OCR/Tesseract/TesseractRunner.cs
+++ b/src/Logic/OCR/Tesseract/TesseractRunner.cs
@@ -16,7 +16,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr.Tesseract
         public TesseractRunner()
         {
             TesseractErrors = new List<string>();
-            _runningOnWindows = !Configuration.IsRunningOnMac() && !Configuration.IsRunningOnLinux();
+            _runningOnWindows = Configuration.IsRunningOnWindows;
         }
 
         public string Run(string languageCode, string psmMode, string engineMode, string imageFileName, bool run302 = false)
@@ -101,7 +101,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr.Tesseract
                 }
                 File.Delete(imageFileName);
             }
-            catch 
+            catch
             {
                 // ignored
             }

--- a/src/Logic/SpellCheck/Hunspell.cs
+++ b/src/Logic/SpellCheck/Hunspell.cs
@@ -8,12 +8,12 @@ namespace Nikse.SubtitleEdit.Logic.SpellCheck
     {
         public static Hunspell GetHunspell(string dictionary)
         {
-            if (Configuration.IsRunningOnLinux())
+            if (Configuration.IsRunningOnLinux)
             {
                 return new LinuxHunspell(dictionary + ".aff", dictionary + ".dic");
             }
 
-            if (Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnMac)
             {
                 return new MacHunspell(dictionary + ".aff", dictionary + ".dic");
             }

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -170,7 +170,7 @@ namespace Nikse.SubtitleEdit.Logic
         {
             get
             {
-                if (Configuration.IsRunningOnLinux() || Utilities.IsRunningOnMono())
+                if (Configuration.IsRunningOnLinux || Utilities.IsRunningOnMono())
                 {
                     return File.Exists(Path.Combine(Configuration.BaseDirectory, "mplayer"));
                 }
@@ -205,7 +205,7 @@ namespace Nikse.SubtitleEdit.Logic
             int RTLD_GLOBAL = 0x0100;
             GeneralSettings gs = Configuration.Settings.General;
 
-            if (Configuration.IsRunningOnLinux())
+            if (Configuration.IsRunningOnLinux)
             {
                 //TODO: Improve finding libmpv.so.*
                 var handle = NativeMethods.dlopen("libmpv.so", RTLD_NOW | RTLD_GLOBAL);
@@ -233,7 +233,7 @@ namespace Nikse.SubtitleEdit.Logic
             // folder as Subtitle Edit and add this to the app.config inside the
             // "configuration" element:
             // <dllmap dll="libvlc" target="VLC.app/Contents/MacOS/lib/libvlc.dylib" />
-            if (Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnMac)
             {
                 return new LibVlcMono();
             }

--- a/src/Logic/VideoPlayers/LibVlcDynamic.cs
+++ b/src/Logic/VideoPlayers/LibVlcDynamic.cs
@@ -538,135 +538,153 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
 
         public static string GetVlcPath(string fileName)
         {
-            if (Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnWindows)
             {
-                return null;
-            }
-
-            var path = Path.Combine(Configuration.BaseDirectory, @"VLC\" + fileName);
-            if (File.Exists(path))
-            {
-                return path;
-            }
-
-            if (!string.IsNullOrEmpty(Configuration.Settings.General.VlcLocation))
-            {
-                try
+                var path = Path.Combine(Configuration.BaseDirectory, "VLC", fileName);
+                if (File.Exists(path))
                 {
-                    if (Configuration.Settings.General.VlcLocation.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-                    {
-                        Configuration.Settings.General.VlcLocation = Path.GetDirectoryName(Configuration.Settings.General.VlcLocation);
-                    }
-
-                    if (!string.IsNullOrEmpty(Configuration.Settings.General.VlcLocation))
-                    {
-                        path = Path.Combine(Configuration.Settings.General.VlcLocation, fileName);
-                        if (File.Exists(path))
-                        {
-                            return path;
-                        }
-                    }
+                    return path;
                 }
-                catch
-                {
-                    // ignored
-                }
-            }
 
-            if (!string.IsNullOrEmpty(Configuration.Settings.General.VlcLocationRelative))
-            {
-                try
+                if (!string.IsNullOrEmpty(Configuration.Settings.General.VlcLocation))
                 {
-                    path = Configuration.Settings.General.VlcLocationRelative;
-                    if (path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                    try
                     {
-                        path = Path.GetDirectoryName(path);
-                    }
-
-                    if (path != null)
-                    {
-                        path = Path.Combine(path, fileName);
-                        string path2 = Path.GetFullPath(path);
-                        if (File.Exists(path2))
+                        if (Configuration.Settings.General.VlcLocation.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                         {
-                            return path2;
+                            Configuration.Settings.General.VlcLocation = Path.GetDirectoryName(Configuration.Settings.General.VlcLocation);
                         }
 
-                        while (path.StartsWith(".."))
+                        if (!string.IsNullOrEmpty(Configuration.Settings.General.VlcLocation))
                         {
-                            path = path.Remove(0, 3);
-                            path2 = Path.GetFullPath(path);
-                            if (File.Exists(path2))
+                            path = Path.Combine(Configuration.Settings.General.VlcLocation, fileName);
+                            if (File.Exists(path))
                             {
-                                return path2;
+                                return path;
                             }
                         }
                     }
+                    catch
+                    {
+                        // ignored
+                    }
                 }
-                catch
+
+                if (!string.IsNullOrEmpty(Configuration.Settings.General.VlcLocationRelative))
                 {
-                    // ignored
+                    try
+                    {
+                        path = Configuration.Settings.General.VlcLocationRelative;
+                        if (path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                        {
+                            path = Path.GetDirectoryName(path);
+                        }
+
+                        if (path != null)
+                        {
+                            path = Path.Combine(path, fileName);
+                            var fullPath = Path.GetFullPath(path);
+                            if (File.Exists(fullPath))
+                            {
+                                return fullPath;
+                            }
+
+                            while (path.StartsWith(".."))
+                            {
+                                path = path.Remove(0, 3);
+                                fullPath = Path.GetFullPath(path);
+                                if (File.Exists(fullPath))
+                                {
+                                    return fullPath;
+                                }
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
                 }
-            }
 
-            // XP via registry path
-            path = RegistryUtil.GetValue(@"SOFTWARE\VideoLAN\VLC", "InstallDir");
-            if (path != null && Directory.Exists(path))
-            {
-                path = Path.Combine(path, fileName);
-            }
+                // XP via registry path
+                path = RegistryUtil.GetValue(@"SOFTWARE\VideoLAN\VLC", "InstallDir");
+                if (path != null && Directory.Exists(path))
+                {
+                    path = Path.Combine(path, fileName);
+                }
 
-            if (File.Exists(path))
-            {
-                return path;
-            }
+                if (File.Exists(path))
+                {
+                    return path;
+                }
 
-            // Winows 7 via registry path
-            path = RegistryUtil.GetValue(@"SOFTWARE\Wow6432Node\VideoLAN\VLC", "InstallDir");
-            if (path != null && Directory.Exists(path))
-            {
-                path = Path.Combine(path, fileName);
-            }
+                // Windows 7 via registry path
+                path = RegistryUtil.GetValue(@"SOFTWARE\Wow6432Node\VideoLAN\VLC", "InstallDir");
+                if (path != null && Directory.Exists(path))
+                {
+                    path = Path.Combine(path, fileName);
+                }
 
-            if (File.Exists(path))
-            {
-                return path;
-            }
+                if (File.Exists(path))
+                {
+                    return path;
+                }
 
-            path = Path.Combine(@"C:\Program Files (x86)\VideoLAN\VLC", fileName);
-            if (File.Exists(path))
-            {
-                return path;
-            }
+                path = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+                if (!string.IsNullOrEmpty(path))
+                {
+                    var p = Path.Combine(path, "VideoLAN", "VLC", fileName);
+                    if (File.Exists(p))
+                    {
+                        return p;
+                    }
 
-            path = Path.Combine(@"C:\Program Files\VideoLAN\VLC", fileName);
-            if (File.Exists(path))
-            {
-                return path;
-            }
+                    p = Path.Combine(path, "VLC", fileName);
+                    if (File.Exists(p))
+                    {
+                        return p;
+                    }
+                }
 
-            path = Path.Combine(@"C:\Program Files (x86)\VLC", fileName);
-            if (File.Exists(path))
-            {
-                return path;
-            }
+                path = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                if (!string.IsNullOrEmpty(path))
+                {
+                    var p = Path.Combine(path, "VideoLAN", "VLC", fileName);
+                    if (File.Exists(p))
+                    {
+                        return p;
+                    }
 
-            path = Path.Combine(@"C:\Program Files\VLC", fileName);
-            if (File.Exists(path))
-            {
-                return path;
-            }
+                    p = Path.Combine(path, "VLC", fileName);
+                    if (File.Exists(p))
+                    {
+                        return p;
+                    }
+                }
 
-            path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), @"VideoLAN\VLC\" + fileName);
-            if (File.Exists(path))
-            {
-                return path;
-            }
+                path = Path.Combine(@"C:\Program Files (x86)\VideoLAN\VLC", fileName);
+                if (File.Exists(path))
+                {
+                    return path;
+                }
 
-            path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), @"VLC\" + fileName);
-            if (File.Exists(path))
-            {
-                return path;
+                path = Path.Combine(@"C:\Program Files\VideoLAN\VLC", fileName);
+                if (File.Exists(path))
+                {
+                    return path;
+                }
+
+                path = Path.Combine(@"C:\Program Files (x86)\VLC", fileName);
+                if (File.Exists(path))
+                {
+                    return path;
+                }
+
+                path = Path.Combine(@"C:\Program Files\VLC", fileName);
+                if (File.Exists(path))
+                {
+                    return path;
+                }
             }
 
             return null;

--- a/src/Logic/VideoPlayers/MPlayer.cs
+++ b/src/Logic/VideoPlayers/MPlayer.cs
@@ -132,7 +132,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
             {
                 _mplayer = new Process { StartInfo = { FileName = mplayerExeName } };
                 //vo options: gl, gl2, directx:noaccel
-                if (Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac())
+                if (Configuration.IsRunningOnLinux || Configuration.IsRunningOnMac)
                 {
                     _mplayer.StartInfo.Arguments = "-nofs -quiet -slave -idle -nosub -noautosub -loop 0 -osdlevel 0 -vsync -wid " + ownerControl.Handle.ToInt32() + " \"" + videoFileName + "\" ";
                 }
@@ -318,7 +318,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
         {
             get
             {
-                if (Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac())
+                if (Configuration.IsRunningOnLinux || Configuration.IsRunningOnMac)
                 {
                     return "mplayer";
                 }

--- a/src/Logic/VideoPlayers/libMpvDynamic.cs
+++ b/src/Logic/VideoPlayers/libMpvDynamic.cs
@@ -416,15 +416,13 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
 
         public static string GetMpvPath(string fileName)
         {
-            if (Configuration.IsRunningOnLinux() || Configuration.IsRunningOnMac())
+            if (Configuration.IsRunningOnWindows)
             {
-                return null;
-            }
-
-            var path = Path.Combine(Configuration.DataDirectory, fileName);
-            if (File.Exists(path))
-            {
-                return path;
+                var path = Path.Combine(Configuration.DataDirectory, fileName);
+                if (File.Exists(path))
+                {
+                    return path;
+                }
             }
 
             return null;


### PR DESCRIPTION
1. Refact CommandLineConvert
   - Move command line argument details from Main to CommandLineConvert.
   - Use HashSet<> with StringComparer i/o List<>.
   - Use [FlagsAttribute] i/o List<>.
   - Avoid ToList() where feasible.
2. Try to fix Codacy anomalies
3. Allow multiple track numbers in '/track-number' command line option
4. Add IsRunningOnWindows property to Configuration class
   - Keep IsRunningOn* logic in one class only.
   - Do the Directory.Exists() invocations only once.
5. Add FilePathComparer (Unix, Windows, Native)
6. Use FilePathComparer i/o StringComparer in CommandLineConvert
7. Add GetOffset() to CommandLineConvert
8. Apply GetOffset() in CommandLineConvert