### PR TITLE
Plugins: add couple options for plugin [WIP]

### DIFF
--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -649,6 +649,19 @@ $HorzAlign          =   Center
         }
     }
 
+    public class Misc
+    {
+        public bool LoadPlugins { get; set; }
+        public bool LoadSubtitleFormatFromPlugins { get; set; }
+        public string SubtitleFormatForRaw { get; set; }
+
+        public Misc()
+        {
+            LoadPlugins = true;
+            SubtitleFormatForRaw = "SubRip";
+        }
+    }
+
     public class FixCommonErrorsSettings
     {
         public string StartPosition { get; set; }
@@ -2151,6 +2164,7 @@ $HorzAlign          =   Center
         public VideoControlsSettings VideoControls { get; set; }
         public NetworkSettings NetworkSettings { get; set; }
         public Shortcuts Shortcuts { get; set; }
+        public Misc Misc { get; set; }
         public RemoveTextForHearingImpairedSettings RemoveTextForHearingImpaired { get; set; }
         public SubtitleBeaming SubtitleBeaming { get; set; }
         public List<MultipleSearchAndReplaceGroup> MultipleSearchAndReplaceGroups { get; set; }
@@ -2177,6 +2191,7 @@ $HorzAlign          =   Center
             RemoveTextForHearingImpaired = new RemoveTextForHearingImpairedSettings();
             SubtitleBeaming = new SubtitleBeaming();
             Compare = new CompareSettings();
+            Misc = new Misc();
         }
 
         private Settings()
@@ -5411,6 +5426,29 @@ $HorzAlign          =   Center
                 }
             }
 
+            // Misc
+            node = doc.DocumentElement.SelectSingleNode("MiscSettings");
+            if (node != null)
+            {
+                subNode = node.SelectSingleNode(nameof(Configuration.Settings.Misc.LoadPlugins));
+                if (subNode != null)
+                {
+                    settings.Misc.LoadPlugins = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+                }
+
+                subNode = node.SelectSingleNode(nameof(Configuration.Settings.Misc.LoadSubtitleFormatFromPlugins));
+                if (subNode != null)
+                {
+                    settings.Misc.LoadSubtitleFormatFromPlugins = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+                }
+
+                subNode = node.SelectSingleNode(nameof(Configuration.Settings.Misc.SubtitleFormatForRaw));
+                if (subNode != null)
+                {
+                    settings.Misc.SubtitleFormatForRaw = subNode.InnerText;
+                } 
+            }
+
             // VobSub Ocr
             node = doc.DocumentElement.SelectSingleNode("VobSubOcr");
             subNode = node.SelectSingleNode("XOrMorePixelsMakesSpace");
