### PR TITLE
Calculate frames in MS in "Apply min. gap"

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -1776,7 +1776,8 @@ can edit in same subtitle file (collaboration)</Information>
     <ShowOnlyModifiedLines>Show only modified lines</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum milliseconds between lines</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Frame rate info</FrameInfo>
-    <OneFrameXisYMilliseconds>One frame at {0:0.00} fps is {1} milliseconds</OneFrameXisYMilliseconds>
+    <Frames>Frames</Frames>
+    <XFrameYisZMilliseconds>{0} frame(s) at {1} fps is {2} milliseconds</XFrameYisZMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Set Sync point for line {0}</Title>

--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -818,7 +818,7 @@ Go to "Options -&gt; Settings -&gt; Tools" to enter your Google translate API ke
     <Join>Join</Join>
     <TotalNumberOfLinesX>Total number of lines: {0:#,###,###}</TotalNumberOfLinesX>
     <AlreadyCorrectTimeCodes>Files already have correct time codes</AlreadyCorrectTimeCodes>
-    <AppendTimeCodes>Add end time of previous  file</AppendTimeCodes>
+    <AppendTimeCodes>Add end time of previous file</AppendTimeCodes>
     <AddMs>Add milliseconds after each file</AddMs>
   </JoinSubtitles>
   <LanguageNames>
@@ -2020,8 +2020,8 @@ can edit in same subtitle file (collaboration)</Information>
     <AdjustEndOneFrameForward>Move end 1 frame forward</AdjustEndOneFrameForward>
     <AdjustStartOneFrameBackKeepGapPrev>Move start 1 frame back (keep gap to previous if close)</AdjustStartOneFrameBackKeepGapPrev>
     <AdjustStartOneFrameForwardKeepGapPrev>Move start 1 frame forward (keep gap to previous if close)</AdjustStartOneFrameForwardKeepGapPrev>
-    <AdjustEndOneFrameBackKeepGapNext>Move end 1 frame back  (keep gap to next if close)</AdjustEndOneFrameBackKeepGapNext>
-    <AdjustEndOneFrameForwardKeepGapNext>Move end 1 frame forward  (keep gap to next if close)</AdjustEndOneFrameForwardKeepGapNext>
+    <AdjustEndOneFrameBackKeepGapNext>Move end 1 frame back (keep gap to next if close)</AdjustEndOneFrameBackKeepGapNext>
+    <AdjustEndOneFrameForwardKeepGapNext>Move end 1 frame forward (keep gap to next if close)</AdjustEndOneFrameForwardKeepGapNext>
     <AdjustSetStartTimeKeepDuration>Set start time, keep duration</AdjustSetStartTimeKeepDuration>
     <AdjustSetEndAndOffsetTheRest>Set end, offset the rest</AdjustSetEndAndOffsetTheRest>
     <AdjustSetEndAndOffsetTheRestAndGoToNext>Set end, offset the rest and go to next</AdjustSetEndAndOffsetTheRestAndGoToNext>

--- a/libse/Language.cs
+++ b/libse/Language.cs
@@ -1035,7 +1035,7 @@ namespace Nikse.SubtitleEdit.Core
                 Join = "Join",
                 TotalNumberOfLinesX = "Total number of lines: {0:#,###,###}",
                 AlreadyCorrectTimeCodes = "Files already have correct time codes",
-                AppendTimeCodes = "Add end time of previous  file",
+                AppendTimeCodes = "Add end time of previous file",
                 AddMs = "Add milliseconds after each file"
             };
 
@@ -2314,8 +2314,8 @@ can edit in same subtitle file (collaboration)",
                 AdjustEndOneFrameForward = "Move end 1 frame forward",
                 AdjustStartOneFrameBackKeepGapPrev = "Move start 1 frame back (keep gap to previous if close)",
                 AdjustStartOneFrameForwardKeepGapPrev = "Move start 1 frame forward (keep gap to previous if close)",
-                AdjustEndOneFrameBackKeepGapNext = "Move end 1 frame back  (keep gap to next if close)",
-                AdjustEndOneFrameForwardKeepGapNext = "Move end 1 frame forward  (keep gap to next if close)",
+                AdjustEndOneFrameBackKeepGapNext = "Move end 1 frame back (keep gap to next if close)",
+                AdjustEndOneFrameForwardKeepGapNext = "Move end 1 frame forward (keep gap to next if close)",
                 AdjustSetStartTimeKeepDuration = "Set start time, keep duration",
                 AdjustSetEndAndOffsetTheRest = "Set end, offset the rest",
                 AdjustSetEndAndOffsetTheRestAndGoToNext = "Set end, offset the rest and go to next",

