### PR TITLE
Minor updates / optimization

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -13047,10 +13047,10 @@ namespace Nikse.SubtitleEdit.Forms
 
                     Cursor.Current = Cursors.WaitCursor;
                     var selectedLines = new Subtitle();
-                    var selectedIndices = SubtitleListview1.SelectedIndices.Cast<int>().ToList();
+                    var selectedIndices = new List<int>(SubtitleListview1.GetSelectedIndices());
                     if (onlySelectedLines)
                     {
-                        foreach (int index in SubtitleListview1.SelectedIndices)
+                        foreach (int index in selectedIndices)
                         {
                             selectedLines.Paragraphs.Add(new Paragraph(_subtitle.Paragraphs[index]));
                         }

--- a/src/Forms/MultipleReplace.cs
+++ b/src/Forms/MultipleReplace.cs
@@ -310,8 +310,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     fixedLines++;
                     fixes.Add(MakePreviewListItem(p, newText));
-                    int index = _subtitle.GetIndex(p);
-                    FixedSubtitle.Paragraphs[index].Text = newText;
+                    FixedSubtitle.Paragraphs[i].Text = newText;
                 }
             }
 
@@ -419,6 +418,7 @@ namespace Nikse.SubtitleEdit.Forms
                 return;
             }
 
+            listViewRules.BeginUpdate();
             for (int i = listViewRules.Items.Count - 1; i >= 0; i--)
             {
                 ListViewItem item = listViewRules.Items[i];
@@ -428,6 +428,7 @@ namespace Nikse.SubtitleEdit.Forms
                     _currentGroup.Rules.Remove(item.Tag as MultipleSearchAndReplaceSetting);
                 }
             }
+            listViewRules.EndUpdate();
             GeneratePreview();
         }
 


### PR DESCRIPTION
- call faster get listview selected indices helper method
- use already know paragraph index to retrieve the paragraph and avoid calling "subtitle.GetIndex"