### PR TITLE
Work on list view's column header

### DIFF
--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -1139,7 +1139,7 @@ namespace Nikse.SubtitleEdit.Controls
             }
             if (Columns.Count > 0)
             {
-                Columns[Columns.Count - 1].Width = Width - (width + 25);
+                Columns[Columns.Count - 1].Width = ClientSize.Width - width;
             }
         }
 

--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -56,26 +56,6 @@ namespace Nikse.SubtitleEdit.Controls
 
         private string _subtitleFontName = "Tahoma";
 
-        public override bool RightToLeftLayout
-        {
-            get => base.RightToLeftLayout;
-            set
-            {
-                var hzAlignment = value ? HorizontalAlignment.Left : HorizontalAlignment.Right;
-                if (ColumnIndexCps >= 0)
-                {
-                    Columns[ColumnIndexCps].TextAlign = hzAlignment;
-                }
-
-                if (ColumnIndexWpm >= 0)
-                {
-                    Columns[ColumnIndexWpm].TextAlign = hzAlignment;
-                }
-
-                base.RightToLeftLayout = value;
-            }
-        }
-
         public string SubtitleFontName
         {
             get => _subtitleFontName;
@@ -780,7 +760,7 @@ namespace Nikse.SubtitleEdit.Controls
         {
             if (GetColumnIndex(SubtitleColumn.End) == -1)
             {
-                var ch = new ColumnHeader { Text = title, TextAlign = RightToLeftLayout ? HorizontalAlignment.Right : HorizontalAlignment.Left };
+                var ch = new ColumnHeader { Text = title };
                 if (ColumnIndexStart >= 0)
                 {
                     SubtitleColumns.Insert(ColumnIndexStart + 1, SubtitleColumn.End);
@@ -820,7 +800,7 @@ namespace Nikse.SubtitleEdit.Controls
         {
             if (GetColumnIndex(SubtitleColumn.Duration) == -1)
             {
-                var ch = new ColumnHeader { Text = title, TextAlign = RightToLeftLayout ? HorizontalAlignment.Right : HorizontalAlignment.Left };
+                var ch = new ColumnHeader { Text = title };
                 if (ColumnIndexEnd >= 0)
                 {
                     SubtitleColumns.Insert(ColumnIndexEnd + 1, SubtitleColumn.Duration);
@@ -928,7 +908,7 @@ namespace Nikse.SubtitleEdit.Controls
         {
             if (GetColumnIndex(SubtitleColumn.CharactersPerSeconds) == -1)
             {
-                var ch = new ColumnHeader { Text = title, TextAlign = RightToLeftLayout ? HorizontalAlignment.Left : HorizontalAlignment.Right };
+                var ch = new ColumnHeader { Text = title };
                 if (ColumnIndexDuration >= 0)
                 {
                     SubtitleColumns.Insert(ColumnIndexDuration + 1, SubtitleColumn.CharactersPerSeconds);
@@ -960,7 +940,7 @@ namespace Nikse.SubtitleEdit.Controls
         {
             if (GetColumnIndex(SubtitleColumn.WordsPerMinute) == -1)
             {
-                var ch = new ColumnHeader { Text = title, TextAlign = RightToLeftLayout ? HorizontalAlignment.Left : HorizontalAlignment.Right };
+                var ch = new ColumnHeader { Text = title };
                 if (ColumnIndexCps >= 0)
                 {
                     SubtitleColumns.Insert(ColumnIndexCps + 1, SubtitleColumn.WordsPerMinute);


### PR DESCRIPTION
Is there a reason for reversing `Words/min` and `Chars/sec`?
They were causing an issue for the dark theme.
![image](https://user-images.githubusercontent.com/20923700/102722940-870e8680-42fc-11eb-9719-0cef2a2d6c38.png)
The issue left now is the column header in RTL mode with the dark theme.

I also tested and found there is no reason to set `TextAlign` based on `RightToLeftLayout`.

Let me know what you think.