### PR TITLE
Ignore Alt alone in normal text box

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -14396,6 +14396,13 @@ namespace Nikse.SubtitleEdit.Forms
                 return;
             }
 
+            // Ignore Alt alone key presses, doesn't work with RichTextBox
+            if (!Configuration.Settings.General.SubtitleTextBoxSyntaxColor && e.Modifiers == Keys.Alt && e.KeyCode == (Keys.RButton | Keys.ShiftKey) && (textBoxListViewText.Focused || textBoxListViewTextOriginal.Focused))
+            {
+                e.SuppressKeyPress = true;
+                return;
+            }
+
             if (e.Modifiers == Keys.Alt && e.KeyCode == (Keys.RButton | Keys.ShiftKey))
             {
                 return;


### PR DESCRIPTION
When pressing the `Alt` key alone while a text box is focused, SE used to ignore that keypress because it's annoying.

After adding the RichTextBox, we found that the code is causing an issue for the Alt codes, so we removed this feature.
But why remove it completely?
It used to word for the normal text box, so why not leave it for the normal text box?

In this PR, I just returned the feature for the normal text box, as it doesn't cause any issues in it.