### PR TITLE
BUGFIX: FPC Paragraph Decode Fix

### DIFF
--- a/src/libse/SubtitleFormats/PacUnicode.cs
+++ b/src/libse/SubtitleFormats/PacUnicode.cs
@@ -125,7 +125,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return null; // probably not correct index
             }
 
-            int maxIndex = timeStartIndex + 10 + textLength;
+            int maxIndex = timeStartIndex + 11 + textLength;
 
             var sb = new StringBuilder();
             index = feIndex + 3;
@@ -142,13 +142,29 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         {
                             if (buffer[j] == 0xff)
                             {
+                                // I never hit this on a breakpoint...
                                 buffer[j] = 0x2e; // replace end of line marker
                             }
                         }
-
+                        
                         sb.AppendLine(Encoding.UTF8.GetString(buffer, textBegin, textIndex - textBegin));
-                        textBegin = textIndex + 7;
-                        textIndex += 6;
+                        for (var v = 0; v < 5; v++)
+                        {
+                            if (buffer[textIndex + 1 + v] == 0x1F &&
+                                buffer[textIndex + 2 + v] == 0xEF &&
+                                buffer[textIndex + 3 + v] == 0xBB &&
+                                buffer[textIndex + 4 + v] == 0xBF)
+                            {
+                                // skip utf8 BOM
+                                textBegin = textIndex + 7;
+                                textIndex += 6;
+                            }
+                            else
+                            {
+                                // ASCI or Header Paragraph no BOM 
+                                textBegin = textIndex + 1;
+                            }
+                        }
                     }
                 }
                 else if (buffer[textIndex] == 0xFF)

--- a/src/ui/Logic/NikseBitmapImageSplitter.cs
+++ b/src/ui/Logic/NikseBitmapImageSplitter.cs
@@ -549,7 +549,7 @@ namespace Nikse.SubtitleEdit.Logic
                     if (keysInSequence > 2 && lastTransparentY - startY > minLineHeight)
                     {
                         var part = bmp.CopyRectangle(new Rectangle(0, startY, bmp.Width, lastTransparentY - startY - 1));
-                        if (!part.IsImageOnlyTransparent() && part.GetNonTransparentHeight() >= minLineHeight)
+                        if (!part.IsImageOnlyTransparent() && part.GetNonTransparentHeight() + keysInSequence * 0.4 >= minLineHeight)
                         {
                             var croppedTop = part.CropTopTransparent(0);
                             parts.Add(new ImageSplitterItem(0, startY + croppedTop, part));


### PR DESCRIPTION
While working on a library of subtitle validation tools using the LibSE I noticed some files would fail to validate, due to a missing tag or missing character.

Looking closely at the files in a Hex Editor I noticed that the last character was missing from single line paragraphs, and the second line of multi-line paragraphs. 

The change on **Line 128**  fixes the missing character, 11 is required as time codes use 8 bytes then length uses the next 2, so it needed to skip 1 more from the `timeStartIndex` to get the actual `maxIndex`.

The changes to **line 150/151** rectify an issue when reading the first paragraph where some valid text would be missed, see Story / Lang.

The two changes can been seen in the screenshot below 3.5.11 was the version i had installed locally and found the issue in, 3.6.0 was a build after making the two changes below.

This change has been tested against 100+ FPC subtitles, all are decoding correctly. 

Apologies in advance but I cannot provide the FPC subtitles as they are my employers content.

![image](https://user-images.githubusercontent.com/32466972/114907701-412d7f00-9e13-11eb-829f-df6763823322.png)
