### PR TITLE
remove redundant fix

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixInvalidItalicTags.cs
+++ b/src/libse/Forms/FixCommonErrors/FixInvalidItalicTags.cs
@@ -13,10 +13,6 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
-            const string beginTagUpper = "<I>";
-            const string endTagUpper = "</I>";
-            const string beginTag = "<i>";
-            const string endTag = "</i>";
             string fixAction = Language.FixInvalidItalicTag;
             int noOfInvalidHtmlTags = 0;
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
@@ -26,13 +22,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     var text = subtitle.Paragraphs[i].Text;
                     if (text.Contains('<'))
                     {
-                        if (!text.Contains("i>") && !text.Contains("<i"))
-                        {
-                            text = text.Replace(beginTagUpper, beginTag).Replace(endTagUpper, endTag);
-                        }
-
                         string oldText = text;
-
                         text = HtmlUtil.FixInvalidItalicTags(text);
                         if (text != oldText)
                         {


### PR DESCRIPTION
Calling `HtmlUtil.FixInvalidItalicTags(text);` already handle these cases!