### PR TITLE
Fix bug when opening a file with video offset

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -4394,6 +4394,7 @@ namespace Nikse.SubtitleEdit.Forms
             if (rfe.VideoOffsetInMs != 0)
             {
                 _subtitle.AddTimeToAllParagraphs(TimeSpan.FromMilliseconds(-Configuration.Settings.General.CurrentVideoOffsetInMs));
+                InitializeListViewEditBoxTimeOnly(_subtitle.GetParagraphOrDefault(_subtitleListViewIndex));
                 _changeSubtitleHash = GetFastSubtitleHash();
                 if (_subtitleOriginal != null && _subtitleOriginal.Paragraphs.Count > 0)
                 {


### PR DESCRIPTION
NOTE:
I closed the previous PR because I was setting the timing to the wrong index.
Also, I do not know if this is the best fix, but I've explained the problem as best as I can and spent as much time as I can trying to figure it out.

How to recreate:
1. Open any file.
2. Apply a video offset.
3. Focus the listview on a line that is not the first line, for example, double click on the fourth line.
4. Close the file.
5. Reopen the file.
The first line will get a double offset and the timecode with be corrupted.

Here is the file: [Episode 6.zip](https://github.com/SubtitleEdit/subtitleedit/files/8444833/Episode.6.zip)
Open it with any video.
The file needs to have an offset before you offset just the video.

https://user-images.githubusercontent.com/20923700/162252891-17e86d29-ca8d-486d-9f45-85c3f61f7ab4.mp4