### PR TITLE
fix: Timed Text styles dialog crashes

### DIFF
--- a/src/Forms/Styles/TimedTextStyles.cs
+++ b/src/Forms/Styles/TimedTextStyles.cs
@@ -64,6 +64,10 @@ namespace Nikse.SubtitleEdit.Forms.Styles
 
             foreach (FontFamily ff in FontFamily.Families)
             {
+                if (ff.Name.Length == 0)
+                {
+                    continue;
+                }
                 comboBoxFontName.Items.Add(char.ToLower(ff.Name[0]) + ff.Name.Substring(1));
             }
 


### PR DESCRIPTION
If one of font families is with an empty name, the Timed Text Styles form crashes when initializing.