### PR TITLE
Fix opening URLs, files, and folders on Linux with recent versions of Mono

### DIFF
--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -854,7 +854,18 @@ namespace Nikse.SubtitleEdit.Core
             }
             try
             {
-                System.Diagnostics.Process.Start(helpFile + parameter);
+                if (Configuration.IsRunningOnWindows || Configuration.IsRunningOnMac)
+                {
+                    System.Diagnostics.Process.Start(helpFile + parameter);
+                }
+                else if (Configuration.IsRunningOnLinux)
+                {
+                    System.Diagnostics.Process process = new System.Diagnostics.Process();
+                    process.EnableRaisingEvents = false;
+                    process.StartInfo.FileName = "xdg-open";
+                    process.StartInfo.Arguments = helpFile + parameter;
+                    process.Start();
+                }
             }
             catch (Exception exception)
             {

--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -852,8 +852,15 @@ namespace Nikse.SubtitleEdit.Core
             {
                 helpFile = "https://www.nikse.dk/SubtitleEdit/Help";
             }
-
-            System.Diagnostics.Process.Start(helpFile + parameter);
+            try
+            {
+                System.Diagnostics.Process.Start(helpFile + parameter);
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine("ERROR: Cannot open help");
+                Console.Write(exception);
+            }
         }
 
         public static string AssemblyVersion => Assembly.GetEntryAssembly().GetName().Version.ToString();

--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -867,7 +867,7 @@ namespace Nikse.SubtitleEdit.Core
                     process.Start();
                 }
             }
-            catch (Exception exception)
+            catch
             {
                 //Don't do anything
             }

--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -869,8 +869,7 @@ namespace Nikse.SubtitleEdit.Core
             }
             catch (Exception exception)
             {
-                Console.WriteLine("ERROR: Cannot open help");
-                Console.Write(exception);
+                //Don't do anything
             }
         }
 

--- a/src/Forms/About.cs
+++ b/src/Forms/About.cs
@@ -87,24 +87,17 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void RichTextBoxAbout1LinkClicked(object sender, LinkClickedEventArgs e)
         {
-            try
-            {
-                Process.Start(e.LinkText);
-            }
-            catch
-            {
-                MessageBox.Show("Unable to start link: " + e.LinkText, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            UiUtil.OpenURL(e.LinkText);
         }
 
         private void buttonDonate_Click(object sender, EventArgs e)
         {
-            Process.Start("https://www.nikse.dk/Donate");
+            UiUtil.OpenURL("https://www.nikse.dk/Donate");
         }
 
         private void linkLabelGitBuildHash_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(GetGitHubHashLink());
+            UiUtil.OpenURL(GetGitHubHashLink());
         }
 
         private static string GetGitHubHashLink()

--- a/src/Forms/AddWaveform.cs
+++ b/src/Forms/AddWaveform.cs
@@ -146,7 +146,7 @@ namespace Nikse.SubtitleEdit.Forms
                                     Configuration.Settings.Language.AddWaveform.VlcMediaPlayerNotFoundTitle,
                                     MessageBoxButtons.YesNo) == DialogResult.Yes)
                 {
-                    Process.Start("http://www.videolan.org/");
+                    UiUtil.OpenURL("http://www.videolan.org/");
                 }
                 buttonRipWave.Enabled = true;
                 return;

--- a/src/Forms/AddWaveformBatch.cs
+++ b/src/Forms/AddWaveformBatch.cs
@@ -256,7 +256,7 @@ namespace Nikse.SubtitleEdit.Forms
                                             Configuration.Settings.Language.AddWaveform.VlcMediaPlayerNotFoundTitle,
                                             MessageBoxButtons.YesNo) == DialogResult.Yes)
                         {
-                            Process.Start("http://www.videolan.org/");
+                            UiUtil.OpenURL("http://www.videolan.org/");
                         }
                         buttonRipWave.Enabled = true;
                         return;

