### PR TITLE
Add progress counter to GetDictionaries form

### DIFF
--- a/src/Forms/GetDictionaries.cs
+++ b/src/Forms/GetDictionaries.cs
@@ -146,6 +146,10 @@ namespace Nikse.SubtitleEdit.Forms
 
                 var wc = new WebClient { Proxy = Utilities.GetProxy() };
                 wc.DownloadDataCompleted += wc_DownloadDataCompleted;
+                wc.DownloadProgressChanged += (o, args) =>
+                {
+                    labelPleaseWait.Text = Configuration.Settings.Language.General.PleaseWait + "  " + args.ProgressPercentage + "%";
+                };
                 wc.DownloadDataAsync(new Uri(url));
             }
             catch (Exception exception)


### PR DESCRIPTION
This adds a percentage display to the NHunspell dictionary downloader.

It's implemented in the exact same way as for the ffmpeg downloader or the Tesseract downloader.