### PR TITLE
Some work on dropdown menus

### DIFF
--- a/src/libse/Common/FastBitmap.cs
+++ b/src/libse/Common/FastBitmap.cs
@@ -41,21 +41,6 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             _workingBitmap = inputBitmap;
 
-            if (_workingBitmap.PixelFormat != PixelFormat.Format32bppArgb &&
-                Environment.OSVersion.Version.Major < 6 && Configuration.Settings.General.SubtitleFontName == Utilities.WinXP2KUnicodeFontName) // 6 == Vista/Win2008Server/Win7
-            { // WinXp Fix
-                var newBitmap = new Bitmap(_workingBitmap.Width, _workingBitmap.Height, PixelFormat.Format32bppArgb);
-                for (int y = 0; y < _workingBitmap.Height; y++)
-                {
-                    for (int x = 0; x < _workingBitmap.Width; x++)
-                    {
-                        newBitmap.SetPixel(x, y, _workingBitmap.GetPixel(x, y));
-                    }
-                }
-
-                _workingBitmap = newBitmap;
-            }
-
             Width = inputBitmap.Width;
             Height = inputBitmap.Height;
         }

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-using System.Security.Authentication;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -18,8 +17,6 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     public static class Utilities
     {
-        public const string WinXP2KUnicodeFontName = "Times New Roman";
-
         /// <summary>
         /// Cached environment new line characters for faster lookup.
         /// </summary>

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -7780,7 +7780,11 @@ namespace Nikse.SubtitleEdit.Forms
                 setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Clear();
                 foreach (var style in styles)
                 {
-                    setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, tsi_Click);
+                    setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, SetStyle);
+                    if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle.GetParagraphOrDefault(SubtitleListview1.SelectedItems[0].Index).Extra == style)
+                    {
+                        ((ToolStripMenuItem)setStylesForSelectedLinesToolStripMenuItem.DropDownItems[setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Count - 1]).Checked = true;
+                    }
                 }
 
                 toolStripMenuItemAssStyles.Visible = true;
@@ -7819,7 +7823,11 @@ namespace Nikse.SubtitleEdit.Forms
                 setActorForSelectedLinesToolStripMenuItem.DropDownItems.Clear();
                 foreach (var actor in actors)
                 {
-                    setActorForSelectedLinesToolStripMenuItem.DropDownItems.Add(actor, null, actor_Click);
+                    setActorForSelectedLinesToolStripMenuItem.DropDownItems.Add(actor, null, SetActor);
+                    if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle.GetParagraphOrDefault(SubtitleListview1.SelectedItems[0].Index).Actor == actor)
+                    {
+                        ((ToolStripMenuItem)setActorForSelectedLinesToolStripMenuItem.DropDownItems[setActorForSelectedLinesToolStripMenuItem.DropDownItems.Count - 1]).Checked = true;
+                    }
                 }
 
                 if (actors.Count > 0)
@@ -7845,7 +7853,11 @@ namespace Nikse.SubtitleEdit.Forms
                 setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Clear();
                 foreach (var style in styles)
                 {
-                    setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, tsi_Click);
+                    setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, SetStyle);
+                    if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle.GetParagraphOrDefault(SubtitleListview1.SelectedItems[0].Index).Style == style)
+                    {
+                        ((ToolStripMenuItem)setStylesForSelectedLinesToolStripMenuItem.DropDownItems[setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Count - 1]).Checked = true;
+                    }
                 }
 
                 if (styles.Count >= 1)
@@ -7875,7 +7887,11 @@ namespace Nikse.SubtitleEdit.Forms
                     toolStripMenuItemSetRegion.Visible = true;
                     foreach (var region in regions)
                     {
-                        toolStripMenuItemSetRegion.DropDownItems.Add(region, null, SetRegionClick);
+                        toolStripMenuItemSetRegion.DropDownItems.Add(region, null, SetRegion);
+                        if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle.GetParagraphOrDefault(SubtitleListview1.SelectedItems[0].Index).Region == region)
+                        {
+                            ((ToolStripMenuItem)toolStripMenuItemSetRegion.DropDownItems[toolStripMenuItemSetRegion.DropDownItems.Count - 1]).Checked = true;
+                        }
                     }
 
                     var tss = new ToolStripSeparator();
