### PR TITLE
libse: add .net6 target and improve Matroska zlib code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "{build}"
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 platform:
   - Any CPU

--- a/src/libse/ContainerFormats/Matroska/MatroskaSubtitle.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaSubtitle.cs
@@ -31,20 +31,22 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
             }
 
             var outStream = new MemoryStream();
+#if NET6_0
+            var outZStream = new System.IO.Compression.ZLibStream(outStream, System.IO.Compression.CompressionMode.Decompress);
+#else
             var outZStream = new ComponentAce.Compression.Libs.zlib.ZOutputStream(outStream);
-            var inStream = new MemoryStream(Data);
+#endif
             byte[] buffer;
             try
             {
-                MatroskaTrackInfo.CopyStream(inStream, outZStream);
-                buffer = new byte[outZStream.TotalOut];
-                outStream.Position = 0;
-                outStream.Read(buffer, 0, buffer.Length);
+                outZStream.Write(Data, 0, Data.Length);
+                outZStream.Flush();
+                return outStream.ToArray();
             }
             finally
             {
+                outStream.Close();
                 outZStream.Close();
-                inStream.Close();
             }
             return buffer;
         }

--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(VisualStudioVersion)' == '15.0' ">net472</TargetFrameworks>
     <RootNamespace>Nikse.SubtitleEdit.Core</RootNamespace>
     <AssemblyName>libse</AssemblyName>
@@ -60,6 +60,9 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="UTF.Unknown" Version="2.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
     <PackageReference Include="zlib.net-mutliplatform" Version="1.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
Uses System.IO.Compression instead of a 3rd party library for zlib when targeting
.net6