### PR TITLE
Fix extend option/shortcuts not committing changes

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -7110,6 +7110,9 @@ namespace Nikse.SubtitleEdit.Forms
                     SubtitleListview1.SetStartTimeAndDuration(index, p, _subtitle.GetParagraphOrDefault(index + 1), _subtitle.GetParagraphOrDefault(index - 1));
                 }
             }
+
+            _subtitleListViewIndex = -1;
+            SubtitleListview1_SelectedIndexChanged(null, null);
         }
 
         private int GetPositionFromWordIndex(string text, int wordIndex)


### PR DESCRIPTION
After using the extend to previous/next shortcuts, the changes would be undone when selecting another subtitle.