### PR TITLE
Implement simple sort method for multiple replace rules view

### DIFF
--- a/src/ui/Forms/MultipleReplace.Designer.cs
+++ b/src/ui/Forms/MultipleReplace.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Nikse.SubtitleEdit.Forms
+namespace Nikse.SubtitleEdit.Forms
 {
     sealed partial class MultipleReplace
     {
@@ -72,6 +72,7 @@
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.inverseSelectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sortToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.radioButtonNormal = new System.Windows.Forms.RadioButton();
             this.buttonOK = new System.Windows.Forms.Button();
             this.buttonCancel = new System.Windows.Forms.Button();
@@ -329,7 +330,14 @@
             this.labelReplaceWith.Size = new System.Drawing.Size(72, 13);
             this.labelReplaceWith.TabIndex = 3;
             this.labelReplaceWith.Text = "Replace with:";
-            // 
+            //
+            // sortToolStripMenuItem
+            //
+            this.sortToolStripMenuItem.Name = "sortItems";
+            this.sortToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Home)));
+            this.sortToolStripMenuItem.Size = new System.Drawing.Size(227, 22);
+            this.sortToolStripMenuItem.Text = "Sort items";
+            this.sortToolStripMenuItem.Click += new System.EventHandler(this.sortToolStripMenuItem_Click);
             // listViewRules
             // 
             this.listViewRules.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -353,6 +361,7 @@
             this.listViewRules.View = System.Windows.Forms.View.Details;
             this.listViewRules.SelectedIndexChanged += new System.EventHandler(this.ListViewReplaceListSelectedIndexChanged);
             this.listViewRules.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ListViewRulesKeyDown);
+            this.listViewRules.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.listViewSort_ColumnClick);
             // 
             // columnHeader1
             // 
@@ -396,7 +405,8 @@
             this.toolStripMenuItemExport,
             this.toolStripSeparator5,
             this.selectAllToolStripMenuItem,
-            this.inverseSelectionToolStripMenuItem});
+            this.inverseSelectionToolStripMenuItem,
+            this.sortToolStripMenuItem});
             this.contextMenuStripRules.Name = "contextMenuStrip1";
             this.contextMenuStripRules.Size = new System.Drawing.Size(228, 270);
             this.contextMenuStripRules.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip1_Opening);
@@ -881,5 +891,6 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemGroupsSelectAll;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemGroupsInvertSelection;
+        private System.Windows.Forms.ToolStripMenuItem sortToolStripMenuItem;
     }
 }

--- a/src/ui/Forms/MultipleReplace.cs
+++ b/src/ui/Forms/MultipleReplace.cs
@@ -120,6 +120,7 @@ namespace Nikse.SubtitleEdit.Forms
             inverseSelectionToolStripMenuItem.Text = LanguageSettings.Current.Main.Menu.Edit.InverseSelection;
             toolStripMenuItemGroupsSelectAll.Text = LanguageSettings.Current.Main.Menu.ContextMenu.SelectAll;
             toolStripMenuItemGroupsInvertSelection.Text = LanguageSettings.Current.Main.Menu.Edit.InverseSelection;
+            sortToolStripMenuItem.Text = LanguageSettings.Current.Main.Menu.Tools.SortBy;
 
             radioButtonCaseSensitive.Left = radioButtonNormal.Left + radioButtonNormal.Width + 40;
             radioButtonRegEx.Left = radioButtonCaseSensitive.Left + radioButtonCaseSensitive.Width + 40;
@@ -1531,6 +1532,36 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 item.Checked = !item.Checked;
             }
+        }
+
+        private void SortItems(int column)
+        {
+            var items = new List<MultipleSearchAndReplaceSetting>();
+
+            switch (column)
+            {
+                case 0: items = _currentGroup.Rules.OrderBy(i => i.Enabled).ToList(); break;
+                case 1: items = _currentGroup.Rules.OrderBy(i => i.FindWhat).ToList(); break;
+                case 2: items = _currentGroup.Rules.OrderBy(i => i.ReplaceWith).ToList(); break;
+                case 3: items = _currentGroup.Rules.OrderBy(i => i.SearchType).ToList(); break;
+                case 4: items = _currentGroup.Rules.OrderBy(i => i.Description).ToList(); break;
+                default: items = _currentGroup.Rules.OrderBy(i => i.FindWhat).ToList(); break;
+            }
+
+            _currentGroup.Rules.Clear();
+            _currentGroup.Rules.AddRange(items);
+            UpdateViewFromModel(Configuration.Settings.MultipleSearchAndReplaceGroups, _currentGroup);
+            GeneratePreview();
+        }
+
+        private void sortToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SortItems(1);
+        }
+
+        private void listViewSort_ColumnClick(object sender, ColumnClickEventArgs e)
+        {
+            SortItems(e.Column);
         }
     }
 }


### PR DESCRIPTION
Hey there!

I noticed my wife faces a recurring challenge while reviewing subtitles with this application – being unable to alphabetically order multiple replace rules. She keeps a substantial playbook of common misspellings, but locating specific rules becomes troublesome when they aren't sorted.

To address this, I've made a simple addition to the MultipleReplace controller. I've introduced a `sortItems` function, along with a `ToolStripMenuItem` that sorts the "FindWhat" column by default. Additionally, I've implemented a ColumnClick handler to allow users to sort by any column they prefer.

While I'm not as experienced with C#, I believe this enhancement could greatly benefit not only my wife but also other users of the software.

Please let me know if you have any suggestions or if there's a more elegant approach to selecting attributes of a class by index. I'm eager to collaborate and improve this feature. :)