### PR TITLE
Refactor ListView select operations to make use of newly added Extensions

### DIFF
--- a/src/ui/Forms/ApplyDurationLimits.cs
+++ b/src/ui/Forms/ApplyDurationLimits.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -338,21 +339,9 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) =>  listViewFixes.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewFixes.InvertCheck();
 
         private void checkBoxCheckShotChanges_CheckedChanged(object sender, EventArgs e)
         {

--- a/src/ui/Forms/Assa/AssaStyles.cs
+++ b/src/ui/Forms/Assa/AssaStyles.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.Assa
@@ -2351,7 +2352,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewStyles.SelectAll();
+                listViewStyles.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -2361,7 +2362,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift))
             {
-                listViewStyles.InverseSelection();
+                listViewStyles.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }
@@ -2378,7 +2379,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewStorage.SelectAll();
+                listViewStorage.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -2388,7 +2389,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift))
             {
-                listViewStorage.InverseSelection();
+                listViewStorage.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }

--- a/src/ui/Forms/Assa/Attachments.cs
+++ b/src/ui/Forms/Assa/Attachments.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.Assa
@@ -665,7 +666,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewAttachments.SelectAll();
+                listViewAttachments.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -675,7 +676,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
             {
-                listViewAttachments.InverseSelection();
+                listViewAttachments.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }

--- a/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesImportExport.cs
+++ b/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesImportExport.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Forms.Assa
@@ -29,9 +30,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
                 listViewCategories.Items.Add(new ListViewItem(category.Name) { Checked = true });
             }
 
-            Text = export ?
-                LanguageSettings.Current.SubStationAlphaStyles.Export :
-                LanguageSettings.Current.SubStationAlphaStyles.Import;
+            Text = export ? LanguageSettings.Current.SubStationAlphaStyles.Export : LanguageSettings.Current.SubStationAlphaStyles.Import;
             labelCategories.Text = string.Format(LanguageSettings.Current.SubStationAlphaStylesCategoriesManager.ChooseCategories, Text.ToLowerInvariant());
             toolStripMenuItemSelectAll.Text = LanguageSettings.Current.FixCommonErrors.SelectAll;
             toolStripMenuItemInverseSelection.Text = LanguageSettings.Current.FixCommonErrors.InverseSelection;
@@ -111,8 +110,10 @@ namespace Nikse.SubtitleEdit.Forms.Assa
                     textWriter.WriteElementString(SubStationAlphaStylesCategoriesManager.BorderStyle, style.BorderStyle);
                     textWriter.WriteEndElement();
                 }
+
                 textWriter.WriteEndElement();
             }
+
             textWriter.WriteEndElement();
             textWriter.WriteEndElement();
             textWriter.WriteEndDocument();
@@ -139,20 +140,8 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
         }
 
-        private void ToolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewCategories.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void ToolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewCategories.CheckAll();
 
-        private void ToolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewCategories.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void ToolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewCategories.UncheckAll();
     }
 }

--- a/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesManager.cs
+++ b/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using Nikse.SubtitleEdit.Logic;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
@@ -699,7 +700,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
         {
             if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewCategories.SelectAll();
+                listViewCategories.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -709,7 +710,7 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift))
             {
-                listViewCategories.InverseSelection();
+                listViewCategories.InvertCheck();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyData == UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainToggleFocus))

--- a/src/ui/Forms/AutoBreakUnbreakLines.cs
+++ b/src/ui/Forms/AutoBreakUnbreakLines.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -237,20 +238,8 @@ namespace Nikse.SubtitleEdit.Forms
             listViewFixes.Columns[3].Width = listViewFixes.Columns[2].Width = newWidth;
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewFixes.InvertCheck();
     }
 }

--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms
@@ -3236,7 +3237,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewInputFiles.SelectAll();
+                listViewInputFiles.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -3246,7 +3247,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
             {
-                listViewInputFiles.InverseSelection();
+                listViewInputFiles.InvertCheck();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyData == UiUtil.HelpKeys)
@@ -3767,21 +3768,9 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewConvertOptions.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)=> listViewConvertOptions.CheckAll();
 
