### PR TITLE
Fix a bug in opening recent files

### DIFF
--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -5773,8 +5773,10 @@ $HorzAlign          =   Center
 
             foreach (XmlNode groupNode in doc.DocumentElement.SelectNodes("MultipleSearchAndReplaceGroups/Group"))
             {
-                var group = new MultipleSearchAndReplaceGroup();
-                group.Rules = new List<MultipleSearchAndReplaceSetting>();
+                var group = new MultipleSearchAndReplaceGroup
+                {
+                    Rules = new List<MultipleSearchAndReplaceSetting>()
+                };
                 subNode = groupNode.SelectSingleNode("Name");
                 if (subNode != null)
                 {

--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -4289,7 +4289,6 @@ namespace Nikse.SubtitleEdit.Forms
 
                 MakeHistoryForUndo(_language.BeforeNew);
                 ResetSubtitle(true);
-                Configuration.Settings.RecentFiles.Add(null, null, null);
             }
         }
 
@@ -11276,9 +11275,17 @@ namespace Nikse.SubtitleEdit.Forms
                 Configuration.Settings.General.SyncListViewWithVideoWhilePlaying = checkBoxSyncListViewWithVideoWhilePlaying.Checked;
                 Configuration.Settings.General.ShowWaveform = audioVisualizer.ShowWaveform;
                 Configuration.Settings.General.ShowSpectrogram = audioVisualizer.ShowSpectrogram;
-                if (Configuration.Settings.General.ShowRecentFiles && !string.IsNullOrEmpty(_fileName))
+                if (Configuration.Settings.General.ShowRecentFiles)
                 {
-                    Configuration.Settings.RecentFiles.Add(_fileName, FirstVisibleIndex, FirstSelectedIndex, VideoFileName, _subtitleAlternateFileName, Configuration.Settings.General.CurrentVideoOffsetInMs);
+                    if (!string.IsNullOrEmpty(_fileName))
+                    {
+                        Configuration.Settings.RecentFiles.Add(_fileName, FirstVisibleIndex, FirstSelectedIndex, VideoFileName, _subtitleAlternateFileName, Configuration.Settings.General.CurrentVideoOffsetInMs);
+
+                    }
+                    else
+                    {
+                        Configuration.Settings.RecentFiles.Add(null, null, null);
+                    }
                 }
 
                 if (SubtitleListview1.StateImageList?.Images.Count > 0)


### PR DESCRIPTION
After this https://github.com/SubtitleEdit/subtitleedit/commit/5a8c859b3c24d1408ccde174dfe2657154b97311 If you:
1. Open SE.
2. Close SE without opening a file.
3. Open SE again.

The last recent file will be opened even if it wasn't opened before closing SE.

I moved creating the empty entry from when using "New file" to when closing SE, seems to fix the issue.