### PR TITLE
Add underline access keys for "Find", "Count" and "Whole Word" in Find

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -565,12 +565,12 @@ Note: Do check free disk space.</WaveFileMalformed>
   </ExtractDateTimeInfo>
   <FindDialog>
     <Title>Find</Title>
-    <Find>Find</Find>
+    <Find>&amp;Find</Find>
     <Normal>&amp;Normal</Normal>
     <CaseSensitive>&amp;Case sensitive</CaseSensitive>
     <RegularExpression>Regular e&amp;xpression</RegularExpression>
-    <WholeWord>Whole word</WholeWord>
-    <Count>Count</Count>
+    <WholeWord>&amp;Whole word</WholeWord>
+    <Count>Coun&amp;t</Count>
     <XNumberOfMatches>{0:#,##0} matches</XNumberOfMatches>
     <OneMatch>One match</OneMatch>
   </FindDialog>

--- a/libse/Language.cs
+++ b/libse/Language.cs
@@ -758,12 +758,12 @@ namespace Nikse.SubtitleEdit.Core
             FindDialog = new LanguageStructure.FindDialog
             {
                 Title = "Find",
-                Find = "Find",
+                Find = "&Find",
                 Normal = "&Normal",
                 CaseSensitive = "&Case sensitive",
                 RegularExpression = "Regular e&xpression",
-                WholeWord = "Whole word",
-                Count = "Count",
+                WholeWord = "&Whole word",
+                Count = "Coun&t",
                 XNumberOfMatches = "{0:#,##0} matches",
                 OneMatch = "One match"
             };


### PR DESCRIPTION
Replace already has ones for "Find" and "Whole word" so I added the same ones to Find with one for Count.