### PR TITLE
Add a hidden option to set Continuation Pause

### DIFF
--- a/libse/ContinuationUtilities.cs
+++ b/libse/ContinuationUtilities.cs
@@ -1261,7 +1261,7 @@ namespace Nikse.SubtitleEdit.Core
 
         public static int GetMinimumGapMs()
         {
-            return Math.Max(Configuration.Settings.General.MinimumMillisecondsBetweenLines + 5, 300);
+            return Math.Max(Configuration.Settings.General.MinimumMillisecondsBetweenLines + 5, Configuration.Settings.General.ContinuationPause);
         }
 
         public static string GetContinuationStyleName(ContinuationStyle continuationStyle)

--- a/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
+++ b/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
@@ -60,7 +60,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 var shouldProcess = true;
 
                 // Detect gap
-                bool gap = pNext.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > minGapMs;
+                bool gap = pNext.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds >= minGapMs;
 
                 // Convert for Arabic
                 if (callbacks.Language == "ar")

--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -1056,6 +1056,7 @@ $HorzAlign          =   Center
         public double SubtitleMaximumWordsPerMinute { get; set; }
         public DialogType DialogStyle { get; set; }
         public ContinuationStyle ContinuationStyle { get; set; }
+        public int ContinuationPause { get; set; }
         public bool FixContinuationStyleUncheckInsertsAllCaps { get; set; }
         public bool FixContinuationStyleUncheckInsertsItalic { get; set; }
         public bool FixContinuationStyleUncheckInsertsLowercase { get; set; }
@@ -1211,6 +1212,7 @@ $HorzAlign          =   Center
             SubtitleMaximumWordsPerMinute = 300;
             DialogStyle = DialogType.DashBothLinesWithSpace;
             ContinuationStyle = ContinuationStyle.None;
+            ContinuationPause = 2000;
             FixContinuationStyleUncheckInsertsAllCaps = true;
             FixContinuationStyleUncheckInsertsItalic = true;
             FixContinuationStyleUncheckInsertsLowercase = true;
@@ -2946,6 +2948,12 @@ $HorzAlign          =   Center
             if (subNode != null)
             {
                 settings.General.ContinuationStyle = (ContinuationStyle)Enum.Parse(typeof(ContinuationStyle), subNode.InnerText);
+            }
+
+            subNode = node.SelectSingleNode("ContinuationPause");
+            if (subNode != null)
+            {
+                settings.General.ContinuationPause = Convert.ToInt32(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
             subNode = node.SelectSingleNode("FixContinuationStyleUncheckInsertsAllCaps");
@@ -7655,6 +7663,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("SubtitleMaximumWordsPerMinute", settings.General.SubtitleMaximumWordsPerMinute.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("DialogStyle", settings.General.DialogStyle.ToString());
                 textWriter.WriteElementString("ContinuationStyle", settings.General.ContinuationStyle.ToString());
+                textWriter.WriteElementString("ContinuationPause", settings.General.ContinuationPause.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("FixContinuationStyleUncheckInsertsAllCaps", settings.General.FixContinuationStyleUncheckInsertsAllCaps.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("FixContinuationStyleUncheckInsertsItalic", settings.General.FixContinuationStyleUncheckInsertsItalic.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("FixContinuationStyleUncheckInsertsLowercase", settings.General.FixContinuationStyleUncheckInsertsLowercase.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
Netflix said today, `A pause has been defined in all TTSGs as being 2 seconds or longer`.

Right now, Fix continuation style suggests removing the ellipses when the gap between 2 lines is 300 or less, meaning it considers the pause as 300 ms, if the gap is more than 300 ms and the first line has ellipses, it doesn't suggest removing the ellipses.
Netflix said that a pause is 2 seconds, which means if the gap between two lines is 2 seconds or more, the ellipses should be removed, SE doesn't handle it this way.
In this PR I made the pause customizable, with the default of 2 seconds.