### PR TITLE
Remove redundant methods in UiUtil.cs

### DIFF
--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -621,15 +621,6 @@ namespace Nikse.SubtitleEdit.Logic
             }
         }
 
-        internal static void FixFonts(ToolStripComboBox item)
-        {
-            item.Font = GetDefaultFont();
-            if (Configuration.Settings.General.UseDarkTheme)
-            {
-                DarkTheme.SetDarkTheme(item);
-            }
-        }
-
         private static void FixFontsInner(Control form, int iterations = 5)
         {
             if (iterations < 1 || form is SETextBox)
@@ -768,12 +759,6 @@ namespace Nikse.SubtitleEdit.Logic
             label.Text = sb.ToString();
         }
 
-        public static void InitializeSubtitleFormatComboBox(ToolStripComboBox comboBox, SubtitleFormat format)
-        {
-            InitializeSubtitleFormatComboBox(comboBox.ComboBox, format);
-            comboBox.DropDownWidth += 5; // .Net quirk?
-        }
-
         public static void InitializeSubtitleFormatComboBox(ToolStripNikseComboBox comboBox, SubtitleFormat format)
         {
             InitializeSubtitleFormatComboBox(comboBox.ComboBox, format);
@@ -785,67 +770,16 @@ namespace Nikse.SubtitleEdit.Logic
             InitializeSubtitleFormatComboBox(comboBox, new List<string> { format.FriendlyName }, format.FriendlyName);
         }
 
-        public static void InitializeSubtitleFormatComboBox(ComboBox comboBox, SubtitleFormat format)
-        {
-            InitializeSubtitleFormatComboBox(comboBox, new List<string> { format.FriendlyName }, format.FriendlyName);
-        }
-
-        public static void InitializeSubtitleFormatComboBox(ToolStripComboBox comboBox, string selectedName)
-        {
-            InitializeSubtitleFormatComboBox(comboBox.ComboBox, selectedName);
-            comboBox.DropDownWidth += 5; // .Net quirk?
-        }
-
         public static void InitializeSubtitleFormatComboBox(ToolStripNikseComboBox comboBox, string selectedName)
         {
             InitializeSubtitleFormatComboBox(comboBox.ComboBox, selectedName);
             //comboBox.DropDownWidth += 5; // .Net quirk?
         }
 
-        public static void InitializeSubtitleFormatComboBox(ComboBox comboBox, string selectedName)
-        {
-            var formatNames = SubtitleFormat.AllSubtitleFormats.Where(format => !format.IsVobSubIndexFile).Select(format => format.FriendlyName);
-            InitializeSubtitleFormatComboBox(comboBox, formatNames.ToList(), selectedName);
-        }
-
         public static void InitializeSubtitleFormatComboBox(NikseComboBox comboBox, string selectedName)
         {
             var formatNames = SubtitleFormat.AllSubtitleFormats.Where(format => !format.IsVobSubIndexFile).Select(format => format.FriendlyName);
             InitializeSubtitleFormatComboBox(comboBox, formatNames.ToList(), selectedName);
-        }
-
-        public static void InitializeSubtitleFormatComboBox(ComboBox comboBox, List<string> formatNames, string selectedName)
-        {
-            var selectedIndex = 0;
-            using (var graphics = comboBox.CreateGraphics())
-            {
-                var maxWidth = (float)comboBox.DropDownWidth;
-                var max = formatNames.Count;
-                for (var index = 0; index < max; index++)
-                {
-                    var name = formatNames[index];
-                    if (name.Equals(selectedName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        selectedIndex = index;
-                    }
-                    if (name.Length > 30)
-                    {
-                        var width = graphics.MeasureString(name, comboBox.Font).Width;
-                        if (width > maxWidth)
-                        {
-                            maxWidth = width;
-                        }
-                    }
-                }
-
-                comboBox.DropDownWidth = (int)Math.Round(maxWidth + 7.5);
-            }
-
-            comboBox.BeginUpdate();
-            comboBox.Items.Clear();
-            comboBox.Items.AddRange(formatNames.ToArray<object>());
-            comboBox.SelectedIndex = selectedIndex;
-            comboBox.EndUpdate();
         }
 
         public static void InitializeSubtitleFormatComboBox(NikseComboBox comboBox, List<string> formatNames, string selectedName)
@@ -880,76 +814,6 @@ namespace Nikse.SubtitleEdit.Logic
             comboBox.Items.AddRange(formatNames.ToArray<object>());
             comboBox.SelectedIndex = selectedIndex;
             comboBox.EndUpdate();
-        }
-
-        public static void InitializeTextEncodingComboBox(ComboBox comboBox)
-        {
-            var defaultEncoding = Configuration.Settings.General.DefaultEncoding;
-            var selectedItem = (TextEncoding)null;
-            comboBox.BeginUpdate();
-            comboBox.Items.Clear();
-            var encList = new List<TextEncoding>();
-            using (var graphics = comboBox.CreateGraphics())
-            {
-                var maxWidth = 0.0F;
-                foreach (var encoding in Configuration.AvailableEncodings)
-                {
-                    if (encoding.CodePage >= 874 && !encoding.IsEbcdic())
-                    {
-                        var item = new TextEncoding(encoding, null);
-                        if (selectedItem == null && item.Equals(defaultEncoding))
-                        {
-                            selectedItem = item;
-                        }
-                        var width = graphics.MeasureString(item.DisplayName, comboBox.Font).Width;
-                        if (width > maxWidth)
-                        {
-                            maxWidth = width;
-                        }
-                        if (encoding.CodePage.Equals(Encoding.UTF8.CodePage))
-                        {
-                            item = new TextEncoding(Encoding.UTF8, TextEncoding.Utf8WithBom);
-                            encList.Insert(TextEncoding.Utf8WithBomIndex, item);
-                            if (item.Equals(defaultEncoding))
-                            {
-                                selectedItem = item;
-                            }
-
-                            item = new TextEncoding(Encoding.UTF8, TextEncoding.Utf8WithoutBom);
-                            encList.Insert(TextEncoding.Utf8WithoutBomIndex, item);
-                            if (item.Equals(defaultEncoding))
-                            {
-                                selectedItem = item;
-                            }
-                        }
-                        else
-                        {
-                            encList.Add(item);
-                        }
-                    }
-                }
-                comboBox.DropDownWidth = (int)Math.Round(maxWidth + 7.5);
-            }
-            comboBox.Items.AddRange(encList.ToArray<object>());
-            if (selectedItem == null)
-            {
-                comboBox.SelectedIndex = TextEncoding.Utf8WithBomIndex; // UTF-8 if DefaultEncoding is not found
-            }
-            else if (selectedItem.DisplayName == TextEncoding.Utf8WithoutBom)
-            {
-                comboBox.SelectedIndex = TextEncoding.Utf8WithoutBomIndex;
-            }
-            else
-            {
-                comboBox.SelectedItem = selectedItem;
-            }
-            comboBox.EndUpdate();
-            if (comboBox.SelectedItem is TextEncoding textEncodingListItem)
-            {
-                Configuration.Settings.General.DefaultEncoding = textEncodingListItem.DisplayName;
-            }
-            comboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
-            comboBox.AutoCompleteMode = AutoCompleteMode.Append;
         }
 
         public static void InitializeTextEncodingComboBox(NikseComboBox comboBox)