--- a/libse/Language.cs
+++ b/libse/Language.cs
@@ -2066,7 +2066,8 @@ can edit in same subtitle file (collaboration)",
                 MinimumMillisecondsBetweenParagraphs = "Minimum milliseconds between lines",
                 ShowOnlyModifiedLines = "Show only modified lines",
                 FrameInfo = "Frame rate info",
-                OneFrameXisYMilliseconds = "One frame at {0:0.00} fps is {1} milliseconds",
+                Frames = "Frames",
+                XFrameYisZMilliseconds = "{0} frame(s) at {1} fps is {2} milliseconds",
             };
 
             SetSyncPoint = new LanguageStructure.SetSyncPoint

--- a/libse/LanguageDeserializer.cs
+++ b/libse/LanguageDeserializer.cs
@@ -4762,8 +4762,11 @@ namespace Nikse.SubtitleEdit.Core
                 case "SetMinimumDisplayTimeBetweenParagraphs/FrameInfo":
                     language.SetMinimumDisplayTimeBetweenParagraphs.FrameInfo = reader.Value;
                     break;
-                case "SetMinimumDisplayTimeBetweenParagraphs/OneFrameXisYMilliseconds":
-                    language.SetMinimumDisplayTimeBetweenParagraphs.OneFrameXisYMilliseconds = reader.Value;
+                case "SetMinimumDisplayTimeBetweenParagraphs/Frames":
+                    language.SetMinimumDisplayTimeBetweenParagraphs.Frames = reader.Value;
+                    break;
+                case "SetMinimumDisplayTimeBetweenParagraphs/XFrameYisZMilliseconds":
+                    language.SetMinimumDisplayTimeBetweenParagraphs.XFrameYisZMilliseconds = reader.Value;
                     break;
                 case "SetSyncPoint/Title":
                     language.SetSyncPoint.Title = reader.Value;

--- a/libse/LanguageStructure.cs
+++ b/libse/LanguageStructure.cs
@@ -1934,7 +1934,8 @@
             public string ShowOnlyModifiedLines { get; set; }
             public string MinimumMillisecondsBetweenParagraphs { get; set; }
             public string FrameInfo { get; set; }
-            public string OneFrameXisYMilliseconds { get; set; }
+            public string Frames { get; set; }
+            public string XFrameYisZMilliseconds { get; set; }
         }
 
         public class SetSyncPoint

--- a/src/Forms/SetMinimumDisplayTimeBetweenParagraphs.Designer.cs
+++ b/src/Forms/SetMinimumDisplayTimeBetweenParagraphs.Designer.cs
@@ -36,7 +36,9 @@
             this.buttonCancel = new System.Windows.Forms.Button();
             this.checkBoxShowOnlyChangedLines = new System.Windows.Forms.CheckBox();
             this.comboBoxFrameRate = new System.Windows.Forms.ComboBox();
-            this.labelOneFrameIsXMS = new System.Windows.Forms.Label();
+            this.labelFrames = new System.Windows.Forms.Label();
+            this.numericUpDownFrames = new System.Windows.Forms.NumericUpDown();
+            this.labelXFrameIsXMS = new System.Windows.Forms.Label();
             this.groupBoxFrameInfo = new System.Windows.Forms.GroupBox();
             this.groupBoxLinesFound.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMinMillisecondsBetweenLines)).BeginInit();
@@ -106,7 +108,7 @@
             this.labelMaxMillisecondsBetweenLines.Location = new System.Drawing.Point(15, 18);
             this.labelMaxMillisecondsBetweenLines.Name = "labelMaxMillisecondsBetweenLines";
             this.labelMaxMillisecondsBetweenLines.Size = new System.Drawing.Size(174, 13);
-            this.labelMaxMillisecondsBetweenLines.TabIndex = 0;
+            this.labelMaxMillisecondsBetweenLines.TabIndex = 2;
             this.labelMaxMillisecondsBetweenLines.Text = "Minimum milliseconds between lines";
             // 
             // buttonOK
