### PR TITLE
Add a hidden option to choose HI tags

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1164,6 +1164,7 @@ $HorzAlign          =   Center
         public DateTime LastCheckForUpdates { get; set; }
         public bool AutoSave { get; set; }
         public string PreviewAssaText { get; set; }
+        public string TagsInToggleHiTags { get; set; }
         public bool ShowProgress { get; set; }
         public bool ShowNegativeDurationInfoOnSave { get; set; }
         public bool ShowFormatRequiresUtf8Warning { get; set; }
@@ -1312,6 +1313,7 @@ $HorzAlign          =   Center
             MeasurementConverterCloseOnInsert = true;
             MeasurementConverterCategories = "Length;Kilometers;Meters";
             PreviewAssaText = "ABCDEFGHIJKL abcdefghijkl 123";
+            TagsInToggleHiTags = "[;]";
             SubtitleTextBoxMaxHeight = 200;
             ShowBetaStuff = false;
             NewEmptyDefaultMs = 2000;
@@ -3582,6 +3584,12 @@ $HorzAlign          =   Center
             if (subNode != null)
             {
                 settings.General.PreviewAssaText = subNode.InnerText;
+            }
+
+            subNode = node.SelectSingleNode("TagsInToggleHiTags");
+            if (subNode != null)
+            {
+                settings.General.TagsInToggleHiTags = subNode.InnerText;
             }
 
             subNode = node.SelectSingleNode("ShowProgress");
@@ -8280,6 +8288,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("LastCheckForUpdates", settings.General.LastCheckForUpdates.ToString("yyyy-MM-dd"));
                 textWriter.WriteElementString("AutoSave", settings.General.AutoSave.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("PreviewAssaText", settings.General.PreviewAssaText);
+                textWriter.WriteElementString("TagsInToggleHiTags", settings.General.TagsInToggleHiTags);
                 textWriter.WriteElementString("ShowProgress", settings.General.ShowProgress.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("ShowNegativeDurationInfoOnSave", settings.General.ShowNegativeDurationInfoOnSave.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("ShowFormatRequiresUtf8Warning", settings.General.ShowFormatRequiresUtf8Warning.ToString(CultureInfo.InvariantCulture));

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -14679,13 +14679,32 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (_shortcuts.MainListViewToggleHiTags == e.KeyData && InListView)
             {
+                var tags = Configuration.Settings.General.TagsInToggleHiTags.Split(';');
+                string openingTag;
+                string closingTag;
+                switch (tags.Length)
+                {
+                    case 1:
+                        openingTag = tags[0];
+                        closingTag = openingTag;
+                        break;
+                    case 2:
+                        openingTag = tags[0];
+                        closingTag = tags[1];
+                        break;
+                    default:
+                        openingTag = "[";
+                        closingTag = "]";
+                        break;
+                }
+
                 if (textBoxListViewText.Focused || textBoxListViewTextOriginal.Focused)
                 {
-                    SurroundWithTag("[", "]", true);
+                    SurroundWithTag(openingTag, closingTag, true);
                 }
                 else
                 {
-                    SurroundWithTag("[", "]");
+                    SurroundWithTag(openingTag, closingTag);
                 }
 
                 e.SuppressKeyPress = true;


### PR DESCRIPTION
Add a hidden option to choose opening and closing tags for `Toggle HI tags` which are separated by a semicolon.