### PR TITLE
Update ro-RO.xml

### DIFF
--- a/src/ui/Languages/ro-RO.xml
+++ b/src/ui/Languages/ro-RO.xml
@@ -1179,6 +1179,7 @@ Pentru folosirea unui cod API de la Google Translate, accesează "Opțiuni -&gt;
       <Options>
         <Title>Opțiuni</Title>
         <Settings>&amp;Setări...</Settings>
+        <WordLists>Liste de cuvinte…</WordLists>
         <ChooseLanguage>&amp;Alege limba...</ChooseLanguage>
       </Options>
       <Networking>


### PR DESCRIPTION
Added the <WordLists>Lista de cuvinte...</WordLists> translation for Romanian. Since it was missing, the English one "Word lists..." was shown by default on the Romanian language user interface.