### PR TITLE
Remove style page from the settings and add categories to Assa

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -2588,6 +2588,10 @@ Continue?</RestoreDefaultSettingsMsg>
     <AddToStorage>Add to storage</AddToStorage>
     <StyleStorage>Style storage</StyleStorage>
     <OverwriteX>Overwrite {0}?</OverwriteX>
+    <Category>Category</Category>
+    <NewCategory>New category</NewCategory>
+    <CategoryName>Category name</CategoryName>
+    <CategoryNote>Note: "Default" styles will be applied to new ASSA files</CategoryNote>
   </SubStationAlphaStyles>
   <PointSync>
     <Title>Point synchronization</Title>

--- a/src/libse/Common/NetflixImsc11JapaneseToAss.cs
+++ b/src/libse/Common/NetflixImsc11JapaneseToAss.cs
@@ -542,13 +542,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 finalSub.Paragraphs.AddRange(SplitToAssRenderLines(paragraph, width, height));
             }
 
-            var oldFontSize = Configuration.Settings.SubtitleSettings.SsaFontSize;
-            var oldFontBold = Configuration.Settings.SubtitleSettings.SsaFontBold;
-            Configuration.Settings.SubtitleSettings.SsaFontSize = 40; // font size
-            Configuration.Settings.SubtitleSettings.SsaFontBold = false;
-            finalSub.Header = AdvancedSubStationAlpha.DefaultHeader;
-            Configuration.Settings.SubtitleSettings.SsaFontSize = oldFontSize;
-            Configuration.Settings.SubtitleSettings.SsaFontBold = oldFontBold;
+            var style = new SsaStyle{ FontSize = 40, Bold = false};
+            finalSub.Header = string.Format(AdvancedSubStationAlpha.HeaderNoStyles, string.Empty, style.ToRawAss());
 
             finalSub.Header = finalSub.Header.Replace("PlayDepth: 0", @"PlayDepth: 0
 PlayResX: 1280

--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -492,17 +492,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
     public class SubtitleSettings
     {
-        public string SsaFontName { get; set; }
-        public double SsaFontSize { get; set; }
-        public int SsaFontColorArgb { get; set; }
-        public bool SsaFontBold { get; set; }
-        public decimal SsaOutline { get; set; }
-        public decimal SsaShadow { get; set; }
-        public bool SsaOpaqueBox { get; set; }
-        public int SsaMarginLeft { get; set; }
-        public int SsaMarginRight { get; set; }
-        public int SsaMarginTopBottom { get; set; }
-        public string AssaStyleStorage { get; set; }
+        public List<AssaStorageCategory> AssaStyleStorageCategories { get; set; }
 
         public string DCinemaFontFile { get; set; }
         public string DCinemaLoadFontResource { get; set; }
@@ -573,19 +563,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public SubtitleSettings()
         {
-            SsaFontName = "Arial";
-            if (Configuration.IsRunningOnLinux)
-            {
-                SsaFontName = Configuration.DefaultLinuxFontName;
-            }
-            SsaFontSize = 20;
-            SsaFontColorArgb = Color.FromArgb(255, 255, 255).ToArgb();
-            SsaOutline = 2;
-            SsaShadow = 1;
-            SsaOpaqueBox = false;
-            SsaMarginLeft = 10;
-            SsaMarginRight = 10;
-            SsaMarginTopBottom = 10;
+            AssaStyleStorageCategories = new List<AssaStorageCategory>();
 
             DCinemaFontFile = "Arial.ttf";
             DCinemaLoadFontResource = "urn:uuid:3dec6dc0-39d0-498d-97d0-928d2eb78391";
@@ -1774,6 +1752,13 @@ $HorzAlign          =   Center
         public List<MultipleSearchAndReplaceSetting> Rules { get; set; }
     }
 
+    public class AssaStorageCategory
+    {
+        public string Name { get; set; }
+        public bool IsDefault { get; set; }
+        public List<SsaStyle> Styles { get; set; }
+    }
+
     public class NetworkSettings
     {
         public string UserName { get; set; }
@@ -2298,7 +2283,7 @@ $HorzAlign          =   Center
 
         public void Save()
         {
-            //this is too slow: Serialize(Configuration.SettingsFileName, this);
+            // this is too slow: Serialize(Configuration.SettingsFileName, this);
             CustomSerialize(Configuration.SettingsFileName, this);
         }
 
@@ -4951,70 +4936,115 @@ $HorzAlign          =   Center
             node = doc.DocumentElement.SelectSingleNode("SubtitleSettings");
             if (node != null)
             {
-                subNode = node.SelectSingleNode("SsaFontName");
-                if (subNode != null)
+                foreach (XmlNode categoryNode in node.SelectNodes("AssaStyleStorageCategories/Category"))
                 {
-                    settings.SubtitleSettings.SsaFontName = subNode.InnerText;
-                }
+                    var category = new AssaStorageCategory
+                    {
+                        Styles = new List<SsaStyle>()
+                    };
+                    subNode = categoryNode.SelectSingleNode("Name");
+                    if (subNode != null)
+                    {
+                        category.Name = subNode.InnerText;
+                    }
 
-                subNode = node.SelectSingleNode("SsaFontSize");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaFontSize = Convert.ToDouble(subNode.InnerText, CultureInfo.InvariantCulture);
-                }
+                    subNode = categoryNode.SelectSingleNode("IsDefault");
+                    if (subNode != null)
+                    {
+                        category.IsDefault = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+                    }
 
-                subNode = node.SelectSingleNode("SsaFontColorArgb");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaFontColorArgb = Convert.ToInt32(subNode.InnerText, CultureInfo.InvariantCulture);
-                }
+                    settings.SubtitleSettings.AssaStyleStorageCategories.Add(category);
 
-                subNode = node.SelectSingleNode("SsaFontBold");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaFontBold = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
-                }
+                    foreach (XmlNode listNode in categoryNode.SelectNodes("Style"))
+                    {
+                        var item = new SsaStyle();
+                        subNode = listNode.SelectSingleNode("Name");
+                        if (subNode != null)
+                        {
+                            item.Name = subNode.InnerText;
+                        }
 
-                subNode = node.SelectSingleNode("SsaOutline");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaOutline = Convert.ToDecimal(subNode.InnerText);
-                }
+                        subNode = listNode.SelectSingleNode("FontName");
+                        if (subNode != null)
+                        {
+                            item.FontName = subNode.InnerText;
+                        }
 
-                subNode = node.SelectSingleNode("SsaShadow");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaShadow = Convert.ToDecimal(subNode.InnerText);
-                }
+                        subNode = listNode.SelectSingleNode("FontSize");
+                        if (subNode != null)
+                        {
+                            item.FontSize = Convert.ToSingle(subNode.InnerText);
+                        }
 
-                subNode = node.SelectSingleNode("SsaOpaqueBox");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaOpaqueBox = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
-                }
+                        subNode = listNode.SelectSingleNode("Primary");
+                        if (subNode != null)
+                        {
+                            item.Primary = Color.FromArgb(int.Parse(subNode.InnerText, CultureInfo.InvariantCulture));
+                        }
 
-                subNode = node.SelectSingleNode("SsaMarginLeft");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaMarginLeft = Convert.ToInt32(subNode.InnerText, CultureInfo.InvariantCulture);
-                }
+                        subNode = listNode.SelectSingleNode("Secondary");
+                        if (subNode != null)
+                        {
+                            item.Secondary = Color.FromArgb(int.Parse(subNode.InnerText, CultureInfo.InvariantCulture));
+                        }
 
-                subNode = node.SelectSingleNode("SsaMarginRight");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaMarginRight = Convert.ToInt32(subNode.InnerText, CultureInfo.InvariantCulture);
-                }
+                        subNode = listNode.SelectSingleNode("Outline");
+                        if (subNode != null)
+                        {
+                            item.Outline = Color.FromArgb(int.Parse(subNode.InnerText, CultureInfo.InvariantCulture));
+                        }
 
-                subNode = node.SelectSingleNode("SsaMarginTopBottom");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.SsaMarginTopBottom = Convert.ToInt32(subNode.InnerText, CultureInfo.InvariantCulture);
-                }
+                        subNode = listNode.SelectSingleNode("Background");
+                        if (subNode != null)
+                        {
+                            item.Background = Color.FromArgb(int.Parse(subNode.InnerText, CultureInfo.InvariantCulture));
+                        }
 
-                subNode = node.SelectSingleNode("AssaStyleStorage");
-                if (subNode != null)
-                {
-                    settings.SubtitleSettings.AssaStyleStorage = subNode.InnerText;
+                        subNode = listNode.SelectSingleNode("ShadowWidth");
+                        if (subNode != null)
+                        {
+                            item.ShadowWidth = Convert.ToDecimal(subNode.InnerText);
+                        }
+
+                        subNode = listNode.SelectSingleNode("OutlineWidth");
+                        if (subNode != null)
+                        {
+                            item.OutlineWidth = Convert.ToDecimal(subNode.InnerText);
+                        }
+
+                        subNode = listNode.SelectSingleNode("Alignment");
+                        if (subNode != null)
+                        {
+                            item.Alignment = subNode.InnerText;
+                        }
+
+                        subNode = listNode.SelectSingleNode("MarginLeft");
+                        if (subNode != null)
+                        {
+                            item.MarginLeft = Convert.ToInt32(subNode.InnerText);
+                        }
+
+                        subNode = listNode.SelectSingleNode("MarginRight");
+                        if (subNode != null)
+                        {
+                            item.MarginRight = Convert.ToInt32(subNode.InnerText);
+                        }
+
+                        subNode = listNode.SelectSingleNode("MarginVertical");
+                        if (subNode != null)
+                        {
+                            item.MarginVertical = Convert.ToInt32(subNode.InnerText);
+                        }
+
+                        subNode = listNode.SelectSingleNode("BorderStyle");
+                        if (subNode != null)
+                        {
+                            item.BorderStyle = subNode.InnerText;
+                        }
+
+                        category.Styles.Add(item);
+                    }
                 }
 
                 subNode = node.SelectSingleNode("DCinemaFontFile");
@@ -8346,17 +8376,38 @@ $HorzAlign          =   Center
                 textWriter.WriteEndElement();
 
                 textWriter.WriteStartElement("SubtitleSettings", string.Empty);
