### PR TITLE
Disable mpc-hc checking on Linux/MacOS

### DIFF
--- a/src/Logic/VideoPlayers/MpcHC/MpcHc.cs
+++ b/src/Logic/VideoPlayers/MpcHC/MpcHc.cs
@@ -279,6 +279,10 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.MpcHC
 
         private static string GetMpcHcFileName(string fileNameSuffix)
         {
+            if (!Configuration.IsRunningOnWindows) //short circuit on Linux to resolve issues with read-only filesystems
+            {
+                return null;
+            }
             if (IntPtr.Size == 8) // 64-bit
             {
                 var fileName = $"mpc-hc64{fileNameSuffix}.exe";


### PR DESCRIPTION
This PR disables checking for MpcHC on Linux/MacOS due to issues with running on read-only file systems.