### PR TITLE
Saving and restoring of the number of active audio track

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -2832,7 +2832,7 @@ $HorzAlign          =   Center
                     videoFileName = listNode.Attributes["VideoFileName"].Value;
                 }
 
-                string audioTrack = "1";
+                string audioTrack = "-1";
                 if (listNode.Attributes["AudioTrack"] != null)
                 {
                     audioTrack = listNode.Attributes["AudioTrack"].Value;

--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -20,6 +20,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         public string FileName { get; set; }
         public string OriginalFileName { get; set; }
         public string VideoFileName { get; set; }
+        public int AudioTrack { get; set; }
         public int FirstVisibleIndex { get; set; }
         public int FirstSelectedIndex { get; set; }
         public long VideoOffsetInMs { get; set; }
@@ -38,7 +39,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             Files = new List<RecentFileEntry>();
         }
 
-        public void Add(string fileName, int firstVisibleIndex, int firstSelectedIndex, string videoFileName, string originalFileName, long videoOffset, bool isSmpte)
+        public void Add(string fileName, int firstVisibleIndex, int firstSelectedIndex, string videoFileName, int audioTrack, string originalFileName, long videoOffset, bool isSmpte)
         {
             Files = Files.Where(p => !string.IsNullOrEmpty(p.FileName)).ToList();
 
@@ -57,7 +58,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var existingEntry = GetRecentFile(fileName, originalFileName);
             if (existingEntry == null)
             {
-                Files.Insert(0, new RecentFileEntry { FileName = fileName ?? string.Empty, FirstVisibleIndex = -1, FirstSelectedIndex = -1, VideoFileName = videoFileName, OriginalFileName = originalFileName });
+                Files.Insert(0, new RecentFileEntry { FileName = fileName ?? string.Empty, FirstVisibleIndex = -1, FirstSelectedIndex = -1, VideoFileName = videoFileName, AudioTrack = audioTrack, OriginalFileName = originalFileName });
             }
             else
             {
@@ -65,6 +66,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 existingEntry.FirstSelectedIndex = firstSelectedIndex;
                 existingEntry.FirstVisibleIndex = firstVisibleIndex;
                 existingEntry.VideoFileName = videoFileName;
+                existingEntry.AudioTrack = audioTrack;
                 existingEntry.OriginalFileName = originalFileName;
                 existingEntry.VideoOffsetInMs = videoOffset;
                 existingEntry.VideoIsSmpte = isSmpte;
@@ -73,14 +75,14 @@ namespace Nikse.SubtitleEdit.Core.Common
             Files = Files.Take(MaxRecentFiles).ToList();
         }
 
-        public void Add(string fileName, string videoFileName, string originalFileName)
+        public void Add(string fileName, string videoFileName, int audioTrack, string originalFileName)
         {
             Files = Files.Where(p => !string.IsNullOrEmpty(p.FileName)).ToList();
 
             var existingEntry = GetRecentFile(fileName, originalFileName);
             if (existingEntry == null)
             {
-                Files.Insert(0, new RecentFileEntry { FileName = fileName ?? string.Empty, FirstVisibleIndex = -1, FirstSelectedIndex = -1, VideoFileName = videoFileName, OriginalFileName = originalFileName });
+                Files.Insert(0, new RecentFileEntry { FileName = fileName ?? string.Empty, FirstVisibleIndex = -1, FirstSelectedIndex = -1, VideoFileName = videoFileName, AudioTrack = audioTrack, OriginalFileName = originalFileName});
             }
             else
             {
@@ -2830,6 +2832,12 @@ $HorzAlign          =   Center
                     videoFileName = listNode.Attributes["VideoFileName"].Value;
                 }
 
+                string audioTrack = "1";
+                if (listNode.Attributes["AudioTrack"] != null)
+                {
+                    audioTrack = listNode.Attributes["AudioTrack"].Value;
+                }
+
                 string originalFileName = null;
                 if (listNode.Attributes["OriginalFileName"] != null)
                 {
@@ -2848,7 +2856,7 @@ $HorzAlign          =   Center
                     bool.TryParse(listNode.Attributes["IsSmpte"].Value, out isSmpte);
                 }
 
-                settings.RecentFiles.Files.Add(new RecentFileEntry { FileName = listNode.InnerText, FirstVisibleIndex = int.Parse(firstVisibleIndex, CultureInfo.InvariantCulture), FirstSelectedIndex = int.Parse(firstSelectedIndex, CultureInfo.InvariantCulture), VideoFileName = videoFileName, OriginalFileName = originalFileName, VideoOffsetInMs = videoOffset, VideoIsSmpte = isSmpte });
+                settings.RecentFiles.Files.Add(new RecentFileEntry { FileName = listNode.InnerText, FirstVisibleIndex = int.Parse(firstVisibleIndex, CultureInfo.InvariantCulture), FirstSelectedIndex = int.Parse(firstSelectedIndex, CultureInfo.InvariantCulture), VideoFileName = videoFileName, AudioTrack = int.Parse(audioTrack, CultureInfo.InvariantCulture), OriginalFileName = originalFileName, VideoOffsetInMs = videoOffset, VideoIsSmpte = isSmpte });
             }
 
             // General
@@ -9237,6 +9245,7 @@ $HorzAlign          =   Center
                     if (item.VideoFileName != null)
                     {
                         textWriter.WriteAttributeString("VideoFileName", item.VideoFileName);
+                        textWriter.WriteAttributeString("AudioTrack", item.AudioTrack.ToString(CultureInfo.InvariantCulture));
                     }
 
                     textWriter.WriteAttributeString("FirstVisibleIndex", item.FirstVisibleIndex.ToString(CultureInfo.InvariantCulture));

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -4367,19 +4367,6 @@ namespace Nikse.SubtitleEdit.Forms
                 }
 
                 GotoSubPosAndPause();
