### PR TITLE
Some new "Beautify time codes" improvements

### DIFF
--- a/src/Test/Logic/BeautifyTimeCodesTest.cs
+++ b/src/Test/Logic/BeautifyTimeCodesTest.cs
@@ -142,5 +142,199 @@ namespace Test.Logic
             result = ShotChangeHelper.IsCueOnShotChange(shotChangesSeconds, paragraph.EndTime, false);
             Assert.AreEqual(false, result);
         }
+
+        [TestMethod]
+        public void TestGetPreviousShotChange()
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25;
+
+            var shotChangesSeconds = new List<double>() { 1, 10, 20 };
+
+            var paragraph = new Paragraph("Test.", 1000, 3000); // On shot
+            var result = ShotChangeHelper.GetPreviousShotChange(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1.0, result);
+
+            paragraph = new Paragraph("Test.", 1500, 3000); // Away from shot
+            result = ShotChangeHelper.GetPreviousShotChange(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1.0, result);
+
+            paragraph = new Paragraph("Test.", 990, 3000); // On shot after rounding
+            result = ShotChangeHelper.GetPreviousShotChange(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1.0, result);
+
+            paragraph = new Paragraph("Test.", 1010, 3000); // Tiny bit from shot
+            result = ShotChangeHelper.GetPreviousShotChange(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1.0, result);
+
+            paragraph = new Paragraph("Test.", 500, 3000); // No more shots
+            result = ShotChangeHelper.GetPreviousShotChange(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(null, result);
+
+            paragraph = new Paragraph("Test.", 20500, 30000); // Other shot
+            result = ShotChangeHelper.GetPreviousShotChange(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(20.0, result);
+        }
+
+        [TestMethod]
+        public void TestGetPreviousShotChangeInMs()
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25;
+
+            var shotChangesSeconds = new List<double>() { 1, 10, 20 };
+
+            var paragraph = new Paragraph("Test.", 1000, 3000); // On shot
+            var result = ShotChangeHelper.GetPreviousShotChangeInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1000, result);
+
+            paragraph = new Paragraph("Test.", 1500, 3000); // Away from shot
+            result = ShotChangeHelper.GetPreviousShotChangeInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1000, result);
+
+            paragraph = new Paragraph("Test.", 990, 3000); // On shot after rounding
+            result = ShotChangeHelper.GetPreviousShotChangeInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1000, result);
+
+            paragraph = new Paragraph("Test.", 1010, 3000); // Tiny bit from shot
+            result = ShotChangeHelper.GetPreviousShotChangeInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1000, result);
+
+            paragraph = new Paragraph("Test.", 500, 3000); // No more shots
+            result = ShotChangeHelper.GetPreviousShotChangeInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(null, result);
+
+            paragraph = new Paragraph("Test.", 20500, 30000); // Other shot
+            result = ShotChangeHelper.GetPreviousShotChangeInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(20000, result);
+        }
+
+        [TestMethod]
+        public void TestGetPreviousShotChangePlusGapInMs()
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25;
+            Configuration.Settings.BeautifyTimeCodes.Profile.InCuesGap = 2;
+
+            var shotChangesSeconds = new List<double>() { 1, 10, 20 };
+
+            var paragraph = new Paragraph("Test.", 1000, 3000); // On shot
+            var result = ShotChangeHelper.GetPreviousShotChangePlusGapInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1080, result);
+
+            paragraph = new Paragraph("Test.", 1500, 3000); // Away from shot
+            result = ShotChangeHelper.GetPreviousShotChangePlusGapInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1080, result);
+
+            paragraph = new Paragraph("Test.", 990, 3000); // On shot after rounding
+            result = ShotChangeHelper.GetPreviousShotChangePlusGapInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1080, result);
+
+            paragraph = new Paragraph("Test.", 1010, 3000); // Tiny bit from shot
+            result = ShotChangeHelper.GetPreviousShotChangePlusGapInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(1080, result);
+
+            paragraph = new Paragraph("Test.", 500, 3000); // No more shots
+            result = ShotChangeHelper.GetPreviousShotChangePlusGapInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(null, result);
+
+            paragraph = new Paragraph("Test.", 20500, 30000); // Other shot
+            result = ShotChangeHelper.GetPreviousShotChangePlusGapInMs(shotChangesSeconds, paragraph.StartTime);
+            Assert.AreEqual(20080, result);
+        }
+
+        [TestMethod]
+        public void TestGetNextShotChange()
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25;
+
+            var shotChangesSeconds = new List<double>() { 1, 10, 20 };
+
+            var paragraph = new Paragraph("Test.", 8000, 10000); // On shot
+            var result = ShotChangeHelper.GetNextShotChange(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(10.0, result);
+
+            paragraph = new Paragraph("Test.", 8000, 9500); // Away from shot
+            result = ShotChangeHelper.GetNextShotChange(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(10.0, result);
+
+            paragraph = new Paragraph("Test.", 8000, 10010); // On shot after rounding
+            result = ShotChangeHelper.GetNextShotChange(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(10.0, result);
+
+            paragraph = new Paragraph("Test.", 8000, 9990); // Tiny bit from shot
+            result = ShotChangeHelper.GetNextShotChange(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(10.0, result);
+
+            paragraph = new Paragraph("Test.", 30000, 32000); // No more shots
+            result = ShotChangeHelper.GetNextShotChange(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(null, result);
+
+            paragraph = new Paragraph("Test.", 0, 800); // Other shot
+            result = ShotChangeHelper.GetNextShotChange(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(1.0, result);
+        }
+
+        [TestMethod]
+        public void TestGetNextShotChangeInMs()
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25;
+
+            var shotChangesSeconds = new List<double>() { 1, 10, 20 };
+
+            var paragraph = new Paragraph("Test.", 8000, 10000); // On shot
+            var result = ShotChangeHelper.GetNextShotChangeInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(10000, result);
+
+            paragraph = new Paragraph("Test.", 8000, 9500); // Away from shot
+            result = ShotChangeHelper.GetNextShotChangeInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(10000, result);
+
+            paragraph = new Paragraph("Test.", 8000, 10010); // On shot after rounding
+            result = ShotChangeHelper.GetNextShotChangeInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(10000, result);
+
+            paragraph = new Paragraph("Test.", 8000, 9990); // Tiny bit from shot
+            result = ShotChangeHelper.GetNextShotChangeInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(10000, result);
+
+            paragraph = new Paragraph("Test.", 30000, 32000); // No more shots
+            result = ShotChangeHelper.GetNextShotChangeInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(null, result);
+
+            paragraph = new Paragraph("Test.", 0, 800); // Other shot
+            result = ShotChangeHelper.GetNextShotChangeInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(1000, result);
+        }
+
+        [TestMethod]
+        public void TestGetNextShotChangeMinusGapInMs()
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25;
+            Configuration.Settings.BeautifyTimeCodes.Profile.OutCuesGap = 2;
+
+            var shotChangesSeconds = new List<double>() { 1, 10, 20 };
+
+            var paragraph = new Paragraph("Test.", 8000, 10000); // On shot
+            var result = ShotChangeHelper.GetNextShotChangeMinusGapInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(9920, result);
+
+            paragraph = new Paragraph("Test.", 8000, 9500); // Away from shot
+            result = ShotChangeHelper.GetNextShotChangeMinusGapInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(9920, result);
+
+            paragraph = new Paragraph("Test.", 8000, 10010); // On shot after rounding
+            result = ShotChangeHelper.GetNextShotChangeMinusGapInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(9920, result);
+
+            paragraph = new Paragraph("Test.", 8000, 9990); // Tiny bit from shot
+            result = ShotChangeHelper.GetNextShotChangeMinusGapInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(9920, result);
+
+            paragraph = new Paragraph("Test.", 30000, 32000); // No more shots
+            result = ShotChangeHelper.GetNextShotChangeMinusGapInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(null, result);
+
+            paragraph = new Paragraph("Test.", 0, 800); // Other shot
+            result = ShotChangeHelper.GetNextShotChangeMinusGapInMs(shotChangesSeconds, paragraph.EndTime);
+            Assert.AreEqual(920, result);
+        }
     }
 }

--- a/src/libse/Common/ShotChangeHelper.cs
+++ b/src/libse/Common/ShotChangeHelper.cs
@@ -87,16 +87,27 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         // Util functions
 
-        public static double? GetPreviousShotChangeInMs(List<double> shotChanges, TimeCode currentTime)
+        public static double? GetPreviousShotChange(List<double> shotChanges, TimeCode currentTime)
         {
             try
             {
-                return shotChanges.Last(x => SubtitleFormat.MillisecondsToFrames(x * 1000) <= SubtitleFormat.MillisecondsToFrames(currentTime.TotalMilliseconds)) * 1000;
+                return shotChanges.Last(x => SubtitleFormat.MillisecondsToFrames(x * 1000) <= SubtitleFormat.MillisecondsToFrames(currentTime.TotalMilliseconds));
             }
             catch (InvalidOperationException)
             {
                 return null;
             }
+        }
+
+        public static double? GetPreviousShotChangeInMs(List<double> shotChanges, TimeCode currentTime)
+        {
+            var previousShotChange = GetPreviousShotChange(shotChanges, currentTime);
+            if (previousShotChange != null)
+            {
+                return previousShotChange * 1000;
+            }
+
+            return null;
         }
 
         public static double? GetPreviousShotChangePlusGapInMs(List<double> shotChanges, TimeCode currentTime)
@@ -110,16 +121,27 @@ namespace Nikse.SubtitleEdit.Core.Common
             return null;
         }
 
