### PR TITLE
Work on multiple replace shortcuts

### DIFF
--- a/src/Forms/MultipleReplace.Designer.cs
+++ b/src/Forms/MultipleReplace.Designer.cs
@@ -380,6 +380,7 @@
             // deleteToolStripMenuItem
             // 
             this.deleteToolStripMenuItem.Name = "deleteToolStripMenuItem";
+            this.deleteToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
             this.deleteToolStripMenuItem.Size = new System.Drawing.Size(227, 22);
             this.deleteToolStripMenuItem.Text = "Remove";
             this.deleteToolStripMenuItem.Click += new System.EventHandler(this.DeleteToolStripMenuItemClick);
@@ -410,6 +411,7 @@
             // moveUpToolStripMenuItem
             // 
             this.moveUpToolStripMenuItem.Name = "moveUpToolStripMenuItem";
+            this.moveUpToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Up)));
             this.moveUpToolStripMenuItem.Size = new System.Drawing.Size(227, 22);
             this.moveUpToolStripMenuItem.Text = "Move up";
             this.moveUpToolStripMenuItem.Click += new System.EventHandler(this.moveUpToolStripMenuItem_Click);
@@ -417,6 +419,7 @@
             // moveDownToolStripMenuItem
             // 
             this.moveDownToolStripMenuItem.Name = "moveDownToolStripMenuItem";
+            this.moveDownToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Down)));
             this.moveDownToolStripMenuItem.Size = new System.Drawing.Size(227, 22);
             this.moveDownToolStripMenuItem.Text = "Move down";
             this.moveDownToolStripMenuItem.Click += new System.EventHandler(this.moveDownToolStripMenuItem_Click);
@@ -424,6 +427,7 @@
             // moveTopToolStripMenuItem
             // 
             this.moveTopToolStripMenuItem.Name = "moveTopToolStripMenuItem";
+            this.moveTopToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Home)));
             this.moveTopToolStripMenuItem.Size = new System.Drawing.Size(227, 22);
             this.moveTopToolStripMenuItem.Text = "Move to top";
             this.moveTopToolStripMenuItem.Click += new System.EventHandler(this.moveTopToolStripMenuItem_Click);
@@ -431,6 +435,7 @@
             // moveBottomToolStripMenuItem
             // 
             this.moveBottomToolStripMenuItem.Name = "moveBottomToolStripMenuItem";
+            this.moveBottomToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.End)));
             this.moveBottomToolStripMenuItem.Size = new System.Drawing.Size(227, 22);
             this.moveBottomToolStripMenuItem.Text = "Move to bottom";
             this.moveBottomToolStripMenuItem.Click += new System.EventHandler(this.moveBottomToolStripMenuItem_Click);
@@ -443,6 +448,7 @@
             // toolStripMenuItemImport
             // 
             this.toolStripMenuItemImport.Name = "toolStripMenuItemImport";
+            this.toolStripMenuItemImport.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
             this.toolStripMenuItemImport.Size = new System.Drawing.Size(227, 22);
             this.toolStripMenuItemImport.Text = "Import...";
             this.toolStripMenuItemImport.Click += new System.EventHandler(this.toolStripMenuItem3_Click);
@@ -450,6 +456,7 @@
             // toolStripMenuItemExport
             // 
             this.toolStripMenuItemExport.Name = "toolStripMenuItemExport";
+            this.toolStripMenuItemExport.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
             this.toolStripMenuItemExport.Size = new System.Drawing.Size(227, 22);
             this.toolStripMenuItemExport.Text = "Export...";
             this.toolStripMenuItemExport.Click += new System.EventHandler(this.toolStripMenuItem4_Click);
@@ -581,7 +588,6 @@
             this.listViewGroups.TabIndex = 0;
             this.listViewGroups.UseCompatibleStateImageBehavior = false;
             this.listViewGroups.View = System.Windows.Forms.View.Details;
-            this.listViewGroups.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listViewGroups_KeyDown);
             // 
             // columnHeaderForName
             // 
@@ -609,6 +615,7 @@
             // newToolStripMenuItem
             // 
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
+            this.newToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.N)));
             this.newToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.newToolStripMenuItem.Text = "New...";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
@@ -616,6 +623,7 @@
             // toolStripMenuItemRename
             // 
             this.toolStripMenuItemRename.Name = "toolStripMenuItemRename";
