### PR TITLE
Introduce StringBuilderPool

### DIFF
--- a/src/Test/Common/StringBuilderPoolTest.cs
+++ b/src/Test/Common/StringBuilderPoolTest.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Test.Common
+{
+    [TestClass]
+    public class StringBuilderPoolTest
+    {
+        [TestMethod]
+        public void GetNotNullTest()
+        {
+            var sb = StringBuilderPool.Get();
+            Assert.IsNotNull(sb);
+        }
+
+        [TestMethod]
+        public void GetAssertMinCapacityTest()
+        {
+            // assert init with the min capacity
+            Assert.AreEqual(1024, StringBuilderPool.Get().Capacity);
+        }
+        
+        [TestMethod]
+        public void ReturnToPoolTest()
+        {
+            var sbOne = StringBuilderPool.Get();
+            var sbTwo = StringBuilderPool.Get();
+            var sbThree = StringBuilderPool.Get();
+
+            // return all to pool
+            var isOneReturned = sbOne.ReturnToPool();
+            var isTwoReturned = sbTwo.ReturnToPool();
+            var isThreeReturned = sbThree.ReturnToPool();
+            
+            Assert.IsTrue(isOneReturned);
+            Assert.IsTrue(isTwoReturned);
+            Assert.IsTrue(isThreeReturned);
+        }
+        
+        [TestMethod]
+        public void ToPoolTest()
+        {
+            const string content = "the quick brown fox jumps over a lazy dog.";
+            var sb = StringBuilderPool.Get();
+            sb.Append(content);
+            Assert.AreEqual(content, sb.ToPool());
+            
+            var freshSbFromPool = StringBuilderPool.Get();
+            // we are expecting the same string builder reference
+            Assert.AreEqual(freshSbFromPool, sb);
+            Assert.AreEqual(0, freshSbFromPool.Length);
+        }
+
+        [TestMethod]
+        public void ReturnToPoolCapacityGreaterThanMax()
+        {
+            // arrange
+            var sb = StringBuilderPool.Get();
+            
+            // act
+            sb.Capacity = 85001;
+            
+            // assert
+            Assert.IsFalse(sb.ReturnToPool());
+        }
+        
+        [TestMethod]
+        public void ReturnToPoolAlreadyFill()
+        {
+            // arrange
+            var sbOne = StringBuilderPool.Get();
+            var sbTwo = StringBuilderPool.Get();
+            var sbThree = StringBuilderPool.Get();
+            var sbFour = StringBuilderPool.Get();
+            
+            // act &&  assert
+            Assert.IsTrue(sbOne.ReturnToPool());
+            Assert.IsTrue(sbTwo.ReturnToPool());
+            Assert.IsTrue(sbThree.ReturnToPool());
+            Assert.IsFalse(sbFour.ReturnToPool());
+        }
+    }
+}

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Assa\TagHelperRemoveTagTest.cs" />
     <Compile Include="Assa\ResamplerTest.cs" />
     <Compile Include="Assa\AssaTimeCodes.cs" />
+    <Compile Include="Common\StringBuilderPoolTest.cs" />
     <Compile Include="Core\AudioToTextTest.cs" />
     <Compile Include="Core\CsvUtilTest.cs" />
     <Compile Include="Core\WebVttHelperTest.cs" />
@@ -197,7 +198,6 @@
       <Name>SubtitleEdit</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/libse/Common/StringBuilderPool.cs
+++ b/src/libse/Common/StringBuilderPool.cs
@@ -67,7 +67,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         /// <param name="sb">The StringBuilder instance to return to the pool.</param>
         /// <returns>A boolean value indicating whether the operation was successful.</returns>
