### PR TITLE
Some work on Netflix quality checks

### DIFF
--- a/src/Test/Logic/NetflixQualityCheckTest.cs
+++ b/src/Test/Logic/NetflixQualityCheckTest.cs
@@ -50,7 +50,7 @@ namespace Test.Logic
         public void TestNetflixCheckDialogeHyphenNoSpace()
         {
             var sub = new Subtitle();
-            var p1 = new Paragraph("- Lorem ipsum dolor sit" + Environment.NewLine + "- nelit focasia venlit dokalalam dilars.", 0, 4000);
+            var p1 = new Paragraph("- Lorem ipsum dolor sit." + Environment.NewLine + "- Nelit focasia venlit dokalalam dilars.", 0, 4000);
             sub.Paragraphs.Add(p1);
             var p2 = new Paragraph("Lorem - ipsum.", 0, 1000);
             sub.Paragraphs.Add(p2);
@@ -61,14 +61,14 @@ namespace Test.Logic
             checker.Check(sub, controller);
 
             Assert.AreEqual(1, controller.Records.Count);
-            Assert.AreEqual(controller.Records[0].FixedParagraph.Text, "-Lorem ipsum dolor sit" + Environment.NewLine + "-nelit focasia venlit dokalalam dilars.");
+            Assert.AreEqual(controller.Records[0].FixedParagraph.Text, "-Lorem ipsum dolor sit." + Environment.NewLine + "-Nelit focasia venlit dokalalam dilars.");
         }
 
         [TestMethod]
         public void TestNetflixCheckDialogeHyphenNoSpaceItalic()
         {
             var sub = new Subtitle();
-            var p1 = new Paragraph("<i>- Lorem ipsum dolor sit</i>" + Environment.NewLine + "<i>- nelit focasia venlit dokalalam dilars.</i>", 0, 4000);
+            var p1 = new Paragraph("<i>- Lorem ipsum dolor sit.</i>" + Environment.NewLine + "<i>- Nelit focasia venlit dokalalam dilars.</i>", 0, 4000);
             sub.Paragraphs.Add(p1);
             var p2 = new Paragraph("Lorem - ipsum.", 0, 1000);
             sub.Paragraphs.Add(p2);
@@ -79,7 +79,7 @@ namespace Test.Logic
             checker.Check(sub, controller);
 
             Assert.AreEqual(1, controller.Records.Count);
-            Assert.AreEqual(controller.Records[0].FixedParagraph.Text, "<i>-Lorem ipsum dolor sit</i>" + Environment.NewLine + "<i>-nelit focasia venlit dokalalam dilars.</i>");
+            Assert.AreEqual(controller.Records[0].FixedParagraph.Text, "<i>-Lorem ipsum dolor sit.</i>" + Environment.NewLine + "<i>-Nelit focasia venlit dokalalam dilars.</i>");
         }
 
         [TestMethod]

--- a/src/Test/Logic/NetflixQualityCheckTest.cs
+++ b/src/Test/Logic/NetflixQualityCheckTest.cs
@@ -196,7 +196,7 @@ namespace Test.Logic
         public void TestNetflixCheckNumberOfLines()
         {
             var sub = new Subtitle();
-            var p1 = new Paragraph("Lorem ipsum." + Environment.NewLine + "Line 2." + Environment.NewLine + "Line 3", 0, 832);
+            var p1 = new Paragraph("Lorem ipsum." + Environment.NewLine + "Line 2." + Environment.NewLine + "Line 3.", 0, 832);
             sub.Paragraphs.Add(p1);
             var p2 = new Paragraph("Lorem ipsum." + Environment.NewLine + "Line 2.", 0, 832);
             sub.Paragraphs.Add(p2);
@@ -209,7 +209,7 @@ namespace Test.Logic
             checker.Check(sub, controller);
 
             Assert.AreEqual(2, controller.Records.Count);
-            Assert.AreEqual(controller.Records[0].OriginalParagraph, p1);
+            Assert.AreEqual(controller.Records[0].FixedParagraph.Text, "Lorem ipsum. Line 2. Line 3.");
             Assert.AreEqual(controller.Records[1].FixedParagraph.Text, "Lorem ipsum. Line 2.");
         }
 

--- a/src/libse/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
@@ -3,12 +3,12 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Close gaps between subtitles of 3-11 frames (inclusive) to 2 frames.
+    /// https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines
+    /// </summary>
     public class NetflixCheckBridgeGaps : INetflixQualityChecker
     {
-        /// <summary>
-        /// Close gaps between subtitles of 3-11 frames (inclusive) to 2 frames.
-        /// https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             if (controller.Language == "ja")

--- a/src/libse/NetflixQualityCheck/NetflixCheckDialogHyphenSpace.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckDialogHyphenSpace.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
@@ -7,102 +7,37 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
     {
 
         /// <summary>
-        /// Use a hyphen with or without a space to indicate two speakers in one subtitle
+        /// Check speaker style depending on the language
         /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
-            if (controller.DualSpeakersHasHyphenAndNoSpace)
-            {
-                RemoveSpaceAfterHyphenInDialogues(subtitle, controller);
-            }
-            else
-            {
-                AddSpaceAfterHyphenInDialogues(subtitle, controller);
-            }
-        }
+            var dialogHelper = new DialogSplitMerge { DialogStyle = controller.SpeakerStyle };
 
-        private static void RemoveSpaceAfterHyphenInDialogues(Subtitle subtitle, NetflixQualityController controller)
-        {
-            foreach (Paragraph p in subtitle.Paragraphs)
+            string comment = "Dual Speakers: Use a hyphen without a space";
+            if (controller.SpeakerStyle == DialogType.DashBothLinesWithSpace)
             {
-                var arr = p.Text.SplitToLines();
-                if (arr.Count == 2 && p.Text.Contains("-"))
+                comment = "Dual Speakers: Use a hyphen with a space";
+            }
+            else if (controller.SpeakerStyle == DialogType.DashSecondLineWithSpace)
+            {
+                comment = "Dual Speakers: Use a hyphen with a space to denote the second speaker only";
+            }
+            else if (controller.SpeakerStyle == DialogType.DashSecondLineWithoutSpace)
+            {
+                comment = "Dual Speakers: Use a hyphen without a space to denote the second speaker only";
+            }
+
+            for (int i = 0; i < subtitle.Paragraphs.Count; i++)
+            {
+                var p = subtitle.Paragraphs[i];
+                string oldText = p.Text;
+                string newText = dialogHelper.FixDashesAndSpaces(p.Text);
+                if (newText != oldText)
                 {
-                    string newText = p.Text;
-                    if (arr[0].StartsWith("- ", StringComparison.Ordinal) && arr[1].StartsWith("- ", StringComparison.Ordinal))
-                    {
-                        newText = "-" + arr[0].Remove(0, 2) + Environment.NewLine + "-" + arr[1].Remove(0, 2);
-                    }
-                    else if (arr[0].StartsWith("<i>- ", StringComparison.Ordinal) && arr[1].StartsWith("<i>- ", StringComparison.Ordinal))
-                    {
-                        newText = "<i>-" + arr[0].Remove(0, 5) + Environment.NewLine + "<i>-" + arr[1].Remove(0, 5);
-                    }
-                    else if (arr[0].StartsWith("<i>- ", StringComparison.Ordinal) && arr[1].StartsWith("- ", StringComparison.Ordinal))
-                    {
-                        newText = "<i>-" + arr[0].Remove(0, 5) + Environment.NewLine + "-" + arr[1].Remove(0, 2);
-                    }
-                    else if (arr[0].StartsWith("- ", StringComparison.Ordinal) && arr[1].StartsWith("<i>- ", StringComparison.Ordinal))
-                    {
-                        newText = "-" + arr[0].Remove(0, 2) + Environment.NewLine + "<i>-" + arr[1].Remove(0, 5);
-                    }
-                    else if ((arr[0].StartsWith("-", StringComparison.Ordinal) || arr[0].StartsWith("<i>-", StringComparison.Ordinal)) && arr[1].StartsWith("- ", StringComparison.Ordinal))
-                    {
-                        newText = "-" + arr[0] + Environment.NewLine + "-" + arr[1].Remove(0, 2);
-                    }
-                    else if (arr[0].StartsWith("- ", StringComparison.Ordinal) && (arr[1].StartsWith("-", StringComparison.Ordinal) || arr[1].StartsWith("<i>-", StringComparison.Ordinal)))
-                    {
-                        newText = "-" + arr[0].Remove(0, 2) + Environment.NewLine + "-" + arr[1];
-                    }
-
-                    if (newText != p.Text)
-                    {
-                        var fixedParagraph = new Paragraph(p, false) { Text = newText };
-                        string comment = "Dual Speakers: Use a hyphen without a space";
-                        controller.AddRecord(p, fixedParagraph, comment);
-                    }
+                    var fixedParagraph = new Paragraph(p, false) { Text = newText };
+                    controller.AddRecord(p, fixedParagraph, comment);
                 }
             }
         }
-
-        private static void AddSpaceAfterHyphenInDialogues(Subtitle subtitle, NetflixQualityController controller)
-        {
-            var sub = new Subtitle(subtitle);
-            for (int i = 0; i < sub.Paragraphs.Count; i++)
-            {
-                Paragraph p = new Paragraph(sub.Paragraphs[i]);
-                var arr = p.Text.SplitToLines();
-                if (arr.Count == 2 && p.Text.Contains("-") && arr[0].Length > 3 && arr[1].Length > 3)
-                {
-                    string newText = p.Text;
-                    if (arr[0][0] == '-' && char.IsLetter(arr[0][1]) && (arr[1].StartsWith("-", StringComparison.Ordinal) || arr[1].StartsWith("<i>-", StringComparison.Ordinal)))
-                    {
-                        newText = arr[0].Insert(1, " ") + Environment.NewLine + arr[1];
-                        arr = newText.SplitToLines();
-                    }
-                    else if (arr[0].StartsWith("<i>-", StringComparison.Ordinal) && arr[0].Length > 5 && char.IsLetter(arr[0][4]) && (arr[1].StartsWith("-", StringComparison.Ordinal) || arr[1].StartsWith("<i>-", StringComparison.Ordinal)))
-                    {
-                        newText = arr[0].Insert(4, " ") + Environment.NewLine + arr[1];
-                        arr = newText.SplitToLines();
-                    }
-
-                    if (arr[1][0] == '-' && char.IsLetter(arr[1][1]) && (arr[0].StartsWith("-", StringComparison.Ordinal) || arr[0].StartsWith("<i>-", StringComparison.Ordinal)))
-                    {
-                        newText = arr[0] + Environment.NewLine + arr[1].Insert(1, " ");
-                    }
-                    else if (arr[1].StartsWith("<i>-", StringComparison.Ordinal) && arr[1].Length > 5 && char.IsLetter(arr[1][4]) && (arr[0].StartsWith("-", StringComparison.Ordinal) || arr[0].StartsWith("<i>-", StringComparison.Ordinal)))
-                    {
-                        newText = arr[0] + Environment.NewLine + arr[1].Insert(4, " ");
-                    }
-
-                    if (newText != p.Text)
-                    {
-                        var fixedParagraph = new Paragraph(p, false) { Text = newText };
-                        string comment = "Dual Speakers: Use a space after hyphen";
-                        controller.AddRecord(p, fixedParagraph, comment);
-                    }
-                }
-            }
-        }
-
     }
 }