@@ -7847,6 +7885,12 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("WebServiceUrl", settings.NetworkSettings.WebServiceUrl);
                 textWriter.WriteElementString("PollIntervalSeconds", settings.NetworkSettings.PollIntervalSeconds.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("NewMessageSound", settings.NetworkSettings.NewMessageSound);
+                textWriter.WriteEndElement();
+
+                textWriter.WriteStartElement("MiscSettings", string.Empty);
+                textWriter.WriteElementString(nameof(settings.Misc.LoadPlugins), settings.Misc.LoadPlugins.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString(nameof(settings.Misc.LoadSubtitleFormatFromPlugins), settings.Misc.LoadSubtitleFormatFromPlugins.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString(nameof(settings.Misc.SubtitleFormatForRaw), settings.Misc.SubtitleFormatForRaw);
                 textWriter.WriteEndElement();
 
                 textWriter.WriteStartElement("VobSubOcr", string.Empty);

--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -653,12 +653,10 @@ $HorzAlign          =   Center
     {
         public bool LoadPlugins { get; set; }
         public bool LoadSubtitleFormatFromPlugins { get; set; }
-        public string SubtitleFormatForRaw { get; set; }
 
         public Misc()
         {
             LoadPlugins = true;
-            SubtitleFormatForRaw = "SubRip";
         }
     }
 
@@ -5441,12 +5439,6 @@ $HorzAlign          =   Center
                 {
                     settings.Misc.LoadSubtitleFormatFromPlugins = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
                 }
-
-                subNode = node.SelectSingleNode(nameof(Configuration.Settings.Misc.SubtitleFormatForRaw));
-                if (subNode != null)
-                {
-                    settings.Misc.SubtitleFormatForRaw = subNode.InnerText;
-                } 
             }
 
             // VobSub Ocr
@@ -7890,7 +7882,6 @@ $HorzAlign          =   Center
                 textWriter.WriteStartElement("MiscSettings", string.Empty);
                 textWriter.WriteElementString(nameof(settings.Misc.LoadPlugins), settings.Misc.LoadPlugins.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString(nameof(settings.Misc.LoadSubtitleFormatFromPlugins), settings.Misc.LoadSubtitleFormatFromPlugins.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString(nameof(settings.Misc.SubtitleFormatForRaw), settings.Misc.SubtitleFormatForRaw);
                 textWriter.WriteEndElement();
 
                 textWriter.WriteStartElement("VobSubOcr", string.Empty);

--- a/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/libse/SubtitleFormats/SubtitleFormat.cs
@@ -315,38 +315,46 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new UnknownSubtitle100(),
                 };
 
-                string path = Configuration.PluginsDirectory;
-                if (Directory.Exists(path))
+                if (Configuration.Settings.Misc.LoadPlugins && Configuration.Settings.Misc.LoadSubtitleFormatFromPlugins)
                 {
-                    foreach (string pluginFileName in Directory.EnumerateFiles(path, "*.DLL"))
-                    {
-                        try
-                        {
-                            var assembly = System.Reflection.Assembly.Load(FileUtil.ReadAllBytesShared(pluginFileName));
-                            foreach (var exportedType in assembly.GetExportedTypes())
-                            {
-                                try
-                                {
-                                    object pluginObject = Activator.CreateInstance(exportedType);
-                                    if (pluginObject is SubtitleFormat po)
-                                    {
-                                        _allSubtitleFormats.Insert(1, po);
-                                    }
-                                }
-                                catch
-                                {
-                                    // ignored
-                                }
-                            }
-                        }
-                        catch
-                        {
-                            // ignored
-                        }
-                    }
+                    LoadSubtitleFormatFromPlugins();
                 }
 
                 return _allSubtitleFormats;
+            }
+        }
+
+        public static void LoadSubtitleFormatFromPlugins()
+        {
+            string path = Configuration.PluginsDirectory;
+            if (Directory.Exists(path))
+            {
+                foreach (string pluginFileName in Directory.EnumerateFiles(path, "*.DLL"))
+                {
+                    try
+                    {
+                        var assembly = System.Reflection.Assembly.Load(FileUtil.ReadAllBytesShared(pluginFileName));
+                        foreach (var exportedType in assembly.GetExportedTypes())
+                        {
+                            try
+                            {
+                                object pluginObject = Activator.CreateInstance(exportedType);
+                                if (pluginObject is SubtitleFormat po)
+                                {
+                                    _allSubtitleFormats.Insert(1, po);
+                                }
+                            }
+                            catch
+                            {
+                                // ignored
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                }
             }
         }
 

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -74,6 +74,7 @@ namespace Nikse.SubtitleEdit.Forms
             set { _videoFileName = value; }
         }
 
+        private bool _loadPluginnAtStarttup;
         private DateTime _fileDateTime;
         private string _title;
         private FindReplaceDialogHelper _findHelper;
@@ -4667,6 +4668,15 @@ namespace Nikse.SubtitleEdit.Forms
             mediaPlayer.VideoPlayerContainerResize(null, null);
             ShowLineInformationListView();
             ShowSourceLineNumber();
+
+            if (Configuration.Settings.Misc.LoadPlugins)
+            {
+                // only if it it wasn't load at beginning
+                if (!_loadPluginnAtStarttup)
+                {
+                    LoadPlugins();
+                }
+            }
         }
 
         private void SetAudioVisualizerSettings()
@@ -20062,7 +20072,11 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxSubtitleFormats.AutoCompleteMode = AutoCompleteMode.Append;
             InitializePlayRateDropDown();
 
-            LoadPlugins();
+            if (Configuration.Settings.Misc.LoadPlugins)
+            {
+                LoadPlugins();
+                _loadPluginnAtStarttup = true;
+            }
 
             mediaPlayer.OnEmptyPlayerClicked += MediaPlayer_OnEmptyPlayerClicked;
             SubtitleListview1.SelectIndexAndEnsureVisible(_subtitleListViewIndex, true);
@@ -25631,7 +25645,10 @@ namespace Nikse.SubtitleEdit.Forms
             using (var form = new PluginsGet())
             {
                 form.ShowDialog(this);
-                LoadPlugins();
+                if (Configuration.Settings.Misc.LoadPlugins)
+                {
+                    LoadPlugins();
+                }
             }
         }
 

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -4677,6 +4677,10 @@ namespace Nikse.SubtitleEdit.Forms
                     LoadPlugins();
                 }
             }
