### PR TITLE
FCE Spanish ¿? and ¡! : Do not apply unchecked fixes

### DIFF
--- a/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
+++ b/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
@@ -14,50 +14,72 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
     {
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
-            var language = Configuration.Settings.Language.FixCommonErrors;
-            string fixAction = language.FixSpanishInvertedQuestionAndExclamationMarks;
             int fixCount = 0;
+            var language = Configuration.Settings.Language.FixCommonErrors;
+            var fixAction = language.FixSpanishInvertedQuestionAndExclamationMarks;
+            var p = (Paragraph)null;
+            var oldText = (string)null;
+
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
-                Paragraph p = subtitle.Paragraphs[i];
-                Paragraph last = subtitle.GetParagraphOrDefault(i - 1);
+                var last = p;
+                var oldLastText = oldText;
+                p = subtitle.Paragraphs[i];
+                oldText = p.Text;
 
-                bool wasLastLineClosed = last == null || last.Text.EndsWith('?') || last.Text.EndsWith('!') || last.Text.EndsWith('.') ||
-                                         last.Text.EndsWith(':') || last.Text.EndsWith(')') || last.Text.EndsWith(']');
-                string trimmedStart = p.Text.TrimStart('-', ' ');
+                var isLastLineClosed = last == null || last.Text.Length > 0 && ".!?:)]".Contains(last.Text[last.Text.Length - 1]);
+                var trimmedStart = p.Text.TrimStart('-', ' ');
                 if (last != null && last.Text.EndsWith("...", StringComparison.Ordinal) && trimmedStart.Length > 0 && char.IsLower(trimmedStart[0]))
                 {
-                    wasLastLineClosed = false;
+                    isLastLineClosed = false;
                 }
 
-                if (!wasLastLineClosed && last.Text == last.Text.ToUpperInvariant())
+                if (!isLastLineClosed && last.Text == last.Text.ToUpperInvariant())
                 {
-                    wasLastLineClosed = true;
+                    isLastLineClosed = true;
                 }
 
-                string oldText = p.Text;
+                FixSpanishInvertedLetter('?', "¿", p, last, ref isLastLineClosed, callbacks);
+                FixSpanishInvertedLetter('!', "¡", p, last, ref isLastLineClosed, callbacks);
 
-                FixSpanishInvertedLetter('?', "¿", p, last, ref wasLastLineClosed, fixAction, ref fixCount, callbacks);
-                FixSpanishInvertedLetter('!', "¡", p, last, ref wasLastLineClosed, fixAction, ref fixCount, callbacks);
-
-                if (p.Text != oldText)
+                if (last?.Text != oldLastText)
+                {
+                    if (callbacks.AllowFix(last, fixAction))
+                    {
+                        fixCount++;
+                        callbacks.AddFixToListView(last, fixAction, oldLastText, last.Text);
+                    }
+                    else
+                    {
+                        last.Text = oldLastText;
+                    }
+                }
+            }
+            if (p?.Text != oldText)
+            {
+                if (callbacks.AllowFix(p, fixAction))
                 {
                     fixCount++;
                     callbacks.AddFixToListView(p, fixAction, oldText, p.Text);
                 }
+                else
+                {
+                    p.Text = oldText;
+                }
             }
+
             callbacks.UpdateFixStatus(fixCount, language.FixSpanishInvertedQuestionAndExclamationMarks, fixCount.ToString(CultureInfo.InvariantCulture));
         }
 
