### PR TITLE
Add hidden option for MPV font size scaling

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -1374,6 +1374,7 @@ $HorzAlign          =   Center
         public bool MpvPreviewTextOpaqueBox { get; set; }
         public string MpvPreviewTextAlignment { get; set; }
         public int MpvPreviewTextMarginVertical { get; set; }
+        public decimal MpvPreviewTextFontSizeFactor { get; set; }
         public string MpcHcLocation { get; set; }
         public string MkvMergeLocation { get; set; }
         public bool UseFFmpegForWaveExtraction { get; set; }
@@ -1552,6 +1553,7 @@ $HorzAlign          =   Center
             MpvPreviewTextOpaqueBox = false;
             MpvPreviewTextAlignment = "2";
             MpvPreviewTextMarginVertical = 10;
+            MpvPreviewTextFontSizeFactor = 1;
             FFmpegSceneThreshold = "0.4"; // threshold for generating shot changes - 0.2 is sensitive (more shot changes), 0.6 is less sensitive (fewer shot changes)
             UseTimeFormatHHMMSSFF = false;
             SplitBehavior = 1; // 0=take gap from left, 1=divide evenly, 2=take gap from right
@@ -4076,6 +4078,13 @@ $HorzAlign          =   Center
             {
                 settings.General.MpvPreviewTextMarginVertical = Convert.ToInt32(subNode.InnerText.Trim());
             }
+
+            subNode = node.SelectSingleNode("MpvPreviewTextFontSizeFactor");
+            if (subNode != null)
+            {
+                settings.General.MpvPreviewTextFontSizeFactor = Convert.ToDecimal(subNode.InnerText.Trim());
+            }
+
             subNode = node.SelectSingleNode("MpcHcLocation");
             if (subNode != null)
             {
@@ -10068,6 +10077,7 @@ $HorzAlign          =   Center
                 textWriter.WriteElementString("MpvPreviewTextOpaqueBox", settings.General.MpvPreviewTextOpaqueBox.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("MpvPreviewTextAlignment", settings.General.MpvPreviewTextAlignment);
                 textWriter.WriteElementString("MpvPreviewTextMarginVertical", settings.General.MpvPreviewTextMarginVertical.ToString(CultureInfo.InvariantCulture));
+                textWriter.WriteElementString("MpvPreviewTextFontSizeFactor", settings.General.MpvPreviewTextFontSizeFactor.ToString(CultureInfo.InvariantCulture));
                 textWriter.WriteElementString("MpcHcLocation", settings.General.MpcHcLocation);
                 textWriter.WriteElementString("MkvMergeLocation", settings.General.MkvMergeLocation);
                 textWriter.WriteElementString("UseFFmpegForWaveExtraction", settings.General.UseFFmpegForWaveExtraction.ToString(CultureInfo.InvariantCulture));

--- a/src/ui/Controls/VideoPlayerContainer.cs
+++ b/src/ui/Controls/VideoPlayerContainer.cs
@@ -418,7 +418,7 @@ namespace Nikse.SubtitleEdit.Controls
             {
                 Name = "Default",
                 FontName = gs.VideoPlayerPreviewFontName,
-                FontSize = gs.VideoPlayerPreviewFontSize,
+                FontSize = gs.VideoPlayerPreviewFontSize * gs.MpvPreviewTextFontSizeFactor,
                 Bold = gs.VideoPlayerPreviewFontBold,
                 Primary = gs.MpvPreviewTextPrimaryColor,
                 OutlineWidth = gs.MpvPreviewTextOutlineWidth,


### PR DESCRIPTION
Okay, hear me out on this. :)

Say I'm using font size 24 for my MPV preview, which looks like this:
![image](https://user-images.githubusercontent.com/20923700/204072459-7d9f5e47-68fe-46ee-8c10-414cd3274760.png)

Just a proper font size.
And then I load a second sub:
![image](https://user-images.githubusercontent.com/20923700/204072466-8418a286-6478-4f40-902a-af13eed22b4b.png)

The difference in font size between MPV and normal preview just doesn't work, I've been struggling with this for a while now, so why not at least have a custom hidden option for MPV font size factor?
That way I can set my font size to something like 16 and the factor to 1.5 which give me 24 for MPV preview:

I tried doing this for MPV using something in the `MpvExtraOptions` setting but sadly couldn't find any option that would only change the default font size for the preview.
