### PR TITLE
center get pac unicode to parent form

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -428,7 +428,7 @@ namespace Nikse.SubtitleEdit.Forms
                 // set up UI interfaces / injections
                 YouTubeAnnotations.GetYouTubeAnnotationStyles = new UiGetYouTubeAnnotationStyles();
                 Ebu.EbuUiHelper = new UiEbuSaveHelper();
-                Pac.GetPacEncodingImplementation = new UiGetPacEncoding();
+                Pac.GetPacEncodingImplementation = new UiGetPacEncoding(this);
                 RichTextToPlainText.NativeRtfTextConverter = new RtfTextConverterRichTextBox();
 
                 toolStripComboBoxFrameRate.Items.Add(23.976.ToString(CultureInfo.CurrentCulture));

--- a/src/Logic/UiGetPacEncoding.cs
+++ b/src/Logic/UiGetPacEncoding.cs
@@ -1,17 +1,24 @@
 ﻿using Nikse.SubtitleEdit.Core;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Forms;
+using System.Windows.Forms;
 
 namespace Nikse.SubtitleEdit.Logic
 {
     public class UiGetPacEncoding : Pac.IGetPacEncoding
     {
+        private readonly Form _parent;
+
+        public UiGetPacEncoding(Form parent)
+        {
+            _parent = parent;
+        }
 
         public int GetPacEncoding(byte[] previewBuffer, string fileName)
         {
             using (var pacEncoding = new PacEncoding(previewBuffer, fileName))
             {
-                if (pacEncoding.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                if (pacEncoding.ShowDialog(_parent) == System.Windows.Forms.DialogResult.OK)
                 {
                     Configuration.Settings.General.LastPacCodePage = pacEncoding.CodePageIndex;
                     return pacEncoding.CodePageIndex;


### PR DESCRIPTION
When you open subtitle edit with a pac subtitle format, get-pac encoding won't start centralized due to the missing of parent form