### PR TITLE
Refactor code for XML document creation

### DIFF
--- a/src/libse/Dictionaries/NameList.cs
+++ b/src/libse/Dictionaries/NameList.cs
@@ -43,6 +43,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
             {
                 LoadNamesList(Path.Combine(_dictionaryFolder, "names.xml"));
             }
+
             foreach (var name in _blackList)
             {
                 if (_namesList.Contains(name))
@@ -97,6 +98,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
             {
                 twoLetterIsoLanguageName = LanguageName.Substring(0, 2);
             }
+
             return Path.Combine(_dictionaryFolder, twoLetterIsoLanguageName + "_names.xml");
         }
 
@@ -171,15 +173,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 _namesMultiList.Remove(name);
 
                 var fileName = GetLocalNamesUserFileName();
-                var nameListXml = new XmlDocument { XmlResolver = null };
-                if (File.Exists(fileName))
-                {
-                    nameListXml.Load(fileName);
-                }
-                else
-                {
-                    nameListXml.LoadXml("<names><blacklist></blacklist></names>");
-                }
+                var nameListXml = CreateDocument(fileName);
 
                 // Add removed name to blacklist
                 var nameNode = nameListXml.CreateElement("name");
@@ -208,6 +202,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                         nameListXml.DocumentElement.RemoveChild(nodeToRemove);
                     }
                 }
+
                 try
                 {
                     nameListXml.Save(fileName);
@@ -218,6 +213,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                     System.Diagnostics.Debug.WriteLine("NamesList.Remove failed");
                 }
             }
+
             return false;
         }
 
@@ -254,15 +250,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
 
             // <two-letter-iso-code>_names.xml, e.g "en_names.xml"
             var fileName = GetLocalNamesUserFileName();
-            var nameListXml = new XmlDocument { XmlResolver = null };
-            if (File.Exists(fileName))
-            {
-                nameListXml.Load(fileName);
-            }
-            else
-            {
-                nameListXml.LoadXml("<names><blacklist></blacklist></names>");
-            }
+            var nameListXml = CreateDocument(fileName);
 
             var de = nameListXml.DocumentElement;
             if (de != null)
@@ -272,7 +260,23 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 de.AppendChild(node);
                 nameListXml.Save(fileName);
             }
+
             return true;
+        }
+
+        private static XmlDocument CreateDocument(string fileName)
+        {
+            var xmlDocument = new XmlDocument { XmlResolver = null };
+            if (File.Exists(fileName))
+            {
+                xmlDocument.Load(fileName);
+            }
+            else
+            {
+                xmlDocument.LoadXml("<names><blacklist></blacklist></names>");
+            }
+
+            return xmlDocument;
         }
 
         public bool IsInNamesMultiWordList(string input, string word)
@@ -327,6 +331,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                     return true;
                 }
             }
+
             return false;
         }
 

--- a/src/libse/Dictionaries/NameList.cs
+++ b/src/libse/Dictionaries/NameList.cs
@@ -225,27 +225,9 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 return false;
             }
 
-            if (name.IndexOf(' ') >= 0)
+            if (!TryAdd(name))
             {
-                if (!_namesMultiList.Contains(name))
-                {
-                    _namesMultiList.Add(name);
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                if (!_namesList.Contains(name))
-                {
-                    _namesList.Add(name);
-                }
-                else
-                {
-                    return false;
-                }
+                return false;
             }
 
             // <two-letter-iso-code>_names.xml, e.g "en_names.xml"
@@ -262,6 +244,12 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
             }
 
             return true;
+        }
+
+        private bool TryAdd(string name)
+        {
+            var collection = name.Contains(" ") ? _namesMultiList : _namesList;
+            return collection.Add(name);
         }
 
         private static XmlDocument CreateDocument(string fileName)


### PR DESCRIPTION
The XML document creation has been refactored into a separate function to reduce repetition. Prior code for creating the XML document was repeated in several places, specifically in the 'Remove' and 'Add' functions. The new 'CreateDocument' function now contains this code, making the overall codebase cleaner and easier to maintain.

The logic for adding names to either _namesMultiList or _namesList in the NameList class was spread widely in the method. It has now been encapsulated within a new private method called TryAdd. This commit leads to cleaner and clearer code within the class and promotes easier maintenance in the future.