### PR TITLE
Even more dark theme work

### DIFF
--- a/src/ui/Forms/MultipleReplace.Designer.cs
+++ b/src/ui/Forms/MultipleReplace.Designer.cs
@@ -122,7 +122,7 @@
             // 
             this.buttonReplacesInverseSelection.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.buttonReplacesInverseSelection.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.buttonReplacesInverseSelection.Location = new System.Drawing.Point(91, 202);
+            this.buttonReplacesInverseSelection.Location = new System.Drawing.Point(89, 202);
             this.buttonReplacesInverseSelection.Name = "buttonReplacesInverseSelection";
             this.buttonReplacesInverseSelection.Size = new System.Drawing.Size(100, 23);
             this.buttonReplacesInverseSelection.TabIndex = 12;
@@ -134,7 +134,7 @@
             // 
             this.buttonReplacesSelectAll.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.buttonReplacesSelectAll.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.buttonReplacesSelectAll.Location = new System.Drawing.Point(10, 202);
+            this.buttonReplacesSelectAll.Location = new System.Drawing.Point(8, 202);
             this.buttonReplacesSelectAll.Name = "buttonReplacesSelectAll";
             this.buttonReplacesSelectAll.Size = new System.Drawing.Size(75, 23);
             this.buttonReplacesSelectAll.TabIndex = 11;
@@ -155,7 +155,7 @@
             this.columnHeader8});
             this.listViewFixes.FullRowSelect = true;
             this.listViewFixes.HideSelection = false;
-            this.listViewFixes.Location = new System.Drawing.Point(10, 21);
+            this.listViewFixes.Location = new System.Drawing.Point(8, 21);
             this.listViewFixes.Name = "listViewFixes";
             this.listViewFixes.Size = new System.Drawing.Size(1030, 177);
             this.listViewFixes.TabIndex = 10;

--- a/src/ui/Forms/PluginsGet.Designer.cs
+++ b/src/ui/Forms/PluginsGet.Designer.cs
@@ -314,6 +314,8 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Plugins";
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.PluginsGet_KeyDown);
+            this.ResizeEnd += new System.EventHandler(this.PluginsGet_ResizeEnd);
+            this.Shown += new System.EventHandler(this.PluginsGet_Shown);
             this.tabControlPlugins.ResumeLayout(false);
             this.tabPageInstalledPlugins.ResumeLayout(false);
             this.tabPageGetPlugins.ResumeLayout(false);

