### PR TITLE
Add `Clear` key to list of shortcut keys

### DIFF
--- a/src/ui/Forms/Options/Settings.Designer.cs
+++ b/src/ui/Forms/Options/Settings.Designer.cs
@@ -1781,6 +1781,7 @@
             "Zoom",
             "NoName",
             "Pa1",
+            "Clear",
             "OemClear",
             "KeyCode",
             "F13",


### PR DESCRIPTION
I don't know if it was intentionally omitted, but I wanted to use it and couldn't find it so I thought I'd add it.
I hope that's okay.