### PR TITLE
Add grammar check functionality to subtitles

### DIFF
--- a/src/libse/Grammar/LanguageToolService.cs
+++ b/src/libse/Grammar/LanguageToolService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Core.Grammar
+{
+    public class LanguageToolService : IDisposable
+    {
+        private readonly HttpClient _httpClient = new HttpClient();
+        // private readonly SeJsonParser _seJsonParser = new SeJsonParser();
+        private readonly Regex _messageRegex = new Regex("(?<=message\\\":\").+?(?=\")", RegexOptions.Compiled);
+        private readonly StringBuilder _stringBuilder = new StringBuilder();
+
+        public async Task<string> CheckAsync(string text)
+        {
+            var httpResponse = await _httpClient.PostAsync($"http://localhost:8010/v2/check?text={Utilities.UrlEncode(text)}&language=en", null);
+            var json = await httpResponse.Content.ReadAsStringAsync();
+            foreach (Match match in _messageRegex.Matches(json))
+            {
+                _stringBuilder.AppendLine($" - {match.Value}");
+            }
+
+            try
+            {
+                return _stringBuilder.Length == 0 ? "All Good :)" : _stringBuilder.ToString();
+            }
+            finally
+            {
+                _stringBuilder.Clear();
+            }
+        }
+
+        public async Task<bool> IsAvailableAsync()
+        {
+            try
+            {
+                using (var cts = new CancellationTokenSource())
+                {
+                    cts.CancelAfter(TimeSpan.FromSeconds(1));
+                    return await _httpClient.GetAsync("http://localhost:8010", cts.Token) != null;
+                }
+            }
+            catch (Exception e)
+            {
+                return false;
+            }
+        }
+
+        public void Dispose() => _httpClient?.Dispose();
+    }
+}

--- a/src/ui/Forms/Main.Designer.cs
+++ b/src/ui/Forms/Main.Designer.cs
@@ -450,6 +450,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.splitToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.mergeWithPreviousToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mergeWithNextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.runWhiperOnParagraphToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
             this.extendToPreviousToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.extendToNextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -579,7 +580,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.timerOriginalTextUndo = new System.Windows.Forms.Timer(this.components);
             this.contextMenuStripShowVideoControls = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripMenuItemShowVideoControls = new System.Windows.Forms.ToolStripMenuItem();
-            this.runWhiperOnParagraphToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemGrammarCheck = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
@@ -2722,7 +2723,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripMenuItemSelectedLines,
             this.toolStripMenuItemGoogleMicrosoftTranslateSelLine});
             this.contextMenuStripListView.Name = "contextMenuStripListView";
-            this.contextMenuStripListView.Size = new System.Drawing.Size(285, 826);
+            this.contextMenuStripListView.Size = new System.Drawing.Size(285, 848);
             this.contextMenuStripListView.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.MenuClosed);
             this.contextMenuStripListView.Opening += new System.ComponentModel.CancelEventHandler(this.ContextMenuStripListViewOpening);
             this.contextMenuStripListView.Opened += new System.EventHandler(this.MenuOpened);
@@ -3176,7 +3177,8 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripMenuItemEvenlyDistributeLines,
             this.toolStripMenuItemSaveSelectedLines,
             this.typeEffectToolStripMenuItem,
-            this.karaokeEffectToolStripMenuItem});
+            this.karaokeEffectToolStripMenuItem,
+            this.toolStripMenuItemGrammarCheck});
             this.toolStripMenuItemSelectedLines.Name = "toolStripMenuItemSelectedLines";
             this.toolStripMenuItemSelectedLines.Size = new System.Drawing.Size(284, 22);
             this.toolStripMenuItemSelectedLines.Text = "Selected lines";
@@ -4477,7 +4479,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.seekSilenceToolStripMenuItem,
             this.insertSubtitleHereToolStripMenuItem});
             this.contextMenuStripWaveform.Name = "contextMenuStripWaveform";
-            this.contextMenuStripWaveform.Size = new System.Drawing.Size(275, 534);
+            this.contextMenuStripWaveform.Size = new System.Drawing.Size(275, 512);
             this.contextMenuStripWaveform.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.ContextMenuStripWaveformClosing);
             this.contextMenuStripWaveform.Opening += new System.ComponentModel.CancelEventHandler(this.ContextMenuStripWaveformOpening);
             // 
@@ -4550,6 +4552,13 @@ namespace Nikse.SubtitleEdit.Forms
             this.mergeWithNextToolStripMenuItem.Size = new System.Drawing.Size(274, 22);
             this.mergeWithNextToolStripMenuItem.Text = "Merge with next";
             this.mergeWithNextToolStripMenuItem.Click += new System.EventHandler(this.MergeWithNextToolStripMenuItemClick);
+            // 
+            // runWhiperOnParagraphToolStripMenuItem
+            // 
+            this.runWhiperOnParagraphToolStripMenuItem.Name = "runWhiperOnParagraphToolStripMenuItem";
+            this.runWhiperOnParagraphToolStripMenuItem.Size = new System.Drawing.Size(274, 22);
+            this.runWhiperOnParagraphToolStripMenuItem.Text = "Run Whiper on paragraph...";
+            this.runWhiperOnParagraphToolStripMenuItem.Click += new System.EventHandler(this.runWhiperOnParagraphToolStripMenuItem_Click);
             // 
             // toolStripSeparator11
             // 