-        public static double? GetNextShotChangeInMs(List<double> shotChanges, TimeCode currentTime)
+        public static double? GetNextShotChange(List<double> shotChanges, TimeCode currentTime)
         {
             try
             {
-                return shotChanges.First(x => SubtitleFormat.MillisecondsToFrames(x * 1000) >= SubtitleFormat.MillisecondsToFrames(currentTime.TotalMilliseconds)) * 1000;
+                return shotChanges.First(x => SubtitleFormat.MillisecondsToFrames(x * 1000) >= SubtitleFormat.MillisecondsToFrames(currentTime.TotalMilliseconds));
             }
             catch (InvalidOperationException)
             {
                 return null;
             }
+        }
+
+        public static double? GetNextShotChangeInMs(List<double> shotChanges, TimeCode currentTime)
+        {
+            var nextShotChange = GetNextShotChange(shotChanges, currentTime);
+            if (nextShotChange != null)
+            {
+                return nextShotChange * 1000;
+            }
+
+            return null;
         }
 
         public static double? GetNextShotChangeMinusGapInMs(List<double> shotChanges, TimeCode currentTime)

--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -131,6 +131,7 @@ namespace Nikse.SubtitleEdit.Controls
         private double _zoomFactor = 1.0; // 1.0=no zoom
 
         public int ShotChangeSnapPixels = 8;
