### PR TITLE
Remove redundant XML load in SpellCheckWordLists

### DIFF
--- a/src/libse/SpellCheck/SpellCheckWordLists.cs
+++ b/src/libse/SpellCheck/SpellCheckWordLists.cs
@@ -154,10 +154,6 @@ namespace Nikse.SubtitleEdit.Core.SpellCheck
                     }
                 }
             }
-            else
-            {
-                xmlDoc.LoadXml("<UseAlways></UseAlways>");
-            }
         }
 
         private string GetUseAlwaysListFileName()


### PR DESCRIPTION
In the SpellCheckWordLists class, the redundant XML load operation in the 'else' clause has been removed. This change simplifies the code by getting rid of an unnecessary operation that was adding complexity and potentially slowing down the application.