-        private void FixSpanishInvertedLetter(char mark, string inverseMark, Paragraph p, Paragraph last, ref bool wasLastLineClosed, string fixAction, ref int fixCount, IFixCallbacks callbacks)
+        private void FixSpanishInvertedLetter(char mark, string inverseMark, Paragraph p, Paragraph last, ref bool isLastLineClosed, IFixCallbacks callbacks)
         {
             if (p.Text.Contains(mark))
             {
-                bool skip = last != null && !p.Text.Contains(inverseMark) && last.Text.Contains(inverseMark) && !last.Text.Contains(mark);
+                var skip = last != null && !p.Text.Contains(inverseMark) && last.Text.Contains(inverseMark) && !last.Text.Contains(mark);
 
                 if (!skip && Utilities.CountTagInText(p.Text, mark) == Utilities.CountTagInText(p.Text, inverseMark) &&
-                    HtmlUtil.RemoveHtmlTags(p.Text).TrimStart(inverseMark[0]).Contains(inverseMark) == false &&
-                    HtmlUtil.RemoveHtmlTags(p.Text).TrimEnd(mark).Contains(mark) == false)
+                    !HtmlUtil.RemoveHtmlTags(p.Text).TrimStart(inverseMark[0]).Contains(inverseMark) &&
+                    !HtmlUtil.RemoveHtmlTags(p.Text).TrimEnd(mark).Contains(mark))
                 {
                     skip = true;
                 }
@@ -66,118 +88,111 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 {
                     int startIndex = 0;
                     int markIndex = p.Text.IndexOf(mark);
-                    if (!wasLastLineClosed && ((p.Text.IndexOf('!') > 0 && p.Text.IndexOf('!') < markIndex) ||
-                                               (p.Text.IndexOf('?') > 0 && p.Text.IndexOf('?') < markIndex) ||
-                                               (p.Text.IndexOf('.') > 0 && p.Text.IndexOf('.') < markIndex)))
+                    if (!isLastLineClosed && ((p.Text.IndexOf('!') > 0 && p.Text.IndexOf('!') < markIndex) ||
+                                              (p.Text.IndexOf('?') > 0 && p.Text.IndexOf('?') < markIndex) ||
+                                              (p.Text.IndexOf('.') > 0 && p.Text.IndexOf('.') < markIndex)))
                     {
-                        wasLastLineClosed = true;
+                        isLastLineClosed = true;
                     }
 
                     while (markIndex > 0 && startIndex < p.Text.Length)
                     {
                         int inverseMarkIndex = p.Text.IndexOf(inverseMark, startIndex, StringComparison.Ordinal);
-                        if (wasLastLineClosed && (inverseMarkIndex < 0 || inverseMarkIndex > markIndex))
+                        if (isLastLineClosed && (inverseMarkIndex < 0 || inverseMarkIndex > markIndex))
                         {
-                            if (callbacks.AllowFix(p, fixAction))
+                            int j = markIndex - 1;
+
+                            while (j > startIndex && (p.Text[j] == '.' || p.Text[j] == '!' || p.Text[j] == '?'))
                             {
-                                int j = markIndex - 1;
+                                j--;
+                            }
 
-                                while (j > startIndex && (p.Text[j] == '.' || p.Text[j] == '!' || p.Text[j] == '?'))
-                                {
-                                    j--;
-                                }
+                            while (j > startIndex &&
+                                   (p.Text[j] != '.' || IsSpanishAbbreviation(p.Text, j, callbacks)) &&
+                                   p.Text[j] != '!' &&
+                                   p.Text[j] != '?' &&
+                                   !(j > 3 && p.Text.Substring(j - 3, 3) == Environment.NewLine + "-") &&
+                                   !(j > 4 && p.Text.Substring(j - 4, 4) == Environment.NewLine + " -") &&
+                                   !(j > 6 && p.Text.Substring(j - 6, 6) == Environment.NewLine + "<i>-"))
+                            {
+                                j--;
+                            }
 
-                                while (j > startIndex &&
-                                       (p.Text[j] != '.' || IsSpanishAbbreviation(p.Text, j, callbacks)) &&
-                                       p.Text[j] != '!' &&
-                                       p.Text[j] != '?' &&
-                                       !(j > 3 && p.Text.Substring(j - 3, 3) == Environment.NewLine + "-") &&
-                                       !(j > 4 && p.Text.Substring(j - 4, 4) == Environment.NewLine + " -") &&
-                                       !(j > 6 && p.Text.Substring(j - 6, 6) == Environment.NewLine + "<i>-"))
-                                {
-                                    j--;
-                                }
+                            if (@".!?".Contains(p.Text[j]))
+                            {
+                                j++;
+                            }
+                            if (j + 3 < p.Text.Length && p.Text.Substring(j + 1, 2) == Environment.NewLine)
+                            {
+                                j += 3;
+                            }
+                            else if (j + 2 < p.Text.Length && p.Text.Substring(j, 2) == Environment.NewLine)
+                            {
+                                j += 2;
+                            }
+                            if (j >= startIndex)
+                            {
+                                var part = p.Text.Substring(j, markIndex - j + 1);
 
-                                if (@".!?".Contains(p.Text[j]))
+                                var speaker = string.Empty;
+                                int speakerEnd = part.IndexOf(')');
+                                if (part.StartsWith('(') && speakerEnd > 0 && speakerEnd < part.IndexOf(mark))
                                 {
-                                    j++;
-                                }
-                                if (j + 3 < p.Text.Length && p.Text.Substring(j + 1, 2) == Environment.NewLine)
-                                {
-                                    j += 3;
-                                }
-                                else if (j + 2 < p.Text.Length && p.Text.Substring(j, 2) == Environment.NewLine)
-                                {
-                                    j += 2;
-                                }
-                                if (j >= startIndex)
-                                {
-                                    string part = p.Text.Substring(j, markIndex - j + 1);
-
-                                    string speaker = string.Empty;
-                                    int speakerEnd = part.IndexOf(')');
-                                    if (part.StartsWith('(') && speakerEnd > 0 && speakerEnd < part.IndexOf(mark))
+                                    while (Environment.NewLine.Contains(part[speakerEnd + 1]))
                                     {
-                                        while (Environment.NewLine.Contains(part[speakerEnd + 1]))
-                                        {
-                                            speakerEnd++;
-                                        }
-
-                                        speaker = part.Substring(0, speakerEnd + 1);
-                                        part = part.Substring(speakerEnd + 1);
-                                    }
-                                    speakerEnd = part.IndexOf(']');
-                                    if (part.StartsWith('[') && speakerEnd > 0 && speakerEnd < part.IndexOf(mark))
-                                    {
-                                        while (Environment.NewLine.Contains(part[speakerEnd + 1]))
-                                        {
-                                            speakerEnd++;
-                                        }
-
-                                        speaker = part.Substring(0, speakerEnd + 1);
-                                        part = part.Substring(speakerEnd + 1);
+                                        speakerEnd++;
                                     }
 
-                                    var st = new StrippableText(part);
-                                    if (j == 0 && mark == '!' && st.Pre == "¿" && Utilities.CountTagInText(p.Text, mark) == 1 && HtmlUtil.RemoveHtmlTags(p.Text).EndsWith(mark))
+                                    speaker = part.Substring(0, speakerEnd + 1);
+                                    part = part.Substring(speakerEnd + 1);
+                                }
+                                speakerEnd = part.IndexOf(']');
+                                if (part.StartsWith('[') && speakerEnd > 0 && speakerEnd < part.IndexOf(mark))
+                                {
+                                    while (Environment.NewLine.Contains(part[speakerEnd + 1]))
                                     {
-                                        p.Text = inverseMark + p.Text;
+                                        speakerEnd++;
                                     }
-                                    else if (j == 0 && mark == '?' && st.Pre == "¡" && Utilities.CountTagInText(p.Text, mark) == 1 && HtmlUtil.RemoveHtmlTags(p.Text).EndsWith(mark))
-                                    {
-                                        p.Text = inverseMark + p.Text;
-                                    }
-                                    else
-                                    {
-                                        string temp = inverseMark;
-                                        int addToIndex = 0;
-                                        while (p.Text.Length > markIndex + 1 && p.Text[markIndex + 1] == mark &&
-                                            Utilities.CountTagInText(p.Text, mark) > Utilities.CountTagInText(p.Text + temp, inverseMark))
-                                        {
-                                            temp += inverseMark;
-                                            st.Post += mark;
-                                            markIndex++;
-                                            addToIndex++;
-                                        }
 
-                                        p.Text = p.Text.Remove(j, markIndex - j + 1).Insert(j, speaker + st.Pre + temp + st.StrippedText + st.Post);
-                                        markIndex += addToIndex;
+                                    speaker = part.Substring(0, speakerEnd + 1);
+                                    part = part.Substring(speakerEnd + 1);
+                                }
+
+                                var st = new StrippableText(part);
+                                if (j == 0 && mark == '!' && st.Pre == "¿" && Utilities.CountTagInText(p.Text, mark) == 1 && HtmlUtil.RemoveHtmlTags(p.Text).EndsWith(mark))
+                                {
+                                    p.Text = inverseMark + p.Text;
+                                }
+                                else if (j == 0 && mark == '?' && st.Pre == "¡" && Utilities.CountTagInText(p.Text, mark) == 1 && HtmlUtil.RemoveHtmlTags(p.Text).EndsWith(mark))
+                                {
+                                    p.Text = inverseMark + p.Text;
+                                }
+                                else
+                                {
+                                    var temp = inverseMark;
+                                    int addToIndex = 0;
+                                    while (p.Text.Length > markIndex + 1 && p.Text[markIndex + 1] == mark && Utilities.CountTagInText(p.Text, mark) > Utilities.CountTagInText(p.Text + temp, inverseMark))
+                                    {
+                                        temp += inverseMark;
+                                        st.Post += mark;
+                                        markIndex++;
+                                        addToIndex++;
                                     }
+
+                                    p.Text = p.Text.Remove(j, markIndex - j + 1).Insert(j, speaker + st.Pre + temp + st.StrippedText + st.Post);
+                                    markIndex += addToIndex;
                                 }
                             }
                         }
-                        else if (last != null && !wasLastLineClosed && inverseMarkIndex == p.Text.IndexOf(mark) && !last.Text.Contains(inverseMark))
+                        else if (last != null && !isLastLineClosed && inverseMarkIndex == p.Text.IndexOf(mark) && !last.Text.Contains(inverseMark))
                         {
-                            string lastOldtext = last.Text;
                             int idx = last.Text.Length - 2;
-                            while (idx > 0 && (last.Text.Substring(idx, 2) != ". ") && (last.Text.Substring(idx, 2) != "! ") && (last.Text.Substring(idx, 2) != "? "))
+                            while (idx > 0 && last.Text.Substring(idx, 2) != ". " && last.Text.Substring(idx, 2) != "! " && last.Text.Substring(idx, 2) != "? ")
                             {
                                 idx--;
                             }
 
                             last.Text = last.Text.Insert(idx, inverseMark);
-                            fixCount++;
-                            callbacks.AddFixToListView(last, fixAction, lastOldtext, last.Text);
                         }
 
                         startIndex = markIndex + 2;
@@ -190,7 +205,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             markIndex = -1;
                         }
 
-                        wasLastLineClosed = true;
+                        isLastLineClosed = true;
                     }
                 }
                 if (p.Text.EndsWith(mark + "...", StringComparison.Ordinal) && p.Text.Length > 4)
@@ -238,7 +253,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 return true;                          // O.R.
             }
 
