### PR TITLE
Remove hardcoded italic shortcut

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1970,7 +1970,6 @@ $HorzAlign          =   Center
         public string MainListViewGoToNextError { get; set; }
         public string MainListViewRemoveBlankLines { get; set; }
         public string MainListViewRemoveTimeCodes { get; set; }
-        public string MainTextBoxItalic { get; set; }
         public string MainTextBoxSplitAtCursor { get; set; }
         public string MainTextBoxSplitAtCursorAndVideoPos { get; set; }
         public string MainTextBoxSplitSelectedLineBilingual { get; set; }
@@ -2118,7 +2117,6 @@ $HorzAlign          =   Center
             MainSynchronizationVisualSync = "Control+Shift+V";
             MainSynchronizationPointSync = "Control+Shift+P";
             MainListViewItalic = "Control+I";
-            MainTextBoxItalic = "Control+I";
             MainTextBoxSplitAtCursor = "Control+Alt+V";
             MainTextBoxSelectionToLower = "Control+U";
             MainTextBoxSelectionToUpper = "Control+Shift+U";
@@ -7429,12 +7427,6 @@ $HorzAlign          =   Center
                     shortcuts.MainToggleVideoControls = subNode.InnerText;
                 }
 
-                subNode = node.SelectSingleNode("MainTextBoxItalic");
-                if (subNode != null)
-                {
-                    shortcuts.MainTextBoxItalic = subNode.InnerText;
-                }
-
                 subNode = node.SelectSingleNode("MainTextBoxSplitAtCursor");
                 if (subNode != null)
                 {
@@ -9013,7 +9005,6 @@ $HorzAlign          =   Center
             textWriter.WriteElementString("MainEditRemoveRTLUnicodeChars", shortcuts.MainEditRemoveRTLUnicodeChars);
             textWriter.WriteElementString("MainEditReverseStartAndEndingForRTL", shortcuts.MainEditReverseStartAndEndingForRTL);
             textWriter.WriteElementString("MainToggleVideoControls", shortcuts.MainToggleVideoControls);
-            textWriter.WriteElementString("MainTextBoxItalic", shortcuts.MainTextBoxItalic);
             textWriter.WriteElementString("MainTextBoxSplitAtCursor", shortcuts.MainTextBoxSplitAtCursor);
             textWriter.WriteElementString("MainTextBoxSplitAtCursorAndVideoPos", shortcuts.MainTextBoxSplitAtCursorAndVideoPos);
             textWriter.WriteElementString("MainTextBoxSplitSelectedLineBilingual", shortcuts.MainTextBoxSplitSelectedLineBilingual);

--- a/src/ui/Forms/ExportPngXml.cs
+++ b/src/ui/Forms/ExportPngXml.cs
@@ -5344,7 +5344,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 
         private void subtitleListView1_KeyDown(object sender, KeyEventArgs e)
         {
-            var italicShortCut = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainTextBoxItalic);
+            var italicShortCut = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainListViewItalic);
             if (e.KeyData == italicShortCut)
             {
                 ListViewToggleTag("i");

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -2893,7 +2893,6 @@ namespace Nikse.SubtitleEdit.Forms
             // italicToolStripMenuItem
             // 
             this.italicToolStripMenuItem.Name = "italicToolStripMenuItem";
-            this.italicToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
             this.italicToolStripMenuItem.Size = new System.Drawing.Size(284, 22);
             this.italicToolStripMenuItem.Text = "Italic";
             this.italicToolStripMenuItem.Click += new System.EventHandler(this.ItalicToolStripMenuItemClick);
@@ -4755,7 +4754,6 @@ namespace Nikse.SubtitleEdit.Forms
             // italicToolStripMenuItem1
             // 
             this.italicToolStripMenuItem1.Name = "italicToolStripMenuItem1";
-            this.italicToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
             this.italicToolStripMenuItem1.Size = new System.Drawing.Size(273, 22);
             this.italicToolStripMenuItem1.Text = "Italic";
             this.italicToolStripMenuItem1.Click += new System.EventHandler(this.ItalicToolStripMenuItem1Click);

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -9762,25 +9762,6 @@ namespace Nikse.SubtitleEdit.Forms
                 AutoBreakAtFirstSpaceFromPos(textBoxListViewText, true);
                 e.SuppressKeyPress = true;
             }
