### PR TITLE
Measure using correct font for vertical bar in Textbox

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -9853,7 +9853,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     var calculatedHeight = TextRenderer.MeasureText(
                          tb.Text,
-                         tb.Font,
+                         new Font(Configuration.Settings.General.SubtitleFontName, Configuration.Settings.General.SubtitleTextBoxFontSize),
                          new Size(tb.Width, 1000),
                          TextFormatFlags.WordBreak | TextFormatFlags.TextBoxControl).Height;
                     tb.ScrollBars = calculatedHeight > tb.Height ? RichTextBoxScrollBars.Vertical : RichTextBoxScrollBars.None;


### PR DESCRIPTION
It's a fix, not sure if it's THE fix, the `tb.Font` was giving `Tahoma`.

https://github.com/SubtitleEdit/subtitleedit/issues/5523#issuecomment-979334182