### PR TITLE
Add additional common profile presets

### DIFF
--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -939,7 +939,21 @@ $HorzAlign          =   Center
                 SubtitleMinimumDisplayMilliseconds = 833,
                 SubtitleMaximumWordsPerMinute = 300,
                 CpsIncludesSpace = true,
-                MinimumMillisecondsBetweenLines = 84, // 2 frames for 23.97 videos
+                MinimumMillisecondsBetweenLines = 84, // 2 frames for 23.976 fps videos
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "Netflix (Other languages)",
+                SubtitleLineMaximumLength = 42,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 42,
+                SubtitleMaximumCharactersPerSeconds = 17,
+                SubtitleOptimalCharactersPerSeconds = 12,
+                SubtitleMaximumDisplayMilliseconds = 7000,
+                SubtitleMinimumDisplayMilliseconds = 833,
+                SubtitleMaximumWordsPerMinute = 200,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 84, // 2 frames for 23.976 fps videos
             });
             profiles.Add(new RulesProfile
             {
@@ -954,6 +968,174 @@ $HorzAlign          =   Center
                 SubtitleMaximumWordsPerMinute = 300,
                 CpsIncludesSpace = true,
                 MinimumMillisecondsBetweenLines = 200, // 5 frames for 25 fps videos
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "Dutch professional subtitles (23.976/24 fps)",
+                SubtitleLineMaximumLength = 42,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 37,
+                SubtitleMaximumCharactersPerSeconds = 15,
+                SubtitleOptimalCharactersPerSeconds = 11,
+                SubtitleMaximumDisplayMilliseconds = 7007,
+                SubtitleMinimumDisplayMilliseconds = 1400,
+                SubtitleMaximumWordsPerMinute = 180,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 125,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "Dutch professional subtitles (25 fps)",
+                SubtitleLineMaximumLength = 42,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 37,
+                SubtitleMaximumCharactersPerSeconds = 15,
+                SubtitleOptimalCharactersPerSeconds = 11,
+                SubtitleMaximumDisplayMilliseconds = 7000,
+                SubtitleMinimumDisplayMilliseconds = 1400,
+                SubtitleMaximumWordsPerMinute = 180,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 120,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "Dutch fansubs (23.976/24 fps)",
+                SubtitleLineMaximumLength = 45,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 40,
+                SubtitleMaximumCharactersPerSeconds = 22.5m,
+                SubtitleOptimalCharactersPerSeconds = 12,
+                SubtitleMaximumDisplayMilliseconds = 7007,
+                SubtitleMinimumDisplayMilliseconds = 1200,
+                SubtitleMaximumWordsPerMinute = 240,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 125,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "Dutch fansubs (25 fps)",
+                SubtitleLineMaximumLength = 45,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 40,
+                SubtitleMaximumCharactersPerSeconds = 22.5m,
+                SubtitleOptimalCharactersPerSeconds = 12,
+                SubtitleMaximumDisplayMilliseconds = 7000,
+                SubtitleMinimumDisplayMilliseconds = 1200,
+                SubtitleMaximumWordsPerMinute = 240,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 120,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "Danish professional subtitles (23.976/24 fps)",
+                SubtitleLineMaximumLength = 40,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 40,
+                SubtitleMaximumCharactersPerSeconds = 15,
+                SubtitleOptimalCharactersPerSeconds = 10,
+                SubtitleMaximumDisplayMilliseconds = 8008,
+                SubtitleMinimumDisplayMilliseconds = 2002,
+                SubtitleMaximumWordsPerMinute = 180,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 125,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "Danish professional subtitles (25 fps)",
+                SubtitleLineMaximumLength = 40,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 40,
+                SubtitleMaximumCharactersPerSeconds = 15,
+                SubtitleOptimalCharactersPerSeconds = 10,
+                SubtitleMaximumDisplayMilliseconds = 8000,
+                SubtitleMinimumDisplayMilliseconds = 2000,
+                SubtitleMaximumWordsPerMinute = 180,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 120,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "SW2 (French) (23.976/24 fps)",
+                SubtitleLineMaximumLength = 40,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 37,
+                SubtitleMaximumCharactersPerSeconds = 25,
+                SubtitleOptimalCharactersPerSeconds = 18,
+                SubtitleMaximumDisplayMilliseconds = 5005,
+                SubtitleMinimumDisplayMilliseconds = 792,
+                SubtitleMaximumWordsPerMinute = 300,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 125,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "SW2 (French) (25 fps)",
+                SubtitleLineMaximumLength = 40,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 37,
+                SubtitleMaximumCharactersPerSeconds = 25,
+                SubtitleOptimalCharactersPerSeconds = 18,
+                SubtitleMaximumDisplayMilliseconds = 5000,
+                SubtitleMinimumDisplayMilliseconds = 800,
+                SubtitleMaximumWordsPerMinute = 300,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 120,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "SW3 (French) (23.976/24 fps)",
+                SubtitleLineMaximumLength = 40,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 37,
+                SubtitleMaximumCharactersPerSeconds = 25,
+                SubtitleOptimalCharactersPerSeconds = 18,
+                SubtitleMaximumDisplayMilliseconds = 5005,
+                SubtitleMinimumDisplayMilliseconds = 792,
+                SubtitleMaximumWordsPerMinute = 300,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 167,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "SW3 (French) (25 fps)",
+                SubtitleLineMaximumLength = 40,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 37,
+                SubtitleMaximumCharactersPerSeconds = 25,
+                SubtitleOptimalCharactersPerSeconds = 18,
+                SubtitleMaximumDisplayMilliseconds = 5000,
+                SubtitleMinimumDisplayMilliseconds = 800,
+                SubtitleMaximumWordsPerMinute = 300,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 160,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "SW4 (French) (23.976/24 fps)",
+                SubtitleLineMaximumLength = 40,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 37,
+                SubtitleMaximumCharactersPerSeconds = 25,
+                SubtitleOptimalCharactersPerSeconds = 18,
+                SubtitleMaximumDisplayMilliseconds = 5005,
+                SubtitleMinimumDisplayMilliseconds = 792,
+                SubtitleMaximumWordsPerMinute = 300,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 250,
+            });
+            profiles.Add(new RulesProfile
+            {
+                Name = "SW4 (French) (25 fps)",
+                SubtitleLineMaximumLength = 40,
+                MaxNumberOfLines = 2,
+                MergeLinesShorterThan = 37,
+                SubtitleMaximumCharactersPerSeconds = 25,
+                SubtitleOptimalCharactersPerSeconds = 18,
+                SubtitleMaximumDisplayMilliseconds = 5000,
+                SubtitleMinimumDisplayMilliseconds = 800,
+                SubtitleMaximumWordsPerMinute = 300,
+                CpsIncludesSpace = true,
+                MinimumMillisecondsBetweenLines = 240,
             });
         }
     }

