### PR TITLE
Work on names and language file

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -2739,6 +2739,7 @@ Keep changes?</KeepChangesMessage>
     <ErrorUnicodeEncodingOnly>Watermark only works with unicode file encoding.</ErrorUnicodeEncodingOnly>
   </Watermark>
   <Waveform>
+    <AddWaveformAndSpectrogram>Add waveform/spectrogram</AddWaveformAndSpectrogram>
     <ClickToAddWaveform>Click to add waveform</ClickToAddWaveform>
     <ClickToAddWaveformAndSpectrogram>Click to add waveform/spectrogram</ClickToAddWaveformAndSpectrogram>
     <Seconds>seconds</Seconds>

--- a/src/libse/Language.cs
+++ b/src/libse/Language.cs
@@ -3101,6 +3101,7 @@ Keep changes?",
 
             Waveform = new LanguageStructure.Waveform
             {
+                AddWaveformAndSpectrogram = "Add waveform/spectrogram",
                 ClickToAddWaveform = "Click to add waveform",
                 ClickToAddWaveformAndSpectrogram = "Click to add waveform/spectrogram",
                 Seconds = "seconds",

--- a/src/libse/LanguageDeserializer.cs
+++ b/src/libse/LanguageDeserializer.cs
@@ -7459,6 +7459,9 @@ namespace Nikse.SubtitleEdit.Core
                 case "Watermark/ErrorUnicodeEncodingOnly":
                     language.Watermark.ErrorUnicodeEncodingOnly = reader.Value;
                     break;
+                case "Waveform/AddWaveformAndSpectrogram":
+                    language.Waveform.AddWaveformAndSpectrogram = reader.Value;
+                    break;
                 case "Waveform/ClickToAddWaveform":
                     language.Waveform.ClickToAddWaveform = reader.Value;
                     break;

--- a/src/libse/LanguageStructure.cs
+++ b/src/libse/LanguageStructure.cs
@@ -2957,6 +2957,7 @@
 
         public class Waveform
         {
+            public string AddWaveformAndSpectrogram { get; set; }
             public string ClickToAddWaveform { get; set; }
             public string ClickToAddWaveformAndSpectrogram { get; set; }
             public string Seconds { get; set; }

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -112,6 +112,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripMenuItemImportTimeCodes = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemImportFromVideo = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemImportBluRaySup = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemImportBluraySupFileForEdit = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemImportSubIdx = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemImportDvdSubtitles = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemImportOcrHardSub = new System.Windows.Forms.ToolStripMenuItem();
@@ -528,7 +529,6 @@ namespace Nikse.SubtitleEdit.Forms
             this.imageListPlayRate = new System.Windows.Forms.ImageList(this.components);
             this.timerTextUndo = new System.Windows.Forms.Timer(this.components);
             this.timerAlternateTextUndo = new System.Windows.Forms.Timer(this.components);
-            this.bluraySupFileForEditToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
@@ -1199,7 +1199,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripMenuItemImportTimeCodes,
             this.toolStripMenuItemImportFromVideo,
             this.toolStripMenuItemImportBluRaySup,
-            this.bluraySupFileForEditToolStripMenuItem,
+            this.toolStripMenuItemImportBluraySupFileForEdit,
             this.toolStripMenuItemImportSubIdx,
             this.toolStripMenuItemImportDvdSubtitles,
             this.toolStripMenuItemImportOcrHardSub,
@@ -1242,6 +1242,13 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripMenuItemImportBluRaySup.Size = new System.Drawing.Size(330, 22);
             this.toolStripMenuItemImportBluRaySup.Text = "Blu-ray sup file for OCR...";
             this.toolStripMenuItemImportBluRaySup.Click += new System.EventHandler(this.toolStripMenuItemImportBluRaySup_Click);
+            // 
+            // toolStripMenuItemImportBluraySupFileForEdit
+            // 
+            this.toolStripMenuItemImportBluraySupFileForEdit.Name = "toolStripMenuItemImportBluraySupFileForEdit";
+            this.toolStripMenuItemImportBluraySupFileForEdit.Size = new System.Drawing.Size(330, 22);
+            this.toolStripMenuItemImportBluraySupFileForEdit.Text = "Blu-ray sup file for edit...";
+            this.toolStripMenuItemImportBluraySupFileForEdit.Click += new System.EventHandler(this.toolStripMenuItemImportBluraySupFileForEdit_Click);
             // 
             // toolStripMenuItemImportSubIdx
             // 
@@ -5131,13 +5138,6 @@ namespace Nikse.SubtitleEdit.Forms
             this.timerAlternateTextUndo.Interval = 700;
             this.timerAlternateTextUndo.Tick += new System.EventHandler(this.TimerAlternateTextUndoTick);
             // 
-            // bluraySupFileForEditToolStripMenuItem
-            // 
-            this.bluraySupFileForEditToolStripMenuItem.Name = "bluraySupFileForEditToolStripMenuItem";
-            this.bluraySupFileForEditToolStripMenuItem.Size = new System.Drawing.Size(330, 22);
-            this.bluraySupFileForEditToolStripMenuItem.Text = "Blu-ray sup file for edit...";
-            this.bluraySupFileForEditToolStripMenuItem.Click += new System.EventHandler(this.bluraySupFileForEditToolStripMenuItem_Click);
-            // 
             // Main
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -5519,6 +5519,7 @@ namespace Nikse.SubtitleEdit.Forms
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemImportTimeCodes;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemImportFromVideo;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemImportBluRaySup;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemImportBluraySupFileForEdit;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemImportSubIdx;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemImportDvdSubtitles;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemImportOcrHardSub;
@@ -5709,6 +5710,5 @@ namespace Nikse.SubtitleEdit.Forms
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemAssaStyles;
         private System.Windows.Forms.ToolStripMenuItem openSecondSubtitleToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aSSStylesToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem bluraySupFileForEditToolStripMenuItem;
     }
 }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -1398,7 +1398,7 @@ namespace Nikse.SubtitleEdit.Forms
             toolStripMenuItemImportSubIdx.Text = _language.Menu.File.ImportOcrVobSubSubtitle;
             toolStripButtonGetFrameRate.ToolTipText = _language.GetFrameRateFromVideoFile;
             toolStripMenuItemImportBluRaySup.Text = _language.Menu.File.ImportBluRaySupFile;
