### PR TITLE
Change text color in some places for dark theme

### DIFF
--- a/src/ui/Forms/Compare.cs
+++ b/src/ui/Forms/Compare.cs
@@ -708,14 +708,15 @@ namespace Nikse.SubtitleEdit.Forms
 
                 if (richTextBox1.Text[richTextBox1.Text.Length - i] == richTextBox2.Text[richTextBox2.Text.Length - i])
                 {
+                    var selectionColor = Configuration.Settings.General.UseDarkTheme ? Configuration.Settings.General.DarkThemeForeColor : Color.Black;
                     richTextBox1.SelectionStart = richTextBox1.Text.Length - i;
                     richTextBox1.SelectionLength = 1;
-                    richTextBox1.SelectionColor = Color.Black;
+                    richTextBox1.SelectionColor = selectionColor;
                     richTextBox1.SelectionBackColor = richTextBox1.BackColor;
 
                     richTextBox2.SelectionStart = richTextBox2.Text.Length - i;
                     richTextBox2.SelectionLength = 1;
-                    richTextBox2.SelectionColor = Color.Black;
+                    richTextBox2.SelectionColor = selectionColor;
                     richTextBox2.SelectionBackColor = richTextBox1.BackColor;
                 }
                 else

--- a/src/ui/Forms/FindDialog.cs
+++ b/src/ui/Forms/FindDialog.cs
@@ -220,7 +220,8 @@ namespace Nikse.SubtitleEdit.Forms
                 return;
             }
             var count = GetFindDialogHelper(0).FindCount(_subtitle, checkBoxWholeWord.Checked);
-            labelCount.ForeColor = count > 0 ? Color.Blue : Color.Red;
+            var colorIfFound = Configuration.Settings.General.UseDarkTheme ? Color.FromArgb(9, 128, 204) : Color.Blue;
+            labelCount.ForeColor = count > 0 ? colorIfFound : Color.Red;
             labelCount.Text = count == 1 ? LanguageSettings.Current.FindDialog.OneMatch : string.Format(LanguageSettings.Current.FindDialog.XNumberOfMatches, count);
         }
 

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -164,7 +164,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void ShowActiveWordWithColor(SpellCheckWord word)
         {
             richTextBoxParagraph.SelectAll();
-            richTextBoxParagraph.SelectionColor = Color.Black;
+            richTextBoxParagraph.SelectionColor = Configuration.Settings.General.UseDarkTheme ? Configuration.Settings.General.DarkThemeForeColor : Color.Black;
             richTextBoxParagraph.SelectionLength = 0;
 
             for (int i = 0; i < 10; i++)


### PR DESCRIPTION
This is how it used to look:
![image](https://user-images.githubusercontent.com/20923700/103446596-19fad980-4c8a-11eb-9103-293449bf7b5d.png)
The text is unreadable.

The same thing goes for Find's count:
![image](https://user-images.githubusercontent.com/20923700/103446733-a8bc2600-4c8b-11eb-9eee-92b62a909cdf.png)
