### PR TITLE
Fix mouse interactions on the PanelPlayer in x11

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic.cs
@@ -691,6 +691,13 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
                     var logFileName = Path.Combine(Configuration.DataDirectory, "mpv-log-" + Guid.NewGuid() + ".txt");
                     _mpvSetOptionString(_mpvHandle, GetUtf8Bytes("log-file"), GetUtf8Bytes(logFileName));
                 }
+
+                
+                if (_mpvSetOptionString(_mpvHandle, GetUtf8Bytes("input-cursor-passthrough"), GetUtf8Bytes("yes")) != 0)
+                {
+                    // if --input-cursor-passthrough=yes is not avaliable, use --input-cursor=no
+                    _mpvSetOptionString(_mpvHandle, GetUtf8Bytes("input-cursor"), GetUtf8Bytes("no"));
+                }
             }
             else if (!Directory.Exists(videoFileName))
             {


### PR DESCRIPTION
In x11, mpv takes over mouse events, so the SE UI doesn't respond to mouse interactions in the PanelPlayer. With this change, the user interface responds to events correctly, such as play/pause with a click and moving the pointer to bring up the video controls in full screen mode.