### PR TITLE
Keep error color consistent

### DIFF
--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -2076,7 +2076,7 @@ namespace Nikse.SubtitleEdit.Forms
             if (_errors > 0)
             {
                 labelError.Text = string.Format(LanguageSettings.Current.EbuSaveOptions.ErrorsX, _errors);
-                labelError.ForeColor = UiUtil.ErrorTextColor;
+                labelError.ForeColor = Color.Red;
                 labelError.Left = labelStatus.Right + 9;
                 labelError.Visible = true;
             }

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -736,13 +736,11 @@ namespace Nikse.SubtitleEdit.Logic
                 sb.Append(count);
                 if (count > Configuration.Settings.General.SubtitleLineMaximumLength || i >= Configuration.Settings.General.MaxNumberOfLines)
                 {
-                    label.ForeColor = ErrorTextColor;
+                    label.ForeColor = Color.Red;
                 }
             }
             label.Text = sb.ToString();
         }
-
-        public static Color ErrorTextColor => Configuration.Settings.General.UseDarkTheme ? Configuration.Settings.Tools.ListViewSyntaxErrorColor : Color.Red;
 
         public static void GetLinePixelWidths(Label label, string text)
         {


### PR DESCRIPTION
Error color for labels across SE is red, for cps, total line length, Split button, line width, and all other types of errors except for list view, so single line length should stay the same:

![image](https://user-images.githubusercontent.com/20923700/185799032-4e3b8fc2-a329-4b6b-bba1-aafde9f0b4b6.png)

As you can see the color isn't clear at all, while it's perfect for list view;
![image](https://user-images.githubusercontent.com/20923700/185797058-eea3c12b-7bf8-4250-b050-dceb1b0cd89d.png)

The red color makes more sense in the dark theme because the darker color used for the list view wouldn't be as clear elsewhere.
I don't see a need to use it just for this, nor for changing it across all error labels, as you can see in my picture, the number doesn't look clear at all.