-                textWriter.WriteElementString("SsaFontName", settings.SubtitleSettings.SsaFontName);
-                textWriter.WriteElementString("SsaFontSize", settings.SubtitleSettings.SsaFontSize.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("SsaFontColorArgb", settings.SubtitleSettings.SsaFontColorArgb.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("SsaFontBold", settings.SubtitleSettings.SsaFontBold.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("SsaOutline", settings.SubtitleSettings.SsaOutline.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("SsaShadow", settings.SubtitleSettings.SsaShadow.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("SsaOpaqueBox", settings.SubtitleSettings.SsaOpaqueBox.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("SsaMarginLeft", settings.SubtitleSettings.SsaMarginLeft.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("SsaMarginRight", settings.SubtitleSettings.SsaMarginRight.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("SsaMarginTopBottom", settings.SubtitleSettings.SsaMarginTopBottom.ToString(CultureInfo.InvariantCulture));
-                textWriter.WriteElementString("AssaStyleStorage", settings.SubtitleSettings.AssaStyleStorage);
+                textWriter.WriteStartElement("AssaStyleStorageCategories", string.Empty);
+                foreach (var category in settings.SubtitleSettings.AssaStyleStorageCategories)
+                {
+                    if (!string.IsNullOrEmpty(category?.Name))
+                    {
+                        textWriter.WriteStartElement("Category", string.Empty);
+                        textWriter.WriteElementString("Name", category.Name);
+                        textWriter.WriteElementString("IsDefault", category.IsDefault.ToString(CultureInfo.InvariantCulture));
+                        foreach (var style in category.Styles)
+                        {
+                            textWriter.WriteStartElement("Style");
+                            textWriter.WriteElementString("Name", style.Name);
+                            textWriter.WriteElementString("FontName", style.FontName);
+                            textWriter.WriteElementString("FontSize", style.FontSize.ToString());
+                            textWriter.WriteElementString("Primary", style.Primary.ToArgb().ToString());
+                            textWriter.WriteElementString("Secondary", style.Secondary.ToArgb().ToString());
+                            textWriter.WriteElementString("Outline", style.Outline.ToArgb().ToString());
+                            textWriter.WriteElementString("Background", style.Background.ToArgb().ToString());
+                            textWriter.WriteElementString("ShadowWidth", style.ShadowWidth.ToString());
+                            textWriter.WriteElementString("OutlineWidth", style.OutlineWidth.ToString());
+                            textWriter.WriteElementString("Alignment", style.Alignment);
+                            textWriter.WriteElementString("MarginLeft", style.MarginLeft.ToString());
+                            textWriter.WriteElementString("MarginRight", style.MarginRight.ToString());
+                            textWriter.WriteElementString("MarginVertical", style.MarginVertical.ToString());
+                            textWriter.WriteElementString("BorderStyle", style.BorderStyle.ToString());
+                            textWriter.WriteEndElement();
+                        }
+                        textWriter.WriteEndElement();
+                    }
+                }
+                textWriter.WriteEndElement();
+
                 textWriter.WriteElementString("DCinemaFontFile", settings.SubtitleSettings.DCinemaFontFile);
                 textWriter.WriteElementString("DCinemaFontSize", settings.SubtitleSettings.DCinemaFontSize.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("DCinemaBottomMargin", settings.SubtitleSettings.DCinemaBottomMargin.ToString(CultureInfo.InvariantCulture));

--- a/src/libse/Common/SsaStyle.cs
+++ b/src/libse/Common/SsaStyle.cs
@@ -32,24 +32,20 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public SsaStyle()
         {
-            FontName = Configuration.Settings.SubtitleSettings.SsaFontName;
-            FontSize = (float)Configuration.Settings.SubtitleSettings.SsaFontSize;
-            Primary = Color.FromArgb(Configuration.Settings.SubtitleSettings.SsaFontColorArgb);
+            Name = "Default";
+            FontName = "Arial";
+            FontSize = 20F;
+            Primary = Color.White;
             Secondary = Color.Yellow;
             Outline = Color.Black;
             Background = Color.Black;
             Alignment = "2";
-            OutlineWidth = Configuration.Settings.SubtitleSettings.SsaOutline;
-            ShadowWidth = Configuration.Settings.SubtitleSettings.SsaShadow;
+            OutlineWidth = 1M;
+            ShadowWidth = 1M;
             MarginLeft = 10;
             MarginRight = 10;
             MarginVertical = 10;
             BorderStyle = "1";
-            if (Configuration.Settings.SubtitleSettings.SsaOpaqueBox)
-            {
-                BorderStyle = "3";
-            }
-
             RawLine = string.Empty;
             LoadedFromHeader = false;
         }
@@ -116,10 +112,6 @@ namespace Nikse.SubtitleEdit.Core.Common
                 else if (f == "tertiarycolour")
                 {
                     sb.Append(ColorTranslator.ToWin32(Tertiary));
-                }
-                else if (f == "outlinecolour")
-                {
-                    sb.Append(ColorTranslator.ToWin32(Outline));
                 }
                 else if (f == "backcolour")
                 {
@@ -192,7 +184,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             return s.Substring(0, s.Length - 1);
         }
 
-        public string ToRawAss(string styleFormat)
+        public string ToRawAss(string styleFormat = DefaultAssStyleFormat)
         {
             var sb = new StringBuilder();
             sb.Append("Style: ");
@@ -219,10 +211,6 @@ namespace Nikse.SubtitleEdit.Core.Common
                 else if (f == "secondarycolour")
                 {
                     sb.Append(AdvancedSubStationAlpha.GetSsaColorString(Secondary));
-                }
-                else if (f == "tertiarycolour")
-                {
-                    sb.Append(AdvancedSubStationAlpha.GetSsaColorString(Tertiary));
                 }
                 else if (f == "outlinecolour")
                 {

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -17,24 +17,25 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             get
             {
-                var borderStyle = "1"; // 1=normal, 3=opaque box
-                if (Configuration.Settings.SubtitleSettings.SsaOpaqueBox)
+                string defaultStyle = string.Empty;
+                var defaultCategory = Configuration.Settings.SubtitleSettings.AssaStyleStorageCategories.SingleOrDefault(item => item.IsDefault);
+                if (defaultCategory == null || defaultCategory.Styles.Count < 0)
                 {
-                    borderStyle = "3";
+                    defaultStyle = new SsaStyle().ToRawAss();
+                }
+                else
+                {
+                    foreach (var defaultCategoryStyle in defaultCategory.Styles)
+                    {
+                        defaultStyle += defaultCategoryStyle.ToRawAss();
+                        if (defaultCategory.Styles.IndexOf(defaultCategoryStyle) != defaultCategory.Styles.Count - 1)
+                        {
+                            defaultStyle += Environment.NewLine;
+                        }
+                    }
                 }
 
-                var boldStyle = "0"; // 0=regular
-                if (Configuration.Settings.SubtitleSettings.SsaFontBold)
-                {
-                    boldStyle = "-1";
-                }
-
-                var ssa = Configuration.Settings.SubtitleSettings;
-                return "Style: Default," + ssa.SsaFontName + "," +
-                       ssa.SsaFontSize.ToString(CultureInfo.InvariantCulture) + "," +
-                       GetSsaColorString(Color.FromArgb(ssa.SsaFontColorArgb)) + "," +
-                       "&H0300FFFF,&H00000000,&H02000000," + boldStyle + ",0,0,0,100,100,0,0," + borderStyle + "," + ssa.SsaOutline.ToString(CultureInfo.InvariantCulture) + "," +
-                       Configuration.Settings.SubtitleSettings.SsaShadow.ToString(CultureInfo.InvariantCulture) + ",2," + ssa.SsaMarginLeft + "," + ssa.SsaMarginRight + "," + ssa.SsaMarginTopBottom + ",1";
+                return defaultStyle;
             }
         }
 
@@ -698,6 +699,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                     }
                 }
             }
+
             return list;
         }
 
@@ -2184,7 +2186,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                         var format = line.Substring(6).Split(',');
                         for (int i = 0; i < format.Length; i++)
                         {
-                            string f = format[i].Trim().ToLowerInvariant();
+                            string f = format[i].Trim();
                             if (i == nameIndex)
                             {
                                 style.Name = format[i].Trim();
@@ -2286,6 +2288,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                     }
                 }
             }
+
             return new SsaStyle { Name = styleName };
         }
     }

--- a/src/libse/SubtitleFormats/SubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/SubStationAlpha.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -65,7 +66,6 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             const string commentWriteFormat = "Comment: Marked={4},{0},{1},{3},{5},{6},{7},{8},{9},{2}";
 
             var sb = new StringBuilder();
-            Color fontColor = Color.FromArgb(Configuration.Settings.SubtitleSettings.SsaFontColorArgb);
             bool isValidAssHeader = !string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4 Styles]");
             var styles = new List<string>();
             if (isValidAssHeader)
@@ -91,23 +91,32 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             }
             else
             {
-                var ssa = Configuration.Settings.SubtitleSettings;
+                SsaStyle style = null;
+                var storageCategories = Configuration.Settings.SubtitleSettings.AssaStyleStorageCategories;
+                if (storageCategories.Count > 0 && storageCategories.Exists(x => x.IsDefault))
+                {
+                    var defaultStyle = storageCategories.SingleOrDefault(x => x.IsDefault).Styles.SingleOrDefault(x => x.Name.ToLowerInvariant() == "default");
+                    style = defaultStyle ?? storageCategories.SingleOrDefault(x => x.IsDefault).Styles[0];
+                }
+
+                style = style ?? new SsaStyle();
+
                 string boldStyle = "0"; // 0=regular
-                if (ssa.SsaFontBold)
+                if (style.Bold)
                 {
                     boldStyle = "-1"; // -1 = true, 0 is false
                 }
 
                 sb.AppendLine(string.Format(header,
                                             title,
-                                            ssa.SsaFontName,
-                                            (int)ssa.SsaFontSize,
-                                            ColorTranslator.ToWin32(fontColor),
-                                            ssa.SsaOutline,
-                                            ssa.SsaShadow,
-                                            ssa.SsaMarginLeft,
-                                            ssa.SsaMarginRight,
-                                            ssa.SsaMarginTopBottom,
+                                            style.FontName,
+                                            style.FontSize,
+                                            ColorTranslator.ToWin32(style.Primary),
+                                            style.OutlineWidth,
+                                            style.ShadowWidth,
+                                            style.MarginLeft,
+                                            style.MarginRight,
+                                            style.MarginVertical,
                                             boldStyle
                                             ));
             }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -7860,6 +7860,10 @@ namespace Nikse.SubtitleEdit.Forms
                 actors = new List<string>();
                 toolStripMenuItemWebVTT.Visible = false;
                 var styles = AdvancedSubStationAlpha.GetStylesFromHeader(_subtitle.Header);
+                if (styles.Count == 0)
+                {
+                    styles = AdvancedSubStationAlpha.GetStylesFromHeader(AdvancedSubStationAlpha.DefaultHeader);
+                }
                 setStylesForSelectedLinesToolStripMenuItem.DropDownItems.Clear();
                 foreach (var style in styles)
                 {

--- a/src/ui/Forms/Options/Settings.Designer.cs
+++ b/src/ui/Forms/Options/Settings.Designer.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Forms;
-
-namespace Nikse.SubtitleEdit.Forms.Options
+﻿namespace Nikse.SubtitleEdit.Forms.Options
 {
     sealed partial class Settings
     {
@@ -364,31 +362,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.labelSubtitleFontColor = new System.Windows.Forms.Label();
             this.panelSubtitleBackgroundColor = new System.Windows.Forms.Panel();
             this.labelSubtitleFontBackgroundColor = new System.Windows.Forms.Label();
-            this.panelSsaStyle = new System.Windows.Forms.Panel();
-            this.groupBoxSsaStyle = new System.Windows.Forms.GroupBox();
-            this.groupBoxSsaBorder = new System.Windows.Forms.GroupBox();
-            this.numericUpDownSsaOutline = new System.Windows.Forms.NumericUpDown();
-            this.labelSsaShadow = new System.Windows.Forms.Label();
-            this.numericUpDownSsaShadow = new System.Windows.Forms.NumericUpDown();
-            this.checkBoxSsaOpaqueBox = new System.Windows.Forms.CheckBox();
-            this.labelSsaOutline = new System.Windows.Forms.Label();
-            this.groupBoxSsaFont = new System.Windows.Forms.GroupBox();
-            this.checkBoxSsaFontBold = new System.Windows.Forms.CheckBox();
-            this.buttonSsaColor = new System.Windows.Forms.Button();
-            this.panelPrimaryColor = new System.Windows.Forms.Panel();
-            this.numericUpDownFontSize = new System.Windows.Forms.NumericUpDown();
-            this.comboBoxFontName = new System.Windows.Forms.ComboBox();
-            this.labelSsaFontSize = new System.Windows.Forms.Label();
-            this.labelFontName = new System.Windows.Forms.Label();
-            this.groupBoxMargins = new System.Windows.Forms.GroupBox();
-            this.numericUpDownSsaMarginVertical = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDownSsaMarginRight = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDownSsaMarginLeft = new System.Windows.Forms.NumericUpDown();
-            this.labelMarginVertical = new System.Windows.Forms.Label();
-            this.labelMarginRight = new System.Windows.Forms.Label();
-            this.labelMarginLeft = new System.Windows.Forms.Label();
-            this.groupBoxPreview = new System.Windows.Forms.GroupBox();
-            this.pictureBoxPreview = new System.Windows.Forms.PictureBox();
             this.panelNetwork = new System.Windows.Forms.Panel();
             this.groupBoxNetworkSession = new System.Windows.Forms.GroupBox();
             this.buttonNetworkSessionNewMessageSound = new System.Windows.Forms.Button();
@@ -472,19 +445,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.groupBoxFontTextBox.SuspendLayout();
             this.groupBoxFontListViews.SuspendLayout();
             this.groupBoxFontGeneral.SuspendLayout();
-            this.panelSsaStyle.SuspendLayout();
-            this.groupBoxSsaStyle.SuspendLayout();
-            this.groupBoxSsaBorder.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaOutline)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaShadow)).BeginInit();
-            this.groupBoxSsaFont.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownFontSize)).BeginInit();
-            this.groupBoxMargins.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaMarginVertical)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaMarginRight)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaMarginLeft)).BeginInit();
-            this.groupBoxPreview.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxPreview)).BeginInit();
             this.panelNetwork.SuspendLayout();
             this.groupBoxNetworkSession.SuspendLayout();
             this.groupBoxProxySettings.SuspendLayout();
