### PR TITLE
"Refactor pixel width calculation in FixShortLinesPixelWidth"

### DIFF
--- a/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
@@ -3489,14 +3489,7 @@ namespace Test.FixCommonErrors
             {
                 Configuration.Settings.General.SubtitleLineMaximumPixelWidth = 576;
                 InitializeFixCommonErrorsLine(target, "It is I this illustrious illiteration.\r\nIt's this...");
-                new FixShortLinesPixelWidth().Fix(_subtitle, new EmptyFixCallback()
-                {
-                    CustomCallbackDataHandler = (sender, input) =>
-                    {
-                        var text = Convert.ToString(input);
-                        return TextWidth.CalcPixelWidth(text);
-                    }
-                });
+                new FixShortLinesPixelWidth(TextWidth.CalcPixelWidth).Fix(_subtitle, new EmptyFixCallback());
                 Assert.AreEqual("It is I this illustrious illiteration. It's this...", _subtitle.Paragraphs[0].Text);
             }
         }
@@ -3509,14 +3502,7 @@ namespace Test.FixCommonErrors
                 Configuration.Settings.General.SubtitleLineMaximumPixelWidth = 576;
                 Configuration.Settings.General.DialogStyle = DialogType.DashSecondLineWithoutSpace;
                 InitializeFixCommonErrorsLine(target, "It is I this illustrious illiteration.\r\n-It's this...");
-                new FixShortLinesPixelWidth().Fix(_subtitle, new EmptyFixCallback()
-                {
-                    CustomCallbackDataHandler = (sender, input) =>
-                    {
-                        var text = Convert.ToString(input);
-                        return TextWidth.CalcPixelWidth(text);
-                    }
-                });
+                new FixShortLinesPixelWidth(TextWidth.CalcPixelWidth).Fix(_subtitle, new EmptyFixCallback());
                 Assert.AreEqual("It is I this illustrious illiteration.\r\n-It's this...", _subtitle.Paragraphs[0].Text);
             }
         }
@@ -3528,14 +3514,7 @@ namespace Test.FixCommonErrors
             {
                 Configuration.Settings.General.SubtitleLineMaximumPixelWidth = 576;
                 InitializeFixCommonErrorsLine(target, "It is I this illustrious illiteration.\r\nIt's super...");
-                new FixShortLinesPixelWidth().Fix(_subtitle, new EmptyFixCallback()
-                {
-                    CustomCallbackDataHandler = (sender, input) =>
-                    {
-                        var text = Convert.ToString(input);
-                        return TextWidth.CalcPixelWidth(text);
-                    }
-                });
+                new FixShortLinesPixelWidth(TextWidth.CalcPixelWidth).Fix(_subtitle, new EmptyFixCallback());
                 Assert.AreEqual("It is I this illustrious illiteration.\r\nIt's super...", _subtitle.Paragraphs[0].Text);
             }
         }
@@ -3547,14 +3526,7 @@ namespace Test.FixCommonErrors
             {
                 Configuration.Settings.General.SubtitleLineMaximumPixelWidth = 576;
                 InitializeFixCommonErrorsLine(target, "<i>It is I this illustrious illiteration.</i>\r\n<i>It's this...</i>");
-                new FixShortLinesPixelWidth().Fix(_subtitle, new EmptyFixCallback()
-                {
-                    CustomCallbackDataHandler = (sender, input) =>
-                    {
-                        var text = Convert.ToString(input);
-                        return TextWidth.CalcPixelWidth(text);
-                    }
-                });
+                new FixShortLinesPixelWidth(TextWidth.CalcPixelWidth).Fix(_subtitle, new EmptyFixCallback());
                 Assert.AreEqual("<i>It is I this illustrious illiteration. It's this...</i>", _subtitle.Paragraphs[0].Text);
             }
         }

