### PR TITLE
Don't show progress for imported plain text

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -24639,7 +24639,7 @@ namespace Nikse.SubtitleEdit.Forms
                 else if (_subtitle.Paragraphs.Count > 0 && !string.IsNullOrWhiteSpace(_videoFileName) && mediaPlayer != null && mediaPlayer.VideoPlayer != null && mediaPlayer.VideoPlayer.Duration > 0)
                 {
                     var last = _subtitle.Paragraphs.LastOrDefault();
-                    if (last != null)
+                    if (last != null && !last.StartTime.IsMaxTime)
                     {
                         var subtitleEndSeconds = last.EndTime.TotalSeconds;
                         var videoEndSeconds = mediaPlayer.VideoPlayer.Duration;


### PR DESCRIPTION
Related to https://github.com/SubtitleEdit/subtitleedit/issues/303#issuecomment-462065206

It used to show a big percentage:
![image](https://user-images.githubusercontent.com/20923700/94180775-34613200-fea7-11ea-9850-76d588d17c7c.png)
