### PR TITLE
Rename a button in "Measurement Converter"

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -26810,11 +26810,11 @@ namespace Nikse.SubtitleEdit.Forms
                 Input = selectedText,
                 IsOriginalActive = GetFocusedTextBox() == textBoxListViewTextAlternate,
             };
-            _measurementConverter.ReplaceClicked += measurementConverter_ReplaceClicked;
+            _measurementConverter.InsertClicked += measurementConverter_InsertClicked;
             _measurementConverter.Show(this);
         }
 
-        private void measurementConverter_ReplaceClicked(object sender, MeasurementConverter.ReplaceEventArgs e)
+        private void measurementConverter_InsertClicked(object sender, MeasurementConverter.InsertEventArgs e)
         {
             if (IsSubtitleLoaded)
             {

--- a/src/Forms/MeasurementConverter.Designer.cs
+++ b/src/Forms/MeasurementConverter.Designer.cs
@@ -37,7 +37,7 @@
             this.textBoxResult = new System.Windows.Forms.TextBox();
             this.linkLabel1 = new System.Windows.Forms.LinkLabel();
             this.checkBoxCloseOnInsert = new System.Windows.Forms.CheckBox();
-            this.buttonReplace = new System.Windows.Forms.Button();
+            this.buttonInsert = new System.Windows.Forms.Button();
             this.buttonOK = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
@@ -129,17 +129,17 @@
             this.checkBoxCloseOnInsert.Text = "Close on insert";
             this.checkBoxCloseOnInsert.UseVisualStyleBackColor = true;
             // 
-            // buttonReplace
+            // buttonInsert
             // 
-            this.buttonReplace.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonReplace.DialogResult = System.Windows.Forms.DialogResult.Yes;
-            this.buttonReplace.Location = new System.Drawing.Point(245, 155);
-            this.buttonReplace.Name = "buttonInsert";
-            this.buttonReplace.Size = new System.Drawing.Size(75, 23);
-            this.buttonReplace.TabIndex = 9;
-            this.buttonReplace.Text = "&Insert";
-            this.buttonReplace.UseVisualStyleBackColor = true;
-            this.buttonReplace.Click += new System.EventHandler(this.buttonReplace_Click);
+            this.buttonInsert.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonInsert.DialogResult = System.Windows.Forms.DialogResult.Yes;
+            this.buttonInsert.Location = new System.Drawing.Point(245, 155);
+            this.buttonInsert.Name = "buttonInsert";
+            this.buttonInsert.Size = new System.Drawing.Size(75, 23);
+            this.buttonInsert.TabIndex = 9;
+            this.buttonInsert.Text = "&Insert";
+            this.buttonInsert.UseVisualStyleBackColor = true;
+            this.buttonInsert.Click += new System.EventHandler(this.buttonInsert_Click);
             // 
             // buttonOK
             // 
@@ -167,7 +167,7 @@
             this.Controls.Add(this.textBoxResult);
             this.Controls.Add(this.linkLabel1);
             this.Controls.Add(this.checkBoxCloseOnInsert);
-            this.Controls.Add(this.buttonReplace);
+            this.Controls.Add(this.buttonInsert);
             this.Controls.Add(this.buttonOK);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.KeyPreview = true;
@@ -198,7 +198,7 @@
         private System.Windows.Forms.TextBox textBoxResult;
         private System.Windows.Forms.LinkLabel linkLabel1;
         private System.Windows.Forms.CheckBox checkBoxCloseOnInsert;
-        private System.Windows.Forms.Button buttonReplace;
+        private System.Windows.Forms.Button buttonInsert;
         private System.Windows.Forms.Button buttonOK;
     }
 }

--- a/src/Forms/MeasurementConverter.cs
+++ b/src/Forms/MeasurementConverter.cs
@@ -10,13 +10,13 @@ namespace Nikse.SubtitleEdit.Forms
 {
     public sealed partial class MeasurementConverter : Form
     {
-        public class ReplaceEventArgs : EventArgs
+        public class InsertEventArgs : EventArgs
         {
             public string Result { get; set; }
             public bool IsOriginalActive { get; set; }
         }
 
-        public event EventHandler<ReplaceEventArgs> ReplaceClicked;
+        public event EventHandler<InsertEventArgs> InsertClicked;
 
         public string Input { get; set; }
         public bool IsOriginalActive { get; set; }
@@ -243,9 +243,9 @@ namespace Nikse.SubtitleEdit.Forms
             textBoxInput_TextChanged(null, null);
         }
 
-        private void buttonReplace_Click(object sender, EventArgs e)
+        private void buttonInsert_Click(object sender, EventArgs e)
         {
-            ReplaceClicked?.Invoke(this, new ReplaceEventArgs { Result = Output, IsOriginalActive = IsOriginalActive });
+            InsertClicked?.Invoke(this, new InsertEventArgs { Result = Output, IsOriginalActive = IsOriginalActive });
 
             if (checkBoxCloseOnInsert.Checked)
             {


### PR DESCRIPTION
It was called "replace" but I renamed it "Insert" and forgot to rename the "variables".
I named it "Insert" because it doesn't just replace the selected text, by the way.