--- a/src/libse/Forms/FixCommonErrors/EmptyFixCallback.cs
+++ b/src/libse/Forms/FixCommonErrors/EmptyFixCallback.cs
@@ -9,8 +9,6 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {
     public class EmptyFixCallback : IFixCallbacks
     {
-        public Func<IFixCommonError, object, object> CustomCallbackDataHandler { get; set; } = null;
-
         public bool AllowFix(Paragraph p, string action)
         {
             return true;
@@ -49,16 +47,6 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         public void AddToDeleteIndices(int index)
         {
             // Empty callback
-        }
-
-        public object GetCustomCallbackData(IFixCommonError sender, object input)
-        {
-            if (CustomCallbackDataHandler != null)
-            {
-                return CustomCallbackDataHandler(sender, input);
-            }
-
-            return null;
         }
 
         public SubtitleFormat Format => new SubRip();

--- a/src/libse/Forms/FixCommonErrors/FixShortLinesPixelWidth.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortLinesPixelWidth.cs
@@ -11,6 +11,13 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string UnbreakShortLine { get; set; } = "Unbreak short line (pixel width)";
             public static string RemoveLineBreaks { get; set; } = "Unbreak subtitles that can fit on one line (pixel width)";
         }
+        
+        private readonly Func<string, int> _calcPixelWidth;
+
+        public FixShortLinesPixelWidth(Func<string, int> calcPixelWidth)
+        {
+            _calcPixelWidth = calcPixelWidth;
+        }
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
@@ -37,8 +44,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                 var unbreakResult = Utilities.UnbreakLine(p.Text);
                 var cleanUnbreakResult = HtmlUtil.RemoveHtmlTags(unbreakResult, true);
-                var totalPixelWidth = Convert.ToInt32(callbacks.GetCustomCallbackData(this, cleanUnbreakResult));
-
+                var totalPixelWidth = Convert.ToInt32(_calcPixelWidth(cleanUnbreakResult));
                 if (totalPixelWidth <= Configuration.Settings.General.SubtitleLineMaximumPixelWidth)
                 {
                     var oldCurrent = p.Text;

--- a/src/libse/Forms/FixCommonErrors/FixShortLinesPixelWidth.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortLinesPixelWidth.cs
@@ -44,7 +44,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                 var unbreakResult = Utilities.UnbreakLine(p.Text);
                 var cleanUnbreakResult = HtmlUtil.RemoveHtmlTags(unbreakResult, true);
-                var totalPixelWidth = Convert.ToInt32(_calcPixelWidth(cleanUnbreakResult));
+                var totalPixelWidth = _calcPixelWidth(cleanUnbreakResult);
                 if (totalPixelWidth <= Configuration.Settings.General.SubtitleLineMaximumPixelWidth)
                 {
                     var oldCurrent = p.Text;

--- a/src/libse/Interfaces/IFixCallbacks.cs
+++ b/src/libse/Interfaces/IFixCallbacks.cs
@@ -17,7 +17,6 @@ namespace Nikse.SubtitleEdit.Core.Interfaces
         HashSet<string> GetAbbreviations();
         void AddToTotalErrors(int count);
         void AddToDeleteIndices(int index);
-        object GetCustomCallbackData(IFixCommonError sender, object input);
         SubtitleFormat Format { get; }
         Encoding Encoding { get; }
         string Language { get; }

--- a/src/ui/Forms/FixCommonErrors.cs
+++ b/src/ui/Forms/FixCommonErrors.cs
@@ -391,7 +391,7 @@ namespace Nikse.SubtitleEdit.Forms
                 new FixItem(_language.BreakLongLines, string.Empty, () => new FixLongLines().Fix(Subtitle, this), ce.BreakLongLinesTicked),
                 new FixItem(_language.RemoveLineBreaks, "Foo</br>bar! -> Foo bar!", () => new FixShortLines().Fix(Subtitle, this), ce.MergeShortLinesTicked),
                 new FixItem(_language.RemoveLineBreaksAll, string.Empty, () => new FixShortLinesAll().Fix(Subtitle, this), ce.MergeShortLinesAllTicked),
-                new FixItem(_language.RemoveLineBreaksPixelWidth, string.Empty, () => new FixShortLinesPixelWidth().Fix(Subtitle, this), ce.MergeShortLinesPixelWidthTicked),
+                new FixItem(_language.RemoveLineBreaksPixelWidth, string.Empty, () => new FixShortLinesPixelWidth(TextWidth.CalcPixelWidth).Fix(Subtitle, this), ce.MergeShortLinesPixelWidthTicked),
                 new FixItem(_language.FixDoubleApostrophes, "''Has double single quotes'' -> \"Has single double quote\"", () => new FixDoubleApostrophes().Fix(Subtitle, this), ce.DoubleApostropheToQuoteTicked),
                 new FixItem(_language.FixMusicNotation, _language.FixMusicNotationExample, () => new FixMusicNotation().Fix(Subtitle, this), ce.FixMusicNotationTicked),
                 new FixItem(_language.AddPeriods, "Hello world -> Hello world.", () => new FixMissingPeriodsAtEndOfLine().Fix(Subtitle, this), ce.AddPeriodAfterParagraphTicked),
@@ -681,18 +681,7 @@ namespace Nikse.SubtitleEdit.Forms
                 }
             }
         }
-
-        public object GetCustomCallbackData(IFixCommonError sender, object input)
-        {
-            if (sender is FixShortLinesPixelWidth)
-            {
-                var text = Convert.ToString(input);
-                return TextWidth.CalcPixelWidth(text);
-            }
-
-            return null;
-        }
-
+        
         public bool IsName(string candidate)
         {
             MakeSureNameListIsLoaded();


### PR DESCRIPTION
The pixel width calculation for FixShortLinesPixelWidth has been directly incorporated into the constructor for FixShortLinesPixelWidth, replacing the previously used GetCustomCallbackData method. This change simplifies the process significantly by making the pixel width calculation a direct responsibility of the FixShortLinesPixelWidth class, and removing the associated logic from FixCommonErrors class and its interface reducing potential side effects. In addition, the test FixCommonErrorsTest has been updated to reflect these changes.