### PR TITLE
Don't save changes to Multiple Replace rules when canceling

### DIFF
--- a/src/ui/Forms/MultipleReplace.cs
+++ b/src/ui/Forms/MultipleReplace.cs
@@ -134,11 +134,15 @@ namespace Nikse.SubtitleEdit.Forms
 
             foreach (var group in Configuration.Settings.MultipleSearchAndReplaceGroups)
             {
-                var oldGroup = new MultipleSearchAndReplaceGroup { Name = group.Name, Enabled = group.Enabled, Rules = new List<MultipleSearchAndReplaceSetting>() };
-                foreach (var rule in group.Rules)
+                var oldGroup = new MultipleSearchAndReplaceGroup { Name = group.Name, Enabled = group.Enabled };
+                oldGroup.Rules = group.Rules.ConvertAll(rule => new MultipleSearchAndReplaceSetting()
                 {
-                    oldGroup.Rules.Add(rule);
-                }
+                    Enabled = rule.Enabled,
+                    FindWhat = rule.FindWhat,
+                    ReplaceWith = rule.ReplaceWith,
+                    SearchType = rule.SearchType,
+                    Description = rule.Description
+                });
                 _oldMultipleSearchAndReplaceGroups.Add(oldGroup);
             }
 


### PR DESCRIPTION
I don't know if this was on purpose but it is annoying.
When changing a rule in multiple replace then clicking cancel, the changes on the rules used to still be saved.
This is not the behavior I expected.

SE used to make a shallow copy of the group's rules while I think it should be a deep copy.