### PR TITLE
Unify regex newline behavior for modify selection

### DIFF
--- a/src/ui/Forms/ModifySelection.cs
+++ b/src/ui/Forms/ModifySelection.cs
@@ -353,7 +353,7 @@ namespace Nikse.SubtitleEdit.Forms
                             {
                                 try
                                 {
-                                    regEx = new Regex(text, RegexOptions.Compiled);
+                                    regEx = new Regex(RegexUtils.FixNewLine(text), RegexOptions.Compiled);
                                 }
                                 catch (Exception e)
                                 {


### PR DESCRIPTION
Regex everywhere in SE does this, except for modify selection which caused it to show different results from Multiple Replace.