--- a/src/ui/Forms/PluginsGet.cs
+++ b/src/ui/Forms/PluginsGet.cs
@@ -404,6 +404,17 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
+        private void PluginsGet_ResizeEnd(object sender, EventArgs e)
+        {
+            listViewGetPlugins.Columns[listViewGetPlugins.Columns.Count - 1].Width = -2;
+            listViewInstalledPlugins.Columns[listViewInstalledPlugins.Columns.Count - 1].Width = -2;
+        }
+
+        private void PluginsGet_Shown(object sender, EventArgs e)
+        {
+            PluginsGet_ResizeEnd(this, EventArgs.Empty);
+        }
+
         private void buttonRemove_Click(object sender, EventArgs e)
         {
             if (listViewInstalledPlugins.SelectedItems.Count < 1)

--- a/src/ui/Forms/Translate/TranslateViaCopyPaste.cs
+++ b/src/ui/Forms/Translate/TranslateViaCopyPaste.cs
@@ -22,6 +22,11 @@ namespace Nikse.SubtitleEdit.Forms.Translate
             UiUtil.PreInitialize(this);
             InitializeComponent();
             UiUtil.FixFonts(this);
+            if (Configuration.Settings.General.UseDarkTheme)
+            {
+                listViewTranslate.GridLines = Configuration.Settings.General.DarkThemeShowListViewGridLines;
+            }
+
             Text = LanguageSettings.Current.GoogleTranslate.AutoTranslateViaCopyPaste;
             labelMaxTextSize.Text = LanguageSettings.Current.GoogleTranslate.CopyPasteMaxSize;
             checkBoxAutoCopyToClipboard.Text = LanguageSettings.Current.GoogleTranslate.AutoCopyToClipboard;

--- a/src/ui/Logic/DarkTheme.cs
+++ b/src/ui/Logic/DarkTheme.cs
@@ -374,7 +374,7 @@ namespace Nikse.SubtitleEdit.Logic
 
                 if (e.Item.Selected)
                 {
-                    var subtitleFont = UiUtil.GetDefaultFont();
+                    var subtitleFont = e.Item.Font;
                     Rectangle rect = e.Bounds;
                     if (Configuration.Settings != null)
                     {
@@ -423,14 +423,10 @@ namespace Nikse.SubtitleEdit.Logic
                 return;
             }
 
-            int addY;
-            if (sender is SubtitleListView)
+            int addY = 0;
+            if (e.Font.Name != Configuration.Settings.General.SubtitleFontName)
             {
-                addY = 0;
-            }
-            else
-            {
-                addY = 4;
+                addY = 5;
             }
 
             e.DrawDefault = false;

--- a/src/ui/Logic/DarkTheme.cs
+++ b/src/ui/Logic/DarkTheme.cs
@@ -243,8 +243,8 @@ namespace Nikse.SubtitleEdit.Logic
             if (c is SubtitleListView seLV)
             {
                 seLV.OwnerDraw = true;
-                seLV.DrawColumnHeader += ListView_DrawColumnHeader;
                 seLV.GridLines = Configuration.Settings.General.DarkThemeShowListViewGridLines;
+                seLV.DrawColumnHeader += ListView_DrawColumnHeader;
                 seLV.HandleCreated += ListView_HandleCreated;
                 SetWindowThemeDark(seLV);
             }
@@ -255,6 +255,7 @@ namespace Nikse.SubtitleEdit.Logic
                 lv.DrawItem += ListView_DrawItem;
                 lv.DrawSubItem += ListView_DrawSubItem;
                 lv.DrawColumnHeader += ListView_DrawColumnHeader;
+                lv.EnabledChanged += ListView_EnabledChanged;
                 lv.HandleCreated += ListView_HandleCreated;
             }
         }
@@ -453,6 +454,23 @@ namespace Nikse.SubtitleEdit.Logic
                 {
                     e.Graphics.DrawLine(new Pen(ForeColor), e.Bounds.X, e.Bounds.Y, e.Bounds.X, e.Bounds.Height);
                 }
+            }
+        }
+
+        // A hack to set the disabled backcolor of a ListView
+        private static void ListView_EnabledChanged(object sender, EventArgs e)
+        {
+            var listView = sender as ListView;
+            if (!listView.Enabled)
+            {
+                Bitmap disabledBackgroundImage = new Bitmap(listView.ClientSize.Width, listView.ClientSize.Height);
+                Graphics.FromImage(disabledBackgroundImage).Clear(Color.DimGray);
+                listView.BackgroundImage = disabledBackgroundImage;
+                listView.BackgroundImageTiled = true;
+            }
+            else if (listView.BackgroundImage != null)
+            {
+                listView.BackgroundImage = null;
             }
         }
 


### PR DESCRIPTION
Okay, **for commit 1**, the font was not right.
Before:
![image](https://user-images.githubusercontent.com/20923700/104125409-2accde80-535f-11eb-8d41-c39516571256.png)

After:
![image](https://user-images.githubusercontent.com/20923700/104125430-5223ab80-535f-11eb-9df0-3379914b5bcf.png)

**Commit 2** is self-explanatory.

As for **Commit 3**, this is a subtitle list view, so whoever sets the gridlines to true (mainly me xD) might expect it to be the same as well.

As for **Commit 4**, this is a hack, I don't know if you'd like it but it's the only way to do it.
Before:
![image](https://user-images.githubusercontent.com/20923700/104125495-c0686e00-535f-11eb-9159-e712d61fa741.png)

After:
![image](https://user-images.githubusercontent.com/20923700/104125491-b7779c80-535f-11eb-9096-76f71548f6dc.png)