-        private static bool ReturnToPool(this StringBuilder sb)
+        public static bool ReturnToPool(this StringBuilder sb)
         {
             lock (Lock)
             {

--- a/src/libse/Common/StringBuilderPool.cs
+++ b/src/libse/Common/StringBuilderPool.cs
@@ -87,7 +87,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 // the incoming stringbuilder will enter the pool only if it's capacity
                 // is greater than the available one on the top
-                if (Pool.Peek().Capacity < sb.Capacity)
+                if (currentPoolSize < MaxPoolSize || Pool.Peek().Capacity < sb.Capacity)
                 {
                     Pool.Push(sb);
                 }

--- a/src/libse/Common/StringBuilderPool.cs
+++ b/src/libse/Common/StringBuilderPool.cs
@@ -85,7 +85,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     return false;
                 }
 
-                // the incoming stringbuilder will enter the pool only if it's capacity
+                // the incoming stringbuilder will enter the pool only if its capacity
                 // is greater than the available one on the top
                 if (currentPoolSize < MaxPoolSize || Pool.Peek().Capacity < sb.Capacity)
                 {

--- a/src/libse/Common/StringBuilderPool.cs
+++ b/src/libse/Common/StringBuilderPool.cs
@@ -4,6 +4,10 @@ using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
+    /// <summary>
+    /// Represents a pool of StringBuilder objects that can be reused to mitigate the
+    /// performance cost of frequently instantiating StringBuilders.
+    /// </summary>
     internal static class StringBuilderPool
     {
         private const int MinCapacity = 1024;
@@ -14,12 +18,21 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static int _maxCapacity = 85000;
 
+        /// <summary>
+        /// Get or set the maximum capacity of StringBuilder that can be stored in
+        /// the pool.
+        /// </summary>
         internal static int MaxCapacity
         {
             get => _maxCapacity;
             set => _maxCapacity = Math.Max(MinCapacity, value);
         }
 
+        /// <summary>
+        /// Returns a StringBuilder instance from the pool. If the pool is empty,
+        /// a new instance is created with a default minimum capacity.
+        /// </summary>
+        /// <returns>A StringBuilder instance.</returns>
         internal static StringBuilder Get()
         {
             lock (Lock)
@@ -35,6 +48,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
+        /// <summary>
+        /// Converts the StringBuilder into a string, returns the StringBuilder
+        /// to the pool, and then returns the string contents of the StringBuilder.
+        /// </summary>
+        /// <param name="sb">The StringBuilder instance to return to the pool.</param>
+        /// <returns>The string content of the StringBuilder.</returns>
         internal static string ToPool(this StringBuilder sb)
         {
             var content = sb.ToString();
@@ -42,6 +61,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             return content;
         }
 
+        /// <summary>
+        /// Tries to return a StringBuilder to the pool. If the pool is full or
+        /// the capacity of the StringBuilder is too large, it is not added to the pool.
+        /// </summary>
+        /// <param name="sb">The StringBuilder instance to return to the pool.</param>
+        /// <returns>A boolean value indicating whether the operation was successful.</returns>
         private static bool ReturnToPool(this StringBuilder sb)
         {
             lock (Lock)

--- a/src/libse/Common/StringBuilderPool.cs
+++ b/src/libse/Common/StringBuilderPool.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    internal static class StringBuilderPool
+    {
+        private const int MinLimit = 1024;
+
+        private static readonly object _lock = new object();
+        private static readonly Stack<StringBuilder> Pool = new Stack<StringBuilder>();
+
+        private static int _maxPoolSize = 3;
+        private static int _maxLimit = 85000;
+
+        internal static int MaxPoolSize
+        {
+            get => _maxPoolSize;
+            set => _maxPoolSize = Math.Max(1, value);
+        }
+
+        internal static int MaxLimit
+        {
+            get => _maxLimit;
+            set => _maxLimit = Math.Max(MinLimit, value);
+        }
+
+        internal static StringBuilder Retrieve()
+        {
+            lock (_lock)
+            {
+                // nothing in the pool
+                if (Pool.Count == 0)
+                {
+                    return new StringBuilder(MinLimit);
+                }
+
+                // clear and return from the pool
+                return Pool.Pop().Clear();
+            }
+        }
+
+        internal static void ReturnToPool(this StringBuilder sb)
+        {
+            lock (_lock)
+            {
+                var currentPoolSize = Pool.Count;
+                
+                // capacity passes the max allowed limit in the pool
+                if (sb.Capacity > _maxLimit)
+                {
+                    return;
+                }
+
+                if (currentPoolSize == _maxPoolSize)
+                {
+                    // drop min from the bag
+                }
+                else if (currentPoolSize < Math.Min(2, _maxPoolSize) || Pool.Peek().Capacity < sb.Capacity)
+                {
+                    Pool.Push(sb);
+                }
+            }
+        }
+    }
+}

--- a/src/libse/Common/StringBuilderPool.cs
+++ b/src/libse/Common/StringBuilderPool.cs
@@ -67,7 +67,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         /// <param name="sb">The StringBuilder instance to return to the pool.</param>
         /// <returns>A boolean value indicating whether the operation was successful.</returns>
-        public static bool ReturnToPool(this StringBuilder sb)
+        internal static bool ReturnToPool(this StringBuilder sb)
         {
             lock (Lock)
             {

--- a/src/libse/Common/StringBuilderPool.cs
+++ b/src/libse/Common/StringBuilderPool.cs
@@ -80,18 +80,19 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
 
                 // pool already at is max capacity
-                if (currentPoolSize == MaxPoolSize)
+                if (currentPoolSize >= MaxPoolSize)
                 {
                     return false;
                 }
 
                 // the incoming stringbuilder will enter the pool only if its capacity
                 // is greater than the available one on the top
-                if (currentPoolSize < MaxPoolSize || Pool.Peek().Capacity < sb.Capacity)
+                if (currentPoolSize > 0 && Pool.Peek().Capacity > sb.Capacity)
                 {
-                    Pool.Push(sb);
+                    return false;
                 }
 
+                Pool.Push(sb);
                 return true;
             }
         }

--- a/src/libse/Common/StringBuilderPool.cs
+++ b/src/libse/Common/StringBuilderPool.cs
@@ -6,18 +6,18 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     internal static class StringBuilderPool
     {
-        private const int MinLimit = 1024;
+        private const int MinCapacity = 1024;
         private const int MaxPoolSize = 3;
 
         private static readonly object Lock = new object();
         private static readonly Stack<StringBuilder> Pool = new Stack<StringBuilder>();
 
-        private static int _maxLimit = 85000;
+        private static int _maxCapacity = 85000;
 
-        internal static int MaxLimit
+        internal static int MaxCapacity
         {
-            get => _maxLimit;
-            set => _maxLimit = Math.Max(MinLimit, value);
+            get => _maxCapacity;
+            set => _maxCapacity = Math.Max(MinCapacity, value);
         }
 
         internal static StringBuilder Get()
@@ -27,7 +27,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 // nothing in the pool
                 if (Pool.Count == 0)
                 {
-                    return new StringBuilder(MinLimit);
+                    return new StringBuilder(MinCapacity);
                 }
 
                 // clear and return from the pool
@@ -49,7 +49,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var currentPoolSize = Pool.Count;
 
                 // capacity passes the max allowed limit in the pool
-                if (sb.Capacity > _maxLimit)
+                if (sb.Capacity > _maxCapacity)
                 {
                     return false;
                 }

--- a/src/libse/Forms/CheckForUpdatesHelper.cs
+++ b/src/libse/Forms/CheckForUpdatesHelper.cs
@@ -58,7 +58,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
         private string GetLatestChangeLog(string changeLog)
         {
             var releaseOn = false;
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             foreach (var line in changeLog.Replace(Environment.NewLine, "\n").Split('\n'))
             {
                 var s = line.Trim();
@@ -86,7 +86,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 }
             }
 
-            return sb.ToString();
+            return sb.ToPool();
         }
 
         public void CheckForUpdates()

--- a/src/libse/Forms/FixCommonErrors/FixUnneededPeriods.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUnneededPeriods.cs
@@ -58,7 +58,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     var l = callbacks.Language;
                     if (procText.Contains('.') && LanguageAutoDetect.IsLanguageWithoutPeriods(l))
                     {
-                        var sb = new StringBuilder();
+                        var sb = StringBuilderPool.Get();
                         foreach (var line in procText.SplitToLines())
                         {
                             var s = line;
@@ -74,7 +74,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             sb.AppendLine(s);
                         }
 
-                        procText = sb.ToString().TrimEnd();
+                        procText = sb.ToPool().TrimEnd();
                     }
 
                     var diff = p.Text.Length - procText.Length;

--- a/src/libse/Forms/MoveWordUpDown.cs
+++ b/src/libse/Forms/MoveWordUpDown.cs
@@ -28,9 +28,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
             var assTagOn = false;
             var htmlTagOn = false;
-            var sbWord = new StringBuilder();
+            var sbWord = StringBuilderPool.Get();
             var done = false;
-            var sbS2 = new StringBuilder();
+            var sbS2 = StringBuilderPool.Get();
             for (int i = 0; i < S2.Length; i++)
             {
                 var ch = S2[i];
@@ -80,9 +80,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     sbWord.Append(ch);
                 }
             }
-            S1 = AddWordAfter(sbWord.ToString().Trim(), S1);
+            S1 = AddWordAfter(sbWord.ToPool().Trim(), S1);
             S1 = AutoBreakIfNeeded(S1);
-            S2 = sbS2.ToString().Trim();
+            S2 = sbS2.ToPool().Trim();
             S2 = RemoveEmptyTags(S2);
         }
 
@@ -98,9 +98,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
             var assTagOn = false;
             var htmlTagOn = false;
-            var sbWord = new StringBuilder();
+            var sbWord = StringBuilderPool.Get();
             var done = false;
-            var sbS1 = new StringBuilder();
+            var sbS1 = StringBuilderPool.Get();
             for (int i = S1.Length - 1; i >= 0; i--)
             {
                 var ch = S1[i];
@@ -157,9 +157,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     sbWord.Append(ch);
                 }
             }
-            S1 = string.Join(string.Empty, sbS1.ToString().Trim().ToCharArray().Reverse());
+            S1 = string.Join(string.Empty, sbS1.ToPool().Trim().ToCharArray().Reverse());
             S1 = RemoveEmptyTags(S1);
-            S2 = AddWordBefore(string.Join(string.Empty, sbWord.ToString().Trim().ToCharArray().Reverse()), S2);
+            S2 = AddWordBefore(string.Join(string.Empty, sbWord.ToPool().Trim().ToCharArray().Reverse()), S2);
             S2 = AutoBreakIfNeeded(S2);
         }
 