@@ -156,21 +158,50 @@
             this.comboBoxFrameRate.SelectedIndexChanged += new System.EventHandler(this.comboBoxFrameRate_SelectedIndexChanged);
             this.comboBoxFrameRate.KeyUp += new System.Windows.Forms.KeyEventHandler(this.comboBoxFrameRate_KeyUp);
             // 
-            // labelOneFrameIsXMS
+            // labelFrames
             // 
-            this.labelOneFrameIsXMS.AutoSize = true;
-            this.labelOneFrameIsXMS.Location = new System.Drawing.Point(6, 57);
-            this.labelOneFrameIsXMS.Name = "labelOneFrameIsXMS";
-            this.labelOneFrameIsXMS.Size = new System.Drawing.Size(135, 13);
-            this.labelOneFrameIsXMS.TabIndex = 1;
-            this.labelOneFrameIsXMS.Text = "One frame is x milliseconds";
+            this.labelFrames.AutoSize = true;
+            this.labelFrames.Location = new System.Drawing.Point(174, 29);
+            this.labelFrames.Name = "labelFrames";
+            this.labelFrames.Size = new System.Drawing.Size(174, 13);
+            this.labelFrames.TabIndex = 1;
+            this.labelFrames.Text = "Frames:";
+            // 
+            // numericUpDownFrames
+            // 
+            this.numericUpDownFrames.Location = new System.Drawing.Point(220, 25);
+            this.numericUpDownFrames.Maximum = new decimal(new int[] {
+            25,
+            0,
+            0,
+            0});
+            this.numericUpDownFrames.Name = "numericUpDownFrames";
+            this.numericUpDownFrames.Size = new System.Drawing.Size(56, 20);
+            this.numericUpDownFrames.TabIndex = 52;
+            this.numericUpDownFrames.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            this.numericUpDownFrames.ValueChanged += new System.EventHandler(this.numericUpDownFrames_ValueChanged);
+            // 
+            // labelXFrameIsXMS
+            // 
+            this.labelXFrameIsXMS.AutoSize = true;
+            this.labelXFrameIsXMS.Location = new System.Drawing.Point(6, 57);
+            this.labelXFrameIsXMS.Name = "labelXFrameIsXMS";
+            this.labelXFrameIsXMS.Size = new System.Drawing.Size(135, 13);
+            this.labelXFrameIsXMS.TabIndex = 3;
+            this.labelXFrameIsXMS.Text = "x frame is y milliseconds";
             // 
             // groupBoxFrameInfo
             // 
             this.groupBoxFrameInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxFrameInfo.Controls.Add(this.comboBoxFrameRate);
-            this.groupBoxFrameInfo.Controls.Add(this.labelOneFrameIsXMS);
+            this.groupBoxFrameInfo.Controls.Add(this.labelFrames);
+            this.groupBoxFrameInfo.Controls.Add(this.numericUpDownFrames);
+            this.groupBoxFrameInfo.Controls.Add(this.labelXFrameIsXMS);
             this.groupBoxFrameInfo.Location = new System.Drawing.Point(355, 12);
             this.groupBoxFrameInfo.Name = "groupBoxFrameInfo";
             this.groupBoxFrameInfo.Size = new System.Drawing.Size(383, 76);
@@ -219,7 +250,9 @@
         private Controls.SubtitleListView SubtitleListview1;
         private System.Windows.Forms.CheckBox checkBoxShowOnlyChangedLines;
         private System.Windows.Forms.ComboBox comboBoxFrameRate;
-        private System.Windows.Forms.Label labelOneFrameIsXMS;
+        private System.Windows.Forms.Label labelXFrameIsXMS;
+        private System.Windows.Forms.Label labelFrames;
+        private System.Windows.Forms.NumericUpDown numericUpDownFrames;
         private System.Windows.Forms.GroupBox groupBoxFrameInfo;
     }
 }

--- a/src/Forms/SetMinimumDisplayTimeBetweenParagraphs.cs
+++ b/src/Forms/SetMinimumDisplayTimeBetweenParagraphs.cs
@@ -13,6 +13,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private Subtitle _subtitle;
         public int FixCount { get; private set; }
+        public int MinGapMs { get; internal set; }
 
         public SetMinimumDisplayTimeBetweenParagraphs()
         {
@@ -130,6 +131,23 @@ namespace Nikse.SubtitleEdit.Forms
             FixCount = fixes.Count;
         }
 
