### PR TITLE
Add better visual markings during syncing of 2 subtitles.

### DIFF
--- a/src/libse/Common/ColorUtils.cs
+++ b/src/libse/Common/ColorUtils.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Drawing;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    public class ColorUtils
+    {
+        public static Color Blend(Color baseColor, Color targetColor, double percentage = 0.5)
+        {
+            percentage = Math.Abs(percentage);
+            
+            if (percentage == 0)
+                return baseColor;
+            if (percentage >= 1)
+                return targetColor;
+
+            return Color.FromArgb(
+                Lerp(baseColor.A, targetColor.A, percentage),
+                Lerp(baseColor.R, targetColor.R, percentage),
+                Lerp(baseColor.G, targetColor.G, percentage),
+                Lerp(baseColor.B, targetColor.B, percentage));
+        }
+
+        private static int Lerp(int baseColor, int targetColor, double percentage)
+        {
+            return (byte)Math.Round(baseColor  + percentage * (targetColor - baseColor));
+        }
+    }
+}

--- a/src/libse/Common/ColorUtils.cs
+++ b/src/libse/Common/ColorUtils.cs
@@ -3,9 +3,9 @@ using System.Drawing;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public class ColorUtils
+    public static class ColorUtils
     {
-        public static Color Blend(Color baseColor, Color targetColor, double percentage = 0.5)
+        public static Color Blend(this Color baseColor, Color targetColor, double percentage = 0.5)
         {
             percentage = Math.Abs(percentage);
             
@@ -25,5 +25,21 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             return (byte)Math.Round(baseColor  + percentage * (targetColor - baseColor));
         }
+        
+        public static double Luminance(this Color color) => (color.R * 0.299 + color.G * 0.587 + color.B * 0.114) / 255;
+        
+        public static Color OpposingLuminanceColor(this Color baseColor)
+        {
+            var luminance = baseColor.Luminance();
+            var opposingLuminance = Math.Abs(0.5 - luminance) * 2;
+
+            var opposingRed = (int)Math.Round(opposingLuminance * baseColor.R);
+            var opposingGreen = (int)Math.Round(opposingLuminance * baseColor.G);
+            var opposingBlue = (int)Math.Round(opposingLuminance * baseColor.B);
+
+            return Color.FromArgb(opposingRed, opposingGreen, opposingBlue);
+        }
     }
+    
+    
 }

--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -2141,49 +2141,58 @@ namespace Nikse.SubtitleEdit.Controls
 
         public void SetBackgroundColor(int index, Color color)
         {
-            if (IsValidIndex(index))
+            UpdateItem(index, i => i.BackColor = color, si => si.BackColor = color);
+        }
+        
+        public void SetForegroundColor(int index, Color color)
+        {
+            UpdateItem(index, i => i.ForeColor = color, si => si.ForeColor = color);
+        }
+        
+        private void UpdateItem(int index, Action<ListViewItem> itemUpdater,  Action<ListViewItem.ListViewSubItem> subItemUpdater)
+        {
+            if (!IsValidIndex(index)) return;
+            
+            var item = Items[index];
+            itemUpdater(item);
+            if (ColumnIndexStart >= 0)
             {
-                ListViewItem item = Items[index];
-                item.BackColor = color;
-                if (ColumnIndexStart >= 0)
-                {
-                    Items[index].SubItems[ColumnIndexStart].BackColor = color;
-                }
+                subItemUpdater(Items[index].SubItems[ColumnIndexStart]);
+            }
 
-                if (ColumnIndexEnd >= 0)
-                {
-                    Items[index].SubItems[ColumnIndexEnd].BackColor = color;
-                }
+            if (ColumnIndexEnd >= 0)
+            {
+                subItemUpdater(Items[index].SubItems[ColumnIndexEnd]);
+            }
 
-                if (ColumnIndexDuration >= 0)
-                {
-                    Items[index].SubItems[ColumnIndexDuration].BackColor = color;
-                }
+            if (ColumnIndexDuration >= 0)
+            {
+                subItemUpdater(Items[index].SubItems[ColumnIndexDuration]);
+            }
 
-                if (ColumnIndexCps >= 0)
-                {
-                    Items[index].SubItems[ColumnIndexCps].BackColor = color;
-                }
+            if (ColumnIndexCps >= 0)
+            {
+                subItemUpdater(Items[index].SubItems[ColumnIndexCps]);
+            }
 
-                if (ColumnIndexWpm >= 0)
-                {
-                    Items[index].SubItems[ColumnIndexWpm].BackColor = color;
-                }
+            if (ColumnIndexWpm >= 0)
+            {
+                subItemUpdater(Items[index].SubItems[ColumnIndexWpm]);
+            }
 
-                if (ColumnIndexGap >= 0)
-                {
-                    Items[index].SubItems[ColumnIndexGap].BackColor = color;
-                }
+            if (ColumnIndexGap >= 0)
+            {
+                subItemUpdater(Items[index].SubItems[ColumnIndexGap]);
+            }
 
-                if (ColumnIndexText >= 0)
-                {
-                    Items[index].SubItems[ColumnIndexText].BackColor = color;
-                }
+            if (ColumnIndexText >= 0)
+            {
+                subItemUpdater(Items[index].SubItems[ColumnIndexText]);
+            }
 
-                if (ColumnIndexTextOriginal >= 0)
-                {
-                    Items[index].SubItems[ColumnIndexTextOriginal].BackColor = color;
-                }
+            if (ColumnIndexTextOriginal >= 0)
+            {
+                subItemUpdater(Items[index].SubItems[ColumnIndexTextOriginal]);
             }
         }
 

