### PR TITLE
Move "Split line" up a bit and reset it

### DIFF
--- a/src/Forms/Main.Designer.cs
+++ b/src/Forms/Main.Designer.cs
@@ -4386,7 +4386,7 @@
             // 
             this.buttonSplitLine.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonSplitLine.ForeColor = System.Drawing.Color.Red;
-            this.buttonSplitLine.Location = new System.Drawing.Point(604, 88);
+            this.buttonSplitLine.Location = new System.Drawing.Point(604, 80);
             this.buttonSplitLine.Name = "buttonSplitLine";
             this.buttonSplitLine.Size = new System.Drawing.Size(115, 23);
             this.buttonSplitLine.TabIndex = 39;
@@ -4809,7 +4809,7 @@
             // buttonAutoBreak
             // 
             this.buttonAutoBreak.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonAutoBreak.Location = new System.Drawing.Point(604, 59);
+            this.buttonAutoBreak.Location = new System.Drawing.Point(604, 51);
             this.buttonAutoBreak.Name = "buttonAutoBreak";
             this.buttonAutoBreak.Size = new System.Drawing.Size(115, 23);
             this.buttonAutoBreak.TabIndex = 7;
@@ -4850,7 +4850,7 @@
             // buttonUnBreak
             // 
             this.buttonUnBreak.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonUnBreak.Location = new System.Drawing.Point(604, 30);
+            this.buttonUnBreak.Location = new System.Drawing.Point(604, 22);
             this.buttonUnBreak.Name = "buttonUnBreak";
             this.buttonUnBreak.Size = new System.Drawing.Size(115, 23);
             this.buttonUnBreak.TabIndex = 6;

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -4106,6 +4106,7 @@ namespace Nikse.SubtitleEdit.Forms
             _fileDateTime = new DateTime();
             _oldSubtitleFormat = null;
             labelSingleLine.Text = string.Empty;
+            buttonSplitLine.Visible = false;
             labelSingleLinePixels.Text = string.Empty;
             RemoveAlternate(true, false);
             _splitDualSami = false;
@@ -8218,6 +8219,7 @@ namespace Nikse.SubtitleEdit.Forms
                 textBoxListViewText.Text = string.Empty;
                 textBoxListViewTextAlternate.Text = string.Empty;
                 textBoxListViewText.Enabled = false;
+                buttonSplitLine.Visible = false;
                 labelTextLineLengths.Text = string.Empty;
                 labelCharactersPerSecond.Text = string.Empty;
                 labelTextLineTotal.Text = string.Empty;


### PR DESCRIPTION
I don't know if this is the case everywhere, but when I set the splitter to minimum hight and the "Split line!" shows up, this is how it looks:
![image](https://user-images.githubusercontent.com/20923700/93693666-8d2d7500-fb0b-11ea-9ef5-4776bc403891.png)

I lifted it up a bit, I don't know if you think it still looks good:
![image](https://user-images.githubusercontent.com/20923700/93693673-9fa7ae80-fb0b-11ea-9925-70555a75f579.png)

Also, "Split line!" used to not reset when using "new" or deleting all lines:
![image](https://user-images.githubusercontent.com/20923700/93693688-bea64080-fb0b-11ea-93a8-1e6d382e902a.png)