### PR TITLE
Character Inspector produces a null value exception

### DIFF
--- a/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.cs
@@ -91,10 +91,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 }
             }
 
-            for (int i = 0; i < _matches.Count; i++)
-            {
-                listBoxInspectItems.Items.Add(_matches[i]);
-            }
+            SyncListBoxToMatches();
 
             if (LastIndex > listBoxInspectItems.Items.Count)
             {
@@ -454,13 +451,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 _matches[index].ExpandCount = expandCount;
                 _matches[index].Italic = checkBoxItalic.Checked;
                 _matches[index].Text = textBoxText.Text;
-                listBoxInspectItems.Items.Clear();
-                for (int i = 0; i < _matches.Count; i++)
-                {
-                    listBoxInspectItems.Items.Add(_matches[i].Text);
-                }
+                SyncListBoxToMatches();
 
-                listBoxInspectItems.SelectedIndex = index;
                 listBoxInspectItems_SelectedIndexChanged(null, null);
                 ShowCount();
 
@@ -521,13 +513,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 _matches[index].ExpandCount = 0;
                 _matches[index].Italic = checkBoxItalic.Checked;
                 _matches[index].Text = textBoxText.Text;
-                listBoxInspectItems.Items.Clear();
-                for (int i = 0; i < _matches.Count; i++)
-                {
-                    listBoxInspectItems.Items.Add(_matches[i].Text);
-                }
+                SyncListBoxToMatches();
 
-                listBoxInspectItems.SelectedIndex = index;
                 ShowCount();
                 listBoxInspectItems_SelectedIndexChanged(null, null);
             }
@@ -536,6 +523,17 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         private void ShowCount()
         {
             labelCount.Text = listBoxInspectItems.Items.Count > 1 ? listBoxInspectItems.Items.Count.ToString(CultureInfo.InvariantCulture) : string.Empty;
+        }
+
+        private void SyncListBoxToMatches()
+        {
+            int index = listBoxInspectItems.SelectedIndex;
+            listBoxInspectItems.Items.Clear();
+            for (int i = 0; i < _matches.Count; i++)
+            {
+                listBoxInspectItems.Items.Add(_matches[i]);
+            }
+            listBoxInspectItems.SelectedIndex = index;
         }
 
         private void VobSubOcrCharacterInspect_KeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
## Problem:
When having a OCR match with an empty string in the database, all subsequent adding produced a null value exception.

## How to reproduce:
Setting the textbox (below) to an empty string, reopening the dialog and adding a new character will crash the dialog.

![OCR Character Inspector Dialog](https://user-images.githubusercontent.com/8478950/110333827-5cda8400-8022-11eb-8875-cd99eca7a3c4.png)
![Error message](https://user-images.githubusercontent.com/8478950/110333838-5ea44780-8022-11eb-8b47-b17aceb0869f.png)

## Result:
The update was done inconsistent to the initializing of the Form, which calls the ToString() Method of the Match-Object instead of the nullable Text-Property. Both the update and the initialization use the same method in my pull request.