### PR TITLE
Refactor OcrFixEngine to utilize FixExtraSpaces method

### DIFF
--- a/src/ui/Logic/Ocr/OcrFixEngine.cs
+++ b/src/ui/Logic/Ocr/OcrFixEngine.cs
@@ -436,25 +436,16 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
         public string FixOcrErrors(string input, int index, string lastLine, string lastLastLine, bool logSuggestions, AutoGuessLevel autoGuess)
         {
             var text = input;
-            while (text.Contains(Environment.NewLine + " ", StringComparison.Ordinal))
-            {
-                text = text.Replace(Environment.NewLine + " ", Environment.NewLine);
-            }
-
-            while (text.Contains(" " + Environment.NewLine, StringComparison.Ordinal))
-            {
-                text = text.Replace(" " + Environment.NewLine, Environment.NewLine);
-            }
-
-            text = text.RemoveRecursiveLineBreaks().Trim();
+            
+            text = text.FixExtraSpaces()
+                .RemoveRecursiveLineBreaks()
+                .Trim();
             
             var textNoAssa = Utilities.RemoveSsaTags(text, true);
             if (textNoAssa.Length == 0)
             {
                 return text;
             }
-
-
 
             // Try to prevent resizing when fixing Ocr-hardcoded.
             var sb = new StringBuilder(text.Length + 2);


### PR DESCRIPTION
A section of code in OcrFixEngine has been refactored to improve readability and reduce repetition. Previously, two distinct while loops were used to remove additional spaces. This has been replaced by a call to the existing FixExtraSpaces method, which accomplishes the same goal in a simpler and more maintainable way.