### PR TITLE
Add "Make dialog" option to "Merge lines with the same time codes"

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -341,6 +341,9 @@ namespace Nikse.SubtitleEdit.Core.Common
         public int MergeShortLinesMaxGap { get; set; }
         public int MergeShortLinesMaxChars { get; set; }
         public bool MergeShortLinesOnlyContinuous { get; set; }
+        public int MergeTextWithSameTimeCodesMaxGap { get; set; }
+        public bool MergeTextWithSameTimeCodesMakeDialog { get; set; }
+        public bool MergeTextWithSameTimeCodesReBreakLines { get; set; }
         public string ColumnPasteColumn { get; set; }
         public string ColumnPasteOverwriteMode { get; set; }
         public string AssaAttachmentFontTextPreview { get; set; }
@@ -544,6 +547,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             MergeShortLinesMaxGap = 250;
             MergeShortLinesMaxChars = 55;
             MergeShortLinesOnlyContinuous = true;
+            MergeTextWithSameTimeCodesMaxGap = 250;
+            MergeTextWithSameTimeCodesReBreakLines = false;
+            MergeTextWithSameTimeCodesMakeDialog = false;
             ColumnPasteColumn = "all";
             ColumnPasteOverwriteMode = "overwrite";
             AssaAttachmentFontTextPreview =
@@ -5683,6 +5689,24 @@ $HorzAlign          =   Center
                 settings.Tools.MergeShortLinesOnlyContinuous = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
