### PR TITLE
Feature: Hot keys to the Ocr-Character-Inspect-Form

### DIFF
--- a/LanguageBaseEnglish.xml
+++ b/LanguageBaseEnglish.xml
@@ -3353,6 +3353,13 @@ Keep changes?</KeepChangesMessage>
     <InspectItems>Inspect items</InspectItems>
     <AddBetterMatch>Add better match</AddBetterMatch>
     <Add>Add</Add>
+    <AddBetterMultiMatch>Add better multi match</AddBetterMultiMatch>
+    <AddOrUpdateMatch>Add or update match</AddOrUpdateMatch>
+    <SelectPrevousMatch>Select the previous match</SelectPrevousMatch>
+    <SelectNextMatch>Select the next match</SelectNextMatch>
+    <JumpPreviousMissingMatch>Jump to the previous missing match</JumpPreviousMissingMatch>
+    <JumpNextMissingMatch>Jump to the next missing match</JumpNextMissingMatch>
+    <FocusTextbox>Focus the text input</FocusTextbox>
   </VobSubOcrCharacterInspect>
   <VobSubOcrNewFolder>
     <Title>New folder</Title>

--- a/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.Designer.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.Designer.cs
@@ -183,6 +183,7 @@
             this.textBoxText.Name = "textBoxText";
             this.textBoxText.Size = new System.Drawing.Size(100, 23);
             this.textBoxText.TabIndex = 1;
+            this.textBoxText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBoxText_KeyDown);
             // 
             // contextMenuStripLetters
             // 
@@ -222,6 +223,7 @@
             this.listBoxInspectItems.Size = new System.Drawing.Size(240, 290);
             this.listBoxInspectItems.TabIndex = 12;
             this.listBoxInspectItems.SelectedIndexChanged += new System.EventHandler(this.listBoxInspectItems_SelectedIndexChanged);
+            this.listBoxInspectItems.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listBoxInspectItems_KeyDown);
             // 
             // contextMenuStripAddBetterMultiMatch
             // 

--- a/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.Designer.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.Designer.cs
@@ -40,24 +40,38 @@
             this.buttonUpdate = new System.Windows.Forms.Button();
             this.labelImageInfo = new System.Windows.Forms.Label();
             this.textBoxText = new Nikse.SubtitleEdit.Controls.NikseTextBox();
-            this.contextMenuStripLetters = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.contextMenuStripTextbox = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.pictureBoxCompareBitmap = new System.Windows.Forms.PictureBox();
             this.buttonOK = new System.Windows.Forms.Button();
             this.listBoxInspectItems = new System.Windows.Forms.ListBox();
-            this.contextMenuStripAddBetterMultiMatch = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.contextMenuCharacterList = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.addBetterMultiMatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.jumpToPreviousMissingMatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.jumpToNextMissingMatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.focusTheTextInputToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.groupBoxInspectItems = new System.Windows.Forms.GroupBox();
             this.buttonDetectFont = new System.Windows.Forms.Button();
             this.labelImageSize = new System.Windows.Forms.Label();
             this.labelExpandCount = new System.Windows.Forms.Label();
             this.pictureBoxInspectItem = new System.Windows.Forms.PictureBox();
             this.labelCount = new System.Windows.Forms.Label();
+            this.contextMenuStripTextbox2 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripSeparator();
+            this.addOrUpdateMatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
+            this.selectThePreviousMatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectTheNextMatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.jumpToPreviousMissingMatchToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.jumpToNextMissingMatchToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.groupBoxCurrentCompareImage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxCompareBitmapDouble)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxCompareBitmap)).BeginInit();
-            this.contextMenuStripAddBetterMultiMatch.SuspendLayout();
+            this.contextMenuCharacterList.SuspendLayout();
             this.groupBoxInspectItems.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInspectItem)).BeginInit();
+            this.contextMenuStripTextbox2.SuspendLayout();
             this.SuspendLayout();
             // 
             // buttonCancel
@@ -177,18 +191,19 @@
             // 
             // textBoxText
             // 
