### PR TITLE
Change direct font fetching with targeted methods in FontHelper

### DIFF
--- a/src/ui/Forms/Assa/AssaProgressBar.cs
+++ b/src/ui/Forms/Assa/AssaProgressBar.cs
@@ -80,7 +80,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             UiUtil.FixLargeFonts(this, buttonOK);
 
             comboBoxFontName.Items.Clear();
-            foreach (var font in FontFamily.Families)
+            foreach (var font in FontHelper.GetAllSupportedFontFamilies())
             {
                 comboBoxFontName.Items.Add(font.Name);
                 if (font.Name == "Arial")

--- a/src/ui/Forms/Assa/AssaStyles.cs
+++ b/src/ui/Forms/Assa/AssaStyles.cs
@@ -104,7 +104,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
 
             comboBoxFontName.Items.Clear();
-            foreach (var x in FontFamily.Families)
+            foreach (var x in FontHelper.GetAllSupportedFontFamilies())
             {
                 comboBoxFontName.Items.Add(x.Name);
             }

--- a/src/ui/Forms/BinaryEdit/BinEditNewText.cs
+++ b/src/ui/Forms/BinaryEdit/BinEditNewText.cs
@@ -70,7 +70,7 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
                 Configuration.Settings.Tools.ExportBluRayFontName = "Arial";
             }
 