-            string word = string.Empty;
+            var word = string.Empty;
             int i = index - 1;
             while (i >= 0 && char.IsLetter(text[i]))
             {
@@ -260,8 +275,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 return true;
             }
 
-            HashSet<string> abbreviations = callbacks.GetAbbreviations();
-            return abbreviations.Contains(word + ".");
+            return callbacks.GetAbbreviations().Contains(word + ".");
         }
 
     }

--- a/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
+++ b/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
@@ -71,7 +71,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             callbacks.UpdateFixStatus(fixCount, language.FixSpanishInvertedQuestionAndExclamationMarks, fixCount.ToString(CultureInfo.InvariantCulture));
         }
 
-        private void FixSpanishInvertedLetter(char mark, string inverseMark, Paragraph p, Paragraph last, ref bool isLastLineClosed, IFixCallbacks callbacks)
+        private static void FixSpanishInvertedLetter(char mark, string inverseMark, Paragraph p, Paragraph last, ref bool isLastLineClosed, IFixCallbacks callbacks)
         {
             if (p.Text.Contains(mark))
             {
@@ -236,7 +236,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             }
         }
 
-        private bool IsSpanishAbbreviation(string text, int index, IFixCallbacks callbacks)
+        private static bool IsSpanishAbbreviation(string text, int index, IFixCallbacks callbacks)
         {
             if (text[index] != '.')
             {


### PR DESCRIPTION
Closes #3635

Does _not_ address the problem reported in #3639.

Looks like a huge change, unless compared with `git diff --ignore-space-change master..pr/fcesp`.
Basically, `callbacks.AllowFix()` has been moved from `FixSpanishInvertedLetter()` to `Fix()`, because changes in the previous paragraph may affect processing of current paragraph. Therefore, always apply changes, but revert if unchecked, _after_ processing the next paragraph.