-            this.textBoxText.ContextMenuStrip = this.contextMenuStripLetters;
+            this.textBoxText.ContextMenuStrip = this.contextMenuStripTextbox;
+            this.textBoxText.FocusedColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(120)))), ((int)(((byte)(215)))));
             this.textBoxText.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxText.Location = new System.Drawing.Point(14, 35);
             this.textBoxText.Name = "textBoxText";
             this.textBoxText.Size = new System.Drawing.Size(100, 23);
             this.textBoxText.TabIndex = 1;
-            this.textBoxText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBoxText_KeyDown);
+            this.textBoxText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextBoxText_KeyDown);
             // 
-            // contextMenuStripLetters
+            // contextMenuStripTextbox
             // 
-            this.contextMenuStripLetters.Name = "contextMenuStripLetters";
-            this.contextMenuStripLetters.Size = new System.Drawing.Size(181, 26);
+            this.contextMenuStripTextbox.Name = "contextMenuStripLetters";
+            this.contextMenuStripTextbox.Size = new System.Drawing.Size(61, 4);
             // 
             // pictureBoxCompareBitmap
             // 
@@ -215,7 +230,7 @@
             // 
             this.listBoxInspectItems.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.listBoxInspectItems.ContextMenuStrip = this.contextMenuStripAddBetterMultiMatch;
+            this.listBoxInspectItems.ContextMenuStrip = this.contextMenuCharacterList;
             this.listBoxInspectItems.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.listBoxInspectItems.FormattingEnabled = true;
             this.listBoxInspectItems.Location = new System.Drawing.Point(6, 19);
@@ -223,22 +238,61 @@
             this.listBoxInspectItems.Size = new System.Drawing.Size(240, 290);
             this.listBoxInspectItems.TabIndex = 12;
             this.listBoxInspectItems.SelectedIndexChanged += new System.EventHandler(this.listBoxInspectItems_SelectedIndexChanged);
-            this.listBoxInspectItems.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listBoxInspectItems_KeyDown);
+            this.listBoxInspectItems.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ListBoxInspectItems_KeyDown);
             // 
-            // contextMenuStripAddBetterMultiMatch
+            // contextMenuCharacterList
             // 
-            this.contextMenuStripAddBetterMultiMatch.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.addBetterMultiMatchToolStripMenuItem});
-            this.contextMenuStripAddBetterMultiMatch.Name = "contextMenuStripAddBetterMultiMatch";
-            this.contextMenuStripAddBetterMultiMatch.Size = new System.Drawing.Size(199, 26);
-            this.contextMenuStripAddBetterMultiMatch.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStripAddBetterMultiMatch_Opening);
+            this.contextMenuCharacterList.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.addBetterMultiMatchToolStripMenuItem,
+            this.toolStripMenuItem1,
+            this.jumpToPreviousMissingMatchToolStripMenuItem,
+            this.jumpToNextMissingMatchToolStripMenuItem,
+            this.toolStripMenuItem2,
+            this.focusTheTextInputToolStripMenuItem});
+            this.contextMenuCharacterList.Name = "contextMenuStripAddBetterMultiMatch";
+            this.contextMenuCharacterList.Size = new System.Drawing.Size(298, 104);
+            this.contextMenuCharacterList.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStripListBox_Opening);
             // 
             // addBetterMultiMatchToolStripMenuItem
             // 
             this.addBetterMultiMatchToolStripMenuItem.Name = "addBetterMultiMatchToolStripMenuItem";
