### PR TITLE
Fixes related to Live spell check

### DIFF
--- a/src/ui/Controls/SETextBox.cs
+++ b/src/ui/Controls/SETextBox.cs
@@ -42,6 +42,7 @@ namespace Nikse.SubtitleEdit.Controls
         private SpellCheckWord _currentWord;
         private string _currentDictionary;
         private string _currentLanguage;
+        private string _uiTextBoxOldText;
 
         private static readonly char[] SplitChars = { ' ', '.', ',', '?', '!', ':', ';', '"', '“', '”', '(', ')', '[', ']', '{', '}', '|', '<', '>', '/', '+', '\r', '\n', '\b', '¿', '¡', '…', '—', '–', '♪', '♫', '„', '«', '»', '‹', '›', '؛', '،', '؟' };
         
@@ -737,6 +738,18 @@ namespace Nikse.SubtitleEdit.Controls
             if (_checkRtfChange)
             {
                 _checkRtfChange = false;
+
+                if (Configuration.Settings.Tools.LiveSpellCheck)
+                { 
+                    if (!string.IsNullOrEmpty(_uiTextBoxOldText)
+                        && HtmlUtil.RemoveHtmlTags(_uiTextBoxOldText, true) == HtmlUtil.RemoveHtmlTags(_uiTextBox.Text, true))
+                    {
+                        IsSpellCheckRequested = true;
+                    }
+
+                    _uiTextBoxOldText = _uiTextBox.Text;
+                }
+
                 HighlightHtmlText();
                 _checkRtfChange = true;
             }

--- a/src/ui/Forms/Options/Settings.cs
+++ b/src/ui/Forms/Options/Settings.cs
@@ -734,6 +734,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             checkBoxSpellCheckOneLetterWords.Text = LanguageSettings.Current.SpellCheck.CheckOneLetterWords;
             checkBoxTreatINQuoteAsING.Text = LanguageSettings.Current.SpellCheck.TreatINQuoteAsING;
             checkBoxUseAlwaysToFile.Text = LanguageSettings.Current.SpellCheck.RememberUseAlwaysList;
+            checkBoxLiveSpellCheck.Text = LanguageSettings.Current.SpellCheck.LiveSpellCheck;
             buttonFixContinuationStyleSettings.Text = language.EditFixContinuationStyleSettings;
 
             groupBoxToolsAutoBr.Text = LanguageSettings.Current.Main.Controls.AutoBreak.Replace("&", string.Empty);


### PR DESCRIPTION
Now, it keeps the old value of the text box text, if the change was only in HTML tags, it does the spell check on the line again to update the words' indices.