--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -901,7 +901,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             }
 
             var st = new StrippableText(text, pre, post);
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             var parts = st.StrippedText.Trim().SplitToLines();
             var lineNumber = 0;
             var removedDialogInFirstLine = false;
@@ -1003,7 +1003,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             {
                 st.Post = " " + st.Post;
             }
-            text = st.Pre + sb.ToString().Trim() + st.Post;
+            text = st.Pre + sb.ToPool().Trim() + st.Post;
 
             text = text.Replace("  ", " ").Trim();
             text = text.Replace("<i></i>", string.Empty);
@@ -1530,7 +1530,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 return text;
             }
 
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             char[] endTrimChars = { '.', '!', '?', ':' };
             char[] trimChars = { ' ', '-', '—' };
             foreach (var line in text.SplitToLines())
@@ -1549,7 +1549,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     sb.AppendLine(line);
                 }
             }
-            return sb.ToString().Trim();
+            return sb.ToPool().Trim();
         }
 
         public static IList<string> GetInterjectionList()

--- a/src/libse/SubtitleFormats/Cavena890.cs
+++ b/src/libse/SubtitleFormats/Cavena890.cs
@@ -1322,7 +1322,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string ReverseAnsi(string text)
         {
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             var ansi = new StringBuilder();
             foreach (var ch in text)
             {
@@ -1345,7 +1345,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.Append(Utilities.ReverseString(ansi.ToString()));
             }
 
-            return sb.ToString();
+            return sb.ToPool();
         }
 
         private static void AddTwo(byte[] buffer, ref int index, byte b1, byte b2)