+        private void CalcMilliseconds()
+        {
+            var frameRate = GetFrameRate();
+            MinGapMs = (int)Math.Round(1000.0 / frameRate * (double)numericUpDownFrames.Value);
+            labelXFrameIsXMS.Text = string.Format(Configuration.Settings.Language.SetMinimumDisplayTimeBetweenParagraphs.XFrameYisZMilliseconds, numericUpDownFrames.Value, frameRate, MinGapMs);
+        }
+
+        private double GetFrameRate()
+        {
+            if (double.TryParse(comboBoxFrameRate.Text, NumberStyles.AllowDecimalPoint, CultureInfo.CurrentCulture, out var frameRate))
+            {
+                return frameRate;
+            }
+
+            return Configuration.Settings.General.CurrentFrameRate;
+        }
+
         private void buttonOK_Click(object sender, EventArgs e)
         {
             DialogResult = DialogResult.OK;
@@ -170,13 +188,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void comboBoxFrameRate_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (!double.TryParse(comboBoxFrameRate.Text.Trim().Replace(',', '.').Replace(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, "."), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var frameRate))
-            {
-                frameRate = 25.0;
-            }
-
-            long ms = (long)Math.Round(TimeCode.BaseUnit / frameRate);
-            labelOneFrameIsXMS.Text = string.Format(Configuration.Settings.Language.SetMinimumDisplayTimeBetweenParagraphs.OneFrameXisYMilliseconds, frameRate, ms);
+            CalcMilliseconds();
         }
 
         private void comboBoxFrameRate_KeyUp(object sender, KeyEventArgs e)
@@ -187,6 +199,11 @@ namespace Nikse.SubtitleEdit.Forms
         private void SetMinimumDisplayTimeBetweenParagraphs_Shown(object sender, EventArgs e)
         {
             SubtitleListview1.Focus();
+        }
+
+        private void numericUpDownFrames_ValueChanged(object sender, EventArgs e)
+        {
+            CalcMilliseconds();
         }
 
     }

--- a/src/Languages/bg-BG.xml
+++ b/src/Languages/bg-BG.xml
@@ -1781,7 +1781,6 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <ShowOnlyModifiedLines>Показване само редовете за промяна</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Минимален интервал (милисек.) между редовете със субтитри</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Честота на кадрите (fps)</FrameInfo>
-    <OneFrameXisYMilliseconds>Един кадър с {0:0.00} fps е = {1} милисек.</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Задаване на синхро точка за ред {0}</Title>

--- a/src/Languages/ca-ES.xml
+++ b/src/Languages/ca-ES.xml
@@ -1708,7 +1708,6 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <ShowOnlyModifiedLines>Mostra només línies modificades</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Milisegons mínims entre línies</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Info ràtio quadre</FrameInfo>
-    <OneFrameXisYMilliseconds>Un quadre a {0:0.00} fps és {1} milisegons</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Estableix punt Sinc per la línia {0}</Title>

--- a/src/Languages/cs-CZ.xml
+++ b/src/Languages/cs-CZ.xml
@@ -1722,7 +1722,6 @@ upravovat stejný soubor titulků (spolupráce)</Information>
     <ShowOnlyModifiedLines>Zobrazit pouze změněné řádky</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimálně milisekund mezi řádky</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Informace o snímkové frekvenci</FrameInfo>
-    <OneFrameXisYMilliseconds>Jeden snímek při {0:0.00} fps je {1} milisekund</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Nastavit synchronizační bod pro řádek {0}</Title>

--- a/src/Languages/da-DK.xml
+++ b/src/Languages/da-DK.xml
@@ -1769,7 +1769,6 @@ kan redigere i samme undertekst fil (fælles online projekt)</Information>
     <ShowOnlyModifiedLines>Vis kun rettede linier</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum millisekunder mellem linjerne</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Frame info</FrameInfo>
-    <OneFrameXisYMilliseconds>En frame ved {0:0.00} fps er {1} milliseconds</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Set synkroniserings punkt for linje {0}</Title>

--- a/src/Languages/de-DE.xml
+++ b/src/Languages/de-DE.xml
@@ -1734,7 +1734,6 @@ gleiche Untertiteldatei bearbeiten können (Zusammenarbeit)</Information>
     <ShowOnlyModifiedLines>Nur geänderte Texte anzeigen</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimale Millisekunden zwischen Texten</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Bildfrequenz info</FrameInfo>
-    <OneFrameXisYMilliseconds>Ein Bild mit {0:0.00} fps sind {1} Millisekunden</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Sync Punkt für Text {0} setzen</Title>

