### PR TITLE
Change frame color + Don't set font size for 3.5

### DIFF
--- a/libse/Settings.cs
+++ b/libse/Settings.cs
@@ -1183,12 +1183,9 @@ $HorzAlign          =   Center
                 SubtitleFontName = "Times New Roman";
             }
 
-            SubtitleFontSize = 14;
+            SubtitleFontSize = 10;
             SubtitleListViewFontSize = 10;
-            SubtitleTextBoxSyntaxColor = true;
-            SubtitleTextBoxHtmlColor = Color.CornflowerBlue;
-            SubtitleTextBoxAssColor = Color.BlueViolet;
-            SubtitleFontBold = true;
+            SubtitleFontBold = false;
             SubtitleFontColor = Color.Black;
             MeasureFontName = "Arial";
             MeasureFontSize = 24;
@@ -2318,13 +2315,6 @@ $HorzAlign          =   Center
                     {
                         settings.Shortcuts.MainTranslateGoogleTranslate = "Control+Shift+G";
                         settings.Tools.MicrosoftTranslatorTokenEndpoint = "https://api.cognitive.microsoft.com/sts/v1.0/issueToken";
-                    }
-                    
-                    if (settings.Version.StartsWith("3.5", StringComparison.Ordinal) ||
-                        string.IsNullOrEmpty(settings.Version))
-                    {
-                        settings.General.SubtitleFontSize = 14;
-                        settings.General.SubtitleFontBold = true;
                     }
                 }
                 catch (Exception exception)

--- a/src/Controls/SETextBox.cs
+++ b/src/Controls/SETextBox.cs
@@ -81,7 +81,7 @@ namespace Nikse.SubtitleEdit.Controls
             Controls.Add(textBox);
             textBox.Dock = DockStyle.Fill;
             textBox.Enter += (sender, args) => { BackColor = SystemColors.Highlight; };
-            textBox.Leave += (sender, args) => { BackColor = SystemColors.ActiveBorder; };
+            textBox.Leave += (sender, args) => { BackColor = SystemColors.WindowFrame; };
             textBox.TextChanged += (sender, args) => { TextChanged?.Invoke(sender, args); };
         }
 


### PR DESCRIPTION
You were setting the font size to 14, that's too big.
Also, we're still in 3.5, which would cause the font size to change each time we open 3.5.18.

Change frame color, the old one makes the text box seem inactive.