@@ -1507,7 +1507,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (languageId == LanguageIdRussian)
             {
                 var encoding = Encoding.GetEncoding(1252);
-                var sb = new StringBuilder();
+                var sb = StringBuilderPool.Get();
                 for (int i = 0; i < textLength; i++)
                 {
                     int b = buffer[start + i];
@@ -1522,7 +1522,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                 }
 
-                text = sb.ToString();
+                text = sb.ToPool();
 
                 text = text.Replace(encoding.GetString(new byte[] { 0x7F }), string.Empty); // Used to fill empty space upto 51 bytes
                 text = text.Replace(encoding.GetString(new byte[] { 0xBE }), string.Empty); // Unknown?
@@ -1541,7 +1541,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             else if (languageId == LanguageIdHebrew) // (_language == "HEBNOA")
             {
                 var encoding = Encoding.GetEncoding(1252);
-                var sb = new StringBuilder();
+                var sb = StringBuilderPool.Get();
                 for (int i = 0; i < textLength; i++)
                 {
                     int b = buffer[start + i];
@@ -1556,7 +1556,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                 }
 
-                text = sb.ToString();
+                text = sb.ToPool();
 
                 text = text.Replace(encoding.GetString(new byte[] { 0x7F }), string.Empty); // Used to fill empty space upto 51 bytes
                 text = text.Replace(encoding.GetString(new byte[] { 0xBE }), string.Empty); // Unknown?
@@ -1568,7 +1568,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             else if (languageId == LanguageIdArabic)
             {
                 var encoding = Encoding.GetEncoding(1252);
-                var sb = new StringBuilder();
+                var sb = StringBuilderPool.Get();
                 for (int i = 0; i < textLength; i++)
                 {
                     int b = buffer[start + i];
@@ -1582,7 +1582,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                 }
 
-                text = sb.ToString();
+                text = sb.ToPool();
                 text = text.Replace(encoding.GetString(new byte[] { 0xBE }), string.Empty); // Unknown?
                 text = FixColors(text).Trim();
             }
@@ -1802,7 +1802,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             Encoding encoding = Encoding.GetEncoding(1252);
             bool fontColorOn = false;
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             for (int i = 0; i < text.Length; i++)
             {
                 var s = text.Substring(i, 1);
@@ -1882,7 +1882,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 sb.Append("</font>"); // white
             }
-            return sb.ToString();
+            return sb.ToPool();
         }
 
     }

