### PR TITLE
Bring BTC Cancel button to front and fix positioning

### DIFF
--- a/src/ui/Forms/BeautifyTimeCodes/BeautifyTimeCodes.Designer.cs
+++ b/src/ui/Forms/BeautifyTimeCodes/BeautifyTimeCodes.Designer.cs
@@ -128,11 +128,11 @@ namespace Nikse.SubtitleEdit.Forms.BeautifyTimeCodes
             // 
             // panelExtractTimeCodes
             // 
+            this.panelExtractTimeCodes.Controls.Add(this.buttonCancelTimeCodes);
             this.panelExtractTimeCodes.Controls.Add(this.labelExtractTimeCodesProgress);
             this.panelExtractTimeCodes.Controls.Add(this.progressBarExtractTimeCodes);
             this.panelExtractTimeCodes.Controls.Add(this.buttonExtractTimeCodes);
             this.panelExtractTimeCodes.Controls.Add(this.labelTimeCodesStatus);
-            this.panelExtractTimeCodes.Controls.Add(this.buttonCancelTimeCodes);
             this.panelExtractTimeCodes.Location = new System.Drawing.Point(0, 27);
             this.panelExtractTimeCodes.Name = "panelExtractTimeCodes";
             this.panelExtractTimeCodes.Size = new System.Drawing.Size(546, 87);
@@ -177,7 +177,7 @@ namespace Nikse.SubtitleEdit.Forms.BeautifyTimeCodes
             // 
             // buttonCancelTimeCodes
             // 
-            this.buttonCancelTimeCodes.Location = new System.Drawing.Point(23, 18);
+            this.buttonCancelTimeCodes.Location = new System.Drawing.Point(23, 20);
             this.buttonCancelTimeCodes.Name = "buttonCancelTimeCodes";
             this.buttonCancelTimeCodes.Size = new System.Drawing.Size(149, 23);
             this.buttonCancelTimeCodes.TabIndex = 5;


### PR DESCRIPTION
A small fix. When extracting exact time codes on the "Beautify time codes" dialog, the Cancel button was behind the disabled "Extract time codes" button, and slightly higher:

![image](https://github.com/SubtitleEdit/subtitleedit/assets/3516155/544c9cd7-32b9-4ad2-9171-8d5c7fed8c73)

The button is now on top, so you can better click it.