--- a/src/Forms/AudioToText.cs
+++ b/src/Forms/AudioToText.cs
@@ -105,7 +105,7 @@ namespace Nikse.SubtitleEdit.Forms
                                         Configuration.Settings.Language.AddWaveform.VlcMediaPlayerNotFoundTitle,
                                         MessageBoxButtons.YesNo) == DialogResult.Yes)
                     {
-                        Process.Start("http://www.videolan.org/");
+                        UiUtil.OpenURL("http://www.videolan.org/");
                     }
                     return;
                 }

--- a/src/Forms/CheckForUpdates.cs
+++ b/src/Forms/CheckForUpdates.cs
@@ -148,7 +148,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void buttonDownloadAndInstall_Click(object sender, EventArgs e)
         {
-            System.Diagnostics.Process.Start("https://github.com/SubtitleEdit/subtitleedit/releases");
+            UiUtil.OpenURL("https://github.com/SubtitleEdit/subtitleedit/releases");
         }
 
         private void buttonDontCheckUpdates_Click(object sender, EventArgs e)

--- a/src/Forms/FixCommonErrors.cs
+++ b/src/Forms/FixCommonErrors.cs
@@ -838,7 +838,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             sb.Append("</table></body></html>");
             File.WriteAllText(htmlFileName, sb.ToString());
-            System.Diagnostics.Process.Start(htmlFileName);
+            UiUtil.OpenFile(htmlFileName);
         }
 
         private static string[] MakeDiffHtml(string before, string after)

--- a/src/Forms/GoogleTranslate.cs
+++ b/src/Forms/GoogleTranslate.cs
@@ -523,7 +523,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void LinkLabel1LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start(_googleTranslate ? GoogleTranslateUrl : _translator.GetUrl());
+            UiUtil.OpenURL(_googleTranslate ? GoogleTranslateUrl : _translator.GetUrl());
         }
 
         private void ButtonOkClick(object sender, EventArgs e)

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -15198,7 +15198,7 @@ namespace Nikse.SubtitleEdit.Forms
                 RunTranslateSearch((text) =>
                 {
                     url = string.Format(url, Utilities.UrlEncode(text));
-                    System.Diagnostics.Process.Start(url);
+                    UiUtil.OpenURL(url);
                 });
             }
         }
@@ -18418,7 +18418,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void buttonGoogleIt_Click(object sender, EventArgs e)
         {
-            RunTranslateSearch((text) => { System.Diagnostics.Process.Start("https://www.google.com/search?q=" + Utilities.UrlEncode(text)); });
+            RunTranslateSearch((text) => { UiUtil.OpenURL("https://www.google.com/search?q=" + Utilities.UrlEncode(text)); });
         }
 
         private void buttonGoogleTranslateIt_Click(object sender, EventArgs e)
@@ -18426,7 +18426,7 @@ namespace Nikse.SubtitleEdit.Forms
             RunTranslateSearch((text) =>
             {
                 string languageId = LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitle);
-                System.Diagnostics.Process.Start("https://translate.google.com/#auto|" + languageId + "|" + Utilities.UrlEncode(text));
+                UiUtil.OpenURL("https://translate.google.com/#auto|" + languageId + "|" + Utilities.UrlEncode(text));
             });
         }
 

--- a/src/Forms/NetflixFixErrors.cs
+++ b/src/Forms/NetflixFixErrors.cs
@@ -226,7 +226,14 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void linkLabelOpenReportFolder_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("explorer.exe", $@"/select,""{MakeReport()}"" ");
+            if (Configuration.IsRunningOnWindows)
+            {
+                Process.Start("explorer.exe", $@"/select,""{MakeReport()}"" ");
+            }
+            else
+            {
+                Logic.UiUtil.OpenFile(MakeReport());
+            }
         }
 
         private string MakeReport()

