### PR TITLE
[installer] Conditionally update "Dictionaries" XML files

### DIFF
--- a/Dictionaries/ar_NoBreakAfterList.xml
+++ b/Dictionaries/ar_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>أن</Item>
   <Item>أو</Item>
   <Item>أي</Item>

--- a/Dictionaries/bg_NoBreakAfterList.xml
+++ b/Dictionaries/bg_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>г-жа</Item>
   <Item>Г-жа</Item>
   <Item>г-н</Item>

--- a/Dictionaries/da_DK_user.xml
+++ b/Dictionaries/da_DK_user.xml
@@ -1,4 +1,6 @@
-﻿<words>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<words Update="Merge">
   <word>1/2</word>
   <word>aflæsningszone</word>
   <word>afterparty</word>

--- a/Dictionaries/da_NoBreakAfterList.xml
+++ b/Dictionaries/da_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>Dr</Item>
   <Item>Dr.</Item>
   <Item>Frk.</Item>

--- a/Dictionaries/da_names.xml
+++ b/Dictionaries/da_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names with specific casing - and specific to Danish only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist>
     <name>Rabat</name>
   </blacklist>

--- a/Dictionaries/dan_OCRFixReplaceList.xml
+++ b/Dictionaries/dan_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="Haner" to="Han er" />
     <Word from="JaveL" to="Javel" />

--- a/Dictionaries/de_DE_user.xml
+++ b/Dictionaries/de_DE_user.xml
@@ -1,4 +1,6 @@
-﻿<words>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<words Update="Merge">
   <word>15er</word>
   <word>70er</word>
   <word>80er</word>

--- a/Dictionaries/de_names.xml
+++ b/Dictionaries/de_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names with specific casing - and specific to German only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist />
   <name>Abelard</name>
   <name>Ada</name>

--- a/Dictionaries/deu_OCRFixReplaceList.xml
+++ b/Dictionaries/deu_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="/a" to="Ja" />
     <Word from="/ch" to="Ich" />

--- a/Dictionaries/el_NoBreakAfterList.xml
+++ b/Dictionaries/el_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>αν</Item>
   <Item>ανά</Item>
   <Item>αντί</Item>

--- a/Dictionaries/en_NoBreakAfterList.xml
+++ b/Dictionaries/en_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>Dr</Item>
   <Item>Dr.</Item>
   <Item>Mr.</Item>

--- a/Dictionaries/en_US_user.xml
+++ b/Dictionaries/en_US_user.xml
@@ -1,4 +1,6 @@
-﻿<words>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<words Update="Merge">
   <word>50s</word>
   <word>9/11</word>
   <word>a.m.</word>

--- a/Dictionaries/en_names.xml
+++ b/Dictionaries/en_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names with specific casing - and specific to English only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist>
     <name>Bill</name>
     <name>Black</name>

--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="$COff$" to="scoffs" />
     <Word from="$ergei" to="Sergei" />

--- a/Dictionaries/es_MX_user.xml
+++ b/Dictionaries/es_MX_user.xml
@@ -1,4 +1,6 @@
-﻿<words>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<words Update="Merge">
   <word>»</word>
   <word>a</word>
   <word>abnegada</word>

--- a/Dictionaries/es_NoBreakAfterList.xml
+++ b/Dictionaries/es_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>Dr.</Item>
   <Item>Mr.</Item>
   <Item>Mrs.</Item>

--- a/Dictionaries/es_names.xml
+++ b/Dictionaries/es_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names with specific casing - and specific to Spanish only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist />
   <name>Aang</name>
   <name>Aarón</name>

--- a/Dictionaries/fi_FI_user.xml
+++ b/Dictionaries/fi_FI_user.xml
@@ -1,4 +1,6 @@
-﻿<words>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<words Update="Merge">
   <word>25th</word>
   <word>adieu</word>
   <word>adios</word>

--- a/Dictionaries/fi_names.xml
+++ b/Dictionaries/fi_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names with specific casing - and specific to Finnish only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist />
   <name>AA</name>
   <name>Aasia</name>

--- a/Dictionaries/fin_OCRFixReplaceList.xml
+++ b/Dictionaries/fin_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="kellojo" to="kello jo" />
     <Word from="onjo" to="on jo" />

--- a/Dictionaries/fr_names.xml
+++ b/Dictionaries/fr_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names with specific casing - and specific to French only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist />
   <name>Abdon</name>
   <name>Abdonie</name>

--- a/Dictionaries/fra_OCRFixReplaceList.xml
+++ b/Dictionaries/fra_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="@immatriculation" to="d'immatriculation" />
     <Word from="acquer" to="acquér" />

--- a/Dictionaries/hr_NoBreakAfterList.xml
+++ b/Dictionaries/hr_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>bl</Item>
   <Item>bl.</Item>
   <Item>dipl</Item>

