### PR TITLE
Refactor GetVideoInfo method for code simplicity

### DIFF
--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -19,9 +19,11 @@ namespace Nikse.SubtitleEdit.Logic
 {
     internal static class UiUtil
     {
+        private delegate VideoInfo VideoDecoder(string fileName);
+
         public static readonly Lazy<string> SubtitleExtensionFilter = new Lazy<string>(GetOpenDialogFilter);
 
-        private static readonly Lazy<List<Func<string, VideoInfo>>> DecodersLazy = new Lazy<List<Func<string, VideoInfo>>>(() => new List<Func<string, VideoInfo>>()
+        private static readonly Lazy<List<VideoDecoder>> DecodersLazy = new Lazy<List<VideoDecoder>>(() => new List<VideoDecoder>()
         {
             FileUtil.TryReadVideoInfoViaAviHeader,
             FileUtil.TryReadVideoInfoViaMatroskaHeader,


### PR DESCRIPTION
The GetVideoInfo method in src/ui/Logic/UiUtil.cs was refactored to use a list of decoder functions instead of individual "try read". This change simplifies the code and makes it more DRY (Don't Repeat Yourself). Future decoder functions can now be easily added to the DecodersLazy list.