### PR TITLE
Fix beep sound with some shortcut for Go to bookmark

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -15694,7 +15694,7 @@ namespace Nikse.SubtitleEdit.Forms
             else if (_shortcuts.MainGeneralGoToBookmark == e.KeyData)
             {
                 e.SuppressKeyPress = true;
-                GoToBookmark();
+                BeginInvoke(new Action(() => GoToBookmark()));
             }
             else if (_shortcuts.MainGeneralGoToPreviousBookmark == e.KeyData)
             {


### PR DESCRIPTION
Shortcuts like `Alt + G` were causing this to make a beep sound.
Found the fix here: https://stackoverflow.com/questions/19219597/cannot-disable-beep-sound-on-textbox-keydown-event/19230895#19230895