### PR TITLE
Refactor list view item checking actions

### DIFF
--- a/src/ui/Forms/ApplyDurationLimits.cs
+++ b/src/ui/Forms/ApplyDurationLimits.cs
@@ -338,21 +338,9 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewFixes.CheckAll();
 
-        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewFixes.InvertCheck();
 
         private void checkBoxCheckShotChanges_CheckedChanged(object sender, EventArgs e)
         {

--- a/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesImportExport.cs
+++ b/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesImportExport.cs
@@ -125,20 +125,8 @@ namespace Nikse.SubtitleEdit.Forms.Assa
             }
         }
 
-        private void ToolStripMenuItemSelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewCategories.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void ToolStripMenuItemSelectAll_Click(object sender, EventArgs e) => listViewCategories.CheckAll();
 
-        private void ToolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listViewCategories.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void ToolStripMenuItemInverseSelection_Click(object sender, EventArgs e) => listViewCategories.InvertCheck();
     }
 }

--- a/src/ui/Forms/AutoBreakUnbreakLines.cs
+++ b/src/ui/Forms/AutoBreakUnbreakLines.cs
@@ -251,18 +251,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
         }
 
         private void AutoBreakUnbreakLines_FormClosing(object sender, FormClosingEventArgs e)

--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -3977,18 +3977,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewConvertOptions.Items)
-            {
-                item.Checked = true;
-            }
+            listViewConvertOptions.CheckAll();
         }
 
         private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewConvertOptions.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewConvertOptions.InvertCheck();
         }
 
         private void listViewInputFiles_ColumnClick(object sender, ColumnClickEventArgs e)

--- a/src/ui/Forms/ChangeCasingNames.cs
+++ b/src/ui/Forms/ChangeCasingNames.cs
@@ -335,18 +335,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
         }
 
         private void toolStripMenuItem1SelectAll_Click(object sender, EventArgs e)

--- a/src/ui/Forms/FixCommonErrors.cs
+++ b/src/ui/Forms/FixCommonErrors.cs
@@ -1145,21 +1145,9 @@ namespace Nikse.SubtitleEdit.Forms
             listViewFixes.Sort();
         }
 
-        private void ButtonSelectAllClick(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listView1.Items)
-            {
-                item.Checked = true;
-            }
-        }
+        private void ButtonSelectAllClick(object sender, EventArgs e) => listView1.CheckAll();
 
-        private void ButtonInverseSelectionClick(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in listView1.Items)
-            {
-                item.Checked = !item.Checked;
-            }
-        }
+        private void ButtonInverseSelectionClick(object sender, EventArgs e) => listView1.InvertCheck();
 
         private void ListViewFixesSelectedIndexChanged(object sender, EventArgs e)
         {
@@ -1370,18 +1358,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void ButtonFixesSelectAllClick(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
         }
 
         private void ButtonFixesInverseClick(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
         }
 
         private void ButtonFixesApplyClick(object sender, EventArgs e)
@@ -1948,18 +1930,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
         }
 
         private void setCurrentFixesAsDefaultToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/ui/Forms/MergeShortLines.cs
+++ b/src/ui/Forms/MergeShortLines.cs
@@ -346,18 +346,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
         }
     }
 }

--- a/src/ui/Forms/MergeTextWithSameTimeCodes.cs
+++ b/src/ui/Forms/MergeTextWithSameTimeCodes.cs
@@ -297,18 +297,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
         }
 
         private void checkBoxMakeDialog_CheckedChanged(object sender, EventArgs e)

--- a/src/ui/Forms/ModifySelection.cs
+++ b/src/ui/Forms/ModifySelection.cs
@@ -642,18 +642,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
         }
 
         private void ModifySelection_Resize(object sender, EventArgs e)

--- a/src/ui/Forms/MultipleReplace.cs
+++ b/src/ui/Forms/MultipleReplace.cs
@@ -570,18 +570,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void buttonReplacesSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
         }
 
         private void buttonReplacesInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
         }
 
         private void contextMenuStrip1_Opening(object sender, System.ComponentModel.CancelEventArgs e)
@@ -1446,18 +1440,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewRules.Items)
-            {
-                item.Checked = true;
-            }
+            listViewRules.CheckAll();
         }
 
         private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewRules.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewRules.InvertCheck();
         }
 
         private void ContextMenuStripListViewFixesOpening(object sender, System.ComponentModel.CancelEventArgs e)

--- a/src/ui/Forms/MultipleReplaceExportImport.cs
+++ b/src/ui/Forms/MultipleReplaceExportImport.cs
@@ -136,18 +136,12 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
+            listViewExportStyles.CheckAll();
         }
 
         private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewExportStyles.InvertCheck();
         }
     }
 }