+            subNode = node.SelectSingleNode("MergeTextWithSameTimeCodesMaxGap");
+            if (subNode != null)
+            {
+                settings.Tools.MergeTextWithSameTimeCodesMaxGap = Convert.ToInt32(subNode.InnerText);
+            }
+
+            subNode = node.SelectSingleNode("MergeTextWithSameTimeCodesMakeDialog");
+            if (subNode != null)
+            {
+                settings.Tools.MergeTextWithSameTimeCodesMakeDialog = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+            }
+
+            subNode = node.SelectSingleNode("MergeTextWithSameTimeCodesReBreakLines");
+            if (subNode != null)
+            {
+                settings.Tools.MergeTextWithSameTimeCodesReBreakLines = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+            }
+
             subNode = node.SelectSingleNode("ColumnPasteColumn");
             if (subNode != null)
             {
@@ -10144,6 +10168,9 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("MergeShortLinesMaxGap", settings.Tools.MergeShortLinesMaxGap.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("MergeShortLinesMaxChars", settings.Tools.MergeShortLinesMaxChars.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("MergeShortLinesOnlyContinuous", settings.Tools.MergeShortLinesOnlyContinuous.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString("MergeTextWithSameTimeCodesMaxGap", settings.Tools.MergeTextWithSameTimeCodesMaxGap.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString("MergeTextWithSameTimeCodesMakeDialog", settings.Tools.MergeTextWithSameTimeCodesMakeDialog.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString("MergeTextWithSameTimeCodesReBreakLines", settings.Tools.MergeTextWithSameTimeCodesReBreakLines.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("ColumnPasteColumn", settings.Tools.ColumnPasteColumn);
                 textWriter.WriteElementString("ColumnPasteOverwriteMode", settings.Tools.ColumnPasteOverwriteMode);
                 textWriter.WriteElementString("AssaAttachmentFontTextPreview", settings.Tools.AssaAttachmentFontTextPreview);

--- a/src/libse/SubtitleFormats/IsmtDfxp.cs
+++ b/src/libse/SubtitleFormats/IsmtDfxp.cs
@@ -78,9 +78,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
 
                     // merge lines with same time codes
-                    sub = Forms.MergeLinesWithSameTimeCodes.Merge(sub, new List<int>(), out _, true, false, 1000, "en", new List<int>(), new Dictionary<int, bool>(), new Subtitle());
+                    sub = Forms.MergeLinesWithSameTimeCodes.Merge(sub, new List<int>(), out _, true, false, false, 1000, "en", new List<int>(), new Dictionary<int, bool>(), new Subtitle());
 
-                    // adjust to last exisiting sub
+                    // adjust to last existing sub
                     var lastSub = subtitle.GetParagraphOrDefault(subtitle.Paragraphs.Count - 1);
                     if (lastSub != null && sub.Paragraphs.Count > 0 && lastSub.StartTime.TotalMilliseconds > sub.Paragraphs[0].StartTime.TotalMilliseconds)
                     {

--- a/src/ui/Forms/BatchConvert.Designer.cs
+++ b/src/ui/Forms/BatchConvert.Designer.cs
@@ -158,6 +158,11 @@ namespace Nikse.SubtitleEdit.Forms
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.labelStatus = new System.Windows.Forms.Label();
             this.labelError = new System.Windows.Forms.Label();
+            this.groupBoxMergeSameTimeCodes = new System.Windows.Forms.GroupBox();
+            this.checkBoxMergeSameTimeCodesMakeDialog = new System.Windows.Forms.CheckBox();
+            this.numericUpDownMergeSameTimeCodesMaxDifference = new System.Windows.Forms.NumericUpDown();
+            this.labelMergeSameTimeCodesMaxDifference = new System.Windows.Forms.Label();
+            this.checkBoxMergeSameTimeCodesReBreakLines = new System.Windows.Forms.CheckBox();
             this.groupBoxConvertOptions.SuspendLayout();
             this.contextMenuStripOptions.SuspendLayout();
             this.groupBoxDeleteLines.SuspendLayout();
@@ -189,6 +194,8 @@ namespace Nikse.SubtitleEdit.Forms
             this.groupBoxOutput.SuspendLayout();
             this.groupBoxInput.SuspendLayout();
             this.contextMenuStripFiles.SuspendLayout();
+            this.groupBoxMergeSameTimeCodes.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMergeSameTimeCodesMaxDifference)).BeginInit();
             this.SuspendLayout();
             // 
             // buttonConvert
@@ -219,6 +226,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             this.groupBoxConvertOptions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBoxConvertOptions.Controls.Add(this.groupBoxMergeSameTimeCodes);
             this.groupBoxConvertOptions.Controls.Add(this.listViewConvertOptions);
             this.groupBoxConvertOptions.Controls.Add(this.groupBoxDeleteLines);
             this.groupBoxConvertOptions.Controls.Add(this.groupBoxRemoveStyle);
@@ -1617,6 +1625,70 @@ namespace Nikse.SubtitleEdit.Forms
             this.labelError.TabIndex = 10;
             this.labelError.Text = "labelError";
             // 
+            // groupBoxMergeSameTimeCodes
+            // 
+            this.groupBoxMergeSameTimeCodes.Controls.Add(this.checkBoxMergeSameTimeCodesReBreakLines);
+            this.groupBoxMergeSameTimeCodes.Controls.Add(this.checkBoxMergeSameTimeCodesMakeDialog);
+            this.groupBoxMergeSameTimeCodes.Controls.Add(this.numericUpDownMergeSameTimeCodesMaxDifference);
+            this.groupBoxMergeSameTimeCodes.Controls.Add(this.labelMergeSameTimeCodesMaxDifference);
+            this.groupBoxMergeSameTimeCodes.Location = new System.Drawing.Point(308, 17);
+            this.groupBoxMergeSameTimeCodes.Name = "groupBoxMergeSameTimeCodes";
+            this.groupBoxMergeSameTimeCodes.Size = new System.Drawing.Size(268, 149);
+            this.groupBoxMergeSameTimeCodes.TabIndex = 310;
+            this.groupBoxMergeSameTimeCodes.TabStop = false;
+            this.groupBoxMergeSameTimeCodes.Text = "Merge lines with same time codes";
+            this.groupBoxMergeSameTimeCodes.Visible = false;
+            // 
+            // checkBoxMergeSameTimeCodesMakeDialog
+            // 
+            this.checkBoxMergeSameTimeCodesMakeDialog.AutoSize = true;
+            this.checkBoxMergeSameTimeCodesMakeDialog.Checked = true;
+            this.checkBoxMergeSameTimeCodesMakeDialog.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxMergeSameTimeCodesMakeDialog.Location = new System.Drawing.Point(15, 79);
+            this.checkBoxMergeSameTimeCodesMakeDialog.Name = "checkBoxMergeSameTimeCodesMakeDialog";
+            this.checkBoxMergeSameTimeCodesMakeDialog.Size = new System.Drawing.Size(84, 17);
+            this.checkBoxMergeSameTimeCodesMakeDialog.TabIndex = 42;
+            this.checkBoxMergeSameTimeCodesMakeDialog.Text = "Make dialog";
+            this.checkBoxMergeSameTimeCodesMakeDialog.UseVisualStyleBackColor = true;
+            // 
+            // numericUpDownMergeSameTimeCodesMaxDifference
+            // 
+            this.numericUpDownMergeSameTimeCodesMaxDifference.Location = new System.Drawing.Point(15, 41);
+            this.numericUpDownMergeSameTimeCodesMaxDifference.Maximum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            0});
+            this.numericUpDownMergeSameTimeCodesMaxDifference.Name = "numericUpDownMergeSameTimeCodesMaxDifference";
+            this.numericUpDownMergeSameTimeCodesMaxDifference.Size = new System.Drawing.Size(64, 20);
+            this.numericUpDownMergeSameTimeCodesMaxDifference.TabIndex = 38;
+            this.numericUpDownMergeSameTimeCodesMaxDifference.Value = new decimal(new int[] {
+            250,
+            0,
+            0,
+            0});
+            // 
+            // labelMergeSameTimeCodesMaxDifference
+            // 
+            this.labelMergeSameTimeCodesMaxDifference.AutoSize = true;
+            this.labelMergeSameTimeCodesMaxDifference.Location = new System.Drawing.Point(12, 23);
+            this.labelMergeSameTimeCodesMaxDifference.Name = "labelMergeSameTimeCodesMaxDifference";
+            this.labelMergeSameTimeCodesMaxDifference.Size = new System.Drawing.Size(139, 13);
+            this.labelMergeSameTimeCodesMaxDifference.TabIndex = 40;
+            this.labelMergeSameTimeCodesMaxDifference.Text = "Max. milliseconds difference";
+            // 
+            // checkBoxMergeSameTimeCodesReBreakLines
+            // 
+            this.checkBoxMergeSameTimeCodesReBreakLines.AutoSize = true;
+            this.checkBoxMergeSameTimeCodesReBreakLines.Checked = true;
+            this.checkBoxMergeSameTimeCodesReBreakLines.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxMergeSameTimeCodesReBreakLines.Location = new System.Drawing.Point(15, 102);
+            this.checkBoxMergeSameTimeCodesReBreakLines.Name = "checkBoxMergeSameTimeCodesReBreakLines";
+            this.checkBoxMergeSameTimeCodesReBreakLines.Size = new System.Drawing.Size(94, 17);
+            this.checkBoxMergeSameTimeCodesReBreakLines.TabIndex = 43;
+            this.checkBoxMergeSameTimeCodesReBreakLines.Text = "Re-break lines";
+            this.checkBoxMergeSameTimeCodesReBreakLines.UseVisualStyleBackColor = true;
+            // 
             // BatchConvert
             // 
             this.AllowDrop = true;
@@ -1686,6 +1758,9 @@ namespace Nikse.SubtitleEdit.Forms
             this.groupBoxInput.ResumeLayout(false);
             this.groupBoxInput.PerformLayout();
             this.contextMenuStripFiles.ResumeLayout(false);
+            this.groupBoxMergeSameTimeCodes.ResumeLayout(false);
+            this.groupBoxMergeSameTimeCodes.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMergeSameTimeCodesMaxDifference)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1819,5 +1894,10 @@ namespace Nikse.SubtitleEdit.Forms
         private System.Windows.Forms.ToolStripMenuItem tesseractToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem nOCRToolStripMenuItem;
         private System.Windows.Forms.Label labelError;
+        private System.Windows.Forms.GroupBox groupBoxMergeSameTimeCodes;
+        private System.Windows.Forms.CheckBox checkBoxMergeSameTimeCodesReBreakLines;
+        private System.Windows.Forms.CheckBox checkBoxMergeSameTimeCodesMakeDialog;
+        private System.Windows.Forms.NumericUpDown numericUpDownMergeSameTimeCodesMaxDifference;
+        private System.Windows.Forms.Label labelMergeSameTimeCodesMaxDifference;
     }
 }

--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -1685,7 +1685,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (IsActionEnabled(CommandLineConverter.BatchAction.MergeSameTimeCodes))
             {
-                var mergedSameTimeCodesSub = MergeLinesWithSameTimeCodes.Merge(sub, new List<int>(), out _, true, false, 1000, "en", new List<int>(), new Dictionary<int, bool>(), new Subtitle());
+                var mergedSameTimeCodesSub = MergeLinesWithSameTimeCodes.Merge(sub, new List<int>(), out _, true, Configuration.Settings.Tools.MergeTextWithSameTimeCodesMakeDialog, Configuration.Settings.Tools.MergeTextWithSameTimeCodesReBreakLines, Configuration.Settings.Tools.MergeTextWithSameTimeCodesMaxGap, "en", new List<int>(), new Dictionary<int, bool>(), new Subtitle());
                 if (mergedSameTimeCodesSub.Paragraphs.Count != sub.Paragraphs.Count)
                 {
                     sub.Paragraphs.Clear();

--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -408,6 +408,15 @@ namespace Nikse.SubtitleEdit.Forms
 
             checkBoxOnlyContinuationLines.Checked = Configuration.Settings.Tools.MergeShortLinesOnlyContinuous;
 
+            groupBoxMergeSameTimeCodes.Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.Title;
+            labelMergeSameTimeCodesMaxDifference.Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.MaxDifferenceMilliseconds;
+            checkBoxMergeSameTimeCodesMakeDialog.Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.MakeDialog;
+            checkBoxMergeSameTimeCodesReBreakLines.Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.ReBreakLines;
+
+            numericUpDownMergeSameTimeCodesMaxDifference.Value = Configuration.Settings.Tools.MergeTextWithSameTimeCodesMaxGap;
+            checkBoxMergeSameTimeCodesMakeDialog.Checked = Configuration.Settings.Tools.MergeTextWithSameTimeCodesMakeDialog;
+            checkBoxMergeSameTimeCodesReBreakLines.Checked = Configuration.Settings.Tools.MergeTextWithSameTimeCodesReBreakLines;
+
             inverseSelectionToolStripMenuItem.Text = LanguageSettings.Current.Main.Menu.Edit.InverseSelection;
             toolStripMenuItemSelectAll.Text = LanguageSettings.Current.Main.Menu.ContextMenu.SelectAll;
             UpdateNumberOfFiles();
@@ -510,7 +519,8 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.Title,
                     Checked = Configuration.Settings.Tools.BatchConvertMergeSameTimeCodes,
-                    Action = CommandLineConverter.BatchAction.MergeSameTimeCodes
+                    Action = CommandLineConverter.BatchAction.MergeSameTimeCodes,
+                    Control = groupBoxMergeSameTimeCodes
                 },
                 new FixActionItem
                 {
@@ -1685,7 +1695,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (IsActionEnabled(CommandLineConverter.BatchAction.MergeSameTimeCodes))
             {
-                var mergedSameTimeCodesSub = MergeLinesWithSameTimeCodes.Merge(sub, new List<int>(), out _, true, Configuration.Settings.Tools.MergeTextWithSameTimeCodesMakeDialog, Configuration.Settings.Tools.MergeTextWithSameTimeCodesReBreakLines, Configuration.Settings.Tools.MergeTextWithSameTimeCodesMaxGap, "en", new List<int>(), new Dictionary<int, bool>(), new Subtitle());
+                var mergedSameTimeCodesSub = MergeLinesWithSameTimeCodes.Merge(sub, new List<int>(), out _, true, checkBoxMergeSameTimeCodesMakeDialog.Checked, checkBoxMergeSameTimeCodesReBreakLines.Checked, Convert.ToInt32(numericUpDownMergeSameTimeCodesMaxDifference.Value), "en", new List<int>(), new Dictionary<int, bool>(), new Subtitle());
                 if (mergedSameTimeCodesSub.Paragraphs.Count != sub.Paragraphs.Count)
                 {
                     sub.Paragraphs.Clear();
@@ -2633,6 +2643,9 @@ namespace Nikse.SubtitleEdit.Forms
             Configuration.Settings.Tools.MergeShortLinesOnlyContinuous = checkBoxOnlyContinuationLines.Checked;
             Configuration.Settings.Tools.BatchConvertDeleteLines = IsActionEnabled(CommandLineConverter.BatchAction.DeleteLines);
             Configuration.Settings.Tools.BatchConvertAssaChangeRes = IsActionEnabled(CommandLineConverter.BatchAction.AssaChangeRes);
+            Configuration.Settings.Tools.MergeTextWithSameTimeCodesMaxGap = Convert.ToInt32(numericUpDownMergeSameTimeCodesMaxDifference.Value);
+            Configuration.Settings.Tools.MergeTextWithSameTimeCodesMakeDialog = checkBoxMergeSameTimeCodesMakeDialog.Checked;
+            Configuration.Settings.Tools.MergeTextWithSameTimeCodesReBreakLines = checkBoxMergeSameTimeCodesReBreakLines.Checked;
 
             UpdateRtlSettings();
         }

--- a/src/ui/Forms/MergeTextWithSameTimeCodes.Designer.cs
+++ b/src/ui/Forms/MergeTextWithSameTimeCodes.Designer.cs
@@ -37,12 +37,13 @@
             this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeaderText = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.buttonOK = new System.Windows.Forms.Button();
-            this.buttonCancel = new System.Windows.Forms.Button();
-            this.SubtitleListview1 = new Nikse.SubtitleEdit.Controls.SubtitleListView();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripMenuItemSelectAll = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemInverseSelection = new System.Windows.Forms.ToolStripMenuItem();
+            this.buttonOK = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.checkBoxMakeDialog = new System.Windows.Forms.CheckBox();
+            this.SubtitleListview1 = new Nikse.SubtitleEdit.Controls.SubtitleListView();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMaxMillisecondsBetweenLines)).BeginInit();
             this.groupBoxLinesFound.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
@@ -58,7 +59,7 @@
             0});
             this.numericUpDownMaxMillisecondsBetweenLines.Name = "numericUpDownMaxMillisecondsBetweenLines";
             this.numericUpDownMaxMillisecondsBetweenLines.Size = new System.Drawing.Size(64, 20);
