### PR TITLE
Add "Stop" shortcut for video player

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1847,6 +1847,7 @@ $HorzAlign          =   Center
         public string MainVideoOpen { get; set; }
         public string MainVideoClose { get; set; }
         public string MainVideoPause { get; set; }
+        public string MainVideoStop { get; set; }
         public string MainVideoPlayFromJustBefore { get; set; }
         public string MainVideoPlayFromBeginning { get; set; }
         public string MainVideoPlayPauseToggle { get; set; }
@@ -6602,6 +6603,12 @@ $HorzAlign          =   Center
                     shortcuts.MainVideoPause = subNode.InnerText;
                 }
 
+                subNode = node.SelectSingleNode("MainVideoStop");
+                if (subNode != null)
+                {
+                    shortcuts.MainVideoStop = subNode.InnerText;
+                }
+
                 subNode = node.SelectSingleNode("MainVideoPlayFromJustBefore");
                 if (subNode != null)
                 {
@@ -8488,6 +8495,7 @@ $HorzAlign          =   Center
             textWriter.WriteElementString("MainVideoOpen", shortcuts.MainVideoOpen);
             textWriter.WriteElementString("MainVideoClose", shortcuts.MainVideoClose);
             textWriter.WriteElementString("MainVideoPause", shortcuts.MainVideoPause);
+            textWriter.WriteElementString("MainVideoStop", shortcuts.MainVideoStop);
             textWriter.WriteElementString("MainVideoPlayFromJustBefore", shortcuts.MainVideoPlayFromJustBefore);
             textWriter.WriteElementString("MainVideoPlayFromBeginning", shortcuts.MainVideoPlayFromBeginning);
             textWriter.WriteElementString("MainVideoPlayPauseToggle", shortcuts.MainVideoPlayPauseToggle);

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -14509,7 +14509,6 @@ namespace Nikse.SubtitleEdit.Forms
             else if (_shortcuts.MainVideoPlayFromBeginning == e.KeyData)
             {
                 mediaPlayer.Stop();
-                mediaPlayer.CurrentPosition = 0;
                 mediaPlayer.Play();
                 e.SuppressKeyPress = true;
             }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -14493,6 +14493,14 @@ namespace Nikse.SubtitleEdit.Forms
                     e.SuppressKeyPress = true;
                 }
             }
+            else if (e.KeyData == _shortcuts.VideoStop)
+            {
+                if (mediaPlayer.VideoPlayer != null)
+                {
+                    mediaPlayer.Stop();
+                    e.SuppressKeyPress = true;
+                }
+            }
             else if (_shortcuts.MainVideoPlayFromJustBefore == e.KeyData)
             {
                 buttonBeforeText_Click(null, null);

--- a/src/ui/Forms/Options/Settings.cs
+++ b/src/ui/Forms/Options/Settings.cs
@@ -1208,6 +1208,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             AddNode(videoNode, Configuration.Settings.Language.Main.Menu.Video.CloseVideo, nameof(Configuration.Settings.Shortcuts.MainVideoClose), true);
             AddNode(videoNode, language.TogglePlayPause, nameof(Configuration.Settings.Shortcuts.MainVideoPlayPauseToggle));
             AddNode(videoNode, language.Pause, nameof(Configuration.Settings.Shortcuts.MainVideoPause));
+            AddNode(videoNode, Configuration.Settings.Language.Main.VideoControls.Stop, nameof(Configuration.Settings.Shortcuts.MainVideoStop));
             AddNode(videoNode, Configuration.Settings.Language.Main.VideoControls.PlayFromJustBeforeText, nameof(Configuration.Settings.Shortcuts.MainVideoPlayFromJustBefore));
             AddNode(videoNode, Configuration.Settings.Language.Main.VideoControls.PlayFromBeginning, nameof(Configuration.Settings.Shortcuts.MainVideoPlayFromBeginning));
             AddNode(videoNode, Configuration.Settings.Language.Main.Menu.Video.ShowHideVideo, nameof(Configuration.Settings.Shortcuts.MainVideoShowHideVideo), true);

--- a/src/ui/Logic/MainShortcuts.cs
+++ b/src/ui/Logic/MainShortcuts.cs
@@ -30,6 +30,7 @@ namespace Nikse.SubtitleEdit.Logic
         public Keys MainVideoFoucsSetVideoPosition { get; set; }
         public Keys ToggleVideoDockUndock { get; set; }
         public Keys VideoPause { get; set; }
+        public Keys VideoStop { get; set; }
         public Keys VideoPlayPauseToggle { get; set; }
         public Keys MainVideoPlayFromJustBefore { get; set; }
         public Keys MainVideoPlayFromBeginning { get; set; }
@@ -214,6 +215,7 @@ namespace Nikse.SubtitleEdit.Logic
             MainVideoPlayFromJustBefore = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoPlayFromJustBefore);
             MainVideoPlayFromBeginning = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoPlayFromBeginning);
             VideoPause = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoPause);
+            VideoStop = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoStop);
             MainVideoFoucsSetVideoPosition = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoFoucsSetVideoPosition);
             ToggleVideoDockUndock = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoToggleVideoControls);
             VideoPlayPauseToggle = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoPlayPauseToggle);


### PR DESCRIPTION
AKA Go to the beginning of the video without playing.
Closes https://github.com/SubtitleEdit/subtitleedit/issues/4584

As for the second commit, `Stop()` already does `mediaPlayer.CurrentPosition = 0;`
So there is no need for it.