### PR TITLE
Remove spell check functionality from FixCommonErrors

### DIFF
--- a/src/libse/Interfaces/IFixCallbacks.cs
+++ b/src/libse/Interfaces/IFixCallbacks.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.Interfaces
 {
-    public interface IFixCallbacks : IDoSpell
+    public interface IFixCallbacks
     {
         bool AllowFix(Paragraph p, string action);
         void AddFixToListView(Paragraph p, string action, string before, string after);

--- a/src/ui/Forms/FixCommonErrors.cs
+++ b/src/ui/Forms/FixCommonErrors.cs
@@ -1899,35 +1899,6 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private Hunspell _hunspell;
-
-        public bool DoSpell(string word)
-        {
-            if (_hunspell == null && Language != null)
-            {
-                var fileMatches = Directory.GetFiles(Utilities.DictionaryFolder, Language + "*.dic");
-                if (fileMatches.Length > 0)
-                {
-                    var dictionary = fileMatches[0].Substring(0, fileMatches[0].Length - 4);
-                    try
-                    {
-                        _hunspell = Hunspell.GetHunspell(dictionary);
-                    }
-                    catch
-                    {
-                        _hunspell = null;
-                    }
-                }
-            }
-
-            if (_hunspell == null)
-            {
-                return false;
-            }
-
-            return _hunspell.Spell(word);
-        }
-
         private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
             listViewFixes.CheckAll();


### PR DESCRIPTION
Remove unused IDoSpell.DoSpell method from FixCommonErrors