### PR TITLE
Add a separate timer for live spell check

### DIFF
--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -789,6 +789,27 @@ namespace Nikse.SubtitleEdit.Core
                         hash = hash * 23 + p.Actor.GetHashCode();
                     }
                 }
+
+                return hash;
+            }
+        }
+
+        /// <summary>
+        /// Fast hash code for subtitle text.
+        /// </summary>
+        /// <returns>Hash value that can be used for quick text compare</returns>
+        public int GetFastHashCodeTextOnly()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hash = 17;
+                var max = Paragraphs.Count;
+                for (int i = 0; i < max; i++)
+                {
+                    var p = Paragraphs[i];
+                    hash = hash * 23 + p.Text.GetHashCode();
+                }
+
                 return hash;
             }
         }


### PR DESCRIPTION
Related to https://github.com/SubtitleEdit/subtitleedit/issues/4754#issuecomment-774634035

@niksedk Do you the language check and the initialization should be separated?
They work well as is.
If we separate them, the initialization will have to be done in multiple places and all functions that include it will have to be `async`.