--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -34,6 +34,9 @@ namespace Nikse.SubtitleEdit.Controls
             return SubtitleColumns.IndexOf(column);
         }
 
+        public const int InvalidIndex = -1;
+        public int SelectedIndex => SelectedIndices.Count == 1 ? SelectedIndices[0] : InvalidIndex;
+
         public int ColumnIndexNumber { get; private set; }
         public int ColumnIndexStart { get; private set; }
         public int ColumnIndexEnd { get; private set; }

--- a/src/ui/Forms/SyncPointsSync.Designer.cs
+++ b/src/ui/Forms/SyncPointsSync.Designer.cs
@@ -39,7 +39,7 @@
             this.labelNoOfSyncPoints = new System.Windows.Forms.Label();
             this.buttonRemoveSyncPoint = new System.Windows.Forms.Button();
             this.buttonSetSyncPoint = new System.Windows.Forms.Button();
-            this.SubtitleListview1 = new Nikse.SubtitleEdit.Controls.SubtitleListView();
+            this.subtitleListView1 = new Nikse.SubtitleEdit.Controls.SubtitleListView();
             this.labelSyncInfo = new System.Windows.Forms.Label();
             this.buttonApplySync = new System.Windows.Forms.Button();
             this.buttonCancel = new System.Windows.Forms.Button();
@@ -62,7 +62,7 @@
             this.groupBoxImportResult.Controls.Add(this.labelNoOfSyncPoints);
             this.groupBoxImportResult.Controls.Add(this.buttonRemoveSyncPoint);
             this.groupBoxImportResult.Controls.Add(this.buttonSetSyncPoint);
-            this.groupBoxImportResult.Controls.Add(this.SubtitleListview1);
+            this.groupBoxImportResult.Controls.Add(this.subtitleListView1);
             this.groupBoxImportResult.Location = new System.Drawing.Point(12, 12);
             this.groupBoxImportResult.Name = "groupBoxImportResult";
             this.groupBoxImportResult.Size = new System.Drawing.Size(1096, 434);
@@ -143,6 +143,7 @@
             this.subtitleListView2.UseCompatibleStateImageBehavior = false;
             this.subtitleListView2.UseSyntaxColoring = true;
             this.subtitleListView2.View = System.Windows.Forms.View.Details;
+            this.subtitleListView2.SelectedIndexChanged += new System.EventHandler(this.subtitleListView2_SelectedIndexChanged);
             // 
             // listBoxSyncPoints
             // 
@@ -186,32 +187,33 @@
             this.buttonSetSyncPoint.UseVisualStyleBackColor = true;
             this.buttonSetSyncPoint.Click += new System.EventHandler(this.buttonSetSyncPoint_Click);
             // 
-            // SubtitleListview1
+            // subtitleListView1
             // 
