### PR TITLE
Try to fix an issue with Undo and format

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -197,12 +197,12 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void SetCurrentFormat(string formatName)
+        private void SetCurrentFormat(string formatName, bool subscribed = true)
         {
-            SetCurrentFormat(SubtitleFormat.FromName(formatName, new SubRip()));
+            SetCurrentFormat(SubtitleFormat.FromName(formatName, new SubRip()), subscribed);
         }
 
-        private void SetCurrentFormat(SubtitleFormat format)
+        private void SetCurrentFormat(SubtitleFormat format, bool subscribed = true)
         {
             if (format.IsVobSubIndexFile)
             {
@@ -221,14 +221,15 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     if (name == format.FriendlyName)
                     {
-                        var oldIdx = comboBoxSubtitleFormats.SelectedIndex;
-                        comboBoxSubtitleFormats.SelectedIndex = index;
-                        if (oldIdx == comboBoxSubtitleFormats.SelectedIndex)
+                        if (index == comboBoxSubtitleFormats.SelectedIndex && subscribed)
                         {
-                            _makeHistoryPaused = true;
                             ComboBoxSubtitleFormatsSelectedIndexChanged(null, null);
-                            _makeHistoryPaused = false;
                         }
+                        else
+                        {
+                            comboBoxSubtitleFormats.SelectedIndex = index;
+                        }
+
                         return;
                     }
 
@@ -7348,7 +7349,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
 
                     comboBoxSubtitleFormats.SelectedIndexChanged -= ComboBoxSubtitleFormatsSelectedIndexChanged;
-                    SetCurrentFormat(subtitleFormatFriendlyName);
+                    SetCurrentFormat(subtitleFormatFriendlyName, false);
                     comboBoxSubtitleFormats.SelectedIndexChanged += ComboBoxSubtitleFormatsSelectedIndexChanged;
 
                     UpdateSourceView();
@@ -13006,7 +13007,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             comboBoxSubtitleFormats.SelectedIndexChanged -= ComboBoxSubtitleFormatsSelectedIndexChanged;
-            SetCurrentFormat(format);
+            SetCurrentFormat(format, false);
             comboBoxSubtitleFormats.SelectedIndexChanged += ComboBoxSubtitleFormatsSelectedIndexChanged;
             _oldSubtitleFormat = format;
             SetEncoding(Encoding.UTF8);
@@ -13079,7 +13080,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             comboBoxSubtitleFormats.SelectedIndexChanged -= ComboBoxSubtitleFormatsSelectedIndexChanged;
-            SetCurrentFormat(Configuration.Settings.General.DefaultSubtitleFormat);
+            SetCurrentFormat(Configuration.Settings.General.DefaultSubtitleFormat, false);
             comboBoxSubtitleFormats.SelectedIndexChanged += ComboBoxSubtitleFormatsSelectedIndexChanged;
             SetEncoding(Encoding.UTF8);
             ShowStatus(_language.SubtitleImportedFromMatroskaFile);


### PR DESCRIPTION
The `ComboBoxSubtitleFormatsSelectedIndexChanged` event was sometimes being called even after you unsubscribe from it.
This was causing SE to record a history item for a format change to the same format.
Using `_makeHistoryPaused = true;` alone wasn't enough, because the history is recorded in `_subtile.MakeHistoryForUndo`.

The issue that was being caused is that this was showing up even when I don't change the format:

![image](https://user-images.githubusercontent.com/20923700/115325798-f0ac7d80-a194-11eb-9ae0-7cf62b6c7ec6.png)

Which cases issue when using `Redo`.

Steps to recreate: Just open any file, make a change and use `Undo`, then check the `History`.