+            this.toolStripMenuItemRename.ShortcutKeys = System.Windows.Forms.Keys.F2;
             this.toolStripMenuItemRename.Size = new System.Drawing.Size(161, 22);
             this.toolStripMenuItemRename.Text = "Rename...";
             this.toolStripMenuItemRename.Click += new System.EventHandler(this.ToolStripMenuItemRenameClick);
@@ -623,6 +631,7 @@
             // deleteToolStripMenuItem1
             // 
             this.deleteToolStripMenuItem1.Name = "deleteToolStripMenuItem1";
+            this.deleteToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Delete;
             this.deleteToolStripMenuItem1.Size = new System.Drawing.Size(161, 22);
             this.deleteToolStripMenuItem1.Text = "Delete...";
             this.deleteToolStripMenuItem1.Click += new System.EventHandler(this.deleteToolStripMenuItem1_Click);
@@ -635,6 +644,7 @@
             // moveUpToolStripMenuItem1
             // 
             this.moveUpToolStripMenuItem1.Name = "moveUpToolStripMenuItem1";
+            this.moveUpToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Up)));
             this.moveUpToolStripMenuItem1.Size = new System.Drawing.Size(161, 22);
             this.moveUpToolStripMenuItem1.Text = "Move up";
             this.moveUpToolStripMenuItem1.Click += new System.EventHandler(this.moveUpToolStripMenuItem1_Click);
@@ -642,6 +652,7 @@
             // moveDownToolStripMenuItem1
             // 
             this.moveDownToolStripMenuItem1.Name = "moveDownToolStripMenuItem1";
+            this.moveDownToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Down)));
             this.moveDownToolStripMenuItem1.Size = new System.Drawing.Size(161, 22);
             this.moveDownToolStripMenuItem1.Text = "Move down";
             this.moveDownToolStripMenuItem1.Click += new System.EventHandler(this.moveDownToolStripMenuItem1_Click);
@@ -649,6 +660,7 @@
             // moveToTopToolStripMenuItem
             // 
             this.moveToTopToolStripMenuItem.Name = "moveToTopToolStripMenuItem";
+            this.moveToTopToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Home)));
             this.moveToTopToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.moveToTopToolStripMenuItem.Text = "Move to top";
             this.moveToTopToolStripMenuItem.Click += new System.EventHandler(this.moveToTopToolStripMenuItem_Click);
@@ -656,6 +668,7 @@
             // moveToBottomToolStripMenuItem
             // 
             this.moveToBottomToolStripMenuItem.Name = "moveToBottomToolStripMenuItem";
+            this.moveToBottomToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.End)));
             this.moveToBottomToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.moveToBottomToolStripMenuItem.Text = "Move to bottom";
             this.moveToBottomToolStripMenuItem.Click += new System.EventHandler(this.moveToBottomToolStripMenuItem_Click);
@@ -668,6 +681,7 @@
             // importToolStripMenuItem
             // 
             this.importToolStripMenuItem.Name = "importToolStripMenuItem";
+            this.importToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
             this.importToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.importToolStripMenuItem.Text = "Import...";
             this.importToolStripMenuItem.Click += new System.EventHandler(this.importToolStripMenuItem_Click);
@@ -675,6 +689,7 @@
             // exportToolStripMenuItem
             // 
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
+            this.exportToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
             this.exportToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.exportToolStripMenuItem.Text = "Export...";
             this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);

--- a/src/Forms/MultipleReplace.cs
+++ b/src/Forms/MultipleReplace.cs
@@ -435,12 +435,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void ListViewRulesKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.KeyCode == Keys.Delete)
-            {
-                DeleteToolStripMenuItemClick(null, null);
-                e.SuppressKeyPress = true;
-            }
-            else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
+            if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
                 listViewRules.SelectAll();
                 e.SuppressKeyPress = true;
@@ -454,27 +449,6 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 listViewRules.InverseSelection();
                 e.SuppressKeyPress = true;
-            }
-            else if (listViewRules.SelectedItems.Count == 1)
-            {
-                if (e.KeyCode == Keys.Up && e.Control && !e.Alt && !e.Shift)
-                {
-                    moveUpToolStripMenuItem_Click(sender, e);
-                }
-
-                if (e.KeyCode == Keys.Down && e.Control && !e.Alt && !e.Shift)
-                {
-                    moveDownToolStripMenuItem_Click(sender, e);
-                }
-
-                if (e.KeyData == (Keys.Control | Keys.Home))
-                {
-                    moveTopToolStripMenuItem_Click(sender, e);
-                }
-                else if (e.KeyData == (Keys.Control | Keys.End))
-                {
-                    moveBottomToolStripMenuItem_Click(sender, e);
-                }
             }
         }
 
