### PR TITLE
Refactor bookmark persistence to use Subtitle class

### DIFF
--- a/src/libse/Common/Bookmarks.cs
+++ b/src/libse/Common/Bookmarks.cs
@@ -5,25 +5,23 @@ using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public class BookmarkPersistence
+    public class Bookmarks
     {
         private readonly Subtitle _subtitle;
-        private readonly string _fileName;
 
-        public BookmarkPersistence(Subtitle subtitle, string fileName)
+        public Bookmarks(Subtitle subtitle)
         {
             _subtitle = subtitle;
-            _fileName = fileName;
         }
 
         private string GetBookmarksFileName()
         {
-            return _fileName + ".SE.bookmarks";
+            return _subtitle.FileName + ".SE.bookmarks";
         }
 
         public bool Save()
         {
-            if (_fileName == null)
+            if (_subtitle.FileName == null)
             {
                 return false;
             }
@@ -79,34 +77,30 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public bool Load()
         {
-            if (_fileName == null)
+            var fileName = GetBookmarksFileName();
+            if (!File.Exists(fileName))
             {
                 return false;
             }
 
-            var fileName = GetBookmarksFileName();
-            if (File.Exists(fileName))
+            try
             {
-                try
+                var dic = DeserializeBookmarks(File.ReadAllText(fileName, Encoding.UTF8));
+                foreach (var kvp in dic)
                 {
-                    var dic = DeserializeBookmarks(File.ReadAllText(fileName, Encoding.UTF8));
-                    foreach (var kvp in dic)
+                    var p = _subtitle.GetParagraphOrDefault(kvp.Key);
+                    if (p != null)
                     {
-                        var p = _subtitle.GetParagraphOrDefault(kvp.Key);
-                        if (p != null)
-                        {
-                            p.Bookmark = kvp.Value;
-                        }
+                        p.Bookmark = kvp.Value;
                     }
+                }
 
-                }
-                catch
-                {
-                    return false;
-                }
+                return true;
             }
-
-            return true;
+            catch
+            {
+                return false;
+            }
         }
 
         private static Dictionary<int, string> DeserializeBookmarks(string input)

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -17,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Common
         public string Header { get; set; } = string.Empty;
         public string Footer { get; set; } = string.Empty;
 
+        public Bookmarks Bookmarks { get; }
+
         public string FileName { get; set; }
 
         public static int MaximumHistoryItems => 100;
@@ -44,6 +46,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             HistoryItems = historyItems;
             Paragraphs = paragraphs;
             FileName = "Untitled";
+            Bookmarks = new Bookmarks(this);
         }
 
         /// <summary>
@@ -73,6 +76,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             FileName = subtitle.FileName;
             OriginalFormat = subtitle.OriginalFormat;
             OriginalEncoding = subtitle.OriginalEncoding;
+            Bookmarks = new Bookmarks(this);
         }
 
 

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -3889,7 +3889,7 @@ namespace Nikse.SubtitleEdit.Forms
                     SubtitleListview1.ShowExtraColumn(_languageGeneral.Style);
                 }
 
-                new BookmarkPersistence(newSubtitle, fileName).Load();
+                newSubtitle.Bookmarks.Load();
 
                 if (Configuration.Settings.General.RemoveBlankLinesWhenOpening)
                 {
@@ -5322,7 +5322,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 Configuration.Settings.RecentFiles.Add(_fileName, FirstVisibleIndex, FirstSelectedIndex, _videoFileName, VideoAudioTrackNumber, _subtitleOriginalFileName, Configuration.Settings.General.CurrentVideoOffsetInMs, Configuration.Settings.General.CurrentVideoIsSmpte);
                 Configuration.Settings.Save();
-                new BookmarkPersistence(_subtitle, _fileName).Save();
+                _subtitle.Bookmarks.Save();
                 _fileDateTime = File.GetLastWriteTime(_fileName);
                 _oldSubtitleFormat = format;
                 _formatManuallyChanged = false;
@@ -20311,7 +20311,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             SetListViewStateImages();
-            new BookmarkPersistence(_subtitle, _fileName).Save();
+            _subtitle.Bookmarks.Save();
         }
 
         private void SetListViewStateImages()
@@ -20367,7 +20367,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             SetListViewStateImages();
-            new BookmarkPersistence(_subtitle, _fileName).Save();
+            _subtitle.Bookmarks.Save();
         }
 
         private void MoveTextFromCursorToNext(SETextBox tb)
@@ -34809,7 +34809,7 @@ namespace Nikse.SubtitleEdit.Forms
                 SubtitleListview1.ShowState(_subtitleListViewIndex, p);
                 ShowHideBookmark(p);
                 SetListViewStateImages();
-                new BookmarkPersistence(_subtitle, _fileName).Save();
+                _subtitle.Bookmarks.Save();
             }
         }
 
@@ -34833,7 +34833,7 @@ namespace Nikse.SubtitleEdit.Forms
                         SubtitleListview1.ShowState(_subtitleListViewIndex, p);
                         ShowHideBookmark(p);
                         SetListViewStateImages();
-                        new BookmarkPersistence(_subtitle, _fileName).Save();
+                        _subtitle.Bookmarks.Save();
                     }
                 }
             }


### PR DESCRIPTION
The logic for loading and saving bookmarks has been refactored. Instead of creating a new BookmarkPersistence instance for each operation, the Subtitle class now has a Bookmarks property that handles this. This change simplifies code and reduces redundancy by centralizing the bookmark persistence logic inside the Subtitle class.


Now you can just **Subtitle.Bookmarks.Save/Load** instead of  creating
new instance of **BookmarkPersistence** then passing **Subtitle** and **FileName** (which are all known and should be
managed by the Subtitle instance)

Plus no extra-allocation of BookmarkPersistence when save/loading bookmarks