### PR TITLE
Add Multiple Replace group state to Export + Fix bug in CLI

### DIFF
--- a/src/Forms/MultipleReplace.cs
+++ b/src/Forms/MultipleReplace.cs
@@ -14,6 +14,7 @@ namespace Nikse.SubtitleEdit.Forms
     {
         internal const string Group = "Group";
         internal const string GroupName = "Name";
+        internal const string GroupEnabled = "Enabled";
         internal const string MultipleSearchAndReplaceItem = "MultipleSearchAndReplaceItem";
         internal const string RuleEnabled = "Enabled";
         internal const string FindWhat = "FindWhat";
@@ -167,7 +168,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     else
                     {
-                        ImportRulesFile(fileName);
+                        Configuration.Settings.MultipleSearchAndReplaceGroups.AddRange(ImportGroupsFile(fileName));
                     }
                 }
                 RunFromBatch(subtitle);
@@ -763,10 +764,10 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     var group = new MultipleSearchAndReplaceGroup();
                     var nameNode = groupNode.SelectSingleNode(GroupName);
-                    if (nameNode != null)
-                    {
-                        group.Name = nameNode.InnerText;
-                    }
+                    var enabledNode = groupNode.SelectSingleNode(GroupEnabled);
+
+                    group.Name = nameNode != null ? nameNode.InnerText : "Untitled";
+                    group.Enabled = enabledNode != null ? Convert.ToBoolean(enabledNode.InnerText) : false;
 
                     group.Rules = new List<MultipleSearchAndReplaceSetting>();
                     list.Add(group);
@@ -786,9 +787,11 @@ namespace Nikse.SubtitleEdit.Forms
             if (list.Count == 0)
             {
                 // import into "untitled" group if only rules
-                var group = new MultipleSearchAndReplaceGroup();
-                group.Name = "untitled";
-                group.Rules = new List<MultipleSearchAndReplaceSetting>();
+                var group = new MultipleSearchAndReplaceGroup
+                {
+                    Name = "untitled",
+                    Rules = new List<MultipleSearchAndReplaceSetting>()
+                };
                 var replaceItems = doc.DocumentElement?.SelectNodes("//MultipleSearchAndReplaceItem");
                 if (replaceItems != null)
                 {

--- a/src/Forms/MultipleReplaceExportImport.cs
+++ b/src/Forms/MultipleReplaceExportImport.cs
@@ -108,6 +108,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 textWriter.WriteStartElement(MultipleReplace.Group, string.Empty);
                 textWriter.WriteElementString(MultipleReplace.GroupName, group.Name);
+                textWriter.WriteElementString(MultipleReplace.GroupEnabled, group.Enabled.ToString());
                 foreach (var item in group.Rules)
                 {
                     textWriter.WriteStartElement(MultipleReplace.MultipleSearchAndReplaceItem, string.Empty);


### PR DESCRIPTION
1. Fixed /multiplereplace<> not working after adding groups to multiple replace.
2. Made the group state -Enable- exported when using "Export" and imported when using "Import". (Also affects CLI)