@@ -7910,7 +7926,11 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     foreach (var language in languages)
                     {
-                        toolStripMenuItemSetLanguage.DropDownItems.Add(language, null, AddLanguageClick);
+                        toolStripMenuItemSetLanguage.DropDownItems.Add(language, null, SetLanguage);
+                        if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle.GetParagraphOrDefault(SubtitleListview1.SelectedItems[0].Index).Language == language)
+                        {
+                            ((ToolStripMenuItem)toolStripMenuItemSetLanguage.DropDownItems[toolStripMenuItemSetLanguage.DropDownItems.Count - 1]).Checked = true;
+                        }
                     }
 
                     var tss = new ToolStripSeparator();
@@ -7979,7 +7999,11 @@ namespace Nikse.SubtitleEdit.Forms
                 setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Clear();
                 foreach (var style in styles)
                 {
-                    setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, tsi_Click);
+                    setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, SetStyle);
+                    if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle.GetParagraphOrDefault(SubtitleListview1.SelectedItems[0].Index).Extra == style)
+                    {
+                        ((ToolStripMenuItem)setStylesForSelectedLinesToolStripMenuItem.DropDownItems[setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Count - 1]).Checked = true;
+                    }
                 }
 
                 if (styles.Count > 1)
@@ -8002,9 +8026,9 @@ namespace Nikse.SubtitleEdit.Forms
                 toolStripMenuItemWebVTT.Visible = true;
                 var voices = WebVTT.GetVoices(_subtitle);
                 toolStripMenuItemWebVTT.DropDownItems.Clear();
-                foreach (var style in voices)
+                foreach (var voice in voices)
                 {
-                    toolStripMenuItemWebVTT.DropDownItems.Add(style, null, WebVTTSetVoice);
+                    toolStripMenuItemWebVTT.DropDownItems.Add(voice, null, WebVTTSetVoice);
                 }
 
                 if (voices.Count > 0)
@@ -8022,7 +8046,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 UiUtil.FixFonts(toolStripMenuItemWebVTT);
             }
-            else if ((format.Name == "Nuendo" && SubtitleListview1.SelectedItems.Count > 0))
+            else if (format.Name == "Nuendo" && SubtitleListview1.SelectedItems.Count > 0)
             {
                 toolStripMenuItemWebVTT.Visible = false;
                 var styles = GetNuendoStyles();
@@ -8030,6 +8054,10 @@ namespace Nikse.SubtitleEdit.Forms
                 foreach (var style in styles)
                 {
                     setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, NuendoSetStyle);
+                    if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle.GetParagraphOrDefault(SubtitleListview1.SelectedItems[0].Index).Extra == style)
+                    {
+                        ((ToolStripMenuItem)setStylesForSelectedLinesToolStripMenuItem.DropDownItems[setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Count - 1]).Checked = true;
+                    }
                 }
 
                 if (styles.Count > 1)