@@ -498,7 +458,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.buttonOK.Location = new System.Drawing.Point(733, 539);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
-            this.buttonOK.TabIndex = 3;
+            this.buttonOK.TabIndex = 12;
             this.buttonOK.Text = "&OK";
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.ButtonOkClick);
@@ -510,7 +470,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.buttonCancel.Location = new System.Drawing.Point(814, 539);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-            this.buttonCancel.TabIndex = 2;
+            this.buttonCancel.TabIndex = 13;
             this.buttonCancel.Text = "C&ancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
@@ -530,7 +490,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             "Wordlists",
             "Toolbar",
             "Font",
-            "ASS/SSA Style",
             "Network"});
             this.listBoxSection.Location = new System.Drawing.Point(10, 10);
             this.listBoxSection.Name = "listBoxSection";
@@ -4470,292 +4429,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.labelSubtitleFontBackgroundColor.TabIndex = 36;
             this.labelSubtitleFontBackgroundColor.Text = "Subtitle font background color";
             // 
-            // panelSsaStyle
-            // 
-            this.panelSsaStyle.Controls.Add(this.groupBoxSsaStyle);
-            this.panelSsaStyle.Location = new System.Drawing.Point(230, 6);
-            this.panelSsaStyle.Name = "panelSsaStyle";
-            this.panelSsaStyle.Padding = new System.Windows.Forms.Padding(3);
-            this.panelSsaStyle.Size = new System.Drawing.Size(864, 521);
-            this.panelSsaStyle.TabIndex = 10;
-            this.panelSsaStyle.Text = "SSA style";
-            // 
-            // groupBoxSsaStyle
-            // 
-            this.groupBoxSsaStyle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBoxSsaStyle.Controls.Add(this.groupBoxSsaBorder);
-            this.groupBoxSsaStyle.Controls.Add(this.groupBoxSsaFont);
-            this.groupBoxSsaStyle.Controls.Add(this.groupBoxMargins);
-            this.groupBoxSsaStyle.Controls.Add(this.groupBoxPreview);
-            this.groupBoxSsaStyle.Location = new System.Drawing.Point(0, 0);
-            this.groupBoxSsaStyle.Name = "groupBoxSsaStyle";
-            this.groupBoxSsaStyle.Size = new System.Drawing.Size(851, 521);
-            this.groupBoxSsaStyle.TabIndex = 0;
-            this.groupBoxSsaStyle.TabStop = false;
-            this.groupBoxSsaStyle.Text = "Sub Station Alpha style";
-            // 
-            // groupBoxSsaBorder
-            // 
-            this.groupBoxSsaBorder.Controls.Add(this.numericUpDownSsaOutline);
-            this.groupBoxSsaBorder.Controls.Add(this.labelSsaShadow);
-            this.groupBoxSsaBorder.Controls.Add(this.numericUpDownSsaShadow);
-            this.groupBoxSsaBorder.Controls.Add(this.checkBoxSsaOpaqueBox);
-            this.groupBoxSsaBorder.Controls.Add(this.labelSsaOutline);
-            this.groupBoxSsaBorder.Location = new System.Drawing.Point(329, 21);
-            this.groupBoxSsaBorder.Name = "groupBoxSsaBorder";
-            this.groupBoxSsaBorder.Size = new System.Drawing.Size(185, 96);
-            this.groupBoxSsaBorder.TabIndex = 8;
-            this.groupBoxSsaBorder.TabStop = false;
-            this.groupBoxSsaBorder.Text = "Border";
-            // 
-            // numericUpDownSsaOutline
-            // 
-            this.numericUpDownSsaOutline.Location = new System.Drawing.Point(64, 16);
-            this.numericUpDownSsaOutline.Maximum = new decimal(new int[] {
-            9,
-            0,
-            0,
-            0});
-            this.numericUpDownSsaOutline.Name = "numericUpDownSsaOutline";
-            this.numericUpDownSsaOutline.Size = new System.Drawing.Size(44, 21);
-            this.numericUpDownSsaOutline.TabIndex = 5;
-            this.numericUpDownSsaOutline.ValueChanged += new System.EventHandler(this.numericUpDownSsaOutline_ValueChanged);
-            // 
-            // labelSsaShadow
-            // 
-            this.labelSsaShadow.AutoSize = true;
-            this.labelSsaShadow.Location = new System.Drawing.Point(10, 45);
-            this.labelSsaShadow.Name = "labelSsaShadow";
-            this.labelSsaShadow.Size = new System.Drawing.Size(45, 13);
-            this.labelSsaShadow.TabIndex = 6;
-            this.labelSsaShadow.Text = "Shadow";
-            // 
-            // numericUpDownSsaShadow
-            // 
-            this.numericUpDownSsaShadow.Location = new System.Drawing.Point(64, 43);
-            this.numericUpDownSsaShadow.Maximum = new decimal(new int[] {
-            9,
-            0,
-            0,
-            0});
-            this.numericUpDownSsaShadow.Name = "numericUpDownSsaShadow";
-            this.numericUpDownSsaShadow.Size = new System.Drawing.Size(44, 21);
-            this.numericUpDownSsaShadow.TabIndex = 7;
-            this.numericUpDownSsaShadow.ValueChanged += new System.EventHandler(this.numericUpDownSsaShadow_ValueChanged);
-            // 
-            // checkBoxSsaOpaqueBox
-            // 
-            this.checkBoxSsaOpaqueBox.AutoSize = true;
-            this.checkBoxSsaOpaqueBox.Location = new System.Drawing.Point(13, 71);
-            this.checkBoxSsaOpaqueBox.Name = "checkBoxSsaOpaqueBox";
-            this.checkBoxSsaOpaqueBox.Size = new System.Drawing.Size(85, 17);
-            this.checkBoxSsaOpaqueBox.TabIndex = 8;
-            this.checkBoxSsaOpaqueBox.Text = "Opaque box";
-            this.checkBoxSsaOpaqueBox.UseVisualStyleBackColor = true;
-            this.checkBoxSsaOpaqueBox.CheckedChanged += new System.EventHandler(this.checkBoxSsaOpaqueBox_CheckedChanged);
-            // 
-            // labelSsaOutline
-            // 
-            this.labelSsaOutline.AutoSize = true;
-            this.labelSsaOutline.Location = new System.Drawing.Point(10, 20);
-            this.labelSsaOutline.Name = "labelSsaOutline";
-            this.labelSsaOutline.Size = new System.Drawing.Size(41, 13);
-            this.labelSsaOutline.TabIndex = 4;
-            this.labelSsaOutline.Text = "Outline";
-            // 
-            // groupBoxSsaFont
-            // 
-            this.groupBoxSsaFont.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBoxSsaFont.Controls.Add(this.checkBoxSsaFontBold);
-            this.groupBoxSsaFont.Controls.Add(this.buttonSsaColor);
-            this.groupBoxSsaFont.Controls.Add(this.panelPrimaryColor);
-            this.groupBoxSsaFont.Controls.Add(this.numericUpDownFontSize);
-            this.groupBoxSsaFont.Controls.Add(this.comboBoxFontName);
-            this.groupBoxSsaFont.Controls.Add(this.labelSsaFontSize);
-            this.groupBoxSsaFont.Controls.Add(this.labelFontName);
-            this.groupBoxSsaFont.Location = new System.Drawing.Point(6, 20);
-            this.groupBoxSsaFont.Name = "groupBoxSsaFont";
-            this.groupBoxSsaFont.Size = new System.Drawing.Size(355, 97);
-            this.groupBoxSsaFont.TabIndex = 7;
-            this.groupBoxSsaFont.TabStop = false;
-            this.groupBoxSsaFont.Text = "Font";
-            // 
-            // checkBoxSsaFontBold
-            // 
-            this.checkBoxSsaFontBold.AutoSize = true;
-            this.checkBoxSsaFontBold.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.checkBoxSsaFontBold.Location = new System.Drawing.Point(184, 45);
-            this.checkBoxSsaFontBold.Name = "checkBoxSsaFontBold";
-            this.checkBoxSsaFontBold.Size = new System.Drawing.Size(51, 17);
-            this.checkBoxSsaFontBold.TabIndex = 7;
-            this.checkBoxSsaFontBold.Text = "Bold";
-            this.checkBoxSsaFontBold.UseVisualStyleBackColor = true;
-            this.checkBoxSsaFontBold.CheckedChanged += new System.EventHandler(this.checkBoxSsaFontBold_CheckedChanged);
-            // 
-            // buttonSsaColor
-            // 
-            this.buttonSsaColor.Location = new System.Drawing.Point(6, 66);
-            this.buttonSsaColor.Name = "buttonSsaColor";
-            this.buttonSsaColor.Size = new System.Drawing.Size(109, 23);
-            this.buttonSsaColor.TabIndex = 6;
-            this.buttonSsaColor.Text = "Choose color";
-            this.buttonSsaColor.UseVisualStyleBackColor = true;
-            this.buttonSsaColor.Click += new System.EventHandler(this.buttonSsaColor_Click);
-            // 
-            // panelPrimaryColor
-            // 
-            this.panelPrimaryColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panelPrimaryColor.Location = new System.Drawing.Point(121, 68);
-            this.panelPrimaryColor.Name = "panelPrimaryColor";
-            this.panelPrimaryColor.Size = new System.Drawing.Size(21, 20);
-            this.panelPrimaryColor.TabIndex = 4;
-            this.panelPrimaryColor.MouseClick += new System.Windows.Forms.MouseEventHandler(this.panelPrimaryColor_MouseClick);
-            // 
-            // numericUpDownFontSize
-            // 
-            this.numericUpDownFontSize.Location = new System.Drawing.Point(121, 44);
-            this.numericUpDownFontSize.Maximum = new decimal(new int[] {
-            200,
-            0,
-            0,
-            0});
-            this.numericUpDownFontSize.Name = "numericUpDownFontSize";
-            this.numericUpDownFontSize.Size = new System.Drawing.Size(51, 21);
-            this.numericUpDownFontSize.TabIndex = 3;
-            this.numericUpDownFontSize.ValueChanged += new System.EventHandler(this.numericUpDownFontSize_ValueChanged);
-            // 
-            // comboBoxFontName
-            // 
-            this.comboBoxFontName.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBoxFontName.FormattingEnabled = true;
-            this.comboBoxFontName.Location = new System.Drawing.Point(121, 17);
-            this.comboBoxFontName.Name = "comboBoxFontName";
-            this.comboBoxFontName.Size = new System.Drawing.Size(188, 21);
-            this.comboBoxFontName.TabIndex = 1;
-            this.comboBoxFontName.TextChanged += new System.EventHandler(this.comboBoxFontName_TextChanged);
-            // 
-            // labelSsaFontSize
-            // 
-            this.labelSsaFontSize.AutoSize = true;
-            this.labelSsaFontSize.Location = new System.Drawing.Point(10, 46);
-            this.labelSsaFontSize.Name = "labelSsaFontSize";
-            this.labelSsaFontSize.Size = new System.Drawing.Size(50, 13);
-            this.labelSsaFontSize.TabIndex = 2;
-            this.labelSsaFontSize.Text = "Font size";
-            // 
-            // labelFontName
-            // 
-            this.labelFontName.AutoSize = true;
-            this.labelFontName.Location = new System.Drawing.Point(10, 20);
-            this.labelFontName.Name = "labelFontName";
-            this.labelFontName.Size = new System.Drawing.Size(58, 13);
-            this.labelFontName.TabIndex = 0;
-            this.labelFontName.Text = "Font name";
-            // 
-            // groupBoxMargins
-            // 
-            this.groupBoxMargins.Controls.Add(this.numericUpDownSsaMarginVertical);
-            this.groupBoxMargins.Controls.Add(this.numericUpDownSsaMarginRight);
-            this.groupBoxMargins.Controls.Add(this.numericUpDownSsaMarginLeft);
-            this.groupBoxMargins.Controls.Add(this.labelMarginVertical);
-            this.groupBoxMargins.Controls.Add(this.labelMarginRight);
-            this.groupBoxMargins.Controls.Add(this.labelMarginLeft);
-            this.groupBoxMargins.Location = new System.Drawing.Point(520, 20);
-            this.groupBoxMargins.Name = "groupBoxMargins";
-            this.groupBoxMargins.Size = new System.Drawing.Size(281, 97);
-            this.groupBoxMargins.TabIndex = 9;
-            this.groupBoxMargins.TabStop = false;
-            this.groupBoxMargins.Text = "Margins";
-            // 
-            // numericUpDownSsaMarginVertical
-            // 
-            this.numericUpDownSsaMarginVertical.Location = new System.Drawing.Point(168, 33);
-            this.numericUpDownSsaMarginVertical.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.numericUpDownSsaMarginVertical.Name = "numericUpDownSsaMarginVertical";
-            this.numericUpDownSsaMarginVertical.Size = new System.Drawing.Size(44, 21);
-            this.numericUpDownSsaMarginVertical.TabIndex = 5;
-            this.numericUpDownSsaMarginVertical.ValueChanged += new System.EventHandler(this.numericUpDownSsaMarginVertical_ValueChanged);
-            // 
-            // numericUpDownSsaMarginRight
-            // 
-            this.numericUpDownSsaMarginRight.Location = new System.Drawing.Point(93, 33);
-            this.numericUpDownSsaMarginRight.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.numericUpDownSsaMarginRight.Name = "numericUpDownSsaMarginRight";
-            this.numericUpDownSsaMarginRight.Size = new System.Drawing.Size(44, 21);
-            this.numericUpDownSsaMarginRight.TabIndex = 3;
-            // 
-            // numericUpDownSsaMarginLeft
-            // 
-            this.numericUpDownSsaMarginLeft.Location = new System.Drawing.Point(16, 33);
-            this.numericUpDownSsaMarginLeft.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.numericUpDownSsaMarginLeft.Name = "numericUpDownSsaMarginLeft";
-            this.numericUpDownSsaMarginLeft.Size = new System.Drawing.Size(44, 21);
-            this.numericUpDownSsaMarginLeft.TabIndex = 1;
-            // 
-            // labelMarginVertical
-            // 
-            this.labelMarginVertical.AutoSize = true;
-            this.labelMarginVertical.Location = new System.Drawing.Point(165, 17);
-            this.labelMarginVertical.Name = "labelMarginVertical";
-            this.labelMarginVertical.Size = new System.Drawing.Size(42, 13);
-            this.labelMarginVertical.TabIndex = 4;
-            this.labelMarginVertical.Text = "Vertical";
-            // 
-            // labelMarginRight
-            // 
-            this.labelMarginRight.AutoSize = true;
-            this.labelMarginRight.Location = new System.Drawing.Point(90, 16);
-            this.labelMarginRight.Name = "labelMarginRight";
-            this.labelMarginRight.Size = new System.Drawing.Size(32, 13);
-            this.labelMarginRight.TabIndex = 2;
-            this.labelMarginRight.Text = "Right";
-            // 
-            // labelMarginLeft
-            // 
-            this.labelMarginLeft.AutoSize = true;
-            this.labelMarginLeft.Location = new System.Drawing.Point(13, 16);
-            this.labelMarginLeft.Name = "labelMarginLeft";
-            this.labelMarginLeft.Size = new System.Drawing.Size(26, 13);
-            this.labelMarginLeft.TabIndex = 0;
-            this.labelMarginLeft.Text = "Left";
-            // 
-            // groupBoxPreview
-            // 
-            this.groupBoxPreview.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBoxPreview.Controls.Add(this.pictureBoxPreview);
-            this.groupBoxPreview.Location = new System.Drawing.Point(6, 118);
-            this.groupBoxPreview.Name = "groupBoxPreview";
-            this.groupBoxPreview.Size = new System.Drawing.Size(839, 397);
-            this.groupBoxPreview.TabIndex = 10;
-            this.groupBoxPreview.TabStop = false;
-            this.groupBoxPreview.Text = "Preview";
-            // 
-            // pictureBoxPreview
-            // 
-            this.pictureBoxPreview.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pictureBoxPreview.Location = new System.Drawing.Point(3, 17);
-            this.pictureBoxPreview.Name = "pictureBoxPreview";
-            this.pictureBoxPreview.Size = new System.Drawing.Size(833, 377);
-            this.pictureBoxPreview.TabIndex = 0;
-            this.pictureBoxPreview.TabStop = false;
-            this.pictureBoxPreview.Click += new System.EventHandler(this.pictureBoxPreview_Click);
-            // 
             // panelNetwork
             // 
             this.panelNetwork.Controls.Add(this.groupBoxNetworkSession);
