### PR TITLE
Adjust FixCommonOcrLineErrors implementation in OcrFixEngine

### DIFF
--- a/src/ui/Logic/Ocr/OcrFixEngine.cs
+++ b/src/ui/Logic/Ocr/OcrFixEngine.cs
@@ -868,9 +868,9 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
         private string FixCommonOcrLineErrors(string input, Subtitle subtitle, int index, string lastLine, string lastLastLine)
         {
             var text = input;
-            text = _ocrFixReplaceList.FixOcrErrorViaLineReplaceList(input, subtitle, index);
+            text = _ocrFixReplaceList.FixOcrErrorViaLineReplaceList(text, subtitle, index);
             text = FixOcrErrorsViaHardcodedRules(text, lastLine, lastLastLine, _abbreviationList);
-            text = _ocrFixReplaceList.FixOcrErrorViaLineReplaceList(input, subtitle, index);
+            text = _ocrFixReplaceList.FixOcrErrorViaLineReplaceList(text, subtitle, index);
 
             if (Configuration.Settings.Tools.OcrFixUseHardcodedRules)
             {


### PR DESCRIPTION
Changed input parameter to a local variable 'text' while calling FixOcrErrorViaLineReplaceList method in FixCommonOcrLineErrors. This improves the accuracy of OCR correction by ensuring the original text is not repeatedly used instead of the corrected version.