-
-                /*if (VideoAudioTrackNumber > 0)
-                {
-                    if (mediaPlayer.VideoPlayer is LibVlcDynamic libVlc)
-                    {
-                        libVlc.AudioTrackNumber = VideoAudioTrackNumber;
-                    }
-                    else if (mediaPlayer.VideoPlayer is LibMpvDynamic libMpv)
-                    {
-                        libMpv.AudioTrackNumber = VideoAudioTrackNumber;
-                    }
-                }*/
-
                 SetRecentIndices(rfe);
                 SubtitleListview1.EndUpdate();
                 if (rfe != null && !string.IsNullOrEmpty(rfe.VideoFileName))

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -2820,7 +2820,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void OpenSubtitle(string fileName, Encoding encoding)
         {
-            OpenSubtitle(fileName, encoding, null, 1, null);
+            OpenSubtitle(fileName, encoding, null, -1, null);
         }
 
         private void ResetHistory()
@@ -21313,6 +21313,18 @@ namespace Nikse.SubtitleEdit.Forms
                 System.Threading.SynchronizationContext.Current.Post(TimeSpan.FromMilliseconds(5000), () => LoadVideoInfoAfterVideoFromUrlLoad());
                 System.Threading.SynchronizationContext.Current.Post(TimeSpan.FromMilliseconds(10000), () => LoadVideoInfoAfterVideoFromUrlLoad());
             }
+
+            if (VideoAudioTrackNumber > 0)
+            {
+                if (mediaPlayer.VideoPlayer is LibVlcDynamic libVlc)
+                {
+                    libVlc.AudioTrackNumber = VideoAudioTrackNumber;
+                }
+                else if (mediaPlayer.VideoPlayer is LibMpvDynamic libMpv2)
+                {
+                    libMpv2.AudioTrackNumber = VideoAudioTrackNumber;
+                }
+            }
         }
 
         private void LoadVideoInfoAfterVideoFromUrlLoad()
@@ -22543,18 +22555,6 @@ namespace Nikse.SubtitleEdit.Forms
 
                 mediaPlayer.CurrentPosition = newPos;
                 ShowSubtitle();
-
-                if (VideoAudioTrackNumber > 0)
-                {
-                   if (mediaPlayer.VideoPlayer is LibVlcDynamic libVlc)
-                    {
-                        libVlc.AudioTrackNumber = VideoAudioTrackNumber;
-                    }
-                    else if (mediaPlayer.VideoPlayer is LibMpvDynamic libMpv)
-                    {
-                        libMpv.AudioTrackNumber = VideoAudioTrackNumber;
-                    }
-                }
 
                 double startPos = mediaPlayer.CurrentPosition - 1;
                 if (startPos < 0)


### PR DESCRIPTION
Hi,

I like your application very much. Great job!

I need to open several times the same video file on the same audio track which is not the first in the list. 
Any time I had to switch it back manually...
I do not have any experience in C# but managed to solve the task by following your code.
I think it could be a useful new feature.

By the way, I use the application for studying foreign languages combining it with QTranslate. It's rather convenient but could be even better with something like keystroke macro.