### PR TITLE
Remove duplicate registration

### DIFF
--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -653,7 +653,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 new AvidStl(),
                 new WinCaps32(),
                 new IsmtDfxp(),
-                new Cavena890(),
                 new Spt(),
                 new Sptx(),
                 new IaiSub(),


### PR DESCRIPTION
Cavena890 is already registered.
Was there any particular reason it was registered twice?