### PR TITLE
Minor fix for go to and set video position

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -15368,8 +15368,9 @@ namespace Nikse.SubtitleEdit.Forms
                     textBoxListViewText.SelectAll();
                     GotoSubtitleIndex(newIndex);
                     ShowSubtitle();
-                    e.SuppressKeyPress = true;
                 }
+
+                e.SuppressKeyPress = true;
             }
             else if (_shortcuts.MainGoToNextSubtitleAndFocusVideo == e.KeyData)
             {
@@ -15383,8 +15384,9 @@ namespace Nikse.SubtitleEdit.Forms
                     textBoxListViewText.SelectAll();
                     GotoSubtitleIndex(newIndex);
                     ShowSubtitle();
-                    e.SuppressKeyPress = true;
                 }
+
+                e.SuppressKeyPress = true;
             }
             else if (_shortcuts.MainGoToNextSubtitleAndPlay == e.KeyData && mediaPlayer != null)
             {


### PR DESCRIPTION
I was using `Numpad6` as a shortcut to go to next, and when It reached the last line, it changed the text to `6` because the key isn't suppressed when the condition isn't met.