### PR TITLE
Fix some issues with backup shortcut

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -15929,9 +15929,9 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                 }
 
-                if (_subtitleOriginal != null)
+                if (_subtitleOriginalFileName != null && _subtitleOriginal != null && _subtitleOriginal.Paragraphs.Count > 0)
                 {
-                    SaveAutoBackup(_subtitle, saveFormat, _subtitleOriginal.ToText(saveFormat));
+                    SaveAutoBackup(_subtitleOriginal, saveFormat, _subtitleOriginal.ToText(saveFormat));
                 }
 
                 e.SuppressKeyPress = true;


### PR DESCRIPTION
When no original file was opened, it was doing a backup of the original over the normal resulting in an empty file.

This fixes it so:
1. It doesn't backup the original over the normal.
2. It doesn't backup the original if empty.