### PR TITLE
Fix a crash in RTL when activating syntax coloring

### DIFF
--- a/src/ui/Controls/AdvancedTextBox.cs
+++ b/src/ui/Controls/AdvancedTextBox.cs
@@ -157,7 +157,7 @@ namespace Nikse.SubtitleEdit.Controls
             set
             {
                 _fixedArabicComma = false;
-                var s = value;
+                var s = value ?? string.Empty;
                 if (!Configuration.Settings.General.RightToLeftMode && !s.ContainsUnicodeControlChars())
                 {
                     string textNoTags = HtmlUtil.RemoveHtmlTags(s, true);


### PR DESCRIPTION
I do not know if this is the best fix for the issue.

Here is what happens.
1. Run SE in RTL mode with syntax coloring disabled.
2. Go to the settings and activate syntax coloring.
3. A crash happens.

Somehow, OnRightToLeftChanged is causing a change in the Text property with a null value,
so SE crashes on `base.Text = string.Join("\n", s.SplitToLines());`