### PR TITLE
Fix issue with original text box vertical scroll bar

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -23386,6 +23386,7 @@ namespace Nikse.SubtitleEdit.Forms
             splitContainerListViewAndText.SplitterMoved += splitContainerListViewAndText_SplitterMoved;
             splitContainerListViewAndText.SizeChanged += splitContainerListViewAndText_SizeChanged;
             textBoxListViewText.SizeChanged += TextBoxListViewText_SizeChanged;
+            textBoxListViewTextOriginal.SizeChanged += TextBoxListViewTextOriginal_SizeChanged;
 
             imageListBookmarks.Images.Add(pictureBoxBookmark.Image);
             SetListViewStateImages();
@@ -23723,6 +23724,11 @@ namespace Nikse.SubtitleEdit.Forms
         private void TextBoxListViewText_SizeChanged(object sender, EventArgs e)
         {
             FixVerticalScrollBars(textBoxListViewText);
+        }
+
+        private void TextBoxListViewTextOriginal_SizeChanged(object sender, EventArgs e)
+        {
+            FixVerticalScrollBars(textBoxListViewTextOriginal);
         }
 
         private void InitializePlayRateDropDown()


### PR DESCRIPTION
Just noticed this:
![image](https://user-images.githubusercontent.com/20923700/152217404-f506cc1a-664e-4c79-a5de-27c05cc6aabd.png)

1. Open a file and original file.
2. Close SE while the files are opened.
3. Open SE.

The vertical bar shows up even though it's not needed.

I added checking the vertical bar when the original text box size is changed just as it is implemented for the normal text box.