### PR TITLE
Reset "video position" when closing video

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -23200,6 +23200,10 @@ namespace Nikse.SubtitleEdit.Forms
             audioVisualizer.SetSpectrogram(null);
             audioVisualizer.SceneChanges = new List<double>();
             mediaPlayer.CurrentPosition = 0;
+            timeUpDownVideoPositionAdjust.TimeCode = new TimeCode();
+            timeUpDownVideoPositionAdjust.Enabled = false;
+            timeUpDownVideoPosition.TimeCode = new TimeCode();
+            timeUpDownVideoPosition.Enabled = false;
         }
 
         private void ToolStripMenuItemVideoDropDownOpening(object sender, EventArgs e)


### PR DESCRIPTION
It used to not reset:
![image](https://user-images.githubusercontent.com/20923700/94877770-23469100-0464-11eb-876c-a50b75a02c1a.png)