-            this.SubtitleListview1.AllowColumnReorder = true;
-            this.SubtitleListview1.AllowDrop = true;
-            this.SubtitleListview1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.subtitleListView1.AllowColumnReorder = true;
+            this.subtitleListView1.AllowDrop = true;
+            this.subtitleListView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.SubtitleListview1.FirstVisibleIndex = -1;
-            this.SubtitleListview1.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.SubtitleListview1.FullRowSelect = true;
-            this.SubtitleListview1.GridLines = true;
-            this.SubtitleListview1.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.SubtitleListview1.HideSelection = false;
-            this.SubtitleListview1.Location = new System.Drawing.Point(9, 33);
-            this.SubtitleListview1.MultiSelect = false;
-            this.SubtitleListview1.Name = "SubtitleListview1";
-            this.SubtitleListview1.OwnerDraw = true;
-            this.SubtitleListview1.Size = new System.Drawing.Size(466, 368);
-            this.SubtitleListview1.SubtitleFontBold = false;
-            this.SubtitleListview1.SubtitleFontName = "Tahoma";
-            this.SubtitleListview1.SubtitleFontSize = 8;
-            this.SubtitleListview1.TabIndex = 12;
-            this.SubtitleListview1.UseCompatibleStateImageBehavior = false;
-            this.SubtitleListview1.UseSyntaxColoring = true;
-            this.SubtitleListview1.View = System.Windows.Forms.View.Details;
-            this.SubtitleListview1.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.SubtitleListView1_MouseDoubleClick);
+            this.subtitleListView1.FirstVisibleIndex = -1;
+            this.subtitleListView1.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.subtitleListView1.FullRowSelect = true;
+            this.subtitleListView1.GridLines = true;
+            this.subtitleListView1.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.subtitleListView1.HideSelection = false;
+            this.subtitleListView1.Location = new System.Drawing.Point(9, 33);
+            this.subtitleListView1.MultiSelect = false;
+            this.subtitleListView1.Name = "subtitleListView1";
+            this.subtitleListView1.OwnerDraw = true;
+            this.subtitleListView1.Size = new System.Drawing.Size(466, 368);
+            this.subtitleListView1.SubtitleFontBold = false;
+            this.subtitleListView1.SubtitleFontName = "Tahoma";
+            this.subtitleListView1.SubtitleFontSize = 8;
+            this.subtitleListView1.TabIndex = 12;
+            this.subtitleListView1.UseCompatibleStateImageBehavior = false;
+            this.subtitleListView1.UseSyntaxColoring = true;
+            this.subtitleListView1.View = System.Windows.Forms.View.Details;
+            this.subtitleListView1.SelectedIndexChanged += new System.EventHandler(this.SubtitleListview1_SelectedIndexChanged);
+            this.subtitleListView1.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.SubtitleListView1_MouseDoubleClick);
             // 
             // labelSyncInfo
             // 
@@ -296,7 +298,7 @@
         private System.Windows.Forms.Button buttonSetSyncPoint;
         private System.Windows.Forms.Button buttonApplySync;
         private System.Windows.Forms.Button buttonRemoveSyncPoint;
-        private Controls.SubtitleListView SubtitleListview1;
+        private Controls.SubtitleListView subtitleListView1;
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.Button buttonOK;
         private System.Windows.Forms.ListBox listBoxSyncPoints;

--- a/src/ui/Forms/SyncPointsSync.cs
+++ b/src/ui/Forms/SyncPointsSync.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Controls;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -27,7 +28,7 @@ namespace Nikse.SubtitleEdit.Forms
         private Subtitle _subtitle;
         private Subtitle _originalSubtitle;
         private Subtitle _otherSubtitle;
-        private SortedDictionary<int, TimeSpan> _synchronizationPoints = new SortedDictionary<int, TimeSpan>();
+        private SortedDictionary<int, (TimeSpan Time, int OtherIndex)> _synchronizationPoints = new SortedDictionary<int, (TimeSpan, int)>();
         private readonly Keys _mainGeneralGoToNextSubtitle = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralGoToNextSubtitle);
         private readonly Keys _mainGeneralGoToNextSubtitlePlayTranslate = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralGoToNextSubtitlePlayTranslate);
         private readonly Keys _mainGeneralGoToPrevSubtitle = UiUtil.GetKeys(Configuration.Settings.Shortcuts.GeneralGoToPrevSubtitle);
@@ -52,13 +53,13 @@ namespace Nikse.SubtitleEdit.Forms
             labelSyncInfo.Text = LanguageSettings.Current.PointSync.Info;
             buttonFindText.Text = LanguageSettings.Current.VisualSync.FindText;
             buttonFindTextOther.Text = LanguageSettings.Current.VisualSync.FindText;
-            SubtitleListview1.InitializeLanguage(LanguageSettings.Current.General, Configuration.Settings);
+            subtitleListView1.InitializeLanguage(LanguageSettings.Current.General, Configuration.Settings);
             subtitleListView2.InitializeLanguage(LanguageSettings.Current.General, Configuration.Settings);
-            SubtitleListview1.InitializeTimestampColumnWidths(this);
+            subtitleListView1.InitializeTimestampColumnWidths(this);
             subtitleListView2.InitializeTimestampColumnWidths(this);
-            UiUtil.InitializeSubtitleFont(SubtitleListview1);
+            UiUtil.InitializeSubtitleFont(subtitleListView1);
             UiUtil.InitializeSubtitleFont(subtitleListView2);
-            SubtitleListview1.AutoSizeAllColumns(this);
+            subtitleListView1.AutoSizeAllColumns(this);
             subtitleListView2.AutoSizeAllColumns(this);
             UiUtil.FixLargeFonts(this, buttonOK);
             labelAdjustFactor.Text = string.Empty;
