### PR TITLE
Use a dark tab control + some work on colors

### DIFF
--- a/src/ui/Forms/FixCommonErrors.cs
+++ b/src/ui/Forms/FixCommonErrors.cs
@@ -1433,7 +1433,7 @@ namespace Nikse.SubtitleEdit.Forms
             UiUtil.GetLineLengths(labelSingleLine, text);
 
             var s = text.Replace(Environment.NewLine, " ");
-            labelTextLineTotal.ForeColor = Color.Black;
+            labelTextLineTotal.ForeColor = UiUtil.ForeColor;
             buttonSplitLine.Visible = false;
             var abl = Utilities.AutoBreakLine(s, _autoDetectGoogleLanguage).SplitToLines();
             if (abl.Count > Configuration.Settings.General.MaxNumberOfLines || abl.Any(li => li.CountCharacters(false, Configuration.Settings.General.IgnoreArabicDiacritics) > Configuration.Settings.General.SubtitleLineMaximumLength))

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -349,7 +349,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripButtonWaveformPlay = new System.Windows.Forms.ToolStripButton();
             this.toolStripButtonLockCenter = new System.Windows.Forms.ToolStripButton();
             this.toolStripSplitButtonPlayRate = new System.Windows.Forms.ToolStripSplitButton();
-            this.panelMode = new System.Windows.Forms.Panel();
+            this.panelModes = new System.Windows.Forms.Panel();
             this.buttonModeTranslate = new System.Windows.Forms.Button();
             this.buttonModeCreate = new System.Windows.Forms.Button();
             this.buttonModeAdjust = new System.Windows.Forms.Button();
@@ -545,7 +545,7 @@ namespace Nikse.SubtitleEdit.Forms
             ((System.ComponentModel.ISupportInitialize)(this.trackBarWaveformPosition)).BeginInit();
             this.panelWaveformControls.SuspendLayout();
             this.toolStripWaveControls.SuspendLayout();
-            this.panelMode.SuspendLayout();
+            this.panelModes.SuspendLayout();
             this.panelTranslate.SuspendLayout();
             this.groupBoxTranslateSearch.SuspendLayout();
             this.groupBoxAutoContinue.SuspendLayout();
@@ -2983,7 +2983,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.groupBoxVideo.Controls.Add(this.labelVideoInfo);
             this.groupBoxVideo.Controls.Add(this.trackBarWaveformPosition);
             this.groupBoxVideo.Controls.Add(this.panelWaveformControls);
-            this.groupBoxVideo.Controls.Add(this.panelMode);
+            this.groupBoxVideo.Controls.Add(this.panelModes);
             this.groupBoxVideo.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBoxVideo.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.groupBoxVideo.Location = new System.Drawing.Point(0, 0);
@@ -3192,23 +3192,23 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripSplitButtonPlayRate.Text = "Play rate (speed)";
             this.toolStripSplitButtonPlayRate.ButtonClick += new System.EventHandler(this.toolStripSplitButtonPlayRate_ButtonClick);
             // 
-            // panelMode
+            // panelModes
             // 
-            this.panelMode.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelMode.Controls.Add(this.buttonModeTranslate);
-            this.panelMode.Controls.Add(this.buttonModeCreate);
-            this.panelMode.Controls.Add(this.buttonModeAdjust);
-            this.panelMode.Controls.Add(this.panelTranslate);
-            this.panelMode.Controls.Add(this.panelCreate);
-            this.panelMode.Controls.Add(this.panelAdjust);
-            this.panelMode.Location = new System.Drawing.Point(8, 12);
-            this.panelMode.Name = "panelMode";
-            this.panelMode.Size = new System.Drawing.Size(467, 283);
-            this.panelMode.TabIndex = 0;
+            this.panelModes.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelModes.Controls.Add(this.buttonModeTranslate);
+            this.panelModes.Controls.Add(this.buttonModeCreate);
+            this.panelModes.Controls.Add(this.buttonModeAdjust);
+            this.panelModes.Controls.Add(this.panelTranslate);
+            this.panelModes.Controls.Add(this.panelCreate);
+            this.panelModes.Controls.Add(this.panelAdjust);
+            this.panelModes.Location = new System.Drawing.Point(4, 12);
+            this.panelModes.Name = "panelModes";
+            this.panelModes.Size = new System.Drawing.Size(467, 283);
+            this.panelModes.TabIndex = 0;
             // 
             // buttonModeTranslate
             // 
