### PR TITLE
Remove duration cap when ripping from VobSub or TransportStream

### DIFF
--- a/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
@@ -260,7 +260,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                         {
                             sub.EndMilliseconds = list[i + 1].PresentationTimestampToMilliseconds() - 25;
                         }
-                        if (sub.EndMilliseconds < sub.StartMilliseconds || sub.EndMilliseconds - sub.StartMilliseconds > (ulong)Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                        if (sub.EndMilliseconds < sub.StartMilliseconds)
                         {
                             sub.EndMilliseconds = sub.StartMilliseconds + (ulong)Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                         }

--- a/src/libse/VobSub/VobSubParser.cs
+++ b/src/libse/VobSub/VobSubParser.cs
@@ -221,17 +221,13 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                     pack.EndTime = pack.StartTime.Add(pack.SubPicture.Delay);
                 }
 
-                if (pack.EndTime < pack.StartTime || pack.EndTime.TotalMilliseconds - pack.StartTime.TotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (pack.EndTime < pack.StartTime)
                 {
                     if (i + 1 < list.Count)
                     {
                         pack.EndTime = TimeSpan.FromMilliseconds(list[i + 1].StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines);
-                        if (pack.EndTime.TotalMilliseconds - pack.StartTime.TotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
-                        {
-                            pack.EndTime = TimeSpan.FromMilliseconds(pack.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds);
-                        }
                     }
-                     else
+                    else
                     {
                         pack.EndTime = TimeSpan.FromMilliseconds(pack.StartTime.TotalMilliseconds + 3000);
                     }


### PR DESCRIPTION
Every time I ripped a DVD, I noticed the durations were capped at 7 seconds.
However, Dutch subtitles often exceed 7 seconds, so I had to manually check all subtitles that were 7,000 seconds to extend them if needed.
I figured it was a limitation of VobSub or something.

Recently, when fiddling with my settings in SE, I noticed that the duration cap changed.
I checked the source code and found that SE hard caps the durations at the configured maximum display time, both for DVDs and TS files.

I think it's better to just rip the subtitles with their original timings, after which users can use "Adjust duration limits" if desired.
So, this PR removes these checks for VobSub and TransportStreams.

----

The maximum display time check is also done in several subtitle formats.
Perhaps, the same change should be made there (allow the timings to exceed the maximum duration to keep the original timings -- only recalculate when the duration is negative), but I'm not familiar with these formats.

![image](https://github.com/SubtitleEdit/subtitleedit/assets/3516155/6d33bf7c-bc66-48b1-a9a2-50a77809cb29)