### PR TITLE
Allow choosing alpha for MPV outline and shadow

### DIFF
--- a/src/ui/Forms/Options/Settings.cs
+++ b/src/ui/Forms/Options/Settings.cs
@@ -3775,7 +3775,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
 
         private void buttonMpvOutlineColor_Click(object sender, EventArgs e)
         {
-            using (var colorChooser = new ColorChooser { Color = panelMpvOutlineColor.BackColor, ShowAlpha = false })
+            using (var colorChooser = new ColorChooser { Color = panelMpvOutlineColor.BackColor })
             {
                 if (colorChooser.ShowDialog() == DialogResult.OK)
                 {
@@ -3786,7 +3786,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
 
         private void buttonMpvBackColor_Click(object sender, EventArgs e)
         {
-            using (var colorChooser = new ColorChooser { Color = panelMpvBackColor.BackColor, ShowAlpha = false })
+            using (var colorChooser = new ColorChooser { Color = panelMpvBackColor.BackColor })
             {
                 if (colorChooser.ShowDialog() == DialogResult.OK)
                 {


### PR DESCRIPTION
Since outline and shadow are written to the settings file with the alpha value anyway, it would make more sense to be able to set the alpha when choosing the color.
This is especially useful when wanting an opaque box with transparency.