+            else
+            {
+                UnloadPlugins();
+            }
         }
 
         private void SetAudioVisualizerSettings()
@@ -20447,12 +20451,7 @@ namespace Nikse.SubtitleEdit.Forms
                 return;
             }
 
-            UiUtil.CleanUpMenuItemPlugin(fileToolStripMenuItem);
-            UiUtil.CleanUpMenuItemPlugin(toolsToolStripMenuItem);
-            UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemSpellCheckMain);
-            UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemSynchronization);
-            UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemAutoTranslate);
-            UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemTranslateSelected);
+            UnloadPlugins();
 
             var fileMenuItems = new List<ToolStripMenuItem>();
             var toolsMenuItems = new List<ToolStripMenuItem>();
@@ -20534,6 +20533,16 @@ namespace Nikse.SubtitleEdit.Forms
             toolStripMenuItemTranslateSelected.DropDownItems.AddRange(translateSelectedLinesMenuItems.OrderBy(p => p.Text).ToArray());
             toolStripMenuItemSynchronization.DropDownItems.AddRange(syncMenuItems.OrderBy(p => p.Text).ToArray());
             toolStripMenuItemSpellCheckMain.DropDownItems.AddRange(spellCheckMenuItems.OrderBy(p => p.Text).ToArray());
+        }
+
+        private void UnloadPlugins()
+        {
+            UiUtil.CleanUpMenuItemPlugin(fileToolStripMenuItem);
+            UiUtil.CleanUpMenuItemPlugin(toolsToolStripMenuItem);
+            UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemSpellCheckMain);
+            UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemSynchronization);
+            UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemAutoTranslate);
+            UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemTranslateSelected);
         }
 
         private void AddSeparator(int pluginCount, ToolStripMenuItem parent, int? relativeOffset = null)

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -74,7 +74,7 @@ namespace Nikse.SubtitleEdit.Forms
             set { _videoFileName = value; }
         }
 
-        private bool _loadPluginnAtStarttup;
+        private bool _pluginsLoadedAtStartup;
         private DateTime _fileDateTime;
         private string _title;
         private FindReplaceDialogHelper _findHelper;
@@ -4671,10 +4671,13 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (Configuration.Settings.Misc.LoadPlugins)
             {
-                // only if it it wasn't load at beginning
-                if (!_loadPluginnAtStarttup)
+                // plugin should only be loaded when closing settings if it wasn't previously loaded
+                // else it should be loading only at-startup - this will prevent filling memory / appdomain with assemblies
+                // everytime settings opens and closes
+                if (!_pluginsLoadedAtStartup)
                 {
                     LoadPlugins();
+                    _pluginsLoadedAtStartup = true;
                 }
             }
             else
@@ -20079,7 +20082,7 @@ namespace Nikse.SubtitleEdit.Forms
             if (Configuration.Settings.Misc.LoadPlugins)
             {
                 LoadPlugins();
-                _loadPluginnAtStarttup = true;
+                _pluginsLoadedAtStartup = true;
             }
 
             mediaPlayer.OnEmptyPlayerClicked += MediaPlayer_OnEmptyPlayerClicked;
@@ -20543,6 +20546,7 @@ namespace Nikse.SubtitleEdit.Forms
             UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemSynchronization);
             UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemAutoTranslate);
             UiUtil.CleanUpMenuItemPlugin(toolStripMenuItemTranslateSelected);
+            // TODO: unload appdomain when supported in the future
         }
 
         private void AddSeparator(int pluginCount, ToolStripMenuItem parent, int? relativeOffset = null)

--- a/src/Forms/Settings.Designer.cs
+++ b/src/Forms/Settings.Designer.cs
@@ -386,6 +386,12 @@
             this.openFileDialogFFmpeg = new System.Windows.Forms.OpenFileDialog();
             this.buttonReset = new System.Windows.Forms.Button();
             this.toolTipContinuationPreview = new System.Windows.Forms.ToolTip(this.components);