-            this.numericUpDownMaxMillisecondsBetweenLines.TabIndex = 55;
+            this.numericUpDownMaxMillisecondsBetweenLines.TabIndex = 2;
             this.numericUpDownMaxMillisecondsBetweenLines.Value = new decimal(new int[] {
             250,
             0,
@@ -72,16 +73,16 @@
             this.labelMaxDifferenceMS.Location = new System.Drawing.Point(12, 14);
             this.labelMaxDifferenceMS.Name = "labelMaxDifferenceMS";
             this.labelMaxDifferenceMS.Size = new System.Drawing.Size(171, 13);
-            this.labelMaxDifferenceMS.TabIndex = 56;
+            this.labelMaxDifferenceMS.TabIndex = 1;
             this.labelMaxDifferenceMS.Text = "Maximum difference in milliseconds";
             // 
             // checkBoxAutoBreakOn
             // 
             this.checkBoxAutoBreakOn.AutoSize = true;
-            this.checkBoxAutoBreakOn.Location = new System.Drawing.Point(291, 15);
+            this.checkBoxAutoBreakOn.Location = new System.Drawing.Point(401, 14);
             this.checkBoxAutoBreakOn.Name = "checkBoxAutoBreakOn";
             this.checkBoxAutoBreakOn.Size = new System.Drawing.Size(90, 17);
-            this.checkBoxAutoBreakOn.TabIndex = 54;
+            this.checkBoxAutoBreakOn.TabIndex = 4;
             this.checkBoxAutoBreakOn.Text = "Re-break text";
             this.checkBoxAutoBreakOn.UseVisualStyleBackColor = true;
             this.checkBoxAutoBreakOn.CheckedChanged += new System.EventHandler(this.checkBoxAutoBreakOn_CheckedChanged);
@@ -94,7 +95,7 @@
             this.groupBoxLinesFound.Location = new System.Drawing.Point(9, 41);
             this.groupBoxLinesFound.Name = "groupBoxLinesFound";
             this.groupBoxLinesFound.Size = new System.Drawing.Size(983, 207);
-            this.groupBoxLinesFound.TabIndex = 53;
+            this.groupBoxLinesFound.TabIndex = 5;
             this.groupBoxLinesFound.TabStop = false;
             this.groupBoxLinesFound.Text = "Lines that will be merged";
             // 
@@ -133,6 +134,28 @@
             this.columnHeaderText.Text = "New text";
             this.columnHeaderText.Width = 500;
             // 
+            // contextMenuStrip1
+            // 
+            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemSelectAll,
+            this.toolStripMenuItemInverseSelection});
+            this.contextMenuStrip1.Name = "contextMenuStrip1";
+            this.contextMenuStrip1.Size = new System.Drawing.Size(162, 48);
+            // 
+            // toolStripMenuItemSelectAll
+            // 
+            this.toolStripMenuItemSelectAll.Name = "toolStripMenuItemSelectAll";
+            this.toolStripMenuItemSelectAll.Size = new System.Drawing.Size(161, 22);
+            this.toolStripMenuItemSelectAll.Text = "Select all";
+            this.toolStripMenuItemSelectAll.Click += new System.EventHandler(this.toolStripMenuItemSelectAll_Click);
+            // 
+            // toolStripMenuItemInverseSelection
+            // 
+            this.toolStripMenuItemInverseSelection.Name = "toolStripMenuItemInverseSelection";
+            this.toolStripMenuItemInverseSelection.Size = new System.Drawing.Size(161, 22);
+            this.toolStripMenuItemInverseSelection.Text = "Inverse selection";
+            this.toolStripMenuItemInverseSelection.Click += new System.EventHandler(this.toolStripMenuItemInverseSelection_Click);
+            // 
             // buttonOK
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -140,7 +163,7 @@
             this.buttonOK.Location = new System.Drawing.Point(836, 501);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
