### PR TITLE
Netflix quality check time

### DIFF
--- a/libse/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
@@ -26,7 +26,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 
                 double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
                 var gapInFrames = SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds) - SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds);
-                if (gapInFrames >= 3 && gapInFrames <= 11)
+                if (gapInFrames >= 3 && gapInFrames <= 11 && !p.StartTime.IsMaxTime)
                 {
                     var fixedParagraph = new Paragraph(p, false) { EndTime = { TotalMilliseconds = next.StartTime.TotalMilliseconds - twoFramesGap } };
                     string comment = "3-11 frames gap => 2 frames gap";

--- a/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
@@ -24,7 +24,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                         jp.Text = NetflixImsc11Japanese.RemoveTags(jp.Text);
                     }
                     var charactersPerSeconds = Utilities.GetCharactersPerSecond(jp);
-                    if (charactersPerSeconds > controller.CharactersPerSecond)
+                    if (charactersPerSeconds > controller.CharactersPerSecond && !p.StartTime.IsMaxTime)
                     {
                         var fixedParagraph = new Paragraph(p, false);
                         while (Utilities.GetCharactersPerSecond(fixedParagraph) > controller.CharactersPerSecond)

--- a/libse/NetflixQualityCheck/NetflixCheckMinDuration.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckMinDuration.cs
@@ -25,7 +25,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                 }
 
                 var next = subtitle.GetParagraphOrDefault(index + 1);
-                if (p.Duration.TotalMilliseconds < 833)
+                if (p.Duration.TotalMilliseconds < 833 && !p.StartTime.IsMaxTime)
                 {
                     Paragraph fixedParagraph = null;
                     if (next == null || next.StartTime.TotalMilliseconds > p.StartTime.TotalMilliseconds + 834)

--- a/libse/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
@@ -13,7 +13,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
         /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
-            if (controller.Language == "ja")
+            if (controller.Language == "ja" || controller.Language == "ar")
             {
                 return;
             }

--- a/libse/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs
+++ b/libse/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs
@@ -20,7 +20,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                 Paragraph p = subtitle.Paragraphs[index];
                 var next = subtitle.GetParagraphOrDefault(index + 1);
                 double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
-                if (next != null && SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds + twoFramesGap) > SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds))
+                if (next != null && SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds + twoFramesGap) > SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds) && !p.StartTime.IsMaxTime)
                 {
                     var fixedParagraph = new Paragraph(p, false) { EndTime = { TotalMilliseconds = next.StartTime.TotalMilliseconds - twoFramesGap } };
                     string comment = "Minimum two frames gap";

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -27481,6 +27481,10 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 netflixController.FrameRate = _videoInfo.FramesPerSecond;
             }
+            else if (string.IsNullOrEmpty(_videoFileName) && CurrentFrameRate != 23.976 && CurrentFrameRate != 24)
+            {
+                netflixController.FrameRate = CurrentFrameRate;
+            }
 
             netflixController.RunChecks(_subtitle);
 
@@ -27494,7 +27498,7 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         if (form.ShowDialog(this) == DialogResult.OK)
                         {
-
+                            // Do nothing for now
                         }
                     }
                 }


### PR DESCRIPTION
Netflix's platform allows exporting text files without timecodes to do checks outside its platform, and in this case, some checks shouldn't run.

The second commit is in this case: If the user has a file with a specific frame rate and so he changes the frame rate in SE and imports the file, the checks should be run on that frame rate.
Real case scenario, I'm working on a project in the platform and its frame rate is 25.000 and not 24.000.

Also, numbers 1-10 shouldn't be spelled out in Arabic, so I excluded Arabic.