-            bluraySupFileForEditToolStripMenuItem.Text = _language.Menu.File.ImportBluRaySupFileEdit;
+            toolStripMenuItemImportBluraySupFileForEdit.Text = _language.Menu.File.ImportBluRaySupFileEdit;
             toolStripMenuItemImportFromVideo.Text = _language.Menu.File.ImportSubtitleFromVideoFile;
             toolStripMenuItemImportManualAnsi.Text = _language.Menu.File.ImportSubtitleWithManualChosenEncoding;
             toolStripMenuItemImportText.Text = _language.Menu.File.ImportText;
@@ -28914,7 +28914,7 @@ namespace Nikse.SubtitleEdit.Forms
             splitContainerListViewAndText_SplitterMoved(null, null);
         }
 
-        private void bluraySupFileForEditToolStripMenuItem_Click(object sender, EventArgs e)
+        private void toolStripMenuItemImportBluraySupFileForEdit_Click(object sender, EventArgs e)
         {
             if (ContinueNewOrExit())
             {

--- a/src/ui/Forms/Settings.cs
+++ b/src/ui/Forms/Settings.cs
@@ -1405,7 +1405,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             var audioVisualizerNode = new ShortcutNode(language.WaveformAndSpectrogram);
-            AddNode(audioVisualizerNode, Configuration.Settings.Language.Waveform.ClickToAddWaveformAndSpectrogram, nameof(Configuration.Settings.Shortcuts.WaveformAdd));
+            AddNode(audioVisualizerNode, Configuration.Settings.Language.Waveform.AddWaveformAndSpectrogram, nameof(Configuration.Settings.Shortcuts.WaveformAdd));
             AddNode(audioVisualizerNode, Configuration.Settings.Language.Waveform.ZoomIn, nameof(Configuration.Settings.Shortcuts.WaveformZoomIn));
             AddNode(audioVisualizerNode, Configuration.Settings.Language.Waveform.ZoomOut, nameof(Configuration.Settings.Shortcuts.WaveformZoomOut));
             AddNode(audioVisualizerNode, language.VerticalZoom, nameof(Configuration.Settings.Shortcuts.WaveformVerticalZoom));


### PR DESCRIPTION
Add a language tag for this:
![image](https://user-images.githubusercontent.com/20923700/101531443-f6e74d80-399b-11eb-9e07-74a2c4b9e20c.png)

to become: "Add waveform/spectrogram".

Also, unified the name of the newly added import menu item.