### PR TITLE
Remove redundant overrides + Minor refact

### DIFF
--- a/libse/SubtitleFormats/AribB36.cs
+++ b/libse/SubtitleFormats/AribB36.cs
@@ -343,11 +343,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             get { return "ARIB"; }
         }
 
-        public override bool IsTimeBased
-        {
-            get { return true; }
-        }
-
         public override bool IsMine(List<string> lines, string fileName)
         {
             if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))

--- a/libse/SubtitleFormats/NetflixTimedText.cs
+++ b/libse/SubtitleFormats/NetflixTimedText.cs
@@ -329,13 +329,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             subtitle.Paragraphs.ForEach(p => p.Text = Regex.Replace(p.Text, @"^({\\an[1-7,9]})", string.Empty));
         }
 
-        public override bool HasStyleSupport
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool HasStyleSupport => false;
 
     }
 }

--- a/libse/SubtitleFormats/UnknownSubtitle65.cs
+++ b/libse/SubtitleFormats/UnknownSubtitle65.cs
@@ -17,8 +17,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string Name => "Unknown 65";
 
-        public override bool IsTimeBased => true;
-
         public override string ToText(Subtitle subtitle, string title)
         {
             const string paragraphWriteFormat = "{0:00}:{1:00}:{2:00},{3:00}:{4:00}:{5:00}{6}{7}";


### PR DESCRIPTION
The base value of **`IsTimeBased`** is already **`true`**.