@@ -4764,7 +4437,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.panelNetwork.Name = "panelNetwork";
             this.panelNetwork.Padding = new System.Windows.Forms.Padding(3);
             this.panelNetwork.Size = new System.Drawing.Size(864, 521);
-            this.panelNetwork.TabIndex = 11;
+            this.panelNetwork.TabIndex = 10;
             this.panelNetwork.Text = "Network";
             // 
             // groupBoxNetworkSession
@@ -4908,7 +4581,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.labelStatus.Location = new System.Drawing.Point(12, 549);
             this.labelStatus.Name = "labelStatus";
             this.labelStatus.Size = new System.Drawing.Size(60, 13);
-            this.labelStatus.TabIndex = 1;
+            this.labelStatus.TabIndex = 11;
             this.labelStatus.Text = "labelStatus";
             // 
             // openFileDialogFFmpeg
@@ -4921,7 +4594,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.buttonReset.Location = new System.Drawing.Point(895, 539);
             this.buttonReset.Name = "buttonReset";
             this.buttonReset.Size = new System.Drawing.Size(185, 23);
-            this.buttonReset.TabIndex = 4;
+            this.buttonReset.TabIndex = 14;
             this.buttonReset.Text = "Restore default settings";
             this.buttonReset.UseVisualStyleBackColor = true;
             this.buttonReset.Click += new System.EventHandler(this.buttonReset_Click);
