### PR TITLE
Add `Allow overlap` to `Change speed`

### DIFF
--- a/LanguageMaster.xml
+++ b/LanguageMaster.xml
@@ -398,6 +398,7 @@ Note: Do check free disk space.</WaveFileMalformed>
     <Custom>Custom</Custom>
     <ToDropFrame>To drop frame</ToDropFrame>
     <FromDropFrame>From drop frame</FromDropFrame>
+    <AllowOverlap>Allow overlap</AllowOverlap>
   </ChangeSpeedInPercent>
   <CheckForUpdates>
     <Title>Check for updates</Title>

--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -330,6 +330,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         public int AdjustDurationPercent { get; set; }
         public string AdjustDurationLast { get; set; }
         public bool AdjustDurationExtendOnly { get; set; }
+        public bool ChangeSpeedAllowOverlap { get; set; }
         public bool AutoBreakCommaBreakEarly { get; set; }
         public bool AutoBreakDashEarly { get; set; }
         public bool AutoBreakLineEndingEarly { get; set; }
@@ -5617,6 +5618,12 @@ $HorzAlign          =   Center
                 settings.Tools.AdjustDurationExtendOnly = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
+            subNode = node.SelectSingleNode("ChangeSpeedAllowOverlap");
+            if (subNode != null)
+            {
+                settings.Tools.ChangeSpeedAllowOverlap = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+            }
+
             subNode = node.SelectSingleNode("AutoBreakCommaBreakEarly");
             if (subNode != null)
             {
@@ -10133,6 +10140,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("AdjustDurationPercent", settings.Tools.AdjustDurationPercent.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("AdjustDurationLast", settings.Tools.AdjustDurationLast);
                 textWriter.WriteElementString("AdjustDurationExtendOnly", settings.Tools.AdjustDurationExtendOnly.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString("ChangeSpeedAllowOverlap", settings.Tools.ChangeSpeedAllowOverlap.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("AutoBreakCommaBreakEarly", settings.Tools.AutoBreakCommaBreakEarly.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("AutoBreakDashEarly", settings.Tools.AutoBreakDashEarly.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("AutoBreakLineEndingEarly", settings.Tools.AutoBreakLineEndingEarly.ToString(CultureInfo.InvariantCulture));

--- a/src/ui/Forms/ChangeSpeedInPercent.Designer.cs
+++ b/src/ui/Forms/ChangeSpeedInPercent.Designer.cs
@@ -30,6 +30,7 @@
         {
             this.buttonCancel = new System.Windows.Forms.Button();
             this.buttonOK = new System.Windows.Forms.Button();
+            this.checkBoxAllowOverlap = new System.Windows.Forms.CheckBox();
             this.numericUpDownPercent = new System.Windows.Forms.NumericUpDown();
             this.labelPercent = new System.Windows.Forms.Label();
             this.radioButtonSelectedLinesOnly = new System.Windows.Forms.RadioButton();
@@ -50,7 +51,7 @@
             this.buttonCancel.Location = new System.Drawing.Point(295, 158);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-            this.buttonCancel.TabIndex = 4;
+            this.buttonCancel.TabIndex = 5;
             this.buttonCancel.Text = "C&ancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
@@ -62,10 +63,20 @@
             this.buttonOK.Location = new System.Drawing.Point(214, 158);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
-            this.buttonOK.TabIndex = 3;
+            this.buttonOK.TabIndex = 4;
             this.buttonOK.Text = "&OK";
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
+            // 
+            // checkBoxAllowOverlap
+            // 
+            this.checkBoxAllowOverlap.AutoSize = true;
+            this.checkBoxAllowOverlap.Location = new System.Drawing.Point(24, 160);
+            this.checkBoxAllowOverlap.Name = "checkBoxAllowOverlap";
+            this.checkBoxAllowOverlap.Size = new System.Drawing.Size(109, 21);
+            this.checkBoxAllowOverlap.TabIndex = 3;
+            this.checkBoxAllowOverlap.Text = "Allow overlap";
+            this.checkBoxAllowOverlap.UseVisualStyleBackColor = true;
             // 
             // numericUpDownPercent
             // 
@@ -180,6 +191,7 @@
             this.Controls.Add(this.groupBoxInfo);
             this.Controls.Add(this.radioButtonSelectedLinesOnly);
             this.Controls.Add(this.radioButtonAllLines);
+            this.Controls.Add(this.checkBoxAllowOverlap);
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.buttonOK);
             this.KeyPreview = true;
@@ -203,6 +215,7 @@
 
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.Button buttonOK;
+        private System.Windows.Forms.CheckBox checkBoxAllowOverlap;
         private System.Windows.Forms.NumericUpDown numericUpDownPercent;
         private System.Windows.Forms.Label labelPercent;
         private System.Windows.Forms.RadioButton radioButtonSelectedLinesOnly;

--- a/src/ui/Forms/ChangeSpeedInPercent.cs
+++ b/src/ui/Forms/ChangeSpeedInPercent.cs
@@ -24,6 +24,7 @@ namespace Nikse.SubtitleEdit.Forms
             radioButtonSpeedCustom.Text = LanguageSettings.Current.ChangeSpeedInPercent.Custom;
             radioButtonSpeedFromDropFrame.Text = LanguageSettings.Current.ChangeSpeedInPercent.FromDropFrame;
             radioButtonToDropFrame.Text = LanguageSettings.Current.ChangeSpeedInPercent.ToDropFrame;
+            checkBoxAllowOverlap.Text = LanguageSettings.Current.ChangeSpeedInPercent.AllowOverlap;
             buttonOK.Text = LanguageSettings.Current.General.Ok;
             buttonCancel.Text = LanguageSettings.Current.General.Cancel;
 
@@ -44,6 +45,8 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 radioButtonAllLines.Checked = true;
             }
+
+            checkBoxAllowOverlap.Checked = Configuration.Settings.Tools.ChangeSpeedAllowOverlap;
         }
 
         private void ChangeSpeedInPercent_KeyDown(object sender, KeyEventArgs e)
@@ -66,18 +69,22 @@ namespace Nikse.SubtitleEdit.Forms
                 AdjustParagraph(p);
             }
 
-            for (int i = 0; i < subtitle.Paragraphs.Count; i++)
+            if (!checkBoxAllowOverlap.Checked)
             {
-                Paragraph p = subtitle.Paragraphs[i];
-                Paragraph next = subtitle.GetParagraphOrDefault(i + 1);
-                if (next != null)
+                for (int i = 0; i < subtitle.Paragraphs.Count; i++)
                 {
-                    if (p.EndTime.TotalMilliseconds >= next.StartTime.TotalMilliseconds)
+                    Paragraph p = subtitle.Paragraphs[i];
+                    Paragraph next = subtitle.GetParagraphOrDefault(i + 1);
+                    if (next != null)
                     {
-                        p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - 1;
+                        if (p.EndTime.TotalMilliseconds >= next.StartTime.TotalMilliseconds)
+                        {
+                            p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - 1;
+                        }
                     }
                 }
             }
+
             return subtitle;
         }
 
@@ -92,6 +99,7 @@ namespace Nikse.SubtitleEdit.Forms
             Percentage = numericUpDownPercent.Value;
             AdjustFactor = Convert.ToDouble(numericUpDownPercent.Value) / 100.0;
             AdjustAllLines = radioButtonAllLines.Checked;
+            Configuration.Settings.Tools.ChangeSpeedAllowOverlap = checkBoxAllowOverlap.Checked;
             DialogResult = DialogResult.OK;
         }
 

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -572,6 +572,7 @@ namespace Nikse.SubtitleEdit.Logic
                 Custom = "Custom",
                 ToDropFrame = "To drop frame",
                 FromDropFrame = "From drop frame",
+                AllowOverlap = "Allow overlap"
             };
 
             CheckForUpdates = new LanguageStructure.CheckForUpdates