-            this.buttonModeTranslate.Location = new System.Drawing.Point(6, 8);
+            this.buttonModeTranslate.Location = new System.Drawing.Point(4, 4);
             this.buttonModeTranslate.Name = "buttonModeTranslate";
             this.buttonModeTranslate.Size = new System.Drawing.Size(65, 23);
             this.buttonModeTranslate.TabIndex = 0;
@@ -3217,7 +3217,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             // buttonModeCreate
             // 
-            this.buttonModeCreate.Location = new System.Drawing.Point(73, 8);
+            this.buttonModeCreate.Location = new System.Drawing.Point(71, 4);
             this.buttonModeCreate.Name = "buttonModeCreate";
             this.buttonModeCreate.Size = new System.Drawing.Size(65, 23);
             this.buttonModeCreate.TabIndex = 1;
@@ -3226,7 +3226,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             // buttonModeAdjust
             // 
-            this.buttonModeAdjust.Location = new System.Drawing.Point(140, 8);
+            this.buttonModeAdjust.Location = new System.Drawing.Point(138, 4);
             this.buttonModeAdjust.Name = "buttonModeAdjust";
             this.buttonModeAdjust.Size = new System.Drawing.Size(65, 23);
             this.buttonModeAdjust.TabIndex = 2;
@@ -3243,7 +3243,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.panelTranslate.Controls.Add(this.buttonPlayPrevious);
             this.panelTranslate.Controls.Add(this.buttonPlayCurrent);
             this.panelTranslate.Controls.Add(this.buttonPlayNext);
-            this.panelTranslate.Location = new System.Drawing.Point(4, 22);
+            this.panelTranslate.Location = new System.Drawing.Point(0, 20);
             this.panelTranslate.Name = "panelTranslate";
             this.panelTranslate.Padding = new System.Windows.Forms.Padding(3);
             this.panelTranslate.Size = new System.Drawing.Size(459, 257);
@@ -3498,7 +3498,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.panelCreate.Controls.Add(this.numericUpDownSec1);
             this.panelCreate.Controls.Add(this.labelVideoPosition);
             this.panelCreate.Controls.Add(this.buttonSecBack1);
-            this.panelCreate.Location = new System.Drawing.Point(4, 22);
+            this.panelCreate.Location = new System.Drawing.Point(6, 20);
             this.panelCreate.Name = "panelCreate";
             this.panelCreate.Padding = new System.Windows.Forms.Padding(3);
             this.panelCreate.Size = new System.Drawing.Size(214, 257);
@@ -3738,7 +3738,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.panelAdjust.Controls.Add(this.labelVideoPosition2);
             this.panelAdjust.Controls.Add(this.buttonAdjustGoToPosAndPause);
             this.panelAdjust.Controls.Add(this.buttonAdjustPlayBefore);
-            this.panelAdjust.Location = new System.Drawing.Point(4, 22);
+            this.panelAdjust.Location = new System.Drawing.Point(6, 20);
             this.panelAdjust.Name = "panelAdjust";
             this.panelAdjust.Size = new System.Drawing.Size(214, 257);
             this.panelAdjust.TabIndex = 5;
@@ -3842,7 +3842,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             this.labelAdjustF9.AutoSize = true;
             this.labelAdjustF9.ForeColor = System.Drawing.Color.Gray;
-            this.labelAdjustF9.Location = new System.Drawing.Point(188, 26);
+            this.labelAdjustF9.Location = new System.Drawing.Point(188, 18);
             this.labelAdjustF9.Name = "labelAdjustF9";
             this.labelAdjustF9.Size = new System.Drawing.Size(19, 13);
             this.labelAdjustF9.TabIndex = 61;
