### PR TITLE
Change the Gridline view

### DIFF
--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -915,7 +915,7 @@ namespace Nikse.SubtitleEdit.Controls
                 else
                     intervaljaafar = 0.1d;
                 var interval = _zoomFactor >= 0.4d ?
-                    0.1d : // a pixel is 0.1 second
+                    intervaljaafar : // a pixel is 0.1 second
                     1.0d;  // a pixel is 1.0 second
                 using (var pen = new Pen(GridColor))
                 {

--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -909,6 +909,11 @@ namespace Nikse.SubtitleEdit.Controls
                 var xPosition = SecondsToXPosition(seconds);
                 var yPosition = 0;
                 var yCounter = 0d;
+                double intervaljaafar=0;
+                if (Configuration.Settings.General.CurrentFrameRate == 25)
+                    intervaljaafar = 0.04d;
+                else
+                    intervaljaafar = 0.1d;
                 var interval = _zoomFactor >= 0.4d ?
                     0.1d : // a pixel is 0.1 second
                     1.0d;  // a pixel is 1.0 second


### PR DESCRIPTION
Change the gridline view so each second is divided into 25 equal parts when the video's framerate is 25, rather 10 parts which is the general case.