@@ -73,13 +74,13 @@ namespace Nikse.SubtitleEdit.Forms
             _subtitleFileName = subtitleFileName;
             VideoFileName = videoFileName;
             _audioTrackNumber = audioTrackNumber;
-            SubtitleListview1.Fill(subtitle);
-            if (SubtitleListview1.Items.Count > 0)
+            subtitleListView1.Fill(subtitle);
+            if (subtitleListView1.Items.Count > 0)
             {
-                SubtitleListview1.Items[0].Selected = true;
+                subtitleListView1.Items[0].Selected = true;
             }
 
-            SubtitleListview1.Anchor = AnchorStyles.Left;
+            subtitleListView1.Anchor = AnchorStyles.Left;
             buttonSetSyncPoint.Anchor = AnchorStyles.Left;
             buttonRemoveSyncPoint.Anchor = AnchorStyles.Left;
             labelNoOfSyncPoints.Anchor = AnchorStyles.Left;
@@ -90,13 +91,13 @@ namespace Nikse.SubtitleEdit.Forms
             buttonFindTextOther.Visible = false;
             groupBoxImportResult.Width = listBoxSyncPoints.Left + listBoxSyncPoints.Width + 20;
             Width = groupBoxImportResult.Left + groupBoxImportResult.Width + 15;
-            SubtitleListview1.Anchor = AnchorStyles.Left | AnchorStyles.Bottom | AnchorStyles.Top | AnchorStyles.Right;
+            subtitleListView1.Anchor = AnchorStyles.Left | AnchorStyles.Bottom | AnchorStyles.Top | AnchorStyles.Right;
             buttonSetSyncPoint.Anchor = AnchorStyles.Right;
             buttonRemoveSyncPoint.Anchor = AnchorStyles.Right;
             labelNoOfSyncPoints.Anchor = AnchorStyles.Right;
             listBoxSyncPoints.Anchor = AnchorStyles.Right;
             groupBoxImportResult.Anchor = AnchorStyles.Left | AnchorStyles.Bottom | AnchorStyles.Top | AnchorStyles.Right;
-            buttonFindText.Left = SubtitleListview1.Left + SubtitleListview1.Width - buttonFindText.Width;
+            buttonFindText.Left = subtitleListView1.Left + subtitleListView1.Width - buttonFindText.Width;
             Width = 900;
             groupBoxImportResult.Width = Width - groupBoxImportResult.Left * 3;
             labelAdjustFactor.Left = listBoxSyncPoints.Left;
@@ -114,16 +115,16 @@ namespace Nikse.SubtitleEdit.Forms
             _subtitleFileName = subtitleFileName;
             VideoFileName = videoFileName;
             _audioTrackNumber = audioTrackNumber;
-            SubtitleListview1.Fill(subtitle);
-            if (SubtitleListview1.Items.Count > 0)
+            subtitleListView1.Fill(subtitle);
+            if (subtitleListView1.Items.Count > 0)
             {
-                SubtitleListview1.Items[0].Selected = true;
+                subtitleListView1.Items[0].Selected = true;
             }
 
             labelOtherSubtitleFileName.Text = otherSubtitleFileName;
             subtitleListView2.Fill(otherSubtitle);
 
-            SubtitleListview1.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Bottom;
+            subtitleListView1.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Bottom;
             subtitleListView2.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Bottom;
             buttonSetSyncPoint.Anchor = AnchorStyles.Left;
             buttonRemoveSyncPoint.Anchor = AnchorStyles.Left;
@@ -136,7 +137,7 @@ namespace Nikse.SubtitleEdit.Forms
             Width = subtitleListView2.Width * 2 + 250;
             MinimumSize = new Size(Width - 50, MinimumSize.Height);
         }
