### PR TITLE
Edit selected lines details in status bar

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -23696,7 +23696,7 @@ namespace Nikse.SubtitleEdit.Forms
                 var selectedIndices = SubtitleListview1.GetSelectedIndices();
                 if (selectedIndices.Length == 1)
                 {
-                    toolStripSelected.Text = profile + string.Format("{0}/{1}", 1, _subtitle.Paragraphs.Count);
+                    toolStripSelected.Text = profile + string.Format("{0}/{1}", SubtitleListview1.SelectedIndices[0] + 1, _subtitle.Paragraphs.Count);
                 }
                 else if (selectedIndices.Length >= 2 && selectedIndices.Length <= 4)
                 {
@@ -23713,16 +23713,16 @@ namespace Nikse.SubtitleEdit.Forms
                         var minMs = list.Min(px => px.StartTime.TotalMilliseconds);
                         var maxMs = list.Max(px => px.EndTime.TotalMilliseconds);
                         var mergedTime = new TimeCode(maxMs - minMs);
-                        toolStripSelected.Text = profile + string.Format("{0}/{1}  {2}", selectedIndices.Length, _subtitle.Paragraphs.Count, mergedTime.ToShortDisplayString());
+                        toolStripSelected.Text = profile + string.Format(_language.XLinesSelected + "/{1}  {2}", selectedIndices.Length, _subtitle.Paragraphs.Count, mergedTime.ToShortDisplayString());
                     }
                     else
                     {
-                        toolStripSelected.Text = profile + string.Format("{0}/{1}", selectedIndices.Length, _subtitle.Paragraphs.Count);
+                        toolStripSelected.Text = profile + string.Format(_language.XLinesSelected + "/{1}", selectedIndices.Length, _subtitle.Paragraphs.Count);
                     }
                 }
                 else
                 {
-                    toolStripSelected.Text = profile + string.Format(_language.XLinesSelected, selectedIndices.Length);
+                    toolStripSelected.Text = profile + string.Format(_language.XLinesSelected + "/{1}", selectedIndices.Length, _subtitle.Paragraphs.Count);
                 }
             }
 


### PR DESCRIPTION
One line selected: 
We get like we did before 50/340 or 88/340
![image](https://user-images.githubusercontent.com/20923700/151796940-05922911-80e3-47ab-9898-87b6bb1763cb.png)
It's really useful to know your progress instead of having to check the current like number from the listview then see the total number from the bar. 


Between 2 and 4 like: 
2 lines selected/350 8:08 or 3 lines selected/350 5:10
![image](https://user-images.githubusercontent.com/20923700/151796928-08a46d0f-73ea-4c32-9c90-b1539ac30135.png)


More than 4 lines selected: 
50 lines selected/350 or 90 lines selected/350
![image](https://user-images.githubusercontent.com/20923700/151796915-f063f3f8-fe30-4783-b383-5c6a534514fa.png)


The format difference between `{0} lines selected/350` and `{0}/350` makes the user know if {0} is the number of the current line or the number of selected lines. 
