### PR TITLE
Some work on spell check design

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1186,7 +1186,6 @@ $HorzAlign          =   Center
         public bool FixContinuationStyleHideContinuationCandidatesWithoutName { get; set; }
         public bool FixContinuationStyleIgnoreLyrics { get; set; }
         public string SpellCheckLanguage { get; set; }
-        public bool SpellCheckFontBold { get; set; }
         public string VideoPlayer { get; set; }
         public int VideoPlayerDefaultVolume { get; set; }
         public string VideoPlayerPreviewFontName { get; set; }
@@ -1361,7 +1360,6 @@ $HorzAlign          =   Center
             FixContinuationStyleHideContinuationCandidatesWithoutName = true;
             FixContinuationStyleIgnoreLyrics = true;
             SpellCheckLanguage = null;
-            SpellCheckFontBold = false;
             VideoPlayer = string.Empty;
             VideoPlayerDefaultVolume = 75;
             VideoPlayerPreviewFontName = "Tahoma";
@@ -3342,12 +3340,6 @@ $HorzAlign          =   Center
             if (subNode != null)
             {
                 settings.General.SpellCheckLanguage = subNode.InnerText;
-            }
-
-            subNode = node.SelectSingleNode("SpellCheckFontBold");
-            if (subNode != null)
-            {
-                settings.General.SpellCheckFontBold = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
             subNode = node.SelectSingleNode("VideoPlayer");
@@ -8952,7 +8944,6 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("FixContinuationStyleUncheckInsertsLowercase", settings.General.FixContinuationStyleUncheckInsertsLowercase.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("FixContinuationStyleHideContinuationCandidatesWithoutName", settings.General.FixContinuationStyleHideContinuationCandidatesWithoutName.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("SpellCheckLanguage", settings.General.SpellCheckLanguage);
-                textWriter.WriteElementString("SpellCheckFontBold", settings.General.SpellCheckFontBold.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("VideoPlayer", settings.General.VideoPlayer);
                 textWriter.WriteElementString("VideoPlayerDefaultVolume", settings.General.VideoPlayerDefaultVolume.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("VideoPlayerPreviewFontName", settings.General.VideoPlayerPreviewFontName);

--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1186,6 +1186,7 @@ $HorzAlign          =   Center
         public bool FixContinuationStyleHideContinuationCandidatesWithoutName { get; set; }
         public bool FixContinuationStyleIgnoreLyrics { get; set; }
         public string SpellCheckLanguage { get; set; }
+        public bool SpellCheckFontBold { get; set; }
         public string VideoPlayer { get; set; }
         public int VideoPlayerDefaultVolume { get; set; }
         public string VideoPlayerPreviewFontName { get; set; }
@@ -1360,6 +1361,7 @@ $HorzAlign          =   Center
             FixContinuationStyleHideContinuationCandidatesWithoutName = true;
             FixContinuationStyleIgnoreLyrics = true;
             SpellCheckLanguage = null;
+            SpellCheckFontBold = false;
             VideoPlayer = string.Empty;
             VideoPlayerDefaultVolume = 75;
             VideoPlayerPreviewFontName = "Tahoma";
@@ -3340,6 +3342,12 @@ $HorzAlign          =   Center
             if (subNode != null)
             {
                 settings.General.SpellCheckLanguage = subNode.InnerText;
+            }
+
+            subNode = node.SelectSingleNode("SpellCheckFontBold");
+            if (subNode != null)
+            {
+                settings.General.SpellCheckFontBold = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
             subNode = node.SelectSingleNode("VideoPlayer");
@@ -8944,6 +8952,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("FixContinuationStyleUncheckInsertsLowercase", settings.General.FixContinuationStyleUncheckInsertsLowercase.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("FixContinuationStyleHideContinuationCandidatesWithoutName", settings.General.FixContinuationStyleHideContinuationCandidatesWithoutName.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("SpellCheckLanguage", settings.General.SpellCheckLanguage);
+                textWriter.WriteElementString("SpellCheckFontBold", settings.General.SpellCheckFontBold.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("VideoPlayer", settings.General.VideoPlayer);
                 textWriter.WriteElementString("VideoPlayerDefaultVolume", settings.General.VideoPlayerDefaultVolume.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("VideoPlayerPreviewFontName", settings.General.VideoPlayerPreviewFontName);

--- a/src/ui/Forms/SpellCheck.Designer.cs
+++ b/src/ui/Forms/SpellCheck.Designer.cs
@@ -154,7 +154,7 @@
             this.listBoxSuggestions.ItemHeight = 16;
             this.listBoxSuggestions.Location = new System.Drawing.Point(8, 47);
             this.listBoxSuggestions.Name = "listBoxSuggestions";
-            this.listBoxSuggestions.Size = new System.Drawing.Size(272, 146);
+            this.listBoxSuggestions.Size = new System.Drawing.Size(272, 212);
             this.listBoxSuggestions.TabIndex = 2;
             this.listBoxSuggestions.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.ListBoxSuggestionsMouseDoubleClick);
             // 
@@ -303,9 +303,9 @@
             this.groupBoxSuggestions.Controls.Add(this.buttonUseSuggestionAlways);
             this.groupBoxSuggestions.Controls.Add(this.checkBoxAutoChangeNames);
             this.groupBoxSuggestions.Controls.Add(this.listBoxSuggestions);
-            this.groupBoxSuggestions.Location = new System.Drawing.Point(386, 165);
+            this.groupBoxSuggestions.Location = new System.Drawing.Point(386, 100);
             this.groupBoxSuggestions.Name = "groupBoxSuggestions";
-            this.groupBoxSuggestions.Size = new System.Drawing.Size(291, 222);
+            this.groupBoxSuggestions.Size = new System.Drawing.Size(291, 287);
             this.groupBoxSuggestions.TabIndex = 1;
             this.groupBoxSuggestions.TabStop = false;
             this.groupBoxSuggestions.Text = "Suggestions";
@@ -314,7 +314,7 @@
             // 
             this.checkBoxAutoChangeNames.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.checkBoxAutoChangeNames.AutoSize = true;
-            this.checkBoxAutoChangeNames.Location = new System.Drawing.Point(8, 192);
+            this.checkBoxAutoChangeNames.Location = new System.Drawing.Point(8, 264);
             this.checkBoxAutoChangeNames.Name = "checkBoxAutoChangeNames";
             this.checkBoxAutoChangeNames.Size = new System.Drawing.Size(221, 17);
             this.checkBoxAutoChangeNames.TabIndex = 3;

--- a/src/ui/Forms/SpellCheck.Designer.cs
+++ b/src/ui/Forms/SpellCheck.Designer.cs
@@ -58,7 +58,7 @@
             // 
             this.buttonAddToDictionary.Location = new System.Drawing.Point(6, 134);
             this.buttonAddToDictionary.Name = "buttonAddToDictionary";
-            this.buttonAddToDictionary.Size = new System.Drawing.Size(280, 23);
+            this.buttonAddToDictionary.Size = new System.Drawing.Size(346, 23);
             this.buttonAddToDictionary.TabIndex = 6;
             this.buttonAddToDictionary.Text = "Add to user dictionary (not case sensitive)";
             this.buttonAddToDictionary.UseVisualStyleBackColor = true;
@@ -70,7 +70,7 @@
             // 
             this.buttonSkipOnce.Location = new System.Drawing.Point(6, 76);
             this.buttonSkipOnce.Name = "buttonSkipOnce";
-            this.buttonSkipOnce.Size = new System.Drawing.Size(136, 23);
+            this.buttonSkipOnce.Size = new System.Drawing.Size(170, 23);
             this.buttonSkipOnce.TabIndex = 3;
             this.buttonSkipOnce.Text = "Skip &once";
             this.buttonSkipOnce.UseVisualStyleBackColor = true;
@@ -82,7 +82,7 @@
             // 
             this.comboBoxDictionaries.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxDictionaries.FormattingEnabled = true;
-            this.comboBoxDictionaries.Location = new System.Drawing.Point(393, 34);
+            this.comboBoxDictionaries.Location = new System.Drawing.Point(386, 34);
             this.comboBoxDictionaries.Name = "comboBoxDictionaries";
             this.comboBoxDictionaries.Size = new System.Drawing.Size(245, 21);
             this.comboBoxDictionaries.TabIndex = 8;
@@ -91,7 +91,7 @@
             // labelLanguage
             // 
             this.labelLanguage.AutoSize = true;
-            this.labelLanguage.Location = new System.Drawing.Point(390, 14);
+            this.labelLanguage.Location = new System.Drawing.Point(383, 14);
             this.labelLanguage.Name = "labelLanguage";
             this.labelLanguage.Size = new System.Drawing.Size(54, 13);
             this.labelLanguage.TabIndex = 7;
@@ -101,7 +101,6 @@
             // 
             this.richTextBoxParagraph.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.richTextBoxParagraph.ContextMenuStrip = this.contextMenuStrip1;
-            this.richTextBoxParagraph.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.richTextBoxParagraph.Location = new System.Drawing.Point(11, 33);
             this.richTextBoxParagraph.Name = "richTextBoxParagraph";
             this.richTextBoxParagraph.ReadOnly = true;
@@ -155,7 +154,7 @@
             this.listBoxSuggestions.ItemHeight = 16;
             this.listBoxSuggestions.Location = new System.Drawing.Point(8, 47);
             this.listBoxSuggestions.Name = "listBoxSuggestions";
-            this.listBoxSuggestions.Size = new System.Drawing.Size(272, 180);
+            this.listBoxSuggestions.Size = new System.Drawing.Size(272, 146);
             this.listBoxSuggestions.TabIndex = 2;
             this.listBoxSuggestions.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.ListBoxSuggestionsMouseDoubleClick);
             // 
@@ -170,10 +169,9 @@
             // 
             // textBoxWord
             // 
-            this.textBoxWord.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxWord.Location = new System.Drawing.Point(6, 20);
             this.textBoxWord.Name = "textBoxWord";
-            this.textBoxWord.Size = new System.Drawing.Size(280, 21);
+            this.textBoxWord.Size = new System.Drawing.Size(346, 21);
             this.textBoxWord.TabIndex = 0;
             this.textBoxWord.TextChanged += new System.EventHandler(this.textBoxWord_TextChanged);
             // 
@@ -190,9 +188,9 @@
             // 
             // buttonSkipAll
             // 
-            this.buttonSkipAll.Location = new System.Drawing.Point(147, 76);
+            this.buttonSkipAll.Location = new System.Drawing.Point(182, 76);
             this.buttonSkipAll.Name = "buttonSkipAll";
-            this.buttonSkipAll.Size = new System.Drawing.Size(138, 23);
+            this.buttonSkipAll.Size = new System.Drawing.Size(170, 23);
             this.buttonSkipAll.TabIndex = 4;
             this.buttonSkipAll.Text = "&Skip all";
             this.buttonSkipAll.UseVisualStyleBackColor = true;
@@ -204,7 +202,7 @@
             // 
             this.buttonChange.Location = new System.Drawing.Point(6, 47);
             this.buttonChange.Name = "buttonChange";
-            this.buttonChange.Size = new System.Drawing.Size(136, 23);
+            this.buttonChange.Size = new System.Drawing.Size(170, 23);
             this.buttonChange.TabIndex = 1;
             this.buttonChange.Text = "Change";
             this.buttonChange.UseVisualStyleBackColor = true;
@@ -224,9 +222,9 @@
             // 
             // buttonChangeAll
             // 
-            this.buttonChangeAll.Location = new System.Drawing.Point(148, 47);
+            this.buttonChangeAll.Location = new System.Drawing.Point(182, 47);
             this.buttonChangeAll.Name = "buttonChangeAll";
-            this.buttonChangeAll.Size = new System.Drawing.Size(138, 23);
+            this.buttonChangeAll.Size = new System.Drawing.Size(170, 23);
             this.buttonChangeAll.TabIndex = 2;
             this.buttonChangeAll.Text = "Change all";
             this.buttonChangeAll.UseVisualStyleBackColor = true;
@@ -246,9 +244,9 @@
             // 
             // buttonAddToNames
             // 
-            this.buttonAddToNames.Location = new System.Drawing.Point(5, 105);
+            this.buttonAddToNames.Location = new System.Drawing.Point(6, 105);
             this.buttonAddToNames.Name = "buttonAddToNames";
-            this.buttonAddToNames.Size = new System.Drawing.Size(280, 23);
+            this.buttonAddToNames.Size = new System.Drawing.Size(346, 23);
             this.buttonAddToNames.TabIndex = 5;
             this.buttonAddToNames.Text = "Add to names/noise list (case sensitive)";
             this.buttonAddToNames.UseVisualStyleBackColor = true;
@@ -271,7 +269,7 @@
             this.groupBoxWordNotFound.Controls.Add(this.buttonChange);
             this.groupBoxWordNotFound.Location = new System.Drawing.Point(11, 165);
             this.groupBoxWordNotFound.Name = "groupBoxWordNotFound";
-            this.groupBoxWordNotFound.Size = new System.Drawing.Size(358, 218);
+            this.groupBoxWordNotFound.Size = new System.Drawing.Size(358, 222);
             this.groupBoxWordNotFound.TabIndex = 0;
             this.groupBoxWordNotFound.TabStop = false;
             this.groupBoxWordNotFound.Text = "Word not found";
@@ -280,7 +278,7 @@
             // 
             this.buttonGoogleIt.Location = new System.Drawing.Point(6, 163);
             this.buttonGoogleIt.Name = "buttonGoogleIt";
-            this.buttonGoogleIt.Size = new System.Drawing.Size(280, 23);
+            this.buttonGoogleIt.Size = new System.Drawing.Size(346, 23);
             this.buttonGoogleIt.TabIndex = 7;
             this.buttonGoogleIt.Text = "&Google it";
             this.buttonGoogleIt.UseVisualStyleBackColor = true;
@@ -290,7 +288,7 @@
             // 
             this.buttonUndo.Location = new System.Drawing.Point(6, 192);
             this.buttonUndo.Name = "buttonUndo";
-            this.buttonUndo.Size = new System.Drawing.Size(280, 23);
+            this.buttonUndo.Size = new System.Drawing.Size(346, 23);
             this.buttonUndo.TabIndex = 8;
             this.buttonUndo.Text = "Undo: skip all \'A\'";
             this.buttonUndo.UseVisualStyleBackColor = true;
@@ -305,9 +303,9 @@
             this.groupBoxSuggestions.Controls.Add(this.buttonUseSuggestionAlways);
             this.groupBoxSuggestions.Controls.Add(this.checkBoxAutoChangeNames);
             this.groupBoxSuggestions.Controls.Add(this.listBoxSuggestions);
-            this.groupBoxSuggestions.Location = new System.Drawing.Point(393, 73);
+            this.groupBoxSuggestions.Location = new System.Drawing.Point(386, 165);
             this.groupBoxSuggestions.Name = "groupBoxSuggestions";
-            this.groupBoxSuggestions.Size = new System.Drawing.Size(291, 271);
+            this.groupBoxSuggestions.Size = new System.Drawing.Size(291, 222);
             this.groupBoxSuggestions.TabIndex = 1;
             this.groupBoxSuggestions.TabStop = false;
             this.groupBoxSuggestions.Text = "Suggestions";
@@ -316,7 +314,7 @@
             // 
             this.checkBoxAutoChangeNames.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.checkBoxAutoChangeNames.AutoSize = true;
-            this.checkBoxAutoChangeNames.Location = new System.Drawing.Point(8, 247);
+            this.checkBoxAutoChangeNames.Location = new System.Drawing.Point(8, 192);
             this.checkBoxAutoChangeNames.Name = "checkBoxAutoChangeNames";
             this.checkBoxAutoChangeNames.Size = new System.Drawing.Size(221, 17);
             this.checkBoxAutoChangeNames.TabIndex = 3;
@@ -368,7 +366,7 @@
             // 
             // textBoxWholeText
             // 
-            this.textBoxWholeText.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.textBoxWholeText.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxWholeText.Location = new System.Drawing.Point(6, 19);
             this.textBoxWholeText.Multiline = true;
             this.textBoxWholeText.Name = "textBoxWholeText";
@@ -388,7 +386,7 @@
             // buttonSpellCheckDownload
             // 
             this.buttonSpellCheckDownload.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonSpellCheckDownload.Location = new System.Drawing.Point(644, 32);
+            this.buttonSpellCheckDownload.Location = new System.Drawing.Point(637, 32);
             this.buttonSpellCheckDownload.Name = "buttonSpellCheckDownload";
             this.buttonSpellCheckDownload.Size = new System.Drawing.Size(28, 23);
             this.buttonSpellCheckDownload.TabIndex = 9;

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -115,11 +115,10 @@ namespace Nikse.SubtitleEdit.Forms
             buttonGoogleIt.Text = LanguageSettings.Current.Main.VideoControls.GoogleIt;
             deleteToolStripMenuItem.Text = LanguageSettings.Current.General.DeleteCurrentLine;
 
-            if (Configuration.Settings.General.SpellCheckFontBold)
-            {
-                richTextBoxParagraph.Font = new Font(richTextBoxParagraph.Font.FontFamily, 9.75F, FontStyle.Bold);
-                textBoxWholeText.Font = new Font(textBoxWholeText.Font, FontStyle.Bold);
-            }
+            var gs = Configuration.Settings.General;
+            var textBoxFont = gs.SubtitleTextBoxFontBold ? new Font(gs.SubtitleFontName, gs.SubtitleTextBoxFontSize, FontStyle.Bold) : new Font(gs.SubtitleFontName, gs.SubtitleTextBoxFontSize);
+            richTextBoxParagraph.Font = textBoxFont;
+            textBoxWholeText.Font = textBoxFont;
 
             UiUtil.FixLargeFonts(this, buttonAbort);
             richTextBoxParagraph.DetectUrls = false;

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -114,6 +114,13 @@ namespace Nikse.SubtitleEdit.Forms
             buttonAddToNames.Text = LanguageSettings.Current.SpellCheck.AddToNamesAndIgnoreList;
             buttonGoogleIt.Text = LanguageSettings.Current.Main.VideoControls.GoogleIt;
             deleteToolStripMenuItem.Text = LanguageSettings.Current.General.DeleteCurrentLine;
+
+            if (Configuration.Settings.General.SpellCheckFontBold)
+            {
+                richTextBoxParagraph.Font = new Font(richTextBoxParagraph.Font.FontFamily, 9.75F, FontStyle.Bold);
+                textBoxWholeText.Font = new Font(textBoxWholeText.Font, FontStyle.Bold);
+            }
+
             UiUtil.FixLargeFonts(this, buttonAbort);
             richTextBoxParagraph.DetectUrls = false;
         }


### PR DESCRIPTION
I never liked that the using a bold font was forced, maybe it looked good for English but It didn't look good for other languages, Arabic at least.
Also, the buttons that are not filling the groupbox didn't look good, and there wasn't enough proper space for the Undo button.
The way the Suggestions section was in a proper section of its own was better as well in my opinion.

So I did some tweaks, before:
![image](https://user-images.githubusercontent.com/20923700/143583348-c93cb7ef-57ca-4554-bff2-166fcfdce0c0.png)

After:
![image](https://user-images.githubusercontent.com/20923700/143583376-d6004cca-681d-4d1c-a6b0-27231274a71d.png)

I added the `Bold` option as a hidden setting, one might activate it if the font is too small for them.

@niksedk What's your take on this? Do you think there should be visible options to select the font and its size and boldness in the UI?