### PR TITLE
Re-add full timestring for video player time code

### DIFF
--- a/src/Controls/VideoPlayerContainer.cs
+++ b/src/Controls/VideoPlayerContainer.cs
@@ -205,7 +205,7 @@ namespace Nikse.SubtitleEdit.Controls
                     }
                     FontSizeFactor = 1.0F;
                     SetSubtitleFont();
-                    _labelTimeCode.Text = $"{new TimeCode().ToShortDisplayString()} / ?";
+                    _labelTimeCode.Text = $"{new TimeCode().ToDisplayString()} / ?";
                     ShowAllControls();
                     VideoPlayerContainerResize(this, null);
                     ShowAllControls();
@@ -1147,7 +1147,7 @@ namespace Nikse.SubtitleEdit.Controls
             if (string.IsNullOrEmpty(_labelTimeCode.Text))
             {
                 var span = TimeCode.FromSeconds(1);
-                _labelTimeCode.Text = $"{span.ToShortDisplayString()} / {span.ToShortDisplayString()}{(SmpteMode ? " SMPTE" : string.Empty)}";
+                _labelTimeCode.Text = $"{span.ToDisplayString()} / {span.ToDisplayString()}{(SmpteMode ? " SMPTE" : string.Empty)}";
                 _labelTimeCode.Left = Width - _labelTimeCode.Width - 9;
                 if (_labelTimeCode.Top + _labelTimeCode.Height >= _panelControls.Height - 4)
                 {
@@ -1650,12 +1650,12 @@ namespace Nikse.SubtitleEdit.Controls
                 if (SmpteMode)
                 {
                     var span = TimeCode.FromSeconds(pos + 0.017 + Configuration.Settings.General.CurrentVideoOffsetInMs / TimeCode.BaseUnit);
-                    _labelTimeCode.Text = $"{span.ToShortDisplayString()} / {dur.ToShortDisplayString()} SMPTE";
+                    _labelTimeCode.Text = $"{span.ToDisplayString()} / {dur.ToDisplayString()} SMPTE";
                 }
                 else
                 {
                     var span = TimeCode.FromSeconds(pos + Configuration.Settings.General.CurrentVideoOffsetInMs / TimeCode.BaseUnit);
-                    _labelTimeCode.Text = $"{span.ToShortDisplayString()} / {dur.ToShortDisplayString()}";
+                    _labelTimeCode.Text = $"{span.ToDisplayString()} / {dur.ToDisplayString()}";
                 }
                 ResizeTimeCode();
 


### PR DESCRIPTION
The new timecode text color is definitely an improvement for readability, but I find the shortened timestrings confusing. With the full timestring, it's clear what are the seconds, minutes, hours etc. at a glance. Especially when using frames instead of seconds; it's the industry-standard timecode format.

![image](https://user-images.githubusercontent.com/3516155/77942095-7411dd00-72bb-11ea-95fd-862237411a97.png)
