### PR TITLE
Fix another typo for RichTextBox in Paste

### DIFF
--- a/src/ui/Controls/SETextBox.cs
+++ b/src/ui/Controls/SETextBox.cs
@@ -738,7 +738,7 @@ namespace Nikse.SubtitleEdit.Controls
             {
                 _textBox.Paste();
             }
-            else if (_textBox != null)
+            else if (_uiTextBox!= null)
             {
                 _uiTextBox?.Paste();
             }


### PR DESCRIPTION
@niksedk **Also, double-clicking a word or using Control + Shift + Arrrow in the normal text box is wrong:**

![image](https://user-images.githubusercontent.com/20923700/100669068-80c46480-3365-11eb-8a19-3ede514497c6.png)

I noticed you removed:
```
            if (m.Msg == WM_DBLCLICK || m.Msg == WM_LBUTTONDBLCLK)
            {
                UiUtil.SelectWordAtCaret(this);
                return;
            }
```

From WndProc, but it doesn't work even if I add it back.