--- a/src/Languages/el-GR.xml
+++ b/src/Languages/el-GR.xml
@@ -1767,7 +1767,6 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <ShowOnlyModifiedLines>Εμφάνιση μόνο τροποποιημένων γραμμών</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Ελάχιστα χιλ. δευτερολέπτου μεταξύ γραμμών</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Πληροφορίες ρυθμού καρέ</FrameInfo>
-    <OneFrameXisYMilliseconds>Ένα καρέ στο {0:0.00} καρέ είναι {1} χιλιοστά δευτερολέπτου</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Ορισμός σημείου συγχρονισμού για τη γραμμή {0}</Title>

--- a/src/Languages/es-AR.xml
+++ b/src/Languages/es-AR.xml
@@ -1742,7 +1742,6 @@ puede editar el mismo archivo de subtítulo (colaboración)</Information>
     <ShowOnlyModifiedLines>Mostrar sólo las líneas modificadas</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Milisegundos mínimos entre líneas</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Info velocidad de cuadros</FrameInfo>
-    <OneFrameXisYMilliseconds>Un cuadro en {0:0.00} fps es {1} milisegundos</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Establecer sincronización puntual para la línea {0}</Title>

--- a/src/Languages/es-ES.xml
+++ b/src/Languages/es-ES.xml
@@ -1743,7 +1743,6 @@ puede editar el mismo archivo de subtítulo (colaboración)</Information>
     <ShowOnlyModifiedLines>Mostrar sólo las líneas modificadas</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Milisegundos mínimos entre líneas</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Información de la velocidad de cuadros</FrameInfo>
-    <OneFrameXisYMilliseconds>Un fotograma a {0:0.00} fps son {1} milisegundos</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Establecer sincronización puntual para la línea {0}</Title>

--- a/src/Languages/es-MX.xml
+++ b/src/Languages/es-MX.xml
@@ -1743,7 +1743,6 @@ puedan editar el mismo archivo de subtítulo (colaboración)</Information>
     <ShowOnlyModifiedLines>Mostrar sólo las líneas modificadas</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Milisegundos mínimos entre líneas</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Información de la velocidad de cuadros</FrameInfo>
-    <OneFrameXisYMilliseconds>Un fotograma a {0:0.00} fps son {1} milisegundos</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Establecer sincronización puntual para la línea {0}</Title>

--- a/src/Languages/eu-ES.xml
+++ b/src/Languages/eu-ES.xml
@@ -1759,7 +1759,6 @@ Jarraitu horrela ere?</PromptInsertSubtitleOverlap>
     <ShowOnlyModifiedLines>&amp;Erakutsi aldatutako lerroak bakarrik</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Lerroen arteko segundumilaen gutxiengoa</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Frame neurri argibideak</FrameInfo>
-    <OneFrameXisYMilliseconds>Bat frame {0:0.00} fs-ko dira {1} segundumilaen</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Ezarri Albiberetze gunea lerro honi {0}</Title>

--- a/src/Languages/fa-IR.xml
+++ b/src/Languages/fa-IR.xml
@@ -1728,7 +1728,6 @@ Continue anyway?</PromptInsertSubtitleOverlap>
     <ShowOnlyModifiedLines>فقط نمایش تغییر خطوط</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>حداقل میلی ثانیه بین خطوط</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>اطلاعات نرخ فریم</FrameInfo>
-    <OneFrameXisYMilliseconds>یک فریم در {0:0.00} fps {1} میلی ثانیه است</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>تنظیم نقطه همگام سازی برای خط {0}</Title>

--- a/src/Languages/fi-FI.xml
+++ b/src/Languages/fi-FI.xml
@@ -1755,7 +1755,6 @@ Mikäli tiedostoa on muokattu Subtitle Edit:llä, varmuuskopio voi olla käytett
     <ShowOnlyModifiedLines>Näytä vain muokatut rivit</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Pienin aika (ms) rivien välillä</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Kehystietoja</FrameInfo>
-    <OneFrameXisYMilliseconds>Yksi kehys nopudella {0:0.00} fps on {1} millisekuntia</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Aseta tahdistuskohta riville {0}</Title>

--- a/src/Languages/fr-BE.xml
+++ b/src/Languages/fr-BE.xml
@@ -1734,7 +1734,6 @@ peuvent éditer le même fichier sous-titres (collaboration)</Information>
     <ShowOnlyModifiedLines>Afficher uniquement les lignes modifiées</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum de millisecondes entre les lignes</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Informations sur la fréquence d'image</FrameInfo>
