### PR TITLE
Redefine "CountCharacters" to ignore all Unicode Control Chars

### DIFF
--- a/libse/Forms/FixCommonErrors/FixLongLines.cs
+++ b/libse/Forms/FixCommonErrors/FixLongLines.cs
@@ -16,7 +16,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 bool tooLong = false;
                 foreach (string line in lines)
                 {
-                    if (HtmlUtil.RemoveHtmlTags(line, true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength)
+                    if (line.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength)
                     {
                         tooLong = true;
                         break;

--- a/libse/Forms/MoveWordUpDown.cs
+++ b/libse/Forms/MoveWordUpDown.cs
@@ -228,7 +228,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             bool doBreak = false;
             foreach (var line in s.SplitToLines())
             {
-                if (HtmlUtil.RemoveHtmlTags(line, true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength)
+                if (line.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength)
                 {
                     doBreak = true;
                     break;

--- a/libse/NetflixQualityCheck/NetflixCheckMaxLineLength.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckMaxLineLength.cs
@@ -38,7 +38,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                             }
                         }
                     }
-                    else if (HtmlUtil.RemoveHtmlTags(line, true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > controller.SingleLineMaxLength)
+                    else if (line.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > controller.SingleLineMaxLength)
                     {
                         var fixedParagraph = new Paragraph(p, false);
                         fixedParagraph.Text = Utilities.AutoBreakLine(fixedParagraph.Text, controller.SingleLineMaxLength, controller.SingleLineMaxLength - 3, controller.Language);

--- a/libse/StringExtensions.cs
+++ b/libse/StringExtensions.cs
@@ -450,45 +450,28 @@ namespace Nikse.SubtitleEdit.Core
         /// </summary>
         public static int CountCharacters(this string value, bool removeNormalSpace, bool ignoreArabicDiacritics)
         {
-            int length = 0;
-            const char zeroWidthSpace = '\u200B';
-            const char zeroWidthNoBreakSpace = '\uFEFF';
-            char normalSpace = removeNormalSpace ? ' ' : zeroWidthSpace;
-            bool ssaTagOn = false;
-            bool htmlTagOn = false;
-            var max = value.Length;
-            for (int i = 0; i < max; i++)
+            var newText = HtmlUtil.RemoveHtmlTags(value, true);
+            newText = Utilities.RemoveUnicodeControlChars(newText).Replace("\n", string.Empty).Replace("\r", string.Empty).Replace("\t", string.Empty).Replace("\u200B", string.Empty).Replace("\uFEFF", string.Empty);
+
+            if (removeNormalSpace)
             {
-                char ch = value[i];
-                if (ssaTagOn)
-                {
-                    if (ch == '}')
-                    {
-                        ssaTagOn = false;
-                    }
-                }
-                else if (htmlTagOn)
-                {
-                    if (ch == '>')
-                    {
-                        htmlTagOn = false;
-                    }
-                }
-                else if (ch == '{' && i < value.Length - 1 && value[i + 1] == '\\')
-                {
-                    ssaTagOn = true;
-                }
-                else if (ch == '<' && i < value.Length - 1 && (value[i + 1] == '/' || char.IsLetter(value[i + 1])) && value.IndexOf('>', i) > 0)
-                {
-                    htmlTagOn = true;
-                }
-                else if (ch != '\n' && ch != '\r' && ch != '\t' && ch != zeroWidthSpace && ch != zeroWidthNoBreakSpace && ch != normalSpace && ch != '\u202B' && !(ignoreArabicDiacritics && ch >= '\u064B' && ch <= '\u0653'))
-                {
-                    length++;
-                }
+                newText = newText.Replace(" ", string.Empty);
             }
 
-            return length;
+            if (ignoreArabicDiacritics)
+            {
+                newText = newText.Replace("\u064B", string.Empty)
+                    .Replace("\u064C", string.Empty)
+                    .Replace("\u064D", string.Empty)
+                    .Replace("\u064E", string.Empty)
+                    .Replace("\u064F", string.Empty)
+                    .Replace("\u0650", string.Empty)
+                    .Replace("\u0651", string.Empty)
+                    .Replace("\u0652", string.Empty)
+                    .Replace("\u0653", string.Empty);
+            }
+
+            return newText.Length;
         }
 
         public static bool HasSentenceEnding(this string value)

--- a/libse/Utilities.cs
+++ b/libse/Utilities.cs
@@ -547,7 +547,7 @@ namespace Nikse.SubtitleEdit.Core
             }
 
             string s = RemoveLineBreaks(text);
-            if (HtmlUtil.RemoveHtmlTags(s, true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) < mergeLinesShorterThan)
+            if (s.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) < mergeLinesShorterThan)
             {
                 var lastIndexOfDash = s.LastIndexOf(" -", StringComparison.Ordinal);
                 if (Configuration.Settings.Tools.AutoBreakDashEarly && lastIndexOfDash > 4 && s.Substring(0, lastIndexOfDash).HasSentenceEnding(language))

--- a/src/Forms/Statistics.cs
+++ b/src/Forms/Statistics.cs
@@ -159,7 +159,7 @@ https://github.com/SubtitleEdit/subtitleedit
             sb.AppendLine(string.Format(_l.LengthInFormatXinCharactersY, _format.FriendlyName, sourceLength));
             sb.AppendLine(string.Format(_l.NumberOfCharactersInTextOnly, allText.ToString().CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics)));
             sb.AppendLine(string.Format(_l.TotalDuration, new TimeCode(totalDuration).ToDisplayString()));
-            sb.AppendLine(string.Format(_l.TotalCharsPerSecond, HtmlUtil.RemoveHtmlTags(allText.ToString()).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) / (totalDuration / TimeCode.BaseUnit)));
+            sb.AppendLine(string.Format(_l.TotalCharsPerSecond, allText.ToString().CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) / (totalDuration / TimeCode.BaseUnit)));
             sb.AppendLine(string.Format(_l.TotalWords, _totalWords));
             sb.AppendLine(string.Format(_l.NumberOfItalicTags, Utilities.CountTagInText(allTextToLower, "<i>")));
             sb.AppendLine(string.Format(_l.NumberOfBoldTags, Utilities.CountTagInText(allTextToLower, "<b>")));
@@ -198,12 +198,12 @@ https://github.com/SubtitleEdit/subtitleedit
 
         private static int GetLineLength(Paragraph p)
         {
-            return HtmlUtil.RemoveHtmlTags(p.Text.Replace(Environment.NewLine, string.Empty), true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics);
+            return p.Text.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics);
         }
 
         private static int GetSingleLineLength(string s)
         {
-            return HtmlUtil.RemoveHtmlTags(s, true).CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics);
+            return s.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics);
         }
 
         private static int GetSingleLineWidth(string s)


### PR DESCRIPTION
This now ignores all control characters.

I don't know if this makes it better or worse.
I just figured why ignore the tags here while you can remove them?
Please let me know what you think.