### PR TITLE
optimize merge line with same text

### DIFF
--- a/src/libse/Common/MergeLinesSameTextUtils.cs
+++ b/src/libse/Common/MergeLinesSameTextUtils.cs
@@ -29,6 +29,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
 
                     var next = subtitle.GetParagraphOrDefault(j);
+
+                    // short circuit as we know non of the paragraph following the next will have shorted start time / gaps
+                    double gaps = next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds;
+                    if (gaps > maxMsBetween)
+                    {
+                        break;
+                    }
+
                     var incrementText = string.Empty;
                     if ((QualifiesForMerge(p, next, maxMsBetween) || fixIncrementing && QualifiesForMergeIncrement(p, next, maxMsBetween, out incrementText)))
                     {

--- a/src/ui/Forms/MergeDoubleLines.cs
+++ b/src/ui/Forms/MergeDoubleLines.cs
@@ -155,6 +155,14 @@ namespace Nikse.SubtitleEdit.Forms
                     }
 
                     var next = subtitle.GetParagraphOrDefault(j);
+                    
+                    // short circuit as we know non of the paragraph following the next will have shorted start time / gaps
+                    double gaps = next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds;
+                    if (gaps > maxMsBetween)
+                    {
+                        break;
+                    }
+                    
                     var incrementText = string.Empty;
                     if ((MergeLinesSameTextUtils.QualifiesForMerge(p, next, maxMsBetween) || fixIncrementing && MergeLinesSameTextUtils.QualifiesForMergeIncrement(p, next, maxMsBetween, out incrementText)) && IsFixAllowed(p))
                     {


### PR DESCRIPTION
We want to out the nested for-loop as soon as ((p+1).StartTime - (p).EndTime)) > `max_allowed_gaps`
otherwise we will run useless `n-1` operation as it's certain that non of the paragraph following the (p+1) will have lesser gaps