--- a/src/ui/Forms/Ocr/BinaryOcrTrain.cs
+++ b/src/ui/Forms/Ocr/BinaryOcrTrain.cs
@@ -328,12 +328,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
         private void SelectAll_Click(object sender, EventArgs e)
         {
-            listViewFonts.BeginUpdate();
-            foreach (ListViewItem fontItem in listViewFonts.Items)
-            {
-                fontItem.Checked = true;
-            }
-            listViewFonts.EndUpdate();
+            listViewFonts.CheckAll();
         }
 
         public void InitializeDetectFont(BinaryOcrBitmap bob, string text)

--- a/src/ui/Forms/Ocr/VobSubCharactersImport.cs
+++ b/src/ui/Forms/Ocr/VobSubCharactersImport.cs
@@ -143,11 +143,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         private void buttonFixesSelectAll_Click(object sender, EventArgs e)
         {
             listView1.ItemChecked -= listView1_ItemChecked;
-
-            foreach (ListViewItem item in listView1.Items)
-            {
-                item.Checked = true;
-            }
+            listView1.CheckAll();
 
             foreach (ListViewData d in _data)
             {

--- a/src/ui/Forms/Options/SettingsProfileExport.cs
+++ b/src/ui/Forms/Options/SettingsProfileExport.cs
@@ -76,18 +76,12 @@ namespace Nikse.SubtitleEdit.Forms.Options
 
         private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
+            listViewExportStyles.CheckAll();
         }
 
         private void inverseSelectionToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewExportStyles.InvertCheck();
         }
     }
 }

--- a/src/ui/Forms/SplitLongLines.cs
+++ b/src/ui/Forms/SplitLongLines.cs
@@ -718,10 +718,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
             listViewFixes.ItemChecked -= listViewFixes_ItemChecked;
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = true;
-            }
+            listViewFixes.CheckAll();
             listViewFixes.ItemChecked += listViewFixes_ItemChecked;
             GeneratePreview(false);
         }
@@ -729,10 +726,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
             listViewFixes.ItemChecked -= listViewFixes_ItemChecked;
-            foreach (ListViewItem item in listViewFixes.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewFixes.InvertCheck();
             listViewFixes.ItemChecked += listViewFixes_ItemChecked;
             GeneratePreview(false);
         }

--- a/src/ui/Forms/Styles/SubStationAlphaStylesExport.cs
+++ b/src/ui/Forms/Styles/SubStationAlphaStylesExport.cs
@@ -186,18 +186,12 @@ namespace Nikse.SubtitleEdit.Forms.Styles
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
+            listViewExportStyles.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewExportStyles.InvertCheck();
         }
     }
 }

--- a/src/ui/Forms/VTT/WebVttImportExport.cs
+++ b/src/ui/Forms/VTT/WebVttImportExport.cs
@@ -145,18 +145,12 @@ namespace Nikse.SubtitleEdit.Forms.VTT
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
+            listViewExportStyles.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewExportStyles.InvertCheck();
         }
     }
 }

--- a/src/ui/Forms/VTT/WebVttStylePicker.cs
+++ b/src/ui/Forms/VTT/WebVttStylePicker.cs
@@ -57,18 +57,12 @@ namespace Nikse.SubtitleEdit.Forms.VTT
 
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = true;
-            }
+            listViewExportStyles.CheckAll();
         }
 
         private void toolStripMenuItemInverseSelection_Click(object sender, EventArgs e)
         {
-            foreach (ListViewItem item in listViewExportStyles.Items)
-            {
-                item.Checked = !item.Checked;
-            }
+            listViewExportStyles.InvertCheck();
         }
 
         private void listViewExportStyles_SelectedIndexChanged(object sender, EventArgs e)

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1121,6 +1121,36 @@ namespace Nikse.SubtitleEdit.Logic
         public static void AutoSizeLastColumn(this ListView listView) =>
             listView.Columns[listView.Columns.Count - 1].Width = -2;
 
+        public static void CheckAll(this ListView lv)
+        {
+            lv.BeginUpdate();
+            foreach (ListViewItem item in lv.Items)
+            {
+                item.Checked = true;
+            }
+            lv.EndUpdate();
+        }
+        
+        public static void InvertCheck(this ListView lv)
+        {
+            lv.BeginUpdate();
+            foreach (ListViewItem item in lv.Items)
+            {
+                item.Checked = !item.Checked;
+            }
+            lv.EndUpdate();
+        }
+        
+        public static void UncheckAll(this ListView lv)
+        {
+            lv.BeginUpdate();
+            foreach (ListViewItem item in lv.Items)
+            {
+                item.Checked = false;
+            }
+            lv.EndUpdate();
+        }
+        
         public static void SelectAll(this ListView lv)
         {
             lv.BeginUpdate();


### PR DESCRIPTION
The list view item checking actions, such as "Select All" and "Invert Selection", have been refactored to their own methods (CheckAll, InvertCheck) to reduce repetition. These methods have been implemented in numerous forms across the code. This makes the codebase cleaner and more maintainable as the operations are abstracted out to separate methods.