### PR TITLE
Refactor OnCopyData event invocation in MessageHandlerWindow

### DIFF
--- a/src/ui/Logic/VideoPlayers/MpcHC/MessageHandlerWindow.cs
+++ b/src/ui/Logic/VideoPlayers/MpcHC/MessageHandlerWindow.cs
@@ -17,7 +17,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.MpcHC
         {
             if (m.Msg == NativeMethods.WindowsMessageCopyData && OnCopyData != null)
             {
-                OnCopyData.Invoke(m, new EventArgs());
+                OnCopyData.Invoke(m, EventArgs.Empty);
             }
             base.WndProc(ref m);
         }


### PR DESCRIPTION
The event invocation code in MessageHandlerWindow.cs file specifically for OnCopyData has been updated. Instead of creating a new instance of EventArgs, the code now uses the static EventArgs.Empty instance, which is more efficient and adheres to common C# best practices.