### PR TITLE
Unbreak line when using merge if needed

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -11468,9 +11468,17 @@ namespace Nikse.SubtitleEdit.Forms
                         .Replace(" " + Environment.NewLine, string.Empty)
                         .Replace(Environment.NewLine, string.Empty);
                 }
-                else
+                else if (breakMode == BreakMode.AutoBreak)
                 {
                     text = Utilities.AutoBreakLine(text, LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitle));
+                }
+                else
+                {
+                    var textUnbroken = text.Replace(Environment.NewLine, " ");
+                    if (textUnbroken.Length <= Configuration.Settings.General.SubtitleLineMaximumLength)
+                    {
+                        text = textUnbroken;
+                    }
                 }
 
                 currentParagraph.Text = text;
@@ -11771,8 +11779,10 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     else
                     {
-                        currentParagraph.Text = (currentParagraph.Text.Trim() + Environment.NewLine +
-                                                 RemoveAssStartAlignmentTag(nextParagraph.Text).Trim()).Trim();
+                        var merged = (currentParagraph.Text.Trim() + Environment.NewLine +
+                                              RemoveAssStartAlignmentTag(nextParagraph.Text).Trim()).Trim();
+                        var mergedUnbroken = merged.Replace(Environment.NewLine, " ");
+                        currentParagraph.Text = mergedUnbroken.Length <= Configuration.Settings.General.SubtitleLineMaximumLength ? mergedUnbroken : merged;
                     }
 
                     currentParagraph.Text = ChangeAllLinesTagsToSingleTag(currentParagraph.Text, "i");


### PR DESCRIPTION
When merging two lines, I think it would be better if the two lines are put on one line if they can fit in it?

Like if you have:
```
1
Hey.

2
How are you?
```

Isn't it better for it to become `Hey. How are you?` instead of:
```
Hey.
How are you?
```

when the combined line is shorter than the max length?

This might be a big change to "Merge" behavior, so I would understand if it's not okay.