### PR TITLE
Update Inno Setup installer script

### DIFF
--- a/installer/Subtitle_Edit_installer.iss
+++ b/installer/Subtitle_Edit_installer.iss
@@ -31,7 +31,7 @@
 #endif
 
 
-#define app_copyright "Copyright © 2001-2023, Nikse"
+#define app_copyright "Nikse 2001-2023"
 ; If you don't define "localize", i.e. comment out the following line then no translations
 ; for SubtitleEdit or the installer itself will be included in the installer
 #define localize
@@ -84,7 +84,7 @@ AppPublisher=Nikse
 AppPublisherURL=https://www.nikse.dk/SubtitleEdit/
 AppSupportURL=https://www.nikse.dk/SubtitleEdit/
 AppUpdatesURL=https://www.nikse.dk/SubtitleEdit/
-UninstallDisplayName=Subtitle Edit {#app_ver}
+UninstallDisplayName=Subtitle Edit
 UninstallDisplayIcon={app}\SubtitleEdit.exe
 DefaultDirName={pf}\Subtitle Edit
 DefaultGroupName=Subtitle Edit
@@ -114,38 +114,38 @@ ArchitecturesInstallIn64BitMode=x64
 WizardStyle=modern
 
 [Languages]
-Name: "en"; MessagesFile: "compiler:Default.isl"
+Name: "en";   MessagesFile: "compiler:Default.isl"
 #ifdef localize
-Name: "ar"; MessagesFile: "Languages\Arabic.isl"
-Name: "bg"; MessagesFile: "Languages\Bulgarian.isl"
-Name: "ca"; MessagesFile: "compiler:Languages\Catalan.isl"
-Name: "cs"; MessagesFile: "compiler:Languages\Czech.isl"
-Name: "da"; MessagesFile: "compiler:Languages\Danish.isl"
-Name: "de"; MessagesFile: "compiler:Languages\German.isl"
-Name: "es"; MessagesFile: "compiler:Languages\Spanish.isl"
-Name: "eu"; MessagesFile: "Languages\Basque.isl"
-Name: "fa"; MessagesFile: "Languages\Farsi.isl"
-Name: "fi"; MessagesFile: "compiler:Languages\Finnish.isl"
-Name: "fr"; MessagesFile: "compiler:Languages\French.isl"
-Name: "hr"; MessagesFile: "Languages\Croatian.isl"
-Name: "it"; MessagesFile: "compiler:Languages\Italian.isl"
-Name: "ja"; MessagesFile: "compiler:Languages\Japanese.isl"
-Name: "ko"; MessagesFile: "Languages\Korean.isl"
-Name: "mk"; MessagesFile: "Languages\Macedonian.isl"
-Name: "nl"; MessagesFile: "compiler:Languages\Dutch.isl"
-Name: "no"; MessagesFile: "compiler:Languages\Norwegian.isl"
-Name: "pl"; MessagesFile: "compiler:Languages\Polish.isl"
-Name: "pt"; MessagesFile: "compiler:Languages\Portuguese.isl"
+Name: "ar";   MessagesFile: "Languages\Arabic.isl"
+Name: "bg";   MessagesFile: "Languages\Bulgarian.isl"
+Name: "ca";   MessagesFile: "compiler:Languages\Catalan.isl"
+Name: "cs";   MessagesFile: "compiler:Languages\Czech.isl"
+Name: "da";   MessagesFile: "compiler:Languages\Danish.isl"
+Name: "de";   MessagesFile: "compiler:Languages\German.isl"
+Name: "es";   MessagesFile: "compiler:Languages\Spanish.isl"
+Name: "eu";   MessagesFile: "Languages\Basque.isl"
+Name: "fa";   MessagesFile: "Languages\Farsi.isl"
+Name: "fi";   MessagesFile: "compiler:Languages\Finnish.isl"
+Name: "fr";   MessagesFile: "compiler:Languages\French.isl"
+Name: "hr";   MessagesFile: "Languages\Croatian.isl"
+Name: "it";   MessagesFile: "compiler:Languages\Italian.isl"
+Name: "ja";   MessagesFile: "compiler:Languages\Japanese.isl"
+Name: "ko";   MessagesFile: "Languages\Korean.isl"
+Name: "mk";   MessagesFile: "Languages\Macedonian.isl"
+Name: "nl";   MessagesFile: "compiler:Languages\Dutch.isl"
+Name: "no";   MessagesFile: "compiler:Languages\Norwegian.isl"
+Name: "pl";   MessagesFile: "compiler:Languages\Polish.isl"
+Name: "pt";   MessagesFile: "compiler:Languages\Portuguese.isl"
 Name: "ptBR"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"
-Name: "ro"; MessagesFile: "Languages\Romanian.isl"
-Name: "ru"; MessagesFile: "compiler:Languages\Russian.isl"
-Name: "sl"; MessagesFile: "compiler:Languages\Slovenian.isl"
-Name: "sv"; MessagesFile: "Languages\Swedish.isl"
-Name: "th"; MessagesFile: "Languages\Thai.isl"
-Name: "tr"; MessagesFile: "compiler:Languages\Turkish.isl"
-Name: "uk"; MessagesFile: "compiler:Languages\Ukrainian.isl"
-Name: "vi"; MessagesFile: "Languages\Vietnamese.islu"
-Name: "zh"; MessagesFile: "Languages\ChineseSimplified.islu"
+Name: "ro";   MessagesFile: "Languages\Romanian.isl"
+Name: "ru";   MessagesFile: "compiler:Languages\Russian.isl"
+Name: "sl";   MessagesFile: "compiler:Languages\Slovenian.isl"
+Name: "sv";   MessagesFile: "Languages\Swedish.isl"
+Name: "th";   MessagesFile: "Languages\Thai.isl"
+Name: "tr";   MessagesFile: "compiler:Languages\Turkish.isl"
+Name: "uk";   MessagesFile: "compiler:Languages\Ukrainian.isl"
+Name: "vi";   MessagesFile: "Languages\Vietnamese.islu"
+Name: "zh";   MessagesFile: "Languages\ChineseSimplified.islu"
 Name: "zhTW"; MessagesFile: "Languages\ChineseTraditional.isl"
 #endif
 
@@ -156,6 +156,10 @@ Name: "zhTW"; MessagesFile: "Languages\ChineseTraditional.isl"
 ;BeveledLabel=Subtitle Edit {#app_ver} by Nikse
 SetupAppTitle=Setup - Subtitle Edit
 SetupWindowTitle=Setup - Subtitle Edit {#app_ver}
+
+;it.BeveledLabel=Subtitle Edit {#app_ver} di Nikse
+it.SetupAppTitle=Installazione di Subtitle Edit
+it.SetupWindowTitle=Installazione di Subtitle Edit {#app_ver}
 
 
 [Types]


### PR DESCRIPTION
@niksedk 

- Modify app name in Windows program list
Remove fron app name in Windows program list the version because is already present in Version column

- M;odify copyright info
Remove not necessary "Copyright" text because "Copyright" is already the name of the filed.
This field should cointain only copyrighter company name and copyright starting/ending year.

- Add italian string for top left info.
Add text string for "Setup - Subtitle Edit"

