### PR TITLE
Center Measurement Converter

### DIFF
--- a/src/Forms/MeasurementConverter.Designer.cs
+++ b/src/Forms/MeasurementConverter.Designer.cs
@@ -181,6 +181,7 @@
             this.Activated += new System.EventHandler(this.MeasurementConverter_Activated);
             this.Deactivate += new System.EventHandler(this.MeasurementConverter_Deactivate);
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MeasurementConverter_FormClosed);
+            this.Load += new System.EventHandler(this.MeasurementConverter_Load);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MeasurementConverter_KeyDown);
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/src/Forms/MeasurementConverter.cs
+++ b/src/Forms/MeasurementConverter.cs
@@ -4897,5 +4897,10 @@ namespace Nikse.SubtitleEdit.Forms
                 Opacity = 0.5;
             }
         }
+
+        private void MeasurementConverter_Load(object sender, EventArgs e)
+        {
+            CenterToParent();
+        }
     }
 }


### PR DESCRIPTION
Closes: https://github.com/SubtitleEdit/subtitleedit/issues/4429

@niksedk Please close both if you prefer the current positioning.
Also, do let me know if you prefer using this in main:
```
            _measurementConverter.Top = (Top + (Height / 2)) - _measurementConverter.Height / 2;
            _measurementConverter.Left = (Left + (Width / 2)) - _measurementConverter.Width / 2;
```