-        private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewConvertOptions.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e) => listViewConvertOptions.InvertCheck();
 
         private void listViewInputFiles_ColumnClick(object sender, ColumnClickEventArgs e)
         {

--- a/src/ui/Forms/BinaryEdit/BinEdit.cs
+++ b/src/ui/Forms/BinaryEdit/BinEdit.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.ProgressBar;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
@@ -1413,7 +1414,7 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
             else if (e.Modifiers == Keys.Control && e.KeyCode == Keys.A)
             {
                 subtitleListView1.SelectedIndexChanged -= subtitleListView1_SelectedIndexChanged;
-                subtitleListView1.SelectAll();
+                subtitleListView1.CheckAll();
                 subtitleListView1.SelectedIndexChanged += subtitleListView1_SelectedIndexChanged;
                 e.SuppressKeyPress = true;
             }
@@ -1427,7 +1428,7 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
             {
                 subtitleListView1.SelectedIndexChanged -= subtitleListView1_SelectedIndexChanged;
-                subtitleListView1.InverseSelection();
+                subtitleListView1.InvertCheck();
                 subtitleListView1.SelectedIndexChanged += subtitleListView1_SelectedIndexChanged;
                 e.SuppressKeyPress = true;
             }

--- a/src/ui/Forms/ChangeCasingNames.cs
+++ b/src/ui/Forms/ChangeCasingNames.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -296,32 +297,21 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void buttonSelectAll_Click(object sender, EventArgs e)
-        {
-            DoSelection(true);
-        }
+        private void buttonSelectAll_Click(object sender, EventArgs e) => DoSelection(true);
 
-        private void buttonInverseSelection_Click(object sender, EventArgs e)
-        {
-            DoSelection(false);
-        }
+        private void buttonInverseSelection_Click(object sender, EventArgs e) => DoSelection(false);
 
         private void DoSelection(bool selectAll)
         {
             listViewNames.ItemChecked -= ListViewNamesItemChecked;
-            listViewNames.BeginUpdate();
-            foreach (ListViewItem item in listViewNames.Items)
+            if (selectAll)
             {
-                if (selectAll)
-                {
-                    item.Checked = true;
-                }
-                else
-                {
-                    item.Checked = !item.Checked;
-                }
+                listViewNames.CheckAll();
             }
-            listViewNames.EndUpdate();
+            else
+            {
+                listViewNames.InvertCheck();
+            }
             listViewNames.ItemChecked += ListViewNamesItemChecked;
             GeneratePreview();
         }
@@ -333,21 +323,9 @@ namespace Nikse.SubtitleEdit.Forms
             FindAllNames();
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewFixes.InvertCheck();
 
         private void toolStripMenuItem1SelectAll_Click(object sender, EventArgs e)
         {

--- a/src/ui/Forms/ExportPngXml.cs
+++ b/src/ui/Forms/ExportPngXml.cs
@@ -22,6 +22,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
 using System.Xml;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms
@@ -5656,7 +5657,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
             }
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                subtitleListView1.SelectAll();
+                subtitleListView1.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -5666,7 +5667,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift))
             {
-                subtitleListView1.InverseSelection();
+                subtitleListView1.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }

--- a/src/ui/Forms/Extensions/ListViewExtensions.cs
+++ b/src/ui/Forms/Extensions/ListViewExtensions.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Windows.Forms;
+
+namespace Nikse.SubtitleEdit.Forms.Extensions
+{
+    public static class ListViewExtensions
+    {
+        public static void CheckAll(this ListView listView) => CheckAll(listView, false);
+
+        public static void CheckAll(this ListView listView, Predicate<ListViewItem> predicate)
+        {
+            listView.BeginUpdate();
+            foreach (ListViewItem item in listView.Items)
+            {
+                item.Checked = predicate(item);
+            }
+
+            listView.EndUpdate();
+        }
+
+        public static void CheckAll(this ListView listView, bool select)
+        {
+            listView.BeginUpdate();
+            foreach (ListViewItem item in listView.Items)
+            {
+                item.Checked = true;
+                if (select) item.Selected = true;
+            }
+
+            listView.EndUpdate();
+        }
+
+        public static void UncheckAll(this ListView listView) => UncheckAll(listView, false);
+
+        public static void UncheckAll(this ListView listView, Predicate<ListViewItem> predicate)
+        {
+            listView.BeginUpdate();
+            foreach (ListViewItem item in listView.Items)
+            {
+                item.Checked = !predicate(item);
+            }
+
+            listView.EndUpdate();
+        }
+
+        public static void UncheckAll(this ListView listView, bool unSelect)
+        {
+            listView.BeginUpdate();
+            foreach (ListViewItem item in listView.Items)
+            {
+                item.Checked = true;
+                if (unSelect) item.Selected = false;
+            }
+
+            listView.EndUpdate();
+        }
+
+        public static void InvertCheck(this ListView listView)
+        {
+            listView.BeginUpdate();
+            foreach (ListViewItem item in listView.Items)
+            {
+                item.Checked = !item.Checked;
+            }
+
+            listView.EndUpdate();
+        }
+    }
+}

