### PR TITLE
Work on "Single Line Length" label color

### DIFF
--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -639,14 +639,13 @@ namespace Nikse.SubtitleEdit.Logic
 
                 if (i > max)
                 {
-                    label.ForeColor = Color.Red;
                     sb.Append("...");
                     label.Text = sb.ToString();
                     return;
                 }
 
                 sb.Append(line.Length);
-                if (line.Length > Configuration.Settings.General.SubtitleLineMaximumLength)
+                if (line.Length > Configuration.Settings.General.SubtitleLineMaximumLength || i >= Configuration.Settings.General.MaxNumberOfLines)
                 {
                     label.ForeColor = Color.Red;
                 }
@@ -670,7 +669,6 @@ namespace Nikse.SubtitleEdit.Logic
 
                 if (i > max)
                 {
-                    label.ForeColor = Color.Red;
                     sb.Append("...");
                     label.Text = sb.ToString();
                     return;


### PR DESCRIPTION
Only color when Max Number Of Lines or Max Chars/Line is exceeded.

No need to color it if there are more than 4 lines but still under or equal to the allowed max number of lines.