+        private bool _snappingDistanceFirstUpdated = false;
 
         public double ZoomFactor
         {
@@ -327,6 +328,11 @@ namespace Nikse.SubtitleEdit.Controls
                 _subtitle = new Subtitle();
                 _noClear = false;
                 _wavePeaks = value;
+
+                if (!_snappingDistanceFirstUpdated)
+                {
+                    UpdateSnappingDistance();
+                }
             }
         }
 
@@ -2734,6 +2740,7 @@ namespace Nikse.SubtitleEdit.Controls
                 var snappingDistance = (int) Math.Round(pixelsPerFrame * Math.Max(1, largestGapInFrames));
 
                 ShotChangeSnapPixels = Math.Max(8, snappingDistance);
+                _snappingDistanceFirstUpdated = true;
             } 
             else
             {

--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -131,7 +131,6 @@ namespace Nikse.SubtitleEdit.Controls
         private double _zoomFactor = 1.0; // 1.0=no zoom
 
         public int ShotChangeSnapPixels = 8;
-        private bool _snappingDistanceFirstUpdated = false;
 
         public double ZoomFactor
         {
@@ -329,10 +328,7 @@ namespace Nikse.SubtitleEdit.Controls
                 _noClear = false;
                 _wavePeaks = value;
 
-                if (!_snappingDistanceFirstUpdated)
-                {
-                    UpdateSnappingDistance();
-                }
+                UpdateSnappingDistance();
             }
         }
 
@@ -2740,7 +2736,6 @@ namespace Nikse.SubtitleEdit.Controls
                 var snappingDistance = (int) Math.Round(pixelsPerFrame * Math.Max(1, largestGapInFrames));
 
                 ShotChangeSnapPixels = Math.Max(8, snappingDistance);
