### PR TITLE
Add Dispose method to SubtitleListView control

### DIFF
--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -2384,5 +2384,23 @@ namespace Nikse.SubtitleEdit.Controls
 
             EndUpdate();
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                // unhook handler
+                _setLastColumnWidthTimer.Tick -= SetLastColumnWidthTimer_Tick;
+                _syntaxColorLineTimer.Tick -= SyntaxColorLineTimerTick;
+                _setStartAndDurationTimer.Tick -= SetStartAndDurationTimerTick;
+
+                // dispose timers
+                _setLastColumnWidthTimer.Dispose();
+                _syntaxColorLineTimer.Dispose();
+                _setStartAndDurationTimer.Dispose();
+            }
+        }
     }
 }


### PR DESCRIPTION
Added override to the Dispose method in SubtitleListView control which unregisters any tick events and disposes timer objects when control is being discarded. This helps to ensure resources are properly freed up, reducing potential memory leaks.