@@ -4945,7 +4618,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.Controls.Add(this.panelToolBar);
             this.Controls.Add(this.panelWaveform);
             this.Controls.Add(this.panelSyntaxColoring);
-            this.Controls.Add(this.panelSsaStyle);
             this.Controls.Add(this.panelNetwork);
             this.Controls.Add(this.panelShortcuts);
             this.Controls.Add(this.listBoxSection);
@@ -5054,22 +4726,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             this.groupBoxFontListViews.PerformLayout();
             this.groupBoxFontGeneral.ResumeLayout(false);
             this.groupBoxFontGeneral.PerformLayout();
-            this.panelSsaStyle.ResumeLayout(false);
-            this.groupBoxSsaStyle.ResumeLayout(false);
-            this.groupBoxSsaBorder.ResumeLayout(false);
-            this.groupBoxSsaBorder.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaOutline)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaShadow)).EndInit();
-            this.groupBoxSsaFont.ResumeLayout(false);
-            this.groupBoxSsaFont.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownFontSize)).EndInit();
-            this.groupBoxMargins.ResumeLayout(false);
-            this.groupBoxMargins.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaMarginVertical)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaMarginRight)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownSsaMarginLeft)).EndInit();
-            this.groupBoxPreview.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxPreview)).EndInit();
             this.panelNetwork.ResumeLayout(false);
             this.groupBoxNetworkSession.ResumeLayout(false);
             this.groupBoxNetworkSession.PerformLayout();
@@ -5088,7 +4744,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.ListBox listBoxSection;
         private System.Windows.Forms.Panel panelGeneral;
-        private System.Windows.Forms.Panel panelSsaStyle;
         private System.Windows.Forms.GroupBox groupBoxMiscellaneous;
         private System.Windows.Forms.GroupBox groupBoxShowToolBarButtons;
         private System.Windows.Forms.PictureBox pictureBoxNew;
@@ -5126,7 +4781,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
         private System.Windows.Forms.ComboBox comboBoxFrameRate;
         private System.Windows.Forms.ComboBox comboBoxEncoding;
         private System.Windows.Forms.CheckBox checkBoxRememberRecentFiles;
-        private System.Windows.Forms.GroupBox groupBoxSsaStyle;
         private System.Windows.Forms.ColorDialog colorDialogSSAStyle;
         private System.Windows.Forms.CheckBox checkBoxStartInSourceView;
         private System.Windows.Forms.CheckBox checkBoxReopenLastOpened;
@@ -5290,13 +4944,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
         private System.Windows.Forms.Label labelWaveformBorderHitMs2;
         private System.Windows.Forms.NumericUpDown numericUpDownWaveformBorderHitMs;
         private System.Windows.Forms.Label labelWaveformBorderHitMs1;
-        private System.Windows.Forms.Label labelSsaOutline;
-        private System.Windows.Forms.NumericUpDown numericUpDownSsaShadow;
-        private System.Windows.Forms.NumericUpDown numericUpDownSsaOutline;
-        private System.Windows.Forms.Label labelSsaShadow;
-        private System.Windows.Forms.GroupBox groupBoxPreview;
-        private System.Windows.Forms.PictureBox pictureBoxPreview;
-        private System.Windows.Forms.CheckBox checkBoxSsaOpaqueBox;
         private System.Windows.Forms.CheckBox checkBoxSpellCheckOneLetterWords;
         private System.Windows.Forms.CheckBox checkBoxTreatINQuoteAsING;
         private System.Windows.Forms.GroupBox groupBoxFfmpeg;
@@ -5330,22 +4977,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
         private System.Windows.Forms.Button buttonNetworkSessionNewMessageSound;
         private System.Windows.Forms.TextBox textBoxNetworkSessionNewMessageSound;
         private System.Windows.Forms.Label labelNetworkSessionNewMessageSound;
-        private System.Windows.Forms.GroupBox groupBoxMargins;
-        private System.Windows.Forms.NumericUpDown numericUpDownSsaMarginVertical;
-        private System.Windows.Forms.NumericUpDown numericUpDownSsaMarginRight;
-        private System.Windows.Forms.NumericUpDown numericUpDownSsaMarginLeft;
-        private System.Windows.Forms.Label labelMarginVertical;
-        private System.Windows.Forms.Label labelMarginRight;
-        private System.Windows.Forms.Label labelMarginLeft;
-        private System.Windows.Forms.GroupBox groupBoxSsaBorder;
-        private System.Windows.Forms.GroupBox groupBoxSsaFont;
-        private System.Windows.Forms.NumericUpDown numericUpDownFontSize;
-        private System.Windows.Forms.ComboBox comboBoxFontName;
-        private System.Windows.Forms.Label labelSsaFontSize;
-        private System.Windows.Forms.Label labelFontName;
-        private System.Windows.Forms.Panel panelPrimaryColor;
-        private System.Windows.Forms.Button buttonSsaColor;
-        private System.Windows.Forms.CheckBox checkBoxSsaFontBold;
         private System.Windows.Forms.CheckBox checkBoxFceSkipStep1;
         private System.Windows.Forms.Button buttonMpvSettings;
         private System.Windows.Forms.Label labelMpvSettings;
@@ -5461,7 +5092,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
         private System.Windows.Forms.ColumnHeader columnHeaderNames;
         private System.Windows.Forms.Panel panelShortcuts;
         private System.Windows.Forms.CheckBox checkBoxLiveSpellCheck;
-        private Label labelVideoPlayerPreviewFontColor;
-        private Panel panelVideoPlayerPreviewFontColor;
+        private System.Windows.Forms.Label labelVideoPlayerPreviewFontColor;
+        private System.Windows.Forms.Panel panelVideoPlayerPreviewFontColor;
     }
 }

--- a/src/ui/Forms/Options/Settings.cs
+++ b/src/ui/Forms/Options/Settings.cs
@@ -30,12 +30,8 @@ namespace Nikse.SubtitleEdit.Forms.Options
         private const int WordListsSection = 6;
         private const int ToolbarSection = 7;
         private const int FontSection = 8;
-        private const int SsaStyleSection = 9;
-        private const int NetworkSection = 10;
+        private const int NetworkSection = 9;
 
-        private string _ssaFontName;
-        private double _ssaFontSize;
-        private int _ssaFontColor;
         private string _listBoxSearchString = string.Empty;
         private DateTime _listBoxSearchStringLastUsed = DateTime.UtcNow;
         private List<string> _wordListNames = new List<string>();
@@ -47,8 +43,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
         private bool _oldListViewShowWpm;
         private readonly Dictionary<ShortcutHelper, string> _newShortcuts = new Dictionary<ShortcutHelper, string>();
         private List<RulesProfile> _rulesProfiles;
