### PR TITLE
Try to fix some text box issues (selection length + text when switching syntax coloring on)

### DIFF
--- a/src/ui/Controls/SETextBox.cs
+++ b/src/ui/Controls/SETextBox.cs
@@ -33,15 +33,18 @@ namespace Nikse.SubtitleEdit.Controls
         {
             ContextMenuStrip oldContextMenuStrip = null;
             var oldEnabled = true;
+            var oldText = string.Empty;
             if (_simpleTextBox != null)
             {
                 oldContextMenuStrip = _simpleTextBox.ContextMenuStrip;
                 oldEnabled = _simpleTextBox.Enabled;
+                oldText = _simpleTextBox.Text;
             }
             else if (_uiTextBox != null)
             {
                 oldContextMenuStrip = _uiTextBox.ContextMenuStrip;
                 oldEnabled = _uiTextBox.Enabled;
+                oldText = _uiTextBox.Text;
             }
 
             BorderStyle = BorderStyle.None;
@@ -147,6 +150,7 @@ namespace Nikse.SubtitleEdit.Controls
             }
 
             Enabled = oldEnabled;
+            Text = oldText;
         }
 
         private void InitializeBackingControl(Control textBox)
@@ -344,7 +348,7 @@ namespace Nikse.SubtitleEdit.Controls
                 }
                 else if (_uiTextBox != null)
                 {
-                    var target = _uiTextBox.SelectionLength;
+                    var target = value;
                     if (target == 0)
                     {
                         _uiTextBox.SelectionLength = 0;
@@ -817,7 +821,7 @@ namespace Nikse.SubtitleEdit.Controls
             _uiTextBox.Rtf = _richTextBoxTemp.Rtf;
             SelectionStart = start;
             SelectionLength = length;
-            ResumeLayout(false);
+            ResumeLayout(true);
         }
 
         private void SetHtmlColor(string text, int htmlTagStart)

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -5320,7 +5320,7 @@ namespace Nikse.SubtitleEdit.Forms
                     int startPos = tb.SelectedText.Length > 0 ? tb.SelectionStart + 1 : tb.SelectionStart;
                     bool found = _findHelper.Find(_subtitle, _subtitleAlternate, _subtitleListViewIndex, startPos);
                     tb = GetFindReplaceTextBox();
-                    //if we fail to find the text, we might want to start searching from the top of the file.
+                    // if we fail to find the text, we might want to start searching from the top of the file.
                     if (!found && _findHelper.StartLineIndex >= 1)
                     {
                         if (MessageBox.Show(_language.FindContinue, _language.FindContinueTitle, MessageBoxButtons.YesNoCancel) == DialogResult.Yes)


### PR DESCRIPTION
The first issue is that when using "Find", the word isn't selected, therefore using "Find next" doesn't work:
![image](https://user-images.githubusercontent.com/20923700/103162652-dfadba00-47fb-11eb-9460-215bd41c0515.png)

The second issue is that if you had "Syntax coloring" off, then you turn it on, the selected line is lost:

I don't know if this is the best solution for either.