### PR TITLE
Allow empty splitting for split at video/cursor

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -11193,7 +11193,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 string oldText = currentParagraph.Text;
                 var lines = currentParagraph.Text.SplitToLines();
-                if (textIndex != null && textIndex.Value > 1 && textIndex.Value < oldText.Length - 1)
+                if (textIndex != null)
                 {
                     string a = oldText.Substring(0, textIndex.Value).Trim();
                     string b = oldText.Substring(textIndex.Value).Trim();
@@ -11415,7 +11415,7 @@ namespace Nikse.SubtitleEdit.Forms
                         }
 
                         oldText = originalCurrent.Text;
-                        if (originalTextIndex != null && originalTextIndex.Value > 1 && originalTextIndex.Value < oldText.Length - 1)
+                        if (originalTextIndex != null)
                         {
                             var firstPart = oldText.Substring(0, originalTextIndex.Value).Trim();
                             var secondPart = oldText.Substring(originalTextIndex.Value).Trim();
@@ -28527,13 +28527,10 @@ namespace Nikse.SubtitleEdit.Forms
         private void toolStripMenuItemSplitViaWaveform_Click(object sender, EventArgs e)
         {
             var tb = GetFocusedTextBox();
-            if (tb.SelectionStart > 1 && tb.SelectionStart < tb.Text.Length - 1)
-            {
-                int? pos = tb.SelectionStart;
-                SplitSelectedParagraph(mediaPlayer.CurrentPosition, pos);
-                tb.Focus();
-                tb.SelectionStart = tb.Text.Length;
-            }
+            int? pos = tb.SelectionStart;
+            SplitSelectedParagraph(mediaPlayer.CurrentPosition, pos);
+            tb.Focus();
+            tb.SelectionStart = tb.Text.Length;
         }
 
         private void ContextMenuStripTextBoxListViewOpening(object sender, CancelEventArgs e)


### PR DESCRIPTION
I know, I know, just… hear me out on this. "^^

So, let's say I have this line:
![image](https://user-images.githubusercontent.com/20923700/184044000-e9fbe75d-4222-412d-95fb-85b5161d3966.png)

The text written in the text box is for the section that is before the video position, so now I want to split the line at video position and keep the whole text in the first line, while the second line is empty and takes the rest of the duration:
![image](https://user-images.githubusercontent.com/20923700/184044163-5f24ddf1-39f0-4a50-9639-f5387dfbd1d2.png)

Right now, there is no easy way to do this, you'd have to type an extra word and split before it, or set end time, add a new line, and set its end time as well.
But what's the harm in allowing the user to split at the start or end of the line when using split at video/cursor?
He would know where the cursor is, thus knowing that he's making a new empty line for the rest of the duration.
Right now, using split at video/cursor does nothing when it's at the start or end of the line, so I would see this as an extra feature. :D

Are there any side effects for removing the index condition in the split function? I could not find any.