-
+        
         private void RefreshSynchronizationPointsUi()
         {
             buttonApplySync.Enabled = _synchronizationPoints.Count > 0;
@@ -144,26 +145,27 @@ namespace Nikse.SubtitleEdit.Forms
 
             listBoxSyncPoints.Items.Clear();
 
-            for (var i = 0; i < SubtitleListview1.Items.Count; i++)
+            for (var i = 0; i < subtitleListView1.Items.Count; i++)
             {
                 if (_synchronizationPoints.ContainsKey(i))
                 {
-                    var p = new Paragraph { StartTime = { TotalMilliseconds = _synchronizationPoints[i].TotalMilliseconds } };
+                    var p = new Paragraph { StartTime = { TotalMilliseconds = _synchronizationPoints[i].Time.TotalMilliseconds } };
                     p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + _subtitle.Paragraphs[i].Duration.TotalMilliseconds;
-                    SubtitleListview1.SetStartTimeAndDuration(i, p, _subtitle.GetParagraphOrDefault(i + 1), _subtitle.GetParagraphOrDefault(i - 1));
+                    subtitleListView1.SetStartTimeAndDuration(i, p, _subtitle.GetParagraphOrDefault(i + 1), _subtitle.GetParagraphOrDefault(i - 1));
 
                     var item = new ListBoxSyncPoint { Index = i, Text = _subtitle.Paragraphs[i].Number + " - " + p.StartTime };
                     listBoxSyncPoints.Items.Add(item);
-                    SubtitleListview1.SetBackgroundColor(i, ColorTranslator.FromHtml("#6ebe6e"));
-                    SubtitleListview1.SetNumber(_subtitle.Paragraphs[i].Number, "* * * *");
+                    subtitleListView1.SetNumber(_subtitle.Paragraphs[i].Number, "* * * *");
                 }
                 else
                 {
-                    SubtitleListview1.SetBackgroundColor(i, SubtitleListview1.BackColor);
-                    SubtitleListview1.SetNumber(i, _subtitle.Paragraphs[i].Number.ToString(CultureInfo.InvariantCulture));
-                    SubtitleListview1.SetStartTimeAndDuration(i, _subtitle.Paragraphs[i], _subtitle.GetParagraphOrDefault(i + 1), _subtitle.GetParagraphOrDefault(i - 1));
+                    subtitleListView1.SetNumber(i, _subtitle.Paragraphs[i].Number.ToString(CultureInfo.InvariantCulture));
+                    subtitleListView1.SetStartTimeAndDuration(i, _subtitle.Paragraphs[i], _subtitle.GetParagraphOrDefault(i + 1), _subtitle.GetParagraphOrDefault(i - 1));
                 }
             }
+
+            SetViewBackgroundColor( _otherSubtitle, subtitleListView2, _synchronizationPoints.Values.Select(v => v.OtherIndex), GetSelectedParagraph(_subtitle, subtitleListView1));
+            SetViewBackgroundColor( _subtitle, subtitleListView1,  _synchronizationPoints.Keys, GetSelectedParagraph(_otherSubtitle, subtitleListView2));
         }
 
         private void buttonSetSyncPoint_Click(object sender, EventArgs e)
@@ -174,65 +176,54 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else
             {
-                if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle != null)
+                if (subtitleListView1.SelectedItems.Count == 1 && _subtitle != null)
                 {
                     using (var getTime = new SetSyncPoint())
                     {
-                        var index = SubtitleListview1.SelectedItems[0].Index;
+                        var index = subtitleListView1.SelectedItems[0].Index;
                         getTime.Initialize(_subtitle, _subtitleFileName, index, VideoFileName, _audioTrackNumber);
                         if (getTime.ShowDialog(this) == DialogResult.OK)
                         {
-                            if (_synchronizationPoints.ContainsKey(index))
-                            {
-                                _synchronizationPoints[index] = getTime.SynchronizationPoint;
-                            }
-                            else
-                            {
-                                _synchronizationPoints.Add(index, getTime.SynchronizationPoint);
-                            }
+                            _synchronizationPoints[index] = (getTime.SynchronizationPoint, SubtitleListView.InvalidIndex);
 
                             RefreshSynchronizationPointsUi();
                             VideoFileName = getTime.VideoFileName;
                         }
+
                         Activate();
                         VideoFileName = getTime.VideoFileName;
                     }
                 }
             }
