### PR TITLE
Implement async actions in spell checker

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -8518,17 +8518,17 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void ToolStripButtonSpellCheckClick(object sender, EventArgs e)
+        private async void ToolStripButtonSpellCheckClick(object sender, EventArgs e)
         {
-            SpellCheck(true, 0);
+            await SpellCheck(true, 0);
         }
 
-        private void SpellCheckToolStripMenuItemClick(object sender, EventArgs e)
+        private async void SpellCheckToolStripMenuItemClick(object sender, EventArgs e)
         {
-            SpellCheck(true, 0);
+            await SpellCheck(true, 0);
         }
 
-        private void SpellCheck(bool autoDetect, int startFromLine)
+        private async Task SpellCheck(bool autoDetect, int startFromLine)
         {
             if (!IsSubtitleLoaded)
             {
@@ -8563,7 +8563,7 @@ namespace Nikse.SubtitleEdit.Forms
                         }
                         else
                         {
-                            _spellCheckForm.ContinueSpellCheck(_subtitle);
+                            await _spellCheckForm.ResumeSpellCheckAsync(_subtitle);
                         }
                     }
                     else

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -650,7 +650,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             try
             {
-                return await Task.Run(() => _hunspell.Suggest(word), NewAutoCancelTokenAfter3Sec().Token);
+                return await Task.Run(() => _hunspell.Suggest(word), NewAutoCancelTokenAfter3Sec().Token).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -661,11 +661,18 @@ namespace Nikse.SubtitleEdit.Forms
             return new List<string>();
         }
 
+        private CancellationTokenSource _cancellationTokenSource;
+
         private CancellationTokenSource NewAutoCancelTokenAfter3Sec()
         {
-            var tokenSource = new CancellationTokenSource();
-            tokenSource.CancelAfter(3 * 1000);
-            return tokenSource;
+            // only create new if previous is null or cancelled
+            if (_cancellationTokenSource == null || _cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                _cancellationTokenSource = new CancellationTokenSource();
+                _cancellationTokenSource.CancelAfter(3 * 1000);
+            }
+
+            return _cancellationTokenSource;
         }
 
         private async void ButtonChangeAllClick(object sender, EventArgs e)

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -1218,7 +1218,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                                 if (_currentWord.ToUpperInvariant() != "LT'S" && _currentWord.ToUpperInvariant() != "SOX'S" && !_currentWord.ToUpperInvariant().StartsWith("HTTP", StringComparison.Ordinal)) // TODO: Get fixed nhunspell
                                 {
-                                    suggestions.AddRange(await DoSuggestAsync(_currentWord)); // TODO: 0.9.6 fails on "Lt'S"
+                                    suggestions.AddRange(await DoSuggestAsync(_currentWord).ConfigureAwait(true)); // TODO: 0.9.6 fails on "Lt'S"
                                 }
 
                                 if (_languageName.StartsWith("fr_", StringComparison.Ordinal) && (_currentWord.StartsWith("I'", StringComparison.Ordinal) || _currentWord.StartsWith("I’", StringComparison.Ordinal)))
@@ -1413,7 +1413,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        public void ContinueSpellCheck(Subtitle subtitle)
+        public Task ResumeSpellCheckAsync(Subtitle subtitle)
         {
             _subtitle = subtitle;
 
@@ -1428,16 +1428,16 @@ namespace Nikse.SubtitleEdit.Forms
             _currentParagraph = _subtitle.GetParagraphOrDefault(_currentIndex);
             if (_currentParagraph == null)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             SetWords(_currentParagraph.Text);
             _wordsIndex = -1;
 
-            PrepareNextWordAsync();
+            return PrepareNextWordAsync();
         }
 
-        public void DoSpellCheck(bool autoDetect, Subtitle subtitle, string dictionaryFolder, Main mainWindow, int startLine)
+        public async Task DoSpellCheck(bool autoDetect, Subtitle subtitle, string dictionaryFolder, Main mainWindow, int startLine)
         {
             _subtitle = subtitle;
             LanguageStructure.Main mainLanguage = LanguageSettings.Current.Main;
@@ -1507,7 +1507,7 @@ namespace Nikse.SubtitleEdit.Forms
             SetWords(_currentParagraph.Text);
             _wordsIndex = -1;
 
-            PrepareNextWordAsync();
+            await PrepareNextWordAsync();
         }
 
         private void LoadDictionaries(string dictionaryFolder, string dictionary, string languageName)

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -646,11 +646,16 @@ namespace Nikse.SubtitleEdit.Forms
             return _hunspell.Spell(word);
         }
 
+        /// <summary>
+        /// Asynchronously suggests alternative words for a misspelled word using Hunspell spell-checker.
+        /// </summary>
+        /// <param name="word">The misspelled word to suggest alternatives for.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a list of suggested alternative words for the misspelled word.</returns>
         private async Task<List<string>> DoSuggestAsync(string word)
         {
             try
             {
-                return await Task.Run(() => _hunspell.Suggest(word), NewAutoCancelTokenAfter3Sec().Token).ConfigureAwait(false);
+                return await Task.Run(() => _hunspell.Suggest(word), CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -660,21 +665,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             return new List<string>();
         }
-
-        private CancellationTokenSource _cancellationTokenSource;
-
-        private CancellationTokenSource NewAutoCancelTokenAfter3Sec()
-        {
-            // only create new if previous is null or cancelled
-            if (_cancellationTokenSource == null || _cancellationTokenSource.Token.IsCancellationRequested)
-            {
-                _cancellationTokenSource = new CancellationTokenSource();
-                _cancellationTokenSource.CancelAfter(3 * 1000);
-            }
-
-            return _cancellationTokenSource;
-        }
-
+        
         private async void ButtonChangeAllClick(object sender, EventArgs e)
         {
             PushUndo($"{LanguageSettings.Current.SpellCheck.ChangeAll}: {_currentWord + " > " + textBoxWord.Text}", SpellCheckAction.ChangeAll);

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -653,17 +653,22 @@ namespace Nikse.SubtitleEdit.Forms
         /// <returns>A task that represents the asynchronous operation. The task result contains a list of suggested alternative words for the misspelled word.</returns>
         private async Task<List<string>> DoSuggestAsync(string word)
         {
-            try
+            using (var cts = new CancellationTokenSource())
             {
-                return await Task.Run(() => _hunspell.Suggest(word), CancellationToken.None).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                Debug.Write(e.Message);
-                LoadHunspell(_currentDictionary);
-            }
+                // don't wait indefinitely
+                cts.CancelAfter(TimeSpan.FromSeconds(1.8));
+                try
+                {
+                    return await Task.Run(() => _hunspell.Suggest(word), cts.Token).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    Debug.Write(e.Message);
+                    LoadHunspell(_currentDictionary);
+                }
 
-            return new List<string>();
+                return new List<string>();
+            }
         }
         
         private async void ButtonChangeAllClick(object sender, EventArgs e)


### PR DESCRIPTION
Refactored the spell-check actions and related functions in the SubtitleEdit application to be asynchronous, allowing for smoother user experience and improved application performance. All actions related to spelling correction have been turned into asynchronous tasks, leading to a more responsive user interface as now operations won't block the UI thread. Also, converted synchronous Hunspell suggestions to an async operation with timeout, reducing the risk for application freezing in case of delay in suggestions retrieval.


In short words, use thread-pool instead of creating a new thread every-time you are requesting word suggestion
as already known created new thread is very expensive!