--- a/Dictionaries/hr_names.xml
+++ b/Dictionaries/hr_names.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<names>
+<!-- This list contains names with specific casing - and specific to Croatian only -->
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist />
   <name>Adrijana</name>
   <name>Afganistan</name>

--- a/Dictionaries/hrb_OCRFixReplaceList.xml
+++ b/Dictionaries/hrb_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="andele" to="anđele" />
     <Word from="andeli" to="anđeli" />

--- a/Dictionaries/hrv_OCRFixReplaceList.xml
+++ b/Dictionaries/hrv_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="()d" to="Od" />
     <Word from="advokati" to="odvjetnici" />

--- a/Dictionaries/hun_OCRFixReplaceList.xml
+++ b/Dictionaries/hun_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords />
   <PartialWordsAlways />
   <PartialWords />

--- a/Dictionaries/mk_NoBreakAfterList.xml
+++ b/Dictionaries/mk_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>анг.</Item>
   <Item>англ.</Item>
   <Item>г.ш.</Item>

--- a/Dictionaries/mkd_OCRFixReplaceList.xml
+++ b/Dictionaries/mkd_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="5ВЕЗДЕНИ" to="ЅВЕЗДЕНИ" />
     <Word from="5везден" to="ѕвезден" />

--- a/Dictionaries/names.xml
+++ b/Dictionaries/names.xml
@@ -3,7 +3,8 @@
 Contains names that should not be translated.
 This file is case sensitive.
 -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <name>1A</name>
   <name>2 Chainz</name>
   <name>2 Pac</name>

--- a/Dictionaries/nb_names.xml
+++ b/Dictionaries/nb_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- This list contains names with specific casing - and specific to Norwegian only -->
-<names>
+<!-- This list contains names with specific casing - and specific to Norwegian Bokmål only -->
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist>
     <name>Ben</name>
     <name>Bo</name>

--- a/Dictionaries/nl_NL_user.xml
+++ b/Dictionaries/nl_NL_user.xml
@@ -1,4 +1,6 @@
-﻿<words>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<words Update="Merge">
   <word>à</word>
   <word>brucellose</word>
   <word>chantages</word>
@@ -36,8 +38,8 @@
   <word>staatspet</word>
   <word>studentenanarchie</word>
   <word>'t</word>
-  <word>tuurlijk</word>
   <word>u</word>
   <word>wijnmeer</word>
+  <word>wĳnmeer</word>
   <word>zegene</word>
 </words>

--- a/Dictionaries/nl_names.xml
+++ b/Dictionaries/nl_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names/words with specific casing - and specific to Dutch only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist>
     <name>Anders</name>
     <name>April</name>

--- a/Dictionaries/nld_OCRFixReplaceList.xml
+++ b/Dictionaries/nld_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="aandachtmag" to="aandacht mag" />
     <Word from="agrariers" to="agrariërs" />

--- a/Dictionaries/nob_OCRFixReplaceList.xml
+++ b/Dictionaries/nob_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="avjordens" to="av jordens" />
     <Word from="forjorden" to="for jorden" />

--- a/Dictionaries/nor_OCRFixReplaceList.xml
+++ b/Dictionaries/nor_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords />
   <PartialWordsAlways />
   <PartialWords>

--- a/Dictionaries/pol_OCRFixReplaceList.xml
+++ b/Dictionaries/pol_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords />
   <PartialWordsAlways />
   <PartialWords>

--- a/Dictionaries/por_OCRFixReplaceList.xml
+++ b/Dictionaries/por_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="abitual" to="habitual" />
     <Word from="àcerca" to="acerca" />

--- a/Dictionaries/pt_NoBreakAfterList.xml
+++ b/Dictionaries/pt_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>D.</Item>
   <Item>D.ª</Item>
   <Item>decr.</Item>

--- a/Dictionaries/pt_PT_user.xml
+++ b/Dictionaries/pt_PT_user.xml
@@ -1,4 +1,6 @@
-﻿<words>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<words Update="Merge">
   <word>a</word>
   <word>à</word>
   <word>e</word>

--- a/Dictionaries/pt_names.xml
+++ b/Dictionaries/pt_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names with specific casing - and specific to Portuguese only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist />
   <name>Aarão</name>
   <name>Abdénago</name>

--- a/Dictionaries/ru_RU_user.xml
+++ b/Dictionaries/ru_RU_user.xml
@@ -1,4 +1,6 @@
-﻿<words>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<words Update="Merge">
   <word>А</word>
   <word>Ага</word>
   <word>Ай</word>

--- a/Dictionaries/ru_names.xml
+++ b/Dictionaries/ru_names.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This list contains names with specific casing - and specific to Russian only -->
-<names>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<names Update="Replace">
   <blacklist />
   <name>Абакум</name>
   <name>Абакумович</name>

