### PR TITLE
Add "Ignore Arabic Diacritics" + Fix bugs

### DIFF
--- a/libse/Forms/FixCommonErrors/EmptyFixCallback.cs
+++ b/libse/Forms/FixCommonErrors/EmptyFixCallback.cs
@@ -53,26 +53,14 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             get { return new SubRip(); }
         }
 
-        private string _language = "en";
-
-        public string Language
-        {
-            get { return _language; }
-            set { _language = value; }
-        }
+        public string Language { get; set; } = "en";
 
         public bool IsName(string candidate)
         {
             return false;
         }
 
-        private Encoding _encoding = Encoding.UTF8;
-
-        public Encoding Encoding
-        {
-            get { return _encoding; }
-            set { _encoding = value; }
-        }
+        public Encoding Encoding { get; set; } = Encoding.UTF8;
 
         public HashSet<string> GetAbbreviations()
         {

--- a/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
+++ b/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
@@ -65,7 +65,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 if (!skip && charactersPerSecond > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                 {
                     var temp = new Paragraph(p);
-                    var numberOfCharacters = temp.Text.CountCharacters(Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace);
+                    var numberOfCharacters = temp.Text.CountCharacters(Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace, Configuration.Settings.General.IgnoreArabicDiacritics);
                     while (Utilities.GetCharactersPerSecond(temp, numberOfCharacters) > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                     {
                         temp.EndTime.TotalMilliseconds++;

--- a/libse/Forms/FixCommonErrors/FixShortLines.cs
+++ b/libse/Forms/FixCommonErrors/FixShortLines.cs
@@ -13,7 +13,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             {
                 Paragraph p = subtitle.Paragraphs[i];
                 string oldText = p.Text;
-                var text = Helper.FixShortLines(p.Text);
+                var text = Helper.FixShortLines(p.Text, callbacks.Language);
                 if (callbacks.AllowFix(p, fixAction) && oldText != text)
                 {
                     p.Text = text;

--- a/libse/Forms/FixCommonErrors/FixShortLinesAll.cs
+++ b/libse/Forms/FixCommonErrors/FixShortLinesAll.cs
@@ -16,7 +16,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 if (callbacks.AllowFix(p, fixAction))
                 {
                     string s = HtmlUtil.RemoveHtmlTags(p.Text, true);
-                    if (s.Replace(Environment.NewLine, " ").Replace("  ", " ").Length < Configuration.Settings.General.MergeLinesShorterThan && p.Text.Contains(Environment.NewLine))
+                    if (s.Contains(Environment.NewLine) && s.Replace(Environment.NewLine, " ").Replace("  ", " ").CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) < Configuration.Settings.General.MergeLinesShorterThan)
                     {
                         s = Utilities.AutoBreakLine(p.Text, callbacks.Language);
                         if (s != p.Text)

--- a/libse/Forms/FixCommonErrors/Helper.cs
+++ b/libse/Forms/FixCommonErrors/Helper.cs
@@ -566,7 +566,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
         private static readonly char[] NoShortLineList = { '.', '?', '!', ':', ';', '…', '♪', '♫' };
 
-        public static string FixShortLines(string text)
+        public static string FixShortLines(string text, string language)
         {
             if (string.IsNullOrWhiteSpace(text) || !text.Contains(Environment.NewLine, StringComparison.Ordinal))
             {
@@ -574,7 +574,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             }
 
             string s = HtmlUtil.RemoveHtmlTags(text, true);
-            if (s.Contains(Environment.NewLine) && s.Replace(Environment.NewLine, " ").Replace("  ", " ").Length < Configuration.Settings.General.MergeLinesShorterThan)
+            if (s.Contains(Environment.NewLine) && s.Replace(Environment.NewLine, " ").Replace("  ", " ").CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) < Configuration.Settings.General.MergeLinesShorterThan)
             {
                 s = s.TrimEnd().TrimEnd('.', '?', '!', ':', ';');
                 s = s.TrimStart('-');
@@ -582,7 +582,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     !s.Contains(Environment.NewLine + "-") &&
                     !(s.StartsWith('[') && s.Contains("]" + Environment.NewLine, StringComparison.Ordinal)) &&
                     !(s.StartsWith('(') && s.Contains(")" + Environment.NewLine, StringComparison.Ordinal)) &&
-                    s != s.ToUpperInvariant())
+                    (language == "ar" || s != s.ToUpperInvariant()))
                 {
                     return Utilities.UnbreakLine(text);
                 }

--- a/libse/NetflixQualityCheck/NetflixCheckMaxLineLength.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckMaxLineLength.cs
@@ -38,7 +38,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                             }
                         }
                     }
-                    else if (HtmlUtil.RemoveHtmlTags(line, true).Length > controller.SingleLineMaxLength)
+                    else if (HtmlUtil.RemoveHtmlTags(line, true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > controller.SingleLineMaxLength)
                     {
                         var fixedParagraph = new Paragraph(p, false);
                         fixedParagraph.Text = Utilities.AutoBreakLine(fixedParagraph.Text, controller.SingleLineMaxLength, controller.SingleLineMaxLength - 3, controller.Language);

--- a/libse/NetflixQualityCheck/NetflixCheckNumberOfLines.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckNumberOfLines.cs
@@ -1,10 +1,13 @@
-﻿namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
+﻿using System;
+
+namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
     public class NetflixCheckNumberOfLines : INetflixQualityChecker
     {
 
         /// <summary>
         /// Two lines maximum
+        /// Text should be on one line if it fits
         /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
@@ -19,6 +22,13 @@
                         fixedParagraph = null; // cannot fix text
                     }
                     string comment = "Two lines maximum";
+                    controller.AddRecord(p, fixedParagraph, comment);
+                }
+                else if (p.Text.SplitToLines().Count == 2 && p.Text.Contains(Environment.NewLine) && p.Text.Replace(Environment.NewLine, " ").Replace("  ", " ").CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) <= controller.SingleLineMaxLength)
+                {
+                    var fixedParagraph = new Paragraph(p, false);
+                    fixedParagraph.Text = Utilities.AutoBreakLine(fixedParagraph.Text, controller.SingleLineMaxLength, controller.SingleLineMaxLength - 3, controller.Language);
+                    string comment = "Text can fit on one line";
                     controller.AddRecord(p, fixedParagraph, comment);
                 }
             }

--- a/libse/NetflixQualityCheck/NetflixCheckNumberOfLines.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckNumberOfLines.cs
@@ -24,7 +24,9 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                     string comment = "Two lines maximum";
                     controller.AddRecord(p, fixedParagraph, comment);
                 }
-                else if (p.Text.SplitToLines().Count == 2 && p.Text.Contains(Environment.NewLine) && p.Text.Replace(Environment.NewLine, " ").Replace("  ", " ").CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) <= controller.SingleLineMaxLength)
+                else if (p.Text.SplitToLines().Count == 2 && p.Text.Contains(Environment.NewLine) &&
+                    p.Text.Replace(Environment.NewLine, " ").Replace("  ", " ").CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) <= controller.SingleLineMaxLength &&
+                    p.Text != Utilities.AutoBreakLine(p.Text, controller.Language))
                 {
                     var fixedParagraph = new Paragraph(p, false);
                     fixedParagraph.Text = Utilities.AutoBreakLine(fixedParagraph.Text, controller.SingleLineMaxLength, controller.SingleLineMaxLength - 3, controller.Language);

--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -1039,6 +1039,7 @@ $HorzAlign          =   Center
         public double SubtitleMaximumCharactersPerSeconds { get; set; }
         public double SubtitleOptimalCharactersPerSeconds { get; set; }
         public bool CharactersPerSecondsIgnoreWhiteSpace { get; set; }
+        public bool IgnoreArabicDiacritics { get; set; }
         public double SubtitleMaximumWordsPerMinute { get; set; }
         public DialogType DialogStyle { get; set; }
         public ContinuationStyle ContinuationStyle { get; set; }
@@ -1174,6 +1175,7 @@ $HorzAlign          =   Center
             DefaultSubtitleFormat = "SubRip";
             DefaultEncoding = TextEncoding.Utf8WithBom;
             AutoConvertToUtf8 = false;
+            IgnoreArabicDiacritics = false;
             AutoGuessAnsiEncoding = true;
             ShowRecentFiles = true;
             RememberSelectedLine = true;
@@ -2900,6 +2902,12 @@ $HorzAlign          =   Center
             if (subNode != null)
             {
                 settings.General.CharactersPerSecondsIgnoreWhiteSpace = Convert.ToBoolean(subNode.InnerText);
+            }
+
+            subNode = node.SelectSingleNode("IgnoreArabicDiacritics");
+            if (subNode != null)
+            {
+                settings.General.IgnoreArabicDiacritics = Convert.ToBoolean(subNode.InnerText);
             }
 
             subNode = node.SelectSingleNode("SubtitleMaximumWordsPerMinute");
@@ -7494,6 +7502,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("SubtitleMaximumCharactersPerSeconds", settings.General.SubtitleMaximumCharactersPerSeconds.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("SubtitleOptimalCharactersPerSeconds", settings.General.SubtitleOptimalCharactersPerSeconds.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("CharactersPerSecondsIgnoreWhiteSpace", settings.General.CharactersPerSecondsIgnoreWhiteSpace.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString("IgnoreArabicDiacritics", settings.General.IgnoreArabicDiacritics.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("SubtitleMaximumWordsPerMinute", settings.General.SubtitleMaximumWordsPerMinute.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("DialogStyle", settings.General.DialogStyle.ToString());
                 textWriter.WriteElementString("ContinuationStyle", settings.General.ContinuationStyle.ToString());

--- a/libse/StringExtensions.cs
+++ b/libse/StringExtensions.cs
@@ -446,9 +446,9 @@ namespace Nikse.SubtitleEdit.Core
         }
 
         /// <summary>
-        /// Count characters excl. white spaces/ssa-tags/html-tags and normal space depending on parameter.
+        /// Count characters excl. white spaces/ssa-tags/html-tag, normal space and Arabic diacritics depending on parameter.
         /// </summary>
-        public static int CountCharacters(this string value, bool removeNormalSpace)
+        public static int CountCharacters(this string value, bool removeNormalSpace, bool ignoreArabicDiacritics)
         {
             int length = 0;
             const char zeroWidthSpace = '\u200B';
@@ -482,7 +482,7 @@ namespace Nikse.SubtitleEdit.Core
                 {
                     htmlTagOn = true;
                 }
-                else if (ch != '\n' && ch != '\r' && ch != '\t' && ch != zeroWidthSpace && ch != zeroWidthNoBreakSpace && ch != normalSpace)
+                else if (ch != '\n' && ch != '\r' && ch != '\t' && ch != zeroWidthSpace && ch != zeroWidthNoBreakSpace && ch != normalSpace && ch != '\u202B' && !(ignoreArabicDiacritics && ch >= '\u064B' && ch <= '\u0653'))
                 {
                     length++;
                 }

--- a/libse/Subtitle.cs
+++ b/libse/Subtitle.cs
@@ -377,7 +377,7 @@ namespace Nikse.SubtitleEdit.Core
 
             var duration = Utilities.GetOptimalDisplayMilliseconds(p.Text, optimalCharactersPerSeconds);
             p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + duration;
-            var numberOfCharacters = p.Text.CountCharacters(Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace);
+            var numberOfCharacters = p.Text.CountCharacters(Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace, Configuration.Settings.General.IgnoreArabicDiacritics);
             while (Utilities.GetCharactersPerSecond(p, numberOfCharacters) > maxCharactersPerSecond)
             {
                 duration++;

--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -547,7 +547,7 @@ namespace Nikse.SubtitleEdit.Core
             }
 
             string s = RemoveLineBreaks(text);
-            if (HtmlUtil.RemoveHtmlTags(s, true).Length < mergeLinesShorterThan)
+            if (HtmlUtil.RemoveHtmlTags(s, true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) < mergeLinesShorterThan)
             {
                 var lastIndexOfDash = s.LastIndexOf(" -", StringComparison.Ordinal);
                 if (Configuration.Settings.Tools.AutoBreakDashEarly && lastIndexOfDash > 4 && s.Substring(0, lastIndexOfDash).HasSentenceEnding(language))
@@ -920,7 +920,7 @@ namespace Nikse.SubtitleEdit.Core
                 optimalCharactersPerSecond = 14.7;
             }
 
-            var duration = text.CountCharacters(Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace) / optimalCharactersPerSecond * TimeCode.BaseUnit;
+            var duration = text.CountCharacters(Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace, Configuration.Settings.General.IgnoreArabicDiacritics) / optimalCharactersPerSecond * TimeCode.BaseUnit;
 
             if (duration < 1400)
             {
@@ -974,7 +974,7 @@ namespace Nikse.SubtitleEdit.Core
                 return 999;
             }
 
-            return paragraph.Text.CountCharacters(Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace) / duration.TotalSeconds;
+            return paragraph.Text.CountCharacters(Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace, Configuration.Settings.General.IgnoreArabicDiacritics) / duration.TotalSeconds;
         }
 
         public static double GetCharactersPerSecond(Paragraph paragraph, int numberOfCharacters)

--- a/src/Controls/SubtitleListView.cs
+++ b/src/Controls/SubtitleListView.cs
@@ -1382,16 +1382,14 @@ namespace Nikse.SubtitleEdit.Controls
                 string s = HtmlUtil.RemoveHtmlTags(paragraph.Text, true);
                 foreach (string line in s.SplitToLines())
                 {
-                    if (line.Length > Configuration.Settings.General.SubtitleLineMaximumLength)
+                    if (line.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength)
                     {
                         item.SubItems[ColumnIndexText].BackColor = Configuration.Settings.Tools.ListViewSyntaxErrorColor;
                         return;
                     }
                 }
                 int noOfLines = paragraph.NumberOfLines;
-                // Length excluding new line characters. (\r\n)
-                int len = noOfLines > 1 ? s.Length - Environment.NewLine.Length * (noOfLines - 1) : s.Length;
-                if (len <= Configuration.Settings.General.SubtitleLineMaximumLength * noOfLines)
+                if (s.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) <= Configuration.Settings.General.SubtitleLineMaximumLength * noOfLines)
                 {
                     if (noOfLines > Configuration.Settings.General.MaxNumberOfLines && _settings.Tools.ListViewSyntaxMoreThanXLines)
                     {

--- a/src/Forms/FixCommonErrors.cs
+++ b/src/Forms/FixCommonErrors.cs
@@ -1365,18 +1365,19 @@ namespace Nikse.SubtitleEdit.Forms
             labelTextLineLengths.Text = _languageGeneral.SingleLineLengths;
             labelSingleLine.Left = labelTextLineLengths.Left + labelTextLineLengths.Width - 6;
             text = HtmlUtil.RemoveHtmlTags(text, true);
+            text = NetflixImsc11Japanese.RemoveTags(text);
             UiUtil.GetLineLengths(labelSingleLine, text);
 
-            string s = text.Replace(Environment.NewLine, " ");
+            var s = text.Replace(Environment.NewLine, " ");
             labelTextLineTotal.ForeColor = Color.Black;
             buttonSplitLine.Visible = false;
             var abl = Utilities.AutoBreakLine(s, _autoDetectGoogleLanguage).SplitToLines();
-            if (abl.Count > Configuration.Settings.General.MaxNumberOfLines || abl.Any(li => li.Length > Configuration.Settings.General.SubtitleLineMaximumLength))
+            if (abl.Count > Configuration.Settings.General.MaxNumberOfLines || abl.Any(li => li.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength))
             {
                 buttonSplitLine.Visible = true;
                 labelTextLineTotal.ForeColor = Color.Red;
             }
-            labelTextLineTotal.Text = string.Format(_languageGeneral.TotalLengthX, s.Length);
+            labelTextLineTotal.Text = string.Format(_languageGeneral.TotalLengthX, text.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics));
         }
 
         private void ButtonFixesSelectAllClick(object sender, EventArgs e)

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -8814,8 +8814,8 @@ namespace Nikse.SubtitleEdit.Forms
 
             buttonSplitLine.Visible = false;
 
-            // remove unicode control characters
-            var s = text.RemoveControlCharacters(); // incl. new line
+            var s = text.Replace(Environment.NewLine, " ");
+            var len = text.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics);
 
             int numberOfLines = Utilities.GetNumberOfLines(text.Trim());
             int maxLines = int.MaxValue;
@@ -8827,9 +8827,10 @@ namespace Nikse.SubtitleEdit.Forms
             var splitLines = text.SplitToLines();
             if (numberOfLines <= maxLines)
             {
-                if (s.Length <= Configuration.Settings.General.SubtitleLineMaximumLength * Math.Max(numberOfLines, 2) &&
+                if (len <= Configuration.Settings.General.SubtitleLineMaximumLength * Math.Max(numberOfLines, 2) &&
                     splitLines.Count == 2 && splitLines[0].StartsWith('-') && splitLines[1].StartsWith('-') &&
-                    (splitLines[0].Length > Configuration.Settings.General.SubtitleLineMaximumLength || splitLines[1].Length > Configuration.Settings.General.SubtitleLineMaximumLength))
+                    (splitLines[0].CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength ||
+                    splitLines[1].CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength))
                 {
                     if (buttonUnBreak.Visible)
                     {
@@ -8838,18 +8839,18 @@ namespace Nikse.SubtitleEdit.Forms
                             if (Configuration.Settings.Tools.ListViewSyntaxColorWideLines)
                             {
                                 var totalLengthPixels = TextWidth.CalcPixelWidth(s);
-                                lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, string.Format("{0}     {1}", s.Length, totalLengthPixels));
+                                lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, string.Format("{0}     {1}", len, totalLengthPixels));
                             }
                             else
                             {
-                                lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, s.Length);
+                                lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, len);
                             }
                         }
 
                         buttonSplitLine.Visible = true;
                     }
                 }
