### PR TITLE
Update name lists in dictionary files

### DIFF
--- a/Dictionaries/en_names.xml
+++ b/Dictionaries/en_names.xml
@@ -6,7 +6,7 @@
     <name>Black</name>
     <name>Male</name>
   </blacklist>
-  <name>2Pac</name>
+  <name>AI</name>
   <name>Aarav</name>
   <name>Abbey</name>
   <name>Abbie</name>

--- a/Dictionaries/names.xml
+++ b/Dictionaries/names.xml
@@ -7,6 +7,7 @@ This file is case sensitive.
   <name>1A</name>
   <name>2 Chainz</name>
   <name>2 Pac</name>
+  <name>2Pac</name>
   <name>2A</name>
   <name>3D</name>
   <name>6ix9ine</name>
@@ -226,7 +227,6 @@ This file is case sensitive.
   <name>Andre</name>
   <name>Andrea</name>
   <name>Andreas</name>
-  <name>AndreasB88</name>
   <name>Andres</name>
   <name>Andrew Dice Clay</name>
   <name>Andrew</name>
@@ -283,6 +283,7 @@ This file is case sensitive.
   <name>Anya</name>
   <name>Aphrodite</name>
   <name>Apia</name>
+  <name>Apple Inc.</name>
   <name>Apolinar</name>
   <name>Apollo</name>
   <name>April</name>
@@ -4746,6 +4747,7 @@ This file is case sensitive.
   <name>Rudys</name>
   <name>Rufus</name>
   <name>Ruidoso</name>
+  <name>Rumble</name>
   <name>Runkle</name>
   <name>Rupert</name>
   <name>Russ</name>
@@ -5343,6 +5345,7 @@ This file is case sensitive.
   <name>Theokoles</name>
   <name>Theresa</name>
   <name>Theroux</name>
+  <name>The Matrix</name>
   <name>Thimphu</name>
   <name>Thomas</name>
   <name>Thomason</name>
@@ -5894,6 +5897,8 @@ This file is case sensitive.
   <name>Zzyzx</name>
   <name>Zürich</name>
   <name>burrito</name>
+  <name>Burger King</name>
+  <name>KFC</name>
   <name>d'Artagnan</name>
   <name>divxsweden</name>
   <name>eBay</name>

--- a/src/ui/Forms/SplitLongLines.cs
+++ b/src/ui/Forms/SplitLongLines.cs
@@ -90,8 +90,8 @@ namespace Nikse.SubtitleEdit.Forms
             var autoBreakIndexes = new List<int>();
 
             NumberOfSplits = 0;
-            SubtitleListview1.Items.Clear();
             SubtitleListview1.BeginUpdate();
+            SubtitleListview1.Items.Clear();
             if (checkBoxSplitAtLineBreaks.Checked)
             {
                 SplitSubtitle = SplitAtLineBreak(_subtitle, splitIndexes, out var count, clearFixes);


### PR DESCRIPTION
Changes were made to the 'en_names.xml' and 'names.xml' dictionary files. The name '2Pac' was moved from 'en_names.xml' to 'names.xml' to enhance the correct language categorization. The name 'AI' was added to 'en_names.xml' . In addition, several other relevant names were also added to 'names.xml', including 'Apple Inc.', 'Rumble', 'The Matrix', 'Burger King', and 'KFC'. The name 'AndreasB88', which seems to be a typo, was removed.