### PR TITLE
Reset fields when deleting the last multiple replace group

### DIFF
--- a/src/Forms/MultipleReplace.cs
+++ b/src/Forms/MultipleReplace.cs
@@ -904,6 +904,11 @@ namespace Nikse.SubtitleEdit.Forms
             if (groups.Count == 0)
             {
                 groupBoxReplaces.Text = string.Empty;
+                textBoxFind.Text = string.Empty;
+                textBoxReplace.Text = string.Empty;
+                textBoxDescription.Text = string.Empty;
+                textBoxDescription.Text = string.Empty;
+                radioButtonNormal.Checked = true;
             }
         }
 


### PR DESCRIPTION
Deleting all groups in multiple replace used to leave some fields with the value of the last chosen rule before deletion.