### PR TITLE
Move MKV Bluray parsing from BinEdit.cs into libse for use by third-party code.

### DIFF
--- a/src/libse/BluRaySup/BluRaySupParser.cs
+++ b/src/libse/BluRaySup/BluRaySupParser.cs
@@ -18,6 +18,7 @@
  */
 
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -397,6 +398,81 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 var lastBitmapObjects = new Dictionary<int, List<OdsData>>();
                 return ParseBluRaySup(fs, log, false, lastPalettes, lastBitmapObjects);
             }
+        }
+
+        public static List<PcsData> ParseBluRaySupFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska)
+        {
+            var sub = matroska.GetSubtitle(matroskaSubtitleInfo.TrackNumber, null);
+            var subtitles = new List<PcsData>();
+            var log = new StringBuilder();
+            var clusterStream = new MemoryStream();
+            var lastPalettes = new Dictionary<int, List<PaletteInfo>>();
+            var lastBitmapObjects = new Dictionary<int, List<OdsData>>();
+            foreach (var p in sub)
+            {
+                byte[] buffer = p.GetData(matroskaSubtitleInfo);
+                if (buffer != null && buffer.Length > 2)
+                {
+                    clusterStream.Write(buffer, 0, buffer.Length);
+                    if (ContainsBluRayStartSegment(buffer))
+                    {
+                        if (subtitles.Count > 0 && subtitles[subtitles.Count - 1].StartTime == subtitles[subtitles.Count - 1].EndTime)
+                        {
+                            subtitles[subtitles.Count - 1].EndTime = (long)((p.Start - 1) * 90.0);
+                        }
+
+                        clusterStream.Position = 0;
+                        var list = ParseBluRaySup(clusterStream, log, true, lastPalettes, lastBitmapObjects);
+                        foreach (var sup in list)
+                        {
+                            sup.StartTime = (long)((p.Start - 1) * 90.0);
+                            sup.EndTime = (long)((p.End - 1) * 90.0);
+                            subtitles.Add(sup);
+
+                            // fix overlapping
+                            if (subtitles.Count > 1 && sub[subtitles.Count - 2].End > sub[subtitles.Count - 1].Start)
+                            {
+                                subtitles[subtitles.Count - 2].EndTime = subtitles[subtitles.Count - 1].StartTime - 1;
+                            }
+                        }
+
+                        clusterStream = new MemoryStream();
+                    }
+                }
+                else if (subtitles.Count > 0)
+                {
+                    var lastSub = subtitles[subtitles.Count - 1];
+                    if (lastSub.StartTime == lastSub.EndTime)
+                    {
+                        lastSub.EndTime = (long)((p.Start - 1) * 90.0);
+                        if (lastSub.EndTime - lastSub.StartTime > 1000000)
+                        {
+                            lastSub.EndTime = lastSub.StartTime;
+                        }
+                    }
+                }
+            }
+
+            return subtitles;
+        }
+
+        private static bool ContainsBluRayStartSegment(byte[] buffer)
+        {
+            const int epochStart = 0x80;
+            var position = 0;
+            while (position + 3 <= buffer.Length)
+            {
+                var segmentType = buffer[position];
+                if (segmentType == epochStart)
+                {
+                    return true;
+                }
+
+                var length = BigEndianInt16(buffer, position + 1) + 3;
+                position += length;
+            }
+
+            return false;
         }
 
         private static SupSegment ParseSegmentHeader(byte[] buffer, StringBuilder log)


### PR DESCRIPTION
I'm currently writing a small utility for myself that counts and reports how many subtitles (forced and total) are present in each track of a .mkv file that was created using MakeMKV.

Some of the MKV Bluray parsing code required to do this is locked away inside the UI project, and at present I have to duplicate it into my project to be able to use it. Whilst this does work, I now need to monitor this repo for any potential changes to that code to then manually carry over.

This change extracts the relevant section of the code from BinEdit.cs and moves it into libse, enabling direct use by third-party code via libse.