### PR TITLE
Add missing namespaces to manager in TimedText properties

### DIFF
--- a/src/ui/Forms/TimedTextProperties.cs
+++ b/src/ui/Forms/TimedTextProperties.cs
@@ -10,10 +10,10 @@ namespace Nikse.SubtitleEdit.Forms
 {
     public partial class TimedTextProperties : PositionAndSizeForm
     {
-        private Subtitle _subtitle;
-        private XmlDocument _xml;
-        private XmlNamespaceManager _nsmgr;
-        private string _NA;
+        private readonly Subtitle _subtitle;
+        private readonly XmlDocument _xml;
+        private readonly XmlNamespaceManager _nsmgr;
+        private readonly string _NA;
 
         public TimedTextProperties(Subtitle subtitle)
         {
@@ -40,7 +40,10 @@ namespace Nikse.SubtitleEdit.Forms
                 _xml.LoadXml(subtitle.Header); // load default xml
             }
             _nsmgr = new XmlNamespaceManager(_xml.NameTable);
-            _nsmgr.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
+            _nsmgr.AddNamespace("ttml", TimedText10.TtmlNamespace);
+            _nsmgr.AddNamespace("ttp", TimedText10.TtmlParameterNamespace);
+            _nsmgr.AddNamespace("tts", TimedText10.TtmlStylingNamespace);
+            _nsmgr.AddNamespace("ttm", TimedText10.TtmlMetadataNamespace);
 
             XmlNode node = _xml.DocumentElement.SelectSingleNode("ttml:head/ttml:metadata/ttml:title", _nsmgr);
             if (node != null)

--- a/src/ui/Forms/TimedTextPropertiesItunes.cs
+++ b/src/ui/Forms/TimedTextPropertiesItunes.cs
@@ -10,10 +10,10 @@ namespace Nikse.SubtitleEdit.Forms
 {
     public partial class TimedTextPropertiesItunes : PositionAndSizeForm
     {
-        private Subtitle _subtitle;
-        private XmlDocument _xml;
-        private XmlNamespaceManager _nsmgr;
-        private string _NA;
+        private readonly Subtitle _subtitle;
+        private readonly XmlDocument _xml;
+        private readonly XmlNamespaceManager _nsmgr;
+        private readonly string _NA;
 
         public TimedTextPropertiesItunes(Subtitle subtitle)
         {
@@ -40,7 +40,10 @@ namespace Nikse.SubtitleEdit.Forms
                 _xml.LoadXml(subtitle.Header); // load default xml
             }
             _nsmgr = new XmlNamespaceManager(_xml.NameTable);
-            _nsmgr.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
+            _nsmgr.AddNamespace("ttml", TimedText10.TtmlNamespace);
+            _nsmgr.AddNamespace("ttp", TimedText10.TtmlParameterNamespace);
+            _nsmgr.AddNamespace("tts", TimedText10.TtmlStylingNamespace);
+            _nsmgr.AddNamespace("ttm", TimedText10.TtmlMetadataNamespace);
 
             XmlNode node = _xml.DocumentElement.SelectSingleNode("ttml:head/ttml:metadata/ttml:title", _nsmgr);
             if (node != null)


### PR DESCRIPTION
I think the `ttp` prefix for `frameRate`, `frameRateMultiplier`, and `dropMode` was not being set because the namespace manager did not have those namespaces in it, and so they are not saved correctly and the file isn't loaded correctly when the frame rate is different and these attributes are not loaded correctly in the properties form.

I hope you weren't working on this. :)