### PR TITLE
Add EBU STL header import to command line

### DIFF
--- a/src/Logic/CommandLineConvert/CommandLineConverter.cs
+++ b/src/Logic/CommandLineConvert/CommandLineConverter.cs
@@ -432,7 +432,15 @@ namespace Nikse.SubtitleEdit.Logic.CommandLineConvert
                     {
                         if (File.Exists(ebuImportFileTemp))
                         {
-                            ebuImportFile = ebuImportFileTemp;
+                            var ebu = new Ebu();
+                            if (ebu.IsMine(null, ebuImportFileTemp))
+                            {
+                                ebuImportFile = ebuImportFileTemp;
+                            }
+                            else
+                            {
+                                throw new Exception($"The /ebuimportfile '{ebuImportFileTemp}' is not a EBU STL file.");
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
This adds command line parameter to import EBU STL header from a file.

I have a lot of subtitles that I need to convert into EBU STL format with strict header parameters. I normally import them via GUI, but at this point I have to automate this process. Local build works fine with `/ebuimportfile:<file name>`.

Please tell me If there is anything you want changed in this PR. I'm new to this project and C#