### PR TITLE
Fix a crash when changing waveform selection

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -1089,7 +1089,7 @@ namespace Nikse.SubtitleEdit.Forms
             //    }
             //}
 
-            if (index == _subtitleListViewIndex)
+            if (index == _subtitleListViewIndex && _subtitleListViewIndex != -1)
             {
                 // Make history item for rollback (change paragraph back for history + change again)
                 _subtitle.Paragraphs[index] = new Paragraph(beforeParagraph);


### PR DESCRIPTION
This happens when you open a video without a subtitle, then make a selection on the waveform and try to change it.
I'm not sure if this is the best fix.

Closes https://github.com/SubtitleEdit/subtitleedit/issues/4742, https://github.com/SubtitleEdit/subtitleedit/issues/4734