### PR TITLE
Refactor ANSI character detection & cleanup in PAC subtitle code

### DIFF
--- a/src/libse/Common/CharUtils.cs
+++ b/src/libse/Common/CharUtils.cs
@@ -3,6 +3,15 @@
     public static class CharUtils
     {
         /// <summary>
+        /// Determines whether the given character is within the ANSI range.
+        /// </summary>
+        /// <param name="ch">The character to check.</param>
+        /// <returns>
+        /// <c>true</c> if the given character is within the ANSI range (0-127); otherwise, <c>false</c>.
+        /// </returns> 
+        public static bool IsAnsi(char ch) => ch >= 0 && ch <= 127;
+        
+        /// <summary>
         /// Checks if character matches [0-9]
         /// </summary>
         /// <param name="ch"></param>

--- a/src/libse/SubtitleFormats/Pac.cs
+++ b/src/libse/SubtitleFormats/Pac.cs
@@ -2125,7 +2125,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     result.Add(3);
                 }
 
-                if (OnlyAnsi(line))
+                if (line.All(CharUtils.IsAnsi))
                 {
                     foreach (var b in GetLatinBytes(GetEncoding(CodePageLatin), line, alignment, null))
                     {
@@ -2150,21 +2150,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             return result.ToArray();
         }
-
-        private static bool OnlyAnsi(string line)
-        {
-            var latin = Utilities.AllLettersAndNumbers + " .!?/%:;=()#$'&\"";
-            foreach (var ch in line)
-            {
-                if (!latin.Contains(ch))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
+        
         private static byte[] GetUnicodeBytes(string text, byte alignment)
         {
             var result = new List<byte>();


### PR DESCRIPTION
Optimized the method for detecting ANSI characters in 'Pac.cs' by replacing the 'OnlyAnsi' method with 'IsAnsi' from 'CharUtils.cs'. Also removed redundant lines of code. Changes make the script more efficient and streamlined, improving ASCII compatibility in parsing PAC subtitles.