-                else if (s.Length <= Configuration.Settings.General.SubtitleLineMaximumLength * Math.Max(numberOfLines, 2))
+                else if (len <= Configuration.Settings.General.SubtitleLineMaximumLength * Math.Max(numberOfLines, 2))
                 {
                     lineTotal.ForeColor = UiUtil.ForeColor;
                     if (!textBoxHasFocus)
@@ -8857,11 +8858,11 @@ namespace Nikse.SubtitleEdit.Forms
                         if (Configuration.Settings.Tools.ListViewSyntaxColorWideLines)
                         {
                             var totalLengthPixels = TextWidth.CalcPixelWidth(s);
-                            lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, string.Format("{0}     {1}", s.Length, totalLengthPixels));
+                            lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, string.Format("{0}     {1}", len, totalLengthPixels));
                         }
                         else
                         {
-                            lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, s.Length);
+                            lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, len);
                         }
                     }
                 }
@@ -8873,11 +8874,11 @@ namespace Nikse.SubtitleEdit.Forms
                         if (Configuration.Settings.Tools.ListViewSyntaxColorWideLines)
                         {
                             var totalLengthPixels = TextWidth.CalcPixelWidth(s);
-                            lineTotal.Text = string.Format(_languageGeneral.TotalLengthXSplitLine, string.Format("{0}     {1}", s.Length, totalLengthPixels));
+                            lineTotal.Text = string.Format(_languageGeneral.TotalLengthXSplitLine, string.Format("{0}     {1}", len, totalLengthPixels));
                         }
                         else
                         {
-                            lineTotal.Text = string.Format(_languageGeneral.TotalLengthXSplitLine, s.Length);
+                            lineTotal.Text = string.Format(_languageGeneral.TotalLengthXSplitLine, len);
                         }
                     }
 