@@ -5881,12 +5890,11 @@ namespace Nikse.SubtitleEdit.Forms
             this.toolStripMenuItemShowVideoControls.Text = "Show video controls";
             this.toolStripMenuItemShowVideoControls.Click += new System.EventHandler(this.ToolStripMenuItemShowVideoControlsClick);
             // 
-            // runWhiperOnParagraphToolStripMenuItem
+            // toolStripMenuItemGrammarCheck
             // 
-            this.runWhiperOnParagraphToolStripMenuItem.Name = "runWhiperOnParagraphToolStripMenuItem";
-            this.runWhiperOnParagraphToolStripMenuItem.Size = new System.Drawing.Size(274, 22);
-            this.runWhiperOnParagraphToolStripMenuItem.Text = "Run Whiper on paragraph...";
-            this.runWhiperOnParagraphToolStripMenuItem.Click += new System.EventHandler(this.runWhiperOnParagraphToolStripMenuItem_Click);
+            this.toolStripMenuItemGrammarCheck.Name = "toolStripMenuItemGrammarCheck";
+            this.toolStripMenuItemGrammarCheck.Size = new System.Drawing.Size(275, 22);
+            this.toolStripMenuItemGrammarCheck.Text = "Grammar Check";
             // 
             // Main
             // 
@@ -6507,5 +6515,6 @@ namespace Nikse.SubtitleEdit.Forms
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemVerifyCompleteness;
         private System.Windows.Forms.ToolStripButton toolStripButtonVideoOpen;
         private System.Windows.Forms.ToolStripMenuItem runWhiperOnParagraphToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemGrammarCheck;
     }
 }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -47,6 +47,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Core.Grammar;
 using Nikse.SubtitleEdit.Forms.Tts;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.TrackBar;
 using CheckForUpdatesHelper = Nikse.SubtitleEdit.Logic.CheckForUpdatesHelper;
@@ -653,6 +654,21 @@ namespace Nikse.SubtitleEdit.Forms
                 toolStripSelected.Text = string.Empty;
 
                 ListViewHelper.RestoreListViewDisplayIndices(SubtitleListview1);
+
+                toolStripMenuItemGrammarCheck.Click += async (sender, args) =>
+                {
+                    var langaugeToolClient = new LanguageToolService();
+                    var isServiceAvailable = await langaugeToolClient.IsAvailableAsync();
+                    if (!isServiceAvailable)
+                    {
+                        MessageBox.Show("Service not availble", MessageBoxIcon.Exclamation);
+                        return;
+                    }
+
+                    var selectedParagraph = SubtitleListview1.GetSelectedParagraph(_subtitle);
+                    var message = await langaugeToolClient.CheckAsync(selectedParagraph.Text);
+                    MessageBox.Show(message, MessageBoxIcon.Information);
+                };
             }
             catch (Exception exception)
             {

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -657,17 +657,19 @@ namespace Nikse.SubtitleEdit.Forms
 
                 toolStripMenuItemGrammarCheck.Click += async (sender, args) =>
                 {
-                    var langaugeToolClient = new LanguageToolService();
-                    var isServiceAvailable = await langaugeToolClient.IsAvailableAsync();
-                    if (!isServiceAvailable)
+                    using (var langaugeToolClient = new LanguageToolService())
                     {
-                        MessageBox.Show("Service not availble", MessageBoxIcon.Exclamation);
-                        return;
-                    }
+                        var isServiceAvailable = await langaugeToolClient.IsAvailableAsync();
+                        if (!isServiceAvailable)
+                        {
+                            MessageBox.Show("Service not availble", MessageBoxIcon.Exclamation);
+                            return;
+                        }
 
-                    var selectedParagraph = SubtitleListview1.GetSelectedParagraph(_subtitle);
-                    var message = await langaugeToolClient.CheckAsync(selectedParagraph.Text);
-                    MessageBox.Show(message, MessageBoxIcon.Information);
+                        var selectedParagraph = SubtitleListview1.GetSelectedParagraph(_subtitle);
+                        var message = await langaugeToolClient.CheckAsync(selectedParagraph.Text);
+                        MessageBox.Show(message, MessageBoxIcon.Information);
+                    }
                 };
             }
             catch (Exception exception)


### PR DESCRIPTION
A new feature has been implemented that adds a grammar check functionality in the UI under the new 'Grammar Check' menu item. This leverages the LanguageToolService to check the grammar of selected subtitles, notifying the user about any potential errors or confirm that the check has passed successfully.


![image](https://github.com/SubtitleEdit/subtitleedit/assets/6579818/f071c9a5-5f18-4e5c-968f-6675378dc8c2)


Hi Nikse, is this something you are interested in so I can continue with the dev @niksedk?
The idea is to have it for now to work only for selected line from main-listview but since it also provide fix-suggestion maybe it can be other version of spell check.

Couple of thing I would like to implement on this current pull request
- Display the offset and length per mistakes found
- If possible highlight found mistakes in textbox (if it's rich-text-box color the offset+length range to red)
- Use language detected from subtitle. (**auto** query param can give false positive if text is too short)
- Localization

If you can also give it a try and provide inputs :)

Steps to setup docker LanguageTool docker image (link below)
https://github.com/meyayl/docker-languagetool