--- a/src/ui/Forms/FixCommonErrors.cs
+++ b/src/ui/Forms/FixCommonErrors.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms
@@ -1128,22 +1129,10 @@ namespace Nikse.SubtitleEdit.Forms
             listViewFixes.Sort();
         }
 
-        private void ButtonSelectAllClick(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listView1.Items)
-            {
-                item.Checked = true;
-            }
-        }
-
-        private void ButtonInverseSelectionClick(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listView1.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
-
+        private void ButtonSelectAllClick(object sender, EventArgs e) => listView1.CheckAll();
+        
+        private void ButtonInverseSelectionClick(object sender, EventArgs e) => listView1.InvertCheck();
+        
         private void ListViewFixesSelectedIndexChanged(object sender, EventArgs e)
         {
             if (listViewFixes.SelectedItems.Count > 0)
@@ -1351,21 +1340,9 @@ namespace Nikse.SubtitleEdit.Forms
             labelTextLineTotal.Text = string.Format(_languageGeneral.TotalLengthX, text.CountCharacters(false));
         }
 
-        private void ButtonFixesSelectAllClick(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void ButtonFixesSelectAllClick(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void ButtonFixesInverseClick(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void ButtonFixesInverseClick(object sender, EventArgs e) => listViewFixes.InvertCheck();
 
         private void ButtonFixesApplyClick(object sender, EventArgs e)
         {
@@ -1572,13 +1549,7 @@ namespace Nikse.SubtitleEdit.Forms
             // restore de-selected fixes
             if (deSelectedFixes.Count > 0)
             {
-                foreach (ListViewItem item in listViewFixes.Items)
-                {
-                    if (deSelectedFixes.Contains(item.SubItems[1].Text + item.SubItems[2].Text + item.SubItems[3].Text))
-                    {
-                        item.Checked = false;
-                    }
-                }
+                listViewFixes.UncheckAll(item => deSelectedFixes.Contains(item.SubItems[1].Text + item.SubItems[2].Text + item.SubItems[3].Text));
             }
 
             if (subtitleListView1.Items.Count > firstIndex)
@@ -1867,7 +1838,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                subtitleListView1.SelectAll();
+                subtitleListView1.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -1877,7 +1848,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
             {
-                subtitleListView1.InverseSelection();
+                subtitleListView1.InvertCheck();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.Delete)
@@ -1915,21 +1886,9 @@ namespace Nikse.SubtitleEdit.Forms
             return _hunspell.Spell(word);
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewFixes.InvertCheck();
 
         private void setCurrentFixesAsDefaultToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -1938,72 +1897,34 @@ namespace Nikse.SubtitleEdit.Forms
             AddFixActions(CultureInfo.GetCultureInfo(_autoDetectGoogleLanguage).GetThreeLetterIsoLanguageName());
         }
 
-        private void selectDefaultToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            buttonResetDefault_Click(null, null);
-        }
+        private void selectDefaultToolStripMenuItem_Click(object sender, EventArgs e) => buttonResetDefault_Click(null, null);
 
-        private void listView1_KeyDown(object sender, KeyEventArgs e)
-        {
-            var items = listView1.Items;
-            if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
-            {
-                foreach (ListViewItem item in items)
-                {
-                    item.Checked = true;
-                    item.Selected = true;
-                }
-                e.SuppressKeyPress = true;
-            }
-            else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
-            {
-                foreach (ListViewItem item in items)
-                {
-                    item.Checked = false;
-                    item.Selected = false;
-                }
-                e.SuppressKeyPress = true;
-            }
-            else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
-            {
-                foreach (ListViewItem item in items)
-                {
-                    item.Checked = !item.Checked;
-                }
-                e.SuppressKeyPress = true;
-                e.SuppressKeyPress = true;
-            }
-        }
+        private void listView1_KeyDown(object sender, KeyEventArgs e) => HandleListViewKeyDown(listView1, e);
 
-        private void listViewFixes_KeyDown(object sender, KeyEventArgs e)
+        private void listViewFixes_KeyDown(object sender, KeyEventArgs e) => HandleListViewKeyDown(listViewFixes, e);
+
+        private void HandleListViewKeyDown(ListView listView, KeyEventArgs e)
         {
-            var items = listViewFixes.Items;
-            if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
+            switch (e.KeyCode)
             {
-                foreach (ListViewItem item in items)
+                case Keys.A when e.Modifiers == Keys.Control:
                 {
-                    item.Checked = true;
-                    item.Selected = true;
+                    listView.CheckAll(select: true);
+                    e.SuppressKeyPress = true;
+                    break;
                 }
-                e.SuppressKeyPress = true;
-            }
-            else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
-            {
-                foreach (ListViewItem item in items)
+                case Keys.D when e.Modifiers == Keys.Control:
                 {
-                    item.Checked = false;
-                    item.Selected = false;
+                    listView.UncheckAll();
+                    e.SuppressKeyPress = true;
+                    break;
                 }
-                e.SuppressKeyPress = true;
-            }
-            else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
-            {
-                foreach (ListViewItem item in items)
+                case Keys.I when e.Modifiers == (Keys.Control | Keys.Shift):
                 {
-                    item.Checked = !item.Checked;
+                    listView.InvertCheck();
+                    e.SuppressKeyPress = true;
+                    break;
                 }
-                e.SuppressKeyPress = true;
-                e.SuppressKeyPress = true;
             }
         }
     }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -17,6 +17,7 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.VobSub;
 using Nikse.SubtitleEdit.Forms.Assa;
 using Nikse.SubtitleEdit.Forms.AudioToText;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using Nikse.SubtitleEdit.Forms.FormatProperties;
 using Nikse.SubtitleEdit.Forms.Networking;
 using Nikse.SubtitleEdit.Forms.Ocr;
@@ -21246,7 +21247,7 @@ namespace Nikse.SubtitleEdit.Forms
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
                 SubtitleListview1.SelectedIndexChanged -= SubtitleListview1_SelectedIndexChanged;
-                SubtitleListview1.SelectAll();
+                SubtitleListview1.CheckAll();
                 SubtitleListview1.SelectedIndexChanged += SubtitleListview1_SelectedIndexChanged;
                 RefreshSelectedParagraph();
                 e.SuppressKeyPress = true;

--- a/src/ui/Forms/MergeShortLines.cs
+++ b/src/ui/Forms/MergeShortLines.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -312,20 +313,8 @@ namespace Nikse.SubtitleEdit.Forms
             Configuration.Settings.Tools.MergeShortLinesMaxChars = (int)numericUpDownMaxCharacters.Value;
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewFixes.InvertCheck();
     }
 }