-            this.buttonOK.TabIndex = 51;
+            this.buttonOK.TabIndex = 10;
             this.buttonOK.Text = "&OK";
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
@@ -153,10 +176,21 @@
             this.buttonCancel.Location = new System.Drawing.Point(917, 501);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-            this.buttonCancel.TabIndex = 52;
+            this.buttonCancel.TabIndex = 11;
             this.buttonCancel.Text = "C&ancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
+            // 
+            // checkBoxMakeDialog
+            // 
+            this.checkBoxMakeDialog.AutoSize = true;
+            this.checkBoxMakeDialog.Location = new System.Drawing.Point(286, 14);
+            this.checkBoxMakeDialog.Name = "checkBoxMakeDialog";
+            this.checkBoxMakeDialog.Size = new System.Drawing.Size(84, 17);
+            this.checkBoxMakeDialog.TabIndex = 3;
+            this.checkBoxMakeDialog.Text = "Make dialog";
+            this.checkBoxMakeDialog.UseVisualStyleBackColor = true;
+            this.checkBoxMakeDialog.CheckedChanged += new System.EventHandler(this.checkBoxMakeDialog_CheckedChanged);
             // 
             // SubtitleListview1
             // 
@@ -178,38 +212,17 @@
             this.SubtitleListview1.SubtitleFontBold = false;
             this.SubtitleListview1.SubtitleFontName = "Tahoma";
             this.SubtitleListview1.SubtitleFontSize = 8;