+            this.tabPageMisc = new System.Windows.Forms.TabPage();
+            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.checkBoxLoadPlugin = new System.Windows.Forms.CheckBox();
+            this.checkBoxLoadSubFromPlugin = new System.Windows.Forms.CheckBox();
+            this.comboBoxPluginRawFormat = new System.Windows.Forms.ComboBox();
+            this.label2 = new System.Windows.Forms.Label();
             this.tabControlSettings.SuspendLayout();
             this.tabPageGeneral.SuspendLayout();
             this.groupBoxMiscellaneous.SuspendLayout();
@@ -465,6 +471,8 @@
             this.groupBoxNetworkSession.SuspendLayout();
             this.groupBoxProxySettings.SuspendLayout();
             this.groupBoxProxyAuthentication.SuspendLayout();
+            this.tabPageMisc.SuspendLayout();
+            this.groupBox3.SuspendLayout();
             this.SuspendLayout();
             // 
             // buttonOK
@@ -507,6 +515,7 @@
             this.tabControlSettings.Controls.Add(this.tabPageFont);
             this.tabControlSettings.Controls.Add(this.tabPageSsaStyle);
             this.tabControlSettings.Controls.Add(this.tabPageNetwork);
+            this.tabControlSettings.Controls.Add(this.tabPageMisc);
             this.tabControlSettings.Location = new System.Drawing.Point(13, 13);
             this.tabControlSettings.Name = "tabControlSettings";
             this.tabControlSettings.SelectedIndex = 0;
@@ -1606,6 +1615,7 @@
             // 
             // contextMenuStripShortcuts
             // 
+            this.contextMenuStripShortcuts.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStripShortcuts.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItemShortcutsCollapse});
             this.contextMenuStripShortcuts.Name = "contextMenuStripShortcuts";
@@ -4687,6 +4697,71 @@
             this.toolTipContinuationPreview.InitialDelay = 500;
             this.toolTipContinuationPreview.ReshowDelay = 100;
             // 
+            // tabPageMisc
+            // 
+            this.tabPageMisc.Controls.Add(this.groupBox3);
+            this.tabPageMisc.Location = new System.Drawing.Point(4, 22);
+            this.tabPageMisc.Name = "tabPageMisc";
+            this.tabPageMisc.Size = new System.Drawing.Size(832, 520);
+            this.tabPageMisc.TabIndex = 11;
+            this.tabPageMisc.Text = "Misc";
+            this.tabPageMisc.UseVisualStyleBackColor = true;
+            // 
+            // groupBox3
+            // 
+            this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox3.Controls.Add(this.label2);
+            this.groupBox3.Controls.Add(this.comboBoxPluginRawFormat);
+            this.groupBox3.Controls.Add(this.checkBoxLoadSubFromPlugin);
+            this.groupBox3.Controls.Add(this.checkBoxLoadPlugin);
+            this.groupBox3.Location = new System.Drawing.Point(9, 14);
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.Size = new System.Drawing.Size(814, 183);
+            this.groupBox3.TabIndex = 0;
+            this.groupBox3.TabStop = false;
+            this.groupBox3.Text = "Plugins:";
+            // 
+            // checkBoxLoadPlugin
+            // 
+            this.checkBoxLoadPlugin.AutoSize = true;
+            this.checkBoxLoadPlugin.Checked = true;
+            this.checkBoxLoadPlugin.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxLoadPlugin.Location = new System.Drawing.Point(40, 42);
+            this.checkBoxLoadPlugin.Name = "checkBoxLoadPlugin";
+            this.checkBoxLoadPlugin.Size = new System.Drawing.Size(85, 17);
+            this.checkBoxLoadPlugin.TabIndex = 1;
+            this.checkBoxLoadPlugin.Text = "Load plugins";
+            this.checkBoxLoadPlugin.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxLoadSubFromPlugin
+            // 
+            this.checkBoxLoadSubFromPlugin.AutoSize = true;
+            this.checkBoxLoadSubFromPlugin.Location = new System.Drawing.Point(40, 65);
+            this.checkBoxLoadSubFromPlugin.Name = "checkBoxLoadSubFromPlugin";
+            this.checkBoxLoadSubFromPlugin.Size = new System.Drawing.Size(183, 17);
+            this.checkBoxLoadSubFromPlugin.TabIndex = 3;
+            this.checkBoxLoadSubFromPlugin.Text = "Load subtitle format from plugins";
+            this.checkBoxLoadSubFromPlugin.UseVisualStyleBackColor = true;
+            // 
+            // comboBoxPluginRawFormat
+            // 
+            this.comboBoxPluginRawFormat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxPluginRawFormat.FormattingEnabled = true;
+            this.comboBoxPluginRawFormat.Location = new System.Drawing.Point(40, 131);
+            this.comboBoxPluginRawFormat.Name = "comboBoxPluginRawFormat";
+            this.comboBoxPluginRawFormat.Size = new System.Drawing.Size(183, 21);
+            this.comboBoxPluginRawFormat.TabIndex = 4;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(38, 115);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(163, 13);
+            this.label2.TabIndex = 5;
+            this.label2.Text = "Default format for \"raw\" param: ";
+            // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -4820,6 +4895,9 @@
             this.groupBoxProxySettings.PerformLayout();
             this.groupBoxProxyAuthentication.ResumeLayout(false);
             this.groupBoxProxyAuthentication.PerformLayout();
