### PR TITLE
Remove SceneChanges file when removing the last scene change

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -14736,6 +14736,10 @@ namespace Nikse.SubtitleEdit.Forms
                 if (idx >= 0)
                 {
                     RemoveSceneChange(idx);
+                    if (audioVisualizer.SceneChanges.Count == 0)
+                    {
+                        SceneChangeHelper.DeleteSceneChanges(_videoFileName);
+                    }
                 }
                 else
                 { // add scene change


### PR DESCRIPTION
Using the toggle scene change shortcut wasn't removing the file if the last scene change is removed.