### PR TITLE
Remove unused variable in Settings.cs

### DIFF
--- a/src/libse/Common/Settings.cs
+++ b/src/libse/Common/Settings.cs
@@ -3544,7 +3544,6 @@ $HorzAlign          =   Center
                     settings.General.Profiles.Clear();
                 }
 
-                var p = new RulesProfile();
                 var subtitleLineMaximumLength = listNode.SelectSingleNode("SubtitleLineMaximumLength")?.InnerText;
                 var subtitleMaximumCharactersPerSeconds = listNode.SelectSingleNode("SubtitleMaximumCharactersPerSeconds")?.InnerText;
                 var subtitleOptimalCharactersPerSeconds = listNode.SelectSingleNode("SubtitleOptimalCharactersPerSeconds")?.InnerText;


### PR DESCRIPTION
An unused variable 'p' of type RulesProfile has been removed from src/libse/Common/Settings.cs.