### PR TITLE
libse: improve Matroska zlib code

### DIFF
--- a/src/libse/ContainerFormats/Matroska/MatroskaSubtitle.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaSubtitle.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
 using System.IO;
+using System.IO.Compression;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
 {
@@ -30,21 +31,20 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
                 return Data;
             }
 
+            var inStream = new MemoryStream(Data, 0, Data.Length, false, true);
             var outStream = new MemoryStream();
-            var outZStream = new ComponentAce.Compression.Libs.zlib.ZOutputStream(outStream);
-            var inStream = new MemoryStream(Data);
+            var decompressStream = new ZLibStream(inStream, CompressionMode.Decompress);
             byte[] buffer;
             try
             {
-                MatroskaTrackInfo.CopyStream(inStream, outZStream);
-                buffer = new byte[outZStream.TotalOut];
-                outStream.Position = 0;
-                outStream.Read(buffer, 0, buffer.Length);
+                decompressStream.CopyTo(outStream);
+                return outStream.ToArray();
             }
             finally
             {
-                outZStream.Close();
                 inStream.Close();
+                outStream.Close();
+                decompressStream.Close();
             }
             return buffer;
         }

--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <UseWindowsForms>true</UseWindowsForms>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Nikse.SubtitleEdit.Core</RootNamespace>
     <AssemblyName>libse</AssemblyName>
@@ -39,15 +38,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
     <PackageReference Include="UTF.Unknown" Version="2.5.0" />
-    <PackageReference Include="zlib.net-mutliplatform" Version="1.0.5" />
-  </ItemGroup>  
-  
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Uses System.IO.Compression instead of a 3rd party library