### PR TITLE
Fix issue with RichTextBox in RTL with arrow keys

### DIFF
--- a/src/ui/Controls/AdvancedTextBox.cs
+++ b/src/ui/Controls/AdvancedTextBox.cs
@@ -95,7 +95,15 @@ namespace Nikse.SubtitleEdit.Controls
             KeyDown += (sender, args) =>
             {
                 // fix annoying "beeps" when moving cursor position
-                if ((args.KeyData == Keys.Left || args.KeyData == Keys.PageUp) && SelectionStart == 0)
+                var startOfLineDirection = Keys.Left;
+                var endOfLineDirection = Keys.Right;
+                if (Configuration.Settings.General.RightToLeftMode)
+                {
+                    startOfLineDirection = Keys.Right;
+                    endOfLineDirection = Keys.Left;
+                }
+
+                if ((args.KeyData == startOfLineDirection || args.KeyData == Keys.PageUp) && SelectionStart == 0 && SelectionLength == 0)
                 {
                     args.SuppressKeyPress = true;
                 }
@@ -111,7 +119,7 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     args.SuppressKeyPress = true;
                 }
-                else if (args.KeyData == Keys.End && (SelectionStart >= Text.Length || SelectionStart + 1 < Text.Length && Text[SelectionStart] == '\n'))
+                else if (args.KeyData == Keys.End && (SelectionStart >= Text.Length || SelectionStart + 1 < Text.Length && Text[SelectionStart + 1] == '\n'))
                 {
                     args.SuppressKeyPress = true;
                 }
@@ -119,7 +127,7 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     args.SuppressKeyPress = true;
                 }
-                else if (args.KeyData == Keys.Right && SelectionStart >= Text.Length)
+                else if (args.KeyData == endOfLineDirection && SelectionStart >= Text.Length)
                 {
                     if (IsLiveSpellCheckEnabled)
                     {


### PR DESCRIPTION
This was causing an issue in RTL, where if you were at the end of the line and pressed `Right`, it should go right into the line, but it doesn't and vice versa.

Also in left-to-right mode, if a word at the beginning of the line is selected and you press left, it should remove the selection but it used to not do anything.