--- a/src/libse/NetflixQualityCheck/NetflixCheckDialogHyphenSpace.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckDialogHyphenSpace.cs
@@ -3,16 +3,19 @@ using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Check speaker style depending on the language.
+    /// </summary>
     public class NetflixCheckDialogHyphenSpace : INetflixQualityChecker
     {
-
-        /// <summary>
-        /// Check speaker style depending on the language
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
-            var dialogHelper = new DialogSplitMerge { DialogStyle = controller.SpeakerStyle };
+            if (controller.Language == "ja")
+            {
+                return;
+            }
 
+            var dialogHelper = new DialogSplitMerge { DialogStyle = controller.SpeakerStyle };
             string comment = "Dual Speakers: Use a hyphen without a space";
             if (controller.SpeakerStyle == DialogType.DashBothLinesWithSpace)
             {

--- a/src/libse/NetflixQualityCheck/NetflixCheckEllipsesNotThreeDots.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckEllipsesNotThreeDots.cs
@@ -1,0 +1,25 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
+{
+    public class NetflixCheckEllipsesNotThreeDots : INetflixQualityChecker
+    {
+
+        /// <summary>
+        /// When including ellipses in subtitles, use the single smart character (U+2026) as opposed to three dots/periods in a row.
+        /// </summary>
+        public void Check(Subtitle subtitle, NetflixQualityController controller)
+        {
+            string comment = "Use the single smart character (U+2026) as opposed to three dots/periods in a row";
+
+            foreach (var paragraph in subtitle.Paragraphs)
+            {
+                if (paragraph.Text.Contains("..."))
+                {
+                    var fixedParagraph = new Paragraph(paragraph, false) { Text = paragraph.Text.Replace("...", "…") };
+                    controller.AddRecord(paragraph, fixedParagraph, comment);
+                }
+            }
+        }
+    }
+}

--- a/src/libse/NetflixQualityCheck/NetflixCheckEllipsesNotThreeDots.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckEllipsesNotThreeDots.cs
@@ -2,12 +2,11 @@
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// When including ellipses in subtitles, use the single smart character (U+2026) as opposed to three dots/periods in a row.
+    /// </summary>
     public class NetflixCheckEllipsesNotThreeDots : INetflixQualityChecker
     {
-
-        /// <summary>
-        /// When including ellipses in subtitles, use the single smart character (U+2026) as opposed to three dots/periods in a row.
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             string comment = "Use the single smart character (U+2026) as opposed to three dots/periods in a row";

--- a/src/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
@@ -8,7 +8,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
     public class NetflixCheckMaxCps : INetflixQualityChecker
     {
         /// <summary>
-        /// Speed - max 17 (for most languages) characters per second
+        /// Speed - max 20 (for most languages) characters per second
         /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {

--- a/src/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
@@ -1,22 +1,14 @@
-﻿using System.Globalization;
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Reading speed - depends on the language.
+    /// </summary>
     public class NetflixCheckMaxCps : INetflixQualityChecker
     {
-        private bool _isChildrenProgram;
-
-        public NetflixCheckMaxCps(bool isChildrenProgram = false)
-        {
-            _isChildrenProgram = isChildrenProgram;
-        }
-
-        /// <summary>
-        /// Speed - max 20 (for most languages) characters per second
-        /// for children programs, it's the normal minus 3
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             var oldIgnoreWhiteSpace = Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace;
@@ -24,9 +16,8 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
             {
                 Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace = false;
 
-                int charactersPerSecond = _isChildrenProgram ? controller.CharactersPerSecond - 3 : controller.CharactersPerSecond;
+                int charactersPerSecond = controller.CharactersPerSecond;
                 string comment = "Maximum " + charactersPerSecond + " characters per second";
-                
                 foreach (Paragraph p in subtitle.Paragraphs)
                 {
                     var jp = new Paragraph(p);
@@ -35,6 +26,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                         jp.Text = HtmlUtil.RemoveHtmlTags(jp.Text, true);
                         jp.Text = NetflixImsc11Japanese.RemoveTags(jp.Text);
                     }
+
                     var charactersPerSeconds = Utilities.GetCharactersPerSecond(jp);
                     if (charactersPerSeconds > charactersPerSecond && !p.StartTime.IsMaxTime)
                     {

--- a/src/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
@@ -7,8 +6,16 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
     public class NetflixCheckMaxCps : INetflixQualityChecker
     {
+        private bool _isChildrenProgram;
+
+        public NetflixCheckMaxCps(bool isChildrenProgram = false)
+        {
+            _isChildrenProgram = isChildrenProgram;
+        }
+
         /// <summary>
         /// Speed - max 20 (for most languages) characters per second
+        /// for children programs, it's the normal minus 3
         /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
@@ -16,6 +23,10 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
             try
             {
                 Configuration.Settings.General.CharactersPerSecondsIgnoreWhiteSpace = false;
+
+                int charactersPerSecond = _isChildrenProgram ? controller.CharactersPerSecond - 3 : controller.CharactersPerSecond;
+                string comment = "Maximum " + charactersPerSecond + " characters per second";
+                
                 foreach (Paragraph p in subtitle.Paragraphs)
                 {
                     var jp = new Paragraph(p);
@@ -25,14 +36,14 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                         jp.Text = NetflixImsc11Japanese.RemoveTags(jp.Text);
                     }
                     var charactersPerSeconds = Utilities.GetCharactersPerSecond(jp);
-                    if (charactersPerSeconds > controller.CharactersPerSecond && !p.StartTime.IsMaxTime)
+                    if (charactersPerSeconds > charactersPerSecond && !p.StartTime.IsMaxTime)
                     {
                         var fixedParagraph = new Paragraph(p, false);
-                        while (Utilities.GetCharactersPerSecond(fixedParagraph) > controller.CharactersPerSecond)
+                        while (Utilities.GetCharactersPerSecond(fixedParagraph) > charactersPerSecond)
                         {
                             fixedParagraph.EndTime.TotalMilliseconds++;
                         }
-                        string comment = "Maximum " + controller.CharactersPerSecond  + " characters per second";
+                        
                         controller.AddRecord(p, fixedParagraph, comment, charactersPerSeconds.ToString(CultureInfo.InvariantCulture));
                     }
                 }

--- a/src/libse/NetflixQualityCheck/NetflixCheckMaxDuration.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMaxDuration.cs
@@ -2,12 +2,11 @@
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Maximum duration: 7 seconds per subtitle event.
+    /// </summary>
     public class NetflixCheckMaxDuration : INetflixQualityChecker
     {
-
-        /// <summary>
-        /// Maximum duration: 7 seconds per subtitle event
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             foreach (Paragraph p in subtitle.Paragraphs)

--- a/src/libse/NetflixQualityCheck/NetflixCheckMaxLineLength.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMaxLineLength.cs
@@ -5,12 +5,11 @@ using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Maximum 42 chars per line for the majority of languages.
+    /// </summary>
     public class NetflixCheckMaxLineLength : INetflixQualityChecker
     {
-
-        /// <summary>
-        /// Maximum 42 chars per line for the majority of languages.
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             foreach (var p in subtitle.Paragraphs)

--- a/src/libse/NetflixQualityCheck/NetflixCheckMinDuration.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMinDuration.cs
@@ -3,12 +3,11 @@ using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Minimum duration: 5/6 second (833 ms) - also see https://github.com/SubtitleEdit/plugins/issues/129
+    /// </summary>
     public class NetflixCheckMinDuration : INetflixQualityChecker
     {
-
-        /// <summary>
-        /// Minimum duration: 5/6 second (833 ms) - also see https://github.com/SubtitleEdit/plugins/issues/129
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             for (int index = 0; index < subtitle.Paragraphs.Count; index++)

--- a/src/libse/NetflixQualityCheck/NetflixCheckNumberOfLines.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckNumberOfLines.cs
@@ -3,13 +3,12 @@ using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Two lines maximum.
+    /// Text should usually be kept to one line, unless it exceeds the character limitation.
+    /// </summary>
     public class NetflixCheckNumberOfLines : INetflixQualityChecker
     {
-
-        /// <summary>
-        /// Two lines maximum
-        /// Text should be on one line if it fits
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             foreach (Paragraph p in subtitle.Paragraphs)

--- a/src/libse/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
@@ -4,14 +4,14 @@ using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// From 1 to 10, numbers should be written out: one, two, three, etc.
+    /// </summary>
     public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
     {
         private static readonly Regex NumberOneToNine = new Regex(@"\b\d\b", RegexOptions.Compiled);
         private static readonly Regex NumberTen = new Regex(@"\b10\b", RegexOptions.Compiled);
 
-        /// <summary>
-        /// From 1 to 10, numbers should be written out: one, two, three, etc.
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             if (controller.Language == "ja" || controller.Language == "ar")

--- a/src/libse/NetflixQualityCheck/NetflixCheckSceneChange.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckSceneChange.cs
@@ -6,12 +6,12 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Check the newly-updated timing to Shot Changes rules.
+    /// https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines
+    /// </summary>
     public class NetflixCheckSceneChange : INetflixQualityChecker
     {
-        /// <summary>
-        /// Check the newly-updated timing to Shot Changes rules.
-        /// https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             if (!controller.VideoExists)

--- a/src/libse/NetflixQualityCheck/NetflixCheckStartNumberSpellOut.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckStartNumberSpellOut.cs
@@ -3,15 +3,15 @@ using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// When a number begins a sentence, it should always be spelled out.
+    /// </summary>
     public class NetflixCheckStartNumberSpellOut : INetflixQualityChecker
     {
         private static readonly Regex NumberStart = new Regex(@"^\d+ [A-Za-z]", RegexOptions.Compiled);
         private static readonly Regex NumberStartInside = new Regex(@"[\.,!] \d+ [A-Za-z]", RegexOptions.Compiled);
         private static readonly Regex NumberStartInside2 = new Regex(@"[\.,!]\r\n\d+ [A-Za-z]", RegexOptions.Compiled);
 
-        /// <summary>
-        /// When a number begins a sentence, it should always be spelled out.
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             foreach (Paragraph p in subtitle.Paragraphs)

--- a/src/libse/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
@@ -3,12 +3,11 @@ using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Use brackets[] to enclose speaker IDs or sound effects.
+    /// </summary>
     public class NetflixCheckTextForHiUseBrackets : INetflixQualityChecker
     {
-
-        /// <summary>
-        /// Use brackets[] to enclose speaker IDs or sound effects
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             if (controller.Language == "jp")

--- a/src/libse/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs
@@ -3,12 +3,11 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
+    /// <summary>
+    /// Two frames gap minimum.
+    /// </summary>
     public class NetflixCheckTwoFramesGap : INetflixQualityChecker
     {
-
-        /// <summary>
-        /// Two frames gap minimum
-        /// </summary>
         public void Check(Subtitle subtitle, NetflixQualityController controller)
         {
             if (controller.Language == "ja")

--- a/src/libse/NetflixQualityCheck/NetflixCheckWhiteSpace.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckWhiteSpace.cs
@@ -40,7 +40,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                     AddWhiteSpaceWarning(p, controller, m.Index + 1);
                 }
 
-                // 2+ consequent spaces
+                // 2+ consecutive spaces
                 foreach (Match m in TwoPlusConsequentSpaces.Matches(p.Text))
                 {
                     AddWhiteSpaceWarning(p, controller, m.Index);

--- a/src/libse/NetflixQualityCheck/NetflixCheckWhiteSpace.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckWhiteSpace.cs
@@ -1,5 +1,5 @@
-﻿using System.Text.RegularExpressions;
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {

--- a/src/libse/NetflixQualityCheck/NetflixQualityController.cs
+++ b/src/libse/NetflixQualityCheck/NetflixQualityController.cs
@@ -26,6 +26,10 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
             {
                 if (!string.IsNullOrEmpty(Language))
                 {
+                    if (Language == "nl") // Dutch
+                    {
+                        return 17;
+                    }
                     if (Language == "ko") // Korean
                     {
                         return 12;

--- a/src/libse/NetflixQualityCheck/NetflixQualityController.cs
+++ b/src/libse/NetflixQualityCheck/NetflixQualityController.cs
@@ -144,7 +144,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                     case "vi": // Vietnamese
                         return DialogType.DashBothLinesWithSpace;
                     case "nl": // Dutch
-                    case "fo": // Finnish
+                    case "fi": // Finnish
                     case "he": // Hebrew
                     case "sr": // Serbian
                         return DialogType.DashSecondLineWithoutSpace;

--- a/src/libse/NetflixQualityCheck/NetflixQualityController.cs
+++ b/src/libse/NetflixQualityCheck/NetflixQualityController.cs
@@ -16,7 +16,6 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
         public string Language { get; set; } = "en";
 
         public string VideoFileName { get; set; }
-
         public double FrameRate { get; set; } = 24;
 
         public int CharactersPerSecond

--- a/src/libse/NetflixQualityCheck/NetflixQualityController.cs
+++ b/src/libse/NetflixQualityCheck/NetflixQualityController.cs
@@ -19,20 +19,85 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
         public string VideoFileName { get; set; }
         public bool VideoExists => !string.IsNullOrEmpty(VideoFileName);
 
+        public bool IsChildrenProgram { get; set; }
+        public bool IsSDH { get; set; }
+
         public int CharactersPerSecond
         {
             get
             {
-                switch (Language)
+                if (IsChildrenProgram && IsSDH)
                 {
-                    case "nl": // Dutch
-                        return 17;
-                    case "ko": // Korean
-                        return 12;
-                    case "zh": // Chinese
-                        return 9;
-                    default:
-                        return 20;
+                    switch (Language)
+                    {
+                        case "ar": // Arabic
+                        case "hi": // Hindi
+                            return 20;
+                        case "ja": // Japanese
+                            return 7;
+                        case "ko": // Korean
+                            return 11;
+                        case "zh": // Chinese
+                            return 9;
+                        default:
+                            return 17;
+                    }
+                }
+                else if (IsChildrenProgram)
+                {
+                    switch (Language)
+                    {
+                        case "ar": // Arabic
+                        case "en": // English
+                            return 17;
+                        case "hi": // Hindi
+                            return 18;
+                        case "ja": // Japanese
+                            return 4;
+                        case "ko": // Korean
+                            return 9;
+                        case "zh": // Chinese
+                            return 7;
+                        default:
+                            return 13;
+                    }
+                }
+                else if (IsSDH)
+                {
+                    switch (Language)
+                    {
+                        case "ar": // Arabic
+                            return 23;
+                        case "hi": // Hindi
+                            return 25;
+                        case "ja": // Japanese
+                            return 7;
+                        case "ko": // Korean
+                            return 14;
+                        case "zh": // Chinese
+                            return 11;
+                        default:
+                            return 20;
+                    }
+                }
+                else
+                {
+                    switch (Language)
+                    {
+                        case "ar": // Arabic
+                        case "en": // English
+                            return 20;
+                        case "hi": // Hindi
+                            return 22;
+                        case "ja": // Japanese
+                            return 4;
+                        case "ko": // Korean
+                            return 12;
+                        case "zh": // Chinese
+                            return 9;
+                        default:
+                            return 17;
+                    }
                 }
             }
         }
@@ -45,11 +110,48 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                 {
                     case "ja": // Japanese
                         return 23;
+                    case "th": // Thai
+                        return 35;
                     case "ko": // Korean
                     case "zh": // Chinese
                         return 16;
                     default:
                         return 42;
+                }
+            }
+        }
+
+        public DialogType SpeakerStyle
+        {
+            get
+            {
+                switch (Language)
+                {
+                    case "ar": // Arabic
+                    case "cs": // Czech
+                    case "fr": // French
+                    case "hu": // Hungarian
+                    case "in": // Indonesian
+                    case "it": // Italian
+                    case "ko": // Korean
+                    case "ms": // Malay
+                    case "pl": // Polish
+                    case "ro": // Romanian
+                    case "ru": // Russian
+                    case "sk": // Slovak
+                    case "es": // Spanish
+                    case "th": // Thai
+                    case "vi": // Vietnamese
+                        return DialogType.DashBothLinesWithSpace;
+                    case "nl": // Dutch
+                    case "fo": // Finnish
+                    case "he": // Hebrew
+                    case "sr": // Serbian
+                        return DialogType.DashSecondLineWithoutSpace;
+                    case "bg": // Bulgarian 
+                        return DialogType.DashSecondLineWithSpace;
+                    default:
+                        return DialogType.DashBothLinesWithoutSpace;
                 }
             }
         }
@@ -75,26 +177,6 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                 }
 
                 return true;
-            }
-        }
-
-        public DialogType SpeakerStyle
-        {
-            get
-            {
-                switch (Language)
-                {
-                    case "ar": // Arabic
-                    case "cs": // Czech
-                    case "fr": // French
-                    case "ko": // Korean
-                        return DialogType.DashBothLinesWithSpace;
-                    case "nl": // Dutch
-                    case "he": // Hebrew
-                        return DialogType.DashSecondLineWithoutSpace;
-                    default:
-                        return DialogType.DashBothLinesWithoutSpace;
-                }
             }
         }
 

--- a/src/libse/NetflixQualityCheck/NetflixQualityController.cs
+++ b/src/libse/NetflixQualityCheck/NetflixQualityController.cs
@@ -4,19 +4,18 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
     public class NetflixQualityController
     {
-
         /// <summary>
         /// Two letter language code (e.g. "en" is English)
         /// </summary>
-
-        public string VideoFileName { get; set; } = string.Empty;
-        
         public string Language { get; set; } = "en";
+
+        public string VideoFileName { get; set; }
 
         public double FrameRate { get; set; } = 24;
 
@@ -89,30 +88,23 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
             }
         }
 
-        public bool DualSpeakersHasHyphenAndNoSpace
+        public DialogType SpeakerStyle
         {
             get
             {
-                if (!string.IsNullOrEmpty(Language))
+                switch (Language)
                 {
-                    if (Language == "cs") // Czech
-                    {
-                        return false;
-                    }
-                    if (Language == "fr") // French
-                    {
-                        return false;
-                    }
-                    if (Language == "ko") // Korean
-                    {
-                        return false;
-                    }
-                    if (Language == "ar") // Arabic
-                    {
-                        return false;
-                    }
+                    case "ar": // Arabic
+                    case "cs": // Czech
+                    case "fr": // French
+                    case "ko": // Korean
+                        return DialogType.DashBothLinesWithSpace;
+                    case "nl": // Dutch
+                    case "he": // Hebrew
+                        return DialogType.DashSecondLineWithoutSpace;
+                    default:
+                        return DialogType.DashBothLinesWithoutSpace;
                 }
-                return true;
             }
         }
 

--- a/src/libse/NetflixQualityCheck/NetflixQualityController.cs
+++ b/src/libse/NetflixQualityCheck/NetflixQualityController.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 {
@@ -15,29 +15,25 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
         /// </summary>
         public string Language { get; set; } = "en";
 
-        public string VideoFileName { get; set; }
         public double FrameRate { get; set; } = 24;
+        public string VideoFileName { get; set; }
+        public bool VideoExists => !string.IsNullOrEmpty(VideoFileName);
 
         public int CharactersPerSecond
         {
             get
             {
-                if (!string.IsNullOrEmpty(Language))
+                switch (Language)
                 {
-                    if (Language == "nl") // Dutch
-                    {
+                    case "nl": // Dutch
                         return 17;
-                    }
-                    if (Language == "ko") // Korean
-                    {
+                    case "ko": // Korean
                         return 12;
-                    }
-                    if (Language == "zh") // Chinese
-                    {
+                    case "zh": // Chinese
                         return 9;
-                    }
+                    default:
+                        return 20;
                 }
-                return 20;
             }
         }
 
@@ -45,22 +41,16 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
         {
             get
             {
-                if (!string.IsNullOrEmpty(Language))
+                switch (Language)
                 {
-                    if (Language == "ja") // Japanese
-                    {
+                    case "ja": // Japanese
                         return 23;
-                    }
-                    if (Language == "ko") // Korean
-                    {
+                    case "ko": // Korean
+                    case "zh": // Chinese
                         return 16;
-                    }
-                    if (Language == "zh") // Chinese
-                    {
-                        return 16;
-                    }
+                    default:
+                        return 42;
                 }
-                return 42;
             }
         }
 
@@ -70,19 +60,20 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
             {
                 if (!string.IsNullOrEmpty(Language))
                 {
-                    if (Language == "ko") // Korean
-                    {
-                        return false;
-                    }
-                    if (Language == "zh") // Chinese
-                    {
-                        return false;
-                    }
                     if (Language == "ar") // Arabic
                     {
                         return false;
                     }
+                    else if (Language == "ko") // Korean
+                    {
+                        return false;
+                    }
+                    else if (Language == "zh") // Chinese
+                    {
+                        return false;
+                    }
                 }
+
                 return true;
             }
         }
@@ -105,11 +96,6 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                         return DialogType.DashBothLinesWithoutSpace;
                 }
             }
-        }
-
-        public bool VideoExists
-        {
-            get => string.IsNullOrEmpty(VideoFileName) ? false : true;
         }
 
         public class Record

--- a/src/ui/Forms/NetflixFixErrors.Designer.cs
+++ b/src/ui/Forms/NetflixFixErrors.Designer.cs
@@ -87,7 +87,7 @@
             this.groupBoxRules.Controls.Add(this.checkBoxMaxDuration);
             this.groupBoxRules.Location = new System.Drawing.Point(12, 12);
             this.groupBoxRules.Name = "groupBoxRules";
-            this.groupBoxRules.Size = new System.Drawing.Size(1016, 254);
+            this.groupBoxRules.Size = new System.Drawing.Size(1016, 260);
             this.groupBoxRules.TabIndex = 0;
             this.groupBoxRules.TabStop = false;
             this.groupBoxRules.Text = "Rules";
@@ -373,7 +373,6 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.listViewFixes.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.columnHeader4,
             this.columnHeader5,
             this.columnHeader6,
             this.columnHeader7,
@@ -391,7 +390,7 @@
             // columnHeader4
             // 
             this.columnHeader4.Text = "Apply";
-            this.columnHeader4.Width = 38;
+            this.columnHeader4.Width = 50;
             // 
             // columnHeader5
             // 
@@ -401,17 +400,17 @@
             // columnHeader6
             // 
             this.columnHeader6.Text = "Function";
-            this.columnHeader6.Width = 169;
+            this.columnHeader6.Width = 225;
             // 
             // columnHeader7
             // 
             this.columnHeader7.Text = "Text";
-            this.columnHeader7.Width = 300;
+            this.columnHeader7.Width = 350;
             // 
             // columnHeader8
             // 
             this.columnHeader8.Text = "Suggested fix";
-            this.columnHeader8.Width = 300;
+            this.columnHeader8.Width = 350;
             // 
             // linkLabelOpenReportFolder
             // 

--- a/src/ui/Forms/NetflixFixErrors.Designer.cs
+++ b/src/ui/Forms/NetflixFixErrors.Designer.cs
@@ -37,8 +37,9 @@
             this.checkBoxNoItalics = new System.Windows.Forms.CheckBox();
             this.checkBoxGapMin = new System.Windows.Forms.CheckBox();
             this.checkBoxCheckValidGlyphs = new System.Windows.Forms.CheckBox();
-            this.checkBox20CharsPerSecond = new System.Windows.Forms.CheckBox();
+            this.checkBox17CharsPerSecond = new System.Windows.Forms.CheckBox();
             this.checkBoxChildrenProgram = new System.Windows.Forms.CheckBox();
+            this.checkBoxSDH = new System.Windows.Forms.CheckBox();
             this.comboBoxLanguage = new System.Windows.Forms.ComboBox();
             this.labelLanguage = new System.Windows.Forms.Label();
             this.checkBoxWriteOutOneToTen = new System.Windows.Forms.CheckBox();
@@ -73,8 +74,9 @@
             this.groupBoxRules.Controls.Add(this.checkBoxNoItalics);
             this.groupBoxRules.Controls.Add(this.checkBoxGapMin);
             this.groupBoxRules.Controls.Add(this.checkBoxCheckValidGlyphs);
+            this.groupBoxRules.Controls.Add(this.checkBoxSDH);
             this.groupBoxRules.Controls.Add(this.checkBoxChildrenProgram);
-            this.groupBoxRules.Controls.Add(this.checkBox20CharsPerSecond);
+            this.groupBoxRules.Controls.Add(this.checkBox17CharsPerSecond);
             this.groupBoxRules.Controls.Add(this.comboBoxLanguage);
             this.groupBoxRules.Controls.Add(this.labelLanguage);
             this.groupBoxRules.Controls.Add(this.checkBoxWriteOutOneToTen);
@@ -100,7 +102,7 @@
             this.checkBoxGapBridge.Location = new System.Drawing.Point(19, 164);
             this.checkBoxGapBridge.Name = "checkBoxGapBridge";
             this.checkBoxGapBridge.Size = new System.Drawing.Size(210, 17);
-            this.checkBoxGapBridge.TabIndex = 7;
+            this.checkBoxGapBridge.TabIndex = 8;
             this.checkBoxGapBridge.Text = "Frame gap:  3 to 11 frames => 2 frames";
             this.checkBoxGapBridge.UseVisualStyleBackColor = true;
             this.checkBoxGapBridge.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -113,7 +115,7 @@
             this.checkBoxWhiteSpace.Location = new System.Drawing.Point(409, 230);
             this.checkBoxWhiteSpace.Name = "checkBoxWhiteSpace";
             this.checkBoxWhiteSpace.Size = new System.Drawing.Size(86, 17);
-            this.checkBoxWhiteSpace.TabIndex = 19;
+            this.checkBoxWhiteSpace.TabIndex = 20;
             this.checkBoxWhiteSpace.Text = "White space";
             this.checkBoxWhiteSpace.UseVisualStyleBackColor = true;
             this.checkBoxWhiteSpace.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -126,7 +128,7 @@
             this.checkBoxMaxLineLength.Location = new System.Drawing.Point(19, 208);
             this.checkBoxMaxLineLength.Name = "checkBoxMaxLineLength";
             this.checkBoxMaxLineLength.Size = new System.Drawing.Size(130, 17);
-            this.checkBoxMaxLineLength.TabIndex = 9;
+            this.checkBoxMaxLineLength.TabIndex = 10;
             this.checkBoxMaxLineLength.Text = "Check max line length";
             this.checkBoxMaxLineLength.UseVisualStyleBackColor = true;
             this.checkBoxMaxLineLength.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -139,7 +141,7 @@
             this.checkBoxSceneChange.Location = new System.Drawing.Point(19, 230);
             this.checkBoxSceneChange.Name = "checkBoxSceneChange";
             this.checkBoxSceneChange.Size = new System.Drawing.Size(194, 17);
-            this.checkBoxSceneChange.TabIndex = 10;
+            this.checkBoxSceneChange.TabIndex = 11;
             this.checkBoxSceneChange.Text = "Check timing to shot changes rules";
             this.checkBoxSceneChange.UseVisualStyleBackColor = true;
             this.checkBoxSceneChange.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -152,7 +154,7 @@
             this.checkBoxTtmlFrameRate.Location = new System.Drawing.Point(409, 208);
             this.checkBoxTtmlFrameRate.Name = "checkBoxTtmlFrameRate";
             this.checkBoxTtmlFrameRate.Size = new System.Drawing.Size(154, 17);
-            this.checkBoxTtmlFrameRate.TabIndex = 18;
+            this.checkBoxTtmlFrameRate.TabIndex = 19;
             this.checkBoxTtmlFrameRate.Text = "Check frame rate for TTML";
             this.checkBoxTtmlFrameRate.UseVisualStyleBackColor = true;
             this.checkBoxTtmlFrameRate.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -178,7 +180,7 @@
             this.checkBoxGapMin.Location = new System.Drawing.Point(19, 142);
             this.checkBoxGapMin.Name = "checkBoxGapMin";
             this.checkBoxGapMin.Size = new System.Drawing.Size(168, 17);
-            this.checkBoxGapMin.TabIndex = 6;
+            this.checkBoxGapMin.TabIndex = 7;
             this.checkBoxGapMin.Text = "Frame gap: minimum 2 frames";
             this.checkBoxGapMin.UseVisualStyleBackColor = true;
             this.checkBoxGapMin.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -191,36 +193,49 @@
             this.checkBoxCheckValidGlyphs.Location = new System.Drawing.Point(409, 164);
             this.checkBoxCheckValidGlyphs.Name = "checkBoxCheckValidGlyphs";
             this.checkBoxCheckValidGlyphs.Size = new System.Drawing.Size(330, 17);
-            this.checkBoxCheckValidGlyphs.TabIndex = 16;
+            this.checkBoxCheckValidGlyphs.TabIndex = 17;
             this.checkBoxCheckValidGlyphs.Text = "Only text/characters included in the Netflix Glyph List (version 2)";
             this.checkBoxCheckValidGlyphs.UseVisualStyleBackColor = true;
             this.checkBoxCheckValidGlyphs.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
-            // checkBox20CharsPerSecond
+            // checkBox17CharsPerSecond
             // 
-            this.checkBox20CharsPerSecond.AutoSize = true;
-            this.checkBox20CharsPerSecond.Checked = true;
-            this.checkBox20CharsPerSecond.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox20CharsPerSecond.Location = new System.Drawing.Point(19, 98);
-            this.checkBox20CharsPerSecond.Name = "checkBox20CharsPerSecond";
-            this.checkBox20CharsPerSecond.Size = new System.Drawing.Size(287, 17);
-            this.checkBox20CharsPerSecond.TabIndex = 4;
-            this.checkBox20CharsPerSecond.Text = "Maximum 20 characters per second (incl. white spaces)";
-            this.checkBox20CharsPerSecond.UseVisualStyleBackColor = true;
-            this.checkBox20CharsPerSecond.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
+            this.checkBox17CharsPerSecond.AutoSize = true;
+            this.checkBox17CharsPerSecond.Checked = true;
+            this.checkBox17CharsPerSecond.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBox17CharsPerSecond.Location = new System.Drawing.Point(19, 98);
+            this.checkBox17CharsPerSecond.Name = "checkBox17CharsPerSecond";
+            this.checkBox17CharsPerSecond.Size = new System.Drawing.Size(287, 17);
+            this.checkBox17CharsPerSecond.TabIndex = 4;
+            this.checkBox17CharsPerSecond.Text = "Maximum 20 characters per second (incl. white spaces)";
+            this.checkBox17CharsPerSecond.UseVisualStyleBackColor = true;
+            this.checkBox17CharsPerSecond.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
             // checkBoxChildrenProgram
             // 
             this.checkBoxChildrenProgram.AutoSize = true;
             this.checkBoxChildrenProgram.Checked = false;
             this.checkBoxChildrenProgram.CheckState = System.Windows.Forms.CheckState.Unchecked;
-            this.checkBoxChildrenProgram.Location = new System.Drawing.Point(34, 120);
+            this.checkBoxChildrenProgram.Location = new System.Drawing.Point(46, 120);
             this.checkBoxChildrenProgram.Name = "checkBoxChildrenProgram";
             this.checkBoxChildrenProgram.Size = new System.Drawing.Size(287, 17);
             this.checkBoxChildrenProgram.TabIndex = 5;
             this.checkBoxChildrenProgram.Text = "Children's Program";
             this.checkBoxChildrenProgram.UseVisualStyleBackColor = true;
-            this.checkBoxChildrenProgram.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
+            this.checkBoxChildrenProgram.CheckedChanged += new System.EventHandler(this.ReadingSpeedChanged);
+            // 
+            // checkBoxSDH
+            // 
+            this.checkBoxSDH.AutoSize = true;
+            this.checkBoxSDH.Checked = false;
+            this.checkBoxSDH.CheckState = System.Windows.Forms.CheckState.Unchecked;
+            this.checkBoxSDH.Location = new System.Drawing.Point(175, 120);
+            this.checkBoxSDH.Name = "checkBoxSDH";
+            this.checkBoxSDH.Size = new System.Drawing.Size(287, 17);
+            this.checkBoxSDH.TabIndex = 6;
+            this.checkBoxSDH.Text = "SDH";
+            this.checkBoxSDH.UseVisualStyleBackColor = true;
+            this.checkBoxSDH.CheckedChanged += new System.EventHandler(this.ReadingSpeedChanged);
             // 
             // comboBoxLanguage
             // 
@@ -249,7 +264,7 @@
             this.checkBoxWriteOutOneToTen.Location = new System.Drawing.Point(409, 142);
             this.checkBoxWriteOutOneToTen.Name = "checkBoxWriteOutOneToTen";
             this.checkBoxWriteOutOneToTen.Size = new System.Drawing.Size(335, 17);
-            this.checkBoxWriteOutOneToTen.TabIndex = 15;
+            this.checkBoxWriteOutOneToTen.TabIndex = 16;
             this.checkBoxWriteOutOneToTen.Text = "From 1 to 10, numbers should be written out: One, two, three, etc.";
             this.checkBoxWriteOutOneToTen.UseVisualStyleBackColor = true;
             this.checkBoxWriteOutOneToTen.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -262,7 +277,7 @@
             this.checkBoxSpellOutStartNumbers.Location = new System.Drawing.Point(409, 120);
             this.checkBoxSpellOutStartNumbers.Name = "checkBoxSpellOutStartNumbers";
             this.checkBoxSpellOutStartNumbers.Size = new System.Drawing.Size(341, 17);
-            this.checkBoxSpellOutStartNumbers.TabIndex = 14;
+            this.checkBoxSpellOutStartNumbers.TabIndex = 15;
             this.checkBoxSpellOutStartNumbers.Text = "When a number begins a sentence, it should always be spelled out";
             this.checkBoxSpellOutStartNumbers.UseVisualStyleBackColor = true;
             this.checkBoxSpellOutStartNumbers.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -275,7 +290,7 @@
             this.checkBoxSquareBracketForHi.Location = new System.Drawing.Point(409, 98);
             this.checkBoxSquareBracketForHi.Name = "checkBoxSquareBracketForHi";
             this.checkBoxSquareBracketForHi.Size = new System.Drawing.Size(286, 17);
-            this.checkBoxSquareBracketForHi.TabIndex = 13;
+            this.checkBoxSquareBracketForHi.TabIndex = 14;
             this.checkBoxSquareBracketForHi.Text = "Use brackets [] to enclose speaker IDs or sound effects";
             this.checkBoxSquareBracketForHi.UseVisualStyleBackColor = true;
             this.checkBoxSquareBracketForHi.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -288,7 +303,7 @@
             this.checkBoxSpeakerStyle.Location = new System.Drawing.Point(409, 54);
             this.checkBoxSpeakerStyle.Name = "checkBoxSpeakerStyle";
             this.checkBoxSpeakerStyle.Size = new System.Drawing.Size(246, 17);
-            this.checkBoxSpeakerStyle.TabIndex = 11;
+            this.checkBoxSpeakerStyle.TabIndex = 12;
             this.checkBoxSpeakerStyle.Text = "Dual Speakers: Use a hyphen without a space";
             this.checkBoxSpeakerStyle.UseVisualStyleBackColor = true;
             this.checkBoxSpeakerStyle.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -301,7 +316,7 @@
             this.checkBoxEllipsesNotThreeDots.Location = new System.Drawing.Point(409, 76);
             this.checkBoxEllipsesNotThreeDots.Name = "checkBoxEllipsesNotThreeDots";
             this.checkBoxEllipsesNotThreeDots.Size = new System.Drawing.Size(246, 17);
-            this.checkBoxEllipsesNotThreeDots.TabIndex = 12;
+            this.checkBoxEllipsesNotThreeDots.TabIndex = 13;
             this.checkBoxEllipsesNotThreeDots.Text = "Use ellipses instead of three dots";
             this.checkBoxEllipsesNotThreeDots.UseVisualStyleBackColor = true;
             this.checkBoxEllipsesNotThreeDots.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -314,7 +329,7 @@
             this.checkBoxTwoLinesMax.Location = new System.Drawing.Point(19, 186);
             this.checkBoxTwoLinesMax.Name = "checkBoxTwoLinesMax";
             this.checkBoxTwoLinesMax.Size = new System.Drawing.Size(117, 17);
-            this.checkBoxTwoLinesMax.TabIndex = 8;
+            this.checkBoxTwoLinesMax.TabIndex = 9;
             this.checkBoxTwoLinesMax.Text = "Two lines maximum";
             this.checkBoxTwoLinesMax.UseVisualStyleBackColor = true;
             this.checkBoxTwoLinesMax.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -454,8 +469,9 @@
         private System.Windows.Forms.GroupBox groupBoxRules;
         private System.Windows.Forms.CheckBox checkBoxGapMin;
         private System.Windows.Forms.CheckBox checkBoxCheckValidGlyphs;
-        private System.Windows.Forms.CheckBox checkBox20CharsPerSecond;
+        private System.Windows.Forms.CheckBox checkBox17CharsPerSecond;
         private System.Windows.Forms.CheckBox checkBoxChildrenProgram;
+        private System.Windows.Forms.CheckBox checkBoxSDH;
         private System.Windows.Forms.ComboBox comboBoxLanguage;
         private System.Windows.Forms.Label labelLanguage;
         private System.Windows.Forms.CheckBox checkBoxWriteOutOneToTen;

--- a/src/ui/Forms/NetflixFixErrors.Designer.cs
+++ b/src/ui/Forms/NetflixFixErrors.Designer.cs
@@ -43,7 +43,7 @@
             this.checkBoxWriteOutOneToTen = new System.Windows.Forms.CheckBox();
             this.checkBoxSpellOutStartNumbers = new System.Windows.Forms.CheckBox();
             this.checkBoxSquareBracketForHi = new System.Windows.Forms.CheckBox();
-            this.checkBoxDialogHypenNoSpace = new System.Windows.Forms.CheckBox();
+            this.checkBoxSpeakerStyle = new System.Windows.Forms.CheckBox();
             this.checkBoxTwoLinesMax = new System.Windows.Forms.CheckBox();
             this.checkBoxMinDuration = new System.Windows.Forms.CheckBox();
             this.checkBoxMaxDuration = new System.Windows.Forms.CheckBox();
@@ -77,7 +77,7 @@
             this.groupBoxRules.Controls.Add(this.checkBoxWriteOutOneToTen);
             this.groupBoxRules.Controls.Add(this.checkBoxSpellOutStartNumbers);
             this.groupBoxRules.Controls.Add(this.checkBoxSquareBracketForHi);
-            this.groupBoxRules.Controls.Add(this.checkBoxDialogHypenNoSpace);
+            this.groupBoxRules.Controls.Add(this.checkBoxSpeakerStyle);
             this.groupBoxRules.Controls.Add(this.checkBoxTwoLinesMax);
             this.groupBoxRules.Controls.Add(this.checkBoxMinDuration);
             this.groupBoxRules.Controls.Add(this.checkBoxMaxDuration);
@@ -263,18 +263,18 @@
             this.checkBoxSquareBracketForHi.UseVisualStyleBackColor = true;
             this.checkBoxSquareBracketForHi.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
-            // checkBoxDialogHypenNoSpace
+            // checkBoxSpeakerStyle
             // 
-            this.checkBoxDialogHypenNoSpace.AutoSize = true;
-            this.checkBoxDialogHypenNoSpace.Checked = true;
-            this.checkBoxDialogHypenNoSpace.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxDialogHypenNoSpace.Location = new System.Drawing.Point(409, 54);
-            this.checkBoxDialogHypenNoSpace.Name = "checkBoxDialogHypenNoSpace";
-            this.checkBoxDialogHypenNoSpace.Size = new System.Drawing.Size(246, 17);
-            this.checkBoxDialogHypenNoSpace.TabIndex = 10;
-            this.checkBoxDialogHypenNoSpace.Text = "Dual Speakers: Use a hyphen without a space";
-            this.checkBoxDialogHypenNoSpace.UseVisualStyleBackColor = true;
-            this.checkBoxDialogHypenNoSpace.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
+            this.checkBoxSpeakerStyle.AutoSize = true;
+            this.checkBoxSpeakerStyle.Checked = true;
+            this.checkBoxSpeakerStyle.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxSpeakerStyle.Location = new System.Drawing.Point(409, 54);
+            this.checkBoxSpeakerStyle.Name = "checkBoxSpeakerStyle";
+            this.checkBoxSpeakerStyle.Size = new System.Drawing.Size(246, 17);
+            this.checkBoxSpeakerStyle.TabIndex = 10;
+            this.checkBoxSpeakerStyle.Text = "Dual Speakers: Use a hyphen without a space";
+            this.checkBoxSpeakerStyle.UseVisualStyleBackColor = true;
+            this.checkBoxSpeakerStyle.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
             // checkBoxTwoLinesMax
             // 
@@ -431,7 +431,7 @@
         private System.Windows.Forms.CheckBox checkBoxWriteOutOneToTen;
         private System.Windows.Forms.CheckBox checkBoxSpellOutStartNumbers;
         private System.Windows.Forms.CheckBox checkBoxSquareBracketForHi;
-        private System.Windows.Forms.CheckBox checkBoxDialogHypenNoSpace;
+        private System.Windows.Forms.CheckBox checkBoxSpeakerStyle;
         private System.Windows.Forms.CheckBox checkBoxTwoLinesMax;
         private System.Windows.Forms.CheckBox checkBoxMinDuration;
         private System.Windows.Forms.CheckBox checkBoxMaxDuration;

--- a/src/ui/Forms/NetflixFixErrors.Designer.cs
+++ b/src/ui/Forms/NetflixFixErrors.Designer.cs
@@ -37,13 +37,15 @@
             this.checkBoxNoItalics = new System.Windows.Forms.CheckBox();
             this.checkBoxGapMin = new System.Windows.Forms.CheckBox();
             this.checkBoxCheckValidGlyphs = new System.Windows.Forms.CheckBox();
-            this.checkBox17CharsPerSecond = new System.Windows.Forms.CheckBox();
+            this.checkBox20CharsPerSecond = new System.Windows.Forms.CheckBox();
+            this.checkBoxChildrenProgram = new System.Windows.Forms.CheckBox();
             this.comboBoxLanguage = new System.Windows.Forms.ComboBox();
             this.labelLanguage = new System.Windows.Forms.Label();
             this.checkBoxWriteOutOneToTen = new System.Windows.Forms.CheckBox();
             this.checkBoxSpellOutStartNumbers = new System.Windows.Forms.CheckBox();
             this.checkBoxSquareBracketForHi = new System.Windows.Forms.CheckBox();
             this.checkBoxSpeakerStyle = new System.Windows.Forms.CheckBox();
+            this.checkBoxEllipsesNotThreeDots = new System.Windows.Forms.CheckBox();
             this.checkBoxTwoLinesMax = new System.Windows.Forms.CheckBox();
             this.checkBoxMinDuration = new System.Windows.Forms.CheckBox();
             this.checkBoxMaxDuration = new System.Windows.Forms.CheckBox();
@@ -71,19 +73,21 @@
             this.groupBoxRules.Controls.Add(this.checkBoxNoItalics);
             this.groupBoxRules.Controls.Add(this.checkBoxGapMin);
             this.groupBoxRules.Controls.Add(this.checkBoxCheckValidGlyphs);
-            this.groupBoxRules.Controls.Add(this.checkBox17CharsPerSecond);
+            this.groupBoxRules.Controls.Add(this.checkBoxChildrenProgram);
+            this.groupBoxRules.Controls.Add(this.checkBox20CharsPerSecond);
             this.groupBoxRules.Controls.Add(this.comboBoxLanguage);
             this.groupBoxRules.Controls.Add(this.labelLanguage);
             this.groupBoxRules.Controls.Add(this.checkBoxWriteOutOneToTen);
             this.groupBoxRules.Controls.Add(this.checkBoxSpellOutStartNumbers);
             this.groupBoxRules.Controls.Add(this.checkBoxSquareBracketForHi);
+            this.groupBoxRules.Controls.Add(this.checkBoxEllipsesNotThreeDots);
             this.groupBoxRules.Controls.Add(this.checkBoxSpeakerStyle);
             this.groupBoxRules.Controls.Add(this.checkBoxTwoLinesMax);
             this.groupBoxRules.Controls.Add(this.checkBoxMinDuration);
             this.groupBoxRules.Controls.Add(this.checkBoxMaxDuration);
             this.groupBoxRules.Location = new System.Drawing.Point(12, 12);
             this.groupBoxRules.Name = "groupBoxRules";
-            this.groupBoxRules.Size = new System.Drawing.Size(1016, 248);
+            this.groupBoxRules.Size = new System.Drawing.Size(1016, 254);
             this.groupBoxRules.TabIndex = 0;
             this.groupBoxRules.TabStop = false;
             this.groupBoxRules.Text = "Rules";
@@ -93,10 +97,10 @@
             this.checkBoxGapBridge.AutoSize = true;
             this.checkBoxGapBridge.Checked = true;
             this.checkBoxGapBridge.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxGapBridge.Location = new System.Drawing.Point(19, 147);
+            this.checkBoxGapBridge.Location = new System.Drawing.Point(19, 164);
             this.checkBoxGapBridge.Name = "checkBoxGapBridge";
             this.checkBoxGapBridge.Size = new System.Drawing.Size(210, 17);
-            this.checkBoxGapBridge.TabIndex = 6;
+            this.checkBoxGapBridge.TabIndex = 7;
             this.checkBoxGapBridge.Text = "Frame gap:  3 to 11 frames => 2 frames";
             this.checkBoxGapBridge.UseVisualStyleBackColor = true;
             this.checkBoxGapBridge.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -106,10 +110,10 @@
             this.checkBoxWhiteSpace.AutoSize = true;
             this.checkBoxWhiteSpace.Checked = true;
             this.checkBoxWhiteSpace.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxWhiteSpace.Location = new System.Drawing.Point(409, 216);
+            this.checkBoxWhiteSpace.Location = new System.Drawing.Point(409, 230);
             this.checkBoxWhiteSpace.Name = "checkBoxWhiteSpace";
             this.checkBoxWhiteSpace.Size = new System.Drawing.Size(86, 17);
-            this.checkBoxWhiteSpace.TabIndex = 17;
+            this.checkBoxWhiteSpace.TabIndex = 19;
             this.checkBoxWhiteSpace.Text = "White space";
             this.checkBoxWhiteSpace.UseVisualStyleBackColor = true;
             this.checkBoxWhiteSpace.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -119,10 +123,10 @@
             this.checkBoxMaxLineLength.AutoSize = true;
             this.checkBoxMaxLineLength.Checked = true;
             this.checkBoxMaxLineLength.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxMaxLineLength.Location = new System.Drawing.Point(19, 193);
+            this.checkBoxMaxLineLength.Location = new System.Drawing.Point(19, 208);
             this.checkBoxMaxLineLength.Name = "checkBoxMaxLineLength";
             this.checkBoxMaxLineLength.Size = new System.Drawing.Size(130, 17);
-            this.checkBoxMaxLineLength.TabIndex = 8;
+            this.checkBoxMaxLineLength.TabIndex = 9;
             this.checkBoxMaxLineLength.Text = "Check max line length";
             this.checkBoxMaxLineLength.UseVisualStyleBackColor = true;
             this.checkBoxMaxLineLength.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -132,11 +136,11 @@
             this.checkBoxSceneChange.AutoSize = true;
             this.checkBoxSceneChange.Checked = true;
             this.checkBoxSceneChange.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxSceneChange.Location = new System.Drawing.Point(19, 216);
+            this.checkBoxSceneChange.Location = new System.Drawing.Point(19, 230);
             this.checkBoxSceneChange.Name = "checkBoxSceneChange";
             this.checkBoxSceneChange.Size = new System.Drawing.Size(194, 17);
-            this.checkBoxSceneChange.TabIndex = 9;
-            this.checkBoxSceneChange.Text = "Check timing to Shot Changes rules";
+            this.checkBoxSceneChange.TabIndex = 10;
+            this.checkBoxSceneChange.Text = "Check timing to shot changes rules";
             this.checkBoxSceneChange.UseVisualStyleBackColor = true;
             this.checkBoxSceneChange.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
@@ -145,10 +149,10 @@
             this.checkBoxTtmlFrameRate.AutoSize = true;
             this.checkBoxTtmlFrameRate.Checked = true;
             this.checkBoxTtmlFrameRate.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxTtmlFrameRate.Location = new System.Drawing.Point(409, 193);
+            this.checkBoxTtmlFrameRate.Location = new System.Drawing.Point(409, 208);
             this.checkBoxTtmlFrameRate.Name = "checkBoxTtmlFrameRate";
             this.checkBoxTtmlFrameRate.Size = new System.Drawing.Size(154, 17);
-            this.checkBoxTtmlFrameRate.TabIndex = 16;
+            this.checkBoxTtmlFrameRate.TabIndex = 18;
             this.checkBoxTtmlFrameRate.Text = "Check frame rate for TTML";
             this.checkBoxTtmlFrameRate.UseVisualStyleBackColor = true;
             this.checkBoxTtmlFrameRate.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -158,10 +162,10 @@
             this.checkBoxNoItalics.AutoSize = true;
             this.checkBoxNoItalics.Checked = true;
             this.checkBoxNoItalics.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxNoItalics.Location = new System.Drawing.Point(409, 170);
+            this.checkBoxNoItalics.Location = new System.Drawing.Point(409, 186);
             this.checkBoxNoItalics.Name = "checkBoxNoItalics";
             this.checkBoxNoItalics.Size = new System.Drawing.Size(109, 17);
-            this.checkBoxNoItalics.TabIndex = 15;
+            this.checkBoxNoItalics.TabIndex = 17;
             this.checkBoxNoItalics.Text = "Do not allow italic";
             this.checkBoxNoItalics.UseVisualStyleBackColor = true;
             this.checkBoxNoItalics.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -171,11 +175,11 @@
             this.checkBoxGapMin.AutoSize = true;
             this.checkBoxGapMin.Checked = true;
             this.checkBoxGapMin.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxGapMin.Location = new System.Drawing.Point(19, 124);
+            this.checkBoxGapMin.Location = new System.Drawing.Point(19, 142);
             this.checkBoxGapMin.Name = "checkBoxGapMin";
             this.checkBoxGapMin.Size = new System.Drawing.Size(168, 17);
-            this.checkBoxGapMin.TabIndex = 5;
-            this.checkBoxGapMin.Text = "Frame gap:  minimum 2 frames";
+            this.checkBoxGapMin.TabIndex = 6;
+            this.checkBoxGapMin.Text = "Frame gap: minimum 2 frames";
             this.checkBoxGapMin.UseVisualStyleBackColor = true;
             this.checkBoxGapMin.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
@@ -184,32 +188,45 @@
             this.checkBoxCheckValidGlyphs.AutoSize = true;
             this.checkBoxCheckValidGlyphs.Checked = true;
             this.checkBoxCheckValidGlyphs.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxCheckValidGlyphs.Location = new System.Drawing.Point(409, 147);
+            this.checkBoxCheckValidGlyphs.Location = new System.Drawing.Point(409, 164);
             this.checkBoxCheckValidGlyphs.Name = "checkBoxCheckValidGlyphs";
             this.checkBoxCheckValidGlyphs.Size = new System.Drawing.Size(330, 17);
-            this.checkBoxCheckValidGlyphs.TabIndex = 14;
-            this.checkBoxCheckValidGlyphs.Text = "Only text/characters included in the Netflix Glyph List (version 2) ";
+            this.checkBoxCheckValidGlyphs.TabIndex = 16;
+            this.checkBoxCheckValidGlyphs.Text = "Only text/characters included in the Netflix Glyph List (version 2)";
             this.checkBoxCheckValidGlyphs.UseVisualStyleBackColor = true;
             this.checkBoxCheckValidGlyphs.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
-            // checkBox17CharsPerSecond
+            // checkBox20CharsPerSecond
             // 
-            this.checkBox17CharsPerSecond.AutoSize = true;
-            this.checkBox17CharsPerSecond.Checked = true;
-            this.checkBox17CharsPerSecond.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox17CharsPerSecond.Location = new System.Drawing.Point(19, 101);
-            this.checkBox17CharsPerSecond.Name = "checkBox17CharsPerSecond";
-            this.checkBox17CharsPerSecond.Size = new System.Drawing.Size(287, 17);
-            this.checkBox17CharsPerSecond.TabIndex = 4;
-            this.checkBox17CharsPerSecond.Text = "Maximum 17 characters per second (incl. white spaces)";
-            this.checkBox17CharsPerSecond.UseVisualStyleBackColor = true;
-            this.checkBox17CharsPerSecond.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
+            this.checkBox20CharsPerSecond.AutoSize = true;
+            this.checkBox20CharsPerSecond.Checked = true;
+            this.checkBox20CharsPerSecond.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBox20CharsPerSecond.Location = new System.Drawing.Point(19, 98);
+            this.checkBox20CharsPerSecond.Name = "checkBox20CharsPerSecond";
+            this.checkBox20CharsPerSecond.Size = new System.Drawing.Size(287, 17);
+            this.checkBox20CharsPerSecond.TabIndex = 4;
+            this.checkBox20CharsPerSecond.Text = "Maximum 20 characters per second (incl. white spaces)";
+            this.checkBox20CharsPerSecond.UseVisualStyleBackColor = true;
+            this.checkBox20CharsPerSecond.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
+            // 
+            // checkBoxChildrenProgram
+            // 
+            this.checkBoxChildrenProgram.AutoSize = true;
+            this.checkBoxChildrenProgram.Checked = false;
+            this.checkBoxChildrenProgram.CheckState = System.Windows.Forms.CheckState.Unchecked;
+            this.checkBoxChildrenProgram.Location = new System.Drawing.Point(34, 120);
+            this.checkBoxChildrenProgram.Name = "checkBoxChildrenProgram";
+            this.checkBoxChildrenProgram.Size = new System.Drawing.Size(287, 17);
+            this.checkBoxChildrenProgram.TabIndex = 5;
+            this.checkBoxChildrenProgram.Text = "Children's Program";
+            this.checkBoxChildrenProgram.UseVisualStyleBackColor = true;
+            this.checkBoxChildrenProgram.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
             // comboBoxLanguage
             // 
             this.comboBoxLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxLanguage.FormattingEnabled = true;
-            this.comboBoxLanguage.Location = new System.Drawing.Point(77, 14);
+            this.comboBoxLanguage.Location = new System.Drawing.Point(77, 20);
             this.comboBoxLanguage.Name = "comboBoxLanguage";
             this.comboBoxLanguage.Size = new System.Drawing.Size(196, 21);
             this.comboBoxLanguage.TabIndex = 1;
@@ -218,7 +235,7 @@
             // labelLanguage
             // 
             this.labelLanguage.AutoSize = true;
-            this.labelLanguage.Location = new System.Drawing.Point(16, 17);
+            this.labelLanguage.Location = new System.Drawing.Point(16, 23);
             this.labelLanguage.Name = "labelLanguage";
             this.labelLanguage.Size = new System.Drawing.Size(55, 13);
             this.labelLanguage.TabIndex = 0;
@@ -229,10 +246,10 @@
             this.checkBoxWriteOutOneToTen.AutoSize = true;
             this.checkBoxWriteOutOneToTen.Checked = true;
             this.checkBoxWriteOutOneToTen.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxWriteOutOneToTen.Location = new System.Drawing.Point(409, 124);
+            this.checkBoxWriteOutOneToTen.Location = new System.Drawing.Point(409, 142);
             this.checkBoxWriteOutOneToTen.Name = "checkBoxWriteOutOneToTen";
             this.checkBoxWriteOutOneToTen.Size = new System.Drawing.Size(335, 17);
-            this.checkBoxWriteOutOneToTen.TabIndex = 13;
+            this.checkBoxWriteOutOneToTen.TabIndex = 15;
             this.checkBoxWriteOutOneToTen.Text = "From 1 to 10, numbers should be written out: One, two, three, etc.";
             this.checkBoxWriteOutOneToTen.UseVisualStyleBackColor = true;
             this.checkBoxWriteOutOneToTen.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -242,10 +259,10 @@
             this.checkBoxSpellOutStartNumbers.AutoSize = true;
             this.checkBoxSpellOutStartNumbers.Checked = true;
             this.checkBoxSpellOutStartNumbers.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxSpellOutStartNumbers.Location = new System.Drawing.Point(409, 101);
+            this.checkBoxSpellOutStartNumbers.Location = new System.Drawing.Point(409, 120);
             this.checkBoxSpellOutStartNumbers.Name = "checkBoxSpellOutStartNumbers";
             this.checkBoxSpellOutStartNumbers.Size = new System.Drawing.Size(341, 17);
-            this.checkBoxSpellOutStartNumbers.TabIndex = 12;
+            this.checkBoxSpellOutStartNumbers.TabIndex = 14;
             this.checkBoxSpellOutStartNumbers.Text = "When a number begins a sentence, it should always be spelled out";
             this.checkBoxSpellOutStartNumbers.UseVisualStyleBackColor = true;
             this.checkBoxSpellOutStartNumbers.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -255,11 +272,11 @@
             this.checkBoxSquareBracketForHi.AutoSize = true;
             this.checkBoxSquareBracketForHi.Checked = true;
             this.checkBoxSquareBracketForHi.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxSquareBracketForHi.Location = new System.Drawing.Point(409, 78);
+            this.checkBoxSquareBracketForHi.Location = new System.Drawing.Point(409, 98);
             this.checkBoxSquareBracketForHi.Name = "checkBoxSquareBracketForHi";
             this.checkBoxSquareBracketForHi.Size = new System.Drawing.Size(286, 17);
-            this.checkBoxSquareBracketForHi.TabIndex = 11;
-            this.checkBoxSquareBracketForHi.Text = "Use brackets[] to enclose speaker IDs or sound effects";
+            this.checkBoxSquareBracketForHi.TabIndex = 13;
+            this.checkBoxSquareBracketForHi.Text = "Use brackets [] to enclose speaker IDs or sound effects";
             this.checkBoxSquareBracketForHi.UseVisualStyleBackColor = true;
             this.checkBoxSquareBracketForHi.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
@@ -271,20 +288,33 @@
             this.checkBoxSpeakerStyle.Location = new System.Drawing.Point(409, 54);
             this.checkBoxSpeakerStyle.Name = "checkBoxSpeakerStyle";
             this.checkBoxSpeakerStyle.Size = new System.Drawing.Size(246, 17);
-            this.checkBoxSpeakerStyle.TabIndex = 10;
+            this.checkBoxSpeakerStyle.TabIndex = 11;
             this.checkBoxSpeakerStyle.Text = "Dual Speakers: Use a hyphen without a space";
             this.checkBoxSpeakerStyle.UseVisualStyleBackColor = true;
             this.checkBoxSpeakerStyle.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
+            // 
+            // checkBoxEllipsesNotThreeDots
+            // 
+            this.checkBoxEllipsesNotThreeDots.AutoSize = true;
+            this.checkBoxEllipsesNotThreeDots.Checked = true;
+            this.checkBoxEllipsesNotThreeDots.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxEllipsesNotThreeDots.Location = new System.Drawing.Point(409, 76);
+            this.checkBoxEllipsesNotThreeDots.Name = "checkBoxEllipsesNotThreeDots";
+            this.checkBoxEllipsesNotThreeDots.Size = new System.Drawing.Size(246, 17);
+            this.checkBoxEllipsesNotThreeDots.TabIndex = 12;
+            this.checkBoxEllipsesNotThreeDots.Text = "Use ellipses instead of three dots";
+            this.checkBoxEllipsesNotThreeDots.UseVisualStyleBackColor = true;
+            this.checkBoxEllipsesNotThreeDots.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
             // 
             // checkBoxTwoLinesMax
             // 
             this.checkBoxTwoLinesMax.AutoSize = true;
             this.checkBoxTwoLinesMax.Checked = true;
             this.checkBoxTwoLinesMax.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxTwoLinesMax.Location = new System.Drawing.Point(19, 170);
+            this.checkBoxTwoLinesMax.Location = new System.Drawing.Point(19, 186);
             this.checkBoxTwoLinesMax.Name = "checkBoxTwoLinesMax";
             this.checkBoxTwoLinesMax.Size = new System.Drawing.Size(117, 17);
-            this.checkBoxTwoLinesMax.TabIndex = 7;
+            this.checkBoxTwoLinesMax.TabIndex = 8;
             this.checkBoxTwoLinesMax.Text = "Two lines maximum";
             this.checkBoxTwoLinesMax.UseVisualStyleBackColor = true;
             this.checkBoxTwoLinesMax.CheckedChanged += new System.EventHandler(this.RuleCheckedChanged);
@@ -307,7 +337,7 @@
             this.checkBoxMaxDuration.AutoSize = true;
             this.checkBoxMaxDuration.Checked = true;
             this.checkBoxMaxDuration.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxMaxDuration.Location = new System.Drawing.Point(19, 78);
+            this.checkBoxMaxDuration.Location = new System.Drawing.Point(19, 76);
             this.checkBoxMaxDuration.Name = "checkBoxMaxDuration";
             this.checkBoxMaxDuration.Size = new System.Drawing.Size(250, 17);
             this.checkBoxMaxDuration.TabIndex = 3;
@@ -425,13 +455,15 @@
         private System.Windows.Forms.GroupBox groupBoxRules;
         private System.Windows.Forms.CheckBox checkBoxGapMin;
         private System.Windows.Forms.CheckBox checkBoxCheckValidGlyphs;
-        private System.Windows.Forms.CheckBox checkBox17CharsPerSecond;
+        private System.Windows.Forms.CheckBox checkBox20CharsPerSecond;
+        private System.Windows.Forms.CheckBox checkBoxChildrenProgram;
         private System.Windows.Forms.ComboBox comboBoxLanguage;
         private System.Windows.Forms.Label labelLanguage;
         private System.Windows.Forms.CheckBox checkBoxWriteOutOneToTen;
         private System.Windows.Forms.CheckBox checkBoxSpellOutStartNumbers;
         private System.Windows.Forms.CheckBox checkBoxSquareBracketForHi;
         private System.Windows.Forms.CheckBox checkBoxSpeakerStyle;
+        private System.Windows.Forms.CheckBox checkBoxEllipsesNotThreeDots;
         private System.Windows.Forms.CheckBox checkBoxTwoLinesMax;
         private System.Windows.Forms.CheckBox checkBoxMinDuration;
         private System.Windows.Forms.CheckBox checkBoxMaxDuration;

--- a/src/ui/Forms/NetflixFixErrors.cs
+++ b/src/ui/Forms/NetflixFixErrors.cs
@@ -28,6 +28,10 @@ namespace Nikse.SubtitleEdit.Forms
             UiUtil.PreInitialize(this);
             InitializeComponent();
             UiUtil.FixFonts(this);
+            if (Configuration.Settings.General.UseDarkTheme)
+            {
+                listViewFixes.GridLines = Configuration.Settings.General.DarkThemeShowListViewGridLines;
+            }
 
             _subtitle = subtitle;
             _subtitleFormat = subtitleFormat;
@@ -152,8 +156,11 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void AddFixToListView(Paragraph p, string action, string before, string after)
         {
-            var item = new ListViewItem(string.Empty) { Checked = true, Tag = p };
-            item.SubItems.Add(p.Number.ToString());
+            // This code should be used when the "Applt" function is added.
+            // var item = new ListViewItem(string.Empty) { Checked = true, Tag = p };
+            // item.SubItems.Add(p.Number.ToString());
+
+            var item = new ListViewItem(p.Number.ToString());
             item.SubItems.Add(action);
             item.SubItems.Add(before.Replace(Environment.NewLine, Configuration.Settings.General.ListViewLineSeparatorString));
             item.SubItems.Add(after.Replace(Environment.NewLine, Configuration.Settings.General.ListViewLineSeparatorString));

--- a/src/ui/Forms/NetflixFixErrors.cs
+++ b/src/ui/Forms/NetflixFixErrors.cs
@@ -93,7 +93,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             checkBoxSpeakerStyle.Text = checkBoxSpeakerStyleText;
 
-            checkBox20CharsPerSecond.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumXCharsPerSecond, _netflixQualityController.CharactersPerSecond);
+            checkBox17CharsPerSecond.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumXCharsPerSecond, _netflixQualityController.CharactersPerSecond);
             checkBoxMaxLineLength.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumLineLength, _netflixQualityController.SingleLineMaxLength);
         }
 
@@ -137,9 +137,7 @@ namespace Nikse.SubtitleEdit.Forms
             labelTotal.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.FoundXIssues, _netflixQualityController.Records.Count);
             linkLabelOpenReportFolder.Left = labelTotal.Left + labelTotal.Width + 15;
             linkLabelOpenReportFolder.Text = LanguageSettings.Current.NetflixQualityCheck.OpenReportInFolder;
-
-            var charactersPerSecond = checkBoxChildrenProgram.Checked ? _netflixQualityController.CharactersPerSecond - 3 : _netflixQualityController.CharactersPerSecond;
-            checkBox20CharsPerSecond.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumXCharsPerSecond, charactersPerSecond);
+            checkBox17CharsPerSecond.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumXCharsPerSecond, _netflixQualityController.CharactersPerSecond);
 
             listViewFixes.BeginUpdate();
             listViewFixes.Items.Clear();
@@ -200,9 +198,9 @@ namespace Nikse.SubtitleEdit.Forms
                 list.Add(new NetflixCheckMaxDuration());
             }
 
-            if (checkBox20CharsPerSecond.Checked)
+            if (checkBox17CharsPerSecond.Checked)
             {
-                list.Add(new NetflixCheckMaxCps(checkBoxChildrenProgram.Checked));
+                list.Add(new NetflixCheckMaxCps());
             }
 
             if (checkBoxGapMin.Checked)
@@ -289,6 +287,13 @@ namespace Nikse.SubtitleEdit.Forms
             var languageItem = (LanguageItem)comboBoxLanguage.Items[comboBoxLanguage.SelectedIndex];
             RefreshCheckBoxes(languageItem.Code.TwoLetterISOLanguageName);
             _loading = false;
+            RuleCheckedChanged(null, null);
+        }
+
+        private void ReadingSpeedChanged(object sender, EventArgs e)
+        {
+            _netflixQualityController.IsChildrenProgram = checkBoxChildrenProgram.Checked;
+            _netflixQualityController.IsSDH = checkBoxSDH.Checked;
             RuleCheckedChanged(null, null);
         }
 

--- a/src/ui/Forms/NetflixFixErrors.cs
+++ b/src/ui/Forms/NetflixFixErrors.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.NetflixQualityCheck;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
@@ -71,7 +72,22 @@ namespace Nikse.SubtitleEdit.Forms
             checkBoxTtmlFrameRate.Checked = checkFrameRate;
             checkBoxTtmlFrameRate.Enabled = checkFrameRate;
 
-            checkBoxDialogHypenNoSpace.Text = !_netflixQualityController.DualSpeakersHasHyphenAndNoSpace ? "Dual Speakers: Use a hyphen with a space" : "Dual Speakers: Use a hyphen without a space";
+            var speakerStyle = _netflixQualityController.SpeakerStyle;
+            var checkBoxSpeakerStyleText = "Dual Speakers: Use a hyphen without a space";
+            if (speakerStyle == DialogType.DashBothLinesWithSpace)
+            {
+                checkBoxSpeakerStyleText = "Dual Speakers: Use a hyphen with a space";
+            }
+            else if (speakerStyle == DialogType.DashSecondLineWithSpace)
+            {
+                checkBoxSpeakerStyleText = "Dual Speakers: Use a hyphen with a space to denote the second speaker only";
+            }
+            else if (speakerStyle == DialogType.DashSecondLineWithoutSpace)
+            {
+                checkBoxSpeakerStyleText = "Dual Speakers: Use a hyphen without a space to denote the second speaker only";
+            }
+
+            checkBoxSpeakerStyle.Text = checkBoxSpeakerStyleText;
 
             checkBox17CharsPerSecond.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumXCharsPerSecond, _netflixQualityController.CharactersPerSecond);
             checkBoxMaxLineLength.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumLineLength, _netflixQualityController.SingleLineMaxLength);
@@ -193,7 +209,7 @@ namespace Nikse.SubtitleEdit.Forms
                 list.Add(new NetflixCheckNumberOfLines());
             }
 
-            if (checkBoxDialogHypenNoSpace.Checked)
+            if (checkBoxSpeakerStyle.Checked)
             {
                 list.Add(new NetflixCheckDialogHyphenSpace());
             }

--- a/src/ui/Forms/NetflixFixErrors.cs
+++ b/src/ui/Forms/NetflixFixErrors.cs
@@ -89,7 +89,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             checkBoxSpeakerStyle.Text = checkBoxSpeakerStyleText;
 
-            checkBox17CharsPerSecond.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumXCharsPerSecond, _netflixQualityController.CharactersPerSecond);
+            checkBox20CharsPerSecond.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumXCharsPerSecond, _netflixQualityController.CharactersPerSecond);
             checkBoxMaxLineLength.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumLineLength, _netflixQualityController.SingleLineMaxLength);
         }
 
