### PR TITLE
Rename "StyleManager" shortcut to "MainToolsStyleManager"

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1864,7 +1864,7 @@ $HorzAlign          =   Center
         public string MainToolsAppend { get; set; }
         public string MainToolsJoin { get; set; }
         public string MainToolsBeamer { get; set; }
-        public string StyleManager { get; set; }
+        public string MainToolsStyleManager { get; set; }
         public string MainVideoOpen { get; set; }
         public string MainVideoClose { get; set; }
         public string MainVideoPause { get; set; }
@@ -6657,10 +6657,10 @@ $HorzAlign          =   Center
                     shortcuts.MainToolsBeamer = subNode.InnerText;
                 }
 
-                subNode = node.SelectSingleNode("StyleManager");
+                subNode = node.SelectSingleNode("MainToolsStyleManager");
                 if (subNode != null)
                 {
-                    shortcuts.StyleManager = subNode.InnerText;
+                    shortcuts.MainToolsStyleManager = subNode.InnerText;
                 }
 
                 subNode = node.SelectSingleNode("MainEditToggleTranslationOriginalInPreviews");
@@ -8597,7 +8597,7 @@ $HorzAlign          =   Center
             textWriter.WriteElementString("MainToolsAppend", shortcuts.MainToolsAppend);
             textWriter.WriteElementString("MainToolsJoin", shortcuts.MainToolsJoin);
             textWriter.WriteElementString("MainToolsBeamer", shortcuts.MainToolsBeamer);
-            textWriter.WriteElementString("StyleManager", shortcuts.StyleManager);
+            textWriter.WriteElementString("MainToolsStyleManager", shortcuts.MainToolsStyleManager);
             textWriter.WriteElementString("MainEditToggleTranslationOriginalInPreviews", shortcuts.MainEditToggleTranslationOriginalInPreviews);
             textWriter.WriteElementString("MainEditInverseSelection", shortcuts.MainEditInverseSelection);
             textWriter.WriteElementString("MainEditModifySelection", shortcuts.MainEditModifySelection);

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -21589,7 +21589,7 @@ namespace Nikse.SubtitleEdit.Forms
             splitToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainToolsSplit);
             appendTextVisuallyToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainToolsAppend);
             joinSubtitlesToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainToolsJoin);
-            toolStripMenuItemAssStyles.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.StyleManager);
+            toolStripMenuItemAssStyles.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainToolsStyleManager);
 
             openVideoToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoOpen);
             closeVideoToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainVideoClose);

--- a/src/ui/Forms/Options/Settings.cs
+++ b/src/ui/Forms/Options/Settings.cs
@@ -1235,7 +1235,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             AddNode(toolsNode, LanguageSettings.Current.Main.Menu.Tools.JoinSubtitles, nameof(Configuration.Settings.Shortcuts.MainToolsJoin), true);
             AddNode(toolsNode, LanguageSettings.Current.Main.Menu.ContextMenu.AutoDurationCurrentLine, nameof(Configuration.Settings.Shortcuts.MainToolsAutoDuration));
             AddNode(toolsNode, language.ShowBeamer, nameof(Configuration.Settings.Shortcuts.MainToolsBeamer), true);
-            AddNode(toolsNode, language.ShowStyleManager, nameof(Configuration.Settings.Shortcuts.StyleManager));
+            AddNode(toolsNode, language.ShowStyleManager, nameof(Configuration.Settings.Shortcuts.MainToolsStyleManager));
             if (toolsNode.Nodes.Count > 0)
             {
                 _shortcuts.Nodes.Add(toolsNode);


### PR DESCRIPTION
Just so it's unified with the rest:

![image](https://user-images.githubusercontent.com/20923700/103586073-03a08800-4eed-11eb-928b-f4fb1d5eb19e.png)