@@ -5247,7 +5247,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.panelWaveformControls.PerformLayout();
             this.toolStripWaveControls.ResumeLayout(false);
             this.toolStripWaveControls.PerformLayout();
-            this.panelMode.ResumeLayout(false);
+            this.panelModes.ResumeLayout(false);
             this.panelTranslate.ResumeLayout(false);
             this.panelTranslate.PerformLayout();
             this.groupBoxTranslateSearch.ResumeLayout(false);
@@ -5454,7 +5454,7 @@ namespace Nikse.SubtitleEdit.Forms
         private System.Windows.Forms.ToolStripMenuItem showhideVideoToolStripMenuItem;
         private System.Windows.Forms.Label labelVideoPosition;
         private Controls.TimeUpDown timeUpDownVideoPosition;
-        private System.Windows.Forms.Panel panelMode;
+        private System.Windows.Forms.Panel panelModes;
         private System.Windows.Forms.Button buttonModeTranslate;
         private System.Windows.Forms.Button buttonModeCreate;
         private System.Windows.Forms.Button buttonModeAdjust;

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -4293,7 +4293,6 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             // groupBoxEdit
             // 
-            this.groupBoxEdit.BackColor = System.Drawing.SystemColors.Control;
             this.groupBoxEdit.Controls.Add(this.labelOriginalSingleLinePixels);
             this.groupBoxEdit.Controls.Add(this.labelSingleLinePixels);
             this.groupBoxEdit.Controls.Add(this.panelBookmark);

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -238,8 +238,8 @@ namespace Nikse.SubtitleEdit.Forms
             UiUtil.FixFonts(contextMenuStripListView);
             UiUtil.FixFonts(contextMenuStripTextBoxListView);
             UiUtil.FixFonts(contextMenuStripWaveform);
-            UiUtil.FixLargeFonts(panelMode, buttonAutoBreak);
-            UiUtil.FixLargeFonts(panelMode, buttonAutoBreak);
+            UiUtil.FixLargeFonts(panelModes, buttonAutoBreak);
+            UiUtil.FixLargeFonts(panelModes, buttonAutoBreak);
             UiUtil.FixLargeFonts(groupBoxEdit, buttonAutoBreak);
             UiUtil.InitializeSubtitleFont(textBoxSource);
             UiUtil.InitializeSubtitleFont(SubtitleListview1);
@@ -19519,21 +19519,21 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     if (audioVisualizer.Visible)
                     {
-                        audioVisualizer.Left = panelMode.Left + panelMode.Width + 5;
+                        audioVisualizer.Left = panelModes.Left + panelModes.Width + 5;
                     }
                     else
                     {
-                        panelVideoPlayer.Left = panelMode.Left + panelMode.Width + 5;
+                        panelVideoPlayer.Left = panelModes.Left + panelModes.Width + 5;
                     }
                 }
                 else if (audioVisualizer.Visible)
                 {
-                    audioVisualizer.Left = panelMode.Left + panelMode.Width + 5;
+                    audioVisualizer.Left = panelModes.Left + panelModes.Width + 5;
                 }
 
                 audioVisualizer.Width = groupBoxVideo.Width - (audioVisualizer.Left + 10);
 
-                checkBoxSyncListViewWithVideoWhilePlaying.Left = panelMode.Left + panelMode.Width + 5;
+                checkBoxSyncListViewWithVideoWhilePlaying.Left = panelModes.Left + panelModes.Width + 5;
                 panelWaveformControls.Left = audioVisualizer.Left;
                 trackBarWaveformPosition.Left = panelWaveformControls.Left + panelWaveformControls.Width + 5;
                 trackBarWaveformPosition.Width = audioVisualizer.Left + audioVisualizer.Width - trackBarWaveformPosition.Left + 5;
@@ -19623,7 +19623,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             panelVideoPlayer.Top = 32;
-            panelVideoPlayer.Left = panelMode.Left + panelMode.Width + 5;
+            panelVideoPlayer.Left = panelModes.Left + panelModes.Width + 5;
             panelVideoPlayer.Height = groupBoxVideo.Height - (panelVideoPlayer.Top + 5);
             panelVideoPlayer.Width = groupBoxVideo.Width - (panelVideoPlayer.Left + 5);
         }
