### PR TITLE
Correct a detail

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/bin/bash
 
 function ShowHelp()
 {


### PR DESCRIPTION
Currently you should use the call “bash build.sh” with this you can just use “./build.sh”