### PR TITLE
Improve UI responsiveness by adding async OnGotFocus

### DIFF
--- a/src/ui/Controls/NikseComboBox.cs
+++ b/src/ui/Controls/NikseComboBox.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Drawing.Drawing2D;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Nikse.SubtitleEdit.Controls
@@ -236,20 +237,28 @@ namespace Nikse.SubtitleEdit.Controls
             }
         }
 
-        protected override void OnGotFocus(EventArgs e)
+        private TaskScheduler _uiTaskScheduler;
+        protected override async void OnGotFocus(EventArgs e)
         {
             base.OnGotFocus(e);
             if (_textBox != null && DropDownStyle == ComboBoxStyle.DropDown)
             {
-                try
+                // init if not already initialized otherwise reuse the cached one
+                _uiTaskScheduler = _uiTaskScheduler ??
+                                   // capture the ui/main thread context
+                                   TaskScheduler.FromCurrentSynchronizationContext();
+
+                Task.Delay(25).ContinueWith(task =>
                 {
-                    Application.DoEvents();
-                    System.Threading.SynchronizationContext.Current.Post(TimeSpan.FromMilliseconds(25), () => _textBox.Focus());
-                }
-                catch
-                {
-                    // ignore
-                }
+                    try
+                    {
+                        _textBox.Focus();
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }, _uiTaskScheduler);
             }
         }
 


### PR DESCRIPTION
This commit replaces the previous synchronous focus handling in the NikseComboBox controller with an asynchronous one. It aims at enhancing the UI responsiveness by implementing an asynchronous handling of the OnGotFocus event and preventing the possible UI freeze due to the blocking call Application.DoEvents(). A Task.Delay is used to create a minor delay before focusing, without blocking the UI thread. A TaskScheduler is used to safely update UI from the async task.


See https://github.com/SubtitleEdit/subtitleedit/commit/da1bb89f753cb78262cf3538e312d4deca170f54#diff-f1a2a06af29f85e247ea02a221e6f732ab20d7fce985981b9ec70e1c70d09c55R231-R236 for more context