-    <OneFrameXisYMilliseconds>Une image à {0:0.00} fps c'est {1} millisecondes</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Définir point de synchronisation à la ligne {0}</Title>

--- a/src/Languages/fr-FR.xml
+++ b/src/Languages/fr-FR.xml
@@ -1708,7 +1708,6 @@ peuvent modifier le même fichier de sous-titres (collaboration)</Information>
     <ShowOnlyModifiedLines>Afficher uniquement les lignes modifiées</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum de millisecondes entre les lignes</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Informations sur la fréquence d'images</FrameInfo>
-    <OneFrameXisYMilliseconds>Une image à {0:0.00} fps c'est {1} millisecondes</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Définir point de synchronisation à la ligne {0}</Title>

--- a/src/Languages/hr-HR.xml
+++ b/src/Languages/hr-HR.xml
@@ -1672,7 +1672,6 @@ određeni podnaslov s drugim ljudima.</Information>
     <ShowOnlyModifiedLines>&amp;Prikaži samo izmijenjene linije</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Milisekundi između linija:</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Info o broju sličica</FrameInfo>
-    <OneFrameXisYMilliseconds>Jedna sličica na {0:0:00} fps je {1} milisekunda</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Točka usklađivanja za liniju {0}</Title>

--- a/src/Languages/hu-HU.xml
+++ b/src/Languages/hu-HU.xml
@@ -1774,7 +1774,6 @@ szerkesztheti ugyanazt a feliratfájlt</Information>
     <ShowOnlyModifiedLines>Csak a módosított sorok megjelenítése</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum ezredmásodperc a sorok között</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Képarány információ</FrameInfo>
-    <OneFrameXisYMilliseconds>Képkockánként {0:0.00} fps 1} ezredmásodperc</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Szinkronizációs pont beállítása a(z) {0} sor esetén</Title>

--- a/src/Languages/id-ID.xml
+++ b/src/Languages/id-ID.xml
@@ -1697,7 +1697,6 @@ bisa mengedit dlm file subjudul yg sama (kolaborasi)</Information>
     <ShowOnlyModifiedLines>Hanya tampilkan baris yg dimodifikasi</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Milidetik minimum di antara baris</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Info laju frame</FrameInfo>
-    <OneFrameXisYMilliseconds>Satu frame pada {0:0.00} fps adalah {1} milidetik</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Atur Sinkron angka untuk baris {0}</Title>

--- a/src/Languages/it-IT.xml
+++ b/src/Languages/it-IT.xml
@@ -1603,7 +1603,6 @@ modificare lo stesso file di sottotitolo (collaborazione)</Information>
     <ShowOnlyModifiedLines>Mostra solo le linee modificate</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Millisecondi minimi fra le linee</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Informazioni sul frame rate</FrameInfo>
-    <OneFrameXisYMilliseconds>Un frame a {0:0.00} fps è di {1} millisecondi</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Imposta punto sincr. per linea {0}</Title>

--- a/src/Languages/ko-KR.xml
+++ b/src/Languages/ko-KR.xml
@@ -1772,7 +1772,6 @@ Google 번역 API 키를 입력하려면 "옵션 -&gt; 환경설정 -&gt; 도구
     <ShowOnlyModifiedLines>수정된 줄만 표시</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>단락 사이의 최소 간격 (밀리초)</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>프레임 속도 정보</FrameInfo>
-    <OneFrameXisYMilliseconds>{0:0.00} fps에서 1 프레임은 {1} 밀리초 입니다.</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>"{0}" 줄의 지점 동기화</Title>

--- a/src/Languages/mk-MK.xml
+++ b/src/Languages/mk-MK.xml
@@ -1746,7 +1746,6 @@ can edit in same subtitle file (collaboration)</Information>
     <ShowOnlyModifiedLines>Прикажи само изменети линии</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Минимум милисекунди меѓу линии</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Инфо за број на кадри</FrameInfo>
-    <OneFrameXisYMilliseconds>Еден кадар во {0:0.00} fps е {1} милисекунди</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Постави точка за синхронизација на линија  {0}</Title>

