### PR TITLE
Implement Ctrl+Enter for "use once", remove duplicate Escape clause

### DIFF
--- a/src/ui/Forms/Ocr/VobSubOcrCharacter.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrCharacter.cs
@@ -170,11 +170,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         {
             if (e.KeyCode == Keys.Enter)
             {
+                if (e.Modifiers == Keys.Control)
+                {
+                    UseOnce = true;
+                }
+
                 DialogResult = DialogResult.OK;
-            }
-            else if (e.KeyCode == Keys.Escape)
-            {
-                DialogResult = DialogResult.Cancel;
             }
             else if (e.KeyCode == Keys.Escape)
             {


### PR DESCRIPTION
Quick addition to be able to press Ctrl+Enter for "Use once".
I chose Ctrl instead of Alt or Shift, because they could be already pressed for capital letters or special characters, in combination with "Submit on first char".

Also removed the duplicate Escape clause from the if statement.