### PR TITLE
Replace magic numbers with named constants

### DIFF
--- a/src/UpdateAssemblyInfo/Program.cs
+++ b/src/UpdateAssemblyInfo/Program.cs
@@ -225,7 +225,9 @@ namespace UpdateAssemblyInfo
 
         private static void SaveWithRetry(string fileName, string content)
         {
-            for (int i = 0; i < 10; i++)
+            const int maxRetries = 10;
+            var delayBetweenRetries = TimeSpan.FromMilliseconds(10);
+            for (var i = 0; i <= maxRetries; i++)
             {
                 try
                 {
@@ -234,10 +236,14 @@ namespace UpdateAssemblyInfo
                 }
                 catch
                 {
-                    System.Threading.Thread.Sleep(10);
+                    if (i == maxRetries)
+                    {
+                        throw;
+                    }
+
+                    System.Threading.Thread.Sleep(delayBetweenRetries);
                 }
             }
-            File.WriteAllText(fileName, content, Encoding.UTF8);
         }
 
         private static void GetRepositoryVersions(out VersionInfo currentRepositoryVersion, out VersionInfo latestRepositoryVersion)

--- a/src/UpdateLanguageFiles/Program.cs
+++ b/src/UpdateLanguageFiles/Program.cs
@@ -109,7 +109,7 @@ namespace UpdateLanguageFiles
                         throw;
                     }
 
-                    System.Threading.Thread.Sleep(10);
+                    System.Threading.Thread.Sleep(delayBetweenRetries);
                 }
             }
         }


### PR DESCRIPTION
This commit replaces magic numbers in the retry mechanism with named constants. In "UpdateLanguageFiles", the hardcoded delay of 10ms between retries has been replaced by the variable 'delayBetweenRetries'. Similarly, in "UpdateAssemblyInfo", the number of retries set to 10 has been replaced with 'maxRetries' and 'delayBetweenRetries' is used for the time gap between each attempt. This makes the code more readable and maintainable.