@@ -20875,7 +20875,7 @@ namespace Nikse.SubtitleEdit.Forms
                 buttonModeTranslate.Enabled = false;
                 panelTranslate.Visible = true;
                 panelTranslate.Focus();
-                panelMode.Width = groupBoxTranslateSearch.Left + groupBoxTranslateSearch.Width + 14;
+                panelModes.Width = groupBoxTranslateSearch.Left + groupBoxTranslateSearch.Width + 14;
                 Configuration.Settings.VideoControls.LastActiveTab = "Translate";
             }
             else if (clickedBtn == buttonModeCreate)
@@ -20883,7 +20883,7 @@ namespace Nikse.SubtitleEdit.Forms
                 buttonModeCreate.Enabled = false;
                 panelCreate.Visible = true;
                 panelCreate.Focus();
-                panelMode.Width = buttonInsertNewText.Left + buttonInsertNewText.Width + 38;
+                panelModes.Width = buttonInsertNewText.Left + buttonInsertNewText.Width + 38;
                 Configuration.Settings.VideoControls.LastActiveTab = "Create";
             }
             else if (clickedBtn == buttonModeAdjust)
@@ -20891,7 +20891,7 @@ namespace Nikse.SubtitleEdit.Forms
                 buttonModeAdjust.Enabled = false;
                 panelAdjust.Visible = true;
                 panelAdjust.Focus();
-                panelMode.Width = buttonInsertNewText.Left + buttonInsertNewText.Width + 38;
+                panelModes.Width = buttonInsertNewText.Left + buttonInsertNewText.Width + 38;
                 Configuration.Settings.VideoControls.LastActiveTab = "Adjust";
             }
 
@@ -20900,12 +20900,12 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (toolStripButtonToggleWaveform.Checked)
                 {
-                    audioVisualizer.Left = panelMode.Left + panelMode.Width + 5;
+                    audioVisualizer.Left = panelModes.Left + panelModes.Width + 5;
                 }
 
                 if (!toolStripButtonToggleWaveform.Checked && toolStripButtonToggleVideo.Checked)
                 {
-                    panelVideoPlayer.Left = panelMode.Left + panelMode.Width + 5;
+                    panelVideoPlayer.Left = panelModes.Left + panelModes.Width + 5;
                     panelVideoPlayer.Width = groupBoxVideo.Width - (panelVideoPlayer.Left + 10);
                 }
 
@@ -20914,7 +20914,7 @@ namespace Nikse.SubtitleEdit.Forms
                 trackBarWaveformPosition.Left = panelWaveformControls.Left + panelWaveformControls.Width + 5;
                 trackBarWaveformPosition.Width = groupBoxVideo.Width - (trackBarWaveformPosition.Left + 10);
                 Main_Resize(null, null);
-                checkBoxSyncListViewWithVideoWhilePlaying.Left = panelMode.Left + panelMode.Width + 5;
+                checkBoxSyncListViewWithVideoWhilePlaying.Left = panelModes.Left + panelModes.Width + 5;
                 if (!_loading)
                 {
                     Refresh();
@@ -20922,8 +20922,8 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (_videoControlsUndocked != null && !_videoControlsUndocked.IsDisposed)
             {
-                _videoControlsUndocked.Width = panelMode.Width + 20;
-                _videoControlsUndocked.Height = panelMode.Height + 65;
+                _videoControlsUndocked.Width = panelModes.Width + 20;
+                _videoControlsUndocked.Height = panelModes.Height + 65;
             }
         }
 