+
             SetSyncFactorLabel();
         }
 
         private void SetSyncPointViaOtherSubtitle()
         {
-            if (SubtitleListview1.SelectedItems.Count != 1 || subtitleListView2.SelectedItems.Count != 1)
+            if (subtitleListView1.SelectedItems.Count != 1 || subtitleListView2.SelectedItems.Count != 1)
             {
                 return;
             }
 
             if (_otherSubtitle != null && subtitleListView2.SelectedItems.Count == 1)
             {
-                var index = SubtitleListview1.SelectedItems[0].Index;
+                var index = subtitleListView1.SelectedItems[0].Index;
                 var indexOther = subtitleListView2.SelectedItems[0].Index;
 
-                if (_synchronizationPoints.ContainsKey(index))
-                {
-                    _synchronizationPoints[index] = TimeSpan.FromMilliseconds(_otherSubtitle.Paragraphs[indexOther].StartTime.TotalMilliseconds);
-                }
-                else
-                {
-                    _synchronizationPoints.Add(index, TimeSpan.FromMilliseconds(_otherSubtitle.Paragraphs[indexOther].StartTime.TotalMilliseconds));
-                }
+                _synchronizationPoints[index] = (TimeSpan.FromMilliseconds(_otherSubtitle.Paragraphs[indexOther].StartTime.TotalMilliseconds), indexOther);
 
                 RefreshSynchronizationPointsUi();
             }
+
             SetSyncFactorLabel();
         }
 
         private void buttonRemoveSyncPoint_Click(object sender, EventArgs e)
         {
-            if (SubtitleListview1.SelectedItems.Count == 1 && _subtitle != null)
+            if (subtitleListView1.SelectedItems.Count == 1 && _subtitle != null)
             {
-                var index = SubtitleListview1.SelectedItems[0].Index;
+                var index = subtitleListView1.SelectedItems[0].Index;
                 if (_synchronizationPoints.ContainsKey(index))
                 {
                     _synchronizationPoints.Remove(index);
@@ -240,6 +231,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 RefreshSynchronizationPointsUi();
             }
+
             SetSyncFactorLabel();
         }
 
@@ -272,29 +264,31 @@ namespace Nikse.SubtitleEdit.Forms
             else if (_mainGeneralGoToNextSubtitle == e.KeyData || _mainGeneralGoToNextSubtitlePlayTranslate == e.KeyData)
             {
                 var selectedIndex = 0;
-                if (SubtitleListview1.SelectedItems.Count > 0)
+                if (subtitleListView1.SelectedItems.Count > 0)
                 {
-                    selectedIndex = SubtitleListview1.SelectedItems[0].Index;
+                    selectedIndex = subtitleListView1.SelectedItems[0].Index;
                     selectedIndex++;
                 }
-                SubtitleListview1.SelectIndexAndEnsureVisible(selectedIndex);
+
+                subtitleListView1.SelectIndexAndEnsureVisible(selectedIndex);
                 e.SuppressKeyPress = true;
             }
             else if (_mainGeneralGoToPrevSubtitle == e.KeyData || _mainGeneralGoToPrevSubtitlePlayTranslate == e.KeyData)
             {
                 var selectedIndex = 0;
-                if (SubtitleListview1.SelectedItems.Count > 0)
+                if (subtitleListView1.SelectedItems.Count > 0)
                 {
-                    selectedIndex = SubtitleListview1.SelectedItems[0].Index;
+                    selectedIndex = subtitleListView1.SelectedItems[0].Index;
                     selectedIndex--;
                 }
-                SubtitleListview1.SelectIndexAndEnsureVisible(selectedIndex);
+
+                subtitleListView1.SelectIndexAndEnsureVisible(selectedIndex);
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyData == (Keys.Control | Keys.G))
             {
-                var subView = SubtitleListview1;
-                if (subtitleListView2 != null && subtitleListView2.Visible && !SubtitleListview1.Focused)
+                var subView = subtitleListView1;
+                if (subtitleListView2 != null && subtitleListView2.Visible && !subtitleListView1.Focused)
                 {
                     var x = PointToClient(MousePosition).X;
                     if (x >= subtitleListView2.Left && x <= subtitleListView2.Left + subtitleListView2.Width)
@@ -302,6 +296,7 @@ namespace Nikse.SubtitleEdit.Forms
                         subView = subtitleListView2;
                     }
                 }
+
                 using (var gotoForm = new GoToLine())
                 {
                     gotoForm.Initialize(1, subView.Items.Count);
@@ -318,7 +313,7 @@ namespace Nikse.SubtitleEdit.Forms
             labelAdjustFactor.Text = string.Empty;
             if (_synchronizationPoints.Count == 1)
             {
-                var startPos = _synchronizationPoints.First().Value.TotalMilliseconds / TimeCode.BaseUnit;
+                var startPos = _synchronizationPoints.First().Value.Time.TotalMilliseconds / TimeCode.BaseUnit;
                 var subStart = _originalSubtitle.Paragraphs[_synchronizationPoints.First().Key].StartTime.TotalMilliseconds / TimeCode.BaseUnit;
 
                 var adjustment = startPos - subStart;
@@ -326,8 +321,8 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (_synchronizationPoints.Count == 2)
             {
-                var startPos = _synchronizationPoints.First().Value.TotalMilliseconds / TimeCode.BaseUnit;
-                var endPos = _synchronizationPoints.Last().Value.TotalMilliseconds / TimeCode.BaseUnit;
+                var startPos = _synchronizationPoints.First().Value.Time.TotalMilliseconds / TimeCode.BaseUnit;
+                var endPos = _synchronizationPoints.Last().Value.Time.TotalMilliseconds / TimeCode.BaseUnit;
 
                 var subStart = _originalSubtitle.Paragraphs[_synchronizationPoints.First().Key].StartTime.TotalMilliseconds / TimeCode.BaseUnit;
                 var subEnd = _originalSubtitle.Paragraphs[_synchronizationPoints.Last().Key].StartTime.TotalMilliseconds / TimeCode.BaseUnit;
@@ -375,13 +370,13 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (_synchronizationPoints.Count == 1)
             {
-                foreach (KeyValuePair<int, TimeSpan> kvp in _synchronizationPoints)
+                foreach (var kvp in _synchronizationPoints)
                 {
-                    AdjustViaShowEarlierLater(kvp.Key, kvp.Value.TotalMilliseconds);
+                    AdjustViaShowEarlierLater(kvp.Key, kvp.Value.Time.TotalMilliseconds);
                 }
 
-                _synchronizationPoints = new SortedDictionary<int, TimeSpan>();
-                SubtitleListview1.Fill(_subtitle);
+                _synchronizationPoints = new SortedDictionary<int, (TimeSpan, int)>();
+                subtitleListView1.Fill(_subtitle);
                 RefreshSynchronizationPointsUi();
                 return;
             }
@@ -415,12 +410,13 @@ namespace Nikse.SubtitleEdit.Forms
                         maxIndex = syncIndices[i];
                     }
 
-                    Sync(startIndex, endIndex, minIndex, maxIndex, _synchronizationPoints[startIndex].TotalMilliseconds / TimeCode.BaseUnit, _synchronizationPoints[endIndex].TotalMilliseconds / TimeCode.BaseUnit);
+                    Sync(startIndex, endIndex, minIndex, maxIndex, _synchronizationPoints[startIndex].Time.TotalMilliseconds / TimeCode.BaseUnit, _synchronizationPoints[endIndex].Time.TotalMilliseconds / TimeCode.BaseUnit);
 
                     minIndex = endIndex;
                 }
             }
-            SubtitleListview1.Fill(_subtitle);
+
+            subtitleListView1.Fill(_subtitle);
             RefreshSynchronizationPointsUi();
         }
 
