### PR TITLE
Brazilian Portuguese using DeepL

### DIFF
--- a/src/libse/AutoTranslate/DeepLTranslate.cs
+++ b/src/libse/AutoTranslate/DeepLTranslate.cs
@@ -44,9 +44,18 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
 
         public List<TranslationPair> GetSupportedSourceLanguages()
         {
+            return GetTranslationPairs();
+        }
+
+        public List<TranslationPair> GetSupportedTargetLanguages()
+        {
+            return GetTranslationPairs();
+        }
+
+        public List<TranslationPair> GetTranslationPairs()
+        {
             return new List<TranslationPair>
             {
-                MakeTranslationPair("Arabic", "ar"),
                 MakeTranslationPair("Bulgarian", "bg"),
                 MakeTranslationPair("Chinese", "zh"),
                 MakeTranslationPair("Czech", "cs"),
@@ -67,7 +76,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 MakeTranslationPair("Lithuanian", "lt"),
                 MakeTranslationPair("Norwegian (Bokmål)", "nb"),
                 MakeTranslationPair("Polish", "pl", true),
-                MakeTranslationPair("Portuguese", "pt", true),
+                MakeTranslationPair("Portuguese (Portugal)", "pt-PT", true),
+                MakeTranslationPair("Portuguese (Brazil)", "pt-BR", true),
                 MakeTranslationPair("Romanian", "ro"),
                 MakeTranslationPair("Russian", "ru", true),
                 MakeTranslationPair("Slovak", "sk"),
@@ -75,46 +85,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 MakeTranslationPair("Spanish", "es", true),
                 MakeTranslationPair("Swedish", "sv"),
                 MakeTranslationPair("Turkish", "tr"),
-                MakeTranslationPair("Ukranian", "uk"),
-            };
-        }
-
-        public List<TranslationPair> GetSupportedTargetLanguages()
-        {
-            return new List<TranslationPair>
-            {
-                MakeTranslationPair("Arabic", "ar"),
-                MakeTranslationPair("Bulgarian", "bg"),
-                MakeTranslationPair("Chinese", "zh"),
-                MakeTranslationPair("Czech", "cs"),
-                MakeTranslationPair("Danish", "da"),
-                MakeTranslationPair("Dutch", "nl", true),
-                MakeTranslationPair("English (British)", "en-gb", true),
-                MakeTranslationPair("English (American)", "en-us", true),
-                MakeTranslationPair("Estonian", "et"),
-                MakeTranslationPair("Finnish", "fi"),
-                MakeTranslationPair("French", "fr", true),
-                MakeTranslationPair("German", "de", true),
-                MakeTranslationPair("Greek", "el"),
-                MakeTranslationPair("Hungarian", "hu"),
-                MakeTranslationPair("Indonesian", "id"),
-                MakeTranslationPair("Italian", "it", true),
-                MakeTranslationPair("Japanese", "ja", true),
-                MakeTranslationPair("Korean", "ko"),
-                MakeTranslationPair("Latvian", "lv"),
-                MakeTranslationPair("Lithuanian", "lt"),
-                MakeTranslationPair("Norwegian (Bokmål)", "nb"),
-                MakeTranslationPair("Polish", "pl", true),
-                MakeTranslationPair("Portuguese", "pt-pt", true),
-                MakeTranslationPair("Portuguese (Brazil)", "pt-br", true),
-                MakeTranslationPair("Romanian", "ro"),
-                MakeTranslationPair("Russian", "ru", true),
-                MakeTranslationPair("Slovak", "sk"),
-                MakeTranslationPair("Slovenian", "sl"),
-                MakeTranslationPair("Spanish", "es", true),
-                MakeTranslationPair("Swedish", "sv"),
-                MakeTranslationPair("Turkish", "tr"),
-                MakeTranslationPair("Ukranian", "uk"),
+                MakeTranslationPair("Ukrainian", "uk"),
             };
         }
 
@@ -128,8 +99,13 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return new TranslationPair(name, code, hasFormality);
         }
 
-        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
+            if (targetLanguageCode == "pt")
+            {
+                targetLanguageCode = "pt-BR"; //Brazilian Portuguese
+            }
+
             var postContent = new FormUrlEncodedContent(new[]
             {
                 new KeyValuePair<string, string>("text", text),
@@ -137,8 +113,9 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 new KeyValuePair<string, string>("source_lang", sourceLanguageCode),
                 new KeyValuePair<string, string>("formality", _formality),
             });
-            var result = _client.PostAsync("/v2/translate", postContent, cancellationToken).Result;
-            var resultContent = result.Content.ReadAsStringAsync().Result;
+
+            var result = await _client.PostAsync("/v2/translate", postContent, cancellationToken);
+            var resultContent = await result.Content.ReadAsStringAsync();
 
             if (!result.IsSuccessStatusCode)
             {
@@ -175,7 +152,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 }
             }
 
-            return Task.FromResult(string.Join(Environment.NewLine, resultList));
+            return string.Join(Environment.NewLine, resultList);
         }
     }
 }


### PR DESCRIPTION
Translate to Brazilian Portuguese (PT-BR) and Portugal Portuguese (PT) using DeepL api.