### PR TITLE
Remove unnecessary return statements

### DIFF
--- a/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesManager.cs
+++ b/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesManager.cs
@@ -381,7 +381,6 @@ namespace Nikse.SubtitleEdit.Forms.Assa
                 catch (Exception exception)
                 {
                     MessageBox.Show(exception.Message);
-                    return;
                 }
             }
         }

--- a/src/ui/Forms/AudioToText/WhisperAudioToText.cs
+++ b/src/ui/Forms/AudioToText/WhisperAudioToText.cs
@@ -1745,7 +1745,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 if (downloadForm.ShowDialog(this) != DialogResult.OK)
                                 {
                                     Configuration.Settings.Tools.WhisperIgnoreVersion = true;
-                                    return;
                                 }
                             }
                         }
@@ -1759,7 +1758,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                         {
                             if (downloadForm.ShowDialog(this) != DialogResult.OK)
                             {
-                                return;
+                                // ignore
                             }
                         }
                     }
@@ -1780,7 +1779,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 if (downloadForm.ShowDialog(this) != DialogResult.OK)
                                 {
                                     Configuration.Settings.Tools.WhisperIgnoreVersion = true;
-                                    return;
                                 }
                             }
                         }
@@ -1794,7 +1792,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                         {
                             if (downloadForm.ShowDialog(this) != DialogResult.OK)
                             {
-                                return;
+                                // ignore
                             }
                         }
                     }
@@ -1816,7 +1814,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 if (downloadForm.ShowDialog(this) != DialogResult.OK)
                                 {
                                     Configuration.Settings.Tools.WhisperIgnoreVersion = true;
-                                    return;
                                 }
                             }
                         }
@@ -1857,7 +1854,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 if (downloadForm.ShowDialog(this) != DialogResult.OK)
                                 {
                                     Configuration.Settings.Tools.WhisperIgnoreVersion = true;
-                                    return;
                                 }
                             }
                         }
@@ -1871,7 +1867,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                         {
                             if (downloadForm.ShowDialog(this) != DialogResult.OK)
                             {
-                                return;
+                                // ignore
                             }
                         }
                     }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -19244,7 +19244,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (form.ShowDialog(this) != DialogResult.OK)
                 {
-                    return;
+                    // ignore
                 }
             }
         }
@@ -32712,8 +32712,6 @@ namespace Nikse.SubtitleEdit.Forms
                         Configuration.Settings.SubtitleSettings.NuendoCharacterListFile = form.CharacterListFile;
                     }
                 }
-
-                return;
             }
         }
 
@@ -36142,7 +36140,6 @@ namespace Nikse.SubtitleEdit.Forms
             if (e.X > 72 && e.X <= (122 + textBoxListViewText.Height) && !textBoxListViewText.Enabled)
             {
                 InsertLineToolStripMenuItemClick(null, null);
-                return;
             }
         }
 
@@ -36919,7 +36916,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (form.ShowDialog(this) != DialogResult.OK)
                 {
-                    return;
+                    // ignore
                 }
             }
         }


### PR DESCRIPTION
The unnecessary return statements in different parts of the code in WhisperAudioToText.cs, Main.cs, and SubStationAlphaStylesCategoriesManager.cs have been removed. This was done to ensure smoother flow of code execution without abrupt termination upon a particular condition. Unsatisfactory dialog results now simply get ignored instead of stopping the flow of the code.