### PR TITLE
Don't auto break when using split at cursor position

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -10082,8 +10082,8 @@ namespace Nikse.SubtitleEdit.Forms
                         b = DialogSplitMerge.RemoveStartDash(b);
                     }
 
-                    currentParagraph.Text = Utilities.AutoBreakLine(a, language);
-                    newParagraph.Text = Utilities.AutoBreakLine(b, language);
+                    currentParagraph.Text = a;
+                    newParagraph.Text = b;
                 }
                 else
                 {
@@ -10281,8 +10281,8 @@ namespace Nikse.SubtitleEdit.Forms
                         oldText = originalCurrent.Text;
                         if (alternateTextIndex != null && alternateTextIndex.Value > 1 && alternateTextIndex.Value < oldText.Length - 1)
                         {
-                            originalCurrent.Text = Utilities.AutoBreakLine(oldText.Substring(0, alternateTextIndex.Value).Trim(), language);
-                            originalNew.Text = Utilities.AutoBreakLine(oldText.Substring(alternateTextIndex.Value).Trim(), language);
+                            originalCurrent.Text = oldText.Substring(0, alternateTextIndex.Value).Trim();
+                            originalNew.Text = oldText.Substring(alternateTextIndex.Value).Trim();
                             if (originalCurrent.Text.Contains("<i>", StringComparison.Ordinal) && !originalCurrent.Text.Contains("</i>", StringComparison.Ordinal) &&
                                 originalNew.Text.Contains("</i>", StringComparison.Ordinal) && !originalNew.Text.Contains("<i>", StringComparison.Ordinal))
                             {


### PR DESCRIPTION
I'm not sure if this is something you want or if you want a new shortcut or an option to toggle, but here it is.

Closes https://github.com/SubtitleEdit/subtitleedit/issues/3932