### PR TITLE
Add hidden "Split removes dashes" option to the settings

### DIFF
--- a/libse/Forms/SplitLongLinesHelper.cs
+++ b/libse/Forms/SplitLongLinesHelper.cs
@@ -58,7 +58,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
                 bool autoBreak = true;
                 if (noHtmlLines.Count == 2 && noHtmlLines[0].Length <= totalLineMaxCharacters && noHtmlLines[1].Length < totalLineMaxCharacters &&
-                    (noHtmlLines[0].EndsWith('.') || noHtmlLines[0].EndsWith('!') || noHtmlLines[0].EndsWith('?')))
+                    (noHtmlLines[0].EndsWith('.') || noHtmlLines[0].EndsWith('!') || noHtmlLines[0].EndsWith('?') || noHtmlLines[0].EndsWith('؟')))
                 {
                     autoBreak = false;
                 }
@@ -99,7 +99,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 newParagraph.EndTime.TotalMilliseconds = newParagraph.StartTime.TotalMilliseconds + millisecondsPerChar * HtmlUtil.RemoveHtmlTags(newParagraph.Text, true).Length;
 
                 // only remove dash (if dialog) if first line is fully closed
-                if (IsTextClosed(oldParagraph.Text))
+                if (IsTextClosed(oldParagraph.Text) && Configuration.Settings.General.SplitRemovesDashes)
                 {
                     RemoveInvalidDash(oldParagraph, newParagraph);
                 }
@@ -164,7 +164,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 return false;
             }
             var lastChar = noTagText[noTagText.Length - 1];
-            return ".!?:)]♪".Contains(lastChar);
+            return ".!?؟:)]♪".Contains(lastChar);
         }
 
     }

--- a/libse/Forms/SplitLongLinesHelper.cs
+++ b/libse/Forms/SplitLongLinesHelper.cs
@@ -98,8 +98,8 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 newParagraph.StartTime.TotalMilliseconds = oldParagraph.EndTime.TotalMilliseconds + halfMinGapsMood;
                 newParagraph.EndTime.TotalMilliseconds = newParagraph.StartTime.TotalMilliseconds + millisecondsPerChar * HtmlUtil.RemoveHtmlTags(newParagraph.Text, true).Length;
 
-                // only remove dash (if dialog) if first line is fully closed
-                if (IsTextClosed(oldParagraph.Text) && Configuration.Settings.General.SplitRemovesDashes)
+                // only remove dash (if dialog) if first line is fully closed and "Split removes dashes" is true
+                if (Configuration.Settings.General.SplitRemovesDashes && IsTextClosed(oldParagraph.Text))
                 {
                     RemoveInvalidDash(oldParagraph, newParagraph);
                 }

--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -1107,6 +1107,7 @@ $HorzAlign          =   Center
         public string FFmpegSceneThreshold { get; set; }
         public bool UseTimeFormatHHMMSSFF { get; set; }
         public int SplitBehavior { get; set; }
+        public bool SplitRemovesDashes { get; set; }
         public int ClearStatusBarAfterSeconds { get; set; }
         public string Company { get; set; }
         public bool MoveVideo100Or500MsPlaySmallSample { get; set; }
@@ -1236,6 +1237,7 @@ $HorzAlign          =   Center
             FFmpegSceneThreshold = "0.4"; // threshold for generating scene changes - 0.2 is sensitive (more scene change), 0.6 is less sensitive (fewer scene changes)
             UseTimeFormatHHMMSSFF = false;
             SplitBehavior = 1; // 0=take gap from left, 1=divide evenly, 2=take gap from right
+            SplitRemovesDashes = true;
             ClearStatusBarAfterSeconds = 10;
             MoveVideo100Or500MsPlaySmallSample = false;
             DisableVideoAutoLoading = false;
@@ -3303,6 +3305,12 @@ $HorzAlign          =   Center
             if (subNode != null)
             {
                 settings.General.SplitBehavior = Convert.ToInt32(subNode.InnerText.Trim());
+            }
+
+            subNode = node.SelectSingleNode("SplitRemovesDashes");
+            if (subNode != null)
+            {
+                settings.General.SplitRemovesDashes = Convert.ToBoolean(subNode.InnerText.Trim());
             }
 
             subNode = node.SelectSingleNode("ClearStatusBarAfterSeconds");
