### PR TITLE
Hide HScroll when opening a file

### DIFF
--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -1140,6 +1140,7 @@ namespace Nikse.SubtitleEdit.Controls
             if (Columns.Count > 0)
             {
                 Columns[Columns.Count - 1].Width = ClientSize.Width - width;
+                NativeMethods.SendMessage(Handle, 0x1014, 0, 0);
             }
         }
 

--- a/src/ui/Logic/NativeMethods.cs
+++ b/src/ui/Logic/NativeMethods.cs
@@ -1,5 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core;
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using Nikse.SubtitleEdit.Core.Common;
 
@@ -54,6 +53,9 @@ namespace Nikse.SubtitleEdit.Logic
 
         [DllImport("user32.dll", EntryPoint = "SetWindowPos")]
         internal static extern IntPtr SetWindowPos(IntPtr hWnd, int hWndInsertAfter, int x, int y, int width, int height, int wFlags);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern int SendMessage(IntPtr hWnd, int msg, int wParam, int lParam);
 
         #endregion Win32 API
 


### PR DESCRIPTION
Okay, this kinda seems dumb, so feel free to close it.
But it's really annoying and I haven't found another way to fix it, even after searching for 2 days!

When you open a file, a Horizontal scrollbar shows up for no reason, even though the last column is sized to exactly the list view's width:
![image](https://user-images.githubusercontent.com/20923700/103140580-f6b3b580-46f0-11eb-8c36-eeaf54c64070.png)

If you scroll down or click on the scrollbar, it just disappears, like it updates itself or something.
In this commit, I send an empty scroll message to the list view's scrollbar so it would disappear right when the last column's width is set. :)