### PR TITLE
Feature/subtitle listview

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1247,7 +1247,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             return isStart && isEnd;
         }
 
-        public static Paragraph GetOriginalParagraph(int index, Paragraph paragraph, List<Paragraph> originalParagraphs)
+        public static Paragraph GetOriginalParagraph(int index, Paragraph paragraph, IReadOnlyList<Paragraph> originalParagraphs)
         {
             if (index < 0)
             {

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1258,6 +1258,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             if (index < originalParagraphs.Count)
             {
                 var o = originalParagraphs[index];
+                
+                if (paragraph.StartTime.IsMaxTime && o.StartTime.IsMaxTime)
+                {
+                    return o;
+                }
+                
                 if (Math.Abs(o.StartTime.TotalMilliseconds - paragraph.StartTime.TotalMilliseconds) < 50)
                 {
                     return o;
@@ -1273,11 +1279,6 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     return o;
                 }
-            }
-
-            if (paragraph.StartTime.IsMaxTime && index < originalParagraphs.Count && originalParagraphs[index].StartTime.IsMaxTime)
-            {
-                return originalParagraphs[index];
             }
 
             foreach (var p in originalParagraphs)

--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -35,6 +35,8 @@ namespace Nikse.SubtitleEdit.Controls
             return SubtitleColumns.IndexOf(column);
         }
 
+        private static readonly IReadOnlyList<Paragraph> EmptyParagraphs = new List<Paragraph>();
+
         public const int InvalidIndex = -1;
         public int SelectedIndex => SelectedIndices.Count == 1 ? SelectedIndices[0] : InvalidIndex;
 
@@ -1292,49 +1294,10 @@ namespace Nikse.SubtitleEdit.Controls
                 Fill(subtitle.Paragraphs, subtitleOriginal.Paragraphs);
             }
         }
+        
+        internal void Fill(List<Paragraph> paragraphs) => Fill(paragraphs, EmptyParagraphs);
 
-        internal void Fill(List<Paragraph> paragraphs)
-        {
-            SaveFirstVisibleIndex();
-            BeginUpdate();
-            Items.Clear();
-            var x = ListViewItemSorter;
-            ListViewItemSorter = null;
-            var font = new Font(SubtitleFontName, SubtitleFontSize, GetFontStyle());
-            var items = new ListViewItem[paragraphs.Count];
-            for (var index = 0; index < paragraphs.Count; index++)
-            {
-                var paragraph = paragraphs[index];
-                Paragraph next = null;
-                if (index + 1 < paragraphs.Count)
-                {
-                    next = paragraphs[index + 1];
-                }
-                items[index] = MakeListViewItem(paragraph, next, null, font);
-            }
-
-            Items.AddRange(items);
-
-            if (UseSyntaxColoring && _settings != null)
-            {
-                for (var index = 0; index < paragraphs.Count; index++)
-                {
-                    var paragraph = paragraphs[index];
-                    var item = items[index];
-                    SyntaxColorListViewItem(paragraphs, index, paragraph, item);
-                }
-            }
-
-            ListViewItemSorter = x;
-            EndUpdate();
-
-            if (FirstVisibleIndex == 0)
-            {
-                FirstVisibleIndex = -1;
-            }
-        }
-
-        internal void Fill(List<Paragraph> paragraphs, List<Paragraph> paragraphsOriginal)
+        internal void Fill(List<Paragraph> paragraphs, IReadOnlyList<Paragraph> paragraphsOriginal)
         {
             SaveFirstVisibleIndex();
             BeginUpdate();
@@ -1346,7 +1309,7 @@ namespace Nikse.SubtitleEdit.Controls
             for (var index = 0; index < paragraphs.Count; index++)
             {
                 var paragraph = paragraphs[index];
-                Paragraph original = Utilities.GetOriginalParagraph(index, paragraph, paragraphsOriginal);
+                var original = Utilities.GetOriginalParagraph(index, paragraph, paragraphsOriginal);
                 Paragraph next = null;
                 if (index + 1 < paragraphs.Count)
                 {


### PR DESCRIPTION
Simplified the Fill method in the SubtitleListView control by removing duplicate code. The 'Fill' method was overloaded with unnecessary individual code blocks for handling 'paragraphs' and 'paragraphsOriginal'. This has been streamlined by creating a single Fill method that takes two lists 'paragraphs' and 'paragraphsOriginal'. The List type for paragraphsOriginal has also been modified to IReadOnlyList, ensuring the original paragraphs remain immutable during the Fill process thus enhancing data safety.