### PR TITLE
Fix for Arabic comma in rich text box when there is a Unicode control char

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -7,6 +7,8 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     public static class StringExtensions
     {
+        public static char[] UnicodeControlChars { get; } = { '\u200E', '\u200F', '\u202A', '\u202B', '\u202C', '\u202D', '\u202E' };
+
         public static bool LineStartsWithHtmlTag(this string text, bool threeLengthTag, bool includeFont = false)
         {
             if (text == null || !threeLengthTag && !includeFont)
@@ -315,6 +317,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             return false;
+        }
+
+        public static bool ContainsUnicodeControlChars(this string s)
+        {
+            return s.Contains(UnicodeControlChars);
         }
 
         public static string RemoveControlCharacters(this string s)

--- a/src/ui/Controls/SETextBox.cs
+++ b/src/ui/Controls/SETextBox.cs
@@ -289,7 +289,7 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     _fixedArabicComma = false;
                     var s = value;
-                    if (!Configuration.Settings.General.RightToLeftMode && !s.Contains('\u202A'))
+                    if (!Configuration.Settings.General.RightToLeftMode && !s.ContainsUnicodeControlChars())
                     {
                         string textNoTags = HtmlUtil.RemoveHtmlTags(s, true);
                         if (textNoTags.EndsWith('،'))


### PR DESCRIPTION
If there is already some Unicode control char in the text box, there is no need to add another one, which would reverse the comma to the wrong place.


Note that this will be removed completely when moving to .NET 5, as it shows everything in the correct place depending on the language.