-                _snappingDistanceFirstUpdated = true;
             } 
             else
             {

--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -1732,7 +1732,7 @@ namespace Nikse.SubtitleEdit.Controls
 
                                 if (Configuration.Settings.VideoControls.WaveformSnapToShotChanges && ModifierKeys != Keys.Shift)
                                 {
-                                    var nearestShotChange = _shotChanges.Count > 0 ? _shotChanges.Aggregate((x, y) => Math.Abs((x * 1000) - milliseconds) < Math.Abs((y * 1000) - milliseconds) ? x : y) : -9999;
+                                    var nearestShotChange = ShotChangeHelper.GetClosestShotChange(_shotChanges, new TimeCode(milliseconds)) ?? double.MinValue;
                                     if (Math.Abs(e.X - SecondsToXPosition(nearestShotChange - _startPositionSeconds)) < ShotChangeSnapPixels)
                                     { 
                                         _mouseDownParagraph.StartTime.TotalMilliseconds = (nearestShotChange * 1000) + TimeCodesBeautifierUtils.GetInCuesGapMs();
@@ -1750,7 +1750,7 @@ namespace Nikse.SubtitleEdit.Controls
 
                                     if (Configuration.Settings.VideoControls.WaveformSnapToShotChanges && ModifierKeys != Keys.Shift)
                                     {
-                                        var nearestShotChange = _shotChanges.Count > 0 ? _shotChanges.Aggregate((x, y) => Math.Abs((x * 1000) - milliseconds) < Math.Abs((y * 1000) - milliseconds) ? x : y) : -9999;
+                                        var nearestShotChange = ShotChangeHelper.GetClosestShotChange(_shotChanges, new TimeCode(milliseconds)) ?? double.MinValue;
                                         if (Math.Abs(e.X - SecondsToXPosition(nearestShotChange - _startPositionSeconds)) < ShotChangeSnapPixels)
                                         {
                                             NewSelectionParagraph.StartTime.TotalMilliseconds = (nearestShotChange * 1000) + TimeCodesBeautifierUtils.GetInCuesGapMs();
@@ -1789,7 +1789,7 @@ namespace Nikse.SubtitleEdit.Controls
 
                                 if (Configuration.Settings.VideoControls.WaveformSnapToShotChanges && ModifierKeys != Keys.Shift)
                                 {
-                                    var nearestShotChange = _shotChanges.Count > 0 ? _shotChanges.Aggregate((x, y) => Math.Abs((x * 1000) - milliseconds) < Math.Abs((y * 1000) - milliseconds) ? x : y) : -9999;
+                                    var nearestShotChange = ShotChangeHelper.GetClosestShotChange(_shotChanges, new TimeCode(milliseconds)) ?? double.MinValue;
                                     if (Math.Abs(e.X - SecondsToXPosition(nearestShotChange - _startPositionSeconds)) < ShotChangeSnapPixels)
                                     {
                                         _mouseDownParagraph.EndTime.TotalMilliseconds = (nearestShotChange * 1000) - TimeCodesBeautifierUtils.GetOutCuesGapMs();
@@ -1807,7 +1807,7 @@ namespace Nikse.SubtitleEdit.Controls
 
                                     if (Configuration.Settings.VideoControls.WaveformSnapToShotChanges && ModifierKeys != Keys.Shift)
                                     {
-                                        var nearestShotChange = _shotChanges.Count > 0 ? _shotChanges.Aggregate((x, y) => Math.Abs((x * 1000) - milliseconds) < Math.Abs((y * 1000) - milliseconds) ? x : y) : -9999;
+                                        var nearestShotChange = ShotChangeHelper.GetClosestShotChange(_shotChanges, new TimeCode(milliseconds)) ?? double.MinValue; 
                                         if (Math.Abs(e.X - SecondsToXPosition(nearestShotChange - _startPositionSeconds)) < ShotChangeSnapPixels)
                                         {
                                             NewSelectionParagraph.EndTime.TotalMilliseconds = (nearestShotChange * 1000) - TimeCodesBeautifierUtils.GetOutCuesGapMs();
@@ -1838,8 +1838,8 @@ namespace Nikse.SubtitleEdit.Controls
 
                             if (Configuration.Settings.VideoControls.WaveformSnapToShotChanges && ModifierKeys != Keys.Shift)
                             {
-                                var nearestShotChangeInFront = _shotChanges.Count > 0 ? _shotChanges.Aggregate((x, y) => Math.Abs((x * 1000) - _mouseDownParagraph.StartTime.TotalMilliseconds) < Math.Abs((y * 1000) - _mouseDownParagraph.StartTime.TotalMilliseconds) ? x : y) : -9999;
-                                var nearestShotChangeInBack = _shotChanges.Count > 0 ? _shotChanges.Aggregate((x, y) => Math.Abs((x * 1000) - _mouseDownParagraph.EndTime.TotalMilliseconds) < Math.Abs((y * 1000) - _mouseDownParagraph.EndTime.TotalMilliseconds) ? x : y) : -9999;
+                                var nearestShotChangeInFront = ShotChangeHelper.GetClosestShotChange(_shotChanges, _mouseDownParagraph.StartTime) ?? double.MinValue;
+                                var nearestShotChangeInBack = ShotChangeHelper.GetClosestShotChange(_shotChanges, _mouseDownParagraph.EndTime) ?? double.MinValue;
 
                                 if (Math.Abs(SecondsToXPosition(_mouseDownParagraph.StartTime.TotalSeconds - _startPositionSeconds) - SecondsToXPosition(nearestShotChangeInFront - _startPositionSeconds)) < ShotChangeSnapPixels)
                                 {
@@ -1902,8 +1902,8 @@ namespace Nikse.SubtitleEdit.Controls
 
                             if (Configuration.Settings.VideoControls.WaveformSnapToShotChanges && ModifierKeys != Keys.Shift)
                             {
-                                var nearestShotChangeInFront = _shotChanges.Count > 0 ? _shotChanges.Aggregate((x, y) => Math.Abs(x - startTotalSeconds) < Math.Abs(y - startTotalSeconds) ? x : y) : -9999;
-                                var nearestShotChangeInBack = _shotChanges.Count > 0 ? _shotChanges.Aggregate((x, y) => Math.Abs(x - endTotalSeconds) < Math.Abs(y - endTotalSeconds) ? x : y) : -9999;
+                                var nearestShotChangeInFront = ShotChangeHelper.GetClosestShotChange(_shotChanges, TimeCode.FromSeconds(startTotalSeconds)) ?? double.MinValue;
+                                var nearestShotChangeInBack = ShotChangeHelper.GetClosestShotChange(_shotChanges, TimeCode.FromSeconds(endTotalSeconds)) ?? double.MinValue;
 
                                 if (Math.Abs(SecondsToXPosition(NewSelectionParagraph.StartTime.TotalSeconds - _startPositionSeconds) - SecondsToXPosition(nearestShotChangeInFront - _startPositionSeconds)) < ShotChangeSnapPixels)
                                 {

--- a/src/ui/Forms/BeautifyTimeCodes/BeautifyTimeCodes.cs
+++ b/src/ui/Forms/BeautifyTimeCodes/BeautifyTimeCodes.cs
@@ -276,7 +276,7 @@ namespace Nikse.SubtitleEdit.Forms.BeautifyTimeCodes
             buttonOK.Enabled = false;
 
             // Actual processing
-            FixedSubtitle = new Subtitle(_subtitle);
+            FixedSubtitle = new Subtitle(_subtitle, false);
 
             TimeCodesBeautifier timeCodesBeautifier = new TimeCodesBeautifier(
                 FixedSubtitle,

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -344,6 +344,7 @@
             this.changeCasingForSelectedLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fixCommonErrorsInSelectedLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.visualSyncSelectedLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.beautifyTimeCodesOfSelectedLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showSelectedLinesEarlierlaterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemTranslateSelected = new System.Windows.Forms.ToolStripMenuItem();
             this.genericTranslateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -3142,6 +3143,7 @@
             this.changeCasingForSelectedLinesToolStripMenuItem,
             this.fixCommonErrorsInSelectedLinesToolStripMenuItem,
             this.visualSyncSelectedLinesToolStripMenuItem,
+            this.beautifyTimeCodesOfSelectedLinesToolStripMenuItem,
             this.showSelectedLinesEarlierlaterToolStripMenuItem,
             this.toolStripMenuItemTranslateSelected,
             this.toolStripMenuItemUnbreakLines,
@@ -3180,6 +3182,13 @@
             this.visualSyncSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(275, 22);
             this.visualSyncSelectedLinesToolStripMenuItem.Text = "Visual sync selected lines...";
             this.visualSyncSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.VisualSyncSelectedLinesToolStripMenuItemClick);
+            // 
+            // beautifyTimeCodesOfSelectedLinesToolStripMenuItem
+            // 
+            this.beautifyTimeCodesOfSelectedLinesToolStripMenuItem.Name = "beautifyTimeCodesOfSelectedLinesToolStripMenuItem";
+            this.beautifyTimeCodesOfSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(275, 22);
+            this.beautifyTimeCodesOfSelectedLinesToolStripMenuItem.Text = "Beautify time codes of selected lines...";
+            this.beautifyTimeCodesOfSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.beautifyTimeCodesOfSelectedLinesToolStripMenuItem_Click);
             // 
             // showSelectedLinesEarlierlaterToolStripMenuItem
             // 
@@ -6378,5 +6387,6 @@
         private Nikse.SubtitleEdit.Controls.NikseUpDown numericUpDownLayer;
         private System.Windows.Forms.Label labelLayer;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemWebVttStyle;
+        private System.Windows.Forms.ToolStripMenuItem beautifyTimeCodesOfSelectedLinesToolStripMenuItem;
     }
 }

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -539,6 +539,7 @@ namespace Nikse.SubtitleEdit.Logic
             BeautifyTimeCodes = new LanguageStructure.BeautifyTimeCodes
             {
                 Title = "Beautify time codes",
+                TitleSelectedLines = "Beautify time codes ({0} selected lines)",
                 GroupTimeCodes = "Time codes",
                 AlignTimeCodes = "Align time codes to frame time codes",
                 ExtractExactTimeCodes = "Use ffprobe to extract exact frame time codes",
@@ -1615,7 +1616,9 @@ namespace Nikse.SubtitleEdit.Logic
                 BeforeRenumbering = "Before renumbering",
                 RenumberedStartingFromX = "Renumbered starting from: {0}",
                 BeforeBeautifyTimeCodes = "Before beautifying time codes",
+                BeforeBeautifyTimeCodesSelectedLines = "Before beautifying time codes of selected lines",
                 BeautifiedTimeCodes = "Time codes beautified",
+                BeautifiedTimeCodesSelectedLines = "Time codes of selected lines beautified",
                 BeforeRemovalOfTextingForHearingImpaired = "Before removal of texting for hearing impaired",
                 TextingForHearingImpairedRemovedOneLine = "Texting for hearing impaired removed: One line",
                 TextingForHearingImpairedRemovedXLines = "Texting for hearing impaired removed: {0} lines",
@@ -2128,6 +2131,7 @@ namespace Nikse.SubtitleEdit.Logic
                         KaraokeEffect = "Karaoke effect...",
                         ShowSelectedLinesEarlierLater = "Show selected lines earlier/later...",
                         VisualSyncSelectedLines = "Visual sync selected lines...",
+                        BeautifyTimeCodesOfSelectedLines = "Beautify time codes of selected lines...",
                         GoogleAndMicrosoftTranslateSelectedLine = "Google/Microsoft translate original line",
                         SelectedLines = "Selected lines",
                         TranslateSelectedLines = "Translate selected lines...",

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -392,6 +392,7 @@ namespace Nikse.SubtitleEdit.Logic
         public class BeautifyTimeCodes
         {
             public string Title { get; set; }
+            public string TitleSelectedLines { get; set; }
             public string GroupTimeCodes { get; set; }
             public string AlignTimeCodes { get; set; }
             public string ExtractExactTimeCodes { get; set; }
@@ -1439,7 +1440,9 @@ namespace Nikse.SubtitleEdit.Logic
             public string BeforeRenumbering { get; set; }
             public string RenumberedStartingFromX { get; set; }
             public string BeforeBeautifyTimeCodes { get; set; }
+            public string BeforeBeautifyTimeCodesSelectedLines { get; set; }
             public string BeautifiedTimeCodes { get; set; }
+            public string BeautifiedTimeCodesSelectedLines { get; set; }
             public string BeforeRemovalOfTextingForHearingImpaired { get; set; }
             public string TextingForHearingImpairedRemovedOneLine { get; set; }
             public string TextingForHearingImpairedRemovedXLines { get; set; }
@@ -1941,6 +1944,7 @@ namespace Nikse.SubtitleEdit.Logic
                     public string KaraokeEffect { get; set; }
                     public string ShowSelectedLinesEarlierLater { get; set; }
                     public string VisualSyncSelectedLines { get; set; }
+                    public string BeautifyTimeCodesOfSelectedLines { get; set; }
                     public string GoogleAndMicrosoftTranslateSelectedLine { get; set; }
                     public string SelectedLines { get; set; }
                     public string TranslateSelectedLines { get; set; }


### PR DESCRIPTION
A new feature, a bugfix and some tidying up.
- Add the ability to beautify time codes of only the selected lines
- Show statuses in status bar
- Use the new public shot change functions in the AudioVisualizer (have the `Aggregate` function in one place)
- Add more tests for those public functions to prevent another case of #7113 
- Calculate the snapping distance when wave peaks are first loaded
- And recalculate them when new wave peaks are loaded (could be different sample rate)

![image](https://github.com/SubtitleEdit/subtitleedit/assets/3516155/2723fab5-eef7-4118-b6bb-26cd499c3aed)


![image](https://github.com/SubtitleEdit/subtitleedit/assets/3516155/664f04f1-fff2-4e39-9a06-4943b5a51853)