--- a/src/Forms/Settings.Designer.cs
+++ b/src/Forms/Settings.Designer.cs
@@ -783,7 +783,7 @@
             // 
             this.numericUpDownDurationMin.Location = new System.Drawing.Point(203, 163);
             this.numericUpDownDurationMin.Maximum = new decimal(new int[] {
-            2000,
+            3000,
             0,
             0,
             0});


### PR DESCRIPTION
- Netflix for most other languages than English, derived from the Timed Text Style Guides: https://partnerhelp.netflixstudios.com/hc/en-us/sections/203480497-Timed-Text-Style-Guides
- Dutch professional subtitles, derived from the style guide from subtitling company Hoek & Sonépouse (http://www.opensubtitles.org/addons/documents/subtitling_guide_nl.html) and the guidelines composed by the Subtitlers division of the Dutch Authors Union (not yet publicly available).
- Dutch fansubs, derived from the OpenSubtitles fansubbing guidelines (https://forum.opensubtitles.org/viewtopic.php?t=12639) and the Dutch SubtitleEdit manual (https://forum.opensubtitles.org/viewtopic.php?f=38&t=15314).
- Danish professional subtitles, derived from the guidelines compiled by the Danish subtitlers’ association: https://undertekstning.dk/english/
- French subtitles, derived from the SW synchronization norms: http://normes.golgeek.fr/

For the language-specific profiles, I added both a 23.976/24 fps and 25 fps version.
Maybe do this for the Netflix profiles as well? Or maybe use frames for the gap setting, since it's the smallest constituent unit for videos.

Maybe also find a way to update the profiles for users who have version 5.3.11 installed (since AddExtraProfiles() will not be called).