-            this.addBetterMultiMatchToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.addBetterMultiMatchToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
             this.addBetterMultiMatchToolStripMenuItem.Text = "Add better multi match";
             this.addBetterMultiMatchToolStripMenuItem.Click += new System.EventHandler(this.addBetterMultiMatchToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(294, 6);
+            // 
+            // jumpToPreviousMissingMatchToolStripMenuItem
+            // 
+            this.jumpToPreviousMissingMatchToolStripMenuItem.Name = "jumpToPreviousMissingMatchToolStripMenuItem";
+            this.jumpToPreviousMissingMatchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Up)));
+            this.jumpToPreviousMissingMatchToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            this.jumpToPreviousMissingMatchToolStripMenuItem.Text = "Jump to previous missing match";
+            this.jumpToPreviousMissingMatchToolStripMenuItem.Click += new System.EventHandler(this.JumpToPreviousMissingMatchToolStripMenuItem_Click);
+            // 
+            // jumpToNextMissingMatchToolStripMenuItem
+            // 
+            this.jumpToNextMissingMatchToolStripMenuItem.Name = "jumpToNextMissingMatchToolStripMenuItem";
+            this.jumpToNextMissingMatchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Down)));
+            this.jumpToNextMissingMatchToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            this.jumpToNextMissingMatchToolStripMenuItem.Text = "Jump to next missing match";
+            this.jumpToNextMissingMatchToolStripMenuItem.Click += new System.EventHandler(this.JumpToNextMissingMatchToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem2
+            // 
+            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(294, 6);
+            // 
+            // focusTheTextInputToolStripMenuItem
+            // 
+            this.focusTheTextInputToolStripMenuItem.Name = "focusTheTextInputToolStripMenuItem";
+            this.focusTheTextInputToolStripMenuItem.ShortcutKeyDisplayString = "Enter";
+            this.focusTheTextInputToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            this.focusTheTextInputToolStripMenuItem.Text = "Focus the text input";
+            this.focusTheTextInputToolStripMenuItem.Click += new System.EventHandler(this.FocusTheTextInputToolStripMenuItem_Click);
             // 
             // groupBoxInspectItems
             // 
@@ -306,6 +360,69 @@
             this.labelCount.TabIndex = 30;
             this.labelCount.Text = "labelCount";
             // 
+            // contextMenuStripTextbox2
+            // 
+            this.contextMenuStripTextbox2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem4,
+            this.addOrUpdateMatchToolStripMenuItem,
+            this.toolStripMenuItem3,
+            this.selectThePreviousMatchToolStripMenuItem,
+            this.selectTheNextMatchToolStripMenuItem,
+            this.jumpToPreviousMissingMatchToolStripMenuItem1,
+            this.jumpToNextMissingMatchToolStripMenuItem1});
+            this.contextMenuStripTextbox2.Name = "contextMenuStripTextbox2";
+            this.contextMenuStripTextbox2.Size = new System.Drawing.Size(298, 126);
+            // 
+            // toolStripMenuItem4
+            // 
+            this.toolStripMenuItem4.Name = "toolStripMenuItem4";
+            this.toolStripMenuItem4.Size = new System.Drawing.Size(294, 6);
+            // 
+            // addOrUpdateMatchToolStripMenuItem
+            // 
+            this.addOrUpdateMatchToolStripMenuItem.Name = "addOrUpdateMatchToolStripMenuItem";
+            this.addOrUpdateMatchToolStripMenuItem.ShortcutKeyDisplayString = "Enter";
+            this.addOrUpdateMatchToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            this.addOrUpdateMatchToolStripMenuItem.Text = "Add or update match";
+            this.addOrUpdateMatchToolStripMenuItem.Click += new System.EventHandler(this.AddOrUpdateMatchToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem3
+            // 
+            this.toolStripMenuItem3.Name = "toolStripMenuItem3";
+            this.toolStripMenuItem3.Size = new System.Drawing.Size(294, 6);
+            // 
+            // selectThePreviousMatchToolStripMenuItem
+            // 
+            this.selectThePreviousMatchToolStripMenuItem.Name = "selectThePreviousMatchToolStripMenuItem";
+            this.selectThePreviousMatchToolStripMenuItem.ShortcutKeyDisplayString = "Up";
+            this.selectThePreviousMatchToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            this.selectThePreviousMatchToolStripMenuItem.Text = "Select the previous match";
+            this.selectThePreviousMatchToolStripMenuItem.Click += new System.EventHandler(this.SelectThePreviousMatchToolStripMenuItem_Click);
+            // 
+            // selectTheNextMatchToolStripMenuItem
+            // 
+            this.selectTheNextMatchToolStripMenuItem.Name = "selectTheNextMatchToolStripMenuItem";
+            this.selectTheNextMatchToolStripMenuItem.ShortcutKeyDisplayString = "Down";
+            this.selectTheNextMatchToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            this.selectTheNextMatchToolStripMenuItem.Text = "Select the next match";
+            this.selectTheNextMatchToolStripMenuItem.Click += new System.EventHandler(this.SelectTheNextMatchToolStripMenuItem_Click);
+            // 
+            // jumpToPreviousMissingMatchToolStripMenuItem1
+            // 
+            this.jumpToPreviousMissingMatchToolStripMenuItem1.Name = "jumpToPreviousMissingMatchToolStripMenuItem1";
+            this.jumpToPreviousMissingMatchToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Up)));
+            this.jumpToPreviousMissingMatchToolStripMenuItem1.Size = new System.Drawing.Size(297, 22);
+            this.jumpToPreviousMissingMatchToolStripMenuItem1.Text = "Jump to previous missing match";
+            this.jumpToPreviousMissingMatchToolStripMenuItem1.Click += new System.EventHandler(this.JumpToPreviousMissingMatchToolStripMenuItem_Click);
+            // 
+            // jumpToNextMissingMatchToolStripMenuItem1
+            // 
+            this.jumpToNextMissingMatchToolStripMenuItem1.Name = "jumpToNextMissingMatchToolStripMenuItem1";
+            this.jumpToNextMissingMatchToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Down)));
+            this.jumpToNextMissingMatchToolStripMenuItem1.Size = new System.Drawing.Size(297, 22);
+            this.jumpToNextMissingMatchToolStripMenuItem1.Text = "Jump to next missing match";
+            this.jumpToNextMissingMatchToolStripMenuItem1.Click += new System.EventHandler(this.JumpToNextMissingMatchToolStripMenuItem_Click);
+            // 
             // VobSubOcrCharacterInspect
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -330,10 +447,11 @@
             this.groupBoxCurrentCompareImage.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxCompareBitmapDouble)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxCompareBitmap)).EndInit();
