### PR TITLE
Do syntax coloring even if there is not tags in the line

### DIFF
--- a/src/ui/Controls/AdvancedTextBox.cs
+++ b/src/ui/Controls/AdvancedTextBox.cs
@@ -306,9 +306,6 @@ namespace Nikse.SubtitleEdit.Controls
             }
         }
 
-        private bool ContainsTags() =>
-            Text.Length != HtmlUtil.RemoveHtmlTags(Text, true).Length;
-
         private void TagsChangedCheck()
         {
             // Request spell check if there is a change in tags to update highlighting indices.
@@ -335,7 +332,7 @@ namespace Nikse.SubtitleEdit.Controls
                         HighlightSpellCheckWords();
                     });
                 }
-                else if (ContainsTags())
+                else
                 {
                     DoFormattingActionOnRtb(HighlightHtmlText);
                 }
@@ -997,20 +994,17 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void HighlightSpellCheckWords()
         {
-            if (_isLiveSpellCheckEnabled)
+            DoLiveSpellCheck();
+            if (_wrongWords?.Count > 0)
             {
-                DoLiveSpellCheck();
-                if (_wrongWords?.Count > 0)
+                foreach (var wrongWord in _wrongWords)
                 {
-                    foreach (var wrongWord in _wrongWords)
-                    {
-                        Select(GetIndexWithLineBreak(wrongWord.Index), wrongWord.Length);
-                        SelectionColor = Configuration.Settings.Tools.ListViewSyntaxErrorColor;
-                    }
+                    Select(GetIndexWithLineBreak(wrongWord.Index), wrongWord.Length);
+                    SelectionColor = Configuration.Settings.Tools.ListViewSyntaxErrorColor;
                 }
-
-                IsSpellCheckRequested = false;
             }
+
+            IsSpellCheckRequested = false;
         }
 
         #endregion


### PR DESCRIPTION
Closes https://github.com/SubtitleEdit/subtitleedit/issues/4749

Looks like there is no escaping it, the line must be colored each time the text changes even if there are no tags in it.