-            else if (e.Modifiers == Keys.Alt && e.KeyCode == Keys.I)
-            {
-                if (textBoxListViewText.SelectionLength == 0)
-                {
-                    if (textBoxListViewText.Text.Contains("<i>", StringComparison.Ordinal))
-                    {
-                        textBoxListViewText.Text = HtmlUtil.RemoveOpenCloseTags(textBoxListViewText.Text, HtmlUtil.TagItalic);
-                    }
-                    else
-                    {
-                        textBoxListViewText.Text = string.Format("<i>{0}</i>", textBoxListViewText.Text);
-                    }
-                }
-                else
-                {
-                    TextBoxListViewToggleTag(HtmlUtil.TagItalic);
-                    e.SuppressKeyPress = true;
-                }
-            }
 
             if (e.Modifiers == Keys.Control && e.KeyCode == Keys.D)
             {
@@ -22241,6 +22222,7 @@ namespace Nikse.SubtitleEdit.Forms
             pointSyncViaOtherSubtitleToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainSynchronizationPointSyncViaFile);
             toolStripMenuItemChangeFrameRate2.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainSynchronizationChangeFrameRate);
             italicToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainListViewItalic);
+            italicToolStripMenuItem1.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainListViewItalic);
             removeAllFormattingsToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainRemoveFormatting);
             normalToolStripMenuItem1.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainRemoveFormatting);
             boldToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainListViewBold);
@@ -22261,7 +22243,6 @@ namespace Nikse.SubtitleEdit.Forms
             moveTextUpToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainListViewColumnTextUp);
             moveTextDownToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainListViewColumnTextDown);
             toolStripMenuItemReverseRightToLeftStartEnd.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainEditReverseStartAndEndingForRTL);
-            italicToolStripMenuItem1.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainTextBoxItalic);
             translateToolStripMenuItem.ShortcutKeys = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainAutoTranslate);
 
             audioVisualizer.InsertAtVideoPositionShortcut = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainWaveformInsertAtCurrentPosition);
@@ -25212,25 +25193,6 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 AutoBreakAtFirstSpaceFromPos(textBoxListViewTextOriginal, true);
                 e.SuppressKeyPress = true;
-            }
-            else if (e.Modifiers == Keys.Alt && e.KeyCode == Keys.I)
-            {
-                if (textBoxListViewTextOriginal.SelectionLength == 0)
-                {
-                    if (textBoxListViewTextOriginal.Text.Contains("<i>"))
-                    {
-                        textBoxListViewTextOriginal.Text = HtmlUtil.RemoveOpenCloseTags(textBoxListViewTextOriginal.Text, HtmlUtil.TagItalic);
-                    }
-                    else
-                    {
-                        textBoxListViewTextOriginal.Text = string.Format("<i>{0}</i>", textBoxListViewTextOriginal.Text);
-                    }
-                }
-                else
-                {
-                    TextBoxListViewToggleTag(HtmlUtil.TagItalic);
-                    e.SuppressKeyPress = true;
-                }
             }
 
             if (e.Modifiers == Keys.Control && e.KeyCode == Keys.D)

--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -343,7 +343,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         private NOcrThreadResult[] _nOcrThreadResults;
         private bool _ocrThreadStop;
 
-        private readonly Keys _italicShortcut = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainTextBoxItalic);
+        private readonly Keys _italicShortcut = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainListViewItalic);
         private readonly Keys _mainGeneralGoToNextSubtitle = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralGoToNextSubtitle);
         private readonly Keys _mainGeneralGoToPrevSubtitle = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralGoToPrevSubtitle);
 


### PR DESCRIPTION
Some italic shortcuts were hardcoded, and even if you choose another shortcut for `Control + I`, it used to always toggle italic in the text box.