### PR TITLE
[VideoPlayerContainer] Fix Pause button coordinates

### DIFF
--- a/src/ui/Controls/VideoPlayerContainer.cs
+++ b/src/ui/Controls/VideoPlayerContainer.cs
@@ -768,7 +768,7 @@ namespace Nikse.SubtitleEdit.Controls
             _panelControls.Controls.Add(_pictureBoxPlayOver);
 
             _pictureBoxPause.Image = (Image)_resources.GetObject("pictureBoxPause.Image");
-            _pictureBoxPause.Location = new Point(23, 126 - 113);
+            _pictureBoxPause.Location = new Point(22, 126 - 113);
             _pictureBoxPause.Name = "_pictureBoxPause";
             _pictureBoxPause.Size = new Size(29, 29);
             _pictureBoxPause.SizeMode = PictureBoxSizeMode.AutoSize;
@@ -777,7 +777,7 @@ namespace Nikse.SubtitleEdit.Controls
             _panelControls.Controls.Add(_pictureBoxPause);
 
             _pictureBoxPauseDown.Image = (Image)_resources.GetObject("pictureBoxPauseDown.Image");
-            _pictureBoxPauseDown.Location = new Point(23, 126 - 113);
+            _pictureBoxPauseDown.Location = new Point(22, 126 - 113);
             _pictureBoxPauseDown.Name = "_pictureBoxPauseDown";
             _pictureBoxPauseDown.Size = new Size(29, 29);
             _pictureBoxPauseDown.SizeMode = PictureBoxSizeMode.AutoSize;
@@ -785,7 +785,7 @@ namespace Nikse.SubtitleEdit.Controls
             _panelControls.Controls.Add(_pictureBoxPauseDown);
 
             _pictureBoxPauseOver.Image = (Image)_resources.GetObject("pictureBoxPauseOver.Image");
-            _pictureBoxPauseOver.Location = new Point(23, 126 - 113);
+            _pictureBoxPauseOver.Location = new Point(22, 126 - 113);
             _pictureBoxPauseOver.Name = "_pictureBoxPauseOver";
             _pictureBoxPauseOver.Size = new Size(29, 29);
             _pictureBoxPauseOver.SizeMode = PictureBoxSizeMode.AutoSize;


### PR DESCRIPTION
Play and Pause buttons were not using the same coordinates, so the button "moves" when clicked as it alternates between Play and Pause states.