### PR TITLE
Ignore ASS tags when converting colors to dialog + WebVTT colors support

### DIFF
--- a/src/Test/Logic/ConvertColorsToDialogTest.cs
+++ b/src/Test/Logic/ConvertColorsToDialogTest.cs
@@ -374,5 +374,33 @@ namespace Test.Logic
 
             Assert.AreEqual("{\\an8}That was really delicious." + Environment.NewLine + "-I know.", result);
         }
+
+        [TestMethod]
+        public void TestVttDialog1()
+        {
+            Configuration.Settings.General.DialogStyle = Nikse.SubtitleEdit.Core.Enums.DialogType.DashBothLinesWithSpace;
+
+            var subtitle = new Subtitle(new List<Paragraph>() { new Paragraph("<c.cyan>That was really delicious.</c>" + Environment.NewLine +
+                                                                              "I know.", 0, 2000) });
+
+            ConvertColorsToDialogUtils.ConvertColorsToDialogInSubtitle(subtitle, true, false, false);
+            var result = subtitle.Paragraphs.First().Text;
+
+            Assert.AreEqual("- That was really delicious." + Environment.NewLine + "- I know.", result);
+        }
+
+        [TestMethod]
+        public void TestVttDialog2()
+        {
+            Configuration.Settings.General.DialogStyle = Nikse.SubtitleEdit.Core.Enums.DialogType.DashBothLinesWithSpace;
+
+            var subtitle = new Subtitle(new List<Paragraph>() { new Paragraph("That's it!" + Environment.NewLine +
+                                                                              "<c.cyan>..sped to victory.</c>", 0, 2000) });
+
+            ConvertColorsToDialogUtils.ConvertColorsToDialogInSubtitle(subtitle, true, false, false);
+            var result = subtitle.Paragraphs.First().Text;
+
+            Assert.AreEqual("- That's it!" + Environment.NewLine + "- ..sped to victory.", result);
+        }
     }
 }

--- a/src/Test/Logic/ConvertColorsToDialogTest.cs
+++ b/src/Test/Logic/ConvertColorsToDialogTest.cs
@@ -318,5 +318,61 @@ namespace Test.Logic
 
             Assert.AreEqual("- No, don't touch that-- - That was stupid." + Environment.NewLine + "- I know.", result);
         }
+
+        [TestMethod]
+        public void TestPositioning()
+        {
+            Configuration.Settings.General.DialogStyle = Nikse.SubtitleEdit.Core.Enums.DialogType.DashBothLinesWithSpace;
+
+            var subtitle = new Subtitle(new List<Paragraph>() { new Paragraph("{\\an8}<font color=\"#ffff00\">That was really delicious.</font>" + Environment.NewLine +
+                                                                              "I know.", 0, 2000) });
+
+            ConvertColorsToDialogUtils.ConvertColorsToDialogInSubtitle(subtitle, true, false, false);
+            var result = subtitle.Paragraphs.First().Text;
+
+            Assert.AreEqual("{\\an8}- That was really delicious." + Environment.NewLine + "- I know.", result);
+        }
+
+        [TestMethod]
+        public void TestPositioning2()
+        {
+            Configuration.Settings.General.DialogStyle = Nikse.SubtitleEdit.Core.Enums.DialogType.DashBothLinesWithSpace;
+
+            var subtitle = new Subtitle(new List<Paragraph>() { new Paragraph("{\\an8}That was really delicious." + Environment.NewLine +
+                                                                              "<font color=\"#ffff00\">I know.</font>", 0, 2000) });
+
+            ConvertColorsToDialogUtils.ConvertColorsToDialogInSubtitle(subtitle, true, false, false);
+            var result = subtitle.Paragraphs.First().Text;
+
+            Assert.AreEqual("{\\an8}- That was really delicious." + Environment.NewLine + "- I know.", result);
+        }
+
+        [TestMethod]
+        public void TestPositioning3()
+        {
+            Configuration.Settings.General.DialogStyle = Nikse.SubtitleEdit.Core.Enums.DialogType.DashSecondLineWithoutSpace;
+
+            var subtitle = new Subtitle(new List<Paragraph>() { new Paragraph("{\\an8}<font color=\"#ffff00\">That was really delicious.</font>" + Environment.NewLine +
+                                                                              "I know.", 0, 2000) });
+
+            ConvertColorsToDialogUtils.ConvertColorsToDialogInSubtitle(subtitle, true, false, false);
+            var result = subtitle.Paragraphs.First().Text;
+
+            Assert.AreEqual("{\\an8}That was really delicious." + Environment.NewLine + "-I know.", result);
+        }
+
+        [TestMethod]
+        public void TestPositioning4()
+        {
+            Configuration.Settings.General.DialogStyle = Nikse.SubtitleEdit.Core.Enums.DialogType.DashSecondLineWithoutSpace;
+
+            var subtitle = new Subtitle(new List<Paragraph>() { new Paragraph("{\\an8}That was really delicious." + Environment.NewLine +
+                                                                              "<font color=\"#ffff00\">I know.</font>", 0, 2000) });
+
+            ConvertColorsToDialogUtils.ConvertColorsToDialogInSubtitle(subtitle, true, false, false);
+            var result = subtitle.Paragraphs.First().Text;
+
+            Assert.AreEqual("{\\an8}That was really delicious." + Environment.NewLine + "-I know.", result);
+        }
     }
 }

