### PR TITLE
Fix width for files with bookmarks

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -17826,7 +17826,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void SetListViewStateImages()
         {
-            var oldStaeImageList = SubtitleListview1.StateImageList;
+            var oldStateImageList = SubtitleListview1.StateImageList;
             SubtitleListview1.StateImageList = _subtitle != null && _subtitle.Paragraphs.Any(p => p.Bookmark != null) ? imageListBookmarks : null;
             if (SubtitleListview1.StateImageList == null)
             {
@@ -17837,7 +17837,7 @@ namespace Nikse.SubtitleEdit.Forms
                 SubtitleListview1.Columns[SubtitleListview1.ColumnIndexNumber].Text = "    " + LanguageSettings.Current.General.NumberSymbol;
             }
 
-            if (oldStaeImageList == SubtitleListview1.StateImageList)
+            if (oldStateImageList == SubtitleListview1.StateImageList)
             {
                 return;
             }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -12260,7 +12260,9 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (SubtitleListview1.ColumnIndexNumber >= 0)
                 {
-                    Configuration.Settings.General.ListViewNumberWidth = SubtitleListview1.Columns[SubtitleListview1.ColumnIndexNumber].Width;
+                    var fileHasBookmarkedLines = _subtitle != null && _subtitle.Paragraphs.Any(p => p.Bookmark != null);
+                    var columnIndexNumberWidth = SubtitleListview1.Columns[SubtitleListview1.ColumnIndexNumber].Width;
+                    Configuration.Settings.General.ListViewNumberWidth = fileHasBookmarkedLines ? columnIndexNumberWidth - 18 : columnIndexNumberWidth;
                 }
 
                 if (SubtitleListview1.ColumnIndexStart >= 0)
@@ -23032,6 +23034,10 @@ namespace Nikse.SubtitleEdit.Forms
 
             imageListBookmarks.Images.Add(pictureBoxBookmark.Image);
             SetListViewStateImages();
+            if (_subtitle != null && _subtitle.Paragraphs.Any(p => p.Bookmark != null))
+            {
+                SubtitleListview1.Columns[SubtitleListview1.ColumnIndexNumber].Width = SubtitleListview1.Columns[SubtitleListview1.ColumnIndexNumber].Width + 18;
+            }
 
             toolStripButtonToggleVideo.Checked = !Configuration.Settings.General.ShowVideoPlayer;
             toolStripButtonToggleVideo_Click(null, null);


### PR DESCRIPTION
As I've explained in my emails, opening a file that has bookmarks and wasn't opened when SE was closed causes an issue in the index column's width.

I tried to fix this here by making SE always save the actual width without the bookmark image width when closing and adding it to the column when SE is opened.

This will not have conflicts with the `SetListViewStateImages` function because it's done before `_loading` is set to `false`.