### PR TITLE
Some OCR improvements

### DIFF
--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -8773,6 +8773,14 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         private void comboBoxNOcrLanguage_SelectedIndexChanged(object sender, EventArgs e)
         {
             _nOcrDb = null;
+
+            if (_ocrMethodIndex == _ocrMethodNocr)
+            {
+                if (comboBoxNOcrLanguage.Items.Count > 0 && comboBoxNOcrLanguage.SelectedIndex >= 0)
+                {
+                    Configuration.Settings.VobSubOcr.LineOcrLastLanguages = comboBoxNOcrLanguage.Items[comboBoxNOcrLanguage.SelectedIndex].ToString();
+                }
+            }
         }
 
         private void buttonSpellCheckDownload_Click(object sender, EventArgs e)

--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -6314,15 +6314,87 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
         private string OcrViaCloudVision(Bitmap bitmap, int listViewIndex)
         {
+            if (_ocrFixEngine == null)
+            {
+                comboBoxDictionaries_SelectedIndexChanged(null, null);
+            }
+
+            string line = string.Empty;
+
             var language = (comboBoxCloudVisionLanguage.SelectedItem as OcrLanguage).Code;
             var cloudVisionResult = _ocrService.PerformOcr(language, new List<Bitmap>() { bitmap });
 
             if (cloudVisionResult.Count > 0)
             {
-                return cloudVisionResult[0];
+                line = cloudVisionResult[0];
             }
 
-            return string.Empty;
+            if (checkBoxAutoFixCommonErrors.Checked && _ocrFixEngine != null)
+            {
+                var lastLastLine = GetLastLastText(listViewIndex);
+                line = _ocrFixEngine.FixOcrErrorsViaHardcodedRules(line, _lastLine, lastLastLine, null); // TODO: Add abbreviations list
+            }
+
+            if (checkBoxRightToLeft.Checked)
+            {
+                line = ReverseNumberStrings(line);
+            }
+
+            //OCR fix engine
+            string textWithOutFixes = line;
+            if (_ocrFixEngine != null && _ocrFixEngine.IsDictionaryLoaded)
+            {
+                var autoGuessLevel = OcrFixEngine.AutoGuessLevel.None;
+                if (checkBoxGuessUnknownWords.Checked)
+                {
+                    autoGuessLevel = OcrFixEngine.AutoGuessLevel.Aggressive;
+                }
+
+                if (checkBoxAutoFixCommonErrors.Checked)
+                {
+                    var lastLastLine = GetLastLastText(listViewIndex);
+                    line = _ocrFixEngine.FixOcrErrors(line, listViewIndex, _lastLine, lastLastLine, true, autoGuessLevel);
+                }
+
+                int wordsNotFound = _ocrFixEngine.CountUnknownWordsViaDictionary(line, out var correctWords);
+
+                if (wordsNotFound > 0 || correctWords == 0 || textWithOutFixes != null)
+                {
+                    _ocrFixEngine.AutoGuessesUsed.Clear();
+                    _ocrFixEngine.UnknownWordsFound.Clear();
+                    line = _ocrFixEngine.FixUnknownWordsViaGuessOrPrompt(out wordsNotFound, line, listViewIndex, bitmap, checkBoxAutoFixCommonErrors.Checked, checkBoxPromptForUnknownWords.Checked, true, autoGuessLevel);
+                }
+
+                if (_ocrFixEngine.Abort)
+                {
+                    ButtonPauseClick(null, null);
+                    _ocrFixEngine.Abort = false;
+
+                    return string.Empty;
+                }
+
+                // Log used word guesses (via word replace list)
+                foreach (var guess in _ocrFixEngine.AutoGuessesUsed)
+                {
+                    listBoxLogSuggestions.Items.Add(guess);
+                }
+
+                _ocrFixEngine.AutoGuessesUsed.Clear();
+
+                // Log unknown words guess (found via spelling dictionaries)
+                LogUnknownWords();
+
+                ColorLineByNumberOfUnknownWords(listViewIndex, wordsNotFound, line);
+            }
+
+            if (textWithOutFixes.Trim() != line.Trim())
+            {
+                _tesseractOcrAutoFixes++;
+                labelFixesMade.Text = $" - {_tesseractOcrAutoFixes}";
+                LogOcrFix(listViewIndex, textWithOutFixes, line);
+            }
+
+            return line;
         }
 
         private void InitializeNOcrForBatch(string db)

