### PR TITLE
Account for one more case for currentVideoPlayer

### DIFF
--- a/src/ui/Forms/VideoError.cs
+++ b/src/ui/Forms/VideoError.cs
@@ -25,6 +25,10 @@ namespace Nikse.SubtitleEdit.Forms
             sb.AppendLine();
 
             var currentVideoPlayer = Configuration.Settings.General.VideoPlayer;
+            if (string.IsNullOrEmpty(currentVideoPlayer))
+            {
+                currentVideoPlayer = "DirectShow";
+            }
 
             var isLibMpvInstalled = LibMpvDynamic.IsInstalled;
             if (currentVideoPlayer == "MPV" && !isLibMpvInstalled)


### PR DESCRIPTION
As you can see here https://github.com/SubtitleEdit/subtitleedit/issues/4868, the video player is empty when SE is used for the first time, so the user doesn't get the proper error message.