### PR TITLE
Fix encoding detection on non-Windows platforms

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -104,7 +104,7 @@ ECHO Merging assemblies with ILRepack...
 FOR /D %%A IN (packages\ILRepack.*) DO (SET "ILREPACKDIR=%%A")
 ECHO.
 "%ILREPACKDIR%\tools\ILRepack.exe" /parallel /internalize /targetplatform:v4 /out:"bin\Release\SubtitleEdit.exe" "bin\Release\SubtitleEdit.exe"^
- "bin\Release\libse.dll" "bin\Release\zlib.net.dll" "bin\Release\NHunspell.dll" "DLLs\Interop.QuartzTypeLib.dll"
+ "bin\Release\libse.dll" "bin\Release\zlib.net.dll" "bin\Release\NHunspell.dll" "bin\Release\UtfUnknown.dll" "DLLs\Interop.QuartzTypeLib.dll"
 IF %ERRORLEVEL% NEQ 0 GOTO EndWithError
 POPD
 

--- a/libse/LanguageAutoDetect.cs
+++ b/libse/LanguageAutoDetect.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -1053,11 +1053,6 @@ namespace Nikse.SubtitleEdit.Core
 
         public static Encoding DetectAnsiEncoding(byte[] buffer)
         {
-            if (Utilities.IsRunningOnMono())
-            {
-                return Encoding.Default;
-            }
-
             try
             {
                 var greekEncoding = Encoding.GetEncoding(1253); // Greek

--- a/libse/LibSE.csproj
+++ b/libse/LibSE.csproj
@@ -38,10 +38,11 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0"/>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="UTF.Unknown" Version="2.3.0" />
     <PackageReference Include="zlib.net-mutliplatform" Version="1.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request fixes ANSI encoding detection for MacOS and Linux by changing the dependency necessary for detection from MLang (mlang.dll, i.e. MultiLang) to UTF.Unknown, which is compatible across all platforms and is compatible with .net Standard 1.0 and up.

I only use UTF.Unknown for detecting input encoding. I left the MLang dependency in because LibSE uses it for detecting output encoding, which UTF.Unknown doesn't do, but SubtitleEdit doesn't use it.