### PR TITLE
Exception handling for opening folders from Subtitle Edit

### DIFF
--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -2226,8 +2226,15 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (Directory.Exists(textBoxOutputFolder.Text))
             {
-                System.Diagnostics.Process.Start(textBoxOutputFolder.Text);
-            }
+                try
+                {
+                    System.Diagnostics.Process.Start(textBoxOutputFolder.Text);
+                }
+                catch (Exception exception)
+                {
+                    MessageBox.Show($"Cannot open folder: {textBoxOutputFolder}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+                }
+        }
             else
             {
                 MessageBox.Show(string.Format(Configuration.Settings.Language.SplitSubtitle.FolderNotFoundX, textBoxOutputFolder.Text));

--- a/src/Forms/ExportPngXmlDialogOpenFolder.cs
+++ b/src/Forms/ExportPngXmlDialogOpenFolder.cs
@@ -46,7 +46,14 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void linkLabelOpenFolder_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(_folder);
+            try
+            {
+                Process.Start(_folder);
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show($"Cannot open folder: {_folder}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+            }
         }
     }
 }

--- a/src/Forms/GetDictionaries.cs
+++ b/src/Forms/GetDictionaries.cs
@@ -124,11 +124,17 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 Directory.CreateDirectory(dictionaryFolder);
             }
-
-            System.Diagnostics.Process.Start(dictionaryFolder);
+            try
+            {
+                System.Diagnostics.Process.Start(dictionaryFolder);
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show($"Cannot open folder: {dictionaryFolder}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+            }
         }
 
-        private void buttonDownload_Click(object sender, EventArgs e)
+		private void buttonDownload_Click(object sender, EventArgs e)
         {
             try
             {

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -18518,7 +18518,14 @@ namespace Nikse.SubtitleEdit.Forms
             string folderName = Path.GetDirectoryName(_fileName);
             if (Utilities.IsRunningOnMono())
             {
-                System.Diagnostics.Process.Start(folderName);
+                try
+                {
+                    System.Diagnostics.Process.Start(folderName);
+                }
+                catch (Exception exception)
+                {
+                    MessageBox.Show($"Cannot open folder: {folderName}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+                }
             }
             else
             {

--- a/src/Forms/Ocr/GetTesseract302Dictionaries.cs
+++ b/src/Forms/Ocr/GetTesseract302Dictionaries.cs
@@ -223,8 +223,14 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             {
                 Directory.CreateDirectory(dictionaryFolder);
             }
-
-            System.Diagnostics.Process.Start(dictionaryFolder);
+            try
+            {
+                System.Diagnostics.Process.Start(dictionaryFolder);
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show($"Cannot open folder: {dictionaryFolder}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+            }
         }
 
         private void GetTesseractDictionaries_KeyDown(object sender, KeyEventArgs e)

--- a/src/Forms/Ocr/GetTesseractDictionaries.cs
+++ b/src/Forms/Ocr/GetTesseractDictionaries.cs
@@ -202,8 +202,14 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             {
                 Directory.CreateDirectory(dictionaryFolder);
             }
-
-            System.Diagnostics.Process.Start(dictionaryFolder);
+            try
+            {
+                System.Diagnostics.Process.Start(dictionaryFolder);
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show($"Cannot open folder: {dictionaryFolder}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+            }
         }
 
         private void GetTesseractDictionaries_KeyDown(object sender, KeyEventArgs e)

--- a/src/Forms/RestoreAutoBackup.cs
+++ b/src/Forms/RestoreAutoBackup.cs
@@ -150,7 +150,14 @@ namespace Nikse.SubtitleEdit.Forms
             string folderName = Configuration.AutoBackupDirectory;
             if (Utilities.IsRunningOnMono())
             {
-                System.Diagnostics.Process.Start(folderName);
+                try
+                {
+                    System.Diagnostics.Process.Start(folderName);
+                }
+                catch (Exception exception)
+                {
+                    MessageBox.Show($"Cannot open folder: {folderName}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+                }
             }
             else
             {
@@ -161,7 +168,14 @@ namespace Nikse.SubtitleEdit.Forms
                 }
                 else
                 {
-                    System.Diagnostics.Process.Start(folderName);
+                    try
+                    {
+                        System.Diagnostics.Process.Start(folderName);
+                    }
+                    catch (Exception exception)
+                    {
+                        MessageBox.Show($"Cannot open folder: {folderName}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+                    }
                 }
             }
         }

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -2849,8 +2849,14 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 Directory.CreateDirectory(dictionaryFolder);
             }
-
-            Process.Start(dictionaryFolder);
+            try
+            {
+                Process.Start(dictionaryFolder);
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show($"Cannot open folder: {dictionaryFolder}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+            }
         }
 
         private void textBoxVlcPath_MouseLeave(object sender, EventArgs e)

--- a/src/Forms/Split.cs
+++ b/src/Forms/Split.cs
@@ -335,7 +335,15 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (Directory.Exists(textBoxOutputFolder.Text))
             {
-                System.Diagnostics.Process.Start(textBoxOutputFolder.Text);
+                try
+                {
+                    System.Diagnostics.Process.Start(textBoxOutputFolder.Text);
+                }
+                catch (Exception exception)
+                {
+                    MessageBox.Show($"Cannot open folder: {textBoxOutputFolder.Text}{Environment.NewLine}{Environment.NewLine}{exception.Source}:{exception.Message}");
+                }
+
             }
             else
             {


### PR DESCRIPTION
Opening folders from subtitle edit will sometimes fail on certain versions of Linux, just handle the exceptions so that it doesn't crash.