--- a/src/ui/Forms/MergeTextWithSameTimeCodes.cs
+++ b/src/ui/Forms/MergeTextWithSameTimeCodes.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -295,21 +296,9 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewFixes.InvertCheck();
 
         private void checkBoxMakeDialog_CheckedChanged(object sender, EventArgs e)
         {

--- a/src/ui/Forms/ModifySelection.cs
+++ b/src/ui/Forms/ModifySelection.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -636,22 +637,10 @@ namespace Nikse.SubtitleEdit.Forms
             Preview();
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
-
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)  => listViewFixes.InvertCheck();
+        
         private void ModifySelection_Resize(object sender, EventArgs e)
         {
             ModifySelection_ResizeEnd(null, null);

--- a/src/ui/Forms/MultipleReplace.cs
+++ b/src/ui/Forms/MultipleReplace.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Xml;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms
@@ -459,7 +460,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewRules.SelectAll();
+                listViewRules.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -469,7 +470,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
             {
-                listViewRules.InverseSelection();
+                listViewRules.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }
@@ -558,21 +559,9 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void buttonReplacesSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void buttonReplacesSelectAll_Click(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void buttonReplacesInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void buttonReplacesInverseSelection_Click(object sender, EventArgs e) => listViewFixes.InvertCheck();
 
         private void contextMenuStrip1_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
@@ -1333,7 +1322,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewFixes.SelectAll();
+                listViewFixes.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -1343,7 +1332,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
             {
-                listViewFixes.InverseSelection();
+                listViewFixes.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }
@@ -1430,20 +1419,8 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void toolStripMenuItemGroupsSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewGroups.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemGroupsSelectAll_Click(object sender, EventArgs e) => listViewGroups.CheckAll();
 
-        private void toolStripMenuItemGroupsInvertSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewGroups.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemGroupsInvertSelection_Click(object sender, EventArgs e) => listViewGroups.InvertCheck();
     }
 }