@@ -8187,7 +8215,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void tsi_Click(object sender, EventArgs e)
+        private void SetStyle(object sender, EventArgs e)
         {
             string style = (sender as ToolStripItem).Text;
             if (!string.IsNullOrEmpty(style))
@@ -8216,7 +8244,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void actor_Click(object sender, EventArgs e)
+        private void SetActor(object sender, EventArgs e)
         {
             string actor = (sender as ToolStripItem).Text;
             if (!string.IsNullOrEmpty(actor))
@@ -8231,7 +8259,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void SetRegionClick(object sender, EventArgs e)
+        private void SetRegion(object sender, EventArgs e)
         {
             string region = (sender as ToolStripItem).Text;
             if (!string.IsNullOrEmpty(region))
@@ -8245,7 +8273,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void AddLanguageClick(object sender, EventArgs e)
+        private void SetLanguage(object sender, EventArgs e)
         {
             string lang = (sender as ToolStripItem).Text;
             if (!string.IsNullOrEmpty(lang))
@@ -24348,7 +24376,7 @@ namespace Nikse.SubtitleEdit.Forms
                         toolStripMenuItemSetAudioTrack.DropDownItems[toolStripMenuItemSetAudioTrack.DropDownItems.Count - 1].Tag = at.Key.ToString(CultureInfo.InvariantCulture);
                         if (at.Key == VideoAudioTrackNumber)
                         {
-                            toolStripMenuItemSetAudioTrack.DropDownItems[toolStripMenuItemSetAudioTrack.DropDownItems.Count - 1].Select();
+                            ((ToolStripMenuItem)toolStripMenuItemSetAudioTrack.DropDownItems[toolStripMenuItemSetAudioTrack.DropDownItems.Count - 1]).Checked = true;
                         }
                     }
 
@@ -24372,7 +24400,7 @@ namespace Nikse.SubtitleEdit.Forms
                         toolStripMenuItemSetAudioTrack.DropDownItems[toolStripMenuItemSetAudioTrack.DropDownItems.Count - 1].Tag = at.Key.ToString(CultureInfo.InvariantCulture);
                         if (i == VideoAudioTrackNumber)
                         {
-                            toolStripMenuItemSetAudioTrack.DropDownItems[toolStripMenuItemSetAudioTrack.DropDownItems.Count - 1].Select();
+                            ((ToolStripMenuItem)toolStripMenuItemSetAudioTrack.DropDownItems[toolStripMenuItemSetAudioTrack.DropDownItems.Count - 1]).Checked = true;
                         }
                     }
 

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -18557,10 +18557,6 @@ namespace Nikse.SubtitleEdit.Forms
                     foreach (var s in Configuration.Settings.Tools.UnicodeSymbolsToInsert.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                     {
                         toolStripMenuItemInsertUnicodeCharacter.DropDownItems.Add(s, null, InsertUnicodeGlyphAllowMultiLine);
-                        if (Environment.OSVersion.Version.Major < 6 && Configuration.Settings.General.SubtitleFontName == Utilities.WinXP2KUnicodeFontName) // 6 == Vista/Win2008Server/Win7
-                        {
-                            toolStripMenuItemInsertUnicodeCharacter.DropDownItems[toolStripMenuItemInsertUnicodeCharacter.DropDownItems.Count - 1].Font = new Font(Utilities.WinXP2KUnicodeFontName, toolStripMenuItemInsertUnicodeSymbol.Font.Size);
-                        }
                     }
 
                     UiUtil.FixFonts(toolStripMenuItemInsertUnicodeCharacter);
@@ -24986,10 +24982,6 @@ namespace Nikse.SubtitleEdit.Forms
                     foreach (var s in Configuration.Settings.Tools.UnicodeSymbolsToInsert.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                     {
                         toolStripMenuItemInsertUnicodeSymbol.DropDownItems.Add(s, null, InsertUnicodeGlyph);
-                        if (Environment.OSVersion.Version.Major < 6 && Configuration.Settings.General.SubtitleFontName == Utilities.WinXP2KUnicodeFontName) // 6 == Vista/Win2008Server/Win7
-                        {
-                            toolStripMenuItemInsertUnicodeSymbol.DropDownItems[toolStripMenuItemInsertUnicodeSymbol.DropDownItems.Count - 1].Font = new Font(Utilities.WinXP2KUnicodeFontName, toolStripMenuItemInsertUnicodeSymbol.Font.Size);
-                        }
                     }
 
                     UiUtil.FixFonts(toolStripMenuItemInsertUnicodeSymbol);
@@ -25000,10 +24992,6 @@ namespace Nikse.SubtitleEdit.Forms
                     foreach (var s in Configuration.Settings.Tools.UnicodeSymbolsToInsert.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                     {
                         insertUnicodeCharactersToolStripMenuItem.DropDownItems.Add(s, null, InsertUnicodeGlyph);
-                        if (Environment.OSVersion.Version.Major < 6 && Configuration.Settings.General.SubtitleFontName == Utilities.WinXP2KUnicodeFontName) // 6 == Vista/Win2008Server/Win7
-                        {
-                            insertUnicodeCharactersToolStripMenuItem.DropDownItems[insertUnicodeCharactersToolStripMenuItem.DropDownItems.Count - 1].Font = new Font(Utilities.WinXP2KUnicodeFontName, toolStripMenuItemInsertUnicodeSymbol.Font.Size);
-                        }
                     }
 
                     UiUtil.FixFonts(insertUnicodeCharactersToolStripMenuItem);

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -3743,9 +3743,10 @@ namespace Nikse.SubtitleEdit.Forms
                             lowerFileNameList.Add(file.FileName.ToLowerInvariant());
                         }
                     }
-                    UiUtil.FixFonts(dropDownItems[dropDownItems.Count - 1]);
                 }
+
                 reopenToolStripMenuItem.DropDownItems.AddRange(dropDownItems.ToArray());
+                UiUtil.FixFonts(reopenToolStripMenuItem);
             }
             else
             {
@@ -7558,7 +7559,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void ContextMenuStripListViewOpening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void ContextMenuStripListViewOpening(object sender, CancelEventArgs e)
         {
             var format = GetCurrentSubtitleFormat();
             var formatType = format.GetType();
@@ -7782,8 +7783,17 @@ namespace Nikse.SubtitleEdit.Forms
                     setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, tsi_Click);
                 }
 
-                setStylesForSelectedLinesToolStripMenuItem.Visible = styles.Count > 1;
                 toolStripMenuItemAssStyles.Visible = true;
+                if (styles.Count > 1)
+                {
+                    setStylesForSelectedLinesToolStripMenuItem.Visible = true;
+                    UiUtil.FixFonts(setStylesForSelectedLinesToolStripMenuItem);
+                }
+                else
+                {
+                    setStylesForSelectedLinesToolStripMenuItem.Visible = false;
+                }
+
                 if (formatType == typeof(AdvancedSubStationAlpha))
                 {
                     toolStripMenuItemAssStyles.Text = _language.Menu.ContextMenu.AdvancedSubStationAlphaStyles;
@@ -7824,6 +7834,8 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     setActorForSelectedLinesToolStripMenuItem.DropDownItems.Add(_language.Menu.ContextMenu.RemoveActors, null, RemoveActors);
                 }
+
+                UiUtil.FixFonts(setActorForSelectedLinesToolStripMenuItem);
             }
             else if (((formatType == typeof(TimedText10) && Configuration.Settings.SubtitleSettings.TimedText10ShowStyleAndLanguage) || formatType == typeof(ItunesTimedText)) && SubtitleListview1.SelectedItems.Count > 0)
             {
@@ -7836,7 +7848,16 @@ namespace Nikse.SubtitleEdit.Forms
                     setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, tsi_Click);
                 }
 
