### PR TITLE
Fix some issues in Live Spell Check

### DIFF
--- a/src/ui/Controls/SETextBox.cs
+++ b/src/ui/Controls/SETextBox.cs
@@ -637,65 +637,20 @@ namespace Nikse.SubtitleEdit.Controls
             }
         }
 
-        public async Task CheckForLanguageChange(Subtitle subtitle)
-        {
-            if (_uiTextBox is null)
-            {
-                return;
-            }
+        public async Task CheckForLanguageChange(Subtitle subtitle) =>
+            await _uiTextBox?.CheckForLanguageChange(subtitle);
 
-            await _uiTextBox.CheckForLanguageChange(subtitle);
-        }
+        public async Task InitializeLiveSpellCheck(Subtitle subtitle, int lineNumber) =>
+            await _uiTextBox?.InitializeLiveSpellCheck(subtitle, lineNumber);
 
-        public async Task InitializeLiveSpellCheck(Subtitle subtitle, int lineNumber)
-        {
-            if (_uiTextBox is null)
-            {
-                return;
-            }
+        public void DisposeHunspellAndDictionaries() =>
+            _uiTextBox?.DisposeHunspellAndDictionaries();
 
-            await _uiTextBox.InitializeLiveSpellCheck(subtitle, lineNumber);
-        }
+        public void AddSuggestionsToMenu() =>
+            _uiTextBox?.AddSuggestionsToMenu();
 
-        public void DisposeHunspellAndDictionaries()
-        {
-            if (_uiTextBox is null)
-            {
-                return;
-            }
-
-            _uiTextBox.DisposeHunspellAndDictionaries();
-        }
-
-        public void DoLiveSpellCheck()
-        {
-            if (_uiTextBox is null)
-            {
-                return;
-            }
-
-            _uiTextBox.DoLiveSpellCheck();
-        }
-
-        public void AddSuggestionsToMenu()
-        {
-            if (_uiTextBox is null)
-            {
-                return;
-            }
-
-            _uiTextBox.AddSuggestionsToMenu();
-        }
-
-        public void DoAction(SpellCheckAction action)
-        {
-            if (_uiTextBox is null)
-            {
-                return;
-            }
-
-            _uiTextBox.DoAction(action);
-        }
+        public void DoAction(SpellCheckAction action) =>
+            _uiTextBox?.DoAction(action);
 
         #endregion
     }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -7333,15 +7333,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void StartOrStopLiveSpellCheckTimer()
         {
-            if (_liveSpellCheckTimer is null && IsLiveSpellCheckEnabled)
+            _liveSpellCheckTimer?.Dispose();
+            if (IsLiveSpellCheckEnabled)
             {
                 _liveSpellCheckTimer = new Timer { Interval = 2000 };
                 _liveSpellCheckTimer.Tick += LiveSpellCheckTimer_Tick;
                 _liveSpellCheckTimer.Start();
-            }
-            else
-            {
-                _liveSpellCheckTimer?.Dispose();
             }
         }
 
@@ -25157,19 +25154,23 @@ namespace Nikse.SubtitleEdit.Forms
             var tb = GetFocusedTextBox();
             toolStripMenuItemSplitTextAtCursor.Visible = tb.Text.Length > 1;
 
-            if (IsLiveSpellCheckEnabled && textBoxListViewText.IsWrongWord && InListView)
+            if (IsLiveSpellCheckEnabled && InListView)
             {
-                var oldItems = new ToolStripItem[contextMenuStripTextBoxListView.Items.Count];
-                contextMenuStripTextBoxListView.Items.CopyTo(oldItems, 0);
-                contextMenuStripTextBoxListView.Items.Clear();
-                tb.AddSuggestionsToMenu();
-                contextMenuStripTextBoxListView.Items.AddRange(oldItems);
-                toolStripSeparatorSpellCheckSuggestions.Visible = true;
-                toolStripMenuItemSpellCheckSkipOnce.Visible = true;
-                toolStripMenuItemSpellCheckSkipAll.Visible = true;
-                toolStripMenuItemSpellCheckAddToDictionary.Visible = true;
-                toolStripMenuItemSpellCheckAddToNames.Visible = true;
-                toolStripSeparatorSpellCheck.Visible = true;
+                var sourceTextBox = ((ContextMenuStrip)sender).SourceControl.Parent;
+                if (sourceTextBox == textBoxListViewText && textBoxListViewText.IsWrongWord)
+                {
+                    var oldItems = new ToolStripItem[contextMenuStripTextBoxListView.Items.Count];
+                    contextMenuStripTextBoxListView.Items.CopyTo(oldItems, 0);
+                    contextMenuStripTextBoxListView.Items.Clear();
+                    tb.AddSuggestionsToMenu();
+                    contextMenuStripTextBoxListView.Items.AddRange(oldItems);
+                    toolStripSeparatorSpellCheckSuggestions.Visible = true;
+                    toolStripMenuItemSpellCheckSkipOnce.Visible = true;
+                    toolStripMenuItemSpellCheckSkipAll.Visible = true;
+                    toolStripMenuItemSpellCheckAddToDictionary.Visible = true;
+                    toolStripMenuItemSpellCheckAddToNames.Visible = true;
+                    toolStripSeparatorSpellCheck.Visible = true;
+                }
             }
 
             if (IsUnicode)


### PR DESCRIPTION
Live spell check was trying to run in the original text box each time, I think it shouldn't.

Live spell check timer was being disposed of each time the settings is closed even if the live spell check option didn't change.

Right-clicking on the original text box was showing suggestions for the wrong word even if the mouse cursor wasn't on it.

The bounds for showing suggestions on right-mouse-click were wrong.

If you open SE with live spell check disabled, then enable it, it didn't work until you restart SE. (Wasn't subscribing to events if Live Spell Check is disabled on launch.)