### PR TITLE
Safeguard http client disposal in AutoTranslate

### DIFF
--- a/src/ui/Forms/Translate/AutoTranslate.Designer.cs
+++ b/src/ui/Forms/Translate/AutoTranslate.Designer.cs
@@ -18,7 +18,7 @@
                 components.Dispose();
             }
 
-            _httpClient.Dispose();
+            _httpClient?.Dispose();
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
This update adds a null-conditional operator before disposing the http client in AutoTranslate form. This ensures that _httpClient.Dispose() only gets called if _httpClient is not null, preventing potential NullReferenceException.