@@ -23917,7 +23917,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void UnDockVideoButtons()
         {
             _videoControlsUndocked = new VideoControlsUndocked(this);
-            var control = panelMode;
+            var control = panelModes;
             groupBoxVideo.Controls.Remove(control);
             control.Top = 25;
             control.Left = 0;
@@ -23996,8 +23996,8 @@ namespace Nikse.SubtitleEdit.Forms
                 _videoControlsUndocked.WindowState = FormWindowState.Normal;
                 _videoControlsUndocked.Top = top + 40;
                 _videoControlsUndocked.Left = Math.Abs(left - 10);
-                _videoControlsUndocked.Width = panelMode.Width + 20;
-                _videoControlsUndocked.Height = panelMode.Height + 65;
+                _videoControlsUndocked.Width = panelModes.Width + 20;
+                _videoControlsUndocked.Height = panelModes.Height + 65;
             }
 
             _isVideoControlsUndocked = true;

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -275,6 +275,11 @@ namespace Nikse.SubtitleEdit.Forms
             textBoxListViewText.BackColor = !IsSubtitleLoaded ? SystemColors.ActiveBorder : SystemColors.WindowFrame;
             textBoxListViewTextOriginal.BackColor = !IsSubtitleLoaded ? SystemColors.ActiveBorder : SystemColors.WindowFrame;
 
+            if (Configuration.IsRunningOnWindows && !Configuration.Settings.General.UseDarkTheme)
+            {
+                groupBoxEdit.BackColor = SystemColors.Window;
+            }
+
             base.OnLoad(e);
         }
 

--- a/src/ui/Forms/Ocr/VobSubOcr.Designer.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.Designer.cs
@@ -1214,7 +1214,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             this.tabControlLogs.Controls.Add(this.tabPageUnknownWords);
             this.tabControlLogs.Controls.Add(this.tabPageAllFixes);
             this.tabControlLogs.Controls.Add(this.tabPageSuggestions);
-            this.tabControlLogs.Location = new System.Drawing.Point(11, 146);
+            this.tabControlLogs.Location = new System.Drawing.Point(8, 144);
             this.tabControlLogs.Name = "tabControlLogs";
             this.tabControlLogs.SelectedIndex = 0;
             this.tabControlLogs.Size = new System.Drawing.Size(383, 181);
@@ -1307,7 +1307,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             this.listBoxUnknownWords.HorizontalScrollbar = true;
             this.listBoxUnknownWords.Location = new System.Drawing.Point(3, 3);
             this.listBoxUnknownWords.Name = "listBoxUnknownWords";
-            this.listBoxUnknownWords.Size = new System.Drawing.Size(143, 147);
+            this.listBoxUnknownWords.Size = new System.Drawing.Size(143, 149);
             this.listBoxUnknownWords.TabIndex = 40;
             this.listBoxUnknownWords.SelectedIndexChanged += new System.EventHandler(this.ListBoxLogSelectedIndexChanged);
             this.listBoxUnknownWords.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listBoxCopyToClipboard_KeyDown);

--- a/src/ui/Logic/DarkTheme.cs
+++ b/src/ui/Logic/DarkTheme.cs
@@ -232,12 +232,8 @@ namespace Nikse.SubtitleEdit.Logic
 
             if (c is TabControl tc)
             {
-                tc.DrawMode = TabDrawMode.OwnerDrawFixed;
-                tc.DrawItem += TabControl1_DrawItem;
-                foreach (TabPage tabPage in tc.TabPages)
-                {
-                    tabPage.Paint += TabPage_Paint;
-                }
+                SetStyle(tc, ControlStyles.UserPaint | ControlStyles.DoubleBuffer, true);
+                tc.Paint += TabControl_Paint;
             }
 
             if (c is SubtitleListView seLV)
@@ -310,28 +306,9 @@ namespace Nikse.SubtitleEdit.Logic
             }
         }
 