-                setStylesForSelectedLinesToolStripMenuItem.Visible = styles.Count >= 1;
+                if (styles.Count >= 1)
+                {
+                    setStylesForSelectedLinesToolStripMenuItem.Visible = true;
+                    UiUtil.FixFonts(setStylesForSelectedLinesToolStripMenuItem);
+                }
+                else
+                {
+                    setStylesForSelectedLinesToolStripMenuItem.Visible = false;
+                }
+
                 toolStripMenuItemAssStyles.Visible = true;
                 setStylesForSelectedLinesToolStripMenuItem.Text = _language.Menu.ContextMenu.TimedTextSetStyle;
 
@@ -7857,7 +7878,10 @@ namespace Nikse.SubtitleEdit.Forms
                         toolStripMenuItemSetRegion.DropDownItems.Add(region, null, SetRegionClick);
                     }
 
-                    toolStripMenuItemSetRegion.DropDownItems.Add("-");
+                    var tss = new ToolStripSeparator();
+                    UiUtil.FixFonts(tss);
+                    toolStripMenuItemSetRegion.DropDownItems.Add(tss);
+
                     var clear = new ToolStripMenuItem(LanguageSettings.Current.DvdSubRip.Clear);
                     toolStripMenuItemSetRegion.DropDownItems.Add(clear);
                     clear.Click += (sender2, e2) =>
