### PR TITLE
Fix an issue in calculating frame gap for NQC

### DIFF
--- a/src/libse/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
@@ -18,6 +18,9 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                 return;
             }
 
+            double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
+            int halfSecGap = (int)Math.Round(controller.FrameRate / 2);
+
             for (int index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
@@ -27,9 +30,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                     continue;
                 }
 
-                double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
-                int halfSecGap = (int)Math.Round(controller.FrameRate / 2);
-                var gapInFrames = SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds) - SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds);
+                var gapInFrames = SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds);
                 if (gapInFrames > 2 && gapInFrames < halfSecGap && !p.StartTime.IsMaxTime)
                 {
                     var fixedParagraph = new Paragraph(p, false) { EndTime = { TotalMilliseconds = next.StartTime.TotalMilliseconds - twoFramesGap } };

--- a/src/libse/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs
@@ -15,11 +15,12 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                 return;
             }
 
+            double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
+
             for (int index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 Paragraph p = subtitle.Paragraphs[index];
                 var next = subtitle.GetParagraphOrDefault(index + 1);
-                double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
                 if (next != null && SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds + twoFramesGap) > SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds) && !p.StartTime.IsMaxTime)
                 {
                     var fixedParagraph = new Paragraph(p, false) { EndTime = { TotalMilliseconds = next.StartTime.TotalMilliseconds - twoFramesGap } };
@@ -33,6 +34,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                     {
                         comment = "Minimum two frames gap";
                     }
+
                     controller.AddRecord(p, fixedParagraph, comment);
                 }
             }


### PR DESCRIPTION
The issue was that it's calculating the frame time for each line then subtracting,
so I made it calculate the gap in ms then convert the ms to frames.

Related to https://github.com/SubtitleEdit/subtitleedit/issues/5091