--- a/src/ui/Forms/MultipleReplaceExportImport.cs
+++ b/src/ui/Forms/MultipleReplaceExportImport.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -134,20 +135,8 @@ namespace Nikse.SubtitleEdit.Forms
             DialogResult = DialogResult.Cancel;
         }
 
-        private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void selectAllToolStripMenuItem_Click(object sender, EventArgs e) => listViewExportStyles.CheckAll();
 
-        private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e) => listViewExportStyles.InvertCheck();
     }
 }

--- a/src/ui/Forms/Ocr/BinaryOcrTrain.cs
+++ b/src/ui/Forms/Ocr/BinaryOcrTrain.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.Ocr
@@ -326,15 +327,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             }
         }
 
-        private void SelectAll_Click(object sender, EventArgs e)
-        {
-            listViewFonts.BeginUpdate();
-            foreach (ListViewItem fontItem in listViewFonts.Items)
-            {
-                fontItem.Checked = true;
-            }
-            listViewFonts.EndUpdate();
-        }
+        private void SelectAll_Click(object sender, EventArgs e) => listViewFonts.CheckAll();
 
         public void InitializeDetectFont(BinaryOcrBitmap bob, string text)
         {

--- a/src/ui/Forms/Ocr/VobSubCharactersImport.cs
+++ b/src/ui/Forms/Ocr/VobSubCharactersImport.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.Ocr
@@ -144,10 +145,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         {
             listView1.ItemChecked -= listView1_ItemChecked;
 
-            foreach (ListViewItem item in listView1.Items)
-            {
-                item.Checked = true;
-            }
+            listView1.CheckAll();
 
             foreach (ListViewData d in _data)
             {

--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
 using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.Ocr
@@ -8248,7 +8249,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             if (e.Modifiers == Keys.Control && e.KeyCode == Keys.A)
             {
                 subtitleListView1.SelectedIndexChanged -= SubtitleListView1SelectedIndexChanged;
-                subtitleListView1.SelectAll();
+                subtitleListView1.CheckAll();
                 subtitleListView1.SelectedIndexChanged += SubtitleListView1SelectedIndexChanged;
                 e.SuppressKeyPress = true;
             }
@@ -8263,7 +8264,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift)) //InverseSelection
             {
                 subtitleListView1.SelectedIndexChanged -= SubtitleListView1SelectedIndexChanged;
-                subtitleListView1.InverseSelection();
+                subtitleListView1.InvertCheck();
                 subtitleListView1.SelectedIndexChanged += SubtitleListView1SelectedIndexChanged;
                 e.SuppressKeyPress = true;
             }

--- a/src/ui/Forms/Options/SettingsProfileExport.cs
+++ b/src/ui/Forms/Options/SettingsProfileExport.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms.Options
 {
@@ -74,13 +75,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
             }
         }
 
-        private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void selectAllToolStripMenuItem_Click(object sender, EventArgs e) => listViewExportStyles.CheckAll();
 
         private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/src/ui/Forms/ShotChangesList.cs
+++ b/src/ui/Forms/ShotChangesList.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms
@@ -87,7 +88,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewShotChanges.SelectAll();
+                listViewShotChanges.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -97,7 +98,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift))
             {
-                listViewShotChanges.InverseSelection();
+                listViewShotChanges.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }

--- a/src/ui/Forms/SplitLongLines.cs
+++ b/src/ui/Forms/SplitLongLines.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -595,10 +596,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
             listViewFixes.ItemChecked -= listViewFixes_ItemChecked;
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
             listViewFixes.ItemChecked += listViewFixes_ItemChecked;
             GeneratePreview(false);
         }
@@ -606,10 +604,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
             listViewFixes.ItemChecked -= listViewFixes_ItemChecked;
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
             listViewFixes.ItemChecked += listViewFixes_ItemChecked;
             GeneratePreview(false);
         }

