### PR TITLE
Add and apply Utilities.GetSubtitleLanguageCultures()

### DIFF
--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Security.Authentication;
@@ -752,6 +753,23 @@ namespace Nikse.SubtitleEdit.Core
                 }
             }
             return list;
+        }
+
+        public static IEnumerable<CultureInfo> GetSubtitleLanguageCultures()
+        {
+            var prospects = new List<CultureInfo>();
+            var excludes = new HashSet<string>();
+
+            foreach (var ci in CultureInfo.GetCultures(CultureTypes.NeutralCultures))
+            {
+                if (ci.Name.Length < 4 && ci.Name == ci.IetfLanguageTag)
+                {
+                    excludes.Add(ci.Parent.Name);
+                    prospects.Add(ci);
+                }
+            }
+
+            return prospects.Where(ci => !excludes.Contains(ci.Name));
         }
 
         public static double GetOptimalDisplayMilliseconds(string text)

--- a/src/Forms/FixCommonErrors.cs
+++ b/src/Forms/FixCommonErrors.cs
@@ -135,17 +135,13 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 comboBoxLanguage.Items.Add(firstItem);
             }
-            foreach (var x in CultureInfo.GetCultures(CultureTypes.NeutralCultures))
+            foreach (var ci in Utilities.GetSubtitleLanguageCultures())
             {
-                if (!string.IsNullOrWhiteSpace(x.ToString()) && !x.EnglishName.Contains("("))
-                {
-                    comboBoxLanguage.Items.Add(new LanguageItem(x, x.EnglishName));
-                }
+                comboBoxLanguage.Items.Add(new LanguageItem(ci, ci.EnglishName));
             }
             comboBoxLanguage.Sorted = true;
             comboBoxLanguage.EndUpdate();
         }
-
 
         public void RunBatchSettings(Subtitle subtitle, SubtitleFormat format, Encoding encoding, string language)
         {

--- a/src/Forms/NetflixFixErrors.cs
+++ b/src/Forms/NetflixFixErrors.cs
@@ -65,30 +65,25 @@ namespace Nikse.SubtitleEdit.Forms
         {
             comboBoxLanguage.BeginUpdate();
             comboBoxLanguage.Items.Clear();
-            var ci = CultureInfo.GetCultureInfo(language);
-            foreach (var x in CultureInfo.GetCultures(CultureTypes.NeutralCultures))
+            foreach (var ci in Utilities.GetSubtitleLanguageCultures())
             {
-                if (!string.IsNullOrWhiteSpace(x.ToString()) && !x.EnglishName.Contains("("))
-                {
-                    comboBoxLanguage.Items.Add(new LanguageItem(x, x.EnglishName));
-                }
+                comboBoxLanguage.Items.Add(new LanguageItem(ci, ci.EnglishName));
             }
             comboBoxLanguage.Sorted = true;
+            var languageCulture = CultureInfo.GetCultureInfo(language);
             int languageIndex = 0;
-            int j = 0;
-            foreach (var x in comboBoxLanguage.Items)
+            for (int i = 0; i < comboBoxLanguage.Items.Count; i++)
             {
-                var li = (LanguageItem)x;
-                if (li.Code.TwoLetterISOLanguageName == ci.TwoLetterISOLanguageName)
+                var li = comboBoxLanguage.Items[i] as LanguageItem;
+                if (li.Code.TwoLetterISOLanguageName == languageCulture.TwoLetterISOLanguageName)
                 {
-                    languageIndex = j;
+                    languageIndex = i;
                     break;
                 }
                 if (li.Code.TwoLetterISOLanguageName == "en")
                 {
-                    languageIndex = j;
+                    languageIndex = i;
                 }
-                j++;
             }
             comboBoxLanguage.SelectedIndex = languageIndex;
             comboBoxLanguage.SelectedIndexChanged += RuleCheckedChanged;


### PR DESCRIPTION
Merge duplicated code.

The current subtitle language exclusion filter suppresses Nynorsk and some other languages that could be supported. The new exclusion filter suppresses only languages that cannot be supported, languages that require an explicit script, e.g. sr-Cyrl.