--- a/src/ui/Forms/Ocr/VobSubOcrNOcrCharacter.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrNOcrCharacter.cs
@@ -870,6 +870,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             if (e.KeyCode == Keys.Enter)
             {
                 e.SuppressKeyPress = true;
+
+                if (e.Modifiers == Keys.Control)
+                {
+                    UseOnce = true;
+                }
+
                 buttonOK_Click(null, null);
             }
         }

--- a/src/ui/Forms/Ocr/VobSubOcrNOcrCharacter.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrNOcrCharacter.cs
@@ -897,10 +897,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
                 if (e.Modifiers == Keys.Control)
                 {
-                    UseOnce = true;
+                    buttonOnce_Click(null, null);
+                } 
+                else
+                {
+                    buttonOK_Click(null, null);
                 }
-
-                buttonOK_Click(null, null);
             }
         }
 

--- a/src/ui/Forms/Ocr/VobSubOcrNOcrCharacter.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrNOcrCharacter.cs
@@ -171,7 +171,31 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
         private void buttonOK_Click(object sender, EventArgs e)
         {
-            HandleOKClicked(false);
+            if (listBoxLinesForeground.Items.Count == 0)
+            {
+                MessageBox.Show("No foreground lines!");
+                return;
+            }
+            if (listBoxlinesBackground.Items.Count == 0 && !_warningNoNotForegroundLinesShown)
+            {
+                MessageBox.Show("No not-foreground lines!");
+                _warningNoNotForegroundLinesShown = true;
+                return;
+            }
+            if (textBoxCharacters.Text.Length == 0)
+            {
+                MessageBox.Show("Text is empty!");
+                return;
+            }
+            if (!IsMatch())
+            {
+                MessageBox.Show("Lines does not match image!");
+                return;
+            }
+            NOcrChar.Text = textBoxCharacters.Text;
+            NOcrChar.Italic = checkBoxItalic.Checked;
+            UseOnce = false;
+            DialogResult = DialogResult.OK;
         }
 
         private void pictureBoxCharacter_Paint(object sender, PaintEventArgs e)
@@ -997,35 +1021,9 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
         private void buttonOnce_Click(object sender, EventArgs e)
         {
-            HandleOKClicked(true);
-        }
-
-        private void HandleOKClicked(bool useOnce)
-        {
-            if (listBoxLinesForeground.Items.Count == 0)
-            {
-                MessageBox.Show("No foreground lines!");
-                return;
-            }
-            if (listBoxlinesBackground.Items.Count == 0 && !_warningNoNotForegroundLinesShown)
-            {
-                MessageBox.Show("No not-foreground lines!");
-                _warningNoNotForegroundLinesShown = true;
-                return;
-            }
-            if (textBoxCharacters.Text.Length == 0)
-            {
-                MessageBox.Show("Text is empty!");
-                return;
-            }
-            if (!IsMatch())
-            {
-                MessageBox.Show("Lines does not match image!");
-                return;
-            }
             NOcrChar.Text = textBoxCharacters.Text;
             NOcrChar.Italic = checkBoxItalic.Checked;
-            UseOnce = useOnce;
+            UseOnce = true;
             DialogResult = DialogResult.OK;
         }
     }


### PR DESCRIPTION
Some fixes/improvements:

- Run OCR Fix Engine after OCR with Cloud Vision (derived from `SplitAndOcrBinaryImageCompare` )
- Enable Ctrl+Enter for "Use once" in VobSubOcrNOcrCharacter as well (the button was already there)
- Don't check for empty text and lines when using "Use once" in VobSubOcrNOcrCharacter
- Remember NOcr language within session (Change NOcr language > Switch to Cloud Vision > Switch back to NOcr > Language is now retained)

There's one more aspect to Cloud Vision that could be improved, for which I created a separate issue:
https://github.com/SubtitleEdit/subtitleedit/issues/6319