### PR TITLE
Add platform-specific input language providers

### DIFF
--- a/src/ui/Forms/Translate/AutoTranslate.cs
+++ b/src/ui/Forms/Translate/AutoTranslate.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Nikse.SubtitleEdit.Forms.Translate.InputLanguage;
 using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
 using Timer = System.Windows.Forms.Timer;
 
@@ -612,18 +613,26 @@ namespace Nikse.SubtitleEdit.Forms.Translate
             return defaultSourceLanguageCode;
         }
 
+        /// <summary>
+        /// Get the input language provider based on the running platform
+        /// </summary>
+        /// <returns>The input language provider</returns>
+        private static IInputLanguage GetInputLanguageProvider()
+        {
+            if (Configuration.IsRunningOnLinux)
+            {
+                return new LinuxInputLanguage();
+            }
+
+            return new WindowInputLanguage();
+        }
+        
         public static string EvaluateDefaultTargetLanguageCode(string defaultSourceLanguage)
         {
             var installedLanguages = new List<string>();
-            foreach (InputLanguage language in InputLanguage.InstalledInputLanguages)
+            foreach (var language in GetInputLanguageProvider().GetLanguages())
             {
-                var layoutName = language.LayoutName;
-                // related to https://github.com/SubtitleEdit/subtitleedit/issues/8084
-                if (string.IsNullOrEmpty(layoutName))
-                {
-                    continue;
-                }
-                var iso639 = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(layoutName);
+                var iso639 = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(language);
                 if (!string.IsNullOrEmpty(iso639) && !installedLanguages.Contains(iso639))
                 {
                     installedLanguages.Add(iso639.ToLowerInvariant());

--- a/src/ui/Forms/Translate/InputLanguage/IInputLanguage.cs
+++ b/src/ui/Forms/Translate/InputLanguage/IInputLanguage.cs
@@ -1,0 +1,7 @@
+namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
+{
+    public interface IInputLanguage
+    {
+        string[] GetLanguages();
+    }
+}

--- a/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
+++ b/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
@@ -18,7 +18,11 @@ namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
             }
             catch
             {
-                return new[] { Thread.CurrentThread.CurrentCulture.EnglishName };
+                return new[]
+                {
+                    Thread.CurrentThread.CurrentCulture.EnglishName,
+                    Thread.CurrentThread.CurrentUICulture.EnglishName
+                };
             }
         }
 

--- a/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
+++ b/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
@@ -19,6 +19,7 @@ namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
             }
             catch
             {
+                // use thread/ui-thread culture english-name as fallbacks
                 return new[]
                 {
                     Thread.CurrentThread.CurrentCulture.EnglishName,

--- a/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
+++ b/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
+{
+    public class LinuxInputLanguage : IInputLanguage
+    {
+        public string[] GetLanguages()
+        {
+            try
+            {
+                // xkb:us::eng  English (US)
+                // xkb:fr::fra  French
+                // xkb:de::ger  German
+                // xkb:es::spa  Spanish
+                return GetFromIbusProcess();
+            }
+            catch (Exception ex)
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        private string[] GetFromIbusProcess()
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/bin/bash",
+                    Arguments = "-c \"ibus list-engine\"",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            var output = new StringBuilder();
+            process.OutputDataReceived += (sender, e) => output.AppendLine(e.Data);
+            process.Start();
+            process.BeginOutputReadLine();
+            process.WaitForExit();
+
+            return output.ToString().Split();
+        }
+    }
+}

--- a/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
+++ b/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 
 namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
 {
@@ -16,9 +16,9 @@ namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
                 // xkb:es::spa  Spanish
                 return GetFromIbusProcess();
             }
-            catch (Exception ex)
+            catch
             {
-                return Array.Empty<string>();
+                return new[] { Thread.CurrentThread.CurrentCulture.EnglishName };
             }
         }
 

--- a/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
+++ b/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
@@ -10,6 +10,7 @@ namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
         {
             try
             {
+                // TODO: Parse 
                 // xkb:us::eng  English (US)
                 // xkb:fr::fra  French
                 // xkb:de::ger  German

--- a/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
+++ b/src/ui/Forms/Translate/InputLanguage/LinuxInputLanguage.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Threading;
 
@@ -10,12 +11,7 @@ namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
         {
             try
             {
-                // TODO: Parse 
-                // xkb:us::eng  English (US)
-                // xkb:fr::fra  French
-                // xkb:de::ger  German
-                // xkb:es::spa  Spanish
-                return GetFromIbusProcess();
+                return ParseTokens(GetFromIbusProcess());
             }
             catch
             {
@@ -28,6 +24,19 @@ namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
             }
         }
 
+        private static string[] ParseTokens(string[] tokens)
+        {
+            // xkb:us::eng  English (US)
+            // xkb:fr::fra  French
+            // xkb:de::ger  German
+            // xkb:es::spa  Spanish
+            return tokens.Select(token =>
+            {
+                var whiteSpaceIndex = token.IndexOf(' ');
+                return whiteSpaceIndex < 0 ? token : token.Substring(whiteSpaceIndex + 1).Trim();
+            }).ToArray();
+        }
+
         private string[] GetFromIbusProcess()
         {
             var process = new Process
@@ -38,7 +47,7 @@ namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
                     Arguments = "-c \"ibus list-engine\"",
                     RedirectStandardOutput = true,
                     UseShellExecute = false,
-                    CreateNoWindow = true
+                    CreateNoWindow = true,
                 }
             };
 

--- a/src/ui/Forms/Translate/InputLanguage/WindowInputLanguage.cs
+++ b/src/ui/Forms/Translate/InputLanguage/WindowInputLanguage.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Forms.Translate.InputLanguage
+{
+    public class WindowInputLanguage : IInputLanguage
+    {
+        public string[] GetLanguages()
+        {
+            // English (United States) - US
+            // French (France) - French
+            // German (Germany) - German
+            // Spanish (Spain) - Spanish
+            return System.Windows.Forms.InputLanguage.InstalledInputLanguages
+                .OfType<System.Windows.Forms.InputLanguage>()
+                .Where(language => !string.IsNullOrEmpty(language.LayoutName))
+                .Select(language => language.LayoutName)
+                .ToArray();
+        }
+    }
+}


### PR DESCRIPTION
Introduced an input language provider interface (IInputLanguage) and implemented separate Linux and Windows classes. This separates platform-specific logic, enhancing maintainability. The translation form now uses the appropriate language provider to get installed languages, improving cross-platform compatibility.

Note: I don't have a way to simulate running from linux but maybe one of the user who reported the issue can help with that.
I would suggest that we prepare a Beta version for them to test and provider feedback.

_Linux user have to make ensure **ibus** is installed on the Linux system. It can be installed by using a package manager like apt (e.g., sudo apt install ibus)._

Refs
https://github.com/SubtitleEdit/subtitleedit/issues/8579
https://github.com/SubtitleEdit/subtitleedit/issues/8084