--- a/src/libse/SubtitleFormats/CheetahCaption.cs
+++ b/src/libse/SubtitleFormats/CheetahCaption.cs
@@ -255,7 +255,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             var i = 128;
             Paragraph last = null;
-            var sb = new StringBuilder();
             while (i < buffer.Length - 16)
             {
                 var p = new Paragraph();
@@ -289,7 +288,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         last.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                     }
 
-                    sb.Clear();
+                    var sb = StringBuilderPool.Get();
                     var j = 0;
                     var italics = false;
                     var encoding = Encoding.GetEncoding(1252);
@@ -332,7 +331,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         sb.Append("</i>");
                     }
 
-                    p.Text = sb.ToString().Trim();
+                    p.Text = sb.ToPool().Trim();
                     p.Text = p.Text.Replace("</i>" + Environment.NewLine + "<i>", Environment.NewLine);
 
                     subtitle.Paragraphs.Add(p);

--- a/src/libse/SubtitleFormats/PListCaption.cs
+++ b/src/libse/SubtitleFormats/PListCaption.cs
@@ -32,9 +32,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = sb.ToPool().Trim();
             if (xmlAsString.Contains("</plist>") && xmlAsString.Contains("</dict>"))
             {
                 XmlDocument xml = new XmlDocument { XmlResolver = null };

--- a/src/libse/SubtitleFormats/Pac.cs
+++ b/src/libse/SubtitleFormats/Pac.cs
@@ -1204,7 +1204,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             text = text.Replace("<I>", "<i>");
             text = text.Replace("</I>", "</i>");
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             var parts = text.SplitToLines();
             var nextPre = string.Empty;
             foreach (string line in parts)
@@ -1232,7 +1232,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     sb.AppendLine(s);
                 }
             }
-            return sb.ToString().Trim();
+            return sb.ToPool().Trim();
         }
 
         internal static void WriteTimeCode(Stream fs, TimeCode timeCode)
@@ -1490,7 +1490,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             var overrides = (CodePage == CodePageLatinTurkish) ? LatinTurkishOverrides : null;
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             index = feIndex + 3;
             var w16 = buffer[index] == 0x1f && Encoding.ASCII.GetString(buffer, index + 1, 3) == "W16";
             if (w16)