-            this.SubtitleListview1.TabIndex = 50;
+            this.SubtitleListview1.TabIndex = 6;
             this.SubtitleListview1.UseCompatibleStateImageBehavior = false;
             this.SubtitleListview1.UseSyntaxColoring = true;
             this.SubtitleListview1.View = System.Windows.Forms.View.Details;
-            // 
-            // contextMenuStrip1
-            // 
-            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItemSelectAll,
-            this.toolStripMenuItemInverseSelection});
-            this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(181, 70);
-            // 
-            // toolStripMenuItemSelectAll
-            // 
-            this.toolStripMenuItemSelectAll.Name = "toolStripMenuItemSelectAll";
-            this.toolStripMenuItemSelectAll.Size = new System.Drawing.Size(180, 22);
-            this.toolStripMenuItemSelectAll.Text = "Select all";
-            this.toolStripMenuItemSelectAll.Click += new System.EventHandler(this.toolStripMenuItemSelectAll_Click);
-            // 
-            // toolStripMenuItemInverseSelection
-            // 
-            this.toolStripMenuItemInverseSelection.Name = "toolStripMenuItemInverseSelection";
-            this.toolStripMenuItemInverseSelection.Size = new System.Drawing.Size(180, 22);
-            this.toolStripMenuItemInverseSelection.Text = "Inverse selection";
-            this.toolStripMenuItemInverseSelection.Click += new System.EventHandler(this.toolStripMenuItemInverseSelection_Click);
             // 
             // MergeTextWithSameTimeCodes
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1004, 534);
+            this.Controls.Add(this.checkBoxMakeDialog);
             this.Controls.Add(this.numericUpDownMaxMillisecondsBetweenLines);
             this.Controls.Add(this.labelMaxDifferenceMS);
             this.Controls.Add(this.checkBoxAutoBreakOn);
