### PR TITLE
Batch dialog: change cancel button from "Ok" to "Cancel"

### DIFF
--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -135,7 +135,7 @@ namespace Nikse.SubtitleEdit.Forms
             linkLabelOpenOutputFolder.Text = LanguageSettings.Current.Main.Menu.File.Open;
             buttonSearchFolder.Text = l.ScanFolder;
             buttonConvert.Text = l.Convert;
-            buttonCancel.Text = LanguageSettings.Current.General.Ok;
+            buttonCancel.Text = LanguageSettings.Current.General.Cancel;
             checkBoxScanFolderRecursive.Text = l.Recursive;
             checkBoxScanFolderRecursive.Left = buttonSearchFolder.Left - checkBoxScanFolderRecursive.Width - 5;
             buttonTransportStreamSettings.Text = l.TransportStreamSettingsButton;


### PR DESCRIPTION
I changed the label of the cancel button from "Ok" to "Cancel" in the "Batch convert" dialog.

If believe the label "Ok" is confusing for this button because if you press the button, the dialog closes and you lose all the settings in the dialog and you have to start from scratch.