### PR TITLE
Check environment variables for directory overrides

### DIFF
--- a/libse/Configuration.cs
+++ b/libse/Configuration.cs
@@ -131,7 +131,12 @@ namespace Nikse.SubtitleEdit.Core
 
             if (IsRunningOnLinux || IsRunningOnMac)
             {
-                if (!Directory.Exists(appDataRoamingPath) && !File.Exists(Path.Combine(BaseDirectory, ".PACKAGE-MANAGER")))
+                var datafolder_override = Environment.GetEnvironmentVariable("DATA_FOLDER_OVERRIDE");
+                if (datafolder_override)
+                {
+                    appDataRoamingPath = Path.Combine(datafolder_override, "");
+                }
+                else if (!Directory.Exists(appDataRoamingPath) && !File.Exists(Path.Combine(BaseDirectory, ".PACKAGE-MANAGER")))
                 {
                     try
                     {
@@ -180,6 +185,11 @@ namespace Nikse.SubtitleEdit.Core
         {
             if (IsRunningOnLinux || IsRunningOnMac)
             {
+                var tesseract_overide = Environment.GetEnvironmentVariable("TESSERACT4_OVERRIDE");
+                if (tesseract_overide)
+                {
+                    return tesseract_overide;
+                }
                 if (Directory.Exists("/usr/share/tesseract-ocr/4.00/tessdata"))
                 {
                     return "/usr/share/tesseract-ocr/4.00/tessdata";
@@ -202,6 +212,11 @@ namespace Nikse.SubtitleEdit.Core
         {
             if (IsRunningOnLinux || IsRunningOnMac)
             {
+                var tesseract_overide = Environment.GetEnvironmentVariable("TESSERACT302_OVERRIDE");
+                if (tesseract_overide)
+                {
+                    return tesseract_overide;
+                }
                 if (Directory.Exists("/usr/share/tesseract-ocr/tessdata"))
                 {
                     return "/usr/share/tesseract-ocr/tessdata";

--- a/libse/Configuration.cs
+++ b/libse/Configuration.cs
@@ -132,7 +132,7 @@ namespace Nikse.SubtitleEdit.Core
             if (IsRunningOnLinux || IsRunningOnMac)
             {
                 var datafolder_override = Environment.GetEnvironmentVariable("DATA_FOLDER_OVERRIDE");
-                if (datafolder_override)
+                if (datafolder_override != null)
                 {
                     appDataRoamingPath = Path.Combine(datafolder_override, "");
                 }
@@ -186,7 +186,7 @@ namespace Nikse.SubtitleEdit.Core
             if (IsRunningOnLinux || IsRunningOnMac)
             {
                 var tesseract_overide = Environment.GetEnvironmentVariable("TESSERACT4_OVERRIDE");
-                if (tesseract_overide)
+                if (tesseract_overide != null)
                 {
                     return tesseract_overide;
                 }
@@ -213,7 +213,7 @@ namespace Nikse.SubtitleEdit.Core
             if (IsRunningOnLinux || IsRunningOnMac)
             {
                 var tesseract_overide = Environment.GetEnvironmentVariable("TESSERACT302_OVERRIDE");
-                if (tesseract_overide)
+                if (tesseract_overide != null)
                 {
                     return tesseract_overide;
                 }

--- a/libse/Configuration.cs
+++ b/libse/Configuration.cs
@@ -131,10 +131,10 @@ namespace Nikse.SubtitleEdit.Core
 
             if (IsRunningOnLinux || IsRunningOnMac)
             {
-                var datafolder_override = Environment.GetEnvironmentVariable("DATA_FOLDER_OVERRIDE");
-                if (datafolder_override != null)
+                var dataFolderOverride = Environment.GetEnvironmentVariable("DATA_FOLDER_OVERRIDE");
+                if (!string.IsNullOrEmpty(dataFolderOverride) && Directory.Exists(dataFolderOverride))
                 {
-                    appDataRoamingPath = Path.Combine(datafolder_override, "");
+                    appDataRoamingPath = Path.Combine(dataFolderOverride, "");
                 }
                 else if (!Directory.Exists(appDataRoamingPath) && !File.Exists(Path.Combine(BaseDirectory, ".PACKAGE-MANAGER")))
                 {
@@ -185,10 +185,10 @@ namespace Nikse.SubtitleEdit.Core
         {
             if (IsRunningOnLinux || IsRunningOnMac)
             {
-                var tesseract_overide = Environment.GetEnvironmentVariable("TESSERACT4_OVERRIDE");
-                if (tesseract_overide != null)
+                var tesseract4Override = Environment.GetEnvironmentVariable("TESSERACT4_OVERRIDE");
+                if (!string.IsNullOrEmpty(tesseract4Override) && Directory.Exists(tesseract4Override))
                 {
-                    return tesseract_overide;
+                    return tesseract4Override;
                 }
                 if (Directory.Exists("/usr/share/tesseract-ocr/4.00/tessdata"))
                 {
@@ -212,10 +212,10 @@ namespace Nikse.SubtitleEdit.Core
         {
             if (IsRunningOnLinux || IsRunningOnMac)
             {
-                var tesseract_overide = Environment.GetEnvironmentVariable("TESSERACT302_OVERRIDE");
-                if (tesseract_overide != null)
+                var tesseract3Override = Environment.GetEnvironmentVariable("TESSERACT302_OVERRIDE");
+                if (!string.IsNullOrEmpty(tesseract3Override) && Directory.Exists(tesseract3Override))
                 {
-                    return tesseract_overide;
+                    return tesseract3Override;
                 }
                 if (Directory.Exists("/usr/share/tesseract-ocr/tessdata"))
                 {


### PR DESCRIPTION
This is intended for when the app is run in confinement, when it won't have access to either the `AppData` directory (or `.config` on linux) or its base directory for writing.