### PR TITLE
Detect ffmpeg on launch if settings file exists

### DIFF
--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -2286,6 +2286,15 @@ $HorzAlign          =   Center
                     settings.Shortcuts.GeneralToggleTranslationMode = "Control+Shift+O";
                     settings.Shortcuts.GeneralSwitchOriginalAndTranslation = "Control+Alt+O";
                 }
+
+                if (settings.General.UseFFmpegForWaveExtraction && string.IsNullOrEmpty(settings.General.FFmpegLocation) && Configuration.IsRunningOnWindows)
+                {
+                    var guessPath = Path.Combine(Configuration.DataDirectory, "ffmpeg", "ffmpeg.exe");
+                    if (File.Exists(guessPath))
+                    {
+                        settings.General.FFmpegLocation = guessPath;
+                    }
+                }
             }
 
             return settings;


### PR DESCRIPTION
Detect FFmpeg on launch if settings file exists and "Use FFmpeg" is checked.

This is to make SE check for FFmpeg when launching if settings file exists without having to open the settings.
It's for cases like, I have a file with no FFmpeg location that I use to test some things, and every time I do this I have to go to settings before using "Generate waveform".
I know it doesn't seem so, but it's annoying to have to open the settings each time.

Do you think this is okay or would it cause issues or delays?