### PR TITLE
Set frame color after settings

### DIFF
--- a/src/Forms/Main.cs
+++ b/src/Forms/Main.cs
@@ -4744,8 +4744,8 @@ namespace Nikse.SubtitleEdit.Forms
                 textBoxListViewTextAlternate.Initialize(Configuration.Settings.General.SubtitleTextBoxSyntaxColor);
                 RefreshSelectedParagraph();
             }
-            textBoxListViewText.BackColor = SystemColors.WindowFrame;
-            textBoxListViewTextAlternate.BackColor = SystemColors.WindowFrame;
+            textBoxListViewText.BackColor = !IsSubtitleLoaded ? SystemColors.ActiveBorder : SystemColors.WindowFrame;
+            textBoxListViewTextAlternate.BackColor = !IsSubtitleLoaded ? SystemColors.ActiveBorder : SystemColors.WindowFrame;
 
             SubtitleListview1.SyntaxColorAllLines(_subtitle);
             mediaPlayer.LastParagraph = null;


### PR DESCRIPTION
It used to be that after opening the settings, the frame color is set to window frame even if no subtitle is loaded:
![image](https://user-images.githubusercontent.com/20923700/99263881-6e581000-2828-11eb-9cf1-9788678535e7.png)