@@ -7869,6 +7893,8 @@ namespace Nikse.SubtitleEdit.Forms
                             SubtitleListview1.SetTimeAndText(index, _subtitle.Paragraphs[index], _subtitle.GetParagraphOrDefault(index + 1));
                         }
                     };
+
+                    UiUtil.FixFonts(toolStripMenuItemSetRegion);
                 }
                 else
                 {
@@ -7887,7 +7913,9 @@ namespace Nikse.SubtitleEdit.Forms
                         toolStripMenuItemSetLanguage.DropDownItems.Add(language, null, AddLanguageClick);
                     }
 
-                    toolStripMenuItemSetLanguage.DropDownItems.Add("-");
+                    var tss = new ToolStripSeparator();
+                    UiUtil.FixFonts(tss);
+                    toolStripMenuItemSetLanguage.DropDownItems.Add(tss);
                 }
 
                 var newItem = new ToolStripMenuItem(_language.New);
@@ -7940,6 +7968,8 @@ namespace Nikse.SubtitleEdit.Forms
                         }
                     };
                 }
+
+                UiUtil.FixFonts(toolStripMenuItemSetLanguage);
             }
             else if ((formatType == typeof(Sami) || formatType == typeof(SamiModern)) && SubtitleListview1.SelectedItems.Count > 0)
             {
@@ -7952,7 +7982,16 @@ namespace Nikse.SubtitleEdit.Forms
                     setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, tsi_Click);
                 }
 
-                setStylesForSelectedLinesToolStripMenuItem.Visible = styles.Count > 1;
+                if (styles.Count > 1)
+                {
+                    setStylesForSelectedLinesToolStripMenuItem.Visible = true;
+                    UiUtil.FixFonts(setStylesForSelectedLinesToolStripMenuItem);
+                }
+                else
+                {
+                    setStylesForSelectedLinesToolStripMenuItem.Visible = false;
+                }
+                
                 toolStripMenuItemAssStyles.Visible = false;
                 setStylesForSelectedLinesToolStripMenuItem.Text = _language.Menu.ContextMenu.SamiSetStyle;
             }
@@ -7968,11 +8007,20 @@ namespace Nikse.SubtitleEdit.Forms
                     toolStripMenuItemWebVTT.DropDownItems.Add(style, null, WebVTTSetVoice);
                 }
 
+                if (voices.Count > 0)
+                {
+                    var tss = new ToolStripSeparator();
+                    UiUtil.FixFonts(tss);
+                    toolStripMenuItemWebVTT.DropDownItems.Add(tss);
+                }
+
                 toolStripMenuItemWebVTT.DropDownItems.Add(_language.Menu.ContextMenu.WebVTTSetNewVoice, null, WebVTTSetNewVoice);
                 if (voices.Count > 0)
                 {
                     toolStripMenuItemWebVTT.DropDownItems.Add(_language.Menu.ContextMenu.WebVTTRemoveVoices, null, WebVTTRemoveVoices);
                 }
+
+                UiUtil.FixFonts(toolStripMenuItemWebVTT);
             }
             else if ((format.Name == "Nuendo" && SubtitleListview1.SelectedItems.Count > 0))
             {
@@ -7984,7 +8032,16 @@ namespace Nikse.SubtitleEdit.Forms
                     setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Add(style, null, NuendoSetStyle);
                 }
 
-                setStylesForSelectedLinesToolStripMenuItem.Visible = styles.Count > 1;
+                if (styles.Count > 1)
+                {
+                    setStylesForSelectedLinesToolStripMenuItem.Visible = true;
+                    UiUtil.FixFonts(setStylesForSelectedLinesToolStripMenuItem);
+                }
+                else
+                {
+                    setStylesForSelectedLinesToolStripMenuItem.Visible = false;
+                }
+                
                 toolStripMenuItemAssStyles.Visible = false;
                 setStylesForSelectedLinesToolStripMenuItem.Text = _language.Menu.ContextMenu.NuendoSetStyle;
             }
