### PR TITLE
Allow more MPV options in "MpvExtraOption"

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1122,7 +1122,7 @@ $HorzAlign          =   Center
         public string VlcLocationRelative { get; set; }
         public string MpvVideoOutputWindows { get; set; }
         public string MpvVideoOutputLinux { get; set; }
-        public string MpvExtraOption { get; set; }
+        public string MpvExtraOptions { get; set; }
         public bool MpvLogging { get; set; }
         public bool MpvHandlesPreviewText { get; set; }
         public Color MpvPreviewTextPrimaryColor { get; set; }
@@ -3377,10 +3377,10 @@ $HorzAlign          =   Center
                 settings.General.MpvVideoOutputLinux = subNode.InnerText.Trim();
             }
 
-            subNode = node.SelectSingleNode("MpvExtraOption");
+            subNode = node.SelectSingleNode("MpvExtraOptions");
             if (subNode != null)
             {
-                settings.General.MpvExtraOption = subNode.InnerText.Trim();
+                settings.General.MpvExtraOptions = subNode.InnerText.Trim();
             }
 
             subNode = node.SelectSingleNode("MpvLogging");
@@ -8095,7 +8095,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("VlcLocationRelative", settings.General.VlcLocationRelative);
                 textWriter.WriteElementString("MpvVideoOutputWindows", settings.General.MpvVideoOutputWindows);
                 textWriter.WriteElementString("MpvVideoOutputLinux", settings.General.MpvVideoOutputLinux);
-                textWriter.WriteElementString("MpvExtraOption", settings.General.MpvExtraOption);
+                textWriter.WriteElementString("MpvExtraOptions", settings.General.MpvExtraOptions);
                 textWriter.WriteElementString("MpvLogging", settings.General.MpvLogging.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("MpvHandlesPreviewText", settings.General.MpvHandlesPreviewText.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("MpvPreviewTextPrimaryColor", ColorTranslator.ToHtml(settings.General.MpvPreviewTextPrimaryColor));

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic.cs
@@ -559,16 +559,23 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
                     _mpvSetOptionString(_mpvHandle, GetUtf8Bytes("ytdl"), GetUtf8Bytes("yes"));
                 }
 
-                if (!string.IsNullOrEmpty(Configuration.Settings.General.MpvExtraOption))
+                if (!string.IsNullOrEmpty(Configuration.Settings.General.MpvExtraOptions))
                 {
-                    var parts = Configuration.Settings.General.MpvExtraOption.Split('=');
-                    if (parts.Length == 2)
+                    var options = Configuration.Settings.General.MpvExtraOptions.Split(' ');
+                    if (options?.Length > 0)
                     {
-                        _mpvSetOptionString(_mpvHandle, GetUtf8Bytes(parts[0]), GetUtf8Bytes(parts[1]));
-                    }
-                    else
-                    {
-                        _mpvSetOptionString(_mpvHandle, GetUtf8Bytes(Configuration.Settings.General.MpvExtraOption), GetUtf8Bytes(""));
+                        foreach (var option in options)
+                        {
+                            var parts = option.TrimStart('-').Split('=');
+                            if (parts.Length == 2)
+                            {
+                                _mpvSetOptionString(_mpvHandle, GetUtf8Bytes(parts[0]), GetUtf8Bytes(parts[1]));
+                            }
+                            else
+                            {
+                                _mpvSetOptionString(_mpvHandle, GetUtf8Bytes(option), GetUtf8Bytes(""));
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
I was trying to add `sub-justify=left` as an option to MPV, but it didn't work.
Turns out you have to do `sub-ass-justify=yes` as well for it to work.

Right now that's not possible, as we are only allowed one option, so I thought it would be better if more options separated by a space are allowed.

Made it split at spaces and trim any `-` at the start of each option.
The way I see it, this can now be used as you would use it in CLI, like arguments.
For example, `--sub-ass-justify=yes --sub-justify=left`
Couldn't find any [options](https://github.com/mpv-player/mpv/blob/master/DOCS/man/options.rst) that contain a space in them, so I think this is safe.