### PR TITLE
Fix a couple of toolStripMenuItem Enabled

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -5129,6 +5129,10 @@ namespace Nikse.SubtitleEdit.Forms
                 MessageBox.Show(exception.Message);
                 return DialogResult.Cancel;
             }
+            finally
+            {
+                toolStripMenuItemOpenContainingFolder.Enabled = !string.IsNullOrEmpty(_fileName) && File.Exists(_fileName);
+            }
         }
 
         private DialogResult SaveOriginalSubtitle(SubtitleFormat format, bool skipPrompts = false)

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -4090,6 +4090,7 @@ namespace Nikse.SubtitleEdit.Forms
             ResetShowEarlierOrLater();
             FixRightToLeftDependingOnLanguage();
             textBoxSource.SelectionLength = 0;
+            toolStripMenuItemOpenContainingFolder.Enabled = !string.IsNullOrEmpty(_fileName) && File.Exists(_fileName);
         }
 
         private bool LoadSeJob(byte[] bytes)
@@ -21670,6 +21671,7 @@ namespace Nikse.SubtitleEdit.Forms
             mediaPlayer.OnButtonClicked -= MediaPlayer_OnButtonClicked;
             mediaPlayer.OnButtonClicked += MediaPlayer_OnButtonClicked;
             closeVideoToolStripMenuItem.Enabled = true;
+            toolStripMenuItemOpenKeepVideo.Enabled = true;
 
             if (_videoInfo.VideoCodec != null)
             {
@@ -23849,6 +23851,10 @@ namespace Nikse.SubtitleEdit.Forms
             if (!string.IsNullOrEmpty(_fileName) && File.Exists(_fileName))
             {
                 UiUtil.OpenFolderFromFileName(_fileName);
+            }
+            else
+            {
+                toolStripMenuItemOpenContainingFolder.Enabled = false;
             }
         }
 


### PR DESCRIPTION
If you open a video and try to use the `OpenKeepVideo`, it didn't use to work because the `toolStripMenuItem` is disabled.

If you try using `OpenContainingFolder` after opening a file, it didn't use to work because the `toolStripMenuItem` is disabled.
I thought adding it to the end of `OpenSubtitle` is a safe bet.