### PR TITLE
Scale the video player's text box font size to match external video players

### DIFF
--- a/src/ui/Controls/VideoPlayerContainer.cs
+++ b/src/ui/Controls/VideoPlayerContainer.cs
@@ -52,7 +52,7 @@ namespace Nikse.SubtitleEdit.Controls
         private string _subtitleText = string.Empty;
         private VideoPlayer _videoPlayer;
 
-        public float FontSizeFactor { get; set; }
+        public float FontSizeFactor { get; set; } = 1 / 1.5F;
 
         public VideoPlayer VideoPlayer
         {
@@ -200,7 +200,6 @@ namespace Nikse.SubtitleEdit.Controls
         {
             _chapters = new List<MatroskaChapter>();
             SmpteMode = false;
-            FontSizeFactor = 1.0F;
             BorderStyle = BorderStyle.None;
             _resources = new System.ComponentModel.ComponentResourceManager(typeof(VideoPlayerContainer));
             _labelVolume.Text = Configuration.Settings.General.VideoPlayerDefaultVolume + "%";

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -23978,7 +23978,7 @@ namespace Nikse.SubtitleEdit.Forms
         public void ReDockVideoPlayer(Control control)
         {
             groupBoxVideo.Controls.Add(control);
-            mediaPlayer.FontSizeFactor = 1.0F;
+            mediaPlayer.FontSizeFactor = 1 / 1.5F;
             mediaPlayer.SetSubtitleFont();
             mediaPlayer.SubtitleText = string.Empty;
         }

--- a/src/ui/Forms/VideoPlayerUndocked.cs
+++ b/src/ui/Forms/VideoPlayerUndocked.cs
@@ -138,7 +138,7 @@ namespace Nikse.SubtitleEdit.Forms
             IsFullscreen = true;
             FormBorderStyle = FormBorderStyle.None;
             WindowState = FormWindowState.Maximized;
-            _videoPlayerContainer.FontSizeFactor = 1.5F;
+            _videoPlayerContainer.FontSizeFactor = 1.0F;
             _videoPlayerContainer.SetSubtitleFont();
             _videoPlayerContainer.SubtitleText = string.Empty;
             _videoPlayerContainer.ShowFullScreenControls();
@@ -152,7 +152,7 @@ namespace Nikse.SubtitleEdit.Forms
             IsFullscreen = false;
             FormBorderStyle = FormBorderStyle.SizableToolWindow;
             WindowState = FormWindowState.Normal;
-            _videoPlayerContainer.FontSizeFactor = 1.0F;
+            _videoPlayerContainer.FontSizeFactor = 1 / 1.5F;
             _videoPlayerContainer.SetSubtitleFont();
             _videoPlayerContainer.SubtitleText = string.Empty;
             _videoPlayerContainer.ShowFullscreenButton = Configuration.Settings.General.VideoPlayerShowFullscreenButton;


### PR DESCRIPTION
@niksedk Please, give this some thought.

Moving from MPV to another video player makes it necessary to change the font size in SE.
In addition to that, the font size in the preview textbox is not in line with other video players, like 24 is too big and goes off the screen, it doesn't make sense.
Scaling the textbox font by 1/1.5 makes it just like other video players and the number makes sense.

Some examples:
Here is the font size in MPV vs other video players without scaling:
![image](https://user-images.githubusercontent.com/20923700/106366709-8a0e8500-6346-11eb-8d31-17631f91218b.png)

![image](https://user-images.githubusercontent.com/20923700/106366715-90046600-6346-11eb-9ae8-2f0bcad61cbe.png)

Here it is with scaling:
![image](https://user-images.githubusercontent.com/20923700/106366748-c8a43f80-6346-11eb-9361-2877f26c670e.png)

![image](https://user-images.githubusercontent.com/20923700/106366753-cfcb4d80-6346-11eb-9a81-e62497722eba.png)

Notice how it is just the same with scaling.
You recently added a shortcut to switch "MPV handles preview text", imagine having to change the font size each time you use it.
And you can't scale MPV's font size, because when you use Ass format, the font size will not match.