@@ -8888,16 +8889,17 @@ namespace Nikse.SubtitleEdit.Forms
                             if (Configuration.Settings.Tools.ListViewSyntaxColorWideLines)
                             {
                                 var totalLengthPixels = TextWidth.CalcPixelWidth(s);
-                                lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, string.Format("{0}     {1}", s.Length, totalLengthPixels));
+                                lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, string.Format("{0}     {1}", len, totalLengthPixels));
                             }
                             else
                             {
-                                lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, s.Length);
+                                lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, len);
                             }
                         }
 
-                        var abl = Utilities.AutoBreakLine(s, "en").SplitToLines();
-                        if (abl.Count > maxLines || abl.Any(li => li.Length > Configuration.Settings.General.SubtitleLineMaximumLength))
+                        var lang = LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitle);
+                        var abl = Utilities.AutoBreakLine(s, lang).SplitToLines();
+                        if (abl.Count > maxLines || abl.Any(li => li.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength))
                         {
                             buttonSplitLine.Visible = true;
                         }
@@ -8911,17 +8913,17 @@ namespace Nikse.SubtitleEdit.Forms
                     if (Configuration.Settings.Tools.ListViewSyntaxColorWideLines)
                     {
                         var totalLengthPixels = TextWidth.CalcPixelWidth(s);
-                        lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, string.Format("{0}     {1}", s.Length, totalLengthPixels));
+                        lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, string.Format("{0}     {1}", len, totalLengthPixels));
                     }
                     else
                     {
-                        lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, s.Length);
+                        lineTotal.Text = string.Format(_languageGeneral.TotalLengthX, len);
                     }
                 }
 
                 var lang = LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitle);
                 var abl = Utilities.AutoBreakLine(s, lang).SplitToLines();