-        private static void TabControl1_DrawItem(object sender, DrawItemEventArgs e)
+        private static void TabControl_Paint(object sender, PaintEventArgs e)
         {
-            var sz = e.Graphics.MeasureString((sender as TabControl)?.TabPages[e.Index].Text, e.Font);
-            using (var br = new SolidBrush(BackColor))
-            {
-                e.Graphics.FillRectangle(br, e.Bounds);
-                e.Graphics.DrawString((sender as TabControl)?.TabPages[e.Index].Text, e.Font, Brushes.WhiteSmoke, e.Bounds.Left + (e.Bounds.Width - sz.Width) / 2, e.Bounds.Top + (e.Bounds.Height - sz.Height) / 2 + 1);
-
-                var rect = e.Bounds;
-                rect.Offset(0, 1);
-                rect.Inflate(0, -1);
-                e.Graphics.DrawRectangle(new Pen(ForeColor, 1), rect);
-                e.DrawFocusRectangle();
-            }
-        }
-
-        private static void TabPage_Paint(object sender, PaintEventArgs e)
-        {
-            using (var fillBrush = new SolidBrush(BackColor))
-            {
-                e.Graphics.FillRectangle(fillBrush, e.ClipRectangle);
-            }
+            new TabControlRenderer(sender as TabControl, e).Paint();
         }
 
         private static void ListView_DrawItem(object sender, DrawListViewItemEventArgs e)
@@ -562,6 +539,289 @@ namespace Nikse.SubtitleEdit.Logic
                     }
                 }
             }
