### PR TITLE
Replace new EventArgs() with EventArgs.Empty

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic.cs
@@ -676,7 +676,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
             {
                 // ignore
             }
-            OnVideoLoaded?.Invoke(_mediaPlayer, new EventArgs());
+            OnVideoLoaded?.Invoke(_mediaPlayer, EventArgs.Empty);
         }
 
         public static string GetVlcPath(string fileName)
@@ -1065,7 +1065,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
                 Stop();
                 Play();
                 Pause();
-                OnVideoEnded?.Invoke(_mediaPlayer, new EventArgs());
+                OnVideoEnded?.Invoke(_mediaPlayer, EventArgs.Empty);
             }
         }
 

--- a/src/ui/Logic/VideoPlayers/LibVlcMono.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcMono.cs
@@ -144,7 +144,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
             NativeMethods.libvlc_media_player_pause(_mediaPlayer);
             _videoLoadedTimer.Stop();
 
-            OnVideoLoaded?.Invoke(_mediaPlayer, new EventArgs());
+            OnVideoLoaded?.Invoke(_mediaPlayer, EventArgs.Empty);
         }
 
         public override void Initialize(Control ownerControl, string videoFileName, EventHandler onVideoLoaded, EventHandler onVideoEnded)
@@ -195,7 +195,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
                 Stop();
                 Play();
                 Pause();
-                OnVideoEnded.Invoke(_mediaPlayer, new EventArgs());
+                OnVideoEnded.Invoke(_mediaPlayer, EventArgs.Empty);
             }
         }
 

--- a/src/ui/Logic/VideoPlayers/MpcHC/MpcHc.cs
+++ b/src/ui/Logic/VideoPlayers/MpcHC/MpcHc.cs
@@ -186,7 +186,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.MpcHC
                         }
 
                         Resize(_initialWidth, _initialHeight);
-                        OnVideoLoaded?.Invoke(this, new EventArgs());
+                        OnVideoLoaded?.Invoke(this, EventArgs.Empty);
 
                         SendMpcMessage(MpcHcCommand.SetSubtitleTrack, "-1");
 
@@ -209,7 +209,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.MpcHC
                     }
                     break;
                 case MpcHcCommand.NotifyEndOfStream:
-                    OnVideoEnded?.Invoke(this, new EventArgs());
+                    OnVideoEnded?.Invoke(this, EventArgs.Empty);
 
                     break;
                 case MpcHcCommand.CurrentPosition:

--- a/src/ui/Logic/VideoPlayers/QuartsPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/QuartsPlayer.cs
@@ -249,7 +249,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
             {
                 try
                 {
-                    OnVideoLoaded.Invoke(_quartzFilgraphManager, new EventArgs());
+                    OnVideoLoaded.Invoke(_quartzFilgraphManager, EventArgs.Empty);
                 }
                 catch
                 {
@@ -266,7 +266,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
                 _isPaused = true;
                 if (OnVideoEnded != null && _quartzFilgraphManager != null)
                 {
-                    OnVideoEnded.Invoke(_quartzFilgraphManager, new EventArgs());
+                    OnVideoEnded.Invoke(_quartzFilgraphManager, EventArgs.Empty);
                 }
             }
         }


### PR DESCRIPTION
The commits replace all instances of `new EventArgs()` with `EventArgs.Empty` in different video player classes. This change improves performance by reducing unnecessary object instantiation.