### PR TITLE
Improve opening a second subtitle

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -15,7 +15,6 @@ namespace Nikse.SubtitleEdit.Core.Common
     // ...but the built-in serialization is too slow - so a custom (de-)serialization has been used!
 
     public class RecentFileEntry
-
     {
         public string FileName { get; set; }
         public string OriginalFileName { get; set; }

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -225,6 +225,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripMenuItemSetAudioTrack = new System.Windows.Forms.ToolStripMenuItem();
             this.closeVideoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openSecondSubtitleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.closeSecondSubtitleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.setVideoOffsetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.smpteTimeModedropFrameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemImportChapters = new System.Windows.Forms.ToolStripMenuItem();
@@ -2099,6 +2100,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripMenuItemSetAudioTrack,
             this.closeVideoToolStripMenuItem,
             this.openSecondSubtitleToolStripMenuItem,
+            this.closeSecondSubtitleToolStripMenuItem,
             this.setVideoOffsetToolStripMenuItem,
             this.smpteTimeModedropFrameToolStripMenuItem,
             this.toolStripMenuItemImportChapters,
@@ -2158,6 +2160,14 @@ namespace Nikse.SubtitleEdit.Forms
             this.openSecondSubtitleToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
             this.openSecondSubtitleToolStripMenuItem.Text = "Open second subtitle...";
             this.openSecondSubtitleToolStripMenuItem.Click += new System.EventHandler(this.openSecondSubtitleToolStripMenuItem_Click);
+            // 
+            // closeSecondSubtitleToolStripMenuItem
+            // 
+            this.closeSecondSubtitleToolStripMenuItem.Name = "closeSecondSubtitleToolStripMenuItem";
+            this.closeSecondSubtitleToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
+            this.closeSecondSubtitleToolStripMenuItem.Text = "Close second subtitle";
+            this.closeSecondSubtitleToolStripMenuItem.Visible = false;
+            this.closeSecondSubtitleToolStripMenuItem.Click += new System.EventHandler(this.closeSecondSubtitleToolStripMenuItem_Click);
             // 
             // setVideoOffsetToolStripMenuItem
             // 
@@ -5778,6 +5788,7 @@ namespace Nikse.SubtitleEdit.Forms
         private System.Windows.Forms.ToolStripMenuItem boxToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemAssaStyles;
         private System.Windows.Forms.ToolStripMenuItem openSecondSubtitleToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem closeSecondSubtitleToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aSSStylesToolStripMenuItem;
     }
 }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -1502,6 +1502,7 @@ namespace Nikse.SubtitleEdit.Forms
             toolStripMenuItemSetAudioTrack.Text = _language.Menu.Video.ChooseAudioTrack;
             closeVideoToolStripMenuItem.Text = _language.Menu.Video.CloseVideo;
             openSecondSubtitleToolStripMenuItem.Text = _language.Menu.Video.OpenSecondSubtitle;
+            closeSecondSubtitleToolStripMenuItem.Text = _language.Menu.Video.CloseSecondSubtitle;
             generateTextFromCurrentVideoToolStripMenuItem.Text = _language.Menu.Video.GenerateTextFromVideo;
 
             smpteTimeModedropFrameToolStripMenuItem.Text = _language.Menu.Video.SmptTimeMode;
@@ -29236,18 +29237,32 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (mediaPlayer.VideoPlayer is LibMpvDynamic libMpv)
             {
-                if (Configuration.Settings.General.MpvHandlesPreviewText)
-                {
-                    Configuration.Settings.General.MpvHandlesPreviewText = false;
-                    mediaPlayer.VideoPlayer = libMpv;
-                    mediaPlayer.SubtitleText = string.Empty;
-                }
-                libMpv.LoadSubtitle(openFileDialog1.FileName);
+                libMpv.LoadSecondSubtitle(openFileDialog1.FileName);
+                closeSecondSubtitleToolStripMenuItem.Visible = true;
             }
             else if (mediaPlayer.VideoPlayer is LibVlcDynamic libvlc)
             {
                 libvlc.LoadSecondSubtitle(openFileDialog1.FileName);
             }
+
+            openSecondSubtitleToolStripMenuItem.Enabled = false;
+        }
+
+        private void closeSecondSubtitleToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (mediaPlayer.VideoPlayer is LibMpvDynamic libMpv)
+            {
+                libMpv.RemoveSecondSubtitle();
+                if (Configuration.Settings.General.MpvHandlesPreviewText)
+                {
+                    mediaPlayer.VideoPlayer = mediaPlayer.VideoPlayer;
+                    mediaPlayer.SetSubtitleText(string.Empty, null, _subtitle);
+                    ShowSubtitle(); 
+                }
+            }
+
+            closeSecondSubtitleToolStripMenuItem.Visible = false;
+            openSecondSubtitleToolStripMenuItem.Enabled = true;
         }
 
         private void aSSStylesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -1597,6 +1597,7 @@ namespace Nikse.SubtitleEdit.Logic
                         ChooseAudioTrack = "Choose audio track",
                         CloseVideo = "Close video file",
                         OpenSecondSubtitle = "Open second subtitle file...",
+                        CloseSecondSubtitle = "Close second subtitle file",
                         SetVideoOffset = "Set video offset...",
                         SmptTimeMode = "SMPTE timing (drop frame)",
                         GenerateTextFromVideo = "Generate text from video...",

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -1456,6 +1456,7 @@
                     public string ChooseAudioTrack { get; set; }
                     public string CloseVideo { get; set; }
                     public string OpenSecondSubtitle { get; set; }
+                    public string CloseSecondSubtitle { get; set; }
                     public string SetVideoOffset { get; set; }
                     public string SmptTimeMode { get; set; }
                     public string GenerateTextFromVideo { get; set; }

--- a/src/ui/Logic/VideoPlayers/LibMpvMono.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvMono.cs
@@ -1,5 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic.cs
@@ -1,5 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core;
-using Nikse.SubtitleEdit.Forms;
+﻿using Nikse.SubtitleEdit.Forms;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -159,7 +158,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
         private libvlc_media_player_next_frame _libvlc_media_player_next_frame;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate int libvlc_media_player_add_slave(IntPtr media, int type, byte[] filePath, bool select);
+        private delegate int libvlc_media_player_add_slave(IntPtr mediaPlayer, int type, byte[] filePath, bool select);
         private libvlc_media_player_add_slave _libvlc_media_player_add_slave;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
Okay, this improves opening a second subtitle with MPV in the following way:
1. It now works with MPV handles preview, the second subtitle is shown on top.
2. Added a `close second subtitle` option if MPV is used.

I tried to make `close second subtitle` work with VLC, but its API doesn't have a clear method for input slaves in `media_player`.

`LanguageDeserializer` and `LanguageMaster` need updating.

Closes https://github.com/SubtitleEdit/subtitleedit/issues/4444