### PR TITLE
Avoid replacing punctuation for French in FixDoubleDash

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixDoubleDash.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDoubleDash.cs
@@ -35,8 +35,12 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         text = text.TrimEnd();
                         text = text.Replace("... " + Environment.NewLine, "..." + Environment.NewLine);
                         text = text.Replace("... </", "...</"); // </i>, </font>...
-                        text = text.Replace("... ?", "...?");
-                        text = text.Replace("... !", "...!");
+                        
+                        if (callbacks.Language != "fr")
+                        {
+                            text = text.Replace("... ?", "...?");
+                            text = text.Replace("... !", "...!");
+                        }
 
                         if (text.IndexOf(Environment.NewLine, StringComparison.Ordinal) > 1)
                         {


### PR DESCRIPTION
This commit introduces a conditional to prevent replacing ellipsis followed by a question mark or exclamation mark with no space in between, specifically for French language. This change was deemed necessary as the original punctuation format is commonly used in French typography.