### PR TITLE
Fix a crash in batch convert + add new filter

### DIFF
--- a/libse/Language.cs
+++ b/libse/Language.cs
@@ -354,6 +354,7 @@ namespace Nikse.SubtitleEdit.Core
                 FilterMoreThanTwoLines = "More than two lines in one subtitle",
                 FilterContains = "Text contains...",
                 FilterFileNameContains = "File name contains...",
+                MkvLanguageCodeContains = "Mkv Language code contains...",
                 FixCommonErrorsErrorX = "Fix common errors: {0}",
                 MultipleReplaceErrorX = "Multiple replace: {0}",
                 AutoBalanceErrorX = "Auto balance: {0}",

--- a/libse/LanguageDeserializer.cs
+++ b/libse/LanguageDeserializer.cs
@@ -583,6 +583,9 @@ namespace Nikse.SubtitleEdit.Core
                 case "BatchConvert/FilterFileNameContains":
                     language.BatchConvert.FilterFileNameContains = reader.Value;
                     break;
+                case "BatchConvert/MkvLanguageCodeContains":
+                    language.BatchConvert.MkvLanguageCodeContains = reader.Value;
+                    break;
                 case "BatchConvert/FixCommonErrorsErrorX":
                     language.BatchConvert.FixCommonErrorsErrorX = reader.Value;
                     break;

--- a/libse/LanguageStructure.cs
+++ b/libse/LanguageStructure.cs
@@ -224,6 +224,7 @@
             public string FilterMoreThanTwoLines { get; set; }
             public string FilterContains { get; set; }
             public string FilterFileNameContains { get; set; }
+            public string MkvLanguageCodeContains { get; set; }
             public string FixCommonErrorsErrorX { get; set; }
             public string MultipleReplaceErrorX { get; set; }
             public string AutoBalanceErrorX { get; set; }

--- a/src/Forms/BatchConvert.Designer.cs
+++ b/src/Forms/BatchConvert.Designer.cs
@@ -864,7 +864,8 @@
             "SubRip .srt files without BOM header",
             "Files with subtitle with more than two lines",
             "Files that contains...",
-            "File name cotains..."});
+            "File name cotains...",
+            "Mkv language code contains..."});
             this.comboBoxFilter.Location = new System.Drawing.Point(81, 258);
             this.comboBoxFilter.Name = "comboBoxFilter";
             this.comboBoxFilter.Size = new System.Drawing.Size(335, 21);

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -269,6 +269,7 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxFilter.Items[2] = l.FilterMoreThanTwoLines;
             comboBoxFilter.Items[3] = l.FilterContains;
             comboBoxFilter.Items[4] = l.FilterFileNameContains;
+            comboBoxFilter.Items[5] = l.MkvLanguageCodeContains;
             comboBoxFilter.SelectedIndex = 0;
             comboBoxFilter.Left = labelFilter.Left + labelFilter.Width + 4;
             textBoxFilter.Left = comboBoxFilter.Left + comboBoxFilter.Width + 4;
@@ -519,6 +520,10 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void AddInputFile(string fileName)
         {
+            if (comboBoxFilter.SelectedIndex == 4 && textBoxFilter.Text.Length > 0 && !fileName.Contains(textBoxFilter.Text, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
             try
             {
                 foreach (ListViewItem lvi in listViewInputFiles.Items)
@@ -669,6 +674,10 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     foreach (var lang in mkvSrt)
                     {
+                        if (comboBoxFilter.SelectedIndex == 5 && textBoxFilter.Text.Length > 0 && !lang.Contains(textBoxFilter.Text, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
                         item = new ListViewItem(fileName);
                         item.SubItems.Add(Utilities.FormatBytesToDisplayFileSize(fi.Length));
                         listViewInputFiles.Items.Add(item);
@@ -2435,7 +2444,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void comboBoxFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            textBoxFilter.Visible = comboBoxFilter.SelectedIndex == 3 || comboBoxFilter.SelectedIndex == 4;
+            textBoxFilter.Visible = comboBoxFilter.SelectedIndex == 3 || comboBoxFilter.SelectedIndex == 4 || comboBoxFilter.SelectedIndex == 5;
         }
 
         private void buttonTransportStreamSettings_Click(object sender, EventArgs e)

--- a/src/Forms/BatchConvert.cs
+++ b/src/Forms/BatchConvert.cs
@@ -2102,7 +2102,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             // keep an item selected/focused for improved UX
-            if (first < listViewInputFiles.Items.Count)
+            if (first < listViewInputFiles.Items.Count && listViewInputFiles.Items.Count > 0)
             {
                 listViewInputFiles.Items[first].Selected = true;
                 listViewInputFiles.FocusedItem = listViewInputFiles.Items[first];


### PR DESCRIPTION
Fixed a crash in batch convert, It used to crash when you press "Delete" when the list view is empty.

Added a new batch filter for MKV language code:
![image](https://user-images.githubusercontent.com/20923700/92274541-1df23700-eef6-11ea-9752-85dc1f53944b.png)

And made "Filename contains..." apply when importing files manually.
This is in case there are a lot of files that the user wants to select a range of them and apply the "filename" filter to then.