--- a/src/Forms/NetflixFixErrors.cs
+++ b/src/Forms/NetflixFixErrors.cs
@@ -232,7 +232,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else
             {
-                Logic.UiUtil.OpenFile(MakeReport());
+                Logic.UiUtil.OpenFolder(Path.GetDirectoryName(MakeReport()));
             }
         }
 

--- a/src/Forms/NetflixQCResult.cs
+++ b/src/Forms/NetflixQCResult.cs
@@ -91,7 +91,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void lblText_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start((string)e.Link.LinkData);
+            UiUtil.OpenURL((string)e.Link.LinkData);
         }
 
         private void OpenFileLocation(string filePath)

--- a/src/Forms/NetflixQCResult.cs
+++ b/src/Forms/NetflixQCResult.cs
@@ -96,7 +96,14 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void OpenFileLocation(string filePath)
         {
-            Process.Start("explorer.exe", $@"/select,""{filePath}"" ");
+            if (Configuration.IsRunningOnWindows)
+            {
+                Process.Start("explorer.exe", $@"/select,""{filePath}"" ");
+            }
+            else
+            {
+                UiUtil.OpenFolder(System.IO.Path.GetDirectoryName(filePath));
+            }
         }
     }
 }

--- a/src/Forms/Ocr/OCRSpellCheck.cs
+++ b/src/Forms/Ocr/OCRSpellCheck.cs
@@ -295,7 +295,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             string text = textBoxWord.Text;
             if (!string.IsNullOrWhiteSpace(text))
             {
-                System.Diagnostics.Process.Start("https://www.google.com/search?q=" + Utilities.UrlEncode(text));
+                UiUtil.OpenURL("https://www.google.com/search?q=" + Utilities.UrlEncode(text));
             }
         }
 

--- a/src/Forms/Ocr/VobSubOcr.cs
+++ b/src/Forms/Ocr/VobSubOcr.cs
@@ -7753,7 +7753,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 File.WriteAllText(htmlFileName, sb.ToString(), Encoding.UTF8);
                 progressBar1.Visible = false;
                 MessageBox.Show($"{imagesSavedCount} images saved in {folderBrowserDialog1.SelectedPath}");
-                Process.Start(htmlFileName);
+                UiUtil.OpenFile(htmlFileName);
             }
         }
 
@@ -8438,7 +8438,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             {
                 if (listBoxUnknownWords.SelectedItems[0] is LogItem uw && uw.Line > 0)
                 {
-                    Process.Start("https://www.google.com/search?q=" + Utilities.UrlEncode(uw.Text));
+                    UiUtil.OpenURL("https://www.google.com/search?q=" + Utilities.UrlEncode(uw.Text));
                 }
             }
         }

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -2952,7 +2952,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void linkLabelBingSubscribe_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(MicrosoftTranslator.SignUpUrl);
+            UiUtil.OpenURL(MicrosoftTranslator.SignUpUrl);
         }
 
         private void ValidateShortcut(object sender, EventArgs e)
@@ -3063,7 +3063,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void linkLabelGoogleTranslateSignUp_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://www.google.com/search?q=google+cloud+get+api+key");
+            UiUtil.OpenURL("https://www.google.com/search?q=google+cloud+get+api+key");
         }
 
         private void buttonEditProfile_Click(object sender, EventArgs e)

--- a/src/Forms/SpellCheck.cs
+++ b/src/Forms/SpellCheck.cs
@@ -203,7 +203,7 @@ namespace Nikse.SubtitleEdit.Forms
             else if (e.Modifiers == Keys.Control && e.KeyCode == Keys.G)
             {
                 e.SuppressKeyPress = true;
-                System.Diagnostics.Process.Start("https://www.google.com/search?q=" + Utilities.UrlEncode(textBoxWord.Text));
+                UiUtil.OpenURL("https://www.google.com/search?q=" + Utilities.UrlEncode(textBoxWord.Text));
             }
             else if (e.Modifiers == Keys.Control && e.KeyCode == Keys.Z)
             {
@@ -1251,7 +1251,7 @@ namespace Nikse.SubtitleEdit.Forms
             string text = textBoxWord.Text.Trim();
             if (!string.IsNullOrWhiteSpace(text))
             {
-                System.Diagnostics.Process.Start("https://www.google.com/search?q=" + Utilities.UrlEncode(text));
+                UiUtil.OpenURL("https://www.google.com/search?q=" + Utilities.UrlEncode(text));
             }
         }
 

