### PR TITLE
Fix: comment and and context was switched for some checks

### DIFF
--- a/src/libse/NetflixQualityCheck/NetflixCheckMaxLineLength.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMaxLineLength.cs
@@ -27,7 +27,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                             if (CalculateJapaneseLength(text) > 11)
                             {
                                 var comment = "Single vertical line length > 11";
-                                controller.AddRecord(p, p.StartTime.ToHHMMSSFF(), comment, line.Length.ToString(CultureInfo.InvariantCulture));
+                                controller.AddRecord(p, p.StartTime.ToHHMMSSFF(),  line.Length.ToString(CultureInfo.InvariantCulture), comment);
                             }
                         }
                         else // Horizontal subtitles - Maximum 13 full-width characters per line
@@ -35,7 +35,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                             if (CalculateJapaneseLength(text) > 13)
                             {
                                 var comment = "Single horizontal line length > 13";
-                                controller.AddRecord(p, p.StartTime.ToHHMMSSFF(), comment, line.Length.ToString(CultureInfo.InvariantCulture));
+                                controller.AddRecord(p, p.StartTime.ToHHMMSSFF(), line.Length.ToString(CultureInfo.InvariantCulture), comment);
                             }
                         }
                     }

--- a/src/libse/NetflixQualityCheck/NetflixCheckMinDuration.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMinDuration.cs
@@ -19,7 +19,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                     if (p.DurationTotalMilliseconds < 500)
                     {
                         string comment = "Minimum duration: 0.5 second";
-                        controller.AddRecord(p, p.StartTime.ToHHMMSSFF(), comment, p.DurationTotalSeconds.ToString(CultureInfo.InvariantCulture));
+                        controller.AddRecord(p, p.StartTime.ToHHMMSSFF(),  p.DurationTotalSeconds.ToString(CultureInfo.InvariantCulture), comment);
                     }
                     continue;
                 }


### PR DESCRIPTION
For some checks in the NetflixQualityCheck the comment and context was the wrong way round.