-        private bool _loading = true;
-        private bool _backgroundImageDark;
 
         private class ComboBoxLanguage
         {
@@ -120,11 +114,9 @@ namespace Nikse.SubtitleEdit.Forms.Options
 
         public void Init()
         {
-            _loading = true;
             labelStatus.Text = string.Empty;
             _rulesProfiles = new List<RulesProfile>(Configuration.Settings.General.Profiles);
             var gs = Configuration.Settings.General;
-            _backgroundImageDark = Configuration.Settings.General.UseDarkTheme;
 
             listBoxSection.SelectedIndex = GeneralSection;
 
@@ -276,19 +268,15 @@ namespace Nikse.SubtitleEdit.Forms.Options
             textBoxCustomSearchUrl4.Text = Configuration.Settings.VideoControls.CustomSearchUrl4;
             textBoxCustomSearchUrl5.Text = Configuration.Settings.VideoControls.CustomSearchUrl5;
 
-            comboBoxFontName.BeginUpdate();
             comboBoxSubtitleFont.BeginUpdate();
             comboBoxVideoPlayerPreviewFontName.BeginUpdate();
-            comboBoxFontName.Items.Clear();
             comboBoxSubtitleFont.Items.Clear();
             comboBoxVideoPlayerPreviewFontName.Items.Clear();
-            var comboBoxFontNameList = new List<string>();
             var comboBoxSubtitleFontList = new List<string>();
             var comboBoxSubtitleFontIndex = 0;
             var comboBoxVideoPlayerPreviewFontIndex = 0;
             foreach (var x in FontFamily.Families.OrderBy(p => p.Name))
             {
-                comboBoxFontNameList.Add(x.Name);
                 if (x.IsStyleAvailable(FontStyle.Regular) && x.IsStyleAvailable(FontStyle.Bold))
                 {
                     comboBoxSubtitleFontList.Add(x.Name);
@@ -303,41 +291,16 @@ namespace Nikse.SubtitleEdit.Forms.Options
                     }
                 }
             }
-            comboBoxFontName.Items.AddRange(comboBoxFontNameList.ToArray<object>());
             comboBoxSubtitleFont.Items.AddRange(comboBoxSubtitleFontList.ToArray<object>());
             comboBoxVideoPlayerPreviewFontName.Items.AddRange(comboBoxSubtitleFontList.ToArray<object>());
             comboBoxSubtitleFont.SelectedIndex = comboBoxSubtitleFontIndex;
             comboBoxVideoPlayerPreviewFontName.SelectedIndex = comboBoxVideoPlayerPreviewFontIndex;
-            comboBoxFontName.EndUpdate();
             comboBoxSubtitleFont.EndUpdate();
             comboBoxVideoPlayerPreviewFontName.EndUpdate();
 
             var wordListSettings = Configuration.Settings.WordLists;
             checkBoxNamesOnline.Checked = wordListSettings.UseOnlineNames;
             textBoxNamesOnline.Text = wordListSettings.NamesUrl;
-
-            var ssa = Configuration.Settings.SubtitleSettings;
-            _ssaFontName = ssa.SsaFontName;
-            _ssaFontSize = ssa.SsaFontSize;
-            _ssaFontColor = ssa.SsaFontColorArgb;
-            if (ssa.SsaOutline >= numericUpDownSsaOutline.Minimum && ssa.SsaOutline <= numericUpDownSsaOutline.Maximum)
-            {
-                numericUpDownSsaOutline.Value = ssa.SsaOutline;
-            }
-
-            if (ssa.SsaShadow >= numericUpDownSsaShadow.Minimum && ssa.SsaShadow <= numericUpDownSsaShadow.Maximum)
-            {
-                numericUpDownSsaShadow.Value = ssa.SsaShadow;
-            }
-
-            numericUpDownSsaMarginLeft.Value = ssa.SsaMarginLeft;
-            numericUpDownSsaMarginRight.Value = ssa.SsaMarginRight;
-            numericUpDownSsaMarginVertical.Value = ssa.SsaMarginTopBottom;
-            checkBoxSsaFontBold.Checked = ssa.SsaFontBold;
-            checkBoxSsaOpaqueBox.Checked = ssa.SsaOpaqueBox;
-            numericUpDownFontSize.Value = (decimal)ssa.SsaFontSize;
-            comboBoxFontName.Text = ssa.SsaFontName;
-            panelPrimaryColor.BackColor = Color.FromArgb(_ssaFontColor);
 
             var proxy = Configuration.Settings.Proxy;
             textBoxProxyAddress.Text = proxy.ProxyAddress;
@@ -372,7 +335,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             listBoxSection.Items[WordListsSection] = language.WordLists;
             listBoxSection.Items[ToolbarSection] = language.Toolbar;
             listBoxSection.Items[FontSection] = LanguageSettings.Current.DCinemaProperties.Font;
-            listBoxSection.Items[SsaStyleSection] = language.SsaStyle;
             listBoxSection.Items[NetworkSection] = language.Network;
 
             Text = language.Title;
@@ -381,7 +343,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             panelWaveform.Text = language.WaveformAndSpectrogram;
             panelWordLists.Text = language.WordLists;
             panelTools.Text = language.Tools;
-            panelSsaStyle.Text = language.SsaStyle;
             panelNetwork.Text = language.Network;
             panelToolBar.Text = language.Toolbar;
             panelFont.Text = LanguageSettings.Current.DCinemaProperties.Font;
@@ -659,39 +620,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             }
 
             labelFFmpegPath.Text = language.WaveformFFmpegPath;
-
-            groupBoxSsaStyle.Text = language.SubStationAlphaStyle;
-
-            var ssaStyles = LanguageSettings.Current.SubStationAlphaStyles;
-            labelSsaFontSize.Text = ssaStyles.FontSize;
-            labelFontName.Text = ssaStyles.FontName;
-            buttonSsaColor.Text = LanguageSettings.Current.Settings.ChooseColor;
-            groupBoxSsaFont.Text = ssaStyles.Font;
-            groupBoxSsaBorder.Text = ssaStyles.Border;
-            groupBoxMargins.Text = ssaStyles.Margins;
-            labelMarginLeft.Text = ssaStyles.MarginLeft;
-            labelMarginRight.Text = ssaStyles.MarginRight;
-            labelMarginVertical.Text = ssaStyles.MarginVertical;
-            labelSsaOutline.Text = language.SsaOutline;
-            labelSsaShadow.Text = language.SsaShadow;
-            checkBoxSsaOpaqueBox.Text = language.SsaOpaqueBox;
-            checkBoxSsaFontBold.Text = LanguageSettings.Current.General.Bold;
-
-            groupBoxPreview.Text = LanguageSettings.Current.General.Preview;
-
-            numericUpDownSsaOutline.Left = labelSsaOutline.Left + labelSsaOutline.Width + 4;
-            numericUpDownSsaShadow.Left = labelSsaShadow.Left + labelSsaShadow.Width + 4;
-            if (Math.Abs(numericUpDownSsaOutline.Left - numericUpDownSsaShadow.Left) < 9)
-            {
-                if (numericUpDownSsaOutline.Left > numericUpDownSsaShadow.Left)
-                {
-                    numericUpDownSsaShadow.Left = numericUpDownSsaOutline.Left;
-                }
-                else
-                {
-                    numericUpDownSsaOutline.Left = numericUpDownSsaShadow.Left;
-                }
-            }
 
             groupBoxWordLists.Text = language.WordLists;
             labelWordListLanguage.Text = language.Language;
@@ -1046,9 +974,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             _oldListViewShowWpm = Configuration.Settings.Tools.ListViewShowColumnWordsPerMin;
 
             labelPlatform.Text = (IntPtr.Size * 8) + "-bit";
-
-            _loading = false;
-            UpdateSsaExample();
         }
 
         private void SetDialogStyle(DialogType dialogStyle)
@@ -1923,18 +1848,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
                 }
             }
 
-            var ssa = Configuration.Settings.SubtitleSettings;
-            ssa.SsaFontName = _ssaFontName;
-            ssa.SsaFontSize = _ssaFontSize;
-            ssa.SsaFontColorArgb = _ssaFontColor;
-            ssa.SsaFontBold = checkBoxSsaFontBold.Checked;
-            ssa.SsaOutline = (int)numericUpDownSsaOutline.Value;
-            ssa.SsaShadow = (int)numericUpDownSsaShadow.Value;
-            ssa.SsaOpaqueBox = checkBoxSsaOpaqueBox.Checked;
-            ssa.SsaMarginLeft = (int)numericUpDownSsaMarginLeft.Value;
-            ssa.SsaMarginRight = (int)numericUpDownSsaMarginRight.Value;
-            ssa.SsaMarginTopBottom = (int)numericUpDownSsaMarginVertical.Value;
-
             var proxy = Configuration.Settings.Proxy;
             proxy.ProxyAddress = textBoxProxyAddress.Text;
             proxy.UserName = textBoxProxyUserName.Text;
@@ -2010,74 +1923,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
                 UiUtil.ShowHelp("#settings");
                 e.SuppressKeyPress = true;
             }
-        }
-
-        private void UpdateSsaExample()
-        {
-            GeneratePreviewReal();
-        }
-
-        private void GeneratePreviewReal()
-        {
-            if (_loading)
-            {
-                return;
-            }
-
-            pictureBoxPreview.Image?.Dispose();
-            var backgroundImage = TextDesigner.MakeBackgroundImage(pictureBoxPreview.Width, pictureBoxPreview.Height, 9, _backgroundImageDark);
-            var outlineWidth = (float)numericUpDownSsaOutline.Value;
-            var shadowWidth = (float)numericUpDownSsaShadow.Value;
-            var outlineColor = Color.Black;
-
-            Font font;
-            try
-            {
-                font = new Font(comboBoxFontName.Text, (float)numericUpDownFontSize.Value * 1.1f, checkBoxSsaFontBold.Checked ? FontStyle.Bold : FontStyle.Regular);
-            }
-            catch
-            {
-                font = new Font(Font, FontStyle.Regular);
-            }
-
-            var measureBmp = TextDesigner.MakeTextBitmapAssa(
-                Configuration.Settings.General.PreviewAssaText,
-                0,
-                0,
-                font,
-                pictureBoxPreview.Width,
-                pictureBoxPreview.Height,
-                outlineWidth,
-                shadowWidth,
-                null,
-                panelPrimaryColor.BackColor,
-                outlineColor,
-                Color.FromArgb(100, Color.Black),
-                checkBoxSsaOpaqueBox.Checked);
-            var nBmp = new NikseBitmap(measureBmp);
-            var measuredWidth = nBmp.GetNonTransparentWidth();
-            var measuredHeight = nBmp.GetNonTransparentHeight();
-
-            float left = (pictureBoxPreview.Width - measuredWidth) / 2.0f;
-            float top = pictureBoxPreview.Height - measuredHeight - (int)numericUpDownSsaMarginVertical.Value;
-            var designedText = TextDesigner.MakeTextBitmapAssa(
-                Configuration.Settings.General.PreviewAssaText,
-                (int)Math.Round(left),
-                (int)Math.Round(top),
-                font,
-                pictureBoxPreview.Width,
-                pictureBoxPreview.Height,
-                outlineWidth,
-                shadowWidth,
-                backgroundImage,
-                panelPrimaryColor.BackColor,
-                Color.Black,
-                Color.FromArgb(200, Color.Black),
-                checkBoxSsaOpaqueBox.Checked);
-
-            pictureBoxPreview.Image?.Dispose();
-            pictureBoxPreview.Image = designedText;
-            font.Dispose();
         }
 
         private void ComboBoxWordListLanguageSelectedIndexChanged(object sender, EventArgs e)
@@ -2580,7 +2425,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             panelWordLists.Visible = false;
             panelToolBar.Visible = false;
             panelFont.Visible = false;
-            panelSsaStyle.Visible = false;
             panelNetwork.Visible = false;
 
             var section = panelGeneral;
@@ -2609,9 +2453,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
                     break;
                 case FontSection:
                     section = panelFont;
-                    break;
-                case SsaStyleSection:
-                    section = panelSsaStyle;
                     break;
                 case NetworkSection:
                     section = panelNetwork;