+        }
+
+        // A dark theme for TabControl taken from gitextensions
+        // https://github.com/gitextensions/gitextensions/blob/master/GitExtUtils/GitUI/Theming/TabControlRenderer.cs
+        private class TabControlRenderer
+        {
+            private readonly Point _mouseCursor;
+            private readonly Graphics _graphics;
+            private readonly Rectangle _clipRectangle;
+            private readonly int _selectedIndex;
+            private readonly int _tabCount;
+            private readonly Size _imageSize;
+            private readonly Font _font;
+            private readonly bool _enabled;
+            private readonly Image[] _tabImages;
+            private readonly Rectangle[] _tabRects;
+            private readonly string[] _tabTexts;
+            private readonly Color[] _tabBackColors;
+            private readonly Size _size;
+            private readonly bool _failed;
+
+            private static readonly Color _selectedTabColor = Color.FromArgb(0, 122, 204);
+            private static readonly Color _highlightedTabColor = Color.FromArgb(28, 151, 234);
+
+            private static readonly int ImagePadding = 6;
+            private static readonly int SelectedTabPadding = 2;
+            private static readonly int BorderWidth = 1;
+
+            public TabControlRenderer(TabControl tabs, PaintEventArgs e)
+            {
+                _mouseCursor = tabs.PointToClient(Cursor.Position);
+                _graphics = e.Graphics;
+                _clipRectangle = e.ClipRectangle;
+                _size = tabs.Size;
+                _selectedIndex = tabs.SelectedIndex;
+                _tabCount = tabs.TabCount;
+                _font = tabs.Font;
+                _imageSize = tabs.ImageList?.ImageSize ?? Size.Empty;
+                _enabled = tabs.Enabled;
+
+                try
+                {
+                    _tabTexts = Enumerable.Range(0, _tabCount)
+                        .Select(i => tabs.TabPages[i].Text)
+                        .ToArray();
+                    _tabImages = Enumerable.Range(0, _tabCount)
+                        .Select(i => GetTabImage(tabs, i))
+                        .ToArray();
+                    _tabRects = Enumerable.Range(0, _tabCount)
+                        .Select(tabs.GetTabRect)
+                        .ToArray();
+                    _tabBackColors = Enumerable.Range(0, _tabCount)
+                        .Select(i => tabs.TabPages[i].BackColor)
+                        .ToArray();
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    _failed = true;
+                }
+            }
+
+            public void Paint()
+            {
+                if (_failed)
+                {
+                    return;
+                }
+
+                using (var canvasBrush = new SolidBrush(BackColor))
+                {
+                    _graphics.FillRectangle(canvasBrush, _clipRectangle);
+                }
+
+                RenderSelectedPageBackground();
+
+                IEnumerable<int> pageIndices;
+                if (_selectedIndex >= 0 && _selectedIndex < _tabCount)
+                {
+                    // Render tabs in pyramid order with selected on top
+                    pageIndices = Enumerable.Range(0, _selectedIndex)
+                        .Concat(Enumerable.Range(_selectedIndex, _tabCount - _selectedIndex).Reverse());
+                }
+                else
+                {
+                    pageIndices = Enumerable.Range(0, _tabCount);
+                }
+
+                foreach (var index in pageIndices)
+                {
+                    RenderTabBackground(index);
+                    RenderTabImage(index);
+                    RenderTabText(index, _tabImages[index] != null);
+                }
+            }
+
+            private void RenderTabBackground(int index)
+            {
+                var outerRect = GetOuterTabRect(index);
+                _graphics.FillRectangle(GetBackgroundBrush(index), outerRect);
+
+                var points = new List<Point>(4);
+                if (index <= _selectedIndex)
+                {
+                    points.Add(new Point(outerRect.Left, outerRect.Bottom - 1));
+                }
+
+                points.Add(new Point(outerRect.Left, outerRect.Top));
+                points.Add(new Point(outerRect.Right - 1, outerRect.Top));
+
+                if (index >= _selectedIndex)
+                {
+                    points.Add(new Point(outerRect.Right - 1, outerRect.Bottom - 1));
+                }
+                using (var borderPen = GetBorderPen())
+                {
+                    _graphics.DrawLines(borderPen, points.ToArray());
+                }
+            }
+
+            private void RenderTabImage(int index)
+            {
+                var image = _tabImages[index];
+                if (image is null)
+                {
+                    return;
+                }
+
+                var imgRect = GetTabImageRect(index);
+                _graphics.DrawImage(image, imgRect);
+            }
+
+            private Rectangle GetTabImageRect(int index)
+            {
+                var innerRect = _tabRects[index];
+                int imgHeight = _imageSize.Height;
+                var imgRect = new Rectangle(
+                    new Point(innerRect.X + ImagePadding,
+                        innerRect.Y + ((innerRect.Height - imgHeight) / 2)),
+                    _imageSize);
+
+                if (index == _selectedIndex)
+                {
+                    imgRect.Offset(0, -SelectedTabPadding);
+                }
+
+                return imgRect;
+            }
+
+            private static Image GetTabImage(TabControl tabs, int index)
+            {
+                var images = tabs.ImageList?.Images;
+                if (images is null)
+                {
+                    return null;
+                }
+
+                var page = tabs.TabPages[index];
+                if (!string.IsNullOrEmpty(page.ImageKey))
+                {
+                    return images[page.ImageKey];
+                }
+
+                if (page.ImageIndex >= 0 && page.ImageIndex < images.Count)
+                {
+                    return images[page.ImageIndex];
+                }
+
+                return null;
+            }
+
+            private void RenderTabText(int index, bool hasImage)
+            {
+                if (string.IsNullOrEmpty(_tabTexts[index]))
+                {
+                    return;
+                }
+
+                var textRect = GetTabTextRect(index, hasImage);
+
+                const TextFormatFlags format =
+                    TextFormatFlags.NoClipping |
+                    TextFormatFlags.NoPrefix |
+                    TextFormatFlags.VerticalCenter |
+                    TextFormatFlags.HorizontalCenter;
+
+                var textColor = _enabled
+                    ? ForeColor
+                    : SystemColors.GrayText;
+
+                TextRenderer.DrawText(_graphics, _tabTexts[index], _font, textRect, textColor, format);
+            }
+
+            private Rectangle GetTabTextRect(int index, bool hasImage)
+            {
+                var innerRect = _tabRects[index];
+                Rectangle textRect;
+                if (hasImage)
+                {
+                    int deltaWidth = _imageSize.Width + ImagePadding;
+                    textRect = new Rectangle(
+                        innerRect.X + deltaWidth,
+                        innerRect.Y,
+                        innerRect.Width - deltaWidth,
+                        innerRect.Height);
+                }
+                else
+                {
+                    textRect = innerRect;
+                }
+
+                if (index == _selectedIndex)
+                {
+                    textRect.Offset(0, -SelectedTabPadding);
+                }
+
+                return textRect;
+            }
+
+            private Rectangle GetOuterTabRect(int index)
+            {
+                var innerRect = _tabRects[index];
+
+                if (index == _selectedIndex)
+                {
+                    return Rectangle.FromLTRB(
+                        innerRect.Left - SelectedTabPadding,
+                        innerRect.Top - SelectedTabPadding,
+                        innerRect.Right + SelectedTabPadding,
+                        innerRect.Bottom + 1); // +1 to overlap tabs bottom line
+                }
+
+                return Rectangle.FromLTRB(
+                    innerRect.Left,
+                    innerRect.Top + 1,
+                    innerRect.Right,
+                    innerRect.Bottom);
+            }
+
+            private void RenderSelectedPageBackground()
+            {
+                if (_selectedIndex < 0 || _selectedIndex >= _tabCount)
+                {
+                    return;
+                }
+
+                var tabRect = _tabRects[_selectedIndex];
+                var pageRect = Rectangle.FromLTRB(0, tabRect.Bottom, _size.Width - 1,
+                    _size.Height - 1);
+
+                if (!_clipRectangle.IntersectsWith(pageRect))
+                {
+                    return;
+                }
+
+                using (var borderPen = GetBorderPen())
+                {
+                    _graphics.DrawRectangle(borderPen, pageRect);
+                }
+            }
+
+            private Brush GetBackgroundBrush(int index)
+            {
+                if (index == _selectedIndex)
+                {
+                    return _tabBackColors[index] == Color.Transparent
+                        ? SystemBrushes.Window
+                        : new SolidBrush(_selectedTabColor);
+                }
+
+                bool isHighlighted = _tabRects[index].Contains(_mouseCursor);
+
+                return isHighlighted
+                    ? new SolidBrush(_highlightedTabColor)
+                    : new SolidBrush(BackColor);
+            }
+
+            private Pen GetBorderPen() =>
+                new Pen(SystemBrushes.ControlDark, BorderWidth);
+        }
+
+        private static void SetStyle(Control control, ControlStyles styles, bool value)
+        {
+            typeof(TabControl).GetMethod("SetStyle", BindingFlags.Instance | BindingFlags.NonPublic).Invoke(control, new object[] { styles, value });
         }
 
         internal static void SetDarkTheme(ToolStripItem item)