@@ -133,6 +133,10 @@ namespace Nikse.SubtitleEdit.Forms
             labelTotal.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.FoundXIssues, _netflixQualityController.Records.Count);
             linkLabelOpenReportFolder.Left = labelTotal.Left + labelTotal.Width + 15;
             linkLabelOpenReportFolder.Text = LanguageSettings.Current.NetflixQualityCheck.OpenReportInFolder;
+
+            var charactersPerSecond = checkBoxChildrenProgram.Checked ? _netflixQualityController.CharactersPerSecond - 3 : _netflixQualityController.CharactersPerSecond;
+            checkBox20CharsPerSecond.Text = string.Format(LanguageSettings.Current.NetflixQualityCheck.MaximumXCharsPerSecond, charactersPerSecond);
+
             listViewFixes.BeginUpdate();
             listViewFixes.Items.Clear();
             foreach (var record in _netflixQualityController.Records)
@@ -189,9 +193,9 @@ namespace Nikse.SubtitleEdit.Forms
                 list.Add(new NetflixCheckMaxDuration());
             }
 
-            if (checkBox17CharsPerSecond.Checked)
+            if (checkBox20CharsPerSecond.Checked)
             {
-                list.Add(new NetflixCheckMaxCps());
+                list.Add(new NetflixCheckMaxCps(checkBoxChildrenProgram.Checked));
             }
 
             if (checkBoxGapMin.Checked)