-            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFonts())
+            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFontFamilies())
             {
                 comboBoxSubtitleFont.Items.Add(fontFamily.Name);
                 if (fontFamily.Name.Equals(Configuration.Settings.Tools.ExportBluRayFontName, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Forms/BinaryEdit/BinEditNewText.cs
+++ b/src/ui/Forms/BinaryEdit/BinEditNewText.cs
@@ -70,15 +70,12 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
                 Configuration.Settings.Tools.ExportBluRayFontName = "Arial";
             }
 
-            foreach (var x in FontFamily.Families)
+            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFonts())
             {
-                if (x.IsStyleAvailable(FontStyle.Regular) || x.IsStyleAvailable(FontStyle.Bold))
+                comboBoxSubtitleFont.Items.Add(fontFamily.Name);
+                if (fontFamily.Name.Equals(Configuration.Settings.Tools.ExportBluRayFontName, StringComparison.OrdinalIgnoreCase))
                 {
-                    comboBoxSubtitleFont.Items.Add(x.Name);
-                    if (x.Name.Equals(Configuration.Settings.Tools.ExportBluRayFontName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        comboBoxSubtitleFont.SelectedIndex = comboBoxSubtitleFont.Items.Count - 1;
-                    }
+                    comboBoxSubtitleFont.SelectedIndex = comboBoxSubtitleFont.Items.Count - 1;
                 }
             }
 

--- a/src/ui/Forms/BinaryEdit/BinEditNewText.cs
+++ b/src/ui/Forms/BinaryEdit/BinEditNewText.cs
@@ -70,7 +70,7 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
                 Configuration.Settings.Tools.ExportBluRayFontName = "Arial";
             }
 
-            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFontFamilies())
+            foreach (var fontFamily in FontHelper.GetRegularOrBoldCapableFontFamilies())
             {
                 comboBoxSubtitleFont.Items.Add(fontFamily.Name);
                 if (fontFamily.Name.Equals(Configuration.Settings.Tools.ExportBluRayFontName, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Forms/ChooseFontName.cs
+++ b/src/ui/Forms/ChooseFontName.cs
@@ -31,12 +31,12 @@ namespace Nikse.SubtitleEdit.Forms
             buttonOK.Enabled = false;
             _fontNames = new List<string>();
             listBox1.Items.Clear();
-            foreach (var x in FontFamily.Families)
+            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFonts())
             {
-                if (!string.IsNullOrEmpty(x.Name) && (x.IsStyleAvailable(FontStyle.Regular) || x.IsStyleAvailable(FontStyle.Bold)))
+                if (!string.IsNullOrEmpty(fontFamily.Name))
                 {
-                    listBox1.Items.Add(x.Name);
-                    _fontNames.Add(x.Name);
+                    listBox1.Items.Add(fontFamily.Name);
+                    _fontNames.Add(fontFamily.Name);
                 }
             }
             labelPreview1.Text = string.Empty;

--- a/src/ui/Forms/ChooseFontName.cs
+++ b/src/ui/Forms/ChooseFontName.cs
@@ -31,7 +31,7 @@ namespace Nikse.SubtitleEdit.Forms
             buttonOK.Enabled = false;
             _fontNames = new List<string>();
             listBox1.Items.Clear();
-            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFonts())
+            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFontFamilies())
             {
                 if (!string.IsNullOrEmpty(fontFamily.Name))
                 {

--- a/src/ui/Forms/ChooseFontName.cs
+++ b/src/ui/Forms/ChooseFontName.cs
@@ -31,7 +31,7 @@ namespace Nikse.SubtitleEdit.Forms
             buttonOK.Enabled = false;
             _fontNames = new List<string>();
             listBox1.Items.Clear();
-            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFontFamilies())
+            foreach (var fontFamily in FontHelper.GetRegularOrBoldCapableFontFamilies())
             {
                 if (!string.IsNullOrEmpty(fontFamily.Name))
                 {

--- a/src/ui/Forms/ExportFcpXmlAdvanced.cs
+++ b/src/ui/Forms/ExportFcpXmlAdvanced.cs
@@ -72,7 +72,7 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxHAlign.Items.Add(LanguageSettings.Current.ExportPngXml.Right);
             comboBoxHAlign.Items.Add(LanguageSettings.Current.ExportPngXml.CenterLeftJustify);
 
-            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFonts())
+            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFontFamilies())
             {
                 comboBoxFontName.Items.Add(fontFamily.Name);
                 if (fontFamily.Name.Equals(_fontName, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Forms/ExportFcpXmlAdvanced.cs
+++ b/src/ui/Forms/ExportFcpXmlAdvanced.cs
@@ -72,7 +72,7 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxHAlign.Items.Add(LanguageSettings.Current.ExportPngXml.Right);
             comboBoxHAlign.Items.Add(LanguageSettings.Current.ExportPngXml.CenterLeftJustify);
 
-            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFontFamilies())
+            foreach (var fontFamily in FontHelper.GetRegularOrBoldCapableFontFamilies())
             {
                 comboBoxFontName.Items.Add(fontFamily.Name);
                 if (fontFamily.Name.Equals(_fontName, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Forms/ExportFcpXmlAdvanced.cs
+++ b/src/ui/Forms/ExportFcpXmlAdvanced.cs
@@ -72,15 +72,12 @@ namespace Nikse.SubtitleEdit.Forms
             comboBoxHAlign.Items.Add(LanguageSettings.Current.ExportPngXml.Right);
             comboBoxHAlign.Items.Add(LanguageSettings.Current.ExportPngXml.CenterLeftJustify);
 
-            foreach (var x in FontFamily.Families)
+            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFonts())
             {
-                if (x.IsStyleAvailable(FontStyle.Regular) || x.IsStyleAvailable(FontStyle.Bold))
+                comboBoxFontName.Items.Add(fontFamily.Name);
+                if (fontFamily.Name.Equals(_fontName, StringComparison.OrdinalIgnoreCase))
                 {
-                    comboBoxFontName.Items.Add(x.Name);
-                    if (x.Name.Equals(_fontName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        comboBoxFontName.SelectedIndex = comboBoxFontName.Items.Count - 1;
-                    }
+                    comboBoxFontName.SelectedIndex = comboBoxFontName.Items.Count - 1;
                 }
             }
 

--- a/src/ui/Forms/ExportPngXml.cs
+++ b/src/ui/Forms/ExportPngXml.cs
@@ -4580,17 +4580,15 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 
             checkBoxSkipEmptyFrameAtStart.Visible = exportType == ExportFormats.ImageFrame;
 
-            foreach (var x in FontFamily.Families)
+            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFonts())
             {
-                if (x.IsStyleAvailable(FontStyle.Regular) || x.IsStyleAvailable(FontStyle.Bold))
+                comboBoxSubtitleFont.Items.Add(fontFamily.Name);
+                if (fontFamily.Name.Equals(_subtitleFontName, StringComparison.OrdinalIgnoreCase))
                 {
-                    comboBoxSubtitleFont.Items.Add(x.Name);
-                    if (x.Name.Equals(_subtitleFontName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        comboBoxSubtitleFont.SelectedIndex = comboBoxSubtitleFont.Items.Count - 1;
-                    }
+                    comboBoxSubtitleFont.SelectedIndex = comboBoxSubtitleFont.Items.Count - 1;
                 }
             }
+
             if (comboBoxSubtitleFont.SelectedIndex == -1)
             {
                 comboBoxSubtitleFont.SelectedIndex = 0; // take first font if default font was not found (e.g. linux)

--- a/src/ui/Forms/ExportPngXml.cs
+++ b/src/ui/Forms/ExportPngXml.cs
@@ -4580,7 +4580,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 
             checkBoxSkipEmptyFrameAtStart.Visible = exportType == ExportFormats.ImageFrame;
 
-            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFontFamilies())
+            foreach (var fontFamily in FontHelper.GetRegularOrBoldCapableFontFamilies())
             {
                 comboBoxSubtitleFont.Items.Add(fontFamily.Name);
                 if (fontFamily.Name.Equals(_subtitleFontName, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Forms/ExportPngXml.cs
+++ b/src/ui/Forms/ExportPngXml.cs
@@ -4580,7 +4580,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 
             checkBoxSkipEmptyFrameAtStart.Visible = exportType == ExportFormats.ImageFrame;
 
-            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFonts())
+            foreach (var fontFamily in FontHelper.GetItalicOrBoldCapableFontFamilies())
             {
                 comboBoxSubtitleFont.Items.Add(fontFamily.Name);
                 if (fontFamily.Name.Equals(_subtitleFontName, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Forms/GenerateVideoWithHardSubs.cs
+++ b/src/ui/Forms/GenerateVideoWithHardSubs.cs
@@ -182,7 +182,7 @@ namespace Nikse.SubtitleEdit.Forms
                 initialFont = UiUtil.GetDefaultFont().Name;
             }
 
-            foreach (var x in FontHelper.GetItalicOrBoldCapableFontFamilies())
+            foreach (var x in FontHelper.GetRegularOrBoldCapableFontFamilies())
             {
                 comboBoxSubtitleFont.Items.Add(x.Name);
                 if (x.Name.Equals(initialFont, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Forms/GenerateVideoWithHardSubs.cs
+++ b/src/ui/Forms/GenerateVideoWithHardSubs.cs
@@ -181,15 +181,13 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 initialFont = UiUtil.GetDefaultFont().Name;
             }
-            foreach (var x in FontFamily.Families)
+
+            foreach (var x in FontHelper.GetItalicOrBoldCapableFonts())
             {
-                if (x.IsStyleAvailable(FontStyle.Regular) || x.IsStyleAvailable(FontStyle.Bold))
+                comboBoxSubtitleFont.Items.Add(x.Name);
+                if (x.Name.Equals(initialFont, StringComparison.OrdinalIgnoreCase))
                 {
-                    comboBoxSubtitleFont.Items.Add(x.Name);
-                    if (x.Name.Equals(initialFont, StringComparison.OrdinalIgnoreCase))
-                    {
-                        comboBoxSubtitleFont.SelectedIndex = comboBoxSubtitleFont.Items.Count - 1;
-                    }
+                    comboBoxSubtitleFont.SelectedIndex = comboBoxSubtitleFont.Items.Count - 1;
                 }
             }
             if (comboBoxSubtitleFont.SelectedIndex < 0 && comboBoxSubtitleFont.Items.Count > 0)

--- a/src/ui/Forms/GenerateVideoWithHardSubs.cs
+++ b/src/ui/Forms/GenerateVideoWithHardSubs.cs
@@ -182,7 +182,7 @@ namespace Nikse.SubtitleEdit.Forms
                 initialFont = UiUtil.GetDefaultFont().Name;
             }
 
-            foreach (var x in FontHelper.GetItalicOrBoldCapableFonts())
+            foreach (var x in FontHelper.GetItalicOrBoldCapableFontFamilies())
             {
                 comboBoxSubtitleFont.Items.Add(x.Name);
                 if (x.Name.Equals(initialFont, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Forms/Ocr/BinaryOcrTrain.cs
+++ b/src/ui/Forms/Ocr/BinaryOcrTrain.cs
@@ -46,14 +46,11 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
             labelInfo.Text = string.Empty;
             var selectedFonts = Configuration.Settings.Tools.OcrTrainFonts.Split(';');
-            foreach (var x in FontFamily.Families)
+            foreach (var fontFamily in FontHelper.GetBoldAndItalicCapableFonts())
             {
-                if (x.IsStyleAvailable(FontStyle.Regular) && x.IsStyleAvailable(FontStyle.Bold))
-                {
-                    var chk = selectedFonts.Contains(x.Name);
-                    ListViewItem item = new ListViewItem(x.Name) { Font = new Font(x.Name, 14), Checked = chk };
-                    listViewFonts.Items.Add(item);
-                }
+                var chk = selectedFonts.Contains(fontFamily.Name);
+                ListViewItem item = new ListViewItem(fontFamily.Name) { Font = new Font(fontFamily.Name, 14), Checked = chk };
+                listViewFonts.Items.Add(item);
             }
             comboBoxSubtitleFontSize.SelectedIndex = 5;
             comboBoxFontSizeEnd.SelectedIndex = 15;

--- a/src/ui/Forms/Ocr/BinaryOcrTrain.cs
+++ b/src/ui/Forms/Ocr/BinaryOcrTrain.cs
@@ -46,7 +46,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
             labelInfo.Text = string.Empty;
             var selectedFonts = Configuration.Settings.Tools.OcrTrainFonts.Split(';');
-            foreach (var fontFamily in FontHelper.GetBoldAndItalicCapableFontFamilies())
+            foreach (var fontFamily in FontHelper.GetRegularAndBoldCapableFontFamilies())
             {
                 var chk = selectedFonts.Contains(fontFamily.Name);
                 ListViewItem item = new ListViewItem(fontFamily.Name) { Font = new Font(fontFamily.Name, 14), Checked = chk };

--- a/src/ui/Forms/Ocr/BinaryOcrTrain.cs
+++ b/src/ui/Forms/Ocr/BinaryOcrTrain.cs
@@ -46,7 +46,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
             labelInfo.Text = string.Empty;
             var selectedFonts = Configuration.Settings.Tools.OcrTrainFonts.Split(';');
-            foreach (var fontFamily in FontHelper.GetBoldAndItalicCapableFonts())
+            foreach (var fontFamily in FontHelper.GetBoldAndItalicCapableFontFamilies())
             {
                 var chk = selectedFonts.Contains(fontFamily.Name);
                 ListViewItem item = new ListViewItem(fontFamily.Name) { Font = new Font(fontFamily.Name, 14), Checked = chk };

--- a/src/ui/Forms/Ocr/VobSubNOcrTrain.cs
+++ b/src/ui/Forms/Ocr/VobSubNOcrTrain.cs
@@ -45,7 +45,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             labelInfo.Text = string.Empty;
             textBoxMerged.Text = Configuration.Settings.Tools.OcrTrainMergedLetters;
             var selectedFonts = Configuration.Settings.Tools.OcrTrainFonts.Split(';');
-            foreach (var fontFamily in FontHelper.GetBoldAndItalicCapableFontFamilies())
+            foreach (var fontFamily in FontHelper.GetRegularAndBoldCapableFontFamilies())
             {
                 var chk = selectedFonts.Contains(fontFamily.Name);
                 ListViewItem item = new ListViewItem(fontFamily.Name) { Font = new Font(fontFamily.Name, 14), Checked = chk };

--- a/src/ui/Forms/Ocr/VobSubNOcrTrain.cs
+++ b/src/ui/Forms/Ocr/VobSubNOcrTrain.cs
@@ -45,7 +45,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             labelInfo.Text = string.Empty;
             textBoxMerged.Text = Configuration.Settings.Tools.OcrTrainMergedLetters;
             var selectedFonts = Configuration.Settings.Tools.OcrTrainFonts.Split(';');
-            foreach (var fontFamily in FontHelper.GetBoldAndItalicCapableFonts())
+            foreach (var fontFamily in FontHelper.GetBoldAndItalicCapableFontFamilies())
             {
                 var chk = selectedFonts.Contains(fontFamily.Name);
                 ListViewItem item = new ListViewItem(fontFamily.Name) { Font = new Font(fontFamily.Name, 14), Checked = chk };

--- a/src/ui/Forms/Ocr/VobSubNOcrTrain.cs
+++ b/src/ui/Forms/Ocr/VobSubNOcrTrain.cs
@@ -45,14 +45,11 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             labelInfo.Text = string.Empty;
             textBoxMerged.Text = Configuration.Settings.Tools.OcrTrainMergedLetters;
             var selectedFonts = Configuration.Settings.Tools.OcrTrainFonts.Split(';');
-            foreach (var x in FontFamily.Families)
+            foreach (var fontFamily in FontHelper.GetBoldAndItalicCapableFonts())
             {
-                if (x.IsStyleAvailable(FontStyle.Regular) && x.IsStyleAvailable(FontStyle.Bold))
-                {
-                    var chk = selectedFonts.Contains(x.Name);
-                    ListViewItem item = new ListViewItem(x.Name) { Font = new Font(x.Name, 14), Checked = chk };
-                    listViewFonts.Items.Add(item);
-                }
+                var chk = selectedFonts.Contains(fontFamily.Name);
+                ListViewItem item = new ListViewItem(fontFamily.Name) { Font = new Font(fontFamily.Name, 14), Checked = chk };
+                listViewFonts.Items.Add(item);
             }
             comboBoxSubtitleFontSize.SelectedIndex = 50;
             textBoxInputFile.Text = Configuration.Settings.Tools.OcrTrainSrtFile;

--- a/src/ui/Forms/Options/Settings.cs
+++ b/src/ui/Forms/Options/Settings.cs
@@ -320,15 +320,15 @@ namespace Nikse.SubtitleEdit.Forms.Options
             var comboBoxSubtitleFontList = new List<string>();
             var comboBoxSubtitleFontIndex = 0;
             var comboBoxVideoPlayerPreviewFontIndex = 0;
-            foreach (var x in FontHelper.GetFontFamilies())
+            foreach (var fontFamily in FontHelper.GetAllSupportedFontFamilies())
             {
-                comboBoxSubtitleFontList.Add(x.Name);
-                if (x.Name.Equals(gs.SubtitleFontName, StringComparison.OrdinalIgnoreCase))
+                comboBoxSubtitleFontList.Add(fontFamily.Name);
+                if (fontFamily.Name.Equals(gs.SubtitleFontName, StringComparison.OrdinalIgnoreCase))
                 {
                     comboBoxSubtitleFontIndex = comboBoxSubtitleFontList.Count - 1;
                 }
 
-                if (x.Name.Equals(gs.VideoPlayerPreviewFontName, StringComparison.OrdinalIgnoreCase))
+                if (fontFamily.Name.Equals(gs.VideoPlayerPreviewFontName, StringComparison.OrdinalIgnoreCase))
                 {
                     comboBoxVideoPlayerPreviewFontIndex = comboBoxSubtitleFontList.Count - 1;
                 }

--- a/src/ui/Forms/Options/SettingsLineWidth.cs
+++ b/src/ui/Forms/Options/SettingsLineWidth.cs
@@ -27,10 +27,10 @@ namespace Nikse.SubtitleEdit.Forms.Options
             comboBoxMeasureFontName.Items.Clear();
             var comboBoxSubtitleFontList = new List<string>();
             var comboBoxSubtitleFontIndex = 0;
-            foreach (var x in FontHelper.GetFontFamilies())
+            foreach (var fontFamily in FontHelper.GetAllSupportedFontFamilies())
             {
-                comboBoxSubtitleFontList.Add(x.Name);
-                if (x.Name.Equals(settings.MeasureFontName, StringComparison.OrdinalIgnoreCase))
+                comboBoxSubtitleFontList.Add(fontFamily.Name);
+                if (fontFamily.Name.Equals(settings.MeasureFontName, StringComparison.OrdinalIgnoreCase))
                 {
                     comboBoxSubtitleFontIndex = comboBoxSubtitleFontList.Count - 1;
                 }

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.cs
@@ -93,7 +93,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             }
 
             comboBoxFontName.Items.Clear();
-            foreach (var x in FontFamily.Families)
+            foreach (var x in FontHelper.GetAllSupportedFontFamilies())
             {
                 comboBoxFontName.Items.Add(x.Name);
             }

--- a/src/ui/Forms/Styles/SubStationAlphaStylesBatchConvert.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStylesBatchConvert.cs
@@ -36,7 +36,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             }
 
             comboBoxFontName.Items.Clear();
-            foreach (var x in FontFamily.Families)
+            foreach (var x in FontHelper.GetAllSupportedFontFamilies())
             {
                 comboBoxFontName.Items.Add(x.Name);
             }

--- a/src/ui/Forms/Styles/TimedTextStyles.cs
+++ b/src/ui/Forms/Styles/TimedTextStyles.cs
@@ -62,7 +62,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             _nsmgr.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
             _xmlHead = _xml.DocumentElement.SelectSingleNode("ttml:head", _nsmgr);
 
-            foreach (var ff in FontFamily.Families)
+            foreach (var ff in FontHelper.GetAllSupportedFontFamilies())
             {
                 if (ff.Name.Length > 0)
                 {

--- a/src/ui/Forms/VTT/WebVttStyleManager.cs
+++ b/src/ui/Forms/VTT/WebVttStyleManager.cs
@@ -43,7 +43,7 @@ namespace Nikse.SubtitleEdit.Forms.VTT
             CheckDuplicateStyles();
 
             var fontNames = new List<string>();
-            foreach (var x in FontFamily.Families)
+            foreach (var x in FontHelper.GetAllSupportedFontFamilies())
             {
                 fontNames.Add(x.Name);
             }

--- a/src/ui/Logic/FontHelper.cs
+++ b/src/ui/Logic/FontHelper.cs
@@ -4,29 +4,51 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Logic
 {
+    /// <summary>
+    /// Provides a set of methods to help with operations on Fonts.
+    /// </summary>
     public static class FontHelper
     {
-        private static List<FontFamily> _fonts;
+        private static readonly FontFamily[] _fonts;
 
-        public static bool AreFontsLoaded => _fonts != null;
-
-        public static List<FontFamily> GetFontFamilies()
+        /// <summary>
+        /// Initializes static members of the <see cref="FontHelper"/> class.
+        /// </summary>
+        static FontHelper()
         {
-            if (_fonts != null)
-            {
-                return _fonts;
-            }
+            _fonts = FontFamily.Families.OrderBy(font => font.Name).ToArray();
+        }
 
-            var fonts = new List<FontFamily>();
-            foreach (var fontFamily in FontFamily.Families.OrderBy(p => p.Name))
-            {
-                if (fontFamily.IsStyleAvailable(FontStyle.Regular) && fontFamily.IsStyleAvailable(FontStyle.Bold))
-                {
-                    fonts.Add(fontFamily);  
-                }
-            }
+        /// <summary>
+        /// Gets fonts which support both Bold and Italic styles.
+        /// </summary>
+        /// <returns>
+        /// Collection of <see cref="FontFamily"/> which support both Bold and Italic styles.
+        /// </returns>
+        public static IEnumerable<FontFamily> GetBoldAndItalicCapableFonts()
+        {
+            return _fonts.Where(font => font.IsStyleAvailable(FontStyle.Bold) && font.IsStyleAvailable(FontStyle.Italic));
+        }
 
-            _fonts = fonts;
+        /// <summary>
+        /// Gets fonts which support either Bold or Italic style.
+        /// </summary>
+        /// <returns>
+        /// Collection of <see cref="FontFamily"/> which support either Bold or Italic style.
+        /// </returns>
+        public static IEnumerable<FontFamily> GetItalicOrBoldCapableFonts()
+        {
+            return _fonts.Where(font => font.IsStyleAvailable(FontStyle.Bold) || font.IsStyleAvailable(FontStyle.Italic));
+        }
+
+        /// <summary>
+        /// Gets all supported font families.
+        /// </summary>
+        /// <returns>
+        /// An enumerable collection of <see cref="FontFamily"/> objects.
+        /// </returns>
+        public static IEnumerable<FontFamily> GetAllSupportedFontFamilies()
+        {
             return _fonts;
         }
     }

--- a/src/ui/Logic/FontHelper.cs
+++ b/src/ui/Logic/FontHelper.cs
@@ -20,7 +20,7 @@ namespace Nikse.SubtitleEdit.Logic
         }
 
         /// <summary>
-        /// Gets fonts which support both Bold and Italic styles.
+        /// Gets fonts which support both Bold and Regular styles.
         /// </summary>
         /// <returns>
         /// Collection of <see cref="FontFamily"/> which support both Bold and Italic styles.
@@ -31,7 +31,7 @@ namespace Nikse.SubtitleEdit.Logic
         }
 
         /// <summary>
-        /// Gets fonts which support either Bold or Italic style.
+        /// Gets fonts which support either Bold or Regular style.
         /// </summary>
         /// <returns>
         /// Collection of <see cref="FontFamily"/> which support either Bold or Italic style.

--- a/src/ui/Logic/FontHelper.cs
+++ b/src/ui/Logic/FontHelper.cs
@@ -25,7 +25,7 @@ namespace Nikse.SubtitleEdit.Logic
         /// <returns>
         /// Collection of <see cref="FontFamily"/> which support both Bold and Italic styles.
         /// </returns>
-        public static IEnumerable<FontFamily> GetBoldAndItalicCapableFonts()
+        public static IEnumerable<FontFamily> GetBoldAndItalicCapableFontFamilies()
         {
             return _fonts.Where(font => font.IsStyleAvailable(FontStyle.Bold) && font.IsStyleAvailable(FontStyle.Italic));
         }
@@ -36,7 +36,7 @@ namespace Nikse.SubtitleEdit.Logic
         /// <returns>
         /// Collection of <see cref="FontFamily"/> which support either Bold or Italic style.
         /// </returns>
-        public static IEnumerable<FontFamily> GetItalicOrBoldCapableFonts()
+        public static IEnumerable<FontFamily> GetItalicOrBoldCapableFontFamilies()
         {
             return _fonts.Where(font => font.IsStyleAvailable(FontStyle.Bold) || font.IsStyleAvailable(FontStyle.Italic));
         }

--- a/src/ui/Logic/FontHelper.cs
+++ b/src/ui/Logic/FontHelper.cs
@@ -25,7 +25,7 @@ namespace Nikse.SubtitleEdit.Logic
         /// <returns>
         /// Collection of <see cref="FontFamily"/> which support both Bold and Italic styles.
         /// </returns>
-        public static IEnumerable<FontFamily> GetBoldAndItalicCapableFontFamilies()
+        public static IEnumerable<FontFamily> GetRegularAndBoldCapableFontFamilies()
         {
             return _fonts.Where(font => font.IsStyleAvailable(FontStyle.Bold) && font.IsStyleAvailable(FontStyle.Italic));
         }
@@ -36,7 +36,7 @@ namespace Nikse.SubtitleEdit.Logic
         /// <returns>
         /// Collection of <see cref="FontFamily"/> which support either Bold or Italic style.
         /// </returns>
-        public static IEnumerable<FontFamily> GetItalicOrBoldCapableFontFamilies()
+        public static IEnumerable<FontFamily> GetRegularOrBoldCapableFontFamilies()
         {
             return _fonts.Where(font => font.IsStyleAvailable(FontStyle.Bold) || font.IsStyleAvailable(FontStyle.Italic));
         }


### PR DESCRIPTION
This commit updates font fetching in many forms and logical parts of the app. Earlier, fonts were directly fetched using `FontFamily.Families`. However, this has been replaced with specific calls to methods of the `FontHelper` class. These methods like `GetAllSupportedFontFamilies()`, `GetItalicOrBoldCapableFonts()`, and `GetBoldAndItalicCapableFonts()` provide an easier and more clear selection of fonts based on specific needs. This makes the code more readable and manageable.


All public methods inside `FontHelper` will retrieve font families from the cache