--- a/src/Forms/VideoError.cs
+++ b/src/Forms/VideoError.cs
@@ -76,7 +76,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void richTextBoxMessage_LinkClicked(object sender, LinkClickedEventArgs e)
         {
-            Process.Start(e.LinkText);
+            UiUtil.OpenURL(e.LinkText);
         }
 
     }

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -1030,36 +1030,37 @@ namespace Nikse.SubtitleEdit.Logic
 
         public static void OpenFolder(string folder)
         {
-            try
-            {
-                System.Diagnostics.Process.Start(folder);
-            }
-            catch (Exception exception)
-            {
-                MessageBox.Show($"Cannot open folder: {folder}{Environment.NewLine}{Environment.NewLine}{exception.Source}: {exception.Message}", "Error opening folder", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            OpenItem(folder, "folder");
         }
-
         public static void OpenURL(string url)
         {
-            try
-            {
-                System.Diagnostics.Process.Start(url);
-            }
-            catch (Exception exception)
-            {
-                MessageBox.Show($"Cannot open url: {url}{Environment.NewLine}{Environment.NewLine}{exception.Source}: {exception.Message}", "Error opening URL", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            OpenItem(url, "url");
         }
         public static void OpenFile(string file)
         {
+            OpenItem(file, "file");
+        }
+
+        public static void OpenItem(string item, string type)
+        {
             try
             {
-                System.Diagnostics.Process.Start(file);
+                if (Configuration.IsRunningOnWindows || Configuration.IsRunningOnMac)
+                {
+                    System.Diagnostics.Process.Start(item);
+                }
+                else if (Configuration.IsRunningOnLinux)
+                {
+                    System.Diagnostics.Process process = new System.Diagnostics.Process();
+                    process.EnableRaisingEvents = false;
+                    process.StartInfo.FileName = "xdg-open";
+                    process.StartInfo.Arguments = item;
+                    process.Start();
+                }
             }
             catch (Exception exception)
             {
-                MessageBox.Show($"Cannot open file: {file}{Environment.NewLine}{Environment.NewLine}{exception.Source}: {exception.Message}", "Error opening file", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show($"Cannot open {type}: {item}{Environment.NewLine}{Environment.NewLine}{exception.Source}: {exception.Message}", "Error opening URL", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -1036,8 +1036,32 @@ namespace Nikse.SubtitleEdit.Logic
             }
             catch (Exception exception)
             {
-                MessageBox.Show($"Cannot open folder: {folder}{Environment.NewLine}{Environment.NewLine}{exception.Source}: {exception.Message}");
+                MessageBox.Show($"Cannot open folder: {folder}{Environment.NewLine}{Environment.NewLine}{exception.Source}: {exception.Message}", "Error opening folder", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
+
+        public static void OpenURL(string url)
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(url);
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show($"Cannot open url: {url}{Environment.NewLine}{Environment.NewLine}{exception.Source}: {exception.Message}", "Error opening URL", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+        public static void OpenFile(string file)
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(file);
+            }
+            catch (Exception exception)
+            {
+                MessageBox.Show($"Cannot open file: {file}{Environment.NewLine}{Environment.NewLine}{exception.Source}: {exception.Message}", "Error opening file", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Recent versions of Mono have broken "system.diagnostics.process.start" for files, urls, and folders on Linux (regular executables work just fine). I have replaced that method with "xdg-open", which will work across all Linux distributions and should work on every mono version.