### PR TITLE
Allow open original with no subtitle loaded

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -21508,7 +21508,6 @@ namespace Nikse.SubtitleEdit.Forms
             bool subtitleLoaded = IsSubtitleLoaded;
             toolStripMenuItemStatistics.Enabled = subtitleLoaded;
             toolStripMenuItemExport.Enabled = subtitleLoaded;
-            openOriginalToolStripMenuItem.Enabled = subtitleLoaded;
             toolStripMenuItemOpenKeepVideo.Enabled = VideoFileName != null;
             if (subtitleLoaded && Configuration.Settings.General.AllowEditOfOriginalSubtitle && _subtitleOriginal != null && _subtitleOriginal.Paragraphs.Count > 0)
             {


### PR DESCRIPTION
I just noticed that I can't use `Open original subtitle` if no subtitle file is loaded.
It used to be that when I open an original subtitle file when no file is loaded, SE opens the file as an original subtitle and makes an empty file for the normal subtitle.
You changed Hidden to Enabled a while ago so now it is `openOriginalToolStripMenuItem.Enabled = subtitleLoaded;` which makes the shortcut for it not work.