### PR TITLE
Feature/context menu combobox

### DIFF
--- a/src/ui/Controls/Adapters/NativeTextBoxAdapter.cs
+++ b/src/ui/Controls/Adapters/NativeTextBoxAdapter.cs
@@ -1,0 +1,18 @@
+using System.Windows.Forms;
+using Nikse.SubtitleEdit.Controls.Interfaces;
+
+namespace Nikse.SubtitleEdit.Controls.Adapters
+{
+    public class NativeTextBoxAdapter : ISelectedText
+    {
+        private readonly TextBoxBase _textBox;
+
+        public string SelectedText
+        {
+            get => _textBox.SelectedText;
+            set => _textBox.SelectedText = value;
+        }
+
+        public NativeTextBoxAdapter(TextBoxBase textBox) => _textBox = textBox;
+    }
+}

--- a/src/ui/Controls/AdvancedTextBox.cs
+++ b/src/ui/Controls/AdvancedTextBox.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Nikse.SubtitleEdit.Controls

--- a/src/ui/Controls/AdvancedTextBox.cs
+++ b/src/ui/Controls/AdvancedTextBox.cs
@@ -9,8 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Nikse.SubtitleEdit.Controls

--- a/src/ui/Controls/Interfaces/ISelectedText.cs
+++ b/src/ui/Controls/Interfaces/ISelectedText.cs
@@ -1,0 +1,7 @@
+namespace Nikse.SubtitleEdit.Controls.Interfaces
+{
+    public interface ISelectedText
+    {
+        string SelectedText { get; set; }
+    }
+}

--- a/src/ui/Controls/NikseComboBox.cs
+++ b/src/ui/Controls/NikseComboBox.cs
@@ -430,7 +430,6 @@ namespace Nikse.SubtitleEdit.Controls
             _textBox.Visible = false;
             _items = new NikseComboBoxCollection(this);
 
-
             SetStyle(ControlStyles.ResizeRedraw | ControlStyles.OptimizedDoubleBuffer, true);
 
             base.KeyDown += (sender, e) =>
@@ -1333,6 +1332,20 @@ namespace Nikse.SubtitleEdit.Controls
             if (_textBox != null && DropDownStyle == ComboBoxStyle.DropDown)
             {
                 _textBox.SelectAll();
+            }
+        }
+
+        // [SRCategory("CatBehavior")]
+        [DefaultValue(null)]
+        // [SRDescription("ControlContextMenuDescr")]
+        public override ContextMenuStrip ContextMenuStrip
+        {
+            get => base.ContextMenuStrip;
+            set
+            {
+                // once the ContextMenuStrip is set for this control (combobox) also set it to the underlying textbox
+                base.ContextMenuStrip = value;
+                _textBox.ContextMenuStrip = value;
             }
         }
     }

