### PR TITLE
Work on normal list view colors and columns' sizes

### DIFF
--- a/src/ui/Forms/BatchConvert.Designer.cs
+++ b/src/ui/Forms/BatchConvert.Designer.cs
@@ -406,7 +406,6 @@ namespace Nikse.SubtitleEdit.Forms
             this.listViewConvertOptions.UseCompatibleStateImageBehavior = false;
             this.listViewConvertOptions.View = System.Windows.Forms.View.Details;
             this.listViewConvertOptions.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this.listViewConvertOptions_ItemChecked);
-            this.listViewConvertOptions.Resize += new System.EventHandler(this.listViewConvertOptions_Resize);
             this.listViewConvertOptions.SelectedIndexChanged += new System.EventHandler(this.listViewConvertOptions_SelectedIndexChanged);
             // 
             // ActionCheckBox
@@ -1457,6 +1456,8 @@ namespace Nikse.SubtitleEdit.Forms
             this.Text = "Batch convert";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.BatchConvert_FormClosing);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.BatchConvert_KeyDown);
+            this.ResizeEnd += new System.EventHandler(this.BatchConvert_ResizeEnd);
+            this.Shown += new System.EventHandler(this.BatchConvert_Shown);
             this.groupBoxConvertOptions.ResumeLayout(false);
             this.groupBoxDeleteLines.ResumeLayout(false);
             this.groupBoxDeleteLines.PerformLayout();

--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -2688,6 +2688,17 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
+        private void BatchConvert_Shown(object sender, EventArgs e)
+        {
+            BatchConvert_ResizeEnd(this, EventArgs.Empty);
+        }
+
+        private void BatchConvert_ResizeEnd(object sender, EventArgs e)
+        {
+            listViewInputFiles.Columns[listViewInputFiles.Columns.Count - 1].Width = -2;
+            listViewConvertOptions.Columns[listViewConvertOptions.Columns.Count - 1].Width = -2;
+        }
+
         private void comboBoxFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
             textBoxFilter.Visible = comboBoxFilter.SelectedIndex == 3 || comboBoxFilter.SelectedIndex == 4 || comboBoxFilter.SelectedIndex == 5;
@@ -2732,11 +2743,6 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 textBoxOutputFolder.Text = folderBrowserDialog1.SelectedPath;
             }
-        }
-
-        private void listViewConvertOptions_Resize(object sender, EventArgs e)
-        {
-            listViewConvertOptions.Columns[1].Width = -2;
         }
 
         private void listViewConvertOptions_SelectedIndexChanged(object sender, EventArgs e)

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -3216,6 +3216,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             // panelMode
             // 
+            this.panelMode.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.panelMode.Controls.Add(this.buttonModeTranslate);
             this.panelMode.Controls.Add(this.buttonModeCreate);
             this.panelMode.Controls.Add(this.buttonModeAdjust);

--- a/src/ui/Forms/MultipleReplace.Designer.cs
+++ b/src/ui/Forms/MultipleReplace.Designer.cs
@@ -122,7 +122,7 @@
             // 
             this.buttonReplacesInverseSelection.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.buttonReplacesInverseSelection.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.buttonReplacesInverseSelection.Location = new System.Drawing.Point(91, 204);
+            this.buttonReplacesInverseSelection.Location = new System.Drawing.Point(91, 202);
             this.buttonReplacesInverseSelection.Name = "buttonReplacesInverseSelection";
             this.buttonReplacesInverseSelection.Size = new System.Drawing.Size(100, 23);
             this.buttonReplacesInverseSelection.TabIndex = 12;
@@ -134,7 +134,7 @@
             // 
             this.buttonReplacesSelectAll.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.buttonReplacesSelectAll.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.buttonReplacesSelectAll.Location = new System.Drawing.Point(10, 204);
+            this.buttonReplacesSelectAll.Location = new System.Drawing.Point(10, 202);
             this.buttonReplacesSelectAll.Name = "buttonReplacesSelectAll";
             this.buttonReplacesSelectAll.Size = new System.Drawing.Size(75, 23);
             this.buttonReplacesSelectAll.TabIndex = 11;
@@ -478,7 +478,7 @@
             // buttonOK
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOK.Location = new System.Drawing.Point(804, 251);
+            this.buttonOK.Location = new System.Drawing.Point(808, 254);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
             this.buttonOK.TabIndex = 14;
@@ -490,7 +490,7 @@
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(885, 251);
+            this.buttonCancel.Location = new System.Drawing.Point(889, 254);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 15;
@@ -538,7 +538,7 @@
             // buttonExportGroups
             // 
             this.buttonExportGroups.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.buttonExportGroups.Location = new System.Drawing.Point(118, 230);
