### PR TITLE
Fix issue with batch convert filter

### DIFF
--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -2855,7 +2855,7 @@ namespace Nikse.SubtitleEdit.Forms
         private List<ListViewItem> _listViewItemBeforeSearch;
         private void textBoxFilter_TextChanged(object sender, EventArgs e)
         {
-            if (listViewInputFiles.Items.Count == 0)
+            if (listViewInputFiles.Items.Count == 0 &&_listViewItemBeforeSearch == null)
             {
                 return;
             }


### PR DESCRIPTION
So, if you write a language code that doesn't exists like: `araa`, `listViewInputFiles.Items.Count` becomes 0, and if you then change the filter text to `ara`, it doesn't work because the `listViewInputFiles` are now 0 and the function returns.

To test this:
1. Open a bunch of files.
2. Use the filter and write a language code that doesn't exist.
3. Try deleting the text and writing a correct language code.
The list won't show any items.