### PR TITLE
Attempt to fix some issues with auto-translate selected lines

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -29889,7 +29889,7 @@ namespace Nikse.SubtitleEdit.Forms
                     var selectedLines = new Subtitle();
                     foreach (int index in SubtitleListview1.SelectedIndices)
                     {
-                        selectedLines.Paragraphs.Add(_subtitle.Paragraphs[index]);
+                        selectedLines.Paragraphs.Add(new Paragraph(_subtitle.Paragraphs[index], false));
                     }
 
                     title += " - " + _language.SelectedLines;
@@ -29901,7 +29901,7 @@ namespace Nikse.SubtitleEdit.Forms
                             var original = Utilities.GetOriginalParagraph(index, _subtitle.Paragraphs[index], _subtitleOriginal.Paragraphs);
                             if (original != null)
                             {
-                                paragraphs.Add(original);
+                                paragraphs.Add(new Paragraph(original, false));
                             }
                         }
 
@@ -29935,7 +29935,7 @@ namespace Nikse.SubtitleEdit.Forms
                         int i = 0;
                         foreach (int index in SubtitleListview1.SelectedIndices)
                         {
-                            _subtitle.Paragraphs[index] = translateDialog.TranslatedSubtitle.Paragraphs[i];
+                            _subtitle.Paragraphs[index].Text = translateDialog.TranslatedSubtitle.Paragraphs[i].Text;
                             i++;
                         }
 

--- a/src/ui/Forms/Translate/GenericTranslate.cs
+++ b/src/ui/Forms/Translate/GenericTranslate.cs
@@ -77,6 +77,7 @@ namespace Nikse.SubtitleEdit.Forms.Translate
             if (target != null)
             {
                 TranslatedSubtitle = new Subtitle(target);
+                TranslatedSubtitle.Renumber();
                 subtitleListViewTarget.Fill(TranslatedSubtitle);
             }
             else


### PR DESCRIPTION
Renumbering the selected lines without renumbering the translation result used to cause a crash.

Also passing the same object of paragraphs then renumbering is causing the selected lines to have the new numbers, which is why I made it pass a new paragraph object as a deep copy.

After the translation of the selected lines is done, only the text needs to be copied, no need to copy anything else.

I don't know if this is the best fix.