### PR TITLE
Round when setting milliseconds

### DIFF
--- a/src/libse/Common/TimeCode.cs
+++ b/src/libse/Common/TimeCode.cs
@@ -119,7 +119,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
-        public double TotalMilliseconds { get; set; }
+        private double _totalMilliseconds;
+        public double TotalMilliseconds 
+        {
+            get => _totalMilliseconds;
+            set => _totalMilliseconds = Math.Round(value, MidpointRounding.AwayFromZero);
+        }
 
         public double TotalSeconds
         {


### PR DESCRIPTION
I'm not sure if this is a proper way to do it or if it may cause some other type of issue, so I'll need you to correct me on this.

Notice this:
![image](https://user-images.githubusercontent.com/20923700/187916375-4eec798d-9707-422d-a7b4-4b370c6007cb.png)

So, I was using `Extend to next shot change minus gap` and my end time was `3366822`, but the extend function gave `3366822.181425`, which caused SE to show an asterisk because the TotalMilliseconds basically changed from 3366822 to 3366822.181425, and of course when you save the file, nothing changes because milliseconds are the smallest unit we have.

And then in SE, the endtime is 3366822.181425 but in the acutall file it's will still be 3366822.
Meaning when I close SE and open it again and extend again, it will still show an asterisk even thought I saved before closing SE.

So why not Roundup the milliseconds when we set them? There can't be anything smaller so there is no need for anything after the decimal.

Am I missing something? Should it be Round of floor?