@@ -212,6 +216,11 @@ namespace Nikse.SubtitleEdit.Forms
             if (checkBoxSpeakerStyle.Checked)
             {
                 list.Add(new NetflixCheckDialogHyphenSpace());
+            }
+
+            if (checkBoxEllipsesNotThreeDots.Checked)
+            {
+                list.Add(new NetflixCheckEllipsesNotThreeDots());
             }
 
             if (checkBoxSquareBracketForHi.Checked)

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -2587,9 +2587,7 @@
         public class NetflixQualityCheck
         {
             public string GlyphCheckReport { get; set; }
-
             public string WhiteSpaceCheckReport { get; set; }
-
             public string ReportPrompt { get; set; }
             public string OpenReportInFolder { get; set; }
             public string FoundXIssues { get; set; }


### PR DESCRIPTION
1. Set CPS for various languages.
2. Include all 4 dialog styles and set the correct ones for various languages.
3. Add an option to set CPS for Children programs.
4.  Add an option to set CPS for SDH subtitles.
5. Add an option for `When including ellipses in subtitles, please use the single smart character (U+2026) as opposed to three dots/periods in a row.`
6. Make the gridlines depend on `DarkThemeShowListViewGridLines`.
7. Hide the "Apply" column for now.

Closes: https://github.com/SubtitleEdit/subtitleedit/issues/4699