### PR TITLE
Replace timed text 1.0 ext in favorite formats if changed

### DIFF
--- a/src/ui/Forms/TimedTextProperties.cs
+++ b/src/ui/Forms/TimedTextProperties.cs
@@ -310,7 +310,21 @@ namespace Nikse.SubtitleEdit.Forms
             _subtitle.Header = _xml.OuterXml;
 
             Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormat = comboBoxTimeCodeFormat.SelectedItem.ToString();
-            Configuration.Settings.SubtitleSettings.TimedText10FileExtension= comboBoxFileExtensions.SelectedItem.ToString();
+
+            var currentTimedTextExt = Configuration.Settings.SubtitleSettings.TimedText10FileExtension;
+            var newTimedTextExt = comboBoxFileExtensions.SelectedItem.ToString();
+            if (currentTimedTextExt != newTimedTextExt)
+            {
+                var favoriteFormats = Configuration.Settings.General.FavoriteSubtitleFormats;
+                var currentTimedTextWithExt = $"Timed Text 1.0 ({currentTimedTextExt})";
+                var newTimedTextWithExt = $"Timed Text 1.0 ({newTimedTextExt})";
+                if (favoriteFormats.Contains(currentTimedTextWithExt))
+                {
+                    Configuration.Settings.General.FavoriteSubtitleFormats = favoriteFormats.Replace(currentTimedTextWithExt, newTimedTextWithExt);
+                }
+
+                Configuration.Settings.SubtitleSettings.TimedText10FileExtension = newTimedTextExt;
+            }
 
             DialogResult = DialogResult.OK;
         }


### PR DESCRIPTION
When you have `TimedText10FileExtension` as `.xml` then change it to `.dfxp`, not changing it in the favorites cases a crash in SE when launching.

I tried fixing it here by replacing the old entry with the new one if it exists.