-            this.contextMenuStripAddBetterMultiMatch.ResumeLayout(false);
+            this.contextMenuCharacterList.ResumeLayout(false);
             this.groupBoxInspectItems.ResumeLayout(false);
             this.groupBoxInspectItems.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxInspectItem)).EndInit();
+            this.contextMenuStripTextbox2.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -359,10 +477,23 @@
         private System.Windows.Forms.Button buttonAddBetterMatch;
         private System.Windows.Forms.Label labelExpandCount;
         private System.Windows.Forms.Label labelCount;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStripAddBetterMultiMatch;
+        private System.Windows.Forms.ContextMenuStrip contextMenuCharacterList;
         private System.Windows.Forms.ToolStripMenuItem addBetterMultiMatchToolStripMenuItem;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStripLetters;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStripTextbox;
         private System.Windows.Forms.Label labelImageSize;
         private System.Windows.Forms.Button buttonDetectFont;
+        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem jumpToPreviousMissingMatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem jumpToNextMissingMatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
+        private System.Windows.Forms.ToolStripMenuItem focusTheTextInputToolStripMenuItem;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStripTextbox2;
+        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem4;
+        private System.Windows.Forms.ToolStripMenuItem addOrUpdateMatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem3;
+        private System.Windows.Forms.ToolStripMenuItem selectThePreviousMatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectTheNextMatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem jumpToPreviousMissingMatchToolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem jumpToNextMissingMatchToolStripMenuItem1;
     }
 }

