### PR TITLE
Try to fix an issue with format change and filename

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -197,12 +197,12 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void SetCurrentFormat(string formatName)
+        private void SetCurrentFormat(string formatName, bool subscribed = true)
         {
-            SetCurrentFormat(SubtitleFormat.FromName(formatName, new SubRip()));
+            SetCurrentFormat(SubtitleFormat.FromName(formatName, new SubRip()), subscribed);
         }
 
-        private void SetCurrentFormat(SubtitleFormat format)
+        private void SetCurrentFormat(SubtitleFormat format, bool subscribed = true)
         {
             if (format.IsVobSubIndexFile)
             {
@@ -221,12 +221,15 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     if (name == format.FriendlyName)
                     {
-                        var oldIdx = comboBoxSubtitleFormats.SelectedIndex;
-                        comboBoxSubtitleFormats.SelectedIndex = index;
-                        if (oldIdx == comboBoxSubtitleFormats.SelectedIndex)
+                        if (index == comboBoxSubtitleFormats.SelectedIndex && subscribed)
                         {
                             ComboBoxSubtitleFormatsSelectedIndexChanged(null, null);
                         }
+                        else
+                        {
+                            comboBoxSubtitleFormats.SelectedIndex = index;
+                        }
+
                         return;
                     }
 
@@ -7346,7 +7349,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
 
                     comboBoxSubtitleFormats.SelectedIndexChanged -= ComboBoxSubtitleFormatsSelectedIndexChanged;
-                    SetCurrentFormat(subtitleFormatFriendlyName);
+                    SetCurrentFormat(subtitleFormatFriendlyName, false);
                     comboBoxSubtitleFormats.SelectedIndexChanged += ComboBoxSubtitleFormatsSelectedIndexChanged;
 
                     UpdateSourceView();
@@ -13004,7 +13007,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             comboBoxSubtitleFormats.SelectedIndexChanged -= ComboBoxSubtitleFormatsSelectedIndexChanged;
-            SetCurrentFormat(format);
+            SetCurrentFormat(format, false);
             comboBoxSubtitleFormats.SelectedIndexChanged += ComboBoxSubtitleFormatsSelectedIndexChanged;
             _oldSubtitleFormat = format;
             SetEncoding(Encoding.UTF8);
@@ -13077,7 +13080,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             comboBoxSubtitleFormats.SelectedIndexChanged -= ComboBoxSubtitleFormatsSelectedIndexChanged;
-            SetCurrentFormat(Configuration.Settings.General.DefaultSubtitleFormat);
+            SetCurrentFormat(Configuration.Settings.General.DefaultSubtitleFormat, false);
             comboBoxSubtitleFormats.SelectedIndexChanged += ComboBoxSubtitleFormatsSelectedIndexChanged;
             SetEncoding(Encoding.UTF8);
             ShowStatus(_language.SubtitleImportedFromMatroskaFile);


### PR DESCRIPTION
I emailed you about the issue I first noticed, I thought it had something to do with Undo:

https://user-images.githubusercontent.com/20923700/115031288-a72c0c00-9ed0-11eb-80ca-9ef22fba8669.mp4

It turned out it's because the `ComboBoxSubtitleFormatsSelectedIndexChanged` code is getting called when the format stays the same, even when you unsubscribe from it first.

I passed a `subscribed` boolean to the function, so it doesn't call the code when it's not subscribed.

I hope this is the proper fix.