### PR TITLE
#7069 Improve AudioVisualizer - show relativeTime inside SelectedParagraph

### DIFF
--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -1067,7 +1067,19 @@ namespace Nikse.SubtitleEdit.Controls
                 // paragraph number
                 if (n > 15)
                 {
+                    // Calculate Relative Playhead time in currently selected paragraph
+                    var relativeTime = Math.Truncate((_currentVideoPositionSeconds - SelectedParagraph.StartTime.TotalSeconds)*1000);
+
                     var text = "#" + paragraph.Number + "  " + paragraph.Duration.ToShortDisplayString();
+
+                    // If paragraph is SelectedParagraph - add relativeTime;
+                    // ! Probably should refactor this to work better with overlaying subtitles 
+
+                    if(paragraph.StartTime == SelectedParagraph.StartTime)
+                    {
+                        text += " / " + relativeTime;
+                    }
+
                     if (n <= 51 || graphics.MeasureString(text, font).Width >= currentRegionWidth - padding - 1)
                     {
                         text = "#" + paragraph.Number;

--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -1067,17 +1067,15 @@ namespace Nikse.SubtitleEdit.Controls
                 // paragraph number
                 if (n > 15)
                 {
-                    // Calculate Relative Playhead time in currently selected paragraph
-                    var relativeTime = Math.Truncate((_currentVideoPositionSeconds - SelectedParagraph.StartTime.TotalSeconds)*1000);
 
                     var text = "#" + paragraph.Number + "  " + paragraph.Duration.ToShortDisplayString();
 
-                    // If paragraph is SelectedParagraph - add relativeTime;
+                    // If paragraph is SelectedParagraph - add relativeTimeInMiliseconds;
                     // ! Probably should refactor this to work better with overlaying subtitles 
-
-                    if(paragraph.StartTime == SelectedParagraph.StartTime)
+                    if (paragraph.StartTime == SelectedParagraph.StartTime)
                     {
-                        text += " / " + relativeTime;
+                        var relativeTimeInMilliseconds = Math.Truncate((_currentVideoPositionSeconds - SelectedParagraph.StartTime.TotalSeconds) * 1000);
+                        text += " / " + relativeTimeInMilliseconds;
                     }
 
                     if (n <= 51 || graphics.MeasureString(text, font).Width >= currentRegionWidth - padding - 1)


### PR DESCRIPTION
Working solution to #7069 issue. Adding relative Playhead time to Selected Paragraph

(If necessary have to refactor, because this is the first time I code in C#)

**Potential lacks:**
1. May look buggy if there are overlapping paragraphs.
2. Performance?

What could be improved more:
✅ Move var calculation after checking if it needs to be added or not (and not calculate it on each paragraph. 
❌ Update the relativeTime variable only on pause and mouse click on the Waveform
❌ Move the relativeTimeInMilliseconds variable into a function to return the value and use that instead. (Still not sure where to do it)
❌ Make it an optional setting