### PR TITLE
Add blank lines to Modify selection

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -1895,6 +1895,7 @@ If you have edited this file with Subtitle Edit you might be able to find a back
     <DurationGreaterThan>Duration greater than</DurationGreaterThan>
     <MoreThanTwoLines>More than two lines</MoreThanTwoLines>
     <Bookmarked>Bookmarked</Bookmarked>
+    <BlankLines>Blank lines</BlankLines>
   </ModifySelection>
   <MultipleReplace>
     <Title>Multiple replace</Title>

--- a/src/ui/Forms/ModifySelection.cs
+++ b/src/ui/Forms/ModifySelection.cs
@@ -29,8 +29,9 @@ namespace Nikse.SubtitleEdit.Forms
         private const int FunctionDurationGreaterThan = 9;
         private const int FunctionMoreThanTwoLines = 10;
         private const int FunctionBookmarked = 11;
-        private const int FunctionStyle = 12;
-        private const int FunctionActor = 13;
+        private const int FunctionBlankLines = 12;
+        private const int FunctionStyle = 13;
+        private const int FunctionActor = 14;
 
         private const string ContainsString = "Contains";
         private const string StartsWith = "Starts with";
@@ -44,6 +45,7 @@ namespace Nikse.SubtitleEdit.Forms
         private const string DurationGreaterThan = "Duration >";
         private const string MoreThanTwoLines = "More than two lines";
         private const string Bookmarked = "Bookmarked";
+        private const string BlankLines = "Blank lines";
         private const string Style = "Style";
         private const string Actor = "Actor";
 
@@ -92,6 +94,7 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxRule.Items.Add(LanguageSettings.Current.ModifySelection.DurationGreaterThan);
             comboBoxRule.Items.Add(LanguageSettings.Current.ModifySelection.MoreThanTwoLines);
             comboBoxRule.Items.Add(LanguageSettings.Current.ModifySelection.Bookmarked);
+            comboBoxRule.Items.Add(LanguageSettings.Current.ModifySelection.BlankLines);
             if (_format.HasStyleSupport)
             {
                 comboBoxRule.Items.Add(LanguageSettings.Current.General.Style);
@@ -137,6 +140,9 @@ namespace Nikse.SubtitleEdit.Forms
                     break;
                 case Bookmarked:
                     comboBoxRule.SelectedIndex = FunctionBookmarked;
+                    break;
+                case BlankLines:
+                    comboBoxRule.SelectedIndex = FunctionBlankLines;
                     break;
                 case Style when _format.HasStyleSupport:
                     comboBoxRule.SelectedIndex = FunctionStyle;
@@ -212,6 +218,9 @@ namespace Nikse.SubtitleEdit.Forms
                     break;
                 case FunctionBookmarked:
                     Configuration.Settings.Tools.ModifySelectionRule = Bookmarked;
+                    break;
+                case FunctionBlankLines:
+                    Configuration.Settings.Tools.ModifySelectionRule = BlankLines;
                     break;
                 case FunctionStyle:
                     Configuration.Settings.Tools.ModifySelectionRule = Style;
@@ -390,6 +399,13 @@ namespace Nikse.SubtitleEdit.Forms
                             listViewItems.Add(MakeListViewItem(p, i));
                         }
                     }
+                    else if (comboBoxRule.SelectedIndex == FunctionBlankLines) // Select blank lines
+                    {
+                        if (string.IsNullOrWhiteSpace(HtmlUtil.RemoveHtmlTags(p.Text, true)))
+                        {
+                            listViewItems.Add(MakeListViewItem(p, i));
+                        }
+                    }
                     else if (comboBoxRule.SelectedIndex == FunctionStyle) // Select styles
                     {
                         if (styles.Contains(string.IsNullOrEmpty(p.Style) ? p.Extra : p.Style))
@@ -461,7 +477,7 @@ namespace Nikse.SubtitleEdit.Forms
                 textBoxText.ContextMenuStrip = FindReplaceDialogHelper.GetRegExContextMenu(textBoxText);
                 checkBoxCaseSensitive.Enabled = false;
             }
-            else if (comboBoxRule.SelectedIndex == FunctionOdd || comboBoxRule.SelectedIndex == FunctionEven || comboBoxRule.SelectedIndex == FunctionMoreThanTwoLines || comboBoxRule.SelectedIndex == FunctionBookmarked)
+            else if (comboBoxRule.SelectedIndex == FunctionOdd || comboBoxRule.SelectedIndex == FunctionEven || comboBoxRule.SelectedIndex == FunctionMoreThanTwoLines || comboBoxRule.SelectedIndex == FunctionBookmarked || comboBoxRule.SelectedIndex == FunctionBlankLines)
             {
                 checkBoxCaseSensitive.Enabled = false;
                 textBoxText.ContextMenuStrip = null;

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -2194,7 +2194,8 @@ namespace Nikse.SubtitleEdit.Logic
                 DurationLessThan = "Duration less than",
                 DurationGreaterThan = "Duration greater than",
                 MoreThanTwoLines = "More than two lines",
-                Bookmarked = "Bookmarked"
+                Bookmarked = "Bookmarked",
+                BlankLines = "Blank lines"
             };
 
             MultipleReplace = new LanguageStructure.MultipleReplace

--- a/src/ui/Logic/LanguageDeserializer.cs
+++ b/src/ui/Logic/LanguageDeserializer.cs
@@ -5152,6 +5152,9 @@ namespace Nikse.SubtitleEdit.Logic
                 case "ModifySelection/Bookmarked":
                     language.ModifySelection.Bookmarked = reader.Value;
                     break;
+                case "ModifySelection/BlankLines":
+                    language.ModifySelection.BlankLines = reader.Value;
+                    break;
                 case "MultipleReplace/Title":
                     language.MultipleReplace.Title = reader.Value;
                     break;

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -2045,6 +2045,7 @@
             public string DurationGreaterThan { get; set; }
             public string MoreThanTwoLines { get; set; }
             public string Bookmarked { get; set; }
+            public string BlankLines { get; set; }
         }
 
         public class MultipleReplace


### PR DESCRIPTION
It's really helpful sometimes instead of having to write `^$` or something else to ignore tags like `^(?:{[^}]+})?(?:<[^>]+>)?$` in regex.