### PR TITLE
Fix bugs in "Insert Unicode symbol"

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -26760,8 +26760,14 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (textBoxListViewTextAlternate.Visible && textBoxListViewTextAlternate.Enabled && textBoxListViewTextAlternate.Focused)
                 {
-                    textBoxListViewTextAlternate.SelectedText = s;
-                    textBoxListViewTextAlternate.Text = textBoxListViewTextAlternate.Text.Insert(textBoxListViewTextAlternate.SelectionStart, s);
+                    if (!string.IsNullOrEmpty(textBoxListViewTextAlternate.SelectedText))
+                    {
+                        textBoxListViewTextAlternate.SelectedText = s; 
+                    }
+                    else
+                    {
+                        textBoxListViewTextAlternate.Text = textBoxListViewTextAlternate.Text.Insert(textBoxListViewTextAlternate.SelectionStart, s + " "); 
+                    }
                 }
                 else
                 {
@@ -26781,7 +26787,14 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     else
                     {
-                        textBoxListViewText.SelectedText = s;
+                        if (!string.IsNullOrEmpty(textBoxListViewText.SelectedText))
+                        {
+                            textBoxListViewText.SelectedText = s;
+                        }
+                        else
+                        {
+                            textBoxListViewText.Text = textBoxListViewText.Text.Insert(textBoxListViewText.SelectionStart, s + " ");
+                        }
                     }
 
                     ShowSource();


### PR DESCRIPTION
It used to be inserted double for original:
![image](https://user-images.githubusercontent.com/20923700/94857060-94bd1a00-0439-11eb-835b-2f0d9656d0e8.png)

And it used to not add a space.