### PR TITLE
Refresh the waveform on video drop

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -18936,6 +18936,13 @@ namespace Nikse.SubtitleEdit.Forms
                     SetWaveformPosition(0, 0, 0);
                     timerWaveform.Start();
                 }
+                else if (audioVisualizer.WavePeaks != null)
+                {
+                    audioVisualizer.WavePeaks = null;
+                    audioVisualizer.SetSpectrogram(null);
+                    audioVisualizer.SceneChanges = new List<double>();
+                    audioVisualizer.Chapters = new List<MatroskaChapter>();
+                }
 
                 Cursor = Cursors.Default;
 
@@ -19953,12 +19960,9 @@ namespace Nikse.SubtitleEdit.Forms
             openFileDialog1.FileName = string.Empty;
             if (openFileDialog1.ShowDialog() == DialogResult.OK)
             {
-                if (audioVisualizer.WavePeaks != null)
+                if (openFileDialog1.FileName == VideoFileName)
                 {
-                    audioVisualizer.WavePeaks = null;
-                    audioVisualizer.SetSpectrogram(null);
-                    audioVisualizer.SceneChanges = new List<double>();
-                    audioVisualizer.Chapters = new List<MatroskaChapter>();
+                    return;
                 }
 
                 openFileDialog1.InitialDirectory = Path.GetDirectoryName(openFileDialog1.FileName);
@@ -21787,6 +21791,11 @@ namespace Nikse.SubtitleEdit.Forms
                         var dirName = Path.GetDirectoryName(fileName);
                         saveFileDialog1.InitialDirectory = dirName;
                         openFileDialog1.InitialDirectory = dirName;
+                    }
+
+                    if (fileName == VideoFileName)
+                    {
+                        return;
                     }
 
                     VideoFileName = fileName;


### PR DESCRIPTION
Should close https://github.com/SubtitleEdit/subtitleedit/issues/2840

1. Reset the waveform on video drop if the video is new and has no wave file.
2. Don't reload the video on drop if it's the same loaded video.
3. Don't reload the video when opening from `Open video` if it's the same loaded video.