### PR TITLE
Don't round up for NQC timing

### DIFF
--- a/src/libse/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
@@ -19,7 +19,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
             }
 
             double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
-            int halfSecGap = (int)Math.Round(controller.FrameRate / 2, MidpointRounding.AwayFromZero);
+            int halfSecGap = (int)Math.Round(controller.FrameRate / 2);
 
             for (int index = 0; index < subtitle.Paragraphs.Count; index++)
             {

--- a/src/libse/NetflixQualityCheck/NetflixCheckShotChange.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckShotChange.cs
@@ -30,7 +30,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                 shotChanges = shotChanges.Select(sc => Math.Round(sc /= 1.001, 3, MidpointRounding.AwayFromZero)).ToList();
             }
 
-            int halfSecGapInFrames = (int)Math.Round(controller.FrameRate / 2, MidpointRounding.AwayFromZero);
+            int halfSecGapInFrames = (int)Math.Round(controller.FrameRate / 2);
             double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
 
             foreach (Paragraph p in subtitle.Paragraphs)


### PR DESCRIPTION
Well, according to Netflix: `We will not be measuring for a one-frame discrepancy.`
So I guess when the frame rate is 25, a gap of 12 frames is acceptable, meaning there is no need to round it up to 13.
I'm still convinced that it should be rounded up because it makes more sense, this is Netflix quality check so my opinion doesn't matter. :3