### PR TITLE
Set empty wave path for online videos in Waveforms folder

### DIFF
--- a/src/libse/Common/WaveToVisualizer.cs
+++ b/src/libse/Common/WaveToVisualizer.cs
@@ -347,13 +347,14 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static string GetPeakWaveFileName(string videoFileName, int trackNumber = 0)
         {
+            var dir = Configuration.WaveformsDirectory.TrimEnd(Path.DirectorySeparatorChar);
+
             if (videoFileName != null && (videoFileName.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
                                           videoFileName.StartsWith("https://", StringComparison.OrdinalIgnoreCase)))
             {
-                return MovieHasher.GenerateHashFromString(videoFileName);
+                return Path.Combine(dir, $"{MovieHasher.GenerateHashFromString(videoFileName)}.wav");
             }
 
-            var dir = Configuration.WaveformsDirectory.TrimEnd(Path.DirectorySeparatorChar);
             if (!Directory.Exists(dir))
             {
                 Directory.CreateDirectory(dir);


### PR DESCRIPTION
Right now the empty wave generated for an online stream is saved on the directory where the executable is, so when the executable is installed, we get an error when it tries to save the file in the installation directory.

![image](https://user-images.githubusercontent.com/20923700/144903508-23ba5e6f-8037-4416-ae06-651d1e0ac859.png)


In this PR, I made it save it like the other waveforms, in the waveforms directory.