@@ -7520,6 +7528,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("FFmpegSceneThreshold", settings.General.FFmpegSceneThreshold);
                 textWriter.WriteElementString("UseTimeFormatHHMMSSFF", settings.General.UseTimeFormatHHMMSSFF.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("SplitBehavior", settings.General.SplitBehavior.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString("SplitRemovesDashes", settings.General.SplitRemovesDashes.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("ClearStatusBarAfterSeconds", settings.General.ClearStatusBarAfterSeconds.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("Company", settings.General.Company);
                 textWriter.WriteElementString("MoveVideo100Or500MsPlaySmallSample", settings.General.MoveVideo100Or500MsPlaySmallSample.ToString(CultureInfo.InvariantCulture));

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -9647,7 +9647,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
 
                     string aTrimmed = HtmlUtil.RemoveHtmlTags(a).TrimEnd('"').TrimEnd().TrimEnd('\'').TrimEnd();
-                    if (aTrimmed.EndsWith('.') || aTrimmed.EndsWith('!') || aTrimmed.EndsWith('?') || aTrimmed.EndsWith('؟'))
+                    if ((aTrimmed.EndsWith('.') || aTrimmed.EndsWith('!') || aTrimmed.EndsWith('?') || aTrimmed.EndsWith('؟')) && Configuration.Settings.General.SplitRemovesDashes)
                     {
                         a = DialogSplitMerge.RemoveStartDash(a);
                         b = DialogSplitMerge.RemoveStartDash(b);
@@ -9682,8 +9682,11 @@ namespace Nikse.SubtitleEdit.Forms
                             newParagraph.Text = "<b>" + newParagraph.Text;
                         }
 
-                        currentParagraph.Text = DialogSplitMerge.RemoveStartDash(currentParagraph.Text);
-                        newParagraph.Text = DialogSplitMerge.RemoveStartDash(newParagraph.Text);
+                        if (Configuration.Settings.General.SplitRemovesDashes)
+                        {
+                            currentParagraph.Text = DialogSplitMerge.RemoveStartDash(currentParagraph.Text);
+                            newParagraph.Text = DialogSplitMerge.RemoveStartDash(newParagraph.Text); 
+                        }
                     }
                     else
                     {
@@ -9870,7 +9873,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 originalNew.Text = "<b>" + originalNew.Text;
                             }
 
-                            if (l0Trimmed.EndsWith('.') || l0Trimmed.EndsWith('!') || l0Trimmed.EndsWith('?') || l0Trimmed.EndsWith('؟'))
+                            if ((l0Trimmed.EndsWith('.') || l0Trimmed.EndsWith('!') || l0Trimmed.EndsWith('?') || l0Trimmed.EndsWith('؟')) && Configuration.Settings.General.SplitRemovesDashes)
                             {
                                 originalCurrent.Text = DialogSplitMerge.RemoveStartDash(originalCurrent.Text);
                                 originalNew.Text = DialogSplitMerge.RemoveStartDash(originalNew.Text);
@@ -9896,8 +9899,11 @@ namespace Nikse.SubtitleEdit.Forms
                                 b = "<b>" + b;
                             }
 
-                            a = DialogSplitMerge.RemoveStartDash(a);
-                            b = DialogSplitMerge.RemoveStartDash(b);
+                            if (Configuration.Settings.General.SplitRemovesDashes)
+                            {
+                                a = DialogSplitMerge.RemoveStartDash(a);
+                                b = DialogSplitMerge.RemoveStartDash(b); 
+                            }
 
                             lines[0] = a;
                             lines[1] = b;
@@ -9946,7 +9952,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 b = "<b>" + b;
                             }
 
-                            if (l0Trimmed.EndsWith('.') || l0Trimmed.EndsWith('!') || l0Trimmed.EndsWith('?') || l0Trimmed.EndsWith('؟'))
+                            if ((l0Trimmed.EndsWith('.') || l0Trimmed.EndsWith('!') || l0Trimmed.EndsWith('?') || l0Trimmed.EndsWith('؟')) && Configuration.Settings.General.SplitRemovesDashes)
                             {
                                 a = DialogSplitMerge.RemoveStartDash(a);
                                 b = DialogSplitMerge.RemoveStartDash(b);

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -9647,7 +9647,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
 
                     string aTrimmed = HtmlUtil.RemoveHtmlTags(a).TrimEnd('"').TrimEnd().TrimEnd('\'').TrimEnd();
-                    if ((aTrimmed.EndsWith('.') || aTrimmed.EndsWith('!') || aTrimmed.EndsWith('?') || aTrimmed.EndsWith('؟')) && Configuration.Settings.General.SplitRemovesDashes)
+                    if (Configuration.Settings.General.SplitRemovesDashes && (aTrimmed.EndsWith('.') || aTrimmed.EndsWith('!') || aTrimmed.EndsWith('?') || aTrimmed.EndsWith('؟')))
                     {
                         a = DialogSplitMerge.RemoveStartDash(a);
                         b = DialogSplitMerge.RemoveStartDash(b);
@@ -9873,7 +9873,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 originalNew.Text = "<b>" + originalNew.Text;
                             }
 
-                            if ((l0Trimmed.EndsWith('.') || l0Trimmed.EndsWith('!') || l0Trimmed.EndsWith('?') || l0Trimmed.EndsWith('؟')) && Configuration.Settings.General.SplitRemovesDashes)
+                            if (Configuration.Settings.General.SplitRemovesDashes && (l0Trimmed.EndsWith('.') || l0Trimmed.EndsWith('!') || l0Trimmed.EndsWith('?') || l0Trimmed.EndsWith('؟')))
                             {
                                 originalCurrent.Text = DialogSplitMerge.RemoveStartDash(originalCurrent.Text);
                                 originalNew.Text = DialogSplitMerge.RemoveStartDash(originalNew.Text);
@@ -9952,7 +9952,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 b = "<b>" + b;
                             }
 
-                            if ((l0Trimmed.EndsWith('.') || l0Trimmed.EndsWith('!') || l0Trimmed.EndsWith('?') || l0Trimmed.EndsWith('؟')) && Configuration.Settings.General.SplitRemovesDashes)
+                            if (Configuration.Settings.General.SplitRemovesDashes && (l0Trimmed.EndsWith('.') || l0Trimmed.EndsWith('!') || l0Trimmed.EndsWith('?') || l0Trimmed.EndsWith('؟')))
                             {
                                 a = DialogSplitMerge.RemoveStartDash(a);
                                 b = DialogSplitMerge.RemoveStartDash(b);

--- a/src/Forms/SplitLongLines.cs
+++ b/src/Forms/SplitLongLines.cs
@@ -257,7 +257,7 @@ namespace Nikse.SubtitleEdit.Forms
                                     newParagraph2.Text = Utilities.AutoBreakLine(arr[1], language);
                                     newParagraph2.StartTime.TotalMilliseconds = newParagraph1.EndTime.TotalMilliseconds + spacing2;
 
-                                    if (isDialog && Configuration.Settings.General.SplitRemovesDashes)
+                                    if (Configuration.Settings.General.SplitRemovesDashes && isDialog)
                                     {
                                         newParagraph1.Text = DialogSplitMerge.RemoveStartDash(newParagraph1.Text);
                                         newParagraph2.Text = DialogSplitMerge.RemoveStartDash(newParagraph2.Text);

--- a/src/Forms/SplitLongLines.cs
+++ b/src/Forms/SplitLongLines.cs
@@ -257,7 +257,7 @@ namespace Nikse.SubtitleEdit.Forms
                                     newParagraph2.Text = Utilities.AutoBreakLine(arr[1], language);
                                     newParagraph2.StartTime.TotalMilliseconds = newParagraph1.EndTime.TotalMilliseconds + spacing2;
 
-                                    if (isDialog)
+                                    if (isDialog && Configuration.Settings.General.SplitRemovesDashes)
                                     {
                                         newParagraph1.Text = DialogSplitMerge.RemoveStartDash(newParagraph1.Text);
                                         newParagraph2.Text = DialogSplitMerge.RemoveStartDash(newParagraph2.Text);


### PR DESCRIPTION
It can be edited from the Settings file found in `%appdata%\Subtitle Edit`
![image](https://user-images.githubusercontent.com/20923700/92999654-5663c780-f52b-11ea-8ee2-80ff9435540b.png)

Closes: https://github.com/SubtitleEdit/subtitleedit/issues/4331