### PR TITLE
Remove Arabic comma processing for richtextbox

### DIFF
--- a/src/ui/Controls/AdvancedTextBox.cs
+++ b/src/ui/Controls/AdvancedTextBox.cs
@@ -147,41 +147,10 @@ namespace Nikse.SubtitleEdit.Controls
             };
         }
 
-        private bool _fixedArabicComma;
         public override string Text
         {
-            get
-            {
-                var s = base.Text;
-                if (_fixedArabicComma)
-                {
-                    s = s.Replace("\u202A،", "،");
-                    s = s.Replace("،\u202A", "،");
-                }
-
-                return string.Join(Environment.NewLine, s.SplitToLines());
-            }
-            set
-            {
-                _fixedArabicComma = false;
-                var s = value ?? string.Empty;
-                if (!Configuration.Settings.General.RightToLeftMode && !s.ContainsUnicodeControlChars())
-                {
-                    string textNoTags = HtmlUtil.RemoveHtmlTags(s, true);
-                    if (textNoTags.EndsWith('،'))
-                    {
-                        s = Regex.Replace(s, @"،(?=(?:<[^>]+>)?(?:{[^}]+})?$)", "\u202A،");
-                    }
-                    else if (textNoTags.StartsWith('،'))
-                    {
-                        s = Regex.Replace(s, @"(?<=^(?:{[^}]+})?(?:<[^>]+>)?)،", "،\u202A");
-                    }
-
-                    _fixedArabicComma = true;
-                }
-
-                base.Text = string.Join("\n", s.SplitToLines());
-            }
+            get => string.Join(Environment.NewLine, base.Text.SplitToLines());
+            set => base.Text = string.Join("\n", value.SplitToLines());
         }
 
         public new int SelectionStart


### PR DESCRIPTION
It's just not worth it, too many issues.

Right now, if the comma is at the end of the first line of two, it's not fixed.
And if I try to change that, syntax coloring would become an issue.
Add to that, adding a comma makes the text box lag a bit while typing.

It will work just fine in RTL mode, and the user would have to adapt to it in LTR because the RichTextBox of the video player is the same and the behavior is not consistent.


Until there is a clear, better solution, I think this is for the best.