### PR TITLE
Remove asterisk if the last line in an unsaved file is deleted

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -8315,6 +8315,11 @@ namespace Nikse.SubtitleEdit.Forms
                 labelAlternateCharactersPerSecond.Text = string.Empty;
                 labelTextAlternateLineLengths.Text = string.Empty;
                 labelTextAlternateLineTotal.Text = string.Empty;
+
+                if (Text.Contains('*'))
+                {
+                    Text = Text.RemoveChar('*').TrimEnd();
+                }
             }
         }
 


### PR DESCRIPTION
The asterisk used to not go away even if the last line in a file was deleted and the file wasn't saved.
![image](https://user-images.githubusercontent.com/20923700/98465177-1ab64880-21d0-11eb-8c52-d778e28b650c.png)

(The force pushes are just renaming the commit)