### PR TITLE
Minor compare patch

### DIFF
--- a/src/ui/Forms/Compare.cs
+++ b/src/ui/Forms/Compare.cs
@@ -688,7 +688,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     richTextBox1.SelectionStart = i;
                     richTextBox1.SelectionLength = 1;
-                    richTextBox1.SelectionColor = _backDifferenceColor;
+                    richTextBox1.SelectionColor = _foregroundDifferenceColor;
                     if (" .,".Contains(richTextBox1.SelectedText))
                     {
                         richTextBox1.SelectionBackColor = _backDifferenceColor;

--- a/src/ui/Forms/Compare.cs
+++ b/src/ui/Forms/Compare.cs
@@ -86,6 +86,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 try
                 {
+                    buttonReloadSubtitle1.Enabled = true;
                     openFileDialog1.InitialDirectory = Path.GetDirectoryName(subtitleFileName1);
                 }
                 catch


### PR DESCRIPTION
Reload didn't work if compare took a loaded file.

There was an issue with the foreground color of the removed text so the user couldn't tell what was removed:

![image](https://user-images.githubusercontent.com/20923700/115786486-8e888e00-a3c9-11eb-8b33-80b33264f4b0.png)
