### PR TITLE
Make extend to scene change with gap work for multiple scene changes

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -16500,7 +16500,8 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 var idx = selectedItem.Index;
                 var p = _subtitle.Paragraphs[idx];
-                List<double> nextSceneChanges = audioVisualizer.SceneChanges.Count > 0 ? audioVisualizer.SceneChanges.Where(x => x > p.EndTime.TotalSeconds + 0.01).ToList() : new List<double>();
+                var endTime = p.EndTime.TotalSeconds + (withGap ? MinGapBetweenLines / TimeCode.BaseUnit + 0.01 : 0.01);
+                List<double> nextSceneChanges = audioVisualizer.SceneChanges.Count > 0 ? audioVisualizer.SceneChanges.Where(x => x > endTime).ToList() : new List<double>();
                 if (nextSceneChanges.Count > 0)
                 {
                     var next = _subtitle.GetParagraphOrDefault(idx + 1);
@@ -16560,7 +16561,8 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 var idx = selectedItem.Index;
                 var p = _subtitle.Paragraphs[idx];
-                List<double> previousSceneChanges = audioVisualizer.SceneChanges.Count > 0 ? audioVisualizer.SceneChanges.Where(x => x < p.StartTime.TotalSeconds - 0.01).ToList() : new List<double>();
+                var startTime = p.StartTime.TotalSeconds - (withGap ? MinGapBetweenLines / TimeCode.BaseUnit + 0.01 : 0.01);
+                List<double> previousSceneChanges = audioVisualizer.SceneChanges.Count > 0 ? audioVisualizer.SceneChanges.Where(x => x < startTime).ToList() : new List<double>();
                 if (previousSceneChanges.Count > 0)
                 {
                     var previous = _subtitle.GetParagraphOrDefault(idx - 1);


### PR DESCRIPTION
It's used to only work for the scene change directly after the end of the line, this should make it work for all scene changes after the end.