### PR TITLE
Remove unnecessary usings across various files

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
@@ -1,7 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
-using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {

--- a/src/libse/Forms/FixCommonErrors/FixUnneededPeriods.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUnneededPeriods.cs
@@ -1,8 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors

--- a/src/libse/Forms/SplitLongLinesHelper.cs
+++ b/src/libse/Forms/SplitLongLinesHelper.cs
@@ -1,6 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
-using System.Xml;
 
 namespace Nikse.SubtitleEdit.Core.Forms
 {

--- a/src/ui/Forms/ApplyDurationLimits.cs
+++ b/src/ui/Forms/ApplyDurationLimits.cs
@@ -3,7 +3,6 @@ using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace Nikse.SubtitleEdit.Forms

--- a/src/ui/Forms/AudioToText/WhisperModelDownload.cs
+++ b/src/ui/Forms/AudioToText/WhisperModelDownload.cs
@@ -4,12 +4,10 @@ using Nikse.SubtitleEdit.Logic;
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
 using Nikse.SubtitleEdit.Core.Common;
-using Vosk;
 
 namespace Nikse.SubtitleEdit.Forms.AudioToText
 {

--- a/src/ui/Forms/ChangeFrameRate.cs
+++ b/src/ui/Forms/ChangeFrameRate.cs
@@ -1,7 +1,5 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Logic;
+﻿using Nikse.SubtitleEdit.Logic;
 using System;
-using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
 

--- a/src/ui/Forms/ConvertColorsToDialog.cs
+++ b/src/ui/Forms/ConvertColorsToDialog.cs
@@ -1,13 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Nikse.SubtitleEdit.Forms

--- a/src/ui/Forms/GetVideoPosition.cs
+++ b/src/ui/Forms/GetVideoPosition.cs
@@ -1,5 +1,4 @@
-﻿using Nikse.SubtitleEdit.Controls;
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.VideoPlayers;

--- a/src/ui/Forms/Translate/TranslateBlock.cs
+++ b/src/ui/Forms/Translate/TranslateBlock.cs
@@ -2,9 +2,7 @@
 using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Drawing;
-using System.IO;
 using System.Windows.Forms;
-using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Forms.Translate
 {

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -1,6 +1,4 @@
-﻿using System.Drawing;
-
-namespace Nikse.SubtitleEdit.Logic
+﻿namespace Nikse.SubtitleEdit.Logic
 {
     // The language classes are built for easy xml-serialization (makes save/load code simple)
     public static class LanguageStructure

--- a/src/ui/Logic/SeJob/SeJobHandler.cs
+++ b/src/ui/Logic/SeJob/SeJobHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.IO.Compression;
 using System.Text;
 using Newtonsoft.Json;

--- a/src/ui/Logic/TimeCodesGenerator.cs
+++ b/src/ui/Logic/TimeCodesGenerator.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Logic
 {


### PR DESCRIPTION
Multiple redundant using directives were removed from various files, contributing to the cleaner and more efficient codebase. These were no longer needed due to previous refactoring operations, where dependencies on these namespaces were eliminated.