+            this.tabPageMisc.ResumeLayout(false);
+            this.groupBox3.ResumeLayout(false);
+            this.groupBox3.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -5184,5 +5262,11 @@
         private System.Windows.Forms.Button buttonGapChoose;
         private System.Windows.Forms.CheckBox checkBoxSpellCheckAutoChangeNamesViaSuggestions;
         private System.Windows.Forms.ComboBox comboBoxBoxBingTokenEndpoint;
+        private System.Windows.Forms.TabPage tabPageMisc;
+        private System.Windows.Forms.GroupBox groupBox3;
+        private System.Windows.Forms.CheckBox checkBoxLoadSubFromPlugin;
+        private System.Windows.Forms.CheckBox checkBoxLoadPlugin;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.ComboBox comboBoxPluginRawFormat;
     }
 }

--- a/src/Forms/Settings.Designer.cs
+++ b/src/Forms/Settings.Designer.cs
@@ -381,17 +381,15 @@
             this.textBoxProxyPassword = new System.Windows.Forms.TextBox();
             this.textBoxProxyAddress = new System.Windows.Forms.TextBox();
             this.labelProxyAddress = new System.Windows.Forms.Label();
+            this.tabPageMisc = new System.Windows.Forms.TabPage();
+            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.checkBoxLoadSubFromPlugin = new System.Windows.Forms.CheckBox();
+            this.checkBoxLoadPlugin = new System.Windows.Forms.CheckBox();
             this.colorDialogSSAStyle = new System.Windows.Forms.ColorDialog();
             this.labelStatus = new System.Windows.Forms.Label();
             this.openFileDialogFFmpeg = new System.Windows.Forms.OpenFileDialog();
             this.buttonReset = new System.Windows.Forms.Button();
             this.toolTipContinuationPreview = new System.Windows.Forms.ToolTip(this.components);
-            this.tabPageMisc = new System.Windows.Forms.TabPage();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.checkBoxLoadPlugin = new System.Windows.Forms.CheckBox();
-            this.checkBoxLoadSubFromPlugin = new System.Windows.Forms.CheckBox();
-            this.comboBoxPluginRawFormat = new System.Windows.Forms.ComboBox();
-            this.label2 = new System.Windows.Forms.Label();
             this.tabControlSettings.SuspendLayout();
             this.tabPageGeneral.SuspendLayout();
             this.groupBoxMiscellaneous.SuspendLayout();
@@ -4666,6 +4664,51 @@
             this.labelProxyAddress.TabIndex = 3;
             this.labelProxyAddress.Text = "Proxy address";
             // 
