### PR TITLE
Allow for "Alt" shortcuts when a textbox is focused

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -13791,7 +13791,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             var fc = FindFocusedControl(this);
-            if (fc != null && e.Modifiers != Keys.Control && e.Modifiers != (Keys.Control | Keys.Shift) && e.Modifiers != (Keys.Control | Keys.Alt) && e.Modifiers != (Keys.Control | Keys.Shift | Keys.Alt))
+            if (fc != null && e.Modifiers != Keys.Control && e.Modifiers != Keys.Alt && e.Modifiers != (Keys.Control | Keys.Shift) && e.Modifiers != (Keys.Control | Keys.Alt) && e.Modifiers != (Keys.Control | Keys.Shift | Keys.Alt))
             {
                 // do not check for shortcuts if text is being entered and a textbox is focused
                 if ((fc.Name == textBoxListViewText.Name || fc.Name == textBoxListViewTextAlternate.Name || fc.Name == textBoxSearchWord.Name) &&


### PR DESCRIPTION
Some shortcuts using "Alt" didn't use to work when a Textbox is focused.

Closes https://github.com/SubtitleEdit/subtitleedit/issues/4490