### PR TITLE
Fix last column size for MultipleReplace in some cases

### DIFF
--- a/src/ui/Forms/MultipleReplace.Designer.cs
+++ b/src/ui/Forms/MultipleReplace.Designer.cs
@@ -164,6 +164,7 @@
             this.listViewFixes.TabIndex = 10;
             this.listViewFixes.UseCompatibleStateImageBehavior = false;
             this.listViewFixes.View = System.Windows.Forms.View.Details;
+            this.listViewFixes.ClientSizeChanged += new System.EventHandler(this.listViewFixes_ClientSizeChanged);
             this.listViewFixes.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listViewFixes_KeyDown);
             // 
             // columnHeader4

--- a/src/ui/Forms/MultipleReplace.cs
+++ b/src/ui/Forms/MultipleReplace.cs
@@ -1134,10 +1134,15 @@ namespace Nikse.SubtitleEdit.Forms
             SwapGroups(index, index + 1);
         }
 
-        private void MultipleReplace_ResizeEnd(object sender, EventArgs e)
+        private void ResizeListViewLastColumn()
         {
             listViewRules.Columns[listViewRules.Columns.Count - 1].Width = -2;
             listViewFixes.Columns[listViewFixes.Columns.Count - 1].Width = -2;
+        }
+
+        private void MultipleReplace_ResizeEnd(object sender, EventArgs e)
+        {
+            ResizeListViewLastColumn();
         }
 
         private void moveToTopToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1289,6 +1294,11 @@ namespace Nikse.SubtitleEdit.Forms
         private void buttonExportGroups_Click(object sender, EventArgs e)
         {
             exportToolStripMenuItem_Click(sender, e);
+        }
+
+        private void listViewFixes_ClientSizeChanged(object sender, EventArgs e)
+        {
+            ResizeListViewLastColumn();
         }
 
         private void listViewFixes_KeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
It used to not be fixed when clicking Apply or disabling a group:

![image](https://user-images.githubusercontent.com/20923700/106225450-ced2d880-61ed-11eb-95a9-77a71d0319a6.png)
