### PR TITLE
Feature/subtitle

### DIFF
--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -510,24 +510,16 @@ namespace Nikse.SubtitleEdit.Core.Common
             p.EndTime.TotalMilliseconds = newEndTimeInMs;
         }
 
-        public void RecalculateDisplayTimes(double maxCharPerSec, List<int> selectedIndexes, double optimalCharPerSec, bool extendOnly = false, List<double> shotChanges = null, bool enforceDurationLimits = true)
+        public void RecalculateDisplayTimes(double maxCharPerSec, IEnumerable<int> selectedIndexes, double optimalCharPerSec, bool extendOnly = false, List<double> shotChanges = null, bool enforceDurationLimits = true)
         {
-            if (selectedIndexes != null)
+            foreach (var index in TryGetIndexOrAll(selectedIndexes))
             {
-                foreach (var index in selectedIndexes)
-                {
-                    RecalculateDisplayTime(maxCharPerSec, index, optimalCharPerSec, extendOnly, false, shotChanges, enforceDurationLimits);
-                }
-            }
-            else
-            {
-                for (int i = 0; i < Paragraphs.Count; i++)
-                {
-                    RecalculateDisplayTime(maxCharPerSec, i, optimalCharPerSec, extendOnly, false, shotChanges, enforceDurationLimits);
-                }
+                RecalculateDisplayTime(maxCharPerSec, index, optimalCharPerSec, extendOnly, false, shotChanges, enforceDurationLimits);
             }
         }
 
+        private IEnumerable<int> TryGetIndexOrAll(IEnumerable<int> indices) => indices ?? Enumerable.Range(0, Paragraphs.Count);
+        
         public void RecalculateDisplayTime(double maxCharactersPerSecond, int index, double optimalCharactersPerSeconds, bool extendOnly = false, bool onlyOptimal = false, List<double> shotChanges = null, bool enforceDurationLimits = true)
         {
             var p = GetParagraphOrDefault(index);

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -444,19 +444,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             var adjustMs = seconds * TimeCode.BaseUnit;
-            if (selectedIndexes != null)
+            foreach (var index in TryGetIndexOrAll(selectedIndexes))
             {
-                foreach (var idx in selectedIndexes)
-                {
-                    AdjustDisplayTimeUsingMilliseconds(idx, adjustMs, shotChanges, enforceDurationLimits);
-                }
-            }
-            else
-            {
-                for (int idx = 0; idx < Paragraphs.Count; idx++)
-                {
-                    AdjustDisplayTimeUsingMilliseconds(idx, adjustMs, shotChanges, enforceDurationLimits);
-                }
+                AdjustDisplayTimeUsingMilliseconds(index, adjustMs, shotChanges, enforceDurationLimits);
             }
         }
 


### PR DESCRIPTION
Removes code duplications for when we want to perform an action
in a set of index if provided or entire paragraph if the provided indices is null

A new helper method is now introduced `TryGetIndexOrAll(selectedIndexes))` which will try
to enumerate by using the provided list if not null otherwise it will use Enumerable.Range(0, Paragraph.Count)
