### PR TITLE
Better align some controls

### DIFF
--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -4967,7 +4967,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.buttonPrevious.Name = "buttonPrevious";
             this.buttonPrevious.Size = new System.Drawing.Size(72, 23);
             this.buttonPrevious.TabIndex = 2;
-            this.buttonPrevious.Text = "< Prev ";
+            this.buttonPrevious.Text = "< Prev";
             this.buttonPrevious.UseVisualStyleBackColor = true;
             this.buttonPrevious.Click += new System.EventHandler(this.ButtonPreviousClick);
             // 

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -3240,7 +3240,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             // buttonModeAdjust
             // 
-            this.buttonModeAdjust.Location = new System.Drawing.Point(141, 8);
+            this.buttonModeAdjust.Location = new System.Drawing.Point(140, 8);
             this.buttonModeAdjust.Name = "buttonModeAdjust";
             this.buttonModeAdjust.Size = new System.Drawing.Size(65, 23);
             this.buttonModeAdjust.TabIndex = 2;
@@ -4419,7 +4419,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             this.labelDurationWarning.AutoSize = true;
             this.labelDurationWarning.ForeColor = System.Drawing.Color.Red;
-            this.labelDurationWarning.Location = new System.Drawing.Point(122, 64);
+            this.labelDurationWarning.Location = new System.Drawing.Point(122, 54);
             this.labelDurationWarning.Name = "labelDurationWarning";
             this.labelDurationWarning.Size = new System.Drawing.Size(109, 13);
             this.labelDurationWarning.TabIndex = 17;
@@ -4429,7 +4429,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             this.labelStartTimeWarning.AutoSize = true;
             this.labelStartTimeWarning.ForeColor = System.Drawing.Color.Red;
-            this.labelStartTimeWarning.Location = new System.Drawing.Point(8, 50);
+            this.labelStartTimeWarning.Location = new System.Drawing.Point(8, 54);
             this.labelStartTimeWarning.Name = "labelStartTimeWarning";
             this.labelStartTimeWarning.Size = new System.Drawing.Size(114, 13);
             this.labelStartTimeWarning.TabIndex = 18;
@@ -4441,7 +4441,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.buttonSplitLine.ForeColor = System.Drawing.Color.Red;
             this.buttonSplitLine.Location = new System.Drawing.Point(604, 80);
             this.buttonSplitLine.Name = "buttonSplitLine";
-            this.buttonSplitLine.Size = new System.Drawing.Size(115, 23);
+            this.buttonSplitLine.Size = new System.Drawing.Size(114, 23);
             this.buttonSplitLine.TabIndex = 39;
             this.buttonSplitLine.Text = "Split line";
             this.buttonSplitLine.UseVisualStyleBackColor = true;
@@ -4870,7 +4870,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.buttonAutoBreak.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonAutoBreak.Location = new System.Drawing.Point(604, 51);
             this.buttonAutoBreak.Name = "buttonAutoBreak";
-            this.buttonAutoBreak.Size = new System.Drawing.Size(115, 23);
+            this.buttonAutoBreak.Size = new System.Drawing.Size(114, 23);
             this.buttonAutoBreak.TabIndex = 7;
             this.buttonAutoBreak.Text = "Auto br";
             this.buttonAutoBreak.UseVisualStyleBackColor = true;
@@ -4911,7 +4911,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.buttonUnBreak.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonUnBreak.Location = new System.Drawing.Point(604, 22);
             this.buttonUnBreak.Name = "buttonUnBreak";
-            this.buttonUnBreak.Size = new System.Drawing.Size(115, 23);
+            this.buttonUnBreak.Size = new System.Drawing.Size(114, 23);
             this.buttonUnBreak.TabIndex = 6;
             this.buttonUnBreak.Text = "Unbreak";
             this.buttonUnBreak.UseVisualStyleBackColor = true;
@@ -4963,7 +4963,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             // buttonPrevious
             // 
-            this.buttonPrevious.Location = new System.Drawing.Point(8, 78);
+            this.buttonPrevious.Location = new System.Drawing.Point(8, 75);
             this.buttonPrevious.Name = "buttonPrevious";
             this.buttonPrevious.Size = new System.Drawing.Size(72, 23);
             this.buttonPrevious.TabIndex = 2;
@@ -4973,7 +4973,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             // buttonNext
             // 
-            this.buttonNext.Location = new System.Drawing.Point(86, 78);
+            this.buttonNext.Location = new System.Drawing.Point(86, 75);
             this.buttonNext.Name = "buttonNext";
             this.buttonNext.Size = new System.Drawing.Size(72, 23);
             this.buttonNext.TabIndex = 3;

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -11009,6 +11009,11 @@ namespace Nikse.SubtitleEdit.Forms
 
             labelStartTimeWarning.Text = startTimeWarning;
             labelDurationWarning.Text = durationWarning;
+
+            if (!string.IsNullOrEmpty(startTimeWarning) && !string.IsNullOrEmpty(durationWarning))
+            {
+                labelDurationWarning.Left = labelStartTimeWarning.Right + 2;
+            }
         }
 
         private double _durationMsInitialValue = 0;


### PR DESCRIPTION
After removing the tab control, some controls needed to be moved.

![image](https://user-images.githubusercontent.com/20923700/102697221-dc835e80-423c-11eb-98f4-0b4c9959b055.png)

Lifted the `Prev`, `Next` buttons up a bit.
Corrected the position of "Overlap".

Also fixed the space between `Translate/Create/Adjust` button, it was 2 and 3, made it 2 in both places.