@@ -18505,6 +18562,8 @@ namespace Nikse.SubtitleEdit.Forms
                             toolStripMenuItemInsertUnicodeCharacter.DropDownItems[toolStripMenuItemInsertUnicodeCharacter.DropDownItems.Count - 1].Font = new Font(Utilities.WinXP2KUnicodeFontName, toolStripMenuItemInsertUnicodeSymbol.Font.Size);
                         }
                     }
+
+                    UiUtil.FixFonts(toolStripMenuItemInsertUnicodeCharacter);
                 }
 
                 toolStripMenuItemInsertUnicodeCharacter.Visible = toolStripMenuItemInsertUnicodeCharacter.DropDownItems.Count > 0;
@@ -24298,6 +24357,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
 
                     toolStripMenuItemSetAudioTrack.Visible = true;
+                    UiUtil.FixFonts(toolStripMenuItemSetAudioTrack);
                 }
             }
             else if (mediaPlayer.VideoPlayer is LibMpvDynamic libMpv)
@@ -24321,6 +24381,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
 
                     toolStripMenuItemSetAudioTrack.Visible = true;
+                    UiUtil.FixFonts(toolStripMenuItemSetAudioTrack);
                 }
             }
 
@@ -24930,6 +24991,8 @@ namespace Nikse.SubtitleEdit.Forms
                             toolStripMenuItemInsertUnicodeSymbol.DropDownItems[toolStripMenuItemInsertUnicodeSymbol.DropDownItems.Count - 1].Font = new Font(Utilities.WinXP2KUnicodeFontName, toolStripMenuItemInsertUnicodeSymbol.Font.Size);
                         }
                     }
+
+                    UiUtil.FixFonts(toolStripMenuItemInsertUnicodeSymbol);
                 }
 
                 if (insertUnicodeCharactersToolStripMenuItem.DropDownItems.Count == 0)
@@ -24942,6 +25005,8 @@ namespace Nikse.SubtitleEdit.Forms
                             insertUnicodeCharactersToolStripMenuItem.DropDownItems[insertUnicodeCharactersToolStripMenuItem.DropDownItems.Count - 1].Font = new Font(Utilities.WinXP2KUnicodeFontName, toolStripMenuItemInsertUnicodeSymbol.Font.Size);
                         }
                     }
+
+                    UiUtil.FixFonts(insertUnicodeCharactersToolStripMenuItem);
                 }
 
                 toolStripMenuItemInsertUnicodeSymbol.Visible = toolStripMenuItemInsertUnicodeSymbol.DropDownItems.Count > 0;
@@ -24974,12 +25039,19 @@ namespace Nikse.SubtitleEdit.Forms
                     toolStripMenuItemWebVttVoice.DropDownItems.Add(style, null, WebVTTSetVoiceTextBox);
                 }
 
+                if (voices.Count > 0)
+                {
+                    var tss = new ToolStripSeparator();
+                    UiUtil.FixFonts(tss);
+                    toolStripMenuItemWebVttVoice.DropDownItems.Add(tss);
+                }
+
                 toolStripMenuItemWebVttVoice.DropDownItems.Add(_language.Menu.ContextMenu.WebVTTSetNewVoice, null, WebVTTSetNewVoiceTextBox);
+                UiUtil.FixFonts(toolStripMenuItemWebVttVoice);
             }
             else
             {
                 toolStripSeparatorWebVTT.Visible = false;
-                toolStripMenuItemWebVttVoice.Visible = false;
                 toolStripMenuItemWebVttVoice.Visible = false;
             }
 

--- a/src/ui/Forms/MultipleReplace.cs
+++ b/src/ui/Forms/MultipleReplace.cs
@@ -583,6 +583,8 @@ namespace Nikse.SubtitleEdit.Forms
                         toolStripMenuItemMoveRulesToGroup.DropDownItems.Add(menuItem);
                     }
                 }