@@ -1643,7 +1643,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return null;
             }
 
-            p.Text = sb.ToString();
+            p.Text = sb.ToPool();
             p.Text = p.Text.Replace("\0", string.Empty);
             p.Text = FixItalics(p.Text);
             if (CodePage == CodePageArabic)

--- a/src/libse/SubtitleFormats/PhoenixSubtitle.cs
+++ b/src/libse/SubtitleFormats/PhoenixSubtitle.cs
@@ -93,7 +93,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override string ToText(Subtitle subtitle, string title)
         {
             const string writeFormat = "{0},{1},\"{2}\"{3}";
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             foreach (var p in subtitle.Paragraphs)
             {
                 string text = HtmlUtil.RemoveHtmlTags(p.Text, true);
@@ -101,7 +101,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 text = text.Replace(Environment.NewLine, "|");
                 sb.AppendFormat(writeFormat, MillisecondsToFrames(p.StartTime.TotalMilliseconds), MillisecondsToFrames(p.EndTime.TotalMilliseconds), text, Environment.NewLine);
             }
-            return sb.ToString();
+            return sb.ToPool();
         }
 
     }

--- a/src/libse/SubtitleFormats/Titra.cs
+++ b/src/libse/SubtitleFormats/Titra.cs
@@ -22,7 +22,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string ToText(Subtitle subtitle, string title)
         {
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             sb.AppendLine(@"TVS - TITRA FILM
 
 Titre VO :   L'heure d'été
@@ -50,7 +50,7 @@ ATTENTION : Pas plus de 40 caractères PAR LIGNE
                     sb.AppendLine();
                 }
             }
-            return sb.ToString();
+            return sb.ToPool();
         }
 
         private static string EncodeTimeCode(TimeCode time)

--- a/src/libse/SubtitleFormats/UnknownSubtitle43.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle43.cs
@@ -14,9 +14,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = sb.ToPool().Trim();
             if (xmlAsString.Contains("<subtitle"))
             {
                 var xml = new XmlDocument { XmlResolver = null };

--- a/src/libse/SubtitleFormats/UnknownSubtitle89.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle89.cs
@@ -17,7 +17,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string ToText(Subtitle subtitle, string title)
         {
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             foreach (var p in subtitle.Paragraphs)
             {
                 sb.Append(EncodeTime(p.StartTime) + " " + (string.IsNullOrWhiteSpace(p.Actor) ? "Speaker" : p.Actor));
@@ -25,7 +25,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.AppendLine(p.Text);
                 sb.AppendLine();
             }
-            return sb.ToString();
+
+            return sb.ToPool();
         }
 
         private static string EncodeTime(TimeCode timeCode)

--- a/src/libse/SubtitleFormats/UnknownSubtitle97.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle97.cs
@@ -22,7 +22,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             //00:00:22 - Wait, he’s the one that…
             //\t\t-ENOUGH!
             const string writeFormat = "{0:00}:{1:00}:{2:00} {3}";
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             foreach (var p in subtitle.Paragraphs)
             {
                 var textBuilder = new StringBuilder();
@@ -39,7 +39,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 sb.AppendLine(string.Format(writeFormat, p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, textBuilder));
             }
-            return sb.ToString().Trim() + Environment.NewLine;
+            return sb.ToPool().Trim() + Environment.NewLine;
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/libse/SubtitleFormats/Utx.cs
+++ b/src/libse/SubtitleFormats/Utx.cs
@@ -26,12 +26,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             const string paragraphWriteFormat = "{0}{1}#{2},{3}{1}";
 
-            var sb = new StringBuilder();
+            var sb = StringBuilderPool.Get();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
                 sb.AppendLine(string.Format(paragraphWriteFormat, p.Text, Environment.NewLine, EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime)));
             }
-            return sb.ToString().Trim();
+            return sb.ToPool().Trim();
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)


### PR DESCRIPTION
The new StringBuilderPool class has been added to provide an implementation of an object pool pattern specifically for StringBuilders. This object pool assists with the use and re-use of StringBuilders, where more-often used string builders are returned from the pool and the least used ones are dropped. Limitations on pool size and capacity of string builders are also set to manage resource usage.