### PR TITLE
Refactor file path resolution in FindVersionNumber

### DIFF
--- a/src/UpdateLanguageFiles/Program.cs
+++ b/src/UpdateLanguageFiles/Program.cs
@@ -128,29 +128,15 @@ namespace UpdateLanguageFiles
         private static string FindVersionNumber()
         {
             var templateFileName = Path.Combine("src", "ui", "Properties", "AssemblyInfo.cs.template");
-            if (!File.Exists(templateFileName))
-            {
-                templateFileName = Path.Combine("..", templateFileName);
-            }
+            var retryCount = 0;
 
-            if (!File.Exists(templateFileName))
+            while (!File.Exists(templateFileName))
             {
                 templateFileName = Path.Combine("..", templateFileName);
-            }
-
-            if (!File.Exists(templateFileName))
-            {
-                templateFileName = Path.Combine("..", templateFileName);
-            }
-
-            if (!File.Exists(templateFileName))
-            {
-                templateFileName = Path.Combine("..", templateFileName);
-            }
-
-            if (!File.Exists(templateFileName))
-            {
-                templateFileName = Path.Combine("..", templateFileName);
+                if (retryCount++ == 5)
+                {
+                    break;
+                }
             }
 
             if (File.Exists(templateFileName))


### PR DESCRIPTION
Removed multiple identical if statements and adjusted it with a while loop to find the template file. The change avoids duplicate code and adds a retry limit to prevent infinite looping if the file is not found.