### PR TITLE
Move CodePageKorean above CodePageChineseSimplified to detect correctly

### DIFF
--- a/libse/SubtitleFormats/Pac.cs
+++ b/libse/SubtitleFormats/Pac.cs
@@ -1692,9 +1692,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     { CodePageHebrew, "he" },
                     { CodePageThai, "th" },
                     { CodePageCyrillic, "ru-uk-mk" },
+                    { CodePageKorean, "ko" },
                     { CodePageChineseTraditional, "zh" },
                     { CodePageChineseSimplified, "zh" },
-                    { CodePageKorean, "ko" },
                     { CodePageJapanese, "ja" }
                 };
                 foreach (var kvp in dictionary)


### PR DESCRIPTION
Hello, and thank you very kindly for maintaining this project!

A colleague (@jason-rayles-nbcuni) and I have found an occasion where the detected codePage of a Korean code page input .pac file is falsely detected as Chinese-Simplified.

We are calling the application via the command-line like so:
`SubtitleEdit.exe /convert truncated-30.pac srt`

The input .pac file is available at: https://subtitleedit-fix-wrong-codepage-convert-example.s3.amazonaws.com/truncated-30.pac

Without this change, the output file truncated-30.srt is written with the Chinese code page, with the change it is written with the Korean code page (desired outcome).

Looking forward to your thoughts!