--- a/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.cs
@@ -31,26 +31,52 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         {
             UiUtil.PreInitialize(this);
             InitializeComponent();
-            VobSubEditCharacters.MakeToolStripLetters(contextMenuStripLetters, InsertLanguageCharacter);
+            VobSubEditCharacters.MakeToolStripLetters(contextMenuStripTextbox, InsertLanguageCharacter);
             UiUtil.FixFonts(this);
+
+            LanguageStructure.VobSubEditCharacters langCharEdit = LanguageSettings.Current.VobSubEditCharacters;
+            LanguageStructure.VobSubOcrCharacterInspect langCharInspect = LanguageSettings.Current.VobSubOcrCharacterInspect;
 
             labelCount.Text = string.Empty;
             labelExpandCount.Text = string.Empty;
             labelImageSize.Text = string.Empty;
-            Text = LanguageSettings.Current.VobSubOcrCharacterInspect.Title;
-            groupBoxInspectItems.Text = LanguageSettings.Current.VobSubOcrCharacterInspect.InspectItems;
+            Text = langCharInspect.Title;
+            groupBoxInspectItems.Text = langCharInspect.InspectItems;
             labelImageInfo.Text = string.Empty;
-            groupBoxCurrentCompareImage.Text = LanguageSettings.Current.VobSubEditCharacters.CurrentCompareImage;
-            labelTextAssociatedWithImage.Text = LanguageSettings.Current.VobSubEditCharacters.TextAssociatedWithImage;
-            checkBoxItalic.Text = LanguageSettings.Current.VobSubEditCharacters.IsItalic;
-            buttonUpdate.Text = LanguageSettings.Current.VobSubEditCharacters.Update;
-            buttonDelete.Text = LanguageSettings.Current.VobSubEditCharacters.Delete;
-            buttonAddBetterMatch.Text = LanguageSettings.Current.VobSubOcrCharacterInspect.AddBetterMatch;
-            labelDoubleSize.Text = LanguageSettings.Current.VobSubEditCharacters.ImageDoubleSize;
-            buttonOK.Text = LanguageSettings.Current.General.Ok;
+            groupBoxCurrentCompareImage.Text = langCharEdit.CurrentCompareImage;
+            labelTextAssociatedWithImage.Text = langCharEdit.TextAssociatedWithImage;
+            checkBoxItalic.Text = langCharEdit.IsItalic;
+            buttonUpdate.Text = langCharEdit.Update;
+            buttonDelete.Text = langCharEdit.Delete;
+            buttonAddBetterMatch.Text = langCharInspect.AddBetterMatch;
+            labelDoubleSize.Text = langCharEdit.ImageDoubleSize;
             buttonCancel.Text = LanguageSettings.Current.General.Cancel;
+            buttonOK.Text = LanguageSettings.Current.General.Ok;
             UiUtil.FixLargeFonts(this, buttonOK);
+
+            addBetterMultiMatchToolStripMenuItem.Text = langCharInspect.AddBetterMultiMatch;
+            addOrUpdateMatchToolStripMenuItem.Text = langCharInspect.AddOrUpdateMatch;
+            selectThePreviousMatchToolStripMenuItem.Text = langCharInspect.SelectPrevousMatch;
+            selectTheNextMatchToolStripMenuItem.Text = langCharInspect.SelectNextMatch;
+            jumpToPreviousMissingMatchToolStripMenuItem1.Text = langCharInspect.JumpPreviousMissingMatch;
+            jumpToPreviousMissingMatchToolStripMenuItem.Text = langCharInspect.JumpPreviousMissingMatch;
+            jumpToNextMissingMatchToolStripMenuItem1.Text = langCharInspect.JumpNextMissingMatch;
+            jumpToNextMissingMatchToolStripMenuItem.Text = langCharInspect.JumpNextMissingMatch;
+            focusTheTextInputToolStripMenuItem.Text = langCharInspect.FocusTextbox;
+
+            addOrUpdateMatchToolStripMenuItem.ShortcutKeyDisplayString = Keys.Enter.ToString();
+            selectThePreviousMatchToolStripMenuItem.ShortcutKeyDisplayString = Keys.Up.ToString();
+            selectTheNextMatchToolStripMenuItem.ShortcutKeyDisplayString = Keys.Down.ToString();
+            focusTheTextInputToolStripMenuItem.ShortcutKeyDisplayString = Keys.Enter.ToString();
+
             buttonDetectFont.Visible = Configuration.Settings.General.ShowBetaStuff;
+
+            ToolStripItem[] extraTextboxItems = new ToolStripItem[contextMenuStripTextbox2.Items.Count];
+            contextMenuStripTextbox2.Items.CopyTo(extraTextboxItems, 0);
+            foreach (ToolStripItem item in extraTextboxItems)
+            {
+                contextMenuStripTextbox.Items.Add(item);
+            }
         }
 
         internal void Initialize(string databaseFolderName, List<VobSubOcr.CompareMatch> matches, List<Bitmap> imageSources, BinaryOcrDb binOcrDb, List<ImageSplitterItem> splitterItems)
@@ -266,10 +292,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             pictureBoxCompareBitmapDouble.Image = bitmap;
         }
 
-        private void buttonUpdate_Click(object sender, EventArgs e)
-        {
-            UpdateMatch();
-        }
+        private void buttonUpdate_Click(object sender, EventArgs e) => UpdateMatch();
 
         private void UpdateMatch()
         {
@@ -384,10 +407,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             listBoxInspectItems_SelectedIndexChanged(null, null);
         }
 