@@ -3062,23 +2903,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             }
         }
 
-        private void numericUpDownSsaOutline_ValueChanged(object sender, EventArgs e)
-        {
-            UpdateSsaExample();
-        }
-
-        private void numericUpDownSsaShadow_ValueChanged(object sender, EventArgs e)
-        {
-            UpdateSsaExample();
-        }
-
-        private void checkBoxSsaOpaqueBox_CheckedChanged(object sender, EventArgs e)
-        {
-            numericUpDownSsaOutline.Enabled = !checkBoxSsaOpaqueBox.Checked;
-            numericUpDownSsaShadow.Enabled = !checkBoxSsaOpaqueBox.Checked;
-            UpdateSsaExample();
-        }
-
         private void buttonBrowseToFFmpeg_Click(object sender, EventArgs e)
         {
             openFileDialogFFmpeg.FileName = string.Empty;
@@ -3174,44 +2998,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
             {
                 textBoxNetworkSessionNewMessageSound.Text = openFileDialogFFmpeg.FileName;
             }
-        }
-
-        private void panelPrimaryColor_MouseClick(object sender, MouseEventArgs e)
-        {
-            colorDialogSSAStyle.Color = Color.FromArgb(_ssaFontColor);
-            if (colorDialogSSAStyle.ShowDialog() == DialogResult.OK)
-            {
-                _ssaFontColor = colorDialogSSAStyle.Color.ToArgb();
-                panelPrimaryColor.BackColor = colorDialogSSAStyle.Color;
-                UpdateSsaExample();
-            }
-        }
-
-        private void numericUpDownSsaMarginVertical_ValueChanged(object sender, EventArgs e)
-        {
-            UpdateSsaExample();
-        }
-
-        private void comboBoxFontName_TextChanged(object sender, EventArgs e)
-        {
-            _ssaFontName = comboBoxFontName.Text;
-            UpdateSsaExample();
-        }
-
-        private void numericUpDownFontSize_ValueChanged(object sender, EventArgs e)
-        {
-            _ssaFontSize = (int)numericUpDownFontSize.Value;
-            UpdateSsaExample();
-        }
-
-        private void buttonSsaColor_Click(object sender, EventArgs e)
-        {
-            panelPrimaryColor_MouseClick(sender, null);
-        }
-
-        private void checkBoxSsaFontBold_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateSsaExample();
         }
 
         private void buttonMpvSettings_Click(object sender, EventArgs e)
@@ -3595,12 +3381,6 @@ namespace Nikse.SubtitleEdit.Forms.Options
                                 exception.StackTrace);
                 SeLogger.Error(exception, "Failed to export shortcuts");
             }
-        }
-
-        private void pictureBoxPreview_Click(object sender, EventArgs e)
-        {
-            _backgroundImageDark = !_backgroundImageDark;
-            GeneratePreviewReal();
         }
 
         private void buttonTextBoxHtmlColor_Click(object sender, EventArgs e)

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace Nikse.SubtitleEdit.Forms.Styles
+﻿using System.Windows.Forms;
+
+namespace Nikse.SubtitleEdit.Forms.Styles
 {
     sealed partial class SubStationAlphaStyles
     {
@@ -129,6 +131,11 @@
             this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.labelCategoryDefaultNote = new System.Windows.Forms.Label();
+            this.buttonStorageCategoryDelete = new System.Windows.Forms.Button();
+            this.buttonStorageCategoryNew = new System.Windows.Forms.Button();
+            this.comboboxStorageCategories = new System.Windows.Forms.ComboBox();
+            this.labelStorageCategory = new System.Windows.Forms.Label();
             this.contextMenuStripStorage = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripMenuItemStorageRemove = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemStorageRemoveAll = new System.Windows.Forms.ToolStripMenuItem();
@@ -173,8 +180,8 @@
             // 
             // listViewStyles
             // 
-            this.listViewStyles.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.listViewStyles.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.listViewStyles.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeaderName,
@@ -484,8 +491,8 @@
             // 
             // groupBoxProperties
             // 
-            this.groupBoxProperties.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxProperties.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxProperties.Controls.Add(this.groupBoxBorder);
             this.groupBoxProperties.Controls.Add(this.textBoxStyleName);
@@ -504,7 +511,7 @@
             // 
             // groupBoxBorder
             // 
-            this.groupBoxBorder.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxBorder.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxBorder.Controls.Add(this.radioButtonOpaqueBox);
             this.groupBoxBorder.Controls.Add(this.radioButtonOutline);
@@ -677,7 +684,7 @@
             // 
             // groupBoxColors
             // 
-            this.groupBoxColors.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxColors.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxColors.Controls.Add(this.panelBackColor);
             this.groupBoxColors.Controls.Add(this.buttonBackColor);
@@ -882,8 +889,8 @@
             // 
             // groupBoxPreview
             // 
-            this.groupBoxPreview.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxPreview.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxPreview.Controls.Add(this.pictureBoxPreview);
             this.groupBoxPreview.Location = new System.Drawing.Point(7, 310);
@@ -920,7 +927,7 @@
             // 
             // groupBoxFont
             // 
-            this.groupBoxFont.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxFont.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxFont.Controls.Add(this.checkBoxFontUnderline);
             this.groupBoxFont.Controls.Add(this.numericUpDownFontSize);
@@ -1042,6 +1049,11 @@
             this.groupBoxStorage.Controls.Add(this.buttonStorageAdd);
             this.groupBoxStorage.Controls.Add(this.buttonStorageRemove);
             this.groupBoxStorage.Controls.Add(this.listViewStorage);
+            this.groupBoxStorage.Controls.Add(this.labelCategoryDefaultNote);
+            this.groupBoxStorage.Controls.Add(this.buttonStorageCategoryDelete);
+            this.groupBoxStorage.Controls.Add(this.buttonStorageCategoryNew);
+            this.groupBoxStorage.Controls.Add(this.comboboxStorageCategories);
+            this.groupBoxStorage.Controls.Add(this.labelStorageCategory);
             this.groupBoxStorage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBoxStorage.Location = new System.Drawing.Point(0, 0);
             this.groupBoxStorage.Name = "groupBoxStorage";
@@ -1057,7 +1069,7 @@
             this.buttonAddToFile.Location = new System.Drawing.Point(280, 222);
             this.buttonAddToFile.Name = "buttonAddToFile";
             this.buttonAddToFile.Size = new System.Drawing.Size(163, 52);
-            this.buttonAddToFile.TabIndex = 135;
+            this.buttonAddToFile.TabIndex = 12;
             this.buttonAddToFile.Text = "Add to file";
             this.buttonAddToFile.UseVisualStyleBackColor = true;
             this.buttonAddToFile.Click += new System.EventHandler(this.buttonAddToFile_Click);
@@ -1069,7 +1081,7 @@
             this.buttonStorageExport.Location = new System.Drawing.Point(6, 251);
             this.buttonStorageExport.Name = "buttonStorageExport";
             this.buttonStorageExport.Size = new System.Drawing.Size(82, 23);
-            this.buttonStorageExport.TabIndex = 140;
+            this.buttonStorageExport.TabIndex = 7;
             this.buttonStorageExport.Text = "Export...";
             this.buttonStorageExport.UseVisualStyleBackColor = true;
             this.buttonStorageExport.Click += new System.EventHandler(this.buttonStorageExport_Click);
@@ -1081,7 +1093,7 @@
             this.buttonStorageImport.Location = new System.Drawing.Point(6, 222);
             this.buttonStorageImport.Name = "buttonStorageImport";
             this.buttonStorageImport.Size = new System.Drawing.Size(82, 23);
-            this.buttonStorageImport.TabIndex = 120;
+            this.buttonStorageImport.TabIndex = 6;
             this.buttonStorageImport.Text = "Import...";
             this.buttonStorageImport.UseVisualStyleBackColor = true;
             this.buttonStorageImport.Click += new System.EventHandler(this.buttonStorageImport_Click);
@@ -1093,7 +1105,7 @@
             this.buttonStorageCopy.Location = new System.Drawing.Point(94, 251);
             this.buttonStorageCopy.Name = "buttonStorageCopy";
             this.buttonStorageCopy.Size = new System.Drawing.Size(82, 23);
-            this.buttonStorageCopy.TabIndex = 150;
+            this.buttonStorageCopy.TabIndex = 9;
             this.buttonStorageCopy.Text = "Copy";
             this.buttonStorageCopy.UseVisualStyleBackColor = true;
             this.buttonStorageCopy.Click += new System.EventHandler(this.buttonStorageCopy_Click);
@@ -1105,7 +1117,7 @@
             this.buttonStorageRemoveAll.Location = new System.Drawing.Point(182, 251);
             this.buttonStorageRemoveAll.Name = "buttonStorageRemoveAll";
             this.buttonStorageRemoveAll.Size = new System.Drawing.Size(92, 23);
-            this.buttonStorageRemoveAll.TabIndex = 160;
+            this.buttonStorageRemoveAll.TabIndex = 11;
             this.buttonStorageRemoveAll.Text = "Remove all";
             this.buttonStorageRemoveAll.UseVisualStyleBackColor = true;
             this.buttonStorageRemoveAll.Click += new System.EventHandler(this.buttonStorageRemoveAll_Click);
@@ -1117,7 +1129,7 @@
             this.buttonStorageAdd.Location = new System.Drawing.Point(94, 222);
             this.buttonStorageAdd.Name = "buttonStorageAdd";
             this.buttonStorageAdd.Size = new System.Drawing.Size(82, 23);
-            this.buttonStorageAdd.TabIndex = 125;
+            this.buttonStorageAdd.TabIndex = 8;
             this.buttonStorageAdd.Text = "New";
             this.buttonStorageAdd.UseVisualStyleBackColor = true;
             this.buttonStorageAdd.Click += new System.EventHandler(this.buttonStorageAdd_Click);
@@ -1129,15 +1141,15 @@
             this.buttonStorageRemove.Location = new System.Drawing.Point(182, 222);
             this.buttonStorageRemove.Name = "buttonStorageRemove";
             this.buttonStorageRemove.Size = new System.Drawing.Size(92, 23);
-            this.buttonStorageRemove.TabIndex = 130;
+            this.buttonStorageRemove.TabIndex = 10;
             this.buttonStorageRemove.Text = "Remove";
             this.buttonStorageRemove.UseVisualStyleBackColor = true;
             this.buttonStorageRemove.Click += new System.EventHandler(this.buttonStorageRemove_Click);
             // 
             // listViewStorage
             // 
-            this.listViewStorage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.listViewStorage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.listViewStorage.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1,
@@ -1149,11 +1161,11 @@
             this.listViewStorage.ContextMenuStrip = this.contextMenuStripStorage;
             this.listViewStorage.FullRowSelect = true;
             this.listViewStorage.HideSelection = false;
-            this.listViewStorage.Location = new System.Drawing.Point(6, 19);
+            this.listViewStorage.Location = new System.Drawing.Point(6, 68);
             this.listViewStorage.MultiSelect = false;
             this.listViewStorage.Name = "listViewStorage";
-            this.listViewStorage.Size = new System.Drawing.Size(545, 197);
-            this.listViewStorage.TabIndex = 110;
+            this.listViewStorage.Size = new System.Drawing.Size(545, 148);
+            this.listViewStorage.TabIndex = 5;
             this.listViewStorage.UseCompatibleStateImageBehavior = false;
             this.listViewStorage.View = System.Windows.Forms.View.Details;
             this.listViewStorage.SelectedIndexChanged += new System.EventHandler(this.listViewStorage_SelectedIndexChanged);
@@ -1189,6 +1201,58 @@
             // 
             this.columnHeader6.Text = "Outline";
             this.columnHeader6.Width = 55;
+            // 
+            // labelCategoryDefaultNote
+            // 
+            this.labelCategoryDefaultNote.AutoSize = true;
+            this.labelCategoryDefaultNote.Location = new System.Drawing.Point(10, 48);
+            this.labelCategoryDefaultNote.Name = "labelCategoryDefaultNote";
+            this.labelCategoryDefaultNote.Size = new System.Drawing.Size(59, 13);
+            this.labelCategoryDefaultNote.TabIndex = 4;
+            this.labelCategoryDefaultNote.Text = "Note: \"Default\" styles will be applied to new ASSA files";
+            // 
+            // buttonStorageCategoryDelete
+            // 
+            this.buttonStorageCategoryDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonStorageCategoryDelete.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.buttonStorageCategoryDelete.Location = new System.Drawing.Point(365, 19);
+            this.buttonStorageCategoryDelete.Name = "buttonStorageRemove";
+            this.buttonStorageCategoryDelete.Size = new System.Drawing.Size(92, 23);
+            this.buttonStorageCategoryDelete.TabIndex = 3;
+            this.buttonStorageCategoryDelete.Text = "Remove";
+            this.buttonStorageCategoryDelete.UseVisualStyleBackColor = true;
+            this.buttonStorageCategoryDelete.Click += new System.EventHandler(this.buttonStorageCategoryDelete_Click);
+            // 
+            // buttonStorageCategoryNew
+            // 
+            this.buttonStorageCategoryNew.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonStorageCategoryNew.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.buttonStorageCategoryNew.Location = new System.Drawing.Point(267, 19);
+            this.buttonStorageCategoryNew.Name = "buttonStorageCategoryNew";
+            this.buttonStorageCategoryNew.Size = new System.Drawing.Size(92, 23);
+            this.buttonStorageCategoryNew.TabIndex = 2;
+            this.buttonStorageCategoryNew.Text = "New";
+            this.buttonStorageCategoryNew.UseVisualStyleBackColor = true;
+            this.buttonStorageCategoryNew.Click += new System.EventHandler(this.buttonStorageCategoryNew_Click);
+            // 
+            // comboboxStorageCategories
+            // 
+            this.comboboxStorageCategories.DropDownStyle = ComboBoxStyle.DropDownList;
+            this.comboboxStorageCategories.FormattingEnabled = true;
+            this.comboboxStorageCategories.Location = new System.Drawing.Point(73, 19);
+            this.comboboxStorageCategories.Name = "comboboxStorageCategories";
+            this.comboboxStorageCategories.Size = new System.Drawing.Size(188, 21);
+            this.comboboxStorageCategories.TabIndex = 1;
+            this.comboboxStorageCategories.SelectedIndexChanged += new System.EventHandler(this.comboboxStorageCategory_SelectedIndexChanged);
+            // 
+            // labelStorageCategory
+            // 
+            this.labelStorageCategory.AutoSize = true;
+            this.labelStorageCategory.Location = new System.Drawing.Point(10, 21);
+            this.labelStorageCategory.Name = "labelStorageCategory";
+            this.labelStorageCategory.Size = new System.Drawing.Size(59, 13);
+            this.labelStorageCategory.TabIndex = 0;
+            this.labelStorageCategory.Text = "Category";
             // 
             // contextMenuStripStorage
             // 
@@ -1321,7 +1385,7 @@
             // 
             // splitContainer1
             // 
-            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
             | System.Windows.Forms.AnchorStyles.Left)));
             this.splitContainer1.Location = new System.Drawing.Point(12, 4);
             this.splitContainer1.Name = "splitContainer1";