@@ -1020,15 +884,6 @@ namespace Nikse.SubtitleEdit.Logic
             }
         }
 
-        public static TextEncoding GetTextEncodingComboBoxCurrentEncoding(ComboBox comboBox)
-        {
-            if (comboBox.SelectedIndex > 0 && comboBox.SelectedItem is TextEncoding textEncodingListItem)
-            {
-                return textEncodingListItem;
-            }
-            return new TextEncoding(Encoding.UTF8, TextEncoding.Utf8WithBom);
-        }
-
         public static TextEncoding GetTextEncodingComboBoxCurrentEncoding(NikseComboBox comboBox)
         {
             if (comboBox.SelectedIndex > 0 && comboBox.SelectedItem is TextEncoding textEncodingListItem)
@@ -1037,32 +892,6 @@ namespace Nikse.SubtitleEdit.Logic
             }
 
             return new TextEncoding(Encoding.UTF8, TextEncoding.Utf8WithBom);
-        }
-
-        public static void SetTextEncoding(ToolStripComboBox comboBoxEncoding, string encodingName)
-        {
-            if (encodingName == TextEncoding.Utf8WithBom)
-            {
-                comboBoxEncoding.SelectedIndex = TextEncoding.Utf8WithBomIndex;
-                return;
-            }
-
-            if (encodingName == TextEncoding.Utf8WithoutBom)
-            {
-                comboBoxEncoding.SelectedIndex = TextEncoding.Utf8WithoutBomIndex;
-                return;
-            }
-
-            foreach (TextEncoding item in comboBoxEncoding.Items)
-            {
-                if (item.Equals(encodingName))
-                {
-                    comboBoxEncoding.SelectedItem = item;
-                    return;
-                }
-            }
-
-            comboBoxEncoding.SelectedIndex = TextEncoding.Utf8WithBomIndex; // UTF-8 with BOM
         }
 
         public static void SetTextEncoding(NikseComboBox comboBoxEncoding, string encodingName)
@@ -1090,7 +919,6 @@ namespace Nikse.SubtitleEdit.Logic
 
             comboBoxEncoding.SelectedIndex = TextEncoding.Utf8WithBomIndex; // UTF-8 with BOM
         }
-
 
         public static void BeginRichTextBoxUpdate(this RichTextBox richTextBox)
         {


### PR DESCRIPTION
This commit streamlines the UiUtil.cs class by removing methods that were overloading the code or duplicating functionality. By detangling the operations and removing surplus methods, the codebase becomes easier to manage and develop further. Such methods include InitializeSubtitleFormatComboBox and InitializeTextEncodingComboBox. The pitfall of potential errors reduces significantly, thereby improving reliability of the code. This change also makes it easier for the developers to find, understand, and modify parts of the code in future tasks.