### PR TITLE
Do not display Dictionaries link on Linux/MacOS

### DIFF
--- a/src/Forms/GetDictionaries.cs
+++ b/src/Forms/GetDictionaries.cs
@@ -38,11 +38,11 @@ namespace Nikse.SubtitleEdit.Forms
 
             LoadDictionaryList("Nikse.SubtitleEdit.Resources.HunspellDictionaries.xml.gz");
             FixLargeFonts();
-			// Disable "Open Dictionaries folder" link on Linux & Mac, it crashes 
-			if (!Configuration.IsRunningOnWindows)
-			{
-				linkLabelOpenDictionaryFolder.Visible = false;
-			}
+            // Disable "Open Dictionaries folder" link on Linux & Mac, it crashes
+            if (!Configuration.IsRunningOnWindows)
+            {
+                linkLabelOpenDictionaryFolder.Visible = false;
+            }
 #if DEBUG
             buttonDownloadAll.Visible = true; // For testing all download links
 #endif

--- a/src/Forms/GetDictionaries.cs
+++ b/src/Forms/GetDictionaries.cs
@@ -38,6 +38,11 @@ namespace Nikse.SubtitleEdit.Forms
 
             LoadDictionaryList("Nikse.SubtitleEdit.Resources.HunspellDictionaries.xml.gz");
             FixLargeFonts();
+			// Disable "Open Dictionaries folder" link on Linux & Mac, it crashes 
+			if (!Configuration.IsRunningOnWindows)
+			{
+				linkLabelOpenDictionaryFolder.Visible = false;
+			}
 #if DEBUG
             buttonDownloadAll.Visible = true; // For testing all download links
 #endif

--- a/src/Forms/Ocr/GetTesseract302Dictionaries.cs
+++ b/src/Forms/Ocr/GetTesseract302Dictionaries.cs
@@ -31,12 +31,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             buttonDownload.Text = Configuration.Settings.Language.GetTesseractDictionaries.Download;
             labelPleaseWait.Text = string.Empty;
             buttonOK.Text = Configuration.Settings.Language.General.Ok;
-			// Disable "Open Dictionaries folder" link on Linux & Mac, it crashes 
-			if (!Configuration.IsRunningOnWindows)
-			{
-				linkLabelOpenDictionaryFolder.Visible = false;
-			}
-			LoadDictionaryList("Nikse.SubtitleEdit.Resources.TesseractDictionaries.xml.gz");
+            // Disable "Open Dictionaries folder" link on Linux & Mac, it crashes
+            if (!Configuration.IsRunningOnWindows)
+            {
+                linkLabelOpenDictionaryFolder.Visible = false;
+            }
+            LoadDictionaryList("Nikse.SubtitleEdit.Resources.TesseractDictionaries.xml.gz");
             FixLargeFonts();
         }
 

--- a/src/Forms/Ocr/GetTesseract302Dictionaries.cs
+++ b/src/Forms/Ocr/GetTesseract302Dictionaries.cs
@@ -31,7 +31,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             buttonDownload.Text = Configuration.Settings.Language.GetTesseractDictionaries.Download;
             labelPleaseWait.Text = string.Empty;
             buttonOK.Text = Configuration.Settings.Language.General.Ok;
-            LoadDictionaryList("Nikse.SubtitleEdit.Resources.TesseractDictionaries.xml.gz");
+			// Disable "Open Dictionaries folder" link on Linux & Mac, it crashes 
+			if (!Configuration.IsRunningOnWindows)
+			{
+				linkLabelOpenDictionaryFolder.Visible = false;
+			}
+			LoadDictionaryList("Nikse.SubtitleEdit.Resources.TesseractDictionaries.xml.gz");
             FixLargeFonts();
         }
 

--- a/src/Forms/Ocr/GetTesseractDictionaries.cs
+++ b/src/Forms/Ocr/GetTesseractDictionaries.cs
@@ -29,12 +29,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             labelPleaseWait.Text = string.Empty;
             buttonOK.Text = Configuration.Settings.Language.General.Ok;
             FixLargeFonts();
-			// Disable "Open Dictionaries folder" link on Linux & Mac, it crashes 
+			// Disable "Open Dictionaries folder" link on Linux & Mac, it crashes
 			if (!Configuration.IsRunningOnWindows)
-			{
-				linkLabelOpenDictionaryFolder.Visible = false;
-			}
-			_dictionaries = TesseractDictionary.List();
+            {
+                linkLabelOpenDictionaryFolder.Visible = false;
+            }
+            _dictionaries = TesseractDictionary.List();
             LoadDictionaryList(first);
         }
 

--- a/src/Forms/Ocr/GetTesseractDictionaries.cs
+++ b/src/Forms/Ocr/GetTesseractDictionaries.cs
@@ -29,7 +29,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             labelPleaseWait.Text = string.Empty;
             buttonOK.Text = Configuration.Settings.Language.General.Ok;
             FixLargeFonts();
-            _dictionaries = TesseractDictionary.List();
+			// Disable "Open Dictionaries folder" link on Linux & Mac, it crashes 
+			if (!Configuration.IsRunningOnWindows)
+			{
+				linkLabelOpenDictionaryFolder.Visible = false;
+			}
+			_dictionaries = TesseractDictionary.List();
             LoadDictionaryList(first);
         }
 


### PR DESCRIPTION
The "Open Dictionaries folder" link on the "Download additional dictionaries" dialog will crash the program when clicked on Linux and MacOS. This PR disables them on Linux and MacOS.