### PR TITLE
Adding Brazilian Portuguese to GoogleTranslationService

### DIFF
--- a/src/libse/Translate/Service/GoogleTranslationService.cs
+++ b/src/libse/Translate/Service/GoogleTranslationService.cs
@@ -133,6 +133,7 @@ namespace Nikse.SubtitleEdit.Core.Translate.Service
                 new TranslationPair("PERSIAN", "fa"),
                 new TranslationPair("POLISH", "pl"),
                 new TranslationPair("PORTUGUESE", "pt"),
+                new TranslationPair("PORTUGUESE (BRAZILIAN)", "pt_br"),
                 new TranslationPair("PUNJABI", "pa"),
                 new TranslationPair("ROMANIAN", "ro"),
 //                new TranslationPair("ROMANJI", "romanji"),


### PR DESCRIPTION
It was missing my language on the list.

I build the app and worked. If there's anything else to do let me know. Thanks.