--- a/src/ui/Forms/Styles/SubStationAlphaStyles.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStyles.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.Styles
@@ -1743,7 +1744,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             }
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewStyles.SelectAll();
+                listViewStyles.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -1753,7 +1754,7 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift))
             {
-                listViewStyles.InverseSelection();
+                listViewStyles.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }

--- a/src/ui/Forms/Styles/SubStationAlphaStylesExport.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStylesExport.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.Styles
@@ -184,20 +185,8 @@ namespace Nikse.SubtitleEdit.Forms.Styles
             }
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewExportStyles.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewExportStyles.UncheckAll();
     }
 }

--- a/src/ui/Forms/VTT/WebVttImportExport.cs
+++ b/src/ui/Forms/VTT/WebVttImportExport.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.VTT
@@ -143,20 +144,8 @@ namespace Nikse.SubtitleEdit.Forms.VTT
             }
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewExportStyles.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewExportStyles.InvertCheck();
     }
 }

--- a/src/ui/Forms/VTT/WebVttStyleManager.cs
+++ b/src/ui/Forms/VTT/WebVttStyleManager.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms.VTT
@@ -801,7 +802,7 @@ namespace Nikse.SubtitleEdit.Forms.VTT
             }
             else if (e.KeyCode == Keys.A && e.Modifiers == Keys.Control)
             {
-                listViewStyles.SelectAll();
+                listViewStyles.CheckAll();
                 e.SuppressKeyPress = true;
             }
             else if (e.KeyCode == Keys.D && e.Modifiers == Keys.Control)
@@ -811,7 +812,7 @@ namespace Nikse.SubtitleEdit.Forms.VTT
             }
             else if (e.KeyCode == Keys.I && e.Modifiers == (Keys.Control | Keys.Shift))
             {
-                listViewStyles.InverseSelection();
+                listViewStyles.InvertCheck();
                 e.SuppressKeyPress = true;
             }
         }

--- a/src/ui/Forms/VTT/WebVttStylePicker.cs
+++ b/src/ui/Forms/VTT/WebVttStylePicker.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Extensions;
 
 namespace Nikse.SubtitleEdit.Forms.VTT
 {
@@ -55,21 +56,9 @@ namespace Nikse.SubtitleEdit.Forms.VTT
             }
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
-        }
-
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewExportStyles.CheckAll();
+        
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewExportStyles.InvertCheck();
 
         private void listViewExportStyles_SelectedIndexChanged(object sender, EventArgs e)
         {

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1133,16 +1133,6 @@ namespace Nikse.SubtitleEdit.Logic
         public static void AutoSizeLastColumn(this ListView listView) =>
             listView.Columns[listView.Columns.Count - 1].Width = -2;
 
-        public static void SelectAll(this ListView lv)
-        {
-            lv.BeginUpdate();
-            foreach (ListViewItem item in lv.Items)
-            {
-                item.Selected = true;
-            }
-            lv.EndUpdate();
-        }
-
         public static void SelectFirstSelectedItemOnly(this ListView lv)
         {
             if (lv.SelectedIndices.Count > 1)
@@ -1155,16 +1145,6 @@ namespace Nikse.SubtitleEdit.Logic
                 lv.Items[first].Selected = true;
                 lv.EndUpdate();
             }
-        }
-
-        public static void InverseSelection(this ListView lv)
-        {
-            lv.BeginUpdate();
-            foreach (ListViewItem item in lv.Items)
-            {
-                item.Selected = !item.Selected;
-            }
-            lv.EndUpdate();
         }
 
         public static void SelectAll(this ListBox listbox)

--- a/src/ui/SubtitleEdit.csproj
+++ b/src/ui/SubtitleEdit.csproj
@@ -393,6 +393,7 @@
     <Compile Include="Forms\DownloadVosk.Designer.cs">
       <DependentUpon>DownloadVosk.cs</DependentUpon>
     </Compile>
+    <Compile Include="Forms\Extensions\ListViewExtensions.cs" />
     <Compile Include="Forms\GenerateVideoFFmpegPrompt.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Replaced all the manual implementations of SelectAll and InversSelection in different ListView instances with reusable extension methods. This is achieved by adding extension methods (CheckAll and InversCheck) contains logic to either select all or inversely select items in a given ListView. This will reduce repetitive code and enhance code maintainability.