### PR TITLE
Use comma not semicolon in CSV export

### DIFF
--- a/src/ui/Forms/BookmarksGoTo.cs
+++ b/src/ui/Forms/BookmarksGoTo.cs
@@ -110,13 +110,13 @@ namespace Nikse.SubtitleEdit.Forms
                     sb.AppendLine(MakeParagraphCsvLine(p));
                 }
 
-                File.WriteAllText(saveDialog.FileName, sb.ToString());
+                File.WriteAllText(saveDialog.FileName, sb.ToString(), Encoding.UTF8);
             }
         }
 
         private static string MakeParagraphCsvLine(Paragraph paragraph)
         {
-            const string separator = ";";
+            const string separator = ",";
             var sb = new StringBuilder();
             sb.Append(paragraph.Number + separator);
             sb.Append(ToCsvText(paragraph.StartTime.ToDisplayString()) + separator);

--- a/src/ui/Forms/ErrorsGoTo.cs
+++ b/src/ui/Forms/ErrorsGoTo.cs
@@ -221,13 +221,13 @@ namespace Nikse.SubtitleEdit.Forms
                     sb.AppendLine(MakeParagraphCsvLine(p));
                 }
 
-                File.WriteAllText(saveDialog.FileName, sb.ToString());
+                File.WriteAllText(saveDialog.FileName, sb.ToString(), Encoding.UTF8);
             }
         }
 
         private static string MakeParagraphCsvLine(Paragraph paragraph)
         {
-            const string separator = ";";
+            const string separator = ",";
             var sb = new StringBuilder();
             sb.Append(paragraph.Number + separator);
             sb.Append(ToCsvText(paragraph.StartTime.ToDisplayString()) + separator);


### PR DESCRIPTION
Was the semicolon intended?
When I opened my exported CSV file is was just one column.

The Encoding was also not set properly.