+            // tabPageMisc
+            // 
+            this.tabPageMisc.Controls.Add(this.groupBox3);
+            this.tabPageMisc.Location = new System.Drawing.Point(4, 22);
+            this.tabPageMisc.Name = "tabPageMisc";
+            this.tabPageMisc.Size = new System.Drawing.Size(832, 520);
+            this.tabPageMisc.TabIndex = 11;
+            this.tabPageMisc.Text = "Misc";
+            this.tabPageMisc.UseVisualStyleBackColor = true;
+            // 
+            // groupBox3
+            // 
+            this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox3.Controls.Add(this.checkBoxLoadSubFromPlugin);
+            this.groupBox3.Controls.Add(this.checkBoxLoadPlugin);
+            this.groupBox3.Location = new System.Drawing.Point(9, 14);
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.Size = new System.Drawing.Size(814, 183);
+            this.groupBox3.TabIndex = 0;
+            this.groupBox3.TabStop = false;
+            this.groupBox3.Text = "Plugins:";
+            // 
+            // checkBoxLoadSubFromPlugin
+            // 
+            this.checkBoxLoadSubFromPlugin.AutoSize = true;
+            this.checkBoxLoadSubFromPlugin.Location = new System.Drawing.Point(40, 65);
+            this.checkBoxLoadSubFromPlugin.Name = "checkBoxLoadSubFromPlugin";
+            this.checkBoxLoadSubFromPlugin.Size = new System.Drawing.Size(183, 17);
+            this.checkBoxLoadSubFromPlugin.TabIndex = 3;
+            this.checkBoxLoadSubFromPlugin.Text = "Load subtitle format from plugins";
+            this.checkBoxLoadSubFromPlugin.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxLoadPlugin
+            // 
+            this.checkBoxLoadPlugin.AutoSize = true;
+            this.checkBoxLoadPlugin.Checked = true;
+            this.checkBoxLoadPlugin.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxLoadPlugin.Location = new System.Drawing.Point(40, 42);
+            this.checkBoxLoadPlugin.Name = "checkBoxLoadPlugin";
+            this.checkBoxLoadPlugin.Size = new System.Drawing.Size(85, 17);
+            this.checkBoxLoadPlugin.TabIndex = 1;
+            this.checkBoxLoadPlugin.Text = "Load plugins";
+            this.checkBoxLoadPlugin.UseVisualStyleBackColor = true;
+            // 
             // labelStatus
             // 
             this.labelStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
@@ -4696,71 +4739,6 @@
             this.toolTipContinuationPreview.AutoPopDelay = 60000;
             this.toolTipContinuationPreview.InitialDelay = 500;
             this.toolTipContinuationPreview.ReshowDelay = 100;
-            // 
-            // tabPageMisc
-            // 
-            this.tabPageMisc.Controls.Add(this.groupBox3);
-            this.tabPageMisc.Location = new System.Drawing.Point(4, 22);
-            this.tabPageMisc.Name = "tabPageMisc";
-            this.tabPageMisc.Size = new System.Drawing.Size(832, 520);
-            this.tabPageMisc.TabIndex = 11;
-            this.tabPageMisc.Text = "Misc";
-            this.tabPageMisc.UseVisualStyleBackColor = true;
-            // 
-            // groupBox3
-            // 
-            this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox3.Controls.Add(this.label2);
-            this.groupBox3.Controls.Add(this.comboBoxPluginRawFormat);
-            this.groupBox3.Controls.Add(this.checkBoxLoadSubFromPlugin);
-            this.groupBox3.Controls.Add(this.checkBoxLoadPlugin);
-            this.groupBox3.Location = new System.Drawing.Point(9, 14);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(814, 183);
-            this.groupBox3.TabIndex = 0;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Plugins:";
-            // 
-            // checkBoxLoadPlugin
-            // 
-            this.checkBoxLoadPlugin.AutoSize = true;
-            this.checkBoxLoadPlugin.Checked = true;
-            this.checkBoxLoadPlugin.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxLoadPlugin.Location = new System.Drawing.Point(40, 42);
-            this.checkBoxLoadPlugin.Name = "checkBoxLoadPlugin";
-            this.checkBoxLoadPlugin.Size = new System.Drawing.Size(85, 17);
-            this.checkBoxLoadPlugin.TabIndex = 1;
-            this.checkBoxLoadPlugin.Text = "Load plugins";
-            this.checkBoxLoadPlugin.UseVisualStyleBackColor = true;
-            // 
-            // checkBoxLoadSubFromPlugin
-            // 
-            this.checkBoxLoadSubFromPlugin.AutoSize = true;
-            this.checkBoxLoadSubFromPlugin.Location = new System.Drawing.Point(40, 65);
-            this.checkBoxLoadSubFromPlugin.Name = "checkBoxLoadSubFromPlugin";
-            this.checkBoxLoadSubFromPlugin.Size = new System.Drawing.Size(183, 17);
-            this.checkBoxLoadSubFromPlugin.TabIndex = 3;
-            this.checkBoxLoadSubFromPlugin.Text = "Load subtitle format from plugins";
-            this.checkBoxLoadSubFromPlugin.UseVisualStyleBackColor = true;
-            // 
-            // comboBoxPluginRawFormat
-            // 
-            this.comboBoxPluginRawFormat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBoxPluginRawFormat.FormattingEnabled = true;
-            this.comboBoxPluginRawFormat.Location = new System.Drawing.Point(40, 131);
-            this.comboBoxPluginRawFormat.Name = "comboBoxPluginRawFormat";
-            this.comboBoxPluginRawFormat.Size = new System.Drawing.Size(183, 21);
-            this.comboBoxPluginRawFormat.TabIndex = 4;
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(38, 115);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(163, 13);
-            this.label2.TabIndex = 5;
-            this.label2.Text = "Default format for \"raw\" param: ";
             // 
             // Settings
             // 
