### PR TITLE
FIxCommas : Improvements

### DIFF
--- a/libse/Forms/FixCommonErrors/FixCommas.cs
+++ b/libse/Forms/FixCommonErrors/FixCommas.cs
@@ -60,7 +60,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             callbacks.UpdateFixStatus(fixCount, Configuration.Settings.Language.FixCommonErrors.FixCommas, fixCount.ToString());
         }
 
-        private IDictionary<Regex, string> GetInvertedRegexList()
+        private static IDictionary<Regex, string> GetInvertedRegexList()
         {
             return new Dictionary<Regex, string>
             {
@@ -72,9 +72,10 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             };
         }
 
-        private string RemovePrefixCommaSymbol(string s, char comma)
+        private static string RemovePrefixCommaSymbol(string s, char comma)
         {
-            for (int i = s.Length - 1; i >= 0; i--)
+            int i = s.Length - 1;
+            while (i >= 0)
             {
                 char ch = s[i];
                 if (i - 1 >= 0 && s[i - 1] == comma && IsCloseChar(ch))
@@ -92,8 +93,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         s = s.Remove(i, k - i);
                     }
                 }
+                i--;
             }
-
             return s;
         }
 

--- a/libse/Forms/FixCommonErrors/FixCommas.cs
+++ b/libse/Forms/FixCommonErrors/FixCommas.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Interfaces;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -7,73 +8,45 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
     {
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
-            var commaDouble = new Regex(@"([\p{L}\d\s])(,,)([\p{L}\d\s])");
-            var commaTriple = new Regex(@"([\p{L}\d\s])( *, *, *,)([\p{L}\d\s])");
-            var commaTripleEndOfLine = new Regex(@"([\p{L}\d\s])(, *, *,)$");
-            var commaWhiteSpaceBetween = new Regex(@"([\p{L}\d\s])(,\s+,)([\p{L}\d\s])");
+            var commaDouble = new Regex(@"([\p{L}\d\s]),,([\p{L}\d\s])");
+            var commaTriple = new Regex(@"([\p{L}\d\s]) *, *, *,([\p{L}\d\s])");
+            var commaTripleEndOfLine = new Regex(@"([\p{L}\d\s]), *, *,$");
+            var commaWhiteSpaceBetween = new Regex(@"([\p{L}\d\s]),\s+,([\p{L}\d\s])");
             var commaFollowedByLetter = new Regex(@",(\p{L})");
+
+            // cache for inverted regex replacement
+            IDictionary<Regex, string> invertedRegex = null;
 
             string fixAction = Configuration.Settings.Language.FixCommonErrors.FixCommas;
             int fixCount = 0;
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 var p = subtitle.Paragraphs[i];
-                if ((p.Text.IndexOf(',') >= 0 || p.Text.IndexOf('،') >= 0) && callbacks.AllowFix(p, fixAction))
+                if (callbacks.AllowFix(p, fixAction))
                 {
                     var s = p.Text;
                     var oldText = s;
 
-                    if (p.Text.IndexOf(',') >= 0)
+                    if (HashComma(p.Text))
                     {
-                        s = commaDouble.Replace(s, "$1,$3");
-                        s = commaTriple.Replace(s, "$1...$3");
+                        s = commaDouble.Replace(s, "$1,$2");
+                        s = commaTriple.Replace(s, "$1...$2");
                         s = commaTripleEndOfLine.Replace(s, "$1...");
-                        s = commaWhiteSpaceBetween.Replace(s, "$1,$3");
+                        s = commaWhiteSpaceBetween.Replace(s, "$1,$2");
                         s = commaFollowedByLetter.Replace(s, ", $1");
 
-                        while (s.Contains(",."))
-                        {
-                            s = s.Replace(",.", ".");
-                        }
-
-                        while (s.Contains(",!"))
-                        {
-                            s = s.Replace(",!", "!");
-                        }
-
-                        while (s.Contains(",?"))
-                        {
-                            s = s.Replace(",?", "?");
-                        }
+                        s = RemovePrefixCommaSymbol(s, ',');
                     }
 
-                    if (p.Text.IndexOf('،') >= 0)
+                    if (HashInvertedComma(p.Text))
                     {
-                        var commaDoubleAr = new Regex(@"([\p{L}\d\s])( *،،)([\p{L}\d\s])");
-                        var commaTripleAr = new Regex(@"([\p{L}\d\s])( *، *، *،)([\p{L}\d\s])");
-                        var commaTripleEndOfLineAr = new Regex(@"([\p{L}\d\s])( *، *، *،)$");
-                        var commaWhiteSpaceBetweenAr = new Regex(@"([\p{L}\d\s])( *،\s+،)([\p{L}\d\s])");
-                        var commaFollowedByLetterAr = new Regex(@"،(\p{L})");
-                        s = commaDoubleAr.Replace(s, "$1،$3");
-                        s = commaTripleAr.Replace(s, "$1...$3");
-                        s = commaTripleEndOfLineAr.Replace(s, "$1...");
-                        s = commaWhiteSpaceBetweenAr.Replace(s, "$1،$3");
-                        s = commaFollowedByLetterAr.Replace(s, "، $1");
-
-                        while (s.Contains("،."))
+                        invertedRegex = invertedRegex ?? GetInvertedRegexList();
+                        foreach (var kvp in invertedRegex)
                         {
-                            s = s.Replace("،.", ".");
+                            s = kvp.Key.Replace(s, kvp.Value);
                         }
 
-                        while (s.Contains("،!"))
-                        {
-                            s = s.Replace("،!", "!");
-                        }
-
-                        while (s.Contains("،?"))
-                        {
-                            s = s.Replace("،?", "?");
-                        }
+                        s = RemovePrefixCommaSymbol(s, '،');
                     }
 
                     if (oldText != s)
@@ -86,5 +59,49 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             }
             callbacks.UpdateFixStatus(fixCount, Configuration.Settings.Language.FixCommonErrors.FixCommas, fixCount.ToString());
         }
