### PR TITLE
Add "Edit bookmark" shortcut

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -2067,6 +2067,7 @@ $HorzAlign          =   Center
         public string GeneralGoToNextSubtitleAndPlay { get; set; }
         public string GeneralToggleBookmarks { get; set; }
         public string GeneralToggleBookmarksWithText { get; set; }
+        public string GeneralEditBookmarks { get; set; }
         public string GeneralClearBookmarks { get; set; }
         public string GeneralGoToBookmark { get; set; }
         public string GeneralGoToPreviousBookmark { get; set; }
@@ -7484,6 +7485,12 @@ $HorzAlign          =   Center
                     shortcuts.GeneralToggleBookmarksWithText = subNode.InnerText;
                 }
 
+                subNode = node.SelectSingleNode("GeneralEditBookmarks");
+                if (subNode != null)
+                {
+                    shortcuts.GeneralEditBookmarks = subNode.InnerText;
+                }
+
                 subNode = node.SelectSingleNode("GeneralClearBookmarks");
                 if (subNode != null)
                 {
@@ -10163,6 +10170,7 @@ $HorzAlign          =   Center
             textWriter.WriteElementString("GeneralPlayFirstSelected", shortcuts.GeneralPlayFirstSelected);
             textWriter.WriteElementString("GeneralToggleBookmarks", shortcuts.GeneralToggleBookmarks);
             textWriter.WriteElementString("GeneralToggleBookmarksWithText", shortcuts.GeneralToggleBookmarksWithText);
+            textWriter.WriteElementString("GeneralEditBookmarks", shortcuts.GeneralEditBookmarks);
             textWriter.WriteElementString("GeneralClearBookmarks", shortcuts.GeneralClearBookmarks);
             textWriter.WriteElementString("GeneralGoToBookmark", shortcuts.GeneralGoToBookmark);
             textWriter.WriteElementString("GeneralGoToNextBookmark", shortcuts.GeneralGoToNextBookmark);

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -15794,6 +15794,16 @@ namespace Nikse.SubtitleEdit.Forms
                 ToggleBookmarks(false);
                 e.SuppressKeyPress = true;
             }
+            else if (_shortcuts.MainGeneralEditBookmark == e.KeyData)
+            {
+                var p = _subtitle.GetParagraphOrDefault(_subtitleListViewIndex);
+                if (p?.Bookmark != null)
+                {
+                    labelBookmark_DoubleClick(null, null);
+                }
+
+                e.SuppressKeyPress = true;
+            }
             else if (_shortcuts.MainGeneralClearBookmarks == e.KeyData)
             {
                 ClearBookmarks();

--- a/src/ui/Forms/Options/Settings.cs
+++ b/src/ui/Forms/Options/Settings.cs
@@ -1256,6 +1256,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             AddNode(generalNode, language.GoToNextSubtitleAndPlay, nameof(Configuration.Settings.Shortcuts.GeneralGoToNextSubtitleAndPlay));
             AddNode(generalNode, language.ToggleBookmarks, nameof(Configuration.Settings.Shortcuts.GeneralToggleBookmarks));
             AddNode(generalNode, language.ToggleBookmarksWithComment, nameof(Configuration.Settings.Shortcuts.GeneralToggleBookmarksWithText), true);
+            AddNode(generalNode, LanguageSettings.Current.Bookmarks.EditBookmark, nameof(Configuration.Settings.Shortcuts.GeneralEditBookmarks), true);
             AddNode(generalNode, language.ClearBookmarks, nameof(Configuration.Settings.Shortcuts.GeneralClearBookmarks));
             AddNode(generalNode, language.GoToBookmark, nameof(Configuration.Settings.Shortcuts.GeneralGoToBookmark));
             AddNode(generalNode, language.GoToPreviousBookmark, nameof(Configuration.Settings.Shortcuts.GeneralGoToPreviousBookmark));

--- a/src/ui/Logic/MainShortcuts.cs
+++ b/src/ui/Logic/MainShortcuts.cs
@@ -81,6 +81,7 @@ namespace Nikse.SubtitleEdit.Logic
         public Keys MainAutoCalcCurrentDurationByMinReadingSpeed { get; set; }
         public Keys MainGeneralToggleBookmarks { get; set; }
         public Keys MainGeneralToggleBookmarksAddComment { get; set; }
+        public Keys MainGeneralEditBookmark { get; set; }
         public Keys MainGeneralClearBookmarks { get; set; }
         public Keys MainGeneralGoToBookmark { get; set; }
         public Keys MainGeneralGoToPreviousBookmark { get; set; }
@@ -292,6 +293,7 @@ namespace Nikse.SubtitleEdit.Logic
             MainAutoCalcCurrentDurationByMinReadingSpeed = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralAutoCalcCurrentDurationByMinReadingSpeed);
             MainGeneralToggleBookmarks = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralToggleBookmarks);
             MainGeneralToggleBookmarksAddComment = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralToggleBookmarksWithText);
+            MainGeneralEditBookmark = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralEditBookmarks);
             MainGeneralClearBookmarks = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralClearBookmarks);
             MainGeneralGoToBookmark = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralGoToBookmark);
             MainGeneralGoToPreviousBookmark = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralGoToPreviousBookmark);


### PR DESCRIPTION
I've been using Bookmarks in my QC process a bit, and I've noticed we already have shortcuts for everything related to them except for when we need to edit a bookmark so I thought I would add it, it's really helpful for when we want to quickly edit a bookmark's text instead of having to re-toggle it with text or use the mouse to edit it from the context menu.