### PR TITLE
Correct typo in variable name

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
@@ -12,7 +12,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string RemovedEmptyLineAtTop { get; set; } = "Remove empty line at top";
             public static string RemovedEmptyLineAtBottom { get; set; } = "Remove empty line at bottom";
             public static string RemovedEmptyLineInMiddle { get; set; } = "Remove empty line in middle";
-            public static string RemovedEmptyLinesUnsedLineBreaks { get; set; } = "Remove empty lines/unused line breaks";
+            public static string RemovedEmptyLinesUnusedLineBreaks { get; set; } = "Remove empty lines/unused line breaks";
         }
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
@@ -174,7 +174,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
             if (emptyLinesRemoved > 0)
             {
-                callbacks.UpdateFixStatus(emptyLinesRemoved, Language.RemovedEmptyLinesUnsedLineBreaks);
+                callbacks.UpdateFixStatus(emptyLinesRemoved, Language.RemovedEmptyLinesUnusedLineBreaks);
                 subtitle.Renumber();
             }
         }

--- a/src/ui/Forms/FixCommonErrors.cs
+++ b/src/ui/Forms/FixCommonErrors.cs
@@ -392,7 +392,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             _fixActions = new List<FixItem>
             {
-                new FixItem(_language.RemovedEmptyLinesUnsedLineBreaks, "Has only one valid line!</br><i> -> Has only one valid line!", () => new FixEmptyLines().Fix(Subtitle, this), ce.EmptyLinesTicked),
+                new FixItem(_language.RemovedEmptyLinesUnusedLineBreaks, "Has only one valid line!</br><i> -> Has only one valid line!", () => new FixEmptyLines().Fix(Subtitle, this), ce.EmptyLinesTicked),
                 new FixItem(_language.FixOverlappingDisplayTimes, string.Empty, () => new FixOverlappingDisplayTimes().Fix(Subtitle, this), ce.OverlappingDisplayTimeTicked),
                 new FixItem(_language.FixShortDisplayTimes, string.Empty, () => new FixShortDisplayTimes().Fix(Subtitle, this), ce.TooShortDisplayTimeTicked),
                 new FixItem(_language.FixLongDisplayTimes, string.Empty, () => new FixLongDisplayTimes().Fix(Subtitle, this), ce.TooLongDisplayTimeTicked),
@@ -559,7 +559,7 @@ namespace Nikse.SubtitleEdit.Forms
             FixEmptyLines.Language.RemovedEmptyLineAtBottom = LanguageSettings.Current.FixCommonErrors.RemovedEmptyLineAtBottom;
             FixEmptyLines.Language.RemovedEmptyLineAtTop = LanguageSettings.Current.FixCommonErrors.RemovedEmptyLineAtTop;
             FixEmptyLines.Language.RemovedEmptyLineInMiddle = LanguageSettings.Current.FixCommonErrors.RemovedEmptyLineInMiddle;
-            FixEmptyLines.Language.RemovedEmptyLinesUnsedLineBreaks = LanguageSettings.Current.FixCommonErrors.RemovedEmptyLinesUnsedLineBreaks;
+            FixEmptyLines.Language.RemovedEmptyLinesUnusedLineBreaks = LanguageSettings.Current.FixCommonErrors.RemovedEmptyLinesUnusedLineBreaks;
             FixHyphensInDialog.Language.FixHyphensInDialogs = LanguageSettings.Current.FixCommonErrors.FixHyphensInDialogs;
             FixHyphensRemoveDashSingleLine.Language.RemoveHyphensSingleLine = LanguageSettings.Current.FixCommonErrors.RemoveHyphensSingleLine;
             FixInvalidItalicTags.Language.FixInvalidItalicTag = LanguageSettings.Current.FixCommonErrors.FixInvalidItalicTag;

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -1136,7 +1136,7 @@ namespace Nikse.SubtitleEdit.Logic
                 RemovedEmptyLineAtTop = "Remove empty line at top",
                 RemovedEmptyLineAtBottom = "Remove empty line at bottom",
                 RemovedEmptyLineInMiddle = "Remove empty line in middle",
-                RemovedEmptyLinesUnsedLineBreaks = "Remove empty lines/unused line breaks",
+                RemovedEmptyLinesUnusedLineBreaks = "Remove empty lines/unused line breaks",
                 FixOverlappingDisplayTimes = "Fix overlapping display times",
                 FixShortDisplayTimes = "Fix short display times",
                 FixLongDisplayTimes = "Fix long display times",

--- a/src/ui/Logic/LanguageDeserializer.cs
+++ b/src/ui/Logic/LanguageDeserializer.cs
@@ -2312,7 +2312,7 @@ namespace Nikse.SubtitleEdit.Logic
                     language.FixCommonErrors.RemovedEmptyLineInMiddle = reader.Value;
                     break;
                 case "FixCommonErrors/RemovedEmptyLinesUnsedLineBreaks":
-                    language.FixCommonErrors.RemovedEmptyLinesUnsedLineBreaks = reader.Value;
+                    language.FixCommonErrors.RemovedEmptyLinesUnusedLineBreaks = reader.Value;
                     break;
                 case "FixCommonErrors/FixOverlappingDisplayTimes":
                     language.FixCommonErrors.FixOverlappingDisplayTimes = reader.Value;

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -957,7 +957,7 @@
             public string RemovedEmptyLineAtTop { get; set; }
             public string RemovedEmptyLineAtBottom { get; set; }
             public string RemovedEmptyLineInMiddle { get; set; }
-            public string RemovedEmptyLinesUnsedLineBreaks { get; set; }
+            public string RemovedEmptyLinesUnusedLineBreaks { get; set; }
             public string FixOverlappingDisplayTimes { get; set; }
             public string FixShortDisplayTimes { get; set; }
             public string FixLongDisplayTimes { get; set; }


### PR DESCRIPTION
The variable name 'RemovedEmptyLinesUnsedLineBreaks' has been changed to 'RemovedEmptyLinesUnusedLineBreaks' across multiple files. This correction improves code readability and avoids potential confusion in future maintenance.