@@ -436,15 +432,15 @@ namespace Nikse.SubtitleEdit.Forms
             if (listBoxSyncPoints.SelectedIndex >= 0)
             {
                 var item = (ListBoxSyncPoint)listBoxSyncPoints.Items[listBoxSyncPoints.SelectedIndex];
-                SubtitleListview1.SelectIndexAndEnsureVisible(item.Index);
+                subtitleListView1.SelectIndexAndEnsureVisible(item.Index);
             }
         }
 
         private void SubtitleListView1_MouseDoubleClick(object sender, MouseEventArgs e)
         {
-            if (SubtitleListview1.SelectedItems.Count == 1)
+            if (subtitleListView1.SelectedItems.Count == 1)
             {
-                var index = SubtitleListview1.SelectedItems[0].Index;
+                var index = subtitleListView1.SelectedItems[0].Index;
                 if (_synchronizationPoints.ContainsKey(index))
                 {
                     buttonRemoveSyncPoint_Click(null, null);
@@ -461,16 +457,16 @@ namespace Nikse.SubtitleEdit.Forms
             if (subtitleListView2.Visible)
             {
                 var widthInMiddle = listBoxSyncPoints.Width;
-                SubtitleListview1.Width = (groupBoxImportResult.Width - widthInMiddle) / 2 - 12;
-                subtitleListView2.Width = SubtitleListview1.Width;
-                subtitleListView2.Left = SubtitleListview1.Left + SubtitleListview1.Width + widthInMiddle + 10;
-                listBoxSyncPoints.Left = SubtitleListview1.Left + SubtitleListview1.Width + 5;
+                subtitleListView1.Width = (groupBoxImportResult.Width - widthInMiddle) / 2 - 12;
+                subtitleListView2.Width = subtitleListView1.Width;
+                subtitleListView2.Left = subtitleListView1.Left + subtitleListView1.Width + widthInMiddle + 10;
+                listBoxSyncPoints.Left = subtitleListView1.Left + subtitleListView1.Width + 5;
                 buttonSetSyncPoint.Left = listBoxSyncPoints.Left;
                 buttonRemoveSyncPoint.Left = listBoxSyncPoints.Left;
                 labelAdjustFactor.Left = listBoxSyncPoints.Left;
                 labelNoOfSyncPoints.Left = listBoxSyncPoints.Left;
                 labelOtherSubtitleFileName.Left = subtitleListView2.Left;
-                buttonFindText.Left = SubtitleListview1.Left + SubtitleListview1.Width - buttonFindText.Width;
+                buttonFindText.Left = subtitleListView1.Left + subtitleListView1.Width - buttonFindText.Width;
             }
         }
 
@@ -487,7 +483,7 @@ namespace Nikse.SubtitleEdit.Forms
                 findSubtitle.ShowDialog();
                 if (findSubtitle.SelectedIndex >= 0)
                 {
-                    SubtitleListview1.SelectIndexAndEnsureVisible(findSubtitle.SelectedIndex);
+                    subtitleListView1.SelectIndexAndEnsureVisible(findSubtitle.SelectedIndex);
                 }
             }
         }
