### PR TITLE
Fix Close video shortcut not working after loading a video

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -20718,6 +20718,7 @@ namespace Nikse.SubtitleEdit.Forms
             mediaPlayer.ShowFullscreenButton = Configuration.Settings.General.VideoPlayerShowFullscreenButton;
             mediaPlayer.OnButtonClicked -= MediaPlayer_OnButtonClicked;
             mediaPlayer.OnButtonClicked += MediaPlayer_OnButtonClicked;
+            closeVideoToolStripMenuItem.Enabled = true;
 
             if (_videoInfo.VideoCodec != null)
             {
@@ -26641,6 +26642,7 @@ namespace Nikse.SubtitleEdit.Forms
             timeUpDownVideoPositionAdjust.Enabled = false;
             timeUpDownVideoPosition.TimeCode = new TimeCode();
             timeUpDownVideoPosition.Enabled = false;
+            closeVideoToolStripMenuItem.Enabled = false;
             CheckSecondSubtitleReset();
         }
 


### PR DESCRIPTION
When you open a video and then try using the `Close video` shortcut without opening the `Video` menu, it doesn't work because the item is disabled and it only gets enabled when opening the `Video` menu.
So I enabled the item when the video is loaded.

Also, when closing the video using the shortcut and then trying to use it again, it tries closing the video because the item isn't disabled until opening the menu, so I made is disable it after the video is closed.