### PR TITLE
Refactor line break removal using new RemoveRecursiveLineBreaks method

### DIFF
--- a/src/Test/Core/StringExtensionsTest.cs
+++ b/src/Test/Core/StringExtensionsTest.cs
@@ -185,6 +185,22 @@ namespace Test.Core
             var res = input.FixExtraSpaces();
             Assert.AreEqual("a" + Environment.NewLine + "b", res);
         }
+        
+        [TestMethod]
+        public void RemoveRecursiveLineBreakTest()
+        {
+            Assert.AreEqual("foo\r\nfoo", "foo\r\n\r\nfoo".RemoveRecursiveLineBreaks());
+            Assert.AreEqual("foo\r\nfoo", "foo\r\nfoo".RemoveRecursiveLineBreaks());
+            Assert.AreEqual("foo\r\nfoo", "foo\r\n\r\n\r\nfoo".RemoveRecursiveLineBreaks());
+        }
+
+        [TestMethod]
+        public void RemoveRecursiveLineBreakNonWindowsStyleTest(string input)
+        {
+            Assert.AreEqual("foo\nfoo", "foo\nfoo".RemoveRecursiveLineBreaks());
+            Assert.AreEqual("foo\n\foo", "foo\n\n\nfoo".RemoveRecursiveLineBreaks());
+            Assert.AreEqual("foo\n.\nfoo", "foo\n.\n\n\nfoo".RemoveRecursiveLineBreaks());
+        }
 
         [TestMethod]
         public void RemoveChar1()

--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -745,11 +745,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 {
                     text = text.Replace(" " + Environment.NewLine, Environment.NewLine);
                     text = text.Replace(Environment.NewLine + " ", Environment.NewLine);
-                    while (text.Contains(Environment.NewLine + Environment.NewLine))
-                    {
-                        text = text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
-                    }
-
+                    text = text.RemoveRecursiveLineBreaks();
+                    
                     if (Utilities.GetNumberOfLines(text) > 2)
                     {
                         text = Utilities.AutoBreakLine(text);
@@ -1042,11 +1039,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 {
                     text = text.Replace(" " + Environment.NewLine, Environment.NewLine);
                     text = text.Replace(Environment.NewLine + " ", Environment.NewLine);
-                    while (text.Contains(Environment.NewLine + Environment.NewLine))
-                    {
-                        text = text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
-                    }
-
+                    text = text.RemoveRecursiveLineBreaks();
+                    
                     if (Utilities.GetNumberOfLines(text) > 2)
                     {
                         text = Utilities.AutoBreakLine(text);
@@ -4973,11 +4967,9 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 {
                     text = text.Replace(" " + Environment.NewLine, Environment.NewLine);
                     text = text.Replace(Environment.NewLine + " ", Environment.NewLine);
-                    while (text.Contains(Environment.NewLine + Environment.NewLine))
-                    {
-                        text = text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
-                    }
 
+                    text = text.RemoveRecursiveLineBreaks();
+                    
                     if (Utilities.GetNumberOfLines(text) > 2)
                     {
                         text = Utilities.AutoBreakLine(text);
@@ -5135,10 +5127,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             {
                 text = text.Replace(" " + Environment.NewLine, Environment.NewLine);
                 text = text.Replace(Environment.NewLine + " ", Environment.NewLine);
-                while (text.Contains(Environment.NewLine + Environment.NewLine))
-                {
-                    text = text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
-                }
+                text = text.RemoveRecursiveLineBreaks();
 
                 if (Utilities.GetNumberOfLines(text) > 2)
                 {

--- a/src/ui/Logic/Ocr/OcrFixEngine.cs
+++ b/src/ui/Logic/Ocr/OcrFixEngine.cs
@@ -445,13 +445,8 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                 text = text.Replace(" " + Environment.NewLine, Environment.NewLine);
             }
 
-            while (text.Contains(Environment.NewLine + Environment.NewLine, StringComparison.Ordinal))
-            {
-                text = text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
-            }
-
-            text = text.Trim();
-
+            text = text.RemoveRecursiveLineBreaks().Trim();
+            
             var textNoAssa = Utilities.RemoveSsaTags(text, true);
             if (textNoAssa.Length == 0)
             {


### PR DESCRIPTION
This commit replaces the previous method of removing repeated line breaks in the text with a new RemoveRecursiveLineBreaks method. The previous implementation consisted of a loop that executed a Replace method each time a repeated line break was found in the text. This was not an optimal solution as it resulted in unnecessary overhead due to the continuous replacement process.

Now, the RemoveRecursiveLineBreaks method performs this operation more efficiently, without the need to continuously call the Replace method. The codebase has been updated to use the new method, improving execution speed and efficiency. Unit tests have also been added to confirm the functionality of this new method.