@@ -224,9 +237,9 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "MergeTextWithSameTimeCodes";
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MergeTextWithSameTimeCodes_KeyDown);
-            this.ResizeEnd += new System.EventHandler(this.MergeTextWithSameTimeCodes_ResizeEnd);
             this.Shown += new System.EventHandler(this.MergeTextWithSameTimeCodes_Shown);
+            this.ResizeEnd += new System.EventHandler(this.MergeTextWithSameTimeCodes_ResizeEnd);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MergeTextWithSameTimeCodes_KeyDown);
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMaxMillisecondsBetweenLines)).EndInit();
             this.groupBoxLinesFound.ResumeLayout(false);
             this.contextMenuStrip1.ResumeLayout(false);
@@ -251,5 +264,6 @@
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemSelectAll;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemInverseSelection;
+        private System.Windows.Forms.CheckBox checkBoxMakeDialog;
     }
 }

--- a/src/ui/Forms/MergeTextWithSameTimeCodes.cs
+++ b/src/ui/Forms/MergeTextWithSameTimeCodes.cs
@@ -53,10 +53,17 @@ namespace Nikse.SubtitleEdit.Forms
 
             Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.Title;
             labelMaxDifferenceMS.Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.MaxDifferenceMilliseconds;
+            checkBoxMakeDialog.Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.MakeDialog;
             checkBoxAutoBreakOn.Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.ReBreakLines;