-        private void buttonAddBetterMatch_Click(object sender, EventArgs e)
-        {
-            AddBetterMatch();
-        }
+        private void buttonAddBetterMatch_Click(object sender, EventArgs e) => AddBetterMatch();
 
         private void AddBetterMatch()
         {
@@ -532,28 +552,42 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             listBoxInspectItems.SelectedIndex = index;
         }
 
-        private void SelectNoMatch(bool previous)
+        private void SelectCharacterItem(bool previous, bool missingMatch)
         {
             if (previous)
             {
-                for (int i = listBoxInspectItems.SelectedIndex - 1; i >= 0; i--)
+                if (missingMatch)
                 {
-                    if (_matches[i].Text == LanguageSettings.Current.VobSubOcr.NoMatch)
+                    for (int i = listBoxInspectItems.SelectedIndex - 1; i >= 0; i--)
                     {
-                        listBoxInspectItems.SelectedIndex = i;
-                        break;
+                        if (_matches[i].Text == LanguageSettings.Current.VobSubOcr.NoMatch)
+                        {
+                            listBoxInspectItems.SelectedIndex = i;
+                            break;
+                        }
                     }
+                }
+                else if (listBoxInspectItems.SelectedIndex > 0)
+                {
+                    listBoxInspectItems.SelectedIndex--;
                 }
             }
             else
             {
-                for (int i = listBoxInspectItems.SelectedIndex + 1; i < _matches.Count; i++)
+                if (missingMatch)
                 {
-                    if (_matches[i].Text == LanguageSettings.Current.VobSubOcr.NoMatch)
+                    for (int i = listBoxInspectItems.SelectedIndex + 1; i < _matches.Count; i++)
                     {
-                        listBoxInspectItems.SelectedIndex = i;
-                        break;
+                        if (_matches[i].Text == LanguageSettings.Current.VobSubOcr.NoMatch)
+                        {
+                            listBoxInspectItems.SelectedIndex = i;
+                            break;
+                        }
                     }
+                }
+                else if (listBoxInspectItems.SelectedIndex < listBoxInspectItems.Items.Count - 1)
+                {
+                    listBoxInspectItems.SelectedIndex++;
                 }
             }
         }
@@ -566,27 +600,27 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             }
         }
 
-        private void contextMenuStripAddBetterMultiMatch_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void contextMenuStripListBox_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             if (listBoxInspectItems.SelectedIndex < 0 ||
                 listBoxInspectItems.SelectedIndex == listBoxInspectItems.Items.Count - 1 ||
                 _binOcrDb == null ||
                 _selectedCompareBinaryOcrBitmap != null && _selectedCompareBinaryOcrBitmap.ExpandCount > 1)
             {
-                e.Cancel = true;
+                addBetterMultiMatchToolStripMenuItem.Enabled = false;
                 return;
             }
 
             if (_matches[listBoxInspectItems.SelectedIndex].ImageSplitterItem == null)
             {
-                e.Cancel = true;
+                addBetterMultiMatchToolStripMenuItem.Enabled = false;
                 return;
             }
 
             var next = _matches[listBoxInspectItems.SelectedIndex + 1];
             if (next.ExpandCount > 0 || next.Extra?.Count > 0)
             {
-                e.Cancel = true;
+                addBetterMultiMatchToolStripMenuItem.Enabled = false;
                 return;
             }
 
@@ -597,7 +631,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
             if (next.ImageSplitterItem?.NikseBitmap == null || !string.IsNullOrWhiteSpace(next.ImageSplitterItem.SpecialCharacter))
             {
-                e.Cancel = true;
+                addBetterMultiMatchToolStripMenuItem.Enabled = false;
             }
         }
 
@@ -662,7 +696,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             }
         }
 
-        private void textBoxText_KeyDown(object sender, KeyEventArgs e)
+        private void TextBoxText_KeyDown(object sender, KeyEventArgs e)
         {
             bool executedAddOrUpdate = false;
             bool changedSelection = false;
@@ -685,17 +719,11 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 //Allow navigating the list box while in the text field. Put the cursor at the end too, in case there already is a character
                 if (e.Modifiers == Keys.Control)
                 {
-                    SelectNoMatch(true);
+                    SelectCharacterItem(true, true);
                 }
                 else
                 {
-                    if (listBoxInspectItems.SelectedIndex > 0)
-                    {
-                        listBoxInspectItems.SelectedIndex--;
-
-                        textBoxText.SelectionStart = 0;
-                        textBoxText.SelectionLength = textBoxText.Text.Length;
-                    }
+                    SelectCharacterItem(true, false);
                 }
                 changedSelection = true;
             }