@@ -5266,7 +5244,5 @@
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.CheckBox checkBoxLoadSubFromPlugin;
         private System.Windows.Forms.CheckBox checkBoxLoadPlugin;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.ComboBox comboBoxPluginRawFormat;
     }
 }

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -999,7 +999,26 @@ namespace Nikse.SubtitleEdit.Forms
 
             _loading = false;
             UpdateSsaExample();
+
+            InitPluginTab();
         }
+
+        private void InitPluginTab()
+        {
+            checkBoxLoadPlugin.CheckedChanged += (sender, e) =>
+            {
+                bool status = checkBoxLoadPlugin.Checked;
+                checkBoxLoadSubFromPlugin.Enabled = status;
+                comboBoxPluginRawFormat.Enabled = status;
+            };
+
+            checkBoxLoadPlugin.Checked = Configuration.Settings.Misc.LoadPlugins;
+            checkBoxLoadSubFromPlugin.Checked = Configuration.Settings.Misc.LoadSubtitleFormatFromPlugins;
+
+            // init combobox format
+            UiUtil.InitializeSubtitleFormatComboBox(comboBoxPluginRawFormat, Configuration.Settings.Misc.SubtitleFormatForRaw);
+        }
+
 
         private void SetDialogStyle(DialogType dialogStyle)
         {
@@ -1894,6 +1913,11 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 kvp.Key.Shortcut.SetValue(Configuration.Settings.Shortcuts, kvp.Value, null);
             }
+
+            // misc
+            Configuration.Settings.Misc.LoadPlugins = checkBoxLoadPlugin.Checked;
+            Configuration.Settings.Misc.LoadSubtitleFormatFromPlugins = checkBoxLoadSubFromPlugin.Checked;
+            Configuration.Settings.Misc.SubtitleFormatForRaw = comboBoxPluginRawFormat.SelectedItem.ToString();
 
             Configuration.Settings.Save();
         }

--- a/src/Forms/Settings.cs
+++ b/src/Forms/Settings.cs
@@ -1009,14 +1009,10 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 bool status = checkBoxLoadPlugin.Checked;
                 checkBoxLoadSubFromPlugin.Enabled = status;
-                comboBoxPluginRawFormat.Enabled = status;
             };
 
             checkBoxLoadPlugin.Checked = Configuration.Settings.Misc.LoadPlugins;
             checkBoxLoadSubFromPlugin.Checked = Configuration.Settings.Misc.LoadSubtitleFormatFromPlugins;
-
-            // init combobox format
-            UiUtil.InitializeSubtitleFormatComboBox(comboBoxPluginRawFormat, Configuration.Settings.Misc.SubtitleFormatForRaw);
         }
 
 
@@ -1917,7 +1913,6 @@ namespace Nikse.SubtitleEdit.Forms
             // misc
             Configuration.Settings.Misc.LoadPlugins = checkBoxLoadPlugin.Checked;
             Configuration.Settings.Misc.LoadSubtitleFormatFromPlugins = checkBoxLoadSubFromPlugin.Checked;
-            Configuration.Settings.Misc.SubtitleFormatForRaw = comboBoxPluginRawFormat.SelectedItem.ToString();
 
             Configuration.Settings.Save();
         }


### PR DESCRIPTION
What's news:
- the ability to define if plugin should be load when the app startup
- user can now load and unload plugin from Setting/Mic
- choose whether to probe *.dll for subtitle format

ps: all the configuration is saved in settings.xml

note: the screenshot below is now deprecated (a new one will be provided): 


![image](https://user-images.githubusercontent.com/6579818/91647648-fd892f00-ea54-11ea-81c2-b67b060093a3.png)


note: ⚠️ this is not done yet...