+
+                UiUtil.FixFonts(toolStripMenuItemMoveRulesToGroup);
             }
             else
             {

--- a/src/ui/Forms/Options/Settings.cs
+++ b/src/ui/Forms/Options/Settings.cs
@@ -892,22 +892,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
 
             UpdateProfileNames(gs.Profiles);
 
-            // Music notes / music symbols
-            if (!Utilities.IsRunningOnMono() && Environment.OSVersion.Version.Major < 6) // 6 == Vista/Win2008Server/Win7
-            {
-                float fontSize = comboBoxToolsMusicSymbol.Font.Size;
-                const string unicodeFontName = Utilities.WinXP2KUnicodeFontName;
-                listViewNames.Font = new Font(unicodeFontName, fontSize);
-                listBoxUserWordLists.Font = new Font(unicodeFontName, fontSize);
-                listBoxOcrFixList.Font = new Font(unicodeFontName, fontSize);
-                comboBoxToolsMusicSymbol.Font = new Font(unicodeFontName, fontSize);
-                textBoxMusicSymbolsToReplace.Font = new Font(unicodeFontName, fontSize);
-                textBoxNameEtc.Font = new Font(unicodeFontName, fontSize);
-                textBoxUserWord.Font = new Font(unicodeFontName, fontSize);
-                textBoxOcrFixKey.Font = new Font(unicodeFontName, fontSize);
-                textBoxOcrFixValue.Font = new Font(unicodeFontName, fontSize);
-            }
-
             comboBoxToolsMusicSymbol.Items.Clear();
             comboBoxToolsMusicSymbol.Items.Add("♪");
             comboBoxToolsMusicSymbol.Items.Add("♫");

--- a/src/ui/Forms/RemoveTextFromHearImpaired.cs
+++ b/src/ui/Forms/RemoveTextFromHearImpaired.cs
@@ -83,14 +83,6 @@ namespace Nikse.SubtitleEdit.Forms
 
         public void Initialize(Subtitle subtitle)
         {
-            if (Environment.OSVersion.Version.Major < 6) // 6 == Vista/Win2008Server/Win7
-            {
-                const string unicodeFontName = Utilities.WinXP2KUnicodeFontName;
-                float fontSize = comboBoxCustomStart.Font.Size;
-                comboBoxCustomStart.Font = new Font(unicodeFontName, fontSize);
-                comboBoxCustomEnd.Font = new Font(unicodeFontName, fontSize);
-                comboBoxRemoveIfTextContains.Font = new Font(unicodeFontName, fontSize);
-            }
             comboBoxRemoveIfTextContains.Left = checkBoxRemoveWhereContains.Left + checkBoxRemoveWhereContains.Width;
             Subtitle = new Subtitle(subtitle);
             GeneratePreview();

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
@@ -1355,10 +1355,11 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Advanced SubStation Alpha styles";
-            this.ResizeEnd += new System.EventHandler(this.SubStationAlphaStyles_ResizeEnd);
-            this.SizeChanged += new System.EventHandler(this.SubStationAlphaStyles_SizeChanged);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.SubStationAlphaStyles_KeyDown);
             this.Resize += new System.EventHandler(this.SubStationAlphaStyles_Resize);
+            this.ResizeEnd += new System.EventHandler(this.SubStationAlphaStyles_ResizeEnd);
+            this.Shown += new System.EventHandler(this.SubStationAlphaStyles_Shown);
+            this.SizeChanged += new System.EventHandler(this.SubStationAlphaStyles_SizeChanged);
             this.contextMenuStripFile.ResumeLayout(false);
             this.groupBoxStyles.ResumeLayout(false);
             this.groupBoxProperties.ResumeLayout(false);

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.cs
@@ -1538,14 +1538,24 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             _lastFormWindowState = WindowState;
         }
 
+        private void SetLastColumnWidth()
+        {
+            listViewStyles.Columns[listViewStyles.Columns.Count - 1].Width = -2;
+            listViewStorage.Columns[listViewStorage.Columns.Count - 1].Width = -2;
+        }
+
         private void SubStationAlphaStyles_ResizeEnd(object sender, EventArgs e)
         {
-            listViewStyles.Columns[5].Width = -2;
-            listViewStorage.Columns[5].Width = -2;
+            SetLastColumnWidth();
             _backgroundImage?.Dispose();
             _backgroundImage = null;
             GeneratePreview();
             _lastFormWindowState = WindowState;
+        }
+
+        private void SubStationAlphaStyles_Shown(object sender, EventArgs e)
+        {
+            SetLastColumnWidth();
         }
 
         private void numericUpDownOutline_ValueChanged(object sender, EventArgs e)

