### PR TITLE
Add support for TimeLineAscii in 'ToText' method

### DIFF
--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -220,6 +220,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new TimedText200604CData(),
                     new TimedText200604Ooyala(),
                     new TimedText(),
+                    new TimeLineAscii(),
                     new TitleExchangePro(),
                     new Titra(),
                     new TmpegEncText(),
@@ -666,7 +667,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 new DlDd(),
                 new Ted20(),
                 new Captionate(),
-                new TimeLineAscii(),
+                new TimeLineAscii(), // TODO: remove from here?
                 new TimeLineFootageAscii(),
                 new TimedTextImage(),
                 new FinalCutProImage(),


### PR DESCRIPTION
Added support for exporting subtitles to TimeLineAscii format in SubtitleFormat class. This would help to provide different formats for the subtitles depending on the user's preference. A new internal class called 'TimeLineAsciiTextWriter' has been introduced to handle the writing of subtitle data into the TimeLineAscii format. There's also a change in the placement of TimeLineAscii in the formats list and a 'TODO' comment has been added for future reference.