### PR TITLE
Round shot changes to 3 decimal places

### DIFF
--- a/src/libse/NetflixQualityCheck/NetflixCheckShotChange.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckShotChange.cs
@@ -27,7 +27,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 
             if (Configuration.Settings.General.CurrentVideoIsSmpte)
             {
-                shotChanges = shotChanges.Select(sc => sc /= 1.001).ToList();
+                shotChanges = shotChanges.Select(sc => Math.Round(sc /= 1.001, 3, MidpointRounding.AwayFromZero)).ToList();
             }
 
             int halfSecGapInFrames = (int)Math.Round(controller.FrameRate / 2, MidpointRounding.AwayFromZero);

--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -345,7 +345,7 @@ namespace Nikse.SubtitleEdit.Controls
 
                 if (_shotChanges?.Count > 0)
                 {
-                    _shotChanges = _shotChanges.Select(sc => sc /= 1.001).ToList();
+                    _shotChanges = _shotChanges.Select(sc => Math.Round(sc /= 1.001, 3, MidpointRounding.AwayFromZero)).ToList();
                 }
             }
         }

--- a/src/ui/Forms/ChangeSpeedInPercent.cs
+++ b/src/ui/Forms/ChangeSpeedInPercent.cs
@@ -83,8 +83,8 @@ namespace Nikse.SubtitleEdit.Forms
 
         public void AdjustParagraph(Paragraph p)
         {
-            p.StartTime.TotalMilliseconds = p.StartTime.TotalMilliseconds * AdjustFactor;
-            p.EndTime.TotalMilliseconds = p.EndTime.TotalMilliseconds * AdjustFactor;
+            p.StartTime.TotalMilliseconds = Math.Round(p.StartTime.TotalMilliseconds * AdjustFactor, MidpointRounding.AwayFromZero);
+            p.EndTime.TotalMilliseconds = Math.Round(p.EndTime.TotalMilliseconds * AdjustFactor, MidpointRounding.AwayFromZero);
         }
 
         private void buttonOK_Click(object sender, EventArgs e)

--- a/src/ui/Forms/ShotChanges/ImportShotChanges.cs
+++ b/src/ui/Forms/ShotChanges/ImportShotChanges.cs
@@ -263,7 +263,7 @@ namespace Nikse.SubtitleEdit.Forms.ShotChanges
                     {
                         if (radioButtonFrames.Checked)
                         {
-                            ShotChangesInSeconds.Add(d / _frameRate);
+                            ShotChangesInSeconds.Add(Math.Round(d / _frameRate, 3, MidpointRounding.AwayFromZero));
                         }
                         else if (radioButtonSeconds.Checked)
                         {


### PR DESCRIPTION
Since our smallest unit is milliseconds and shot changes are saved in seconds, why leave more than 3 decimal places after the decimal point?
```
18.601916518
19.519499844
42.54249966
60.435374517
```

This causes issues when extending to the next shot change for example, the shot change is at `3366.905181425` and when you change to milliseconds `3366905.181425` minus min gap is `3366822.181425` and my end time is at `3366822`, SE shows the line is changed when extending to shot change because of the `0.181425`, but those aren't saved and aren't needed.