### PR TITLE
Revert "Make extend to scene change with gap work for multiple scene changes"

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -16601,8 +16601,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 var idx = selectedItem.Index;
                 var p = _subtitle.Paragraphs[idx];
-                var endTime = p.EndTime.TotalSeconds + (withGap ? MinGapBetweenLines / TimeCode.BaseUnit + 0.01 : 0.01);
-                List<double> nextSceneChanges = audioVisualizer.SceneChanges.Count > 0 ? audioVisualizer.SceneChanges.Where(x => x > endTime).ToList() : new List<double>();
+                List<double> nextSceneChanges = audioVisualizer.SceneChanges.Count > 0 ? audioVisualizer.SceneChanges.Where(x => x > p.EndTime.TotalSeconds + 0.01).ToList() : new List<double>();
                 if (nextSceneChanges.Count > 0)
                 {
                     var next = _subtitle.GetParagraphOrDefault(idx + 1);
@@ -16662,8 +16661,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 var idx = selectedItem.Index;
                 var p = _subtitle.Paragraphs[idx];
-                var startTime = p.StartTime.TotalSeconds - (withGap ? MinGapBetweenLines / TimeCode.BaseUnit + 0.01 : 0.01);
-                List<double> previousSceneChanges = audioVisualizer.SceneChanges.Count > 0 ? audioVisualizer.SceneChanges.Where(x => x < startTime).ToList() : new List<double>();
+                List<double> previousSceneChanges = audioVisualizer.SceneChanges.Count > 0 ? audioVisualizer.SceneChanges.Where(x => x < p.StartTime.TotalSeconds - 0.01).ToList() : new List<double>();
                 if (previousSceneChanges.Count > 0)
                 {
                     var previous = _subtitle.GetParagraphOrDefault(idx - 1);


### PR DESCRIPTION
Reverts SubtitleEdit/subtitleedit#4958

It was a bad move from my end.
I was using the shortcuts and found it more annoying.
If the line ends less the MinGap before the scene change and you use it, it moves it to the next scene change instead of applying the MinGap.