+            this.buttonExportGroups.Location = new System.Drawing.Point(118, 228);
             this.buttonExportGroups.Name = "buttonExportGroups";
             this.buttonExportGroups.Size = new System.Drawing.Size(99, 23);
             this.buttonExportGroups.TabIndex = 3;
@@ -549,7 +549,7 @@
             // buttonImportGroups
             // 
             this.buttonImportGroups.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.buttonImportGroups.Location = new System.Drawing.Point(8, 230);
+            this.buttonImportGroups.Location = new System.Drawing.Point(8, 228);
             this.buttonImportGroups.Name = "buttonImportGroups";
             this.buttonImportGroups.Size = new System.Drawing.Size(104, 23);
             this.buttonImportGroups.TabIndex = 2;
@@ -560,7 +560,7 @@
             // buttonNewGroup
             // 
             this.buttonNewGroup.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.buttonNewGroup.Location = new System.Drawing.Point(8, 203);
+            this.buttonNewGroup.Location = new System.Drawing.Point(8, 201);
             this.buttonNewGroup.Name = "buttonNewGroup";
             this.buttonNewGroup.Size = new System.Drawing.Size(209, 23);
             this.buttonNewGroup.TabIndex = 1;
@@ -697,7 +697,7 @@
             // buttonApply
             // 
             this.buttonApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonApply.Location = new System.Drawing.Point(966, 251);
+            this.buttonApply.Location = new System.Drawing.Point(970, 254);
             this.buttonApply.Name = "buttonApply";
             this.buttonApply.Size = new System.Drawing.Size(75, 23);
             this.buttonApply.TabIndex = 16;

--- a/src/ui/Forms/MultipleReplace.cs
+++ b/src/ui/Forms/MultipleReplace.cs
@@ -1133,6 +1133,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void MultipleReplace_ResizeEnd(object sender, EventArgs e)
         {
             listViewRules.Columns[listViewRules.Columns.Count - 1].Width = -2;
+            listViewFixes.Columns[listViewFixes.Columns.Count - 1].Width = -2;
         }
 
         private void moveToTopToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1304,6 +1305,5 @@ namespace Nikse.SubtitleEdit.Forms
                 e.SuppressKeyPress = true;
             }
         }
-
     }
 }

--- a/src/ui/Forms/Options/Settings.Designer.cs
+++ b/src/ui/Forms/Options/Settings.Designer.cs
@@ -514,6 +514,7 @@
             this.panelSettings.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelSettings.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle; ;
             this.panelSettings.Controls.Add(this.listBoxSection);
             this.panelSettings.Controls.Add(this.panelGeneral);
             this.panelSettings.Controls.Add(this.panelShortcuts);

--- a/src/ui/Logic/DarkTheme.cs
+++ b/src/ui/Logic/DarkTheme.cs
@@ -287,11 +287,19 @@ namespace Nikse.SubtitleEdit.Logic
                 }
             }
 
-            if (c is SubtitleListView lv)
+            if (c is SubtitleListView seLV)
             {
+                seLV.OwnerDraw = true;
+                seLV.DrawColumnHeader += ListView_DrawColumnHeader;
+                seLV.GridLines = Configuration.Settings.General.DarkThemeShowListViewGridLines;
+            }
+            else if (c is ListView lv)
+            {
+                lv.GridLines = false;
                 lv.OwnerDraw = true;
-                lv.DrawColumnHeader += lv_DrawColumnHeader;
-                lv.GridLines = Configuration.Settings.General.DarkThemeShowListViewGridLines;
+                lv.DrawItem += ListView_DrawItem;
+                lv.DrawSubItem += ListView_DrawSubItem;
+                lv.DrawColumnHeader += ListView_DrawColumnHeader;
             }
         }
 
@@ -345,12 +353,104 @@ namespace Nikse.SubtitleEdit.Logic
             }
         }
 
