### PR TITLE
Add return to line start after repeat

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1095,6 +1095,7 @@ $HorzAlign          =   Center
         public int AutoRepeatCount { get; set; }
         public bool AutoContinueOn { get; set; }
         public int AutoContinueDelay { get; set; }
+        public bool ReturnToStartAfterRepeat { get; set; }
         public bool SyncListViewWithVideoWhilePlaying { get; set; }
         public int AutoBackupSeconds { get; set; }
         public int AutoBackupDeleteAfterMonths { get; set; }
@@ -1257,6 +1258,7 @@ $HorzAlign          =   Center
             AutoRepeatCount = 2;
             AutoContinueOn = false;
             AutoContinueDelay = 2;
+            ReturnToStartAfterRepeat = false;
             SyncListViewWithVideoWhilePlaying = false;
             AutoBackupSeconds = 60 * 5;
             AutoBackupDeleteAfterMonths = 3;
@@ -3172,16 +3174,22 @@ $HorzAlign          =   Center
                 settings.General.SyncListViewWithVideoWhilePlaying = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
+            subNode = node.SelectSingleNode("AutoContinueOn");
+            if (subNode != null)
+            {
+                settings.General.AutoContinueOn = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+            }
+
             subNode = node.SelectSingleNode("AutoContinueDelay");
             if (subNode != null)
             {
                 settings.General.AutoContinueDelay = Convert.ToInt32(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
-            subNode = node.SelectSingleNode("AutoContinueOn");
+            subNode = node.SelectSingleNode("ReturnToStartAfterRepeat");
             if (subNode != null)
             {
-                settings.General.AutoContinueOn = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+                settings.General.ReturnToStartAfterRepeat = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
             subNode = node.SelectSingleNode("AutoBackupSeconds");
@@ -8108,6 +8116,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("AutoRepeatCount", settings.General.AutoRepeatCount.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("AutoContinueOn", settings.General.AutoContinueOn.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("AutoContinueDelay", settings.General.AutoContinueDelay.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString("ReturnToStartAfterRepeat", settings.General.ReturnToStartAfterRepeat.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("SyncListViewWithVideoWhilePlaying", settings.General.SyncListViewWithVideoWhilePlaying.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("AutoBackupSeconds", settings.General.AutoBackupSeconds.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("AutoBackupDeleteAfterMonths", settings.General.AutoBackupDeleteAfterMonths.ToString(CultureInfo.InvariantCulture));

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -14621,12 +14621,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (_shortcuts.MainGeneralGoToStartOfCurrentSubtitle == e.KeyData)
             {
-                if (SubtitleListview1.SelectedItems.Count == 1 && mediaPlayer.VideoPlayer != null)
-                {
-                    mediaPlayer.CurrentPosition = _subtitle.Paragraphs[SubtitleListview1.SelectedItems[0].Index].StartTime.TotalSeconds;
-                    e.SuppressKeyPress = true;
-                }
-
+                GotoSubPositionAndPause();
                 e.SuppressKeyPress = true;
             }
             else if (_shortcuts.MainGeneralGoToEndOfCurrentSubtitle == e.KeyData)
@@ -15186,10 +15181,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (_shortcuts.MainVideoGoToStartCurrent == e.KeyData)
             {
-                if (mediaPlayer.VideoPlayer != null)
-                {
-                    GotoSubPositionAndPause();
-                }
+                GotoSubPositionAndPause();
                 e.SuppressKeyPress = true;
             }
             else if (_shortcuts.MainVideo3000MsLeft == e.KeyData)
@@ -20567,6 +20559,11 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void GotoSubPositionAndPause(double adjustSeconds)
         {
+            if (mediaPlayer.VideoPlayer is null)
+            {
+                return;
+            }
+
             if (SubtitleListview1.SelectedItems.Count > 0)
             {
                 int index = SubtitleListview1.SelectedItems[0].Index;

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -20948,6 +20948,10 @@ namespace Nikse.SubtitleEdit.Forms
                                     timerAutoContinue.Start();
                                 }
                             }
+                            else if (Configuration.Settings.General.ReturnToStartAfterRepeat)
+                            {
+                                GotoSubPositionAndPause();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
@niksedk Adding it to `Double click` didn't seem like a good option as the original behavior is to just continue playing.
You were right about the relation to `Translate`, since `Auto repeat` in translate just repeats the like, I added a hidden option to return to the start after repeating.

Note that this was requested by a user, so if more users wanted it, it can be found here in the future.

In the second commit, I noticed that going to the line's start uses different logic in multiple places, so I tried to use `GotoSubPositionAndPause();` in all of them, and I added a null check to it so it doesn't apply if there is no video loaded.