### PR TITLE
Some continuation style improvements

### DIFF
--- a/libse/ContinuationUtilities.cs
+++ b/libse/ContinuationUtilities.cs
@@ -121,7 +121,7 @@ namespace Nikse.SubtitleEdit.Core
             // Remove single-char quotes from the ending
             if (checkString.Length > 0 && Quotes.Contains(checkString[checkString.Length - 1]))
             {
-                if (checkString[checkString.Length - 1] == '\'' && checkString.EndsWith("in'", StringComparison.Ordinal) && char.IsLetter(checkString[checkString.Length - 4]))
+                if (checkString[checkString.Length - 1] == '\'' && checkString.EndsWith("in'", StringComparison.Ordinal) && checkString.Length > 4 && char.IsLetter(checkString[checkString.Length - 4]))
                 {
                     // nothin' -- Don't remove
                 }

--- a/libse/ContinuationUtilities.cs
+++ b/libse/ContinuationUtilities.cs
@@ -1047,10 +1047,11 @@ namespace Nikse.SubtitleEdit.Core
             var nextTextWithDash = SanitizeString(nextInput, false);
 
             // Remove any prefix and suffix when:
-            // - Title 1 ends with a suffix AND title 2 starts with a prefix
-            // - Title 2 is a continuing sentence
-            if (HasSuffix(thisText, profile) && HasPrefix(nextTextWithDash, profile)
-                || !IsNewSentence(nextText) && !string.IsNullOrEmpty(nextText))
+            // - Title 1 ends with a suffix AND title 2 starts with a prefix AND it's both the same type
+            // - Title 2 is a continuing sentence, but only remove a leading dash if it's a dialog
+            if ((HasSuffix(thisText, profile) && HasPrefix(nextTextWithDash, profile) && thisText[thisText.Length - 1] == nextTextWithDash[0])
+                || (!string.IsNullOrEmpty(nextText) && !IsNewSentence(nextText) && !IsEndOfSentence(thisText) 
+                    && (!Dashes.Contains(nextTextWithDash[0]) || (Dashes.Contains(nextTextWithDash[0]) && nextTextWithDash.IndexOf(nextTextWithDash[0], 1) != -1))))
             {
                 var newNextText = RemoveAllPrefixes(nextInput, profile);
                 var newText = RemoveSuffix(input, profile, StartsWithConjunction(newNextText, language));

--- a/libse/ContinuationUtilities.cs
+++ b/libse/ContinuationUtilities.cs
@@ -13,6 +13,21 @@ namespace Nikse.SubtitleEdit.Core
         private static readonly string SingleQuotes = "'‘’‘";
         private static readonly string DoubleQuotes = "''‘‘’’‚‚‘‘";
         private static readonly string MusicSymbols = "♪♫#*¶";
+        private static readonly string ExplanationQuotes = "'\"“”‘’«»‹›";
+
+        private static readonly Dictionary<char, char> QuotePairs = new Dictionary<char, char>()
+        {
+            {'\'', '\''},
+            {'"', '"'},
+            {'“', '”'},
+            {'”', '“'},
+            {'‘', '’'},
+            {'’', '‘'},
+            {'«', '»'},
+            {'»', '«'},
+            {'‹', '›'},
+            {'›', '‹'}
+        };
 
         public static readonly List<string> Prefixes = new List<string> { "...", "..", "-", "‐", "–", "—", "…" };
         public static readonly List<string> DashPrefixes = new List<string> { "-", "‐", "–", "—" };
@@ -315,26 +330,38 @@ namespace Nikse.SubtitleEdit.Core
                 }
             }
 
-            // Check if it's not surrounded by HTML tags, then we'll place it outside the tags (remove comma if present)
-            // Only if it's not a tag across the whole subtitle.
+            // Check if it's not surrounded by HTML tags or quotes, then we'll place it outside the tags (remove comma if present)
+            // Only if it's not a tag/quote across the whole subtitle.
             var wordIndex = originalText.LastIndexOf(lastWord.TrimEnd(','), StringComparison.Ordinal);
