### PR TITLE
Try to fix bookmark showing on first spell check line

### DIFF
--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -773,16 +773,6 @@ namespace Nikse.SubtitleEdit.Forms
                         _currentIndex++;
                         _currentParagraph = _subtitle.Paragraphs[_currentIndex];
 
-                        panelBookmark.Hide();
-                        if (_currentParagraph.Bookmark != null)
-                        {
-                            pictureBoxBookmark.Show();
-                        }
-                        else
-                        {
-                            pictureBoxBookmark.Hide();
-                        }
-
                         SetWords(_currentParagraph.Text);
                         _wordsIndex = 0;
                         if (_words.Count == 0)
@@ -801,6 +791,16 @@ namespace Nikse.SubtitleEdit.Forms
                         DialogResult = DialogResult.OK;
                         return;
                     }
+                }
+
+                panelBookmark.Hide();
+                if (_currentParagraph.Bookmark != null)
+                {
+                    pictureBoxBookmark.Show();
+                }
+                else
+                {
+                    pictureBoxBookmark.Hide();
                 }
 
                 int minLength = 2;


### PR DESCRIPTION
I'm not sure this is the proper fix but I couldn't another way to do this.

It used to be that when the is a wrong word in the first line, SE shows a bookmark for it even if it isn't bookmarked:

![image](https://user-images.githubusercontent.com/20923700/201122292-e14bf8cc-9d1c-484d-bc6c-525aed74e553.png)