@@ -628,17 +602,6 @@ namespace Nikse.SubtitleEdit.Forms
             GeneratePreview();
         }
 
-        private void moveUpToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            int index = listViewRules.SelectedIndices[0];
-            if (index == 0)
-            {
-                return;
-            }
-
-            SwapRules(index, index - 1);
-        }
-
         private void SwapRules(int index, int index2)
         {
             if (_currentGroup == null)
@@ -674,12 +637,35 @@ namespace Nikse.SubtitleEdit.Forms
 
             listViewRules.Items[index].Selected = false;
             listViewRules.Items[index2].Selected = true;
+            listViewRules.Items[index2].Focused = true;
+            listViewRules.EnsureVisible(index2);
             GeneratePreview();
             listViewRules.ItemChecked += ListViewRulesItemChecked;
         }
 
+        private void moveUpToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (listViewRules.SelectedItems.Count != 1 || listViewRules.Items.Count < 2)
+            {
+                return;
+            }
+
+            int index = listViewRules.SelectedIndices[0];
+            if (index == 0)
+            {
+                return;
+            }
+
+            SwapRules(index, index - 1);
+        }
+
         private void moveDownToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            if (listViewRules.SelectedItems.Count != 1 || listViewRules.Items.Count < 2)
+            {
+                return;
+            }
+
             int index = listViewRules.SelectedIndices[0];
             if (index == listViewRules.Items.Count - 1)
             {
@@ -691,6 +677,11 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void moveTopToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            if (listViewRules.SelectedItems.Count != 1 || listViewRules.Items.Count < 2)
+            {
+                return;
+            }
+
             int index = listViewRules.SelectedIndices[0];
             if (index == 0)
             {
@@ -711,6 +702,11 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void moveBottomToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            if (listViewRules.SelectedItems.Count != 1 || listViewRules.Items.Count < 2)
+            {
+                return;
+            }
+
             int index = listViewRules.SelectedIndices[0];
             int bottomIndex = listViewRules.Items.Count - 1;
             if (index == bottomIndex)
@@ -725,6 +721,7 @@ namespace Nikse.SubtitleEdit.Forms
             listViewRules.Items[0].Selected = false;
             listViewRules.Items[bottomIndex].Selected = true;
             listViewRules.Items[bottomIndex].Focused = true;
+            listViewRules.EnsureVisible(bottomIndex);
             GeneratePreview();
         }
 
@@ -899,6 +896,8 @@ namespace Nikse.SubtitleEdit.Forms
                 if (group == focusGroup)
                 {
                     listViewGroups.Items[index].Selected = true;
+                    listViewGroups.Items[index].Focused = true;
+                    listViewGroups.EnsureVisible(index);
                 }
             }
             listViewGroups.EndUpdate();
@@ -1081,29 +1080,6 @@ namespace Nikse.SubtitleEdit.Forms
                 listViewFixes.Items.Clear();
             }
             UpdateViewFromModel(Configuration.Settings.MultipleSearchAndReplaceGroups, _currentGroup);
-        }
-
-        private void listViewGroups_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Delete)
-            {
-                deleteToolStripMenuItem1_Click(sender, null);
-                e.Handled = true;
-            }
-            else if (e.KeyData == (Keys.Control | Keys.Up))
-            {
-                moveUpToolStripMenuItem1_Click(sender, null);
-                e.Handled = true;
-            }
-            else if (e.KeyData == (Keys.Control | Keys.Down))
-            {
-                moveDownToolStripMenuItem1_Click(sender, null);
-                e.Handled = true;
-            }
-            else if (e.KeyCode == Keys.F2)
-            {
-                ToolStripMenuItemRenameClick(sender, e);
-            }
         }
 
         private void SwapGroups(int index, int index2)


### PR DESCRIPTION
Group context menu:
![image](https://user-images.githubusercontent.com/20923700/95023296-f45b3580-0684-11eb-8a6f-dc0844502bba.png)

Rules context menu:
![image](https://user-images.githubusercontent.com/20923700/95023299-fa511680-0684-11eb-9b23-6d73c07cc385.png)

Also fixed some issues where the items aren't visible nor focused after moving them.