### PR TITLE
Feature/translate

### DIFF
--- a/src/libse/Translate/CopyPasteTranslator.cs
+++ b/src/libse/Translate/CopyPasteTranslator.cs
@@ -31,7 +31,7 @@ namespace Nikse.SubtitleEdit.Core.Translate
                 var p = _paragraphs[index];
                 var f = new Formatting();
                 _formattings[index - startIndex] = f;
-                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.PreTranslate(p.Text, sourceLanguage), sourceLanguage);
+                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.ExpandContractions(p.Text, sourceLanguage), sourceLanguage);
                 while (text.Contains(Environment.NewLine + Environment.NewLine))
                     text = text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
                 if (input.Length + text.Length + 3 >= maxBlockSize)
@@ -177,7 +177,7 @@ namespace Nikse.SubtitleEdit.Core.Translate
                 _formattings[index] = f;
                 if (input.Length > 0)
                     input.Append(Environment.NewLine + Environment.NewLine);
-                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.PreTranslate(p.Text, sourceLanguage), sourceLanguage);
+                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.ExpandContractions(p.Text, sourceLanguage), sourceLanguage);
                 while (text.Contains(Environment.NewLine + Environment.NewLine))
                     text = text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
                 text = text.Replace(Environment.NewLine, "\n");

--- a/src/libse/Translate/Service/GoogleTranslator1.cs
+++ b/src/libse/Translate/Service/GoogleTranslator1.cs
@@ -63,7 +63,8 @@ namespace Nikse.SubtitleEdit.Core.Translate.Service
                     input.Append(" " + SplitChar + " ");
                 }
 
-                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.PreTranslate(p.Text.Replace(SplitChar.ToString(), string.Empty), sourceLanguage), sourceLanguage);
+                var text = TranslationHelper.ExpandContractions(p.Text, sourceLanguage);
+                text = f.SetTagsAndReturnTrimmed(text, sourceLanguage);
                 text = f.UnBreak(text, p.Text);
                 input.Append(text);
             }

--- a/src/libse/Translate/Service/GoogleTranslator2.cs
+++ b/src/libse/Translate/Service/GoogleTranslator2.cs
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.Core.Translate.Service
                     input.Append("&");
                 }
 
-                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.PreTranslate(p.Text, sourceLanguage), sourceLanguage);
+                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.ExpandContractions(p.Text, sourceLanguage), sourceLanguage);
                 text = f.UnBreak(text, p.Text);
 
                 input.Append("q=" + Utilities.UrlEncode(text));

--- a/src/libse/Translate/Service/GoogleTranslator3.cs
+++ b/src/libse/Translate/Service/GoogleTranslator3.cs
@@ -68,7 +68,7 @@ namespace Nikse.SubtitleEdit.Core.Translate.Service
                     input.Append(",");
                 }
 
-                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.PreTranslate(p.Text, sourceLanguage), sourceLanguage);
+                var text = f.SetTagsAndReturnTrimmed(TranslationHelper.ExpandContractions(p.Text, sourceLanguage), sourceLanguage);
                 text = f.UnBreak(text, p.Text);
 
                 input.Append("\"" + Json.EncodeJsonText(text) + "\"");

--- a/src/libse/Translate/Service/MicrosoftTranslationService.cs
+++ b/src/libse/Translate/Service/MicrosoftTranslationService.cs
@@ -140,7 +140,7 @@ namespace Nikse.SubtitleEdit.Core.Translate.Service
 
                     var f = new Formatting();
                     formatList.Add(f);
-                    var text = f.SetTagsAndReturnTrimmed(TranslationHelper.PreTranslate(p.Text, sourceLanguage), sourceLanguage);
+                    var text = f.SetTagsAndReturnTrimmed(TranslationHelper.ExpandContractions(p.Text, sourceLanguage), sourceLanguage);
                     text = f.UnBreak(text, p.Text);
                     jsonBuilder.Append("{ \"Text\":\"" + Json.EncodeJsonText(text) + "\"}");
                 }

--- a/src/libse/Translate/TranslationHelper.cs
+++ b/src/libse/Translate/TranslationHelper.cs
@@ -77,7 +77,7 @@ namespace Nikse.SubtitleEdit.Core.Translate
                 s = Regex.Replace(s, @"\b(W|w)hat's ", "$1hat is ");
                 s = Regex.Replace(s, @"\b(W|w)here's ", "$1here is ");
                 s = Regex.Replace(s, @"\b(W|w)ho's ", "$1ho is ");
-                s = Regex.Replace(s, @"\B'(C|c)ause ", "$1ecause "); // \b (word boundry) does not work with '
+                s = Regex.Replace(s, @"\B'(C|c)ause ", "$1ecause "); // \b (word boundary) does not work with '
             }
             return s;
         }

--- a/src/libse/Translate/TranslationHelper.cs
+++ b/src/libse/Translate/TranslationHelper.cs
@@ -51,9 +51,9 @@ namespace Nikse.SubtitleEdit.Core.Translate
             .Replace("</ i>", "</i>");
         }
 
-        public static string PreTranslate(string input, string source)
+        public static string ExpandContractions(string input, string source)
         {
-            string s = FixInvalidCarriageReturnLineFeedCharacters(input);
+            var s = input;
 
             if (source == "en")
             {
@@ -79,14 +79,8 @@ namespace Nikse.SubtitleEdit.Core.Translate
                 s = Regex.Replace(s, @"\b(W|w)ho's ", "$1ho is ");
                 s = Regex.Replace(s, @"\B'(C|c)ause ", "$1ecause "); // \b (word boundary) does not work with '
             }
-            return s;
-        }
 
-        private static string FixInvalidCarriageReturnLineFeedCharacters(string input)
-        {
-            // Fix new line chars (avoid "Specified value has invalid CRLF characters")
-            // See https://github.com/SubtitleEdit/subtitleedit/issues/4589
-            return string.Join(Environment.NewLine, input.SplitToLines()).Trim();
+            return s;
         }
     }
 }


### PR DESCRIPTION
- Fixes method name
- Remove unnecessary method 'FixInvalidCarriageReturnLineFeedCharacters' as the issue mentioned in https://github.com/SubtitleEdit/subtitleedit/compare/main...ivandrofly:feature/translate?expand=1#diff-410c4ad661319da5376718b483cf2f1d332ab8ff21c49721ff6acb5c2ff2a0ebL88 was being caused by replacing '\r' aka "SplitChar" with string.empty which will make the string from => foo\\r\\nbar => foo\\rbar (https://github.com/SubtitleEdit/subtitleedit/compare/main...ivandrofly:feature/translate?expand=1#diff-c5aba14dc988226e5beafa90797051a8a2e7967359d3b702d43316c6bb383058L66)
- Fix typo 