--- a/src/ui/Logic/DarkTheme.cs
+++ b/src/ui/Logic/DarkTheme.cs
@@ -401,12 +401,6 @@ namespace Nikse.SubtitleEdit.Logic
                 return;
             }
 
-            int addY = 0;
-            if (e.Font.Name != Configuration.Settings.General.SubtitleFontName)
-            {
-                addY = 5;
-            }
-
             e.DrawDefault = false;
             using (var b = new SolidBrush(Color.FromArgb(Math.Max(BackColor.R - 9, 0), Math.Max(BackColor.G - 9, 0), Math.Max(BackColor.B - 9, 0))))
             {
@@ -426,7 +420,8 @@ namespace Nikse.SubtitleEdit.Logic
 
             using (var fc = new SolidBrush(ForeColor))
             {
-                e.Graphics.DrawString(e.Header.Text, e.Font, fc, e.Bounds.X + 3, e.Bounds.Y + addY, strFormat);
+                int posY = Math.Abs(e.Bounds.Height - e.Font.Height) / 2;
+                e.Graphics.DrawString(e.Header.Text, e.Font, fc, e.Bounds.X + 3, posY, strFormat);
                 if (e.ColumnIndex != 0)
                 {
                     e.Graphics.DrawLine(new Pen(ForeColor), e.Bounds.X, e.Bounds.Y, e.Bounds.X, e.Bounds.Height);


### PR DESCRIPTION
Welp, it's exactly what it says:
![image](https://user-images.githubusercontent.com/20923700/104469790-91e9cd80-55c1-11eb-8e06-71ba5de6ee24.png)

![image](https://user-images.githubusercontent.com/20923700/104472368-8f3ca780-55c4-11eb-9c1c-6623e4812314.png)

I found this in `gitextensions`'s dark theme and edited it for SE, the license is `GNU General Public License v3.0`, and I mentioned where I got it from.
Is this okay?