--- a/src/Languages/nb-NO.xml
+++ b/src/Languages/nb-NO.xml
@@ -1625,7 +1625,6 @@ Hvis du har redigert denne filen i Subtitle Edit, kan du kanskje finne en backup
     <ShowOnlyModifiedLines>Vis kun endrete linjer</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minst antall millisekunder mellom linjer</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Bilderateinfo</FrameInfo>
-    <OneFrameXisYMilliseconds>Et bilde ved {0:0.00} bilder i sekundet er {1} millisekunder</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Velg synkpunkt for linje # {0}</Title>

--- a/src/Languages/nl-NL.xml
+++ b/src/Languages/nl-NL.xml
@@ -1775,7 +1775,6 @@ hetzelfde ondertitelbestand bewerken (samenwerken)</Information>
     <ShowOnlyModifiedLines>Alleen gewĳzigde regels weergeven</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum milliseconden tussen regels</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Beeldsnelheidinformatie</FrameInfo>
-    <OneFrameXisYMilliseconds>Eén beeld op {0:0.00} fps is {1} milliseconden</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Sync-punt bepalen voor {0}</Title>

--- a/src/Languages/pl-PL.xml
+++ b/src/Languages/pl-PL.xml
@@ -1774,7 +1774,6 @@ może edytować ten sam plik z napisami (współpracować)</Information>
     <ShowOnlyModifiedLines>Pokaż tylko zmodyfikowane linie</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum milisekund między liniami</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Informacje o ilości klatek na sekundę</FrameInfo>
-    <OneFrameXisYMilliseconds>Jedna klatka z {0:0.00} fps ma {1} milisekundy</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Ustaw punkt synchronizacji dla linii {0}</Title>

--- a/src/Languages/pt-BR.xml
+++ b/src/Languages/pt-BR.xml
@@ -1765,7 +1765,6 @@ podem editar o mesmo arquivo de legenda (colaboração)</Information>
     <ShowOnlyModifiedLines>Mostrar somente linhas modificadas</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Milissegundos mínimos entre linhas</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Info da Taxa de quadros</FrameInfo>
-    <OneFrameXisYMilliseconds>Um quadro em {0:0.00} fps é {1} milissegundos</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Estabelecer ponto de sincronização para a linha {0}</Title>

--- a/src/Languages/pt-PT.xml
+++ b/src/Languages/pt-PT.xml
@@ -1774,7 +1774,6 @@ editar o mesmo ficheiro de legenda (colaboração)</Information>
     <ShowOnlyModifiedLines>Mostrar só linhas modificadas</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Milissegundos mínimos entre linhas</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Informação da taxa de fotogramas</FrameInfo>
-    <OneFrameXisYMilliseconds>Um fotograma de {0:0.00} fps é de {1} milissegundos</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Definir ponto de sincronia para a linha {0}</Title>

--- a/src/Languages/ro-RO.xml
+++ b/src/Languages/ro-RO.xml
@@ -1773,7 +1773,6 @@ pot edita acelasi fișier de subtitrare (colaborare)</Information>
     <ShowOnlyModifiedLines>Arată numai linii modificate</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minim de milisecunde între linii</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Informații ale ratei cadrului</FrameInfo>
-    <OneFrameXisYMilliseconds>Un cadru la {0:0.00} fps este {1} milisecunde</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Setare pct. sincroniz. ptr. linia {0}</Title>

--- a/src/Languages/ru-RU.xml
+++ b/src/Languages/ru-RU.xml
@@ -1769,7 +1769,6 @@ https://github.com/SubtitleEdit/subtitleedit
     <ShowOnlyModifiedLines>Показывать только измененные строки</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Минимальный интервал между строками (мс):</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Частота кадров</FrameInfo>
-    <OneFrameXisYMilliseconds>Один кадр в {0:0.00} fps - это {1} мс</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Установить точку синхронизации для строки {0}</Title>

--- a/src/Languages/sl-SI.xml
+++ b/src/Languages/sl-SI.xml
@@ -1499,7 +1499,6 @@ popravlja en podnapis (sodelovanje)</Information>
     <ShowOnlyModifiedLines>Prikaži le spremenjene vrstice</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimalno milisekund med vrsticami</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Informacija o hitrosti slik</FrameInfo>
-    <OneFrameXisYMilliseconds>Ena slika pri {0:0.00} fps je {1} milisekund</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Določi točko sinhronizacije za vrstico {0}</Title>