-            if (wordIndex >= 0 && wordIndex < originalText.Length - 3)
+            if (wordIndex >= 0 && wordIndex < originalText.Length - 1)
             {
+                bool needsInsertion = false;
                 int currentIndex = wordIndex + lastWord.TrimEnd(',').Length;
-                if (((currentIndex < originalText.Length && originalText[currentIndex] == '<')
-                    || (currentIndex + 1 < originalText.Length && originalText[currentIndex + 1] == ',' && originalText[currentIndex] == '<'))
-                    && !IsFullLineTag(originalText, currentIndex))
-                {
-                    if (currentIndex < originalText.Length && originalText[currentIndex] == ',')
-                    {
-                        originalText = originalText.Remove(currentIndex, 1);
-                    }
 
-                    while (currentIndex + 1 < originalText.Length && !(originalText[currentIndex] == '>' && originalText[currentIndex + 1] != '<'))
+                if (currentIndex < originalText.Length && ExplanationQuotes.Contains(originalText[currentIndex])
+                                                       && !IsFullLineQuote(originalText, currentIndex, QuotePairs[originalText[currentIndex]], originalText[currentIndex]))
+                {
+                    char quote = originalText[currentIndex];
+                    while (currentIndex + 1 < originalText.Length && originalText[currentIndex] != quote)
                     {
                         currentIndex++;
                     }
 
+                    needsInsertion = true;
+                }
+
+                if (currentIndex < originalText.Length && originalText[currentIndex] == '<' && !IsFullLineTag(originalText, currentIndex))
+                {
+                    while (currentIndex + 1 < originalText.Length && originalText[currentIndex] != '>')
+                    {
+                        currentIndex++;
+                    }
+
+                    needsInsertion = true;
+                }
+                
+                if (needsInsertion)
+                {
                     var suffix = newLastWord.Replace(lastWord.TrimEnd(','), "");
 
                     if (currentIndex + 1 < originalText.Length && originalText[currentIndex + 1] == ',')
@@ -446,18 +473,38 @@ namespace Nikse.SubtitleEdit.Core
                 }
             }
 
-            // Check if it's not surrounded by HTML tags, then we'll place it outside the tags
-            // Only if it's not a tag across the whole subtitle.
+            // Check if it's not surrounded by HTML tags or quotes, then we'll place it outside the tags
+            // Only if it's not a tag/quote across the whole subtitle.
             var wordIndex = originalText.IndexOf(firstWord, StringComparison.Ordinal);
-            if (wordIndex >= 3)
+            if (wordIndex >= 1)
             {
+                bool needsInsertion = false;
                 int currentIndex = wordIndex - 1;
-                if (currentIndex >= 0 && originalText[currentIndex] == '>' && !IsFullLineTag(originalText, currentIndex))
+
+                if (currentIndex >= 0 && ExplanationQuotes.Contains(originalText[currentIndex]) 
+                                      && !IsFullLineQuote(originalText, currentIndex + 1, originalText[currentIndex], QuotePairs[originalText[currentIndex]]))
                 {
-                    while (currentIndex - 1 >= 0 && !(originalText[currentIndex - 1] != '>' && originalText[currentIndex] == '<'))
+                    char quote = originalText[currentIndex];
+                    while (currentIndex - 1 >= 0 && originalText[currentIndex] != quote)
                     {
                         currentIndex--;
                     }
+
+                    needsInsertion = true;
+                }
+                
+                if (currentIndex >= 0 && originalText[currentIndex] == '>' && !IsFullLineTag(originalText, currentIndex))
+                {
+                    while (currentIndex - 1 >= 0 && originalText[currentIndex] != '<')
+                    {
+                        currentIndex--;
+                    }
+
+                    needsInsertion = true;
+                }
+
+                if (needsInsertion)
+                {
                     var prefix = newFirstWord.Replace(firstWord, "");
                     return originalText.Insert(currentIndex, prefix);
                 }
@@ -839,6 +886,60 @@ namespace Nikse.SubtitleEdit.Core
             {
                 endIndex = input.Length;
             }
+
+            var textToRemove = input.Substring(startIndex, endIndex - startIndex);
+            input = input.Replace(textToRemove, "");
+
+            foreach (var c in input)
+            {
+                if (char.IsLetterOrDigit(c))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool IsFullLineQuote(string input, int position, char quoteStart, char quoteEnd)
+        {
+            input = ExtractParagraphOnly(input);
+
+            // Return if empty string
+            if (string.IsNullOrEmpty(input))
+            {
+                return false;
+            }
+
+            var startIndex = position;
+            var endIndex = position;
+
+            while (startIndex >= 0 && !(input[startIndex] == quoteStart
+                                        && (startIndex - 1 >= 0 && (!char.IsLetterOrDigit(input[startIndex - 1]) && input[startIndex - 1] != '\r' && input[startIndex - 1] != '\n'))))
+            {
+                if (startIndex - 1 >= 0 && (input[startIndex - 1] == '\r' || input[startIndex - 1] == '\n'))
+                {
+                    startIndex = 0;
+                    break;
+                }
+
+                startIndex--;
+            }
+
+            while (endIndex < input.Length && !(input[endIndex] == quoteEnd
+                                                && (endIndex + 1 < input.Length && (!char.IsLetterOrDigit(input[endIndex + 1]) && input[endIndex + 1] != '\r' && input[endIndex + 1] != '\n'))))
+            {
+                if (endIndex + 1 < input.Length && (input[endIndex + 1] == '\r' || input[endIndex + 1] == '\n'))
+                {
+                    endIndex = input.Length;
+                    break;
+                }
+
+                endIndex++;
+            }
+
+            startIndex = Math.Max(0, startIndex);
+            endIndex = Math.Min(input.Length, endIndex);
 
             var textToRemove = input.Substring(startIndex, endIndex - startIndex);
             input = input.Replace(textToRemove, "");

--- a/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
@@ -2980,12 +2980,178 @@ namespace Test.FixCommonErrors
         {
             using (var target = GetFixCommonErrorsLib())
             {
-                InitializeFixCommonErrorsLine(target, "Test,", "test...");
-                _subtitle.Paragraphs.Add(new Paragraph("Test.", 10000, 12000));
+                InitializeFixCommonErrorsLine(target, "Test,", "test,");
+                _subtitle.Paragraphs.Add(new Paragraph("test.", 40000, 50000));
                 Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
                 new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
                 Assert.AreEqual("Test...", _subtitle.Paragraphs[0].Text);
                 Assert.AreEqual("...test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("...test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle31B()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test,", "test,");
+                _subtitle.Paragraphs.Add(new Paragraph("test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.None;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test,", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test,", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle31C()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test,", "test,");
+                _subtitle.Paragraphs.Add(new Paragraph("test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.NoneLeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test,", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("...test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle31D()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test,", "test,");
+                _subtitle.Paragraphs.Add(new Paragraph("test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.NoneTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test,", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle32()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test...", "test...");
+                _subtitle.Paragraphs.Add(new Paragraph("test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test...", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("...test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("...test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle32B()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test...", "test...");
+                _subtitle.Paragraphs.Add(new Paragraph("test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.None;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle32C()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test...", "test...");
+                _subtitle.Paragraphs.Add(new Paragraph("test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.NoneLeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("...test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle32D()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test...", "test...");
+                _subtitle.Paragraphs.Add(new Paragraph("test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.NoneTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle33()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test...", "test...");
+                _subtitle.Paragraphs.Add(new Paragraph("Test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test...", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("...test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("Test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle33B()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test...", "test...");
+                _subtitle.Paragraphs.Add(new Paragraph("Test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.None;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("Test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle33C()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test...", "test...");
+                _subtitle.Paragraphs.Add(new Paragraph("Test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.NoneLeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("Test.", _subtitle.Paragraphs[2].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle33D()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "Test...", "test...");
+                _subtitle.Paragraphs.Add(new Paragraph("Test.", 40000, 50000));
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.NoneTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("Test", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("test...", _subtitle.Paragraphs[1].Text);
+                Assert.AreEqual("Test.", _subtitle.Paragraphs[2].Text);
             }
         }
 

--- a/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
@@ -3154,6 +3154,97 @@ namespace Test.FixCommonErrors
                 Assert.AreEqual("Test.", _subtitle.Paragraphs[2].Text);
             }
         }
+        [TestMethod]
+        public void FixContinuationStyle34()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "This is what you call a 'test'...", "and you can join.");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("This is what you call a 'test'...", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("...and you can join.", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle34B()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "This is what you call a 'test'", "and you can join.");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("This is what you call a 'test'...", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("...and you can join.", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle34C()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "'This is what you call a test'", "'and you can join.'");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("'This is what you call a test...'", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("'...and you can join.'", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle35()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "They wanted to test", "But they couldn't.");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("They wanted to test", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("But they couldn't.", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle35B()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "They wanted to 'test'", "But they couldn't.");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("They wanted to 'test'", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("But they couldn't.", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle35C()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "They wanted to 'test?'", "But they couldn't.");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("They wanted to 'test?'", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("But they couldn't.", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle35D()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "They wanted to 'test?'", "'But they couldn't.' Yeah, sure.");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("They wanted to 'test?'", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("'But they couldn't.' Yeah, sure.", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
 
         /*[TestMethod]
         public void FixContinuationStyle32()

--- a/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
@@ -3185,6 +3185,32 @@ namespace Test.FixCommonErrors
         {
             using (var target = GetFixCommonErrorsLib())
             {
+                InitializeFixCommonErrorsLine(target, "This is what you call a 'test,'", "and you can join.");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("This is what you call a 'test'...", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("...and you can join.", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle34D()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
+                InitializeFixCommonErrorsLine(target, "This is what you call a 'test...'", "and you can join.");
+                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
+                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
+                Assert.AreEqual("This is what you call a 'test'...", _subtitle.Paragraphs[0].Text);
+                Assert.AreEqual("...and you can join.", _subtitle.Paragraphs[1].Text);
+            }
+        }
+
+        [TestMethod]
+        public void FixContinuationStyle34E()
+        {
+            using (var target = GetFixCommonErrorsLib())
+            {
                 InitializeFixCommonErrorsLine(target, "'This is what you call a test'", "'and you can join.'");
                 Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
                 new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
@@ -3205,47 +3231,7 @@ namespace Test.FixCommonErrors
                 Assert.AreEqual("But they couldn't.", _subtitle.Paragraphs[1].Text);
             }
         }
-
-        [TestMethod]
-        public void FixContinuationStyle35B()
-        {
-            using (var target = GetFixCommonErrorsLib())
-            {
-                InitializeFixCommonErrorsLine(target, "They wanted to 'test'", "But they couldn't.");
-                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
-                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
-                Assert.AreEqual("They wanted to 'test'", _subtitle.Paragraphs[0].Text);
-                Assert.AreEqual("But they couldn't.", _subtitle.Paragraphs[1].Text);
-            }
-        }
-
-        [TestMethod]
-        public void FixContinuationStyle35C()
-        {
-            using (var target = GetFixCommonErrorsLib())
-            {
-                InitializeFixCommonErrorsLine(target, "They wanted to 'test?'", "But they couldn't.");
-                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
-                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
-                Assert.AreEqual("They wanted to 'test?'", _subtitle.Paragraphs[0].Text);
-                Assert.AreEqual("But they couldn't.", _subtitle.Paragraphs[1].Text);
-            }
-        }
-
-        [TestMethod]
-        public void FixContinuationStyle35D()
-        {
-            using (var target = GetFixCommonErrorsLib())
-            {
-                InitializeFixCommonErrorsLine(target, "They wanted to 'test?'", "'But they couldn't.' Yeah, sure.");
-                Configuration.Settings.General.ContinuationStyle = ContinuationStyle.LeadingTrailingDots;
-                new FixContinuationStyle().Fix(_subtitle, new EmptyFixCallback());
-                Assert.AreEqual("They wanted to 'test?'", _subtitle.Paragraphs[0].Text);
-                Assert.AreEqual("'But they couldn't.' Yeah, sure.", _subtitle.Paragraphs[1].Text);
-            }
-        }
-
-
+        
         /*[TestMethod]
         public void FixContinuationStyle32()
         {

--- a/src/Test/Logic/ContinuationUtilitiesTest.cs
+++ b/src/Test/Logic/ContinuationUtilitiesTest.cs
@@ -363,26 +363,6 @@ namespace Test.Logic
         }
 
         [TestMethod]
-        public void AddSuffixIfNeeded8D()
-        {
-            string line1 = "This is a 'test'";
-            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
-            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
-            string line1Expected = "This is a 'test'...";
-            Assert.AreEqual(line1Expected, line1Actual);
-        }
-
-        [TestMethod]
-        public void AddSuffixIfNeeded8E()
-        {
-            string line1 = "'This is a test'";
-            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
-            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
-            string line1Expected = "'This is a test...'";
-            Assert.AreEqual(line1Expected, line1Actual);
-        }
-
-        [TestMethod]
         public void AddSuffixIfNeeded8F()
         {
             string line1 = "We just vibin' here you know";
@@ -465,6 +445,16 @@ namespace Test.Logic
         [TestMethod]
         public void AddSuffixIfNeeded10()
         {
+            string line1 = "This is a <i>test</i>";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a <i>test</i>...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded10B()
+        {
             string line1 = "This is a <i>test</i>,";
             var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
             string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
@@ -473,7 +463,17 @@ namespace Test.Logic
         }
 
         [TestMethod]
-        public void AddSuffixIfNeeded10A()
+        public void AddSuffixIfNeeded10C()
+        {
+            string line1 = "This is a <i>test</i>...";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a <i>test</i>...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded10D()
         {
             string line1 = "<i>This is a test,</i>";
             var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
@@ -481,6 +481,36 @@ namespace Test.Logic
             string line1Expected = "<i>This is a test...</i>";
             Assert.AreEqual(line1Expected, line1Actual);
         }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded10E()
+        {
+            string line1 = "<i>This is a test...</i>";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "<i>This is a test...</i>";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        /*[TestMethod]
+        public void AddSuffixIfNeeded10F()
+        {
+            string line1 = "This is a <i>test,</i>";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a <i>test</i>...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded10G()
+        {
+            string line1 = "This is a <i>test...</i>";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a <i>test</i>...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }*/
 
         [TestMethod]
         public void AddSuffixIfNeeded11()
@@ -579,6 +609,86 @@ namespace Test.Logic
             var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
             string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
             string line1Expected = "...test...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+        
+        [TestMethod]
+        public void AddSuffixIfNeeded18()
+        {
+            string line1 = "This is a 'test'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a 'test'...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded18B()
+        {
+            string line1 = "This is a 'test'...";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a 'test'...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded18C()
+        {
+            string line1 = "This is a 'test',";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a 'test'...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        /*[TestMethod]
+        public void AddSuffixIfNeeded18D()
+        {
+            string line1 = "This is a 'test...'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a 'test'...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded18E()
+        {
+            string line1 = "This is a 'test,'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a 'test'...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }*/
+
+        [TestMethod]
+        public void AddSuffixIfNeeded19()
+        {
+            string line1 = "'This is a test'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "'This is a test...'";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded19B()
+        {
+            string line1 = "'This is a test...'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "'This is a test...'";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded19C()
+        {
+            string line1 = "'This is a test,'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "'This is a test...'";
             Assert.AreEqual(line1Expected, line1Actual);
         }
 
@@ -779,6 +889,56 @@ namespace Test.Logic
             var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
             string line1Actual = ContinuationUtilities.AddPrefixIfNeeded(line1, profile, true);
             string line1Expected = "...test...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+        
+        [TestMethod]
+        public void AddPrefixIfNeeded15()
+        {
+            string line1 = "'this' is a test.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddPrefixIfNeeded(line1, profile, false);
+            string line1Expected = "...'this' is a test.";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddPrefixIfNeeded15B()
+        {
+            string line1 = "...'this' is a test.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddPrefixIfNeeded(line1, profile, false);
+            string line1Expected = "...'this' is a test.";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        /*[TestMethod]
+        public void AddPrefixIfNeeded15D()
+        {
+            string line1 = "'...this' is a test.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddPrefixIfNeeded(line1, profile, false);
+            string line1Expected = "...'this' is a test.";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }*/
+
+        [TestMethod]
+        public void AddPrefixIfNeeded16()
+        {
+            string line1 = "'this is a test'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddPrefixIfNeeded(line1, profile, false);
+            string line1Expected = "'...this is a test'";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddPrefixIfNeeded16B()
+        {
+            string line1 = "'...this is a test'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddPrefixIfNeeded(line1, profile, false);
+            string line1Expected = "'...this is a test'";
             Assert.AreEqual(line1Expected, line1Actual);
         }
 

--- a/src/Test/Logic/ContinuationUtilitiesTest.cs
+++ b/src/Test/Logic/ContinuationUtilitiesTest.cs
@@ -1936,5 +1936,140 @@ namespace Test.Logic
             Assert.AreEqual(line1Expected, line1Actual);
             Assert.AreEqual(line2Expected, line2Actual);
         }
+
+        [TestMethod]
+        public void MergeHelper12()
+        {
+            string line1 = "This needs to be merged...";
+            string line2 = "-This is a response.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged...";
+            string line2Expected = "-This is a response.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
+
+        [TestMethod]
+        public void MergeHelper12A()
+        {
+            string line1 = "This needs to be merged...";
+            string line2 = "-This is a response.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDash);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged...";
+            string line2Expected = "-This is a response.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
+
+        [TestMethod]
+        public void MergeHelper12B()
+        {
+            string line1 = "This needs to be merged-";
+            string line2 = "-This is a response.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDash);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged";
+            string line2Expected = "This is a response.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
+
+        [TestMethod]
+        public void MergeHelper13()
+        {
+            string line1 = "This needs to be merged...";
+            string line2 = "with this.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged";
+            string line2Expected = "with this.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
+
+        [TestMethod]
+        public void MergeHelper13B()
+        {
+            string line1 = "This needs to be merged...";
+            string line2 = "-just something random.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged...";
+            string line2Expected = "-just something random.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
+
+        [TestMethod]
+        public void MergeHelper13C()
+        {
+            string line1 = "This needs to be merged.";
+            string line2 = "-just something random.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged.";
+            string line2Expected = "-just something random.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
+
+        [TestMethod]
+        public void MergeHelper13D()
+        {
+            string line1 = "This needs to be merged";
+            string line2 = "-just something random.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged";
+            string line2Expected = "-just something random.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
+
+        [TestMethod]
+        public void MergeHelper13E()
+        {
+            string line1 = "This needs to be merged...";
+            string line2 = "-just something random." + Environment.NewLine + "-Good idea.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged";
+            string line2Expected = "just something random." + Environment.NewLine + "-Good idea.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
+
+        [TestMethod]
+        public void MergeHelper14()
+        {
+            string line1 = "This needs to be merged.";
+            string line2 = "just something random.";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            var result = ContinuationUtilities.MergeHelper(line1, line2, profile, "en");
+            string line1Actual = result.Item1;
+            string line2Actual = result.Item2;
+            string line1Expected = "This needs to be merged.";
+            string line2Expected = "just something random.";
+            Assert.AreEqual(line1Expected, line1Actual);
+            Assert.AreEqual(line2Expected, line2Actual);
+        }
     }
 }

--- a/src/Test/Logic/ContinuationUtilitiesTest.cs
+++ b/src/Test/Logic/ContinuationUtilitiesTest.cs
@@ -363,6 +363,76 @@ namespace Test.Logic
         }
 
         [TestMethod]
+        public void AddSuffixIfNeeded8D()
+        {
+            string line1 = "This is a 'test'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "This is a 'test'...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded8E()
+        {
+            string line1 = "'This is a test'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "'This is a test...'";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded8F()
+        {
+            string line1 = "We just vibin' here you know";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "We just vibin' here you know...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded8G()
+        {
+            string line1 = "'We just vibin' here you know";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "'We just vibin' here you know...";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded8H()
+        {
+            string line1 = "'We just vibin' here you know'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "'We just vibin' here you know...'";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded8I()
+        {
+            string line1 = "test in'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "test in...'";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
+        public void AddSuffixIfNeeded8J()
+        {
+            string line1 = "in'";
+            var profile = ContinuationUtilities.GetContinuationProfile(ContinuationStyle.LeadingTrailingDots);
+            string line1Actual = ContinuationUtilities.AddSuffixIfNeeded(line1, profile, false);
+            string line1Expected = "in...'";
+            Assert.AreEqual(line1Expected, line1Actual);
+        }
+
+        [TestMethod]
         public void AddSuffixIfNeeded9()
         {
             string line1 = "- Hello." + Environment.NewLine + "- This is a <i>test</i>";


### PR DESCRIPTION
Some fixes:
- Improved detection of actual quotes versus 'explanation quotes' around one phrase (e.g. `This is a 'test'` > `This is a 'test'...`, instead of `This is a 'test...'`)
- Improved detection of dialogs when merging (sometimes a dialog dash got removed because it was incorrectly seen as a continuation dash)

Added tests accordingly.