-        private static void lv_DrawColumnHeader(object sender, DrawListViewColumnHeaderEventArgs e)
+        private static void ListView_DrawItem(object sender, DrawListViewItemEventArgs e)
         {
-            if (sender is SubtitleListView lv && lv.RightToLeftLayout)
+            var lv = sender as ListView;
+            if (!lv.Focused && (e.State & ListViewItemStates.Selected) != 0)
             {
-                // until we find a solution for drawing it in RTL
+                if (e.Item.Focused)
+                {
+                    e.DrawFocusRectangle();
+                }
+            }
+            else
+            {
+                e.DrawDefault = true;
+            }
+        }
+
+        private static void ListView_DrawSubItem(object sender, DrawListViewSubItemEventArgs e)
+        {
+            var lv = sender as ListView;
+            Color backgroundColor = lv.Items[e.ItemIndex].SubItems[e.ColumnIndex].BackColor;
+            Color subBackgroundColor = Color.FromArgb(backgroundColor.A, Math.Max(backgroundColor.R - 39, 0), Math.Max(backgroundColor.G - 39, 0), Math.Max(backgroundColor.B - 39, 0));
+            if (lv.Focused && backgroundColor == BackColor || lv.RightToLeftLayout)
+            {
+                e.DrawDefault = true;
                 return;
+            }
+
+            using (var sf = new StringFormat())
+            {
+                switch (e.Header.TextAlign)
+                {
+                    case HorizontalAlignment.Center:
+                        sf.Alignment = StringAlignment.Center;
+                        break;
+                    case HorizontalAlignment.Right:
+                        sf.Alignment = StringAlignment.Far;
+                        break;
+                }
+
+                if (e.Item.Selected)
+                {
+                    var subtitleFont = new Font("Tahoma", 8.25F);
+                    Rectangle rect = e.Bounds;
+                    if (Configuration.Settings != null)
+                    {
+                        backgroundColor = backgroundColor == BackColor ? Configuration.Settings.Tools.ListViewUnfocusedSelectedColor : subBackgroundColor;
+                        using (var sb = new SolidBrush(backgroundColor))
+                        {
+                            e.Graphics.FillRectangle(sb, rect);
+                        }
+                    }
+                    else
+                    {
+                        e.Graphics.FillRectangle(Brushes.LightBlue, rect);
+                    }
+
+                    int addX = 0;
+
+                    if (e.ColumnIndex == 0 && lv.CheckBoxes)
+                    {
+                        addX = 16;
+                        var checkBoxState = e.Item.Checked ? System.Windows.Forms.VisualStyles.CheckBoxState.CheckedNormal : System.Windows.Forms.VisualStyles.CheckBoxState.UncheckedNormal;
+                        CheckBoxRenderer.DrawCheckBox(e.Graphics, new Point(e.Bounds.X + 4, e.Bounds.Y + 2), checkBoxState);
+                    }
+
+                    if (lv.Columns[e.ColumnIndex].TextAlign == HorizontalAlignment.Right)
+                    {
+                        var stringWidth = (int)e.Graphics.MeasureString(e.Item.SubItems[e.ColumnIndex].Text, subtitleFont).Width;
+                        TextRenderer.DrawText(e.Graphics, e.Item.SubItems[e.ColumnIndex].Text, subtitleFont, new Point(e.Bounds.Right - stringWidth - 7, e.Bounds.Top + 2), e.Item.ForeColor, TextFormatFlags.NoPrefix);
+                    }
+                    else
+                    {
+                        TextRenderer.DrawText(e.Graphics, e.Item.SubItems[e.ColumnIndex].Text, subtitleFont, new Point(e.Bounds.Left + 3 + addX, e.Bounds.Top + 2), e.Item.ForeColor, TextFormatFlags.NoPrefix);
+                    }
+                }
+                else
+                {
+                    e.DrawDefault = true;
+                }
+            }
+        }
+
+        private static void ListView_DrawColumnHeader(object sender, DrawListViewColumnHeaderEventArgs e)
+        {
+            if (sender is ListView lv && lv.RightToLeftLayout)
+            {
+                // Until we find a solution for drawing it in RTL
+                return;
+            }
+
+            int addY;
+            if (sender is SubtitleListView)
+            {
+                addY = 0;
+            }
+            else
+            {
+                addY = 4;
             }
 
             e.DrawDefault = false;
@@ -372,7 +472,7 @@ namespace Nikse.SubtitleEdit.Logic
 
             using (var fc = new SolidBrush(ForeColor))
             {
-                e.Graphics.DrawString(e.Header.Text, e.Font, fc, e.Bounds.X + 3, e.Bounds.Y, strFormat);
+                e.Graphics.DrawString(e.Header.Text, e.Font, fc, e.Bounds.X + 3, e.Bounds.Y + addY, strFormat);
                 if (e.ColumnIndex != 0)
                 {
                     e.Graphics.DrawLine(new Pen(ForeColor), e.Bounds.X, e.Bounds.Y, e.Bounds.X, e.Bounds.Height);


### PR DESCRIPTION
This is how multiple replace used to look:
![image](https://user-images.githubusercontent.com/20923700/103445123-ef545500-4c78-11eb-8731-0d321912e7d9.png)

This is how it is now:
![image](https://user-images.githubusercontent.com/20923700/103445130-04c97f00-4c79-11eb-955d-a8da1176b3a7.png)

Changed normal list view unfocused color and header color, and made the last column in batch convert and multiple replace fill the reset of the client size, also better aligned some buttons.