--- a/src/ui/Logic/LanguageDeserializer.cs
+++ b/src/ui/Logic/LanguageDeserializer.cs
@@ -1060,6 +1060,9 @@ namespace Nikse.SubtitleEdit.Logic
                 case "ChangeSpeedInPercent/FromDropFrame":
                     language.ChangeSpeedInPercent.FromDropFrame = reader.Value;
                     break;
+                case "ChangeSpeedInPercent/AllowOverlap":
+                    language.ChangeSpeedInPercent.AllowOverlap = reader.Value;
+                    break;
                 case "CheckForUpdates/Title":
                     language.CheckForUpdates.Title = reader.Value;
                     break;

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -431,6 +431,7 @@
             public string Custom { get; set; }
             public string ToDropFrame { get; set; }
             public string FromDropFrame { get; set; }
+            public string AllowOverlap { get; set; }
         }
 
         public class CheckForUpdates


### PR DESCRIPTION
I know you don't like `Allow overlap` options, but hear me out.

I use `Change speed` a lot to adjust files for `drop frame`, and each time I have a couple of overlapping lines, I have to check for them and save their duration and adjust the duration manually after, so what's the harm in adding an `Allow overlap` option?

Especially now that SE works well with ASSA, and since ASSA files may contain a lot of overlapping lines, I think this option would be really useful.