### PR TITLE
Try to fix auto vertical scrollbar crash

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -10484,7 +10484,10 @@ namespace Nikse.SubtitleEdit.Forms
                         tb.TextBoxFont,
                         new Size(tb.Width, 1000),
                         TextFormatFlags.WordBreak | TextFormatFlags.TextBoxControl).Height;
-                    tb.ScrollBars = calculatedHeight > tb.Height ? RichTextBoxScrollBars.Vertical : RichTextBoxScrollBars.None;
+                    BeginInvoke(new Action(() =>
+                    {
+                        tb.ScrollBars = calculatedHeight > tb.Height ? RichTextBoxScrollBars.Vertical : RichTextBoxScrollBars.None;
+                    }));
                 }
             }
             catch


### PR DESCRIPTION
I had a text box with one long line and a second short one, and each time I tried to change the casing of a couple of words in the first line, SE crashes. Maybe this is the same crash that was happening with other users?

Anyway, I tried adding a BeginInvoke and it worked, maybe too many things were happening to the text box at the same time and this makes handling them easier? Do you think this has any bad effects?