### PR TITLE
Switch MouseDown event to MouseUp in NikseUpDown control

### DIFF
--- a/src/ui/Controls/NikseUpDown.cs
+++ b/src/ui/Controls/NikseUpDown.cs
@@ -532,7 +532,7 @@ namespace Nikse.SubtitleEdit.Controls
                 _buttonLeftIsDown = false;
                 Invalidate();
             }
-            base.OnMouseDown(e);
+            base.OnMouseUp(e);
         }
 
         protected override void OnMouseMove(MouseEventArgs e)


### PR DESCRIPTION
The code changes correct an event handling in the NikseUpDown custom control. Previously, the base's OnMouseDown event was called, but the correct behavior should be to call the base's OnMouseUp event. This switch ensures the control responds properly to mouse interactions.


Short: `OnMouseDown` base is being called on `OnMouseUp` event 