### PR TITLE
Some "Beautify time codes" fixes

### DIFF
--- a/src/libse/Forms/TimeCodesBeautifier.cs
+++ b/src/libse/Forms/TimeCodesBeautifier.cs
@@ -20,7 +20,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
         {
             _subtitle = subtitle;
             _frameRate = frameRate;
-            _timeCodes = timeCodes;
+
+            // Convert time codes to milliseconds
+            _timeCodes = timeCodes.Select(d => d * 1000).ToList();
 
             // Convert shot changes to frame numbers
             _shotChangesFrames = shotChanges.Select(d => SubtitleFormat.MillisecondsToFrames(d * 1000, _frameRate)).ToList();

--- a/src/libse/Forms/TimeCodesBeautifier.cs
+++ b/src/libse/Forms/TimeCodesBeautifier.cs
@@ -84,7 +84,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     }
 
                     // Report progress
-                    var progress = ((pass + 1) / (double)amountOfPasses) * (p / (double)_subtitle.Paragraphs.Count);
+                    var progress = (double)(pass * _subtitle.Paragraphs.Count + p) / (_subtitle.Paragraphs.Count * amountOfPasses);
                     ProgressChanged.Invoke(progress);
                 }
             }

--- a/src/ui/Forms/BeautifyTimeCodes/BeautifyTimeCodes.cs
+++ b/src/ui/Forms/BeautifyTimeCodes/BeautifyTimeCodes.cs
@@ -44,7 +44,7 @@ namespace Nikse.SubtitleEdit.Forms.BeautifyTimeCodes
 
             if (videoInfo != null && videoInfo.TotalMilliseconds > 0)
             {
-                _duration = videoInfo.TotalMilliseconds;
+                _duration = videoInfo.TotalSeconds;
             }
 
             _videoInfo = videoInfo;

--- a/src/ui/Forms/BeautifyTimeCodes/BeautifyTimeCodes.cs
+++ b/src/ui/Forms/BeautifyTimeCodes/BeautifyTimeCodes.cs
@@ -291,6 +291,10 @@ namespace Nikse.SubtitleEdit.Forms.BeautifyTimeCodes
             };
             timeCodesBeautifier.Beautify();
 
+            // Re-enable group boxes, otherwise child controls are also disabled, and we need their original state for the checks below
+            groupBoxTimeCodes.Enabled = true;
+            groupBoxShotChanges.Enabled = true;
+
             // Save settings
             Configuration.Settings.BeautifyTimeCodes.AlignTimeCodes = checkBoxAlignTimeCodes.Checked;
 


### PR DESCRIPTION
Some bugs squashed.
- The selected options on the "Beautify time codes" dialog are now being saved correctly
- The overall progress is now calculated correctly
- Extracting exact timecodes had some bugs with seconds vs. milliseconds mismatches