@@ -503,6 +499,73 @@ namespace Nikse.SubtitleEdit.Forms
                     subtitleListView2.SelectIndexAndEnsureVisible(findSubtitle.SelectedIndex);
                 }
             }
+        }
+        
+        private void SubtitleListview1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            SetViewBackgroundColor( _otherSubtitle, subtitleListView2, _synchronizationPoints.Values.Select(v => v.OtherIndex), GetSelectedParagraph(_subtitle, subtitleListView1));
+        }
+        
+        private void subtitleListView2_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            SetViewBackgroundColor( _subtitle, subtitleListView1,  _synchronizationPoints.Keys, GetSelectedParagraph(_otherSubtitle, subtitleListView2));
+        }
+
+        private static Paragraph GetSelectedParagraph(Subtitle subtitle, SubtitleListView view)
+        {
+            var selectedIndex = view.SelectedIndex;
+            return selectedIndex == SubtitleListView.InvalidIndex ? null : subtitle.Paragraphs[selectedIndex];
+        }
+        
+
+        private static void SetViewBackgroundColor( Subtitle subtitle,  SubtitleListView view, IEnumerable<int> marked, Paragraph syncParagraph = null )
+        {
+            if (!view.Visible) return;
+            var markedHashSet = marked.Where(v => v != SubtitleListView.InvalidIndex).ToHashSet();
+            if (syncParagraph is null)
+            {
+                for (var i = 0; i < view.Items.Count; i++)
+                {
+                    view.SetBackgroundColor(i, CalculateBackgroundColor(view.BackColor, markedHashSet.Contains(i), 1));
+                }
+                return;
+            }
+
+            var selectedLocation = syncParagraph.StartTime.TotalMilliseconds;
+            var selectedDuration = syncParagraph.Duration.TotalMilliseconds;
+            if (selectedDuration == 0)
+                selectedDuration = 1000;
+
+            
+            (int Index, double Dinstance) closesIndex = (SubtitleListView.InvalidIndex, 0d);
+            for (var i = 0; i < view.Items.Count; i++)
+            {
+                var distanceFromSelected = Math.Abs(subtitle.Paragraphs[i].StartTime.TotalMilliseconds - selectedLocation);
+                var percentageDistance = distanceFromSelected / 5 / selectedDuration;
+                view.SetBackgroundColor(i, CalculateBackgroundColor(view.BackColor, markedHashSet.Contains(i), percentageDistance));
+                if (closesIndex.Dinstance > distanceFromSelected || closesIndex.Index == SubtitleListView.InvalidIndex)
+                {
+                    closesIndex = (i, distanceFromSelected);
+                }
+            }
+
+            if (closesIndex.Index == SubtitleListView.InvalidIndex)
+                return;
+            view.SetBackgroundColor(closesIndex.Index, CalculateBackgroundColor(view.BackColor, markedHashSet.Contains(closesIndex.Index), 0));
+            view.Items[closesIndex.Index].EnsureVisible();
+        }
+        private static Color MarkedBackgroundColor { get; } = ColorTranslator.FromHtml("#6ebe6e");
+        private static Color VisualMarkBackgroundColor { get; } = Color.DarkGray;
+
+        private static Color CalculateBackgroundColor(Color baseColor, bool shouldUseSyncColor, double percentageDistance)
+        {
+            var color = shouldUseSyncColor ? MarkedBackgroundColor : baseColor;
+            if (percentageDistance > 1) return color;
+            
+            var visualMarkedColorWithOffset = ColorUtils.Blend(VisualMarkBackgroundColor,baseColor,   percentageDistance);
+            return shouldUseSyncColor
+                ? ColorUtils.Blend(visualMarkedColorWithOffset,MarkedBackgroundColor )
+                : visualMarkedColorWithOffset;
         }
     }
 }


### PR DESCRIPTION
I added visual markings for syncing 2 subtitles. When 1 line in subtitle is selected, other subtitle shows lines closed to this line grayed based of how distant those lines are. Also it makes those close lines visible on the screen.

View list is renamed for consistancy. And Color utils methods are added for blanding colors.


Btw I have made myself translitaration translator for converting between sr-latn to sr-cyrl and vice verse. But I did not prapare that PR as I how to localize the name of translator and also if it is ok to rename sr-cyrl to sr language. Or at least if I can make that naming of translated file ends with .sr-cyrl instead of just .sr