### PR TITLE
Resize Actions column in batch convert to not show HScroll

### DIFF
--- a/src/ui/Forms/BatchConvert.Designer.cs
+++ b/src/ui/Forms/BatchConvert.Designer.cs
@@ -406,6 +406,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.listViewConvertOptions.UseCompatibleStateImageBehavior = false;
             this.listViewConvertOptions.View = System.Windows.Forms.View.Details;
             this.listViewConvertOptions.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this.listViewConvertOptions_ItemChecked);
+            this.listViewConvertOptions.Resize += new System.EventHandler(this.listViewConvertOptions_Resize);
             this.listViewConvertOptions.SelectedIndexChanged += new System.EventHandler(this.listViewConvertOptions_SelectedIndexChanged);
             // 
             // ActionCheckBox

--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -2734,6 +2734,11 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
+        private void listViewConvertOptions_Resize(object sender, EventArgs e)
+        {
+            listViewConvertOptions.Columns[1].Width = -2;
+        }
+
         private void listViewConvertOptions_SelectedIndexChanged(object sender, EventArgs e)
         {
             groupBoxMergeShortLines.Visible = false;


### PR DESCRIPTION
It doesn't look good in the dark theme and the actions' text fits without a scrollbar:
![image](https://user-images.githubusercontent.com/20923700/103256387-cfc9dd80-4995-11eb-9eaa-e69f8fe225ac.png)