### PR TITLE
Allow filtering batch convert files language code after addition

### DIFF
--- a/src/ui/Forms/BatchConvert.Designer.cs
+++ b/src/ui/Forms/BatchConvert.Designer.cs
@@ -1237,6 +1237,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.textBoxFilter.Name = "textBoxFilter";
             this.textBoxFilter.Size = new System.Drawing.Size(158, 20);
             this.textBoxFilter.TabIndex = 13;
+            this.textBoxFilter.TextChanged += new System.EventHandler(this.textBoxFilter_TextChanged);
             // 
             // labelFilter
             // 

--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -2700,6 +2700,29 @@ namespace Nikse.SubtitleEdit.Forms
             textBoxFilter.Visible = comboBoxFilter.SelectedIndex == 3 || comboBoxFilter.SelectedIndex == 4 || comboBoxFilter.SelectedIndex == 5;
         }
 
+        private void textBoxFilter_TextChanged(object sender, EventArgs e)
+        {
+            if (listViewInputFiles.Items.Count == 0)
+            {
+                return;
+            }
+
+            if (comboBoxFilter.SelectedIndex == 5)
+            {
+                var listViewItems = new List<ListViewItem>();
+                foreach (ListViewItem item in listViewInputFiles.Items)
+                {
+                    listViewItems.Add(item);
+                }
+
+                listViewInputFiles.BeginUpdate();
+                listViewInputFiles.Items.Clear();
+                listViewInputFiles.Items.AddRange(listViewItems.FindAll(item => item.SubItems[2].Text.Contains(textBoxFilter.Text, StringComparison.OrdinalIgnoreCase)).ToArray());
+                listViewInputFiles.EndUpdate();
+                UpdateNumberOfFiles();
+            }
+        }
+
         private void buttonTransportStreamSettings_Click(object sender, EventArgs e)
         {
             using (var form = new BatchConvertTsSettings())


### PR DESCRIPTION
Hey, Nik.
Long time no PRs. :)

It's really annoying that sometimes I want to take just the Arabic files from a bunch of MKV files, but I forget to activate the filter before adding, so now I would have to remove the files and add them again after activating the filter.
So, I thought it would be a good idea to add the ability to filter the items based on the language code after adding the files.

Let me know what you think.