### PR TITLE
Feature/http downloader

### DIFF
--- a/src/libse/AutoTranslate/GoogleTranslateV2.cs
+++ b/src/libse/AutoTranslate/GoogleTranslateV2.cs
@@ -30,7 +30,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
         public void Initialize()
         {
             _apiKey = Configuration.Settings.Tools.GoogleApiV2Key;
-            _httpClient = DownloaderFactory.MakeHttpClient();
+            _httpClient = DownloaderFactory.CreateProxiedHttpClient();
             _httpClient.BaseAddress = new Uri("https://translation.googleapis.com/language/translate/v2/");
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }

--- a/src/libse/AutoTranslate/MicrosoftTranslator.cs
+++ b/src/libse/AutoTranslate/MicrosoftTranslator.cs
@@ -117,7 +117,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
         {
             if (_httpClient == null)
             {
-                _httpClient = DownloaderFactory.MakeHttpClient();
+                _httpClient = DownloaderFactory.CreateProxiedHttpClient();
                 _httpClient.BaseAddress = new Uri("https://api.cognitive.microsofttranslator.com/");
                 _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
@@ -128,7 +128,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
 
         private static string GetAccessToken(string apiKey, string tokenEndpoint)
         {
-            using (var httpClient = DownloaderFactory.MakeHttpClient())
+            using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
             {
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 httpClient.DefaultRequestHeaders.TryAddWithoutValidation(SecurityHeaderName, apiKey);
@@ -150,7 +150,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 return _translationPairs;
             }
 
-            using (var httpClient = DownloaderFactory.MakeHttpClient())
+            using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
             {
                 httpClient.DefaultRequestHeaders.Add("user-agent", "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36");
                 httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json; charset=UTF-8");

--- a/src/libse/AutoTranslate/MyMemoryApi.cs
+++ b/src/libse/AutoTranslate/MyMemoryApi.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
 
         public void Initialize()
         {
-            _httpClient = DownloaderFactory.MakeHttpClient();
+            _httpClient = DownloaderFactory.CreateProxiedHttpClient();
             _httpClient.DefaultRequestHeaders.Add("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json; charset=UTF-8");
             _httpClient.BaseAddress = new Uri("https://api.mymemory.translated.net/get");

--- a/src/libse/AutoTranslate/NoLanguageLeftBehindApi.cs
+++ b/src/libse/AutoTranslate/NoLanguageLeftBehindApi.cs
@@ -24,7 +24,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
         public void Initialize()
         {
             _httpClient?.Dispose();
-            _httpClient = DownloaderFactory.MakeHttpClient();
+            _httpClient = DownloaderFactory.CreateProxiedHttpClient();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
             _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.AutoTranslateNllbApiUrl);

--- a/src/libse/AutoTranslate/NoLanguageLeftBehindServe.cs
+++ b/src/libse/AutoTranslate/NoLanguageLeftBehindServe.cs
@@ -25,7 +25,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
         public void Initialize()
         {
             _httpClient?.Dispose();
-            _httpClient = DownloaderFactory.MakeHttpClient();
+            _httpClient = DownloaderFactory.CreateProxiedHttpClient();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
             _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.AutoTranslateNllbServeUrl);

--- a/src/libse/Forms/CheckForUpdatesHelper.cs
+++ b/src/libse/Forms/CheckForUpdatesHelper.cs
@@ -93,7 +93,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
         {
             try
             {
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 {
                     _changeLog = httpClient.GetStringAsync(ChangeLogUrl).Result;
                 }

--- a/src/libse/Http/DownloaderFactory.cs
+++ b/src/libse/Http/DownloaderFactory.cs
@@ -1,15 +1,19 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.Http
 {
     public static class DownloaderFactory
     {
-        public static IDownloader CreateProxiedHttpClient()
+        public static IDownloader CreateProxiedHttpClient() => CreateProxiedHttpClient(Timeout.InfiniteTimeSpan);
+
+        public static IDownloader CreateProxiedHttpClient(TimeSpan timeout)
         {
             var httpClient = new HttpClient(CreateHandler(Configuration.Settings.Proxy));
+            httpClient.Timeout = timeout;
             if (Configuration.Settings.General.UseLegacyDownloader)
             {
                 return new LegacyDownloader(httpClient);

--- a/src/libse/Http/DownloaderFactory.cs
+++ b/src/libse/Http/DownloaderFactory.cs
@@ -7,7 +7,7 @@ namespace Nikse.SubtitleEdit.Core.Http
 {
     public static class DownloaderFactory
     {
-        public static IDownloader MakeHttpClient()
+        public static IDownloader CreateProxiedHttpClient()
         {
             var httpClient = new HttpClient(CreateHandler(Configuration.Settings.Proxy));
             if (Configuration.Settings.General.UseLegacyDownloader)

--- a/src/libse/Http/HttpClientDownloader.cs
+++ b/src/libse/Http/HttpClientDownloader.cs
@@ -38,7 +38,6 @@ namespace Nikse.SubtitleEdit.Core.Http
         {
             try
             {
-                _httpClient.Timeout = Timeout.InfiniteTimeSpan;
                 using (var response = await _httpClient.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
                 {
                     var contentLength = response.Content.Headers.ContentLength;

--- a/src/libse/VobSub/Ocr/Service/GoogleCloudVisionApi.cs
+++ b/src/libse/VobSub/Ocr/Service/GoogleCloudVisionApi.cs
@@ -153,7 +153,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub.Ocr.Service
         public GoogleCloudVisionApi(string apiKey)
         {
             _apiKey = apiKey;
-            _httpClient = DownloaderFactory.MakeHttpClient();
+            _httpClient = DownloaderFactory.CreateProxiedHttpClient();
             _httpClient.BaseAddress = new Uri("https://vision.googleapis.com/v1/images:annotate");
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }

--- a/src/ui/Forms/AudioToText/VoskModelDownload.cs
+++ b/src/ui/Forms/AudioToText/VoskModelDownload.cs
@@ -71,7 +71,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                 buttonDownload.Enabled = false;
                 Refresh();
                 Cursor = Cursors.WaitCursor;
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(url, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/AudioToText/WhisperDownload.cs
+++ b/src/ui/Forms/AudioToText/WhisperDownload.cs
@@ -180,7 +180,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
 
             try
             {
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(downloadUrl, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/AudioToText/WhisperModelDownload.cs
+++ b/src/ui/Forms/AudioToText/WhisperModelDownload.cs
@@ -108,9 +108,10 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                     var pct = (int)Math.Round(progress * 100.0, MidpointRounding.AwayFromZero);
                     labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait + "  " + pct + "%";
                 });
-                foreach (var url in LastDownloadedModel.Urls)
+
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 {
-                    using (var httpClient = DownloaderFactory.MakeHttpClient())
+                    foreach (var url in LastDownloadedModel.Urls)
                     {
                         currentDownloadUrl = url;
                         _downloadFileName = MakeDownloadFileName(LastDownloadedModel, url) + ".$$$";
@@ -137,6 +138,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 {
                                     // ignore
                                 }
+
                                 return;
                             }
 

--- a/src/ui/Forms/DownloadFfmpeg.cs
+++ b/src/ui/Forms/DownloadFfmpeg.cs
@@ -66,7 +66,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait;
                 Cursor = Cursors.WaitCursor;
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(url, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/DownloadVosk.cs
+++ b/src/ui/Forms/DownloadVosk.cs
@@ -64,7 +64,7 @@ namespace Nikse.SubtitleEdit.Forms
                 Refresh();
                 Cursor = Cursors.WaitCursor;
 
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(VoskUrl, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/DownloadYouTubeDl.cs
+++ b/src/ui/Forms/DownloadYouTubeDl.cs
@@ -55,7 +55,7 @@ namespace Nikse.SubtitleEdit.Forms
                 buttonOK.Enabled = false;
                 Refresh();
                 Cursor = Cursors.WaitCursor;
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(Url, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/GetDictionaries.cs
+++ b/src/ui/Forms/GetDictionaries.cs
@@ -196,7 +196,7 @@ namespace Nikse.SubtitleEdit.Forms
                 Refresh();
                 Cursor = Cursors.WaitCursor;
 
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(_downloadLink, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/Ocr/DownloadTesseract302.cs
+++ b/src/ui/Forms/Ocr/DownloadTesseract302.cs
@@ -31,7 +31,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
             try
             {
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(url, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/Ocr/DownloadTesseract5.cs
+++ b/src/ui/Forms/Ocr/DownloadTesseract5.cs
@@ -30,7 +30,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             try
             {
                 Utilities.SetSecurityProtocol();
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(TesseractDownloadUrl, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/Ocr/GetTesseract302Dictionaries.cs
+++ b/src/ui/Forms/Ocr/GetTesseract302Dictionaries.cs
@@ -163,7 +163,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
             try
             {
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(url, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/Ocr/GetTesseractDictionaries.cs
+++ b/src/ui/Forms/Ocr/GetTesseractDictionaries.cs
@@ -138,7 +138,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
                 ChosenLanguage = dictionary.ToString();
 
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(url, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/Options/SettingsMpv.cs
+++ b/src/ui/Forms/Options/SettingsMpv.cs
@@ -37,7 +37,7 @@ namespace Nikse.SubtitleEdit.Forms.Options
                 labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait;
                 Refresh();
                 Cursor = Cursors.WaitCursor;
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(_downloadUrl, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Forms/PluginsGet.cs
+++ b/src/ui/Forms/PluginsGet.cs
@@ -213,7 +213,7 @@ namespace Nikse.SubtitleEdit.Forms
                 Refresh();
                 Cursor = Cursors.WaitCursor;
 
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(url, downloadStream, new Progress<float>((progress) =>
@@ -405,7 +405,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 _updatingAllPluginsCount = 0;
                 _updatingAllPlugins = true;
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 {
                     foreach (var url in _updateAllListUrls)
                     {

--- a/src/ui/Forms/Tts/PiperDownload.cs
+++ b/src/ui/Forms/Tts/PiperDownload.cs
@@ -64,7 +64,7 @@ namespace Nikse.SubtitleEdit.Forms.Tts
             {
                 labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait;
                 Cursor = Cursors.WaitCursor;
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 using (var downloadStream = new MemoryStream())
                 {
                     var downloadTask = httpClient.DownloadAsync(url, downloadStream, new Progress<float>((progress) =>

--- a/src/ui/Logic/CheckForUpdatesHelper.cs
+++ b/src/ui/Logic/CheckForUpdatesHelper.cs
@@ -99,7 +99,7 @@ namespace Nikse.SubtitleEdit.Logic
 
             try
             {
-                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
                 {
                     _changeLog = httpClient.GetStringAsync(ChangeLogUrl).Result;
                 }

--- a/src/ui/Logic/Plugins/OnlinePluginMetadataProvider.cs
+++ b/src/ui/Logic/Plugins/OnlinePluginMetadataProvider.cs
@@ -20,7 +20,7 @@ namespace Nikse.SubtitleEdit.Logic.Plugins
         public IReadOnlyCollection<PluginInfoItem> GetPlugins()
         {
             XDocument xDocument;
-            using (var httpClient = DownloaderFactory.MakeHttpClient())
+            using (var httpClient = DownloaderFactory.CreateProxiedHttpClient())
             using (var downloadStream = new MemoryStream())
             {
                 var downloadTask = httpClient.DownloadAsync(_githubUrl, downloadStream, null, CancellationToken.None);


### PR DESCRIPTION
Allow reusing same httpclient instance to avoid port exhaustion (mainly inside for loop)
- Rename `MakeHttpClient` => `CreateProxiedHttpClient` (as this method alreays create httpclient with proxy)
- Now there are two overloads for *CreateProxiedHttpClient*
    - CreateProxiedHttpClient() => Creates client with infinity timeout
    - CreateProxiedHttpClient(Timeout) => Take timeout

Related to https://github.com/SubtitleEdit/subtitleedit/pull/8303