### PR TITLE
Fixes related to ASSA Style Manager

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -2609,6 +2609,7 @@ Continue?</RestoreDefaultSettingsMsg>
     <CategoryName>Category name</CategoryName>
     <CategorySetDefault>Set as default</CategorySetDefault>
     <CategoryNote>Note: "Default" styles will be applied to new ASSA files</CategoryNote>
+    <CategoryDelete>Are you sure you want to delete this category?</CategoryDelete>
   </SubStationAlphaStyles>
   <PointSync>
     <Title>Point synchronization</Title>

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
@@ -1346,7 +1346,7 @@
             this.buttonStorageCategorySetDefault.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.buttonStorageCategorySetDefault.Location = new System.Drawing.Point(455, 19);
             this.buttonStorageCategorySetDefault.Name = "buttonStorageCategorySetDefault";
-            this.buttonStorageCategorySetDefault.Size = new System.Drawing.Size(94, 23);
+            this.buttonStorageCategorySetDefault.Size = new System.Drawing.Size(98, 23);
             this.buttonStorageCategorySetDefault.TabIndex = 4;
             this.buttonStorageCategorySetDefault.Text = "Set as default";
             this.buttonStorageCategorySetDefault.UseVisualStyleBackColor = true;

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.cs
@@ -1129,9 +1129,6 @@ namespace Nikse.SubtitleEdit.Forms.Styles
                         textBoxStyleName.BackColor = Configuration.Settings.Tools.ListViewSyntaxErrorColor;
                     }
                 }
-
-                _oldSsaName = textBoxStyleName.Text.Trim();
-                _editedName = _oldSsaName;
             }
 
             if (textBoxStyleName.Text.Contains(','))
@@ -1661,14 +1658,9 @@ namespace Nikse.SubtitleEdit.Forms.Styles
 
         private void listViewStorage_SelectedIndexChanged(object sender, EventArgs e)
         {
-            LogNameChanges();
-
             if (listViewStorage.SelectedItems.Count == 1)
             {
                 string styleName = listViewStorage.SelectedItems[0].Text;
-                _startName = styleName;
-                _editedName = null;
-                _oldSsaName = styleName;
                 SsaStyle style = _currentCategory.Styles.First(p => p.Name == styleName);
                 SetControlsFromStyle(style);
                 _doUpdate = true;

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.cs
@@ -2298,7 +2298,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
 
         private void contextMenuStripFile_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            var moreThanOne = listViewStorage.Items.Count > 1;
+            var moreThanOne = listViewStyles.Items.Count > 1;
             moveUpToolStripMenuItem.Visible = moreThanOne;
             moveBottomToolStripMenuItem.Visible = moreThanOne;
             moveTopToolStripMenuItem.Visible = moreThanOne;

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.cs
@@ -1977,10 +1977,14 @@ namespace Nikse.SubtitleEdit.Forms.Styles
 
         private void buttonStorageCategoryDelete_Click(object sender, EventArgs e)
         {
-            _storageCategories.Remove(_currentCategory);
-            comboboxStorageCategories.Items.Remove(_currentCategory.Name);
-            _currentCategory = _storageCategories.Single(x => x.IsDefault);
-            comboboxStorageCategories.SelectedItem = _currentCategory.Name;
+            var result = MessageBox.Show(LanguageSettings.Current.SubStationAlphaStyles.CategoryDelete, string.Empty, MessageBoxButtons.YesNoCancel);
+            if (result == DialogResult.Yes)
+            {
+                _storageCategories.Remove(_currentCategory);
+                comboboxStorageCategories.Items.Remove(_currentCategory.Name);
+                _currentCategory = _storageCategories.Single(x => x.IsDefault);
+                comboboxStorageCategories.SelectedItem = _currentCategory.Name;
+            }
         }
 
         private void buttonStorageCategorySetDefault_Click(object sender, EventArgs e)

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -2947,7 +2947,8 @@ can edit in same subtitle file (collaboration)",
                 NewCategory = "New category",
                 CategoryName = "Category name",
                 CategorySetDefault = "Set as default",
-                CategoryNote = "Note: \"Default\" styles will be applied to new ASSA files"
+                CategoryNote = "Note: \"Default\" styles will be applied to new ASSA files",
+                CategoryDelete = "Are you sure you want to delete this category?"
             };
 
             PointSync = new LanguageStructure.PointSync

--- a/src/ui/Logic/LanguageDeserializer.cs
+++ b/src/ui/Logic/LanguageDeserializer.cs
@@ -7141,6 +7141,9 @@ namespace Nikse.SubtitleEdit.Logic
                 case "SubStationAlphaStyles/CategoryNote":
                     language.SubStationAlphaStyles.CategoryNote = reader.Value;
                     break;
+                case "SubStationAlphaStyles/CategoryDelete":
+                    language.SubStationAlphaStyles.CategoryDelete = reader.Value;
+                    break;
                 case "PointSync/Title":
                     language.PointSync.Title = reader.Value;
                     break;

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -2804,6 +2804,7 @@
             public string CategoryName { get; set; }
             public string CategorySetDefault { get; set; }
             public string CategoryNote { get; set; }
+            public string CategoryDelete { get; set; }
         }
 
         public class PointSync


### PR DESCRIPTION
1. Fix  "Move Up/down/top/bottom" disappearing when the current category contains less than two styles.
2. Prompt for category removal.
3. Don't log name changes for storage. This was causing an issue where, when renaming a style in storage, the style changes for a line in the subtitle. I don't think it's even needed because only styles in the current file should be saved.
4. Increase the size of the "Set as default" button.
5. Manage ASSA style manager buttons state based on selected items, remove all and export and other buttons shouldn't be enabled when there is no style in the list or if no style is selected.

The next step is to make the import/export work on categories instead of styles, and maybe adding "Move to category" to the context menu.

Also, what do you think we should do about renaming categories? Should I make it so the user can write in the combobox and by that the name is changed?

We might also need to allow multiple selection.