### PR TITLE
Don't check Continuation Style when merging dialog

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -12255,7 +12255,7 @@ namespace Nikse.SubtitleEdit.Forms
                 MakeHistoryForUndo(_language.BeforeMergeLines);
 
                 var continuationStyle = Configuration.Settings.General.ContinuationStyle;
-                if (continuationStyle != ContinuationStyle.None)
+                if (continuationStyle != ContinuationStyle.None && !insertDash)
                 {
                     var continuationProfile = ContinuationUtilities.GetContinuationProfile(continuationStyle);
                     var mergeResult = ContinuationUtilities.MergeHelper(currentParagraph.Text, nextParagraph.Text, continuationProfile, LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitle));
@@ -12270,7 +12270,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                     if (original != null && originalNext != null)
                     {
-                        if (continuationStyle != ContinuationStyle.None)
+                        if (continuationStyle != ContinuationStyle.None  && !insertDash)
                         {
                             var continuationProfile = ContinuationUtilities.GetContinuationProfile(continuationStyle);
                             var mergeResult = ContinuationUtilities.MergeHelper(original.Text, originalNext.Text, continuationProfile, LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitleOriginal));


### PR DESCRIPTION
I had two lines where the first is interrupted by another speaker like:
`I was focusing on…`
`One that their family will accept at the funeral.`

And when I merged as dialog it gave me:
```
- I was focusing on
- One that their family will accept at the funeral.
```

As you can see, the Continuation Style should be ignored when merging dialog.