### PR TITLE
Make using Find shortcut in its dialog select text

### DIFF
--- a/src/ui/Forms/FindDialog.cs
+++ b/src/ui/Forms/FindDialog.cs
@@ -13,6 +13,7 @@ namespace Nikse.SubtitleEdit.Forms
     {
         private readonly IFindAndReplace _findAndReplaceMethods;
         private readonly Keys _findNextShortcut;
+        private readonly Keys _findShortcut;
         private Regex _regEx;
         private readonly Subtitle _subtitle;
 
@@ -42,6 +43,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             UiUtil.FixLargeFonts(this, buttonFind);
             _findNextShortcut = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainEditFindNext);
+            _findShortcut = UiUtil.GetKeys(Configuration.Settings.Shortcuts.MainEditFind);
         }
 
         private ReplaceType FindReplaceType
@@ -121,6 +123,21 @@ namespace Nikse.SubtitleEdit.Forms
                 FindNext();
                 Focus();
                 ctrl?.Focus();
+            }
+            else if (e.KeyData == _findShortcut)
+            {
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+                if (comboBoxFind.Visible)
+                {
+                    comboBoxFind.Focus();
+                    comboBoxFind.SelectAll();
+                }
+                else
+                {
+                    textBoxFind.Focus();
+                    textBoxFind.SelectAll();
+                }
             }
         }
 


### PR DESCRIPTION
If I recall correctly, in the old Find, if the focus wasn't on the text box and you use the Find shortcut again, it moves the focus back to the text box and selects the text.
For example, if you use "Count" and then want to Find something else, you use the Find shortcut again and right the new next, it's easier to return the focus to the text box like this.

What do you think?