### PR TITLE
Fix menu shortcuts not working controls undocked

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -30096,5 +30096,13 @@ namespace Nikse.SubtitleEdit.Forms
                 }
             }
         }
+
+        public bool ProcessCmdKeyFromChildForm(ref Message msg, Keys keyData)
+        {
+            Message messageCopy = msg;
+            messageCopy.HWnd = Handle;
+
+            return ProcessCmdKey(ref messageCopy, keyData);
+        }
     }
 }

--- a/src/ui/Forms/VideoControlsUndocked.cs
+++ b/src/ui/Forms/VideoControlsUndocked.cs
@@ -53,5 +53,15 @@ namespace Nikse.SubtitleEdit.Forms
                 _mainForm.MainKeyDown(sender, e);
             }
         }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (_mainForm.ProcessCmdKeyFromChildForm(ref msg, keyData))
+            {
+                return true;
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
     }
 }

--- a/src/ui/Forms/VideoPlayerUndocked.cs
+++ b/src/ui/Forms/VideoPlayerUndocked.cs
@@ -168,5 +168,14 @@ namespace Nikse.SubtitleEdit.Forms
             Refresh();
         }
 
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (_mainForm.ProcessCmdKeyFromChildForm(ref msg, keyData))
+            {
+                return true;
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
     }
 }

--- a/src/ui/Forms/WaveformUndocked.cs
+++ b/src/ui/Forms/WaveformUndocked.cs
@@ -50,5 +50,15 @@ namespace Nikse.SubtitleEdit.Forms
                 _mainForm.MainKeyDown(sender, e);
             }
         }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (_mainForm.ProcessCmdKeyFromChildForm(ref msg, keyData))
+            {
+                return true;
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/SubtitleEdit/subtitleedit/issues/4948

I tried to fix it by making `Main` try to process the key, if it didn't process it, the Keydown event does.
I do not know if this is the best fix.