### PR TITLE
Fix annoying bug when opening a file with video offset

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -4394,6 +4394,7 @@ namespace Nikse.SubtitleEdit.Forms
             if (rfe.VideoOffsetInMs != 0)
             {
                 _subtitle.AddTimeToAllParagraphs(TimeSpan.FromMilliseconds(-Configuration.Settings.General.CurrentVideoOffsetInMs));
+                InitializeListViewEditBoxTimeOnly(_subtitle.GetParagraphOrDefault(rfe.FirstSelectedIndex));
                 _changeSubtitleHash = GetFastSubtitleHash();
                 if (_subtitleOriginal != null && _subtitleOriginal.Paragraphs.Count > 0)
                 {


### PR DESCRIPTION
I've spent 2 hours trying to fix it and this is what I got. I'm not sure this is the way.

How to recreate:
1. Open any file.
2. Apply a video offset.
3. Focus the listview on a line that is not the first line, for example, double click on the fourth line.
4. Close the file.
5. Reopen the file.
The first line will get a double offset and the timecode with be corrupted.

When the file first opens, `timeUpDownStartTime` doesn't have the timecode with the offset, so this code works:
```
var startTime = timeUpDownStartTime.TimeCode;
if (startTime != null && last != null && _subtitle != null &&
	Math.Abs(last.StartTime.TotalMilliseconds - startTime.TotalMilliseconds) > 0.5)
{
	var dur = last.Duration.TotalMilliseconds;
	last.StartTime.TotalMilliseconds = startTime.TotalMilliseconds;
	last.EndTime.TotalMilliseconds = startTime.TotalMilliseconds + dur;
	SubtitleListview1.SetStartTimeAndDuration(_subtitleListViewIndex, last, _subtitle.GetParagraphOrDefault(_subtitleListViewIndex + 1), _subtitle.GetParagraphOrDefault(_subtitleListViewIndex - 1));
	showSource = true;
}
```

I tried setting `timeUpDownStartTime` when a file with an offset first opens.