### PR TITLE
Some work on RichTextBox highlighting

### DIFF
--- a/src/ui/Logic/NativeMethods.cs
+++ b/src/ui/Logic/NativeMethods.cs
@@ -39,9 +39,6 @@ namespace Nikse.SubtitleEdit.Logic
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool FreeLibrary(IntPtr hModule);
 
-        [DllImport("user32.dll")]
-        internal static extern short GetKeyState(int vKey);
-
         [DllImport("kernel32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool AttachConsole(int dwProcessId);
@@ -51,8 +48,15 @@ namespace Nikse.SubtitleEdit.Logic
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool FreeConsole();
 
+        [DllImport("user32.dll")]
+        internal static extern short GetKeyState(int vKey);
+
         [DllImport("user32.dll", EntryPoint = "SetWindowPos")]
         internal static extern IntPtr SetWindowPos(IntPtr hWnd, int hWndInsertAfter, int x, int y, int width, int height, int wFlags);
+
+        [DllImport("user32.dll")]
+        internal static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
+        internal const int WM_SETREDRAW = 0x0b;
 
         [DllImport("dwmapi.dll")]
         internal static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -407,9 +407,10 @@ namespace Nikse.SubtitleEdit.Logic
             {
                 if (AllKeys.ContainsKey(k))
                 {
-                    resultKeys = resultKeys | AllKeys[k];
+                    resultKeys |= AllKeys[k];
                 }
             }
+
             return resultKeys;
         }
 
@@ -899,7 +900,16 @@ namespace Nikse.SubtitleEdit.Logic
             comboBoxEncoding.SelectedIndex = TextEncoding.Utf8WithBomIndex; // UTF-8 with BOM
         }
 
+        public static void BeginRichTextBoxUpdate(this RichTextBox richTextBox)
+        {
+            NativeMethods.SendMessage(richTextBox.Handle, NativeMethods.WM_SETREDRAW, (IntPtr)0, IntPtr.Zero);
+        }
 
+        public static void EndRichTextBoxUpdate(this RichTextBox richTextBox)
+        {
+            NativeMethods.SendMessage(richTextBox.Handle, NativeMethods.WM_SETREDRAW, (IntPtr)1, IntPtr.Zero);
+            richTextBox.Invalidate();
+        }
 
         private const string BreakChars = "\",:;.¡!¿?()[]{}<>♪♫-–—/#*|؟،";
 


### PR DESCRIPTION
Try to fix an issue with the Arabic comma.
Removed the temp RichTextBox.
Make the highlighting only happen when a spell check was requested or there is a tag in the line.

Do check the code and test if you can. :D

Side note: Added a method called `DoFormattingActionOnRtb` which takes an action and does it on the text of the _uiTextBox while saving the cursor position.