### PR TITLE
Speedup OCR DB search with weird images

### DIFF
--- a/src/libse/Interfaces/IBinaryParagraphList.cs
+++ b/src/libse/Interfaces/IBinaryParagraphList.cs
@@ -4,7 +4,7 @@ namespace Nikse.SubtitleEdit.Core.Interfaces
 {
     public interface IBinaryParagraphList
     {
-        Bitmap GetSubtitleBitmap(int index, bool crop = true);
+        Bitmap GetSubtitleBitmap(int index, bool crop = true, bool preCheck = false);
         bool GetIsForced(int index);
     }
 }

--- a/src/ui/Forms/ImportCdg.cs
+++ b/src/ui/Forms/ImportCdg.cs
@@ -222,7 +222,7 @@ namespace Nikse.SubtitleEdit.Forms
             bw.RunWorkerAsync();
         }
 
-        public Bitmap GetSubtitleBitmap(int index, bool crop = true)
+        public Bitmap GetSubtitleBitmap(int index, bool crop = true, bool preCheck = false)
         {
             return _imageList[index].GetBitmap();
         }


### PR DESCRIPTION
There are 2 issues:
1) Image reference is generated several times (including binarization,
   postprocessing and whatnot)
2) Weird images are *not* useful for this, and are better skipped.
   The first issue will make this particularly slow.

Makes loading of a particular subtitle in a couple seconds instead of 10+.

NOTE: the SUP file consists of an emulated fade-in text (with a dozen .1s images) that covers the entire original video. It is obviously copyrighted, so not shareable, and is 8MB even with 7zip. Please tell me whether and how to share, and what to send (eg truncate to first MB of SUP, etc)?