### PR TITLE
Don't try to convert casing if the language is case-insensitive

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -9578,7 +9578,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private string ToggleCasing(string text)
         {
-            if (string.IsNullOrWhiteSpace(text))
+            if (string.IsNullOrWhiteSpace(text) || text.ToLower() == text.ToUpper())
             {
                 return text;
             }


### PR DESCRIPTION
No need to try to toggle casing if the language is case-insensitive.