+            checkBoxAutoBreakOn.Left = checkBoxMakeDialog.Left + checkBoxMakeDialog.Width + 30;
+
             listViewFixes.Columns[0].Text = LanguageSettings.Current.General.Apply;
             listViewFixes.Columns[1].Text = LanguageSettings.Current.General.LineNumber;
             listViewFixes.Columns[2].Text = LanguageSettings.Current.MergeTextWithSameTimeCodes.MergedText;
+
+            numericUpDownMaxMillisecondsBetweenLines.Value = Configuration.Settings.Tools.MergeTextWithSameTimeCodesMaxGap;
+            checkBoxMakeDialog.Checked = Configuration.Settings.Tools.MergeTextWithSameTimeCodesMakeDialog;
+            checkBoxAutoBreakOn.Checked = Configuration.Settings.Tools.MergeTextWithSameTimeCodesReBreakLines;
 
             toolStripMenuItemInverseSelection.Text = LanguageSettings.Current.Main.Menu.Edit.InverseSelection;
             toolStripMenuItemSelectAll.Text = LanguageSettings.Current.Main.Menu.ContextMenu.SelectAll;
@@ -115,7 +122,7 @@ namespace Nikse.SubtitleEdit.Forms
             NumberOfMerges = 0;
             SubtitleListview1.Items.Clear();
             SubtitleListview1.BeginUpdate();
-            MergedSubtitle = MergeLinesWithSameTimeCodes(_subtitle, mergedIndexes, out var count, true, checkBoxAutoBreakOn.Checked, (int)numericUpDownMaxMillisecondsBetweenLines.Value, _language);
+            MergedSubtitle = MergeLinesWithSameTimeCodes(_subtitle, mergedIndexes, out var count, true, checkBoxMakeDialog.Checked, checkBoxAutoBreakOn.Checked, (int)numericUpDownMaxMillisecondsBetweenLines.Value, _language);
             NumberOfMerges = count;
 
             SubtitleListview1.Fill(_subtitle);
@@ -171,7 +178,7 @@ namespace Nikse.SubtitleEdit.Forms
             Cursor = Cursors.WaitCursor;
             SubtitleListview1.Items.Clear();
             SubtitleListview1.BeginUpdate();
-            MergedSubtitle = MergeLinesWithSameTimeCodes(_subtitle, mergedIndexes, out var count, false, checkBoxAutoBreakOn.Checked, (int)numericUpDownMaxMillisecondsBetweenLines.Value, _language);
+            MergedSubtitle = MergeLinesWithSameTimeCodes(_subtitle, mergedIndexes, out var count, false, checkBoxMakeDialog.Checked, checkBoxAutoBreakOn.Checked, (int)numericUpDownMaxMillisecondsBetweenLines.Value, _language);
             NumberOfMerges = count;
             SubtitleListview1.Fill(_subtitle);
             SetBackgroundColors();
@@ -180,7 +187,7 @@ namespace Nikse.SubtitleEdit.Forms
             groupBoxLinesFound.Text = string.Format(LanguageSettings.Current.MergeTextWithSameTimeCodes.NumberOfMergesX, NumberOfMerges);
         }
 
-        public Subtitle MergeLinesWithSameTimeCodes(Subtitle subtitle, List<int> mergedIndexes, out int numberOfMerges, bool clearFixes, bool reBreak, int maxMsBetween, string language)
+        public Subtitle MergeLinesWithSameTimeCodes(Subtitle subtitle, List<int> mergedIndexes, out int numberOfMerges, bool clearFixes, bool makeDialog, bool reBreak, int maxMsBetween, string language)
         {
             listViewFixes.BeginUpdate();
             var removed = new List<int>();
@@ -195,7 +202,7 @@ namespace Nikse.SubtitleEdit.Forms
                 _isFixAllowedList = new Dictionary<int, bool>();
             }
             var info = new Subtitle();
