### PR TITLE
Refactor GermanNouns class for better handling of empty noun lists

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -349,6 +349,23 @@ namespace Nikse.SubtitleEdit.Core.Common
             return false;
         }
 
+        public static bool ContainsLetter(this string s, UnicodeCategory unicodeCategory)
+        {
+            if (s != null)
+            {
+                foreach (var index in StringInfo.ParseCombiningCharacters(s))
+                {
+                    var uc = CharUnicodeInfo.GetUnicodeCategory(s, index);
+                    if (uc == unicodeCategory)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         public static bool ContainsNumber(this string s)
         {
             if (s == null)

--- a/src/libse/GermanNouns.cs
+++ b/src/libse/GermanNouns.cs
@@ -14,13 +14,14 @@ namespace Nikse.SubtitleEdit.Core
 
         public GermanNouns()
         {
-            _germanNouns = new List<string>();
             var inputFile = Path.Combine(Configuration.DictionariesDirectory, "deu_Nouns.txt");
             if (File.Exists(inputFile))
             {
                 _germanNouns = FileUtil.ReadAllLinesShared(inputFile, Encoding.UTF8).Select(p => p.Trim()).Where(p => p.Length > 1).ToList();
             }
 
+            _germanNouns = _germanNouns ?? new List<string>();
+            
             _regularExpressionList = new Dictionary<Regex, string>
             {
                 { new Regex(@"\bDas essen\b", RegexOptions.Compiled), "Das Essen" },
@@ -31,12 +32,14 @@ namespace Nikse.SubtitleEdit.Core
         public string UppercaseNouns(string text)
         {
             var textNoTags = HtmlUtil.RemoveHtmlTags(text, true);
-            if (textNoTags != textNoTags.ToUpperInvariant() && !string.IsNullOrEmpty(text))
+            if (textNoTags.ContainsLetter())
             {
                 var st = new StrippableText(text);
+                if (IsNounsLoaded())
+                {
+                    st.FixCasing(_germanNouns, true, false, false, string.Empty);
+                }
 
-                st.FixCasing(_germanNouns, true, false, false, string.Empty);
-                
                 foreach (var regex in _regularExpressionList.Keys)
                 {
                     st.StrippedText = regex.Replace(st.StrippedText, _regularExpressionList[regex]);
@@ -47,5 +50,7 @@ namespace Nikse.SubtitleEdit.Core
 
             return text;
         }
+
+        private bool IsNounsLoaded() => _germanNouns.Count > 0;
     }
 }

--- a/src/libse/GermanNouns.cs
+++ b/src/libse/GermanNouns.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -32,7 +33,7 @@ namespace Nikse.SubtitleEdit.Core
         public string UppercaseNouns(string text)
         {
             var textNoTags = HtmlUtil.RemoveHtmlTags(text, true);
-            if (textNoTags.ContainsLetter())
+            if (textNoTags.ContainsLetter(UnicodeCategory.LowercaseLetter))
             {
                 var st = new StrippableText(text);
                 if (IsNounsLoaded())


### PR DESCRIPTION
This commit revises the GermanNouns class to handle scenarios where the noun list fails to load from the file. An extra check was added to ensure the list is not null before applying text casing fixes. Additionally, a helper function was added to check if the noun list was successfully loaded.