@@ -703,14 +731,11 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             {
                 if (e.Modifiers == Keys.Control)
                 {
-                    SelectNoMatch(false);
+                    SelectCharacterItem(false, true);
                 }
                 else
                 {
-                    if (listBoxInspectItems.SelectedIndex < listBoxInspectItems.Items.Count - 1)
-                    {
-                        listBoxInspectItems.SelectedIndex++;
-                    }
+                    SelectCharacterItem(false, false);
                 }
                 changedSelection = true;
             }
@@ -728,7 +753,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             }
         }
 
-        private void listBoxInspectItems_KeyDown(object sender, KeyEventArgs e)
+        private void ListBoxInspectItems_KeyDown(object sender, KeyEventArgs e)
         {
             //Allows instantly entering back into the textbox, editing the next recognized character.
             bool handled = false;
@@ -742,12 +767,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 if (e.KeyCode == Keys.Up)
                 {
                     handled = true;
-                    SelectNoMatch(true);
+                    SelectCharacterItem(true, true);
                 }
                 else if (e.KeyCode == Keys.Down)
                 {
                     handled = true;
-                    SelectNoMatch(false);
+                    SelectCharacterItem(false, true);
                 }
             }
 
@@ -757,5 +782,27 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 e.SuppressKeyPress = true;
             }
         }
+
+        private void AddOrUpdateMatchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (buttonAddBetterMatch.Enabled)
+            {
+                AddBetterMatch();
+            }
+            else if (buttonUpdate.Enabled)
+            {
+                UpdateMatch();
+            }
+        }
+
+        private void JumpToPreviousMissingMatchToolStripMenuItem_Click(object sender, EventArgs e) => SelectCharacterItem(true, true);
+
+        private void JumpToNextMissingMatchToolStripMenuItem_Click(object sender, EventArgs e) => SelectCharacterItem(false, true);
+
+        private void FocusTheTextInputToolStripMenuItem_Click(object sender, EventArgs e) => textBoxText.Focus();
+
+        private void SelectThePreviousMatchToolStripMenuItem_Click(object sender, EventArgs e) => SelectCharacterItem(true, false);
+
+        private void SelectTheNextMatchToolStripMenuItem_Click(object sender, EventArgs e) => SelectCharacterItem(false, false);
     }
 }

--- a/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.resx
+++ b/src/ui/Forms/Ocr/VobSubOcrCharacterInspect.resx
@@ -117,10 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="contextMenuStripLetters.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="contextMenuStripTextbox.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>202, 17</value>
   </metadata>
-  <metadata name="contextMenuStripAddBetterMultiMatch.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="contextMenuCharacterList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="contextMenuStripTextbox2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>392, 17</value>
   </metadata>
 </root>

--- a/src/ui/Languages/de-DE.xml
+++ b/src/ui/Languages/de-DE.xml
@@ -3361,6 +3361,13 @@ Wir nutzen den dem Bild innewohnenden Rhythmus.</CreateSimpleChainingToolTip>
     <InspectItems>Untersuche Text</InspectItems>
     <AddBetterMatch>Besseren Treffer hinzufügen</AddBetterMatch>
     <Add>Hinzufügen</Add>
+    <AddBetterMultiMatch>Besseren Multi-Treffer hinzufügen</AddBetterMultiMatch>
+    <AddOrUpdateMatch>Treffer hinzufügen oder ändern</AddOrUpdateMatch>
+    <SelectPrevousMatch>Vorherigen Treffer auswählen</SelectPrevousMatch>
+    <SelectNextMatch>Nächsten Treffer auswählen</SelectNextMatch>
+    <JumpPreviousMissingMatch>Vorherigen fehlenden Treffer auswählen</JumpPreviousMissingMatch>
+    <JumpNextMissingMatch>Nächsten fehlenden Treffer auswählen</JumpNextMissingMatch>
+    <FocusTextbox>Textfeld fokussieren</FocusTextbox>
   </VobSubOcrCharacterInspect>
   <VobSubOcrNewFolder>
     <Title>Neuer Ordner</Title>

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -3768,6 +3768,13 @@ Keep changes?",
                 InspectItems = "Inspect items",
                 AddBetterMatch = "Add better match",
                 Add = "Add",
