### PR TITLE
Don't remove current file when clearing recent files

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -3799,7 +3799,7 @@ namespace Nikse.SubtitleEdit.Forms
                 var clearHistoryMenuItem = new ToolStripMenuItem(LanguageSettings.Current.DvdSubRip.Clear);
                 clearHistoryMenuItem.Click += (sender, args) =>
                 {
-                    Configuration.Settings.RecentFiles.Files.Clear();
+                    Configuration.Settings.RecentFiles.Files.RemoveAll(entry => entry.FileName != _fileName);
                     UpdateRecentFilesUI();
                 };
                 UiUtil.FixFonts(clearHistoryMenuItem);


### PR DESCRIPTION
It will just come back when opening a new file or clicking on `New`, so it's better if the currently opened file is not removed from the list.