### PR TITLE
remove boilerplate code in file-path-comparer

### DIFF
--- a/libse/FilePathComparer.cs
+++ b/libse/FilePathComparer.cs
@@ -6,64 +6,39 @@ namespace Nikse.SubtitleEdit.Core
 {
     public abstract class FilePathComparer : IEqualityComparer<string>, IComparer<string>
     {
-        private sealed class WindowsFilePathComparer : FilePathComparer
-        {
-            public override int Compare(string path1, string path2)
-            {
-                return ReferenceEquals(path1, path2)
-                     ? 0
-                     : ReferenceEquals(path2, null)
-                     ? 1
-                     : ReferenceEquals(path1, null)
-                     ? -1
-                     : string.Compare(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase);
-            }
-
-            public override bool Equals(string path1, string path2)
-            {
-                return ReferenceEquals(path1, path2) ||
-                       (!(ReferenceEquals(path1, null) || ReferenceEquals(path2, null)) &&
-                        string.Equals(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase));
-            }
-
-            public override int GetHashCode(string path)
-            {
-                return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).ToUpperInvariant().GetHashCode();
-            }
-        }
-
-        private sealed class UnixFilePathComparer : FilePathComparer
-        {
-            public override int Compare(string path1, string path2)
-            {
-                return ReferenceEquals(path1, path2)
-                     ? 0
-                     : ReferenceEquals(path2, null)
-                     ? 1
-                     : ReferenceEquals(path1, null)
-                     ? -1
-                     : string.Compare(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), StringComparison.Ordinal);
-            }
-
-            public override bool Equals(string path1, string path2)
-            {
-                return ReferenceEquals(path1, path2) ||
-                       !(ReferenceEquals(path1, null) || ReferenceEquals(path2, null)) &&
-                       string.Equals(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), StringComparison.Ordinal);
-            }
-
-            public override int GetHashCode(string path)
-            {
-                return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).GetHashCode();
-            }
-        }
+        private sealed class WindowsFilePathComparer : FilePathComparer { }
+        private sealed class UnixFilePathComparer : FilePathComparer { }
 
         public static FilePathComparer Native => Configuration.IsRunningOnWindows ? Windows : Unix;
         public static FilePathComparer Windows => new WindowsFilePathComparer();
         public static FilePathComparer Unix => new UnixFilePathComparer();
 
-        public abstract int Compare(string path1, string path2);
-        public abstract bool Equals(string path1, string path2);
-        public abstract int GetHashCode(string path);
+        public int Compare(string path1, string path2)
+        {
+            return ReferenceEquals(path1, path2)
+                    ? 0
+                    : path2 is null
+                    ? 1
+                    : path1 is null
+                    ? -1
+                    : string.Compare(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), GetComparison());
+        }
+
+        public bool Equals(string path1, string path2)
+        {
+            return ReferenceEquals(path1, path2) ||
+                       (!(path1 is null || path2 is null) &&
+                        string.Equals(path1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), path2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), GetComparison()));
+        }
+
+        private StringComparison GetComparison() => IsWindowsInstance() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        private bool IsWindowsInstance() => (this is UnixFilePathComparer) == false;
+
+        public int GetHashCode(string path)
+        {
+            return IsWindowsInstance() ? path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).ToUpperInvariant().GetHashCode()
+                : path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
removes boilatecodes from file comparison,... the only difference was with "StringComparison"  - Windows ignore cases when comparing file paths while linux doe the invert 