+
+        private IDictionary<Regex, string> GetInvertedRegexList()
+        {
+            return new Dictionary<Regex, string>
+            {
+                { new Regex(@"([\p{L}\d\s]) *،،([\p{L}\d\s])", RegexOptions.Compiled | RegexOptions.RightToLeft), "$1،$2"},
+                { new Regex(@"([\p{L}\d\s]) *، *، *،([\p{L}\d\s])", RegexOptions.Compiled | RegexOptions.RightToLeft), "$1...$2"},
+                { new Regex(@"([\p{L}\d\s])( *، *، *،)$", RegexOptions.Compiled | RegexOptions.RightToLeft), "$1..."},
+                { new Regex(@"([\p{L}\d\s]) *،\s+،([\p{L}\d\s])", RegexOptions.Compiled | RegexOptions.RightToLeft), "$1،$2"},
+                { new Regex(@"،(\p{L})", RegexOptions.Compiled | RegexOptions.RightToLeft), "، $1" }
+            };
+        }
+
+        private string RemovePrefixCommaSymbol(string s, char comma)
+        {
+            for (int i = s.Length - 1; i >= 0; i--)
+            {
+                char ch = s[i];
+                if (i - 1 >= 0 && s[i - 1] == comma && IsCloseChar(ch))
+                {
+                    int k = i;
+
+                    do
+                    {
+                        i--;
+                    } while (i - 1 >= 0 && s[i - 1] == comma);
+
+                    // remove commas
+                    if (k - i > 0)
+                    {
+                        s = s.Remove(i, k - i);
+                    }
+                }
+            }
+
+            return s;
+        }
+
+        private static bool IsCloseChar(char ch) => ch == '.' || ch == '!' || ch == '?' || ch == ')' || ch == ']';
+
+        private static bool HashComma(string input) => input.Contains(',');
+
+        private static bool HashInvertedComma(string input) => input.Contains('،');
+
     }
 }

--- a/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
@@ -2317,6 +2317,26 @@ namespace Test.FixCommonErrors
         }
 
         [TestMethod]
+        public void FixCommas6()
+        {
+            var sub = new Subtitle();
+            sub.Paragraphs.Add(new Paragraph("[Hi,]", 0, 1000));
+            var fup = new FixCommas();
+            fup.Fix(sub, new EmptyFixCallback());
+            Assert.AreEqual("[Hi]", sub.Paragraphs[0].Text);
+        }
+
+        [TestMethod]
+        public void FixCommas7()
+        {
+            var sub = new Subtitle();
+            sub.Paragraphs.Add(new Paragraph("(Hi,)", 0, 1000));
+            var fup = new FixCommas();
+            fup.Fix(sub, new EmptyFixCallback());
+            Assert.AreEqual("(Hi)", sub.Paragraphs[0].Text);
+        }
+
+        [TestMethod]
         public void FixCommasArabic()
         {
             var sub = new Subtitle();


### PR DESCRIPTION
- remove unnecessary group capturing
- cache regex for inverted commas
- optimize comma removing before closing characters e.g: ?!
- include "]" & ")" in closing characters
- introduce method which as more meaningful names, 
- add unit-test for "]" and ")"