-                if (abl.Count > maxLines || abl.Any(li => li.Length > Configuration.Settings.General.SubtitleLineMaximumLength) &&
+                if (abl.Count > maxLines || abl.Any(li => li.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength) &&
                     !textBoxListViewTextAlternate.Visible)
                 {
                     buttonSplitLine.Visible = true;
@@ -24659,7 +24661,7 @@ namespace Nikse.SubtitleEdit.Forms
             int lineBreakPos = textBox.Text.IndexOf(Environment.NewLine, StringComparison.Ordinal);
             int pos = textBox.SelectionStart;
             var s = HtmlUtil.RemoveHtmlTags(textBox.Text, true).Replace(Environment.NewLine, string.Empty); // we don't count new line in total length... correct?
-            int totalLength = s.Length;
+            int totalLength = s.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics);
             string totalL;
 
             if (Configuration.Settings.Tools.ListViewSyntaxColorWideLines)

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -5060,10 +5060,10 @@ namespace Nikse.SubtitleEdit.Forms
                 ShowStatus(string.Format(_language.SearchingForXFromLineY, _findHelper.FindText, _subtitleListViewIndex + 1));
                 if (tabControlSubtitle.SelectedIndex == TabControlListView)
                 {
-                    var tb = GetFindRepaceTextBox();
+                    var tb = GetFindReplaceTextBox();
                     int startPos = tb.SelectedText.Length > 0 ? tb.SelectionStart + 1 : tb.SelectionStart;
                     bool found = _findHelper.Find(_subtitle, _subtitleAlternate, _subtitleListViewIndex, startPos);
-                    tb = GetFindRepaceTextBox();
+                    tb = GetFindReplaceTextBox();
                     //if we fail to find the text, we might want to start searching from the top of the file.
                     if (!found && _findHelper.StartLineIndex >= 1)
                     {
@@ -5115,7 +5115,7 @@ namespace Nikse.SubtitleEdit.Forms
             FindNext();
         }
 
-        private TextBox GetFindRepaceTextBox()
+        private TextBox GetFindReplaceTextBox()
         {
             return _findHelper.MatchInOriginal ? textBoxListViewTextAlternate : textBoxListViewText;
         }
@@ -5125,7 +5125,7 @@ namespace Nikse.SubtitleEdit.Forms
             if (_findHelper != null)
             {
                 _findHelper.InProgress = true;
-                TextBox tb = GetFindRepaceTextBox();
+                TextBox tb = GetFindReplaceTextBox();
                 if (tabControlSubtitle.SelectedIndex == TabControlListView)
                 {
                     int selectedIndex = -1;
@@ -5143,7 +5143,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                     if (_findHelper.FindNext(_subtitle, _subtitleAlternate, selectedIndex, textBoxStart, Configuration.Settings.General.AllowEditOfOriginalSubtitle))
                     {
-                        tb = GetFindRepaceTextBox();
+                        tb = GetFindReplaceTextBox();
                         SubtitleListview1.SelectIndexAndEnsureVisible(_findHelper.SelectedIndex, true);
                         ShowStatus(string.Format(_language.XFoundAtLineNumberY, _findHelper.FindText, _findHelper.SelectedIndex + 1));
                         tb.Focus();
@@ -5208,7 +5208,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             _findHelper.InProgress = true;
-            TextBox tb = GetFindRepaceTextBox();
+            TextBox tb = GetFindReplaceTextBox();
             if (tabControlSubtitle.SelectedIndex == TabControlListView)
             {
                 int selectedIndex = -1;
@@ -5226,7 +5226,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 if (_findHelper.FindPrevious(_subtitle, _subtitleAlternate, selectedIndex, textBoxStart, Configuration.Settings.General.AllowEditOfOriginalSubtitle))
                 {
-                    tb = GetFindRepaceTextBox();
+                    tb = GetFindReplaceTextBox();
                     SubtitleListview1.SelectIndexAndEnsureVisible(_findHelper.SelectedIndex, true);
                     ShowStatus(string.Format(_language.XFoundAtLineNumberY, _findHelper.FindText, _findHelper.SelectedIndex + 1));
                     tb.Focus();
@@ -5659,7 +5659,7 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         if (_findHelper.FindNext(_subtitle, _subtitleAlternate, _findHelper.SelectedIndex, _findHelper.SelectedPosition, Configuration.Settings.General.AllowEditOfOriginalSubtitle))
                         {
-                            var tb = GetFindRepaceTextBox();
+                            var tb = GetFindReplaceTextBox();
                             SubtitleListview1.SelectIndexAndEnsureVisible(_findHelper.SelectedIndex, true);
                             tb.Focus();
                             tb.SelectionStart = _findHelper.SelectedPosition;
@@ -5689,7 +5689,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 _findHelper.ReplaceFromPosition = 0;
                                 if (_findHelper.FindNext(_subtitle, _subtitleAlternate, _findHelper.SelectedIndex, _findHelper.SelectedPosition, Configuration.Settings.General.AllowEditOfOriginalSubtitle))
                                 {
-                                    var tb = GetFindRepaceTextBox();
+                                    var tb = GetFindReplaceTextBox();
                                     SubtitleListview1.SelectIndexAndEnsureVisible(_findHelper.SelectedIndex, true);
                                     tb.Focus();
                                     tb.SelectionStart = _findHelper.SelectedPosition;
@@ -5723,7 +5723,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     else if (!replaceDialog.FindOnly) // replace once only
                     {
-                        var tb = GetFindRepaceTextBox();
+                        var tb = GetFindReplaceTextBox();
                         string msg = string.Empty;
                         if (_findHelper.FindReplaceType.FindType == FindType.RegEx)
                         {
@@ -5751,7 +5751,7 @@ namespace Nikse.SubtitleEdit.Forms
                         if (_findHelper.FindNext(_subtitle, _subtitleAlternate, _findHelper.SelectedIndex, _findHelper.SelectedPosition, Configuration.Settings.General.AllowEditOfOriginalSubtitle))
                         {
                             SubtitleListview1.SelectIndexAndEnsureVisible(_findHelper.SelectedIndex, true);
-                            tb = GetFindRepaceTextBox();
+                            tb = GetFindReplaceTextBox();
                             tb.Focus();
                             tb.SelectionStart = _findHelper.SelectedPosition;
                             tb.SelectionLength = _findHelper.FindTextLength;
@@ -5780,7 +5780,7 @@ namespace Nikse.SubtitleEdit.Forms
                                     if (_findHelper.FindNext(_subtitle, _subtitleAlternate, _findHelper.SelectedIndex, _findHelper.SelectedPosition, Configuration.Settings.General.AllowEditOfOriginalSubtitle))
                                     {
                                         SubtitleListview1.SelectIndexAndEnsureVisible(_findHelper.SelectedIndex, true);
-                                        tb = GetFindRepaceTextBox();
+                                        tb = GetFindReplaceTextBox();
                                         tb.Focus();
                                         tb.SelectionStart = _findHelper.SelectedPosition;
                                         tb.SelectionLength = _findHelper.FindTextLength;
@@ -5901,7 +5901,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (replace)
             {
-                var tb = GetFindRepaceTextBox();
+                var tb = GetFindReplaceTextBox();
                 tb.SelectionStart = _findHelper.SelectedPosition;
                 tb.SelectionLength = _findHelper.FindTextLength;
                 if (_findHelper.FindReplaceType.FindType == FindType.RegEx)

--- a/src/Forms/Statistics.cs
+++ b/src/Forms/Statistics.cs
@@ -157,15 +157,15 @@ https://github.com/SubtitleEdit/subtitleedit
 
             sb.AppendLine(string.Format(_l.NumberOfLinesX, _subtitle.Paragraphs.Count));
             sb.AppendLine(string.Format(_l.LengthInFormatXinCharactersY, _format.FriendlyName, sourceLength));
-            sb.AppendLine(string.Format(_l.NumberOfCharactersInTextOnly, allText.Replace("\r\n", "\n").Length));
+            sb.AppendLine(string.Format(_l.NumberOfCharactersInTextOnly, allText.ToString().CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics)));
             sb.AppendLine(string.Format(_l.TotalDuration, new TimeCode(totalDuration).ToDisplayString()));
-            sb.AppendLine(string.Format(_l.TotalCharsPerSecond, HtmlUtil.RemoveHtmlTags(allText.ToString()).Length / (totalDuration / TimeCode.BaseUnit)));
+            sb.AppendLine(string.Format(_l.TotalCharsPerSecond, HtmlUtil.RemoveHtmlTags(allText.ToString()).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) / (totalDuration / TimeCode.BaseUnit)));
             sb.AppendLine(string.Format(_l.TotalWords, _totalWords));
             sb.AppendLine(string.Format(_l.NumberOfItalicTags, Utilities.CountTagInText(allTextToLower, "<i>")));
             sb.AppendLine(string.Format(_l.NumberOfBoldTags, Utilities.CountTagInText(allTextToLower, "<b>")));
             sb.AppendLine(string.Format(_l.NumberOfUnderlineTags, Utilities.CountTagInText(allTextToLower, "<u>")));
             sb.AppendLine(string.Format(_l.NumberOfFontTags, Utilities.CountTagInText(allTextToLower, "<font ")));
-            sb.AppendLine(string.Format(_l.NumberOfAlignmentTags, Utilities.CountTagInText(allTextToLower, "{\\a")));
+            sb.AppendLine(string.Format(_l.NumberOfAlignmentTags, Utilities.CountTagInText(allTextToLower, "{\\an")));
             sb.AppendLine();
             sb.AppendLine(string.Format(_l.LineLengthMinimum, minimumLineLength) + " (" + GetIndicesWithLength(minimumLineLength) + ")");
             sb.AppendLine(string.Format(_l.LineLengthMaximum, maximumLineLength) + " (" + GetIndicesWithLength(maximumLineLength) + ")");
@@ -198,12 +198,12 @@ https://github.com/SubtitleEdit/subtitleedit
 
         private static int GetLineLength(Paragraph p)
         {
-            return HtmlUtil.RemoveHtmlTags(p.Text.Replace(Environment.NewLine, string.Empty), true).Length;
+            return HtmlUtil.RemoveHtmlTags(p.Text.Replace(Environment.NewLine, string.Empty), true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics);
         }
 
         private static int GetSingleLineLength(string s)
         {
-            return HtmlUtil.RemoveHtmlTags(s, true).Length;
+            return HtmlUtil.RemoveHtmlTags(s, true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics);
         }
 
         private static int GetSingleLineWidth(string s)

--- a/src/Logic/FindReplaceDialogHelper.cs
+++ b/src/Logic/FindReplaceDialogHelper.cs
@@ -9,10 +9,7 @@ namespace Nikse.SubtitleEdit.Logic
     public class FindReplaceDialogHelper
     {
         private const string SeparatorChars = " #><-\"„”“[]'‘`´¶(){}♪,.!?:;¿¡.…—،؟\r\n\u2028";
-        private readonly string _findText;
-        private readonly string _replaceText;
         private Regex _regEx;
-        private int _findTextLength;
 
         public bool Success { get; set; }
         public ReplaceType FindReplaceType { get; set; }
@@ -23,26 +20,26 @@ namespace Nikse.SubtitleEdit.Logic
         public bool MatchInOriginal { get; set; }
         public bool InProgress { get; set; }
 
-        public int FindTextLength => _findTextLength;
+        public int FindTextLength { get; private set; }
 
-        public string FindText => _findText;
+        public string FindText { get; }
 
-        public string ReplaceText => _replaceText;
+        public string ReplaceText { get; }
 
         public FindReplaceDialogHelper(ReplaceType findType, string findText, Regex regEx, string replaceText, int startLineIndex)
         {
-            _replaceText = string.Empty;
+            ReplaceText = string.Empty;
             FindReplaceType = findType;
-            _findText = findText;
+            FindText = findText;
 
-            _replaceText = replaceText;
-            if (_replaceText != null)
+            ReplaceText = replaceText;
+            if (ReplaceText != null)
             {
-                _replaceText = RegexUtils.FixNewLine(_replaceText);
+                ReplaceText = RegexUtils.FixNewLine(ReplaceText);
             }
 
             _regEx = regEx;
-            _findTextLength = findText.Length;
+            FindTextLength = findText.Length;
             StartLineIndex = startLineIndex;
             MatchInOriginal = false;
         }
@@ -67,13 +64,13 @@ namespace Nikse.SubtitleEdit.Logic
             if (FindReplaceType.FindType == FindType.CaseSensitive || FindReplaceType.FindType == FindType.Normal)
             {
                 var comparison = GetComparison();
-                var idx = text.IndexOf(_findText, startIndex, comparison);
+                var idx = text.IndexOf(FindText, startIndex, comparison);
                 while (idx >= 0)
                 {
                     if (FindReplaceType.WholeWord)
                     {
                         var startOk = idx == 0 || SeparatorChars.Contains(text[idx - 1]);
-                        var endOk = idx + _findText.Length == text.Length || SeparatorChars.Contains(text[idx + _findText.Length]);
+                        var endOk = idx + FindText.Length == text.Length || SeparatorChars.Contains(text[idx + FindText.Length]);
                         if (startOk && endOk)
                         {
                             return idx;
@@ -83,7 +80,7 @@ namespace Nikse.SubtitleEdit.Logic
                     {
                         return idx;
                     }
-                    idx = text.IndexOf(_findText, idx + _findText.Length, comparison);
+                    idx = text.IndexOf(FindText, idx + FindText.Length, comparison);
                 }
                 return -1;
             }
@@ -91,13 +88,13 @@ namespace Nikse.SubtitleEdit.Logic
             var match = _regEx.Match(text, startIndex);
             if (match.Success)
             {
-                string groupName = RegexUtils.GetRegExGroup(_findText);
+                string groupName = RegexUtils.GetRegExGroup(FindText);
                 if (groupName != null && match.Groups[groupName] != null && match.Groups[groupName].Success)
                 {
-                    _findTextLength = match.Groups[groupName].Length;
+                    FindTextLength = match.Groups[groupName].Length;
                     return match.Groups[groupName].Index;
                 }
-                _findTextLength = match.Length;
+                FindTextLength = match.Length;
                 return match.Index;
             }
             return -1;
@@ -297,15 +294,15 @@ namespace Nikse.SubtitleEdit.Logic
                     Match match = _regEx.Match(text, startIndex);
                     if (match.Success)
                     {
-                        string groupName = RegexUtils.GetRegExGroup(_findText);
+                        string groupName = RegexUtils.GetRegExGroup(FindText);
                         if (groupName != null && match.Groups[groupName] != null && match.Groups[groupName].Success)
                         {
-                            _findTextLength = match.Groups[groupName].Length;
+                            FindTextLength = match.Groups[groupName].Length;
                             SelectedIndex = match.Groups[groupName].Index;
                         }
                         else
                         {
-                            _findTextLength = match.Length;
+                            FindTextLength = match.Length;
                             SelectedIndex = match.Index;
                         }
                         Success = true;
@@ -334,16 +331,16 @@ namespace Nikse.SubtitleEdit.Logic
                     var matches = _regEx.Matches(text.Substring(0, startIndex));
                     if (matches.Count > 0)
                     {
-                        string groupName = RegexUtils.GetRegExGroup(_findText);
+                        string groupName = RegexUtils.GetRegExGroup(FindText);
                         var last = matches[matches.Count - 1];
                         if (groupName != null && last.Groups[groupName] != null && last.Groups[groupName].Success)
                         {
-                            _findTextLength = last.Groups[groupName].Length;
+                            FindTextLength = last.Groups[groupName].Length;
                             SelectedIndex = last.Groups[groupName].Index;
                         }
                         else
                         {
-                            _findTextLength = last.Length;
+                            FindTextLength = last.Length;
                             SelectedIndex = last.Index;
                         }
                         Success = true;
@@ -353,13 +350,13 @@ namespace Nikse.SubtitleEdit.Logic
                 string searchText = text.Substring(0, startIndex);
                 int pos = -1;
                 var comparison = GetComparison();
-                var idx = searchText.LastIndexOf(_findText, startIndex, comparison);
+                var idx = searchText.LastIndexOf(FindText, startIndex, comparison);
                 while (idx >= 0)
                 {
                     if (FindReplaceType.WholeWord)
                     {
                         var startOk = idx == 0 || SeparatorChars.Contains(searchText[idx - 1]);
-                        var endOk = idx + _findText.Length == searchText.Length || SeparatorChars.Contains(searchText[idx + _findText.Length]);
+                        var endOk = idx + FindText.Length == searchText.Length || SeparatorChars.Contains(searchText[idx + FindText.Length]);
                         if (startOk && endOk)
                         {
                             pos = idx;
@@ -372,7 +369,7 @@ namespace Nikse.SubtitleEdit.Logic
                         break;
                     }
                     searchText = text.Substring(0, idx);
-                    idx = searchText.LastIndexOf(_findText, comparison);
+                    idx = searchText.LastIndexOf(FindText, comparison);
                 }
                 if (pos >= 0)
                 {
@@ -390,7 +387,7 @@ namespace Nikse.SubtitleEdit.Logic
             //  validate pattern if find type is regex
             if (FindReplaceType.FindType == FindType.RegEx)
             {
-                var findText = RegexUtils.FixNewLine(_findText);
+                var findText = RegexUtils.FixNewLine(FindText);
                 if (!RegexUtils.IsValidRegex(findText))
                 {
                     MessageBox.Show(Configuration.Settings.Language.General.RegularExpressionIsNotValid);
@@ -407,11 +404,11 @@ namespace Nikse.SubtitleEdit.Logic
                 }
                 else
                 {
-                    if (p.Text.Length < _findText.Length)
+                    if (p.Text.Length < FindText.Length)
                     {
                         continue;
                     }
-                    count += GetWordCount(p.Text, _findText, wholeWord, comparison);
+                    count += GetWordCount(p.Text, FindText, wholeWord, comparison);
                 }
             }
             return count;

--- a/src/Logic/UiUtil.cs
+++ b/src/Logic/UiUtil.cs
@@ -644,8 +644,8 @@ namespace Nikse.SubtitleEdit.Logic
                     return;
                 }
 
-                sb.Append(line.Length);
-                if (line.Length > Configuration.Settings.General.SubtitleLineMaximumLength || i >= Configuration.Settings.General.MaxNumberOfLines)
+                sb.Append(line.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics));
+                if (line.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength || i >= Configuration.Settings.General.MaxNumberOfLines)
                 {
                     label.ForeColor = Color.Red;
                 }

--- a/src/Test/Core/StringExtensionsTest.cs
+++ b/src/Test/Core/StringExtensionsTest.cs
@@ -204,7 +204,7 @@ namespace Test.Core
         public void CountLetters1()
         {
             string input = " Hallo  world! ";
-            var res = input.CountCharacters(false);
+            var res = input.CountCharacters(false, false);
             Assert.AreEqual(" Hallo  world! ".Length, res);
         }
 
@@ -212,7 +212,7 @@ namespace Test.Core
         public void CountLetters2()
         {
             string input = " Hallo " + Environment.NewLine + " world! ";
-            var res = input.CountCharacters(true);
+            var res = input.CountCharacters(true, false);
             Assert.AreEqual("Halloworld!".Length, res);
         }
 
@@ -220,7 +220,7 @@ namespace Test.Core
         public void CountLetters3()
         {
             string input = " Hallo" + Environment.NewLine + "world!";
-            var res = input.CountCharacters(false);
+            var res = input.CountCharacters(false, false);
             Assert.AreEqual(" Halloworld!".Length, res);
         }
 
@@ -228,7 +228,7 @@ namespace Test.Core
         public void CountLetters4Ssa()
         {
             string input = "{\\an1}Hallo";
-            var res = input.CountCharacters(true);
+            var res = input.CountCharacters(true, false);
             Assert.AreEqual("Hallo".Length, res);
         }
 
@@ -236,7 +236,7 @@ namespace Test.Core
         public void CountLetters4Html()
         {
             string input = "<i>Hallo</i>";
-            var res = input.CountCharacters(true);
+            var res = input.CountCharacters(true, false);
             Assert.AreEqual("Hallo".Length, res);
         }
 
@@ -244,7 +244,7 @@ namespace Test.Core
         public void CountLetters5HtmlFont()
         {
             string input = "<font color=\"red\"><i>Hal lo<i></font>";
-            var res = input.CountCharacters(true);
+            var res = input.CountCharacters(true, false);
             Assert.AreEqual("Hallo".Length, res);
         }
 
@@ -252,7 +252,7 @@ namespace Test.Core
         public void CountLetters6HtmlFontMultiLine()
         {
             string input = "<font color=\"red\"><i>Hal lo<i></font>" + Environment.NewLine + "<i>Bye!</i>";
-            var res = input.CountCharacters(true);
+            var res = input.CountCharacters(true, false);
             Assert.AreEqual("HalloBye!".Length, res);
         }
 

--- a/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
@@ -206,8 +206,8 @@ namespace Test.FixCommonErrors
             string expected = input;
             string expected2 = input2;
 
-            var result = Helper.FixShortLines(input);
-            var result2 = Helper.FixShortLines(input2);
+            var result = Helper.FixShortLines(input, "en");
+            var result2 = Helper.FixShortLines(input2, "en");
             Assert.AreEqual(result, expected); Assert.AreEqual(result2, expected2.Replace(Environment.NewLine, " "));
         }
 

--- a/src/Test/Logic/NetflixQualityCheckTest.cs
+++ b/src/Test/Logic/NetflixQualityCheckTest.cs
@@ -199,14 +199,17 @@ namespace Test.Logic
             sub.Paragraphs.Add(p1);
             var p2 = new Paragraph("Lorem ipsum." + Environment.NewLine + "Line 2.", 0, 832);
             sub.Paragraphs.Add(p2);
+            var p3 = new Paragraph("Lorem ipsum dolor sit amet," + Environment.NewLine + "consectetur adipiscing elit", 0, 832);
+            sub.Paragraphs.Add(p3);
 
             var controller = new NetflixQualityController();
             var checker = new NetflixCheckNumberOfLines();
 
             checker.Check(sub, controller);
 
-            Assert.AreEqual(1, controller.Records.Count);
+            Assert.AreEqual(2, controller.Records.Count);
             Assert.AreEqual(controller.Records[0].OriginalParagraph, p1);
+            Assert.AreEqual(controller.Records[1].FixedParagraph.Text, "Lorem ipsum. Line 2.");
         }
 
         [TestMethod]


### PR DESCRIPTION
I didn't expect to run into these things when I started working on this.
This has a lot of changes, I hope you can review it before merging.

### 1. Bug in FCE characters count:
It used to show the newline as a character:
![image](https://user-images.githubusercontent.com/20923700/93714102-2474e580-fb69-11ea-8e44-d6ace33b9d53.png)

### 2. Bug in "Split line!"
It used to show up sometimes -when the words are long- even if the line can be broken into 2:
![image](https://user-images.githubusercontent.com/20923700/93714129-58e8a180-fb69-11ea-967e-c6e646d9a3f9.png)

### 3. Bug in Remove line breaks in short text with only one sentence
It didn't work with Arabic because `s != s.ToUpperInvariant()` can't be True for Arabic and other languages that don't use casing.
Those other languages should be added as well.

### 4. Added "Text can fit on one line" to Netlix's Quality checker
In Netflix's rules, if the text can fit on one line, it should be written in one line.
I added this to "Number of lines".

### 5. Made SE not count the control character used by it `\u202B` as a character in characters count and CPS.
Other control character can be added.

### 6. Fix `{\alpha}` being counted as an alignment tag in the statistics.

### 7. Added a hidden option to ignore Arabic diacritics from characters count and CPS.