### PR TITLE
Work on syntax coloring with plain text

### DIFF
--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -1301,7 +1301,7 @@ namespace Nikse.SubtitleEdit.Controls
                 item.SubItems[ColumnIndexDuration].BackColor = BackColor;
             }
 
-            if (_settings.Tools.ListViewSyntaxColorDurationSmall)
+            if (_settings.Tools.ListViewSyntaxColorDurationSmall && !paragraph.StartTime.IsMaxTime)
             {
                 double charactersPerSecond = Utilities.GetCharactersPerSecond(paragraph);
                 if (charactersPerSecond > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
@@ -1342,7 +1342,7 @@ namespace Nikse.SubtitleEdit.Controls
                 }
             }
 
-            if (_settings.Tools.ListViewSyntaxColorGap && i >= 0 && i < paragraphs.Count - 1 && ColumnIndexGap >= 0)
+            if (_settings.Tools.ListViewSyntaxColorGap && i >= 0 && i < paragraphs.Count - 1 && ColumnIndexGap >= 0 && !paragraph.StartTime.IsMaxTime)
             {
                 Paragraph next = paragraphs[i + 1];
                 if (next.StartTime.TotalMilliseconds - paragraph.EndTime.TotalMilliseconds < Configuration.Settings.General.MinimumMillisecondsBetweenLines)


### PR DESCRIPTION
With plain text, I think `small duration` and `gap` errors shouldn't be there, as there is no timing.