--- a/src/ui/Forms/Styles/TimedTextStyles.Designer.cs
+++ b/src/ui/Forms/Styles/TimedTextStyles.Designer.cs
@@ -380,9 +380,10 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Timed Text - Styles";
-            this.ResizeEnd += new System.EventHandler(this.TimedTextStyles_ResizeEnd);
-            this.SizeChanged += new System.EventHandler(this.TimedTextStyles_SizeChanged);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TimedTextStyles_KeyDown);
+            this.ResizeEnd += new System.EventHandler(this.TimedTextStyles_ResizeEnd);
+            this.Shown += new System.EventHandler(this.TimedTextStyles_Shown);
+            this.SizeChanged += new System.EventHandler(this.TimedTextStyles_SizeChanged);
             this.groupBoxProperties.ResumeLayout(false);
             this.groupBoxProperties.PerformLayout();
             this.groupBoxPreview.ResumeLayout(false);

--- a/src/ui/Forms/Styles/TimedTextStyles.cs
+++ b/src/ui/Forms/Styles/TimedTextStyles.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
 using System;
@@ -8,7 +9,6 @@ using System.Drawing.Text;
 using System.Text;
 using System.Windows.Forms;
 using System.Xml;
-using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Forms.Styles
 {
@@ -572,15 +572,25 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             DialogResult = DialogResult.Cancel;
         }
 
+        private void SetLastColumnWidth()
+        {
+            listViewStyles.Columns[listViewStyles.Columns.Count - 1].Width = -2;
+        }
+
         private void TimedTextStyles_ResizeEnd(object sender, EventArgs e)
         {
+            SetLastColumnWidth();
             GeneratePreview();
+        }
+
+        private void TimedTextStyles_Shown(object sender, EventArgs e)
+        {
+            SetLastColumnWidth();
         }
 
         private void TimedTextStyles_SizeChanged(object sender, EventArgs e)
         {
             GeneratePreview();
         }
-
     }
 }

--- a/src/ui/Forms/TextPrompt.cs
+++ b/src/ui/Forms/TextPrompt.cs
@@ -1,8 +1,6 @@
-﻿using Nikse.SubtitleEdit.Core;
-using Nikse.SubtitleEdit.Logic;
+﻿using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Windows.Forms;
-using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Forms
 {

--- a/src/ui/Logic/DarkTheme.cs
+++ b/src/ui/Logic/DarkTheme.cs
@@ -801,6 +801,16 @@ namespace Nikse.SubtitleEdit.Logic
         {
             item.BackColor = BackColor;
             item.ForeColor = ForeColor;
+
+            if (item is ToolStripDropDownItem dropDownMenu && dropDownMenu.DropDownItems.Count > 0)
+            {
+                foreach (ToolStripItem dropDownItem in dropDownMenu.DropDownItems)
+                {
+                    dropDownItem.ForeColor = ForeColor;
+                    dropDownItem.BackColor = BackColor;
+                }
+            }
+
             if (item is ToolStripSeparator)
             {
                 item.Paint += ToolStripSeparatorPaint;


### PR DESCRIPTION
1. Fix dynamic dropdown menus colors in dark theme like this one:
![image](https://user-images.githubusercontent.com/20923700/104851678-28d6c280-58ff-11eb-97f9-d110fbd83922.png)

2. Remove WinXP font check as it is no longer supported.

3.  Set last column width in Styles Manager and Timed Text Styles.

4. Add a checkmark to some dropdown menus like selected audio track and selected style and actor:
![image](https://user-images.githubusercontent.com/20923700/104851937-9cc59a80-5900-11eb-9f89-46384de753e2.png)
