### PR TITLE
Optimize plugin search in the UI

### DIFF
--- a/src/ui/Forms/PluginsGet.cs
+++ b/src/ui/Forms/PluginsGet.cs
@@ -164,19 +164,19 @@ namespace Nikse.SubtitleEdit.Forms
 
             foreach (var plugin in _downloadList)
             {
-                var item = new ListViewItem(plugin.Name) { Tag = plugin };
-                item.SubItems.Add(plugin.Description);
-                item.SubItems.Add(plugin.Version.ToString(CultureInfo.InvariantCulture));
-                item.SubItems.Add(plugin.Date);
-
                 if (!search ||
                     plugin.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase) ||
                     plugin.Description.Contains(searchText, StringComparison.OrdinalIgnoreCase) ||
                     plugin.Version.ToString(CultureInfo.InvariantCulture).Contains(searchText, StringComparison.OrdinalIgnoreCase))
                 {
+                    var item = new ListViewItem(plugin.Name) { Tag = plugin };
+                    item.SubItems.Add(plugin.Description);
+                    item.SubItems.Add(plugin.Version.ToString(CultureInfo.InvariantCulture));
+                    item.SubItems.Add(plugin.Date);
                     listViewGetPlugins.Items.Add(item);
                 }
             }
+
             listViewGetPlugins.EndUpdate();
         }
 


### PR DESCRIPTION
The plugin creation and addition to the listViewGetPlugins is moved into the conditional statement that checks for a match with the search text. This optimizes the search functionality by avoiding unnecessary plugin item creation when the search text does not match any plugin property, thus improving UI performance.

In short words: Avoid unnecessary ListViewItem allocation