### PR TITLE
Allow all modifiers combinations in textbox

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -14417,7 +14417,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             var fc = FindFocusedControl(this);
-            if (fc != null && e.Modifiers != Keys.Control && e.Modifiers != Keys.Alt && e.Modifiers != (Keys.Control | Keys.Shift) && e.Modifiers != (Keys.Control | Keys.Alt) && e.Modifiers != (Keys.Control | Keys.Shift | Keys.Alt))
+            if (fc != null && (e.Modifiers == Keys.None || e.Modifiers == Keys.Shift))
             {
                 // do not check for shortcuts if text is being entered and a textbox is focused
                 if ((fc.Parent.Name == textBoxListViewText.Name || fc.Parent.Name == textBoxListViewTextOriginal.Name || fc.Name == textBoxSearchWord.Name) &&


### PR DESCRIPTION
Why check all combinations when you can assert two?

The condition was:
```
if (fc != null && e.Modifiers != Keys.Control && e.Modifiers != Keys.Alt && e.Modifiers != (Keys.Control | Keys.Shift) && e.Modifiers != (Keys.Control | Keys.Alt) && e.Modifiers != (Keys.Control | Keys.Shift | Keys.Alt))
```

And I wanted to add `Alt + Shift`, so it would have became:
```
if (fc != null && e.Modifiers != Keys.Control && e.Modifiers != Keys.Alt && e.Modifiers != (Keys.Control | Keys.Shift) && e.Modifiers != (Keys.Control | Keys.Alt) && e.Modifiers != (Keys.Control | Keys.Shift | Keys.Alt) && e.Modifiers != (Keys.Shift | Keys.Alt )
```

But then I thought, instead of adding another case and try to make sure that the modifier is not 6 cases, why not just assert 2 cases?
```
if (fc != null && (e.Modifiers == Keys.None || e.Modifiers == Keys.Shift))
```