-            var mergedSub = Core.Forms.MergeLinesWithSameTimeCodes.Merge(subtitle, mergedIndexes, out numberOfMerges, clearFixes, reBreak, maxMsBetween, language, removed, _isFixAllowedList, info);
+            var mergedSub = Core.Forms.MergeLinesWithSameTimeCodes.Merge(subtitle, mergedIndexes, out numberOfMerges, clearFixes, makeDialog, reBreak, maxMsBetween, language, removed, _isFixAllowedList, info);
             var listViewItems = new List<ListViewItem>();
             foreach (var p in info.Paragraphs)
             {
@@ -221,6 +228,10 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void buttonOK_Click(object sender, EventArgs e)
         {
+            Configuration.Settings.Tools.MergeTextWithSameTimeCodesMaxGap = (int)numericUpDownMaxMillisecondsBetweenLines.Value;
+            Configuration.Settings.Tools.MergeTextWithSameTimeCodesMakeDialog = checkBoxMakeDialog.Checked;
+            Configuration.Settings.Tools.MergeTextWithSameTimeCodesReBreakLines = checkBoxAutoBreakOn.Checked;
+
             DialogResult = DialogResult.OK;
         }
 
@@ -298,6 +309,13 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 item.Checked = !item.Checked;
             }
+        }
+
+        private void checkBoxMakeDialog_CheckedChanged(object sender, EventArgs e)
+        {
+            Cursor = Cursors.WaitCursor;
+            GeneratePreview();
+            Cursor = Cursors.Default;
         }
     }
 }

--- a/src/ui/Logic/CommandLineConvert/CommandLineConverter.cs
+++ b/src/ui/Logic/CommandLineConvert/CommandLineConverter.cs
@@ -1948,7 +1948,7 @@ namespace Nikse.SubtitleEdit.Logic.CommandLineConvert
 
                             break;
                         case BatchAction.MergeSameTimeCodes:
-                            var mergedSameTimeCodesSub = Core.Forms.MergeLinesWithSameTimeCodes.Merge(sub, new List<int>(), out _, true, false, 1000, "en", new List<int>(), new Dictionary<int, bool>(), new Subtitle());
+                            var mergedSameTimeCodesSub = Core.Forms.MergeLinesWithSameTimeCodes.Merge(sub, new List<int>(), out _, true, Configuration.Settings.Tools.MergeTextWithSameTimeCodesMakeDialog, Configuration.Settings.Tools.MergeTextWithSameTimeCodesReBreakLines, Configuration.Settings.Tools.MergeTextWithSameTimeCodesMaxGap, "en", new List<int>(), new Dictionary<int, bool>(), new Subtitle());
                             if (mergedSameTimeCodesSub.Paragraphs.Count != sub.Paragraphs.Count)
                             {
                                 sub.Paragraphs.Clear();

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -2180,6 +2180,7 @@ namespace Nikse.SubtitleEdit.Logic
             {
                 Title = "Merge lines with same time codes",
                 MaxDifferenceMilliseconds = "Max. milliseconds difference",
+                MakeDialog = "Make dialog",
                 ReBreakLines = "Re-break lines",
                 NumberOfMergesX = "Number of merges: {0}",
                 MergedText = "Merged text",

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -2030,6 +2030,7 @@
         {
             public string Title { get; set; }
             public string MaxDifferenceMilliseconds { get; set; }
+            public string MakeDialog { get; set; }
             public string ReBreakLines { get; set; }
             public string NumberOfMergesX { get; set; }
             public string MergedText { get; set; }


### PR DESCRIPTION
A couple of years ago, I wanted to convert a WebVTT file, but it had different speakers in separate subtitles with the same time codes. It were closed captions that had different on-screen positions per speaker.
I wrote a quick tool to merge the subtitles and add dashes.
I now added this functionality to Subtitle Edit, in case anyone faces a similar problem in the future.

![image](https://user-images.githubusercontent.com/3516155/188331618-9cc265aa-b305-47c6-985c-405740d48424.png)

(I moved "Re-break lines" to the right because it will hapen **after** adding dashes.)


Also added options to Batch convert:

![image](https://user-images.githubusercontent.com/3516155/188331633-34142011-5372-4e7c-8cee-2ca774cbaad9.png)

Also works with even more speakers:

![image](https://user-images.githubusercontent.com/3516155/188331956-5f9bea28-f715-42df-b8e4-f98aac1a8a58.png)
