### PR TITLE
Unify shortcut name "ToggleTranslationOriginalInPreviews"

### DIFF
--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -6421,7 +6421,7 @@ $HorzAlign          =   Center
                     shortcuts.MainToolsBeamer = subNode.InnerText;
                 }
 
-                subNode = node.SelectSingleNode("MainToolsToggleTranslationOriginalInPreviews");
+                subNode = node.SelectSingleNode("MainEditToggleTranslationOriginalInPreviews");
                 if (subNode != null)
                 {
                     shortcuts.MainEditToggleTranslationOriginalInPreviews = subNode.InnerText;
@@ -8260,7 +8260,7 @@ $HorzAlign          =   Center
             textWriter.WriteElementString("MainToolsAppend", shortcuts.MainToolsAppend);
             textWriter.WriteElementString("MainToolsJoin", shortcuts.MainToolsJoin);
             textWriter.WriteElementString("MainToolsBeamer", shortcuts.MainToolsBeamer);
-            textWriter.WriteElementString("MainToolsToggleTranslationOriginalInPreviews", shortcuts.MainEditToggleTranslationOriginalInPreviews);
+            textWriter.WriteElementString("MainEditToggleTranslationOriginalInPreviews", shortcuts.MainEditToggleTranslationOriginalInPreviews);
             textWriter.WriteElementString("MainEditInverseSelection", shortcuts.MainEditInverseSelection);
             textWriter.WriteElementString("MainEditModifySelection", shortcuts.MainEditModifySelection);
             textWriter.WriteElementString("MainVideoOpen", shortcuts.MainVideoOpen);


### PR DESCRIPTION
It was named "MainToolsToggleTranslationOriginalInPreviews" in the settings file and "MainEditToggleTranslationOriginalInPreviews" in the shortcuts so it wasn't being imported correctly.