@@ -1464,6 +1528,11 @@
         private System.Windows.Forms.Label labelStatus;
         private System.Windows.Forms.Timer timerClearStatus;
         private System.Windows.Forms.GroupBox groupBoxStorage;
+        private System.Windows.Forms.Label labelStorageCategory;
+        private System.Windows.Forms.ComboBox comboboxStorageCategories;
+        private System.Windows.Forms.Button buttonStorageCategoryNew;
+        private System.Windows.Forms.Button buttonStorageCategoryDelete;
+        private System.Windows.Forms.Label labelCategoryDefaultNote;
         private System.Windows.Forms.ListView listViewStorage;
         private System.Windows.Forms.ColumnHeader columnHeader1;
         private System.Windows.Forms.ColumnHeader columnHeader2;

--- a/src/ui/Forms/Styles/SubStationAlphaStylesExport.Designer.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStylesExport.Designer.cs
@@ -43,8 +43,8 @@
             // 
             // listViewExportStyles
             // 
-            this.listViewExportStyles.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.listViewExportStyles.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.listViewExportStyles.CheckBoxes = true;
             this.listViewExportStyles.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {

--- a/src/ui/Forms/Styles/SubStationAlphaStylesExport.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStylesExport.cs
@@ -161,7 +161,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
                                     toLower = toLower.Replace(" :", ":");
                                 }
 
-                                if (toLower.StartsWith("style:" + styleName.ToLowerInvariant().Trim(), StringComparison.Ordinal))
+                                if (toLower.StartsWith("style:" + styleName.ToLowerInvariant().Trim() + ",", StringComparison.Ordinal))
                                 {
                                     sb.AppendLine(line);
                                 }
@@ -176,15 +176,20 @@ namespace Nikse.SubtitleEdit.Forms.Styles
                     if (content.TrimEnd().EndsWith("[Events]", StringComparison.Ordinal))
                     {
                         content = content.Trim() + Environment.NewLine +
-                            "Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text" + Environment.NewLine +
-                            "Dialogue: 0,0:00:31.91,0:00:33.91,Default,,0,0,0,,My Styles :)";
+                                  "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text" + Environment.NewLine +
+                                  "Dialogue: 0,0:00:31.91,0:00:33.91,Default,,0,0,0,,My Styles :)";
+                    }
+                    else if (content.TrimEnd().EndsWith("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text", StringComparison.Ordinal))
+                    {
+                        content = content.Trim() + Environment.NewLine +
+                                  "Dialogue: 0,0:00:31.91,0:00:33.91,Default,,0,0,0,,My Styles :)";
                     }
                     else if (!content.Contains("[Events]", StringComparison.OrdinalIgnoreCase))
                     {
                         content = content.Trim() + Environment.NewLine +
                             Environment.NewLine +
                             "[Events]" + Environment.NewLine +
-                            "Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text" + Environment.NewLine +
+                            "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text" + Environment.NewLine +
                             "Dialogue: 0,0:00:31.91,0:00:33.91,Default,,0,0,0,,My Styles :)";
                     }
                     File.WriteAllText(saveFileDialogStyle.FileName, content, Encoding.UTF8);

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -2923,7 +2923,11 @@ can edit in same subtitle file (collaboration)",
                 AddToFile = "Add to file",
                 AddToStorage = "Add to storage",
                 StyleStorage = "Style storage",
-                OverwriteX = "Overwrite {0}?"
+                OverwriteX = "Overwrite {0}?",
+                Category = "Category",
+                NewCategory = "New category",
+                CategoryName = "Category name",
+                CategoryNote = "Note: \"Default\" styles will be applied to new ASSA files"
             };
 
             PointSync = new LanguageStructure.PointSync

--- a/src/ui/Logic/LanguageDeserializer.cs
+++ b/src/ui/Logic/LanguageDeserializer.cs
@@ -7084,6 +7084,18 @@ namespace Nikse.SubtitleEdit.Logic
                 case "SubStationAlphaStyles/OverwriteX":
                     language.SubStationAlphaStyles.OverwriteX = reader.Value;
                     break;
+                case "SubStationAlphaStyles/Category":
+                    language.SubStationAlphaStyles.Category = reader.Value;
+                    break;
+                case "SubStationAlphaStyles/NewCategory":
+                    language.SubStationAlphaStyles.NewCategory = reader.Value;
+                    break;
+                case "SubStationAlphaStyles/CategoryName":
+                    language.SubStationAlphaStyles.CategoryName = reader.Value;
+                    break;
+                case "SubStationAlphaStyles/CategoryNote":
+                    language.SubStationAlphaStyles.CategoryNote = reader.Value;
+                    break;
                 case "PointSync/Title":
                     language.PointSync.Title = reader.Value;
                     break;

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -2781,6 +2781,10 @@
             public string AddToStorage { get; set; }
             public string StyleStorage { get; set; }
             public string OverwriteX { get; set; }
+            public string Category { get; set; }
+            public string NewCategory { get; set; }
+            public string CategoryName { get; set; }
+            public string CategoryNote { get; set; }
         }
 
         public class PointSync


### PR DESCRIPTION
@niksedk There have to be together, adding categories and removing the style page makes the default Ass styles be taken from the storage's default category, which means the `SubtitleSettings` Ass options are no longer needed because they can't be set from any place.

Closes https://github.com/SubtitleEdit/subtitleedit/issues/4702, Closes https://github.com/SubtitleEdit/subtitleedit/issues/4483