### PR TITLE
Only add empty entry if there are recent files

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -11414,7 +11414,7 @@ namespace Nikse.SubtitleEdit.Forms
                         Configuration.Settings.RecentFiles.Add(_fileName, FirstVisibleIndex, FirstSelectedIndex, VideoFileName, _subtitleAlternateFileName, Configuration.Settings.General.CurrentVideoOffsetInMs);
 
                     }
-                    else
+                    else if (Configuration.Settings.RecentFiles.Files.Count > 0)
                     {
                         Configuration.Settings.RecentFiles.Add(null, null, null);
                     }


### PR DESCRIPTION
Just so this doesn't happen:
![image](https://user-images.githubusercontent.com/20923700/101807385-ba435f80-3b1d-11eb-807d-958e8885abe5.png)

It also doesn't make sense to add it if we don't need to indicate that no filed was opened.