--- a/src/Languages/sr-Latn-RS.xml
+++ b/src/Languages/sr-Latn-RS.xml
@@ -1737,7 +1737,6 @@ da uređujete određeni prevod sa drugim ljudima.</Information>
     <ShowOnlyModifiedLines>Prikaži samo izmenjene linije</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minimum milisekundi između linija</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Info o broju kadrova</FrameInfo>
-    <OneFrameXisYMilliseconds>Jedan kadar na {0:0.00} fps je {1} milisekundi</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Tačka sinhronizacije za liniju {0}</Title>

--- a/src/Languages/sv-SE.xml
+++ b/src/Languages/sv-SE.xml
@@ -1732,7 +1732,6 @@ kan redigera i samma undertextfil (samarbete)</Information>
     <ShowOnlyModifiedLines>Visa endast ändrade rader</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Minsta millisekunder mellan raderna</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Bildhastighetsinfo</FrameInfo>
-    <OneFrameXisYMilliseconds>En bildruta på {0:0.00} fps är {1} millisekunder</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Sätt synkpunkt för rad {0}</Title>

--- a/src/Languages/th-TH.xml
+++ b/src/Languages/th-TH.xml
@@ -1537,7 +1537,6 @@
     <ShowOnlyModifiedLines>แสดงเฉพาะบรรทัดที่แก้แล้ว</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>มิลลิวินาทีต่ำสุดระหว่างบรรทัด</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>ข้อมูลเฟรมเรต</FrameInfo>
-    <OneFrameXisYMilliseconds>หนึ่งเฟรมเรตที่ {0:0.00} fps คือ {1} มิลลิวินาที</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>กำหนดจุดซิงค์สำหรับบรรทัด {0}</Title>

--- a/src/Languages/tr-TR.xml
+++ b/src/Languages/tr-TR.xml
@@ -1688,7 +1688,6 @@ Yeni oturum başlatın (işbirliği)</Information>
     <ShowOnlyModifiedLines>Sadece düzenlenen satırları göster</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Satırlar arası minimum milisaniye</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Kare hızı bilgisi</FrameInfo>
-    <OneFrameXisYMilliseconds>Bir kare {0:0.00}'de fps {1} milisaniyedir</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Satır için senkron noktası ayarla {0}</Title>

--- a/src/Languages/uk-UA.xml
+++ b/src/Languages/uk-UA.xml
@@ -1620,7 +1620,6 @@ Email: mailto:nikse.dk@gmail.com</AboutText1>
     <ShowOnlyModifiedLines>Показувати тільки змінені рядки</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>Мінімальна відстань між рядками, мілісекунд</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>Інформація про частоту кадрів</FrameInfo>
-    <OneFrameXisYMilliseconds>Один кадр при частоті {0:0.00} кнс - це {1} мілісекунд</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>Встановлення точки синхронізації для субтитру {0}</Title>

--- a/src/Languages/zh-Hans.xml
+++ b/src/Languages/zh-Hans.xml
@@ -1764,7 +1764,6 @@ Command line: {1} {2}
     <ShowOnlyModifiedLines>仅显示已修改的行</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>行间最小毫秒数</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>帧速率信息</FrameInfo>
-    <OneFrameXisYMilliseconds>帧速率为{0:0.00} 帧/秒时，每帧时长为 {1} 毫秒</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>为行 {0} 设置同步点</Title>

--- a/src/Languages/zh-TW.xml
+++ b/src/Languages/zh-TW.xml
@@ -1602,7 +1602,6 @@ C# 原始碼可從 https://github.com/SubtitleEdit/subtitleedit 取得。
     <ShowOnlyModifiedLines>僅顯示已修改的行</ShowOnlyModifiedLines>
     <MinimumMillisecondsBetweenParagraphs>行間最小間隔 (毫秒)</MinimumMillisecondsBetweenParagraphs>
     <FrameInfo>影格率訊息</FrameInfo>
-    <OneFrameXisYMilliseconds>影格率為 {0:0.00} 影格/秒 時，每影格持續時間為 {1} 毫秒</OneFrameXisYMilliseconds>
   </SetMinimumDisplayTimeBetweenParagraphs>
   <SetSyncPoint>
     <Title>為行 {0} 設定同步點</Title>


### PR DESCRIPTION
Add a way to calculate frames in milliseconds in "Apply min. gap between subtitles".
![image](https://user-images.githubusercontent.com/20923700/92155224-b2459680-ee2f-11ea-92b4-67b7cbc4233d.png)

Closes: https://github.com/SubtitleEdit/subtitleedit/issues/4342