### PR TITLE
Correct 'AlternateExtensions' capitalization in AribB36

### DIFF
--- a/src/libse/SubtitleFormats/AribB36.cs
+++ b/src/libse/SubtitleFormats/AribB36.cs
@@ -473,6 +473,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         }
 
         // 1HD = first HD subtitle, 2SD = second SD subtitle
-        public override List<string> AlternateExtensions => new List<string> { ".2HD", ".1SD", ".2SD" };
+        public override List<string> AlternateExtensions { get; } = new List<string> { ".2hd", ".1sd", ".2sd" };
     }
 }


### PR DESCRIPTION
Fixes always false

```c#
public override bool IsMine(List<string> lines, string fileName)
{
    if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
    {
        var fi = new FileInfo(fileName);
        if (fi.Length >= 3000 && fi.Length < 1024000) // not too small or too big
        {
            string fileExt = Path.GetExtension(fileName).ToUpperInvariant();
            if (fileExt != Extension && !AlternateExtensions.Contains(fileExt))
            {
                return false;
            }

            return base.IsMine(lines, fileName);
        }
    }
    return false;
}
```

We are checking `!AlternateExtensions.Contains(fileExt)` using lower-case variant of extension but the `AlternateExtensions` contains only uppercase extensions!