### PR TITLE
More work on Assa style manager

### DIFF
--- a/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
@@ -200,6 +200,7 @@
             this.listViewStyles.UseCompatibleStateImageBehavior = false;
             this.listViewStyles.View = System.Windows.Forms.View.Details;
             this.listViewStyles.SelectedIndexChanged += new System.EventHandler(this.listViewStyles_SelectedIndexChanged);
+            this.listViewStyles.ClientSizeChanged += new System.EventHandler(this.listViewStyles_ClientSizeChanged);
             this.listViewStyles.Enter += new System.EventHandler(this.listViewStyles_Enter);
             this.listViewStyles.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listViewStyles_KeyDown);
             // 
@@ -1168,6 +1169,7 @@
             this.listViewStorage.UseCompatibleStateImageBehavior = false;
             this.listViewStorage.View = System.Windows.Forms.View.Details;
             this.listViewStorage.SelectedIndexChanged += new System.EventHandler(this.listViewStorage_SelectedIndexChanged);
+            this.listViewStorage.ClientSizeChanged += new System.EventHandler(this.listViewStorage_ClientSizeChanged);
             this.listViewStorage.Enter += new System.EventHandler(this.listViewStorage_Enter);
             this.listViewStorage.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listViewStorage_KeyDown);
             // 

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.Designer.cs
@@ -194,7 +194,6 @@
             this.listViewStyles.FullRowSelect = true;
             this.listViewStyles.HideSelection = false;
             this.listViewStyles.Location = new System.Drawing.Point(6, 19);
-            this.listViewStyles.MultiSelect = false;
             this.listViewStyles.Name = "listViewStyles";
             this.listViewStyles.Size = new System.Drawing.Size(545, 201);
             this.listViewStyles.TabIndex = 0;
@@ -1163,7 +1162,6 @@
             this.listViewStorage.FullRowSelect = true;
             this.listViewStorage.HideSelection = false;
             this.listViewStorage.Location = new System.Drawing.Point(6, 68);
-            this.listViewStorage.MultiSelect = false;
             this.listViewStorage.Name = "listViewStorage";
             this.listViewStorage.Size = new System.Drawing.Size(545, 148);
             this.listViewStorage.TabIndex = 6;

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.cs
@@ -238,7 +238,6 @@ namespace Nikse.SubtitleEdit.Forms.Styles
 
                 _currentCategory = _storageCategories.Single(category => category.IsDefault);
                 comboboxStorageCategories.SelectedItem = _currentCategory.Name;
-                SetStorageButtonsEnabled(false);
             }
 
             buttonApply.Text = LanguageSettings.Current.General.Apply;
@@ -717,8 +716,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
                 _doUpdate = false;
             }
 
-            buttonRemove.Enabled = _fileStyleActive && listViewStyles.Items.Count > 1;
-            buttonRemoveAll.Enabled = _fileStyleActive && listViewStyles.Items.Count > 1;
+            UpdateCurrentFileButtonsState();
         }
 
         private void LogNameChanges()
@@ -1669,13 +1667,11 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             }
             else
             {
-                buttonStorageRemove.Enabled = false;
                 groupBoxProperties.Enabled = false;
                 _doUpdate = false;
             }
 
-            buttonStorageRemove.Enabled = listViewStorage.Items.Count > 1 || !_currentCategory.IsDefault;
-            buttonStorageRemoveAll.Enabled = listViewStorage.Items.Count > 1 || !_currentCategory.IsDefault;
+            UpdateStorageButtonsState();
         }
 
         private void buttonStorageRemoveAll_Click(object sender, EventArgs e)
@@ -1706,6 +1702,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             var defaultStyle = new SsaStyle();
             AddStyle(listViewStorage, defaultStyle, Subtitle, _isSubStationAlpha);
             _currentCategory.Styles.Add(defaultStyle);
+            UpdateStorageButtonsState();
         }
 
         private void buttonStorageRemove_Click(object sender, EventArgs e)
@@ -1749,6 +1746,8 @@ namespace Nikse.SubtitleEdit.Forms.Styles
                     listViewStorage.Items[index].Selected = true;
                 }
             }
+
+            UpdateStorageButtonsState();
         }
 
         private void buttonStorageAdd_Click(object sender, EventArgs e)
@@ -1903,31 +1902,26 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             groupBoxStyles.Font = new Font(groupBoxStyles.Font, FontStyle.Bold);
             _fileStyleActive = true;
             listViewStyles_SelectedIndexChanged(null, null);
-
-            SetStorageButtonsEnabled(false);
-            SetCurrentFileButtonsEnabled(true);
         }
 