--- a/Dictionaries/rus_OCRFixReplaceList.xml
+++ b/Dictionaries/rus_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="НЄЙ" to="НЕЙ" />
     <Word from="ОРГЗНИЗМОБ" to="ОРГАНИЗМА" />

--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <!-- Abreviaturas simples -->
     <Word from="KBs" to="kB" />

--- a/Dictionaries/sr_NoBreakAfterList.xml
+++ b/Dictionaries/sr_NoBreakAfterList.xml
@@ -1,4 +1,6 @@
-﻿<NoBreakAfterList>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Set "Update" attribute to "Merge" (default), "Never" or "Replace" -->
+<NoBreakAfterList Update="Merge">
   <Item>bl</Item>
   <Item>bl.</Item>
   <Item>dipl</Item>

--- a/Dictionaries/srp_OCRFixReplaceList.xml
+++ b/Dictionaries/srp_OCRFixReplaceList.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Credit goes to: MilanRS [http://www.prijevodi-online.org] -->
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="če" to="će" />
     <Word from="čemo" to="ćemo" />

--- a/Dictionaries/swe_OCRFixReplaceList.xml
+++ b/Dictionaries/swe_OCRFixReplaceList.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<OCRFixReplaceList>
+<!-- Set "Update" attribute to "Replace" (default) or "Never" -->
+<OCRFixReplaceList Update="Replace">
   <WholeWords>
     <Word from="lârt" to="lärt" />
     <Word from="hedervårda" to="hedervärda" />

--- a/installer/SetupSupport/External.cs
+++ b/installer/SetupSupport/External.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Nikse.SetupSupport.WordLists;
+using RGiesecke.DllExport;
+
+namespace Nikse.SetupSupport
+{
+    public static class External
+    {
+        [DllExport(CallingConvention = CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        public static bool CanUpdateWordlist([MarshalAs(UnmanagedType.LPWStr)] string fileName)
+        {
+            try
+            {
+                var file = new FileInfo(fileName);
+                if (file.Exists)
+                {
+                    if (file.Name.EndsWith("_OCRFixReplaceList.xml", StringComparison.Ordinal))
+                    {
+                        return new OCRFixReplaceList(file).CanUpdate();
+                    }
+                    if (file.Name.EndsWith("_NoBreakAfterList.xml", StringComparison.Ordinal))
+                    {
+                        return new NoBreakAfterList(file).CanUpdate();
+                    }
+                    if (file.Name.EndsWith("_names.xml", StringComparison.Ordinal))
+                    {
+                        return new NamesList(file).CanUpdate();
+                    }
+                    if (file.Name.EndsWith("_user.xml", StringComparison.Ordinal))
+                    {
+                        return new SpellCheckList(file).CanUpdate();
+                    }
+                    if (file.Name.Equals("names.xml", StringComparison.Ordinal))
+                    {
+                        return new NamesList(file).CanUpdate();
+                    }
+                }
+            }
+            catch
+            {
+                // fail silently
+            }
+            return true;
+        }
+
+        [DllExport(CallingConvention = CallingConvention.StdCall)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        public static bool MergeWordlist([MarshalAs(UnmanagedType.LPWStr)] string fileName)
+        {
+            try
+            {
+                var file = new FileInfo(fileName);
+                if (file.Exists)
+                {
+                    if (file.Name.EndsWith("_NoBreakAfterList.xml", StringComparison.Ordinal))
+                    {
+                        return new NoBreakAfterList(file).Merge();
+                    }
+                    if (file.Name.EndsWith("_user.xml", StringComparison.Ordinal))
+                    {
+                        return new SpellCheckList(file).Merge();
+                    }
+                }
+            }
+            catch
+            {
+                // fail silently
+            }
+            return false;
+        }
+
+    }
+}

--- a/installer/SetupSupport/Properties/AssemblyInfo.cs
+++ b/installer/SetupSupport/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Subtitle Edit Setup Support")]
+[assembly: AssemblyDescription("Subtitle Edit installer auxiliary methods")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Nikse")]
+[assembly: AssemblyProduct("SubtitleEdit")]
+[assembly: AssemblyCopyright("Copyright 2020, Nikse")]
+[assembly: AssemblyTrademark("Licensed under the GPL v3")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("44e57354-be5d-4d1f-97f0-eae13bb01c01")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/installer/SetupSupport/SetupSupport.csproj
+++ b/installer/SetupSupport/SetupSupport.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{24F8A238-B627-4006-BA3C-CEB8BC0BC250}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Nikse.SetupSupport</RootNamespace>
+    <AssemblyName>SetupSupport</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp />
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="RGiesecke.DllExport.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=8f52d83c1a22df51, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\UnmanagedExports.1.2.7\lib\net\RGiesecke.DllExport.Metadata.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="External.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Wordlists\NamesList.cs" />
+    <Compile Include="Wordlists\SpellCheckList.cs" />
+    <Compile Include="Wordlists\NoBreakAfterList.cs" />
+    <Compile Include="Wordlists\OCRFixReplaceList.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\UnmanagedExports.1.2.7\tools\RGiesecke.DllExport.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\UnmanagedExports.1.2.7\tools\RGiesecke.DllExport.targets'))" />
+  </Target>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="$(SolutionDir)\packages\UnmanagedExports.1.2.7\tools\RGiesecke.DllExport.targets" Condition="Exists('$(SolutionDir)\packages\UnmanagedExports.1.2.7\tools\RGiesecke.DllExport.targets')" />
+</Project>

--- a/installer/SetupSupport/Wordlists/NamesList.cs
+++ b/installer/SetupSupport/Wordlists/NamesList.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using System.Xml;
+
+namespace Nikse.SetupSupport.WordLists
+{
+    internal class NamesList
+    {
+        private readonly string _fileName;
+
+        public NamesList(FileInfo file)
+        {
+            _fileName = file.FullName;
+        }
+
+        public bool CanUpdate()
+        {
+            var document = new XmlDocument { XmlResolver = null };
+            document.Load(_fileName);
+            var root = document.DocumentElement;
+            if (root.Name.Equals("names", StringComparison.Ordinal) &&
+                (root.GetAttribute("Update").Trim().Equals("Never", StringComparison.OrdinalIgnoreCase) ||
+                 root.GetAttribute("DoNotUpdate").Trim().Equals("True", StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+            return true;
+        }
+
+    }
+}

--- a/installer/SetupSupport/Wordlists/NoBreakAfterList.cs
+++ b/installer/SetupSupport/Wordlists/NoBreakAfterList.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+
+namespace Nikse.SetupSupport.WordLists
+{
+    internal class NoBreakAfterList
+    {
+        private class NoBreakAfterItem : IEquatable<NoBreakAfterItem>
+        {
+            private readonly int _hashCode;
+
+            public bool IsRegex { get; }
+            public string Text { get; }
+
+            private NoBreakAfterItem(bool isRegex, string text)
+            {
+                Text = text;
+                IsRegex = isRegex;
+                _hashCode = Tuple.Create(isRegex, text).GetHashCode();
+            }
+
+            public static NoBreakAfterItem FromNode(XmlElement node)
+            {
+                if (node != null)
+                {
+                    var text = node.InnerText;
+                    if (!string.IsNullOrWhiteSpace(text))
+                    {
+                        var isRegex = node.GetAttribute("IsRegex").Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
+                        return new NoBreakAfterItem(isRegex, text);
+                    }
+                }
+                return null;
+            }
+
+            public bool Equals(NoBreakAfterItem other)
+            {
+                return !ReferenceEquals(other, null) && IsRegex.Equals(other.IsRegex) && Text.Equals(other.Text, StringComparison.Ordinal);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as NoBreakAfterItem);
+            }
+
+            public override int GetHashCode()
+            {
+                return _hashCode;
+            }
+        }
+
+        private readonly string _copyName;
+        private readonly string _fileName;
+
+        public NoBreakAfterList(FileInfo file)
+        {
+            _fileName = file.FullName;
+            _copyName = Path.ChangeExtension(_fileName, "se@inst.xml");
+        }
+
+        public bool CanUpdate()
+        {
+            var document = new XmlDocument { XmlResolver = null };
+            document.Load(_fileName);
+            var root = document.DocumentElement;
+            if (root.Name.Equals("NoBreakAfterList", StringComparison.Ordinal))
+            {
+                if (root.GetAttribute("Update").Trim().Equals("Never", StringComparison.OrdinalIgnoreCase) ||
+                    root.GetAttribute("DoNotUpdate").Trim().Equals("True", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+                document.Save(_copyName);
+            }
+            return true;
+        }
+
+        public bool Merge()
+        {
+            if (File.Exists(_copyName))
+            {
+                try
+                {
+                    var target = new XmlDocument { XmlResolver = null };
+                    target.Load(_copyName);
+                    var targetRoot = target.DocumentElement;
+
+                    var origin = new XmlDocument { XmlResolver = null };
+                    origin.Load(_fileName);
+                    var originRoot = origin.DocumentElement;
+
+                    var update = targetRoot.GetAttribute("Update").Trim().ToUpperInvariant();
+                    if (update.Equals("REPLACE", StringComparison.Ordinal) || update.Equals("OVERWRITE", StringComparison.Ordinal))
+                    {
+                        update = update[0] + update.Substring(1).ToLowerInvariant();
+                        originRoot.SetAttribute("Update", update);
+                        origin.Save(_fileName);
+
+                        return true;
+                    }
+
+                    var items = new HashSet<NoBreakAfterItem>();
+                    foreach (var node in targetRoot.SelectNodes("Item").OfType<XmlElement>().ToList())
+                    {
+                        var item = NoBreakAfterItem.FromNode(node);
+                        if (item == null || !items.Add(item))
+                        {
+                            targetRoot.RemoveChild(node);
+                        }
+                    }
+
+                    targetRoot = origin.ImportNode(targetRoot, true) as XmlElement;
+                    foreach (var node in originRoot.SelectNodes("Item").OfType<XmlElement>().ToList())
+                    {
+                        var item = NoBreakAfterItem.FromNode(node);
+                        if (item == null || !items.Add(item))
+                        {
+                            originRoot.RemoveChild(node);
+                        }
+                        else
+                        {
+                            targetRoot.AppendChild(node);
+                        }
+                    }
+
+                    origin.ReplaceChild(targetRoot, originRoot);
+                    targetRoot.SetAttribute("Update", "Merge");
+                    origin.Save(_fileName);
+                }
+                finally
+                {
+                    File.Delete(_copyName);
+                }
+            }
+            return true;
+        }
+
+    }
+}

--- a/installer/SetupSupport/Wordlists/OCRFixReplaceList.cs
+++ b/installer/SetupSupport/Wordlists/OCRFixReplaceList.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using System.Xml;
+
+namespace Nikse.SetupSupport.WordLists
+{
+    internal class OCRFixReplaceList
+    {
+        private readonly string _fileName;
+
+        public OCRFixReplaceList(FileInfo file)
+        {
+            _fileName = file.FullName;
+        }
+
+        public bool CanUpdate()
+        {
+            var document = new XmlDocument { XmlResolver = null };
+            document.Load(_fileName);
+            var root = document.DocumentElement;
+            if (root.Name.Equals("OCRFixReplaceList", StringComparison.Ordinal) &&
+                (root.GetAttribute("Update").Trim().Equals("Never", StringComparison.OrdinalIgnoreCase) ||
+                 root.GetAttribute("DoNotUpdate").Trim().Equals("True", StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+            return true;
+        }
+
+    }
+}

--- a/installer/SetupSupport/Wordlists/SpellCheckList.cs
+++ b/installer/SetupSupport/Wordlists/SpellCheckList.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace Nikse.SetupSupport.WordLists
+{
+    internal class SpellCheckList
+    {
+        private readonly string _cultureName;
+        private readonly string _copyName;
+        private readonly string _fileName;
+
+        public SpellCheckList(FileInfo file)
+        {
+            _fileName = file.FullName;
+            _copyName = Path.ChangeExtension(_fileName, "se@inst.xml");
+            _cultureName = Regex.Replace(file.Name, @"\A([^_]+)_([^_]+)_user.xml\z", "${1}-${2}", RegexOptions.CultureInvariant);
+        }
+
+        public bool CanUpdate()
+        {
+            var document = new XmlDocument { XmlResolver = null };
+            document.Load(_fileName);
+            var root = document.DocumentElement;
+            if (root.Name.Equals("words", StringComparison.Ordinal))
+            {
+                if (root.GetAttribute("Update").Trim().Equals("Never", StringComparison.OrdinalIgnoreCase) ||
+                    root.GetAttribute("DoNotUpdate").Trim().Equals("True", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+                document.Save(_copyName);
+            }
+            return true;
+        }
+
+        public bool Merge()
+        {
+            if (File.Exists(_copyName))
+            {
+                try
+                {
+                    var document = new XmlDocument { XmlResolver = null };
+                    document.Load(_copyName);
+                    var root = document.DocumentElement;
+
+                    var update = root.GetAttribute("Update").Trim().ToUpperInvariant();
+                    if (update.Equals("REPLACE", StringComparison.Ordinal) || update.Equals("OVERWRITE", StringComparison.Ordinal))
+                    {
+                        update = update[0] + update.Substring(1).ToLowerInvariant();
+                        document.Load(_fileName);
+                        document.DocumentElement.SetAttribute("Update", update);
+                        document.Save(_fileName);
+
+                        return true;
+                    }
+
+                    var phrases = new HashSet<string>();
+                    foreach (XmlNode node in root.SelectNodes("word"))
+                    {
+                        var text = node.InnerText.Trim().ToLowerInvariant();
+                        if (text.Length > 0)
+                        {
+                             phrases.Add(text);
+                        }
+                    }
+                    root.RemoveAll();
+
+                    document.Load(_fileName);
+                    root = document.DocumentElement;
+                    foreach (XmlNode node in root.SelectNodes("word"))
+                    {
+                        var text = node.InnerText.Trim().ToLowerInvariant();
+                        if (text.Length > 0)
+                        {
+                             phrases.Add(text);
+                        }
+                    }
+                    root.RemoveAll();
+
+                    StringComparer comparer;
+                    try
+                    {
+                        comparer = StringComparer.Create(CultureInfo.GetCultureInfo(_cultureName), false);
+                    }
+                    catch
+                    {
+                        comparer = StringComparer.InvariantCulture;
+                    }
+
+                    foreach (var text in phrases.OrderBy(p => p, comparer).ThenBy(p => p, StringComparer.Ordinal))
+                    {
+                        var node = document.CreateElement("word");
+                        node.InnerText = text;
+                        root.AppendChild(node);
+                    }
+                    root.SetAttribute("Update", "Merge");
+                    document.Save(_fileName);
+                }
+                finally
+                {
+                    File.Delete(_copyName);
+                }
+            }
+            return true;
+        }
+
+    }
+}

--- a/installer/SetupSupport/packages.config
+++ b/installer/SetupSupport/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="UnmanagedExports" version="1.2.7" targetFramework="net40-client" />
+</packages>

--- a/installer/Subtitle_Edit_installer.iss
+++ b/installer/Subtitle_Edit_installer.iss
@@ -183,54 +183,57 @@ Name: associate_srt;      Description: {cm:tsk_SetFileTypes};      GroupDescript
 
 
 [Files]
-Source: ..\Dictionaries\dan_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\deu_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\eng_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\fin_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\fra_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\hrb_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\hrv_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\hun_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\mkd_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\nld_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\nob_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\nor_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\pol_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\por_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\rus_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\spa_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\srp_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\swe_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\da_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\de_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\en_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\es_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\fi_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\fr_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\hr_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\nb_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\nl_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\pt_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\ru_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\names.xml;                 DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main
-Source: ..\Dictionaries\ar_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\bg_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\da_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\el_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\en_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\es_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\hr_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\mk_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\pt_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\sr_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\da_DK_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\de_DE_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\en_US_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\es_MX_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\fi_FI_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\nl_NL_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\pt_PT_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
-Source: ..\Dictionaries\ru_RU_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
+; Start with the SetupSupport assembly in the interests of efficiency
+Source: SetupSupport\bin\Release\SetupSupport.dll; Flags: dontcopy
+
+Source: ..\Dictionaries\dan_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\deu_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\eng_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\fin_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\fra_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\hrb_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\hrv_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\hun_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\mkd_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\nld_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\nob_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\nor_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\pol_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\por_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\rus_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\spa_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\srp_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\swe_OCRFixReplaceList.xml; DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\da_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\de_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\en_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\es_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\fi_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\fr_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\hr_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\nb_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\nl_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\pt_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\ru_names.xml;              DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\names.xml;                 DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate
+Source: ..\Dictionaries\ar_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\bg_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\da_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\el_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\en_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\es_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\hr_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\mk_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\pt_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\sr_NoBreakAfterList.xml;   DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\da_DK_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\de_DE_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\en_US_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\es_MX_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\fi_FI_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\nl_NL_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\pt_PT_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
+Source: ..\Dictionaries\ru_RU_user.xml;            DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall; Components: main; Check: CanUpdate; AfterInstall: Merge
 Source: ..\Dictionaries\en_US.aff;                 DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
 Source: ..\Dictionaries\en_US.dic;                 DestDir: {userappdata}\Subtitle Edit\Dictionaries; Flags: ignoreversion uninsneveruninstall onlyifdoesntexist; Components: main
 
@@ -404,7 +407,7 @@ Type: dirifempty; Name: {app}\Languages;                Check: not IsComponentSe
 
 [Run]
 Filename: {win}\Microsoft.NET\Framework\v4.0.30319\ngen.exe; Parameters: "install ""{app}\SubtitleEdit.exe"""; StatusMsg: {cm:msg_OptimizingPerformance}; Flags: runhidden runascurrentuser skipifdoesntexist
-Filename: {app}\SubtitleEdit.exe;            Description: {cm:LaunchProgram,Subtitle Edit}; WorkingDir: {app}; Flags: nowait postinstall skipifsilent unchecked
+Filename: {app}\SubtitleEdit.exe;             Description: {cm:LaunchProgram,Subtitle Edit}; WorkingDir: {app}; Flags: nowait postinstall skipifsilent unchecked
 Filename: https://www.nikse.dk/SubtitleEdit/; Description: {cm:run_VisitWebsite};                               Flags: nowait postinstall skipifsilent unchecked shellexec
 
 
@@ -476,6 +479,22 @@ Root: HKLM; Subkey: "{#keyApps}\SubtitleEdit.exe\SupportedTypes"; ValueType: str
 
 
 [Code]
+function CanUpdateWordlist(FileName: String): Boolean;
+external 'CanUpdateWordlist@files:SetupSupport.dll stdcall setuponly';
+
+function MergeWordlist(FileName: String): Boolean;
+external 'MergeWordlist@files:SetupSupport.dll stdcall setuponly';
+
+function CanUpdate(): Boolean;
+begin
+  Result := CanUpdateWordlist(ExpandConstant(CurrentFilename));
+end;
+
+procedure Merge();
+begin
+  MergeWordlist(ExpandConstant(CurrentFilename));
+end;
+
 // Check if subkey exists in HKLM registry hive
 function HklmKeyExists(const KeyName: String): Boolean;
 begin
@@ -652,7 +671,8 @@ end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
-  if CurStep = ssInstall then begin
+  if CurStep = ssInstall then
+  begin
     if IsTaskSelected('reset_dictionaries') then
       CleanUpDictionaries();
   end;
@@ -731,7 +751,8 @@ begin
     ExpandConstant('{dotnet40}');
   except
     begin
-      if not WizardSilent() then begin
+      if not WizardSilent() then
+      begin
         if SuppressibleMsgBox(CustomMessage('msg_AskToDownNET'), mbCriticalError, MB_YESNO or MB_DEFBUTTON1, IDNO) = IDYES then
           ShellExec('open','http://download.microsoft.com/download/5/6/2/562A10F9-C9F4-4313-A044-9C94E0A8FAC8/dotNetFx40_Client_x86_x64.exe','','',SW_SHOWNORMAL,ewNoWait,ErrorCode);
         Result := False;

--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -285,7 +285,7 @@ namespace Nikse.SubtitleEdit.Core
 
             //load words via xml
             string noBreakAfterFileName = DictionaryFolder + languageName + "_NoBreakAfterList.xml";
-            var doc = new XmlDocument();
+            var doc = new XmlDocument { XmlResolver = null };
             if (File.Exists(noBreakAfterFileName))
             {
                 doc.Load(noBreakAfterFileName);
@@ -1047,7 +1047,7 @@ namespace Nikse.SubtitleEdit.Core
             if (word.Length > 0)
             {
                 string userWordsXmlFileName = DictionaryFolder + languageName + "_user.xml";
-                var userWords = new XmlDocument();
+                var userWords = new XmlDocument { XmlResolver = null };
                 if (File.Exists(userWordsXmlFileName))
                 {
                     userWords.Load(userWordsXmlFileName);
@@ -1075,12 +1075,14 @@ namespace Nikse.SubtitleEdit.Core
 
                 if (userWords.DocumentElement != null)
                 {
-                    userWords.DocumentElement.RemoveAll();
+                    // Remove child nodes, keep attributes
+                    var root = userWords.DocumentElement.CloneNode(false);
+                    userWords.ReplaceChild(root, userWords.DocumentElement);
                     foreach (string w in words)
                     {
-                        XmlNode node = userWords.CreateElement("word");
+                        var node = userWords.CreateElement("word");
                         node.InnerText = w;
-                        userWords.DocumentElement.AppendChild(node);
+                        root.AppendChild(node);
                     }
                 }
 
@@ -1094,7 +1096,7 @@ namespace Nikse.SubtitleEdit.Core
             if (word.Length > 0)
             {
                 string userWordsXmlFileName = DictionaryFolder + languageName + "_user.xml";
-                var userWords = new XmlDocument();
+                var userWords = new XmlDocument { XmlResolver = null };
                 if (File.Exists(userWordsXmlFileName))
                 {
                     userWords.Load(userWordsXmlFileName);
@@ -1127,12 +1129,14 @@ namespace Nikse.SubtitleEdit.Core
 
                     words.Sort();
 
-                    userWords.DocumentElement.RemoveAll();
+                    // Remove child nodes, keep attributes
+                    var root = userWords.DocumentElement.CloneNode(false);
+                    userWords.ReplaceChild(root, userWords.DocumentElement);
                     foreach (string w in words)
                     {
-                        XmlNode node = userWords.CreateElement("word");
+                        var node = userWords.CreateElement("word");
                         node.InnerText = w;
-                        userWords.DocumentElement.AppendChild(node);
+                        root.AppendChild(node);
                     }
                 }
 
@@ -1143,7 +1147,7 @@ namespace Nikse.SubtitleEdit.Core
         public static string LoadUserWordList(List<string> userWordList, string languageName)
         {
             userWordList.Clear();
-            var userWordDictionary = new XmlDocument();
+            var userWordDictionary = new XmlDocument { XmlResolver = null };
             string userWordListXmlFileName = DictionaryFolder + languageName + "_user.xml";
             if (File.Exists(userWordListXmlFileName))
             {
@@ -1163,7 +1167,7 @@ namespace Nikse.SubtitleEdit.Core
         public static string LoadUserWordList(HashSet<string> userWordList, string languageName)
         {
             userWordList.Clear();
-            var userWordDictionary = new XmlDocument();
+            var userWordDictionary = new XmlDocument { XmlResolver = null };
             string userWordListXmlFileName = DictionaryFolder + languageName + "_user.xml";
             if (File.Exists(userWordListXmlFileName))
             {

--- a/src/Forms/DoNotBreakAfterListEdit.cs
+++ b/src/Forms/DoNotBreakAfterListEdit.cs
@@ -71,7 +71,7 @@ namespace Nikse.SubtitleEdit.Forms
             if (idx >= 0)
             {
                 _noBreakAfterList = new List<NoBreakAfterItem>();
-                var doc = new XmlDocument();
+                var doc = new XmlDocument { XmlResolver = null };
                 doc.Load(_languages[idx]);
                 foreach (XmlNode node in doc.DocumentElement.SelectNodes("Item"))
                 {
@@ -143,17 +143,25 @@ namespace Nikse.SubtitleEdit.Forms
             int idx = comboBoxDictionaries.SelectedIndex;
             if (idx >= 0)
             {
-                var doc = new XmlDocument();
-                doc.LoadXml("<NoBreakAfterList />");
-                foreach (NoBreakAfterItem item in _noBreakAfterList)
+                var doc = new XmlDocument { XmlResolver = null };
+                try
                 {
-                    XmlNode node = doc.CreateElement("Item");
+                    doc.Load(_languages[idx]);
+                    // Remove child nodes, keep attributes
+                    var root = doc.DocumentElement.CloneNode(false);
+                    doc.ReplaceChild(root, doc.DocumentElement);
+                }
+                catch
+                {
+                    doc.LoadXml("<NoBreakAfterList />");
+                }
+                foreach (var item in _noBreakAfterList)
+                {
+                    var node = doc.CreateElement("Item");
                     node.InnerText = item.Text;
                     if (item.Regex != null)
                     {
-                        XmlAttribute attribute = doc.CreateAttribute("RegEx");
-                        attribute.InnerText = true.ToString();
-                        node.Attributes.Append(attribute);
+                        node.SetAttribute("RegEx", true.ToString());
                     }
                     doc.DocumentElement.AppendChild(node);
                 }

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -2323,14 +2323,16 @@ namespace Nikse.SubtitleEdit.Forms
                     if (removeCount > 0)
                     {
                         words.Sort();
-                        var doc = new XmlDocument();
+                        var doc = new XmlDocument { XmlResolver = null };
                         doc.Load(userWordFileName);
-                        doc.DocumentElement.RemoveAll();
+                        // Remove child nodes, keep attributes
+                        var root = doc.DocumentElement.CloneNode(false);
+                        doc.ReplaceChild(root, doc.DocumentElement);
                         foreach (string word in words)
                         {
-                            XmlNode node = doc.CreateElement("word");
+                            var node = doc.CreateElement("word");
                             node.InnerText = word;
-                            doc.DocumentElement.AppendChild(node);
+                            root.AppendChild(node);
                         }
                         doc.Save(userWordFileName);
                         LoadUserWords(language, false); // reload

--- a/src/SubtitleEdit.sln
+++ b/src/SubtitleEdit.sln
@@ -28,6 +28,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Win32Resources", "Win32Reso
 		{2CB9698C-F0A8-42FF-8938-DE047292D5FE} = {2CB9698C-F0A8-42FF-8938-DE047292D5FE}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetupSupport", "..\installer\SetupSupport\SetupSupport.csproj", "{24F8A238-B627-4006-BA3C-CEB8BC0BC250}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,9 @@ Global
 		{905ACC84-B353-4313-BFE5-CCF460B959AF}.Debug|Any CPU.ActiveCfg = Debug|Win32
 		{905ACC84-B353-4313-BFE5-CCF460B959AF}.Release|Any CPU.ActiveCfg = Release|Win32
 		{905ACC84-B353-4313-BFE5-CCF460B959AF}.Release|Any CPU.Build.0 = Release|Win32
+		{24F8A238-B627-4006-BA3C-CEB8BC0BC250}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24F8A238-B627-4006-BA3C-CEB8BC0BC250}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24F8A238-B627-4006-BA3C-CEB8BC0BC250}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The `SetupSupport.dll` assembly makes it easy to upgrade user dictionary and no-break-after files by merging the distributed file with the existing file. The update behaviour can be set for each word list separately via the "Update" attribute value: "Merge" (default), "Never" or "Replace" ("Overwrite").

For consistency the other file types (OcrFix and Names) also take an "Update" attribute, whose value can be "Replace"/"Overwrite" (default) or "Never".

To make the "Update" attribute persistent, a few minor changes to the SE code are necessary: `XmlNode.RemoveAll()`, which removes _child nodes and attributes_, has been replaced with `XmlNode.CloneNode(false)`, which removes child nodes while _preserving attributes_.

_Note 1:_ SetupSupport and SubtitleEdit projects must specify the same `<TargetFrameworkVersion>`.
_Note 2:_ SetupSupport `<PlatformTarget>` must be `x86`, because Inno Setup builds 32-bit installers.