--- a/src/ui/Controls/NikseComboBox.cs
+++ b/src/ui/Controls/NikseComboBox.cs
@@ -7,11 +7,12 @@ using System.Drawing;
 using System.Drawing.Design;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Controls.Interfaces;
 
 namespace Nikse.SubtitleEdit.Controls
 {
     [Category("NikseComboBox"), Description("ComboBox with better support for color theme")]
-    public class NikseComboBox : Control
+    public class NikseComboBox : Control, ISelectedText
     {
         // ReSharper disable once InconsistentNaming
         public event EventHandler SelectedIndexChanged;

--- a/src/ui/Controls/NikseTextBox.cs
+++ b/src/ui/Controls/NikseTextBox.cs
@@ -1,10 +1,11 @@
 ﻿using Nikse.SubtitleEdit.Logic;
 using System.Drawing;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Controls.Interfaces;
 
 namespace Nikse.SubtitleEdit.Controls
 {
-    public class NikseTextBox : TextBox
+    public class NikseTextBox : TextBox, ISelectedText
     {
         private const int WM_NCPAINT = 0x85;
         private const int WM_PAINT = 0x0f;

--- a/src/ui/Controls/SETextBox.cs
+++ b/src/ui/Controls/SETextBox.cs
@@ -4,13 +4,14 @@ using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Drawing;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Controls.Interfaces;
 
 namespace Nikse.SubtitleEdit.Controls
 {
     /// <summary>
     /// TextBox that can be either a normal text box or a rich text box.
     /// </summary>
-    public sealed class SETextBox : Panel
+    public sealed class SETextBox : Panel, ISelectedText
     {
         // ReSharper disable once InconsistentNaming
         public new event EventHandler TextChanged;

--- a/src/ui/Forms/FindDialog.cs
+++ b/src/ui/Forms/FindDialog.cs
@@ -213,24 +213,23 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void RadioButton_CheckedChanged(object sender, EventArgs e)
         {
-            if (sender == radioButtonRegEx)
+            // remove any existing context menu
+            textBoxFind.ContextMenuStrip = null;
+            comboBoxFind.ContextMenuStrip = null;
+            
+            // only hook context menu if regex radio button is checked
+            if (sender == radioButtonRegEx && radioButtonRegEx.Checked)
             {
                 if (textBoxFind.Visible)
                 {
-                    comboBoxFind.ContextMenuStrip = null;
                     textBoxFind.ContextMenuStrip = FindReplaceDialogHelper.GetRegExContextMenu(textBoxFind);
                 }
-                else
+                else if (radioButtonRegEx.Checked)
                 {
-                    textBoxFind.ContextMenuStrip = null;
                     comboBoxFind.ContextMenuStrip = FindReplaceDialogHelper.GetRegExContextMenu(comboBoxFind);
                 }
             }
-            else
-            {
-                textBoxFind.ContextMenuStrip = null;
-                comboBoxFind.ContextMenuStrip = null;
-            }
+
             checkBoxWholeWord.Enabled = !radioButtonRegEx.Checked;
             labelCount.Text = string.Empty;
         }

--- a/src/ui/Forms/ModifySelection.cs
+++ b/src/ui/Forms/ModifySelection.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Controls.Adapters;
 
 namespace Nikse.SubtitleEdit.Forms
 {
@@ -506,7 +507,10 @@ namespace Nikse.SubtitleEdit.Forms
             numericUpDownDuration.Visible = comboBoxRule.SelectedIndex == FunctionDurationLessThan || comboBoxRule.SelectedIndex == FunctionDurationGreaterThan;
             if (comboBoxRule.SelectedIndex == FunctionRegEx) // RegEx
             {
-                textBoxText.ContextMenuStrip = FindReplaceDialogHelper.GetRegExContextMenu(textBoxText);
+                // creat new context menu only if textBoxText doesn't already has one, this will prevent unnecessary
+                // allocation regex option is already selected and user re-select it
+                textBoxText.ContextMenuStrip = textBoxText.ContextMenuStrip ?? 
+                                               FindReplaceDialogHelper.GetRegExContextMenu(new NativeTextBoxAdapter(textBoxText));
                 checkBoxCaseSensitive.Enabled = false;
             }
             else if (comboBoxRule.SelectedIndex == FunctionOdd || 

--- a/src/ui/Forms/MultipleReplace.cs
+++ b/src/ui/Forms/MultipleReplace.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Xml;
+using Nikse.SubtitleEdit.Controls.Adapters;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Forms
@@ -207,7 +208,14 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void RadioButtonCheckedChanged(object sender, EventArgs e)
         {
-            textBoxFind.ContextMenuStrip = sender == radioButtonRegEx ? FindReplaceDialogHelper.GetRegExContextMenu(textBoxFind) : null;
+            // remove regex context menu from find text box
+            textBoxFind.ContextMenuStrip = null;
+
+            // only get the regex context menu if we select the regex option
+            if (sender == radioButtonRegEx && radioButtonRegEx.Checked)
+            {
+                textBoxFind.ContextMenuStrip = FindReplaceDialogHelper.GetRegExContextMenu(new NativeTextBoxAdapter(textBoxFind));
+            }
         }
 
         private void ButtonAddClick(object sender, EventArgs e)

--- a/src/ui/Forms/Options/DoNotBreakAfterListEdit.cs
+++ b/src/ui/Forms/Options/DoNotBreakAfterListEdit.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Xml;
+using Nikse.SubtitleEdit.Controls.Adapters;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
@@ -229,13 +230,10 @@ namespace Nikse.SubtitleEdit.Forms.Options
 
         private void RadioButtonCheckedChanged(object sender, EventArgs e)
         {
-            if (sender == radioButtonRegEx)
+            textBoxNoBreakAfter.ContextMenuStrip = null;
+            if (sender == radioButtonRegEx && radioButtonRegEx.Checked)
             {
-                textBoxNoBreakAfter.ContextMenuStrip = FindReplaceDialogHelper.GetRegExContextMenu(textBoxNoBreakAfter);
-            }
-            else
-            {
-                textBoxNoBreakAfter.ContextMenuStrip = null;
+                textBoxNoBreakAfter.ContextMenuStrip = FindReplaceDialogHelper.GetRegExContextMenu(new NativeTextBoxAdapter(textBoxNoBreakAfter));
             }
         }
 

--- a/src/ui/Logic/FindReplaceDialogHelper.cs
+++ b/src/ui/Logic/FindReplaceDialogHelper.cs
@@ -4,6 +4,7 @@ using System;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Controls.Interfaces;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 
 namespace Nikse.SubtitleEdit.Logic
@@ -285,7 +286,7 @@ namespace Nikse.SubtitleEdit.Logic
             return false;
         }
 
-        public static ContextMenuStrip GetRegExContextMenu(TextBox textBox)
+        public static ContextMenuStrip GetRegExContextMenu(ISelectedText textBox)
         {
             var cm = new ContextMenuStrip();
             var l = LanguageSettings.Current.RegularExpressionContextMenu;
@@ -301,44 +302,6 @@ namespace Nikse.SubtitleEdit.Logic
             cm.Items.Add(l.OneOrMore, null, delegate { textBox.SelectedText = "+"; });
             cm.Items.Add(l.InCharacterGroup, null, delegate { textBox.SelectedText = "[test]"; });
             cm.Items.Add(l.NotInCharacterGroup, null, delegate { textBox.SelectedText = "[^test]"; });
-            return cm;
-        }
-
-        public static ContextMenuStrip GetRegExContextMenu(SETextBox textBox)
-        {
-            var cm = new ContextMenuStrip();
-            var l = LanguageSettings.Current.RegularExpressionContextMenu;
-            cm.Items.Add(l.WordBoundary, null, delegate { textBox.SelectedText = "\\b"; });
-            cm.Items.Add(l.NonWordBoundary, null, delegate { textBox.SelectedText = "\\B"; });
-            cm.Items.Add(l.NewLine, null, delegate { textBox.SelectedText = "\\r\\n"; });
-            cm.Items.Add(l.AnyDigit, null, delegate { textBox.SelectedText = "\\d"; });
-            cm.Items.Add(l.NonDigit, null, delegate { textBox.SelectedText = "\\D"; });
-            cm.Items.Add(l.AnyCharacter, null, delegate { textBox.SelectedText = "."; });
-            cm.Items.Add(l.AnyWhitespace, null, delegate { textBox.SelectedText = "\\s"; });
-            cm.Items.Add(l.NonSpaceCharacter, null, delegate { textBox.SelectedText = "\\S"; });
-            cm.Items.Add(l.ZeroOrMore, null, delegate { textBox.SelectedText = "*"; });
-            cm.Items.Add(l.OneOrMore, null, delegate { textBox.SelectedText = "+"; });
-            cm.Items.Add(l.InCharacterGroup, null, delegate { textBox.SelectedText = "[test]"; });
-            cm.Items.Add(l.NotInCharacterGroup, null, delegate { textBox.SelectedText = "[^test]"; });
-            return cm;
-        }
-
-        public static ContextMenuStrip GetRegExContextMenu(NikseComboBox comboBox)
-        {
-            var cm = new ContextMenuStrip();
-            var l = LanguageSettings.Current.RegularExpressionContextMenu;
-            cm.Items.Add(l.WordBoundary, null, delegate { comboBox.SelectedText = "\\b"; });
-            cm.Items.Add(l.NonWordBoundary, null, delegate { comboBox.SelectedText = "\\B"; });
-            cm.Items.Add(l.NewLine, null, delegate { comboBox.SelectedText = "\\r\\n"; });
-            cm.Items.Add(l.AnyDigit, null, delegate { comboBox.SelectedText = "\\d"; });
-            cm.Items.Add(l.NonDigit, null, delegate { comboBox.SelectedText = "\\D"; });
-            cm.Items.Add(l.AnyCharacter, null, delegate { comboBox.SelectedText = "."; });
-            cm.Items.Add(l.AnyWhitespace, null, delegate { comboBox.SelectedText = "\\s"; });
-            cm.Items.Add(l.NonSpaceCharacter, null, delegate { comboBox.SelectedText = "\\S"; });
-            cm.Items.Add(l.ZeroOrMore, null, delegate { comboBox.SelectedText = "*"; });
-            cm.Items.Add(l.OneOrMore, null, delegate { comboBox.SelectedText = "+"; });
-            cm.Items.Add(l.InCharacterGroup, null, delegate { comboBox.SelectedText = "[test]"; });
-            cm.Items.Add(l.NotInCharacterGroup, null, delegate { comboBox.SelectedText = "[^test]"; });
             return cm;
         }
 

--- a/src/ui/SubtitleEdit.csproj
+++ b/src/ui/SubtitleEdit.csproj
@@ -101,9 +101,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controls\Adapters\NativeTextBoxAdapter.cs" />
     <Compile Include="Controls\CuesPreviewView.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Controls\Interfaces\ISelectedText.cs" />
     <Compile Include="Controls\NikseComboBox.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
Fixes a very sneaky issue with **NikseCombobox** and **ContextMenuStrip**

Currently there for example in Find Dialog, if you select "Regular expression" and right click 
inside the textarea it won't show the context menu for that regular expression,
In order to display the context menu, you have to right click in border or the dropbox icon area

This patch fixes that issue as it will capture any click in made in inner textbox and notify the **NikseCombobox** to display the context menu

It also remove the need of having duplicated codes .


PS: I can also add a gift showing the behavior of both in case the explanation above is not clear