### PR TITLE
Remove false no break space

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -2878,6 +2878,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 return text;
             }
+
             return sb.ToString().Replace("  ", " ").Replace(Environment.NewLine + " ", Environment.NewLine);
         }
 
@@ -2891,16 +2892,14 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static string RemoveUnicodeControlChars(string input)
         {
-            input = input.Replace("\u200E", string.Empty);
-            input = input.Replace("\u200F", string.Empty);
-            input = input.Replace("\u202A", string.Empty);
-            input = input.Replace("\u202B", string.Empty);
-            input = input.Replace("\u202C", string.Empty);
-            input = input.Replace("\u202D", string.Empty);
-            input = input.Replace("\u202E", string.Empty);
-            input = input.Replace("\u00C2", " "); // no break space
-            input = input.Replace("\u00A0", " "); // no break space
-            return input;
+            return input.Replace("\u200E", string.Empty)
+                .Replace("\u200F", string.Empty)
+                .Replace("\u202A", string.Empty)
+                .Replace("\u202B", string.Empty)
+                .Replace("\u202C", string.Empty)
+                .Replace("\u202D", string.Empty)
+                .Replace("\u202E", string.Empty)
+                .Replace("\u00A0", " "); // no break space
         }
     }
 }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -7511,14 +7511,14 @@ namespace Nikse.SubtitleEdit.Forms
                 while (startIndex >= 0 && startIndex < p.Text.Length && p.Text.Substring(startIndex).Contains(oldWord))
                 {
                     bool startOk = startIndex == 0 ||
-                                   "«»“” <>-—+/'\"[](){}¿¡….,;:!?%&$£\r\n؛،؟\u200E\u200F\u202A\u202B\u202C\u202D\u202E\u00C2\u00A0".Contains(p.Text[startIndex - 1]) ||
+                                   "«»“” <>-—+/'\"[](){}¿¡….,;:!?%&$£\r\n؛،؟\u200E\u200F\u202A\u202B\u202C\u202D\u202E\u00A0".Contains(p.Text[startIndex - 1]) ||
                                    char.IsPunctuation(p.Text[startIndex - 1]) ||
                                    startIndex == p.Text.Length - oldWord.Length;
                     if (startOk)
                     {
                         int end = startIndex + oldWord.Length;
                         if (end <= p.Text.Length && end == p.Text.Length ||
-                            "«»“” ,.!?:;'()<>\"-—+/[]{}%&$£…\r\n؛،؟\u200E\u200F\u202A\u202B\u202C\u202D\u202E\u00C2\u00A0".Contains(p.Text[end]) ||
+                            "«»“” ,.!?:;'()<>\"-—+/[]{}%&$£…\r\n؛،؟\u200E\u200F\u202A\u202B\u202C\u202D\u202E\u00A0".Contains(p.Text[end]) ||
                             char.IsPunctuation(p.Text[end]))
                         {
                             var lengthBefore = p.Text.Length;

--- a/src/ui/Forms/Ocr/OCRSpellCheck.cs
+++ b/src/ui/Forms/Ocr/OCRSpellCheck.cs
@@ -112,7 +112,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         {
             if (word != null && richTextBoxParagraph.Text.Contains(word))
             {
-                const string expectedWordBoundaryChars = " <>-\"”„“«»[]'‘`´¶()♪¿¡.…—!?,:;/\r\n؛،؟\u200E\u200F\u202A\u202B\u202C\u202D\u202E\u00C2\u00A0";
+                const string expectedWordBoundaryChars = " <>-\"”„“«»[]'‘`´¶()♪¿¡.…—!?,:;/\r\n؛،؟\u200E\u200F\u202A\u202B\u202C\u202D\u202E\u00A0";
                 for (int i = 0; i < richTextBoxParagraph.Text.Length; i++)
                 {
                     if (richTextBoxParagraph.Text.Substring(i).StartsWith(word, StringComparison.Ordinal))


### PR DESCRIPTION
`\u00C2` is actually `Â`: https://www.compart.com/en/unicode/U+00C2
I don't know why it was considered a no-break space.