### PR TITLE
Fix subscript in OcrFixEngine

### DIFF
--- a/src/ui/Logic/Ocr/OcrFixEngine.cs
+++ b/src/ui/Logic/Ocr/OcrFixEngine.cs
@@ -1957,7 +1957,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                                     a = a[0] + a.Substring(1).ToLowerInvariant();
                                 }
 
-                                var b = ar[0];
+                                var b = ar[1];
                                 if (b == b.ToUpperInvariant())
                                 {
                                     b = b[0] + b.Substring(1).ToLowerInvariant();


### PR DESCRIPTION
The index for array 'ar' was incorrectly set to 0. This commit corrects the subscript to 1, ensuring that the variable 'b' is correctly assigned.