--- a/src/libse/Common/ConvertColorsToDialogUtils.cs
+++ b/src/libse/Common/ConvertColorsToDialogUtils.cs
@@ -46,7 +46,16 @@ namespace Nikse.SubtitleEdit.Core.Common
                             {
                                 if (dashFirstLine && !firstLineAdded)
                                 {
-                                    p.Text = dash + p.Text;
+                                    if (p.Text.StartsWith("{"))
+                                    {
+                                        var lastBraceIndex = p.Text.LastIndexOf("}");
+                                        p.Text = p.Text.SafeSubstring(0, lastBraceIndex + 1) + dash + p.Text.SafeSubstring(lastBraceIndex + 1);
+                                    } 
+                                    else
+                                    {
+                                        p.Text = dash + p.Text;
+                                    }
+
                                     index += dash.Length;
 
                                     firstLineAdded = true;
@@ -81,6 +90,11 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                         index += "</font>".Length;
                     }
+                    else if (index + "{".Length <= p.Text.Length && p.Text.SafeSubstring(index, "{".Length) == "{")
+                    {
+                        // ASS tag, jump over
+                        index = p.Text.IndexOf("}", index) + 1;
+                    }
                     else if (index + 1 <= p.Text.Length && p.Text.SafeSubstring(index, 1) == " " || p.Text.SafeSubstring(index, 1) == "\r" || p.Text.SafeSubstring(index, 1) == "\n")
                     {
                         // Whitespace, ignore
@@ -107,7 +121,16 @@ namespace Nikse.SubtitleEdit.Core.Common
                                     {
                                         if (dashFirstLine && !firstLineAdded)
                                         {
-                                            p.Text = dash + p.Text;
+                                            if (p.Text.StartsWith("{"))
+                                            {
+                                                var lastBraceIndex = p.Text.LastIndexOf("}");
+                                                p.Text = p.Text.SafeSubstring(0, lastBraceIndex + 1) + dash + p.Text.SafeSubstring(lastBraceIndex + 1);
+                                            }
+                                            else
+                                            {
+                                                p.Text = dash + p.Text;
+                                            }
+
                                             index += dash.Length;
 
                                             firstLineAdded = true;

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -29674,7 +29674,7 @@ namespace Nikse.SubtitleEdit.Forms
             var formatType = f.GetType();
             actorToolStripMenuItem.Visible = formatType == typeof(AdvancedSubStationAlpha) || formatType == typeof(SubStationAlpha);
 
-            convertColorsToDialogToolStripMenuItem.Visible = _subtitle.Paragraphs.Any(p => p.Text.Contains("<font color"));
+            convertColorsToDialogToolStripMenuItem.Visible = _subtitle.Paragraphs.Any(p => p.Text.Contains("<font color") || p.Text.Contains("<c."));
         }
 
         private void ContextMenuStripWaveformOpening(object sender, CancelEventArgs e)


### PR DESCRIPTION
Small fix to make sure that ASS tags get ignored.

Example:
```
{\an8}<font color="#ffff00">That was really delicious.</font>
I know.
```

Current output (for `DialogType.DashBothLinesWithoutSpace`):
```
-{\an8} -That was really delicious.
-I know.
```

Fixed output:
```
{\an8}-That was really delicious.
-I know.
```

----

Also some basic support for WebVTT colors.

```
{\an8}<c.cyan>That was really delicious.</c>
I know.
```

```
{\an8}-That was really delicious.
-I know.
```