### PR TITLE
Work on batch filters

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -214,6 +214,7 @@ Note: Do check free disk space.</WaveFileMalformed>
     <FilterMoreThanTwoLines>More than two lines in one subtitle</FilterMoreThanTwoLines>
     <FilterContains>Text contains...</FilterContains>
     <FilterFileNameContains>File name contains...</FilterFileNameContains>
+    <MkvLanguageCodeContains>Mkv Language code contains...</MkvLanguageCodeContains>
     <FixCommonErrorsErrorX>Fix common errors: {0}</FixCommonErrorsErrorX>
     <MultipleReplaceErrorX>Multiple replace: {0}</MultipleReplaceErrorX>
     <AutoBalanceErrorX>Auto balance: {0}</AutoBalanceErrorX>

--- a/libse/Language.cs
+++ b/libse/Language.cs
@@ -354,6 +354,7 @@ namespace Nikse.SubtitleEdit.Core
                 FilterMoreThanTwoLines = "More than two lines in one subtitle",
                 FilterContains = "Text contains...",
                 FilterFileNameContains = "File name contains...",
+                MkvLanguageCodeContains = "Mkv Language code contains...",
                 FixCommonErrorsErrorX = "Fix common errors: {0}",
                 MultipleReplaceErrorX = "Multiple replace: {0}",
                 AutoBalanceErrorX = "Auto balance: {0}",

--- a/libse/LanguageDeserializer.cs
+++ b/libse/LanguageDeserializer.cs
@@ -583,6 +583,9 @@ namespace Nikse.SubtitleEdit.Core
                 case "BatchConvert/FilterFileNameContains":
                     language.BatchConvert.FilterFileNameContains = reader.Value;
                     break;
+                case "BatchConvert/MkvLanguageCodeContains":
+                    language.BatchConvert.MkvLanguageCodeContains = reader.Value;
+                    break;
                 case "BatchConvert/FixCommonErrorsErrorX":
                     language.BatchConvert.FixCommonErrorsErrorX = reader.Value;
                     break;

--- a/libse/LanguageStructure.cs
+++ b/libse/LanguageStructure.cs
@@ -224,6 +224,7 @@
             public string FilterMoreThanTwoLines { get; set; }
             public string FilterContains { get; set; }
             public string FilterFileNameContains { get; set; }
+            public string MkvLanguageCodeContains { get; set; }
             public string FixCommonErrorsErrorX { get; set; }
             public string MultipleReplaceErrorX { get; set; }
             public string AutoBalanceErrorX { get; set; }

--- a/src/Forms/BatchConvert.Designer.cs
+++ b/src/Forms/BatchConvert.Designer.cs
@@ -864,7 +864,8 @@
             "SubRip .srt files without BOM header",
             "Files with subtitle with more than two lines",
             "Files that contains...",
-            "File name cotains..."});
+            "File name cotains...",
+            "Mkv language code contains..."});
             this.comboBoxFilter.Location = new System.Drawing.Point(81, 258);
             this.comboBoxFilter.Name = "comboBoxFilter";
             this.comboBoxFilter.Size = new System.Drawing.Size(335, 21);

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -522,7 +522,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (comboBoxFilter.SelectedIndex == 4 && textBoxFilter.Text.Length > 0 && !fileName.Contains(textBoxFilter.Text, StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                //skip
             }
             else
             {


### PR DESCRIPTION
Added a new batch filter for MKV language code:
![image](https://user-images.githubusercontent.com/20923700/92274541-1df23700-eef6-11ea-9752-85dc1f53944b.png)

And made "Filename contains..." apply when importing files manually.
This is in case there are a lot of files that the user wants to select a range of them and apply the "filename" filter to then.