### PR TITLE
Refactor progress report in WhisperModelDownload

### DIFF
--- a/src/ui/Forms/AudioToText/WhisperModelDownload.cs
+++ b/src/ui/Forms/AudioToText/WhisperModelDownload.cs
@@ -103,6 +103,11 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                     }
                 }
 
+                var progressReport = new Progress<float>((progress) =>
+                {
+                    var pct = (int)Math.Round(progress * 100.0, MidpointRounding.AwayFromZero);
+                    labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait + "  " + pct + "%";
+                });
                 foreach (var url in LastDownloadedModel.Urls)
                 {
                     using (var httpClient = DownloaderFactory.MakeHttpClient())
@@ -112,11 +117,8 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                         labelFileName.Text = url.Split('/').Last();
                         using (var downloadStream = new FileStream(_downloadFileName, FileMode.Create, FileAccess.Write))
                         {
-                            var downloadTask = httpClient.DownloadAsync(url, downloadStream, new Progress<float>((progress) =>
-                            {
-                                var pct = (int)Math.Round(progress * 100.0, MidpointRounding.AwayFromZero);
-                                labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait + "  " + pct + "%";
-                            }), _cancellationTokenSource.Token);
+                            var downloadTask = httpClient.DownloadAsync(url, downloadStream, progressReport,
+                                _cancellationTokenSource.Token);
 
                             while (!downloadTask.IsCompleted && !downloadTask.IsCanceled)
                             {


### PR DESCRIPTION
This commit optimizes the code in WhisperModelDownload.cs by pulling out the progress reporting into a separate variable. This new implementation enhances code readability and prevents code redundancy. Now, the 'progressReport' variable is used while calling the 'DownloadAsync' method.