-        private void SetCurrentFileButtonsEnabled(bool enabled)
+        private void UpdateCurrentFileButtonsState()
         {
-            buttonImport.Enabled = enabled;
-            buttonAdd.Enabled = enabled;
-            buttonRemove.Enabled = enabled;
-            buttonExport.Enabled = enabled;
-            buttonCopy.Enabled = enabled;
-            buttonRemoveAll.Enabled = enabled;
-            buttonAddStyleToStorage.Enabled = enabled;
+            bool onlyOneSelected = listViewStyles.SelectedItems.Count == 1;
+            buttonRemove.Enabled = onlyOneSelected || !_currentCategory.IsDefault;
+            buttonCopy.Enabled = onlyOneSelected;
+            buttonAddStyleToStorage.Enabled = onlyOneSelected;
         }
 
-        private void SetStorageButtonsEnabled(bool enabled)
+        private void UpdateStorageButtonsState()
         {
-            buttonStorageImport.Enabled = enabled;
-            buttonStorageAdd.Enabled = enabled;
-            buttonStorageRemove.Enabled = enabled;
-            buttonStorageExport.Enabled = enabled;
-            buttonStorageCopy.Enabled = enabled;
-            buttonStorageRemoveAll.Enabled = enabled;
-            buttonAddToFile.Enabled = enabled;
+            bool onlyOneSelected = listViewStorage.SelectedItems.Count == 1;
+            buttonStorageRemove.Enabled = onlyOneSelected || !_currentCategory.IsDefault;
+            buttonStorageCopy.Enabled = onlyOneSelected;
+            buttonAddToFile.Enabled = onlyOneSelected;
+
+            bool containsStyles = listViewStorage.Items.Count > 0;
+            buttonStorageRemoveAll.Enabled = containsStyles;
+            buttonStorageExport.Enabled = containsStyles;
         }
 
         private void listViewStorage_Enter(object sender, EventArgs e)
@@ -1936,11 +1930,6 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             groupBoxStorage.Font = new Font(groupBoxStyles.Font, FontStyle.Bold);
             _fileStyleActive = false;
             listViewStorage_SelectedIndexChanged(null, null);
-
-            SetStorageButtonsEnabled(true);
-            SetCurrentFileButtonsEnabled(false);
-            //buttonAddStyleToStorage.Enabled = false;
-            //buttonAddToFile.Enabled = true;
         }
 
         private void listViewStyles_KeyDown(object sender, KeyEventArgs e)
@@ -2029,6 +2018,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             buttonStorageRemove.Enabled = listViewStorage.SelectedItems.Count > 0;
             buttonStorageCategoryDelete.Enabled = !_currentCategory.IsDefault;
             buttonStorageCategorySetDefault.Enabled = !_currentCategory.IsDefault;
+            UpdateStorageButtonsState();
         }
 
         private bool StyleExistsInListView(string styleName, ListView listView)

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.cs
@@ -1400,6 +1400,30 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             }
         }
 
+        private void SetLastColumnWidth()
+        {
+            listViewStyles.Columns[listViewStyles.Columns.Count - 1].Width = -2;
+            listViewStorage.Columns[listViewStorage.Columns.Count - 1].Width = -2;
+        }
+
+        private void listViewStyles_ClientSizeChanged(object sender, EventArgs e)
+        {
+            SetLastColumnWidth();
+        }
+
+        private void listViewStorage_ClientSizeChanged(object sender, EventArgs e)
+        {
+            SetLastColumnWidth();
+        }
+
+        private void SubStationAlphaStyles_ResizeEnd(object sender, EventArgs e)
+        {
+            _backgroundImage?.Dispose();
+            _backgroundImage = null;
+            GeneratePreview();
+            _lastFormWindowState = WindowState;
+        }
+
         private void SubStationAlphaStyles_Resize(object sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
@@ -1416,21 +1440,6 @@ namespace Nikse.SubtitleEdit.Forms.Styles
                 });
             }
 
-            _lastFormWindowState = WindowState;
-        }
-
-        private void SetLastColumnWidth()
-        {
-            listViewStyles.Columns[listViewStyles.Columns.Count - 1].Width = -2;
-            listViewStorage.Columns[listViewStorage.Columns.Count - 1].Width = -2;
-        }
-
-        private void SubStationAlphaStyles_ResizeEnd(object sender, EventArgs e)
-        {
-            SetLastColumnWidth();
-            _backgroundImage?.Dispose();
-            _backgroundImage = null;
-            GeneratePreview();
             _lastFormWindowState = WindowState;
         }
 


### PR DESCRIPTION
1. Set buttons state based on selected items and count, so it would still work even if it's not focused and buttons like `Remove all` and `import` are disabled if there are no styles in storage.
2. Allow multiple selection for copying, removing, and moving between storage and the current file.
3. Fixed a white portion of the last column that remained when the scroll bar disappeared.

Of course, this needs testing.