### PR TITLE
Fix syntax coloring bugs for Gap column in SubtitleListView

### DIFF
--- a/src/Controls/SubtitleListView.cs
+++ b/src/Controls/SubtitleListView.cs
@@ -1934,6 +1934,11 @@ namespace Nikse.SubtitleEdit.Controls
                     Items[index].SubItems[ColumnIndexWpm].BackColor = color;
                 }
 
+                if (ColumnIndexGap >= 0)
+                {
+                    Items[index].SubItems[ColumnIndexGap].BackColor = color;
+                }
+
                 if (ColumnIndexText >= 0)
                 {
                     Items[index].SubItems[ColumnIndexText].BackColor = color;
@@ -1985,6 +1990,11 @@ namespace Nikse.SubtitleEdit.Controls
                 if (ColumnIndexText >= 0)
                 {
                     item.SubItems[ColumnIndexText].Text = string.Empty;
+                }
+
+                if (ColumnIndexGap >= 0)
+                {
+                    item.SubItems[ColumnIndexGap].Text = string.Empty;
                 }
 
                 SetBackgroundColor(index, color);


### PR DESCRIPTION
For example in OCR window and Compare window:

![gap1](https://user-images.githubusercontent.com/3516155/70462330-f2ebcb80-1aba-11ea-8fd9-b44d076ea07a.png)

![gap2](https://user-images.githubusercontent.com/3516155/70462345-f717e900-1aba-11ea-85ab-c4a01b59713f.png)

Now the whole row is properly colored and (if applicable) cleared.