+                AddBetterMultiMatch = "Add better multi match",
+                AddOrUpdateMatch = "Add or update match",
+                SelectPrevousMatch = "Select the previous match",
+                SelectNextMatch = "Select the next match",
+                JumpPreviousMissingMatch = "Jump to the previous missing match",
+                JumpNextMissingMatch = "Jump to the next missing match",
+                FocusTextbox = "Focus the text input",
             };
 
             VobSubOcrNewFolder = new LanguageStructure.VobSubOcrNewFolder

--- a/src/ui/Logic/LanguageDeserializer.cs
+++ b/src/ui/Logic/LanguageDeserializer.cs
@@ -9172,6 +9172,27 @@ namespace Nikse.SubtitleEdit.Logic
                 case "VobSubOcrCharacterInspect/Add":
                     language.VobSubOcrCharacterInspect.Add = reader.Value;
                     break;
+                case "VobSubOcrCharacterInspect/AddBetterMultiMatch":
+                    language.VobSubOcrCharacterInspect.AddBetterMultiMatch = reader.Value;
+                    break;
+                case "VobSubOcrCharacterInspect/AddOrUpdateMatch":
+                    language.VobSubOcrCharacterInspect.AddOrUpdateMatch = reader.Value;
+                    break;
+                case "VobSubOcrCharacterInspect/SelectPrevousMatch":
+                    language.VobSubOcrCharacterInspect.SelectPrevousMatch = reader.Value;
+                    break;
+                case "VobSubOcrCharacterInspect/SelectNextMatch":
+                    language.VobSubOcrCharacterInspect.SelectNextMatch = reader.Value;
+                    break;
+                case "VobSubOcrCharacterInspect/JumpPreviousMissingMatch":
+                    language.VobSubOcrCharacterInspect.JumpPreviousMissingMatch = reader.Value;
+                    break;
+                case "VobSubOcrCharacterInspect/JumpNextMissingMatch":
+                    language.VobSubOcrCharacterInspect.JumpNextMissingMatch = reader.Value;
+                    break;
+                case "VobSubOcrCharacterInspect/FocusTextbox":
+                    language.VobSubOcrCharacterInspect.FocusTextbox = reader.Value;
+                    break;
                 case "VobSubOcrNewFolder/Title":
                     language.VobSubOcrNewFolder.Title = reader.Value;
                     break;

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -3575,6 +3575,13 @@
             public string InspectItems { get; set; }
             public string AddBetterMatch { get; set; }
             public string Add { get; set; }
+            public string AddBetterMultiMatch { get; set; }
+            public string AddOrUpdateMatch { get; set; }
+            public string SelectPrevousMatch { get; set; }
+            public string SelectNextMatch { get; set; }
+            public string JumpPreviousMissingMatch { get; set; }
+            public string JumpNextMissingMatch { get; set; }
+            public string FocusTextbox { get; set; }
         }
 
         public class VobSubOcrNewFolder


### PR DESCRIPTION
This pull request allows the user to not have to rely on their mouse as much when mapping a bitmap to a character.

It definitely helped me speed up the OCR-process. It might be useful for others, but that is up to you.

![VOB OCR Character Edit](https://github.com/SubtitleEdit/subtitleedit/assets/8478950/d1759cf8-7e7d-47b0-8888-b8ea8aa2dcd4)

In the list box:
- `Enter` in the list box puts focus onto the text box
- `Ctrl+Up`/`Ctrl+Down` jumps to the next missing match

In the text box:
- `Enter` in the text box adds or updates the character
- `Up`/`Down` navigates up and down in the list box
- `Ctrl+Up`/`Ctrl+Down` jumps to the next missing match

To be honest, I wasn't sure how to make it clear to the user, that these hot keys exist. I was going to add a label with a hint, but I didn't want to do too much and it not being wanted to begin with. Feedback is welcome.