### PR TITLE
batch-convert: provide language to auto-break

### DIFF
--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -1537,7 +1537,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     foreach (var paragraph in p.Subtitle.Paragraphs)
                     {
-                        paragraph.Text = Utilities.AutoBreakLine(paragraph.Text);
+                        paragraph.Text = Utilities.AutoBreakLine(paragraph.Text, p.Language);
                     }
                 }
                 catch (Exception exception)


### PR DESCRIPTION
- provide language to auto-break
- use more coveniet method to avoid unecessary call-stack push-in