### PR TITLE
Refactor code to use GetCharactersPerSecond method in Paragraph class

### DIFF
--- a/src/libse/Common/Paragraph.cs
+++ b/src/libse/Common/Paragraph.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
@@ -122,6 +123,36 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 return 60.0 / DurationTotalSeconds * Text.CountWords();
             }
+        }
+
+        public double GetCharactersPerSecond()
+        {
+            if (DurationTotalMilliseconds < 1)
+            {
+                return 999;
+            }
+
+            return (double)Text.CountCharacters(true) / DurationTotalSeconds;
+        }
+
+        public double GetCharactersPerSecond(double numberOfCharacters)
+        {
+            if (DurationTotalMilliseconds < 1)
+            {
+                return 999;
+            }
+
+            return numberOfCharacters / DurationTotalSeconds;
+        }
+
+        public double GetCharactersPerSecond(ICalcLength calc)
+        {
+            if (DurationTotalMilliseconds < 1)
+            {
+                return 999;
+            }
+
+            return (double)calc.CountCharacters(Text, true) / DurationTotalSeconds;
         }
     }
 }

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -540,7 +540,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             var duration = Utilities.GetOptimalDisplayMilliseconds(p.Text, optimalCharactersPerSeconds, onlyOptimal, enforceDurationLimits);
             p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + duration;
-            while (Utilities.GetCharactersPerSecond(p) > maxCharactersPerSecond)
+            while (p.GetCharactersPerSecond() > maxCharactersPerSecond)
             {
                 duration++;
                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + duration;
@@ -833,7 +833,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     Paragraphs = Paragraphs.OrderBy(p => p.NumberOfLines).ThenBy(p => p.Number).ToList();
                     break;
                 case SubtitleSortCriteria.TextCharactersPerSeconds:
-                    Paragraphs = Paragraphs.OrderBy(Utilities.GetCharactersPerSecond).ThenBy(p => p.Number).ToList();
+                    Paragraphs = Paragraphs.OrderBy(p => p.GetCharactersPerSecond()).ThenBy(p => p.Number).ToList();
                     break;
                 case SubtitleSortCriteria.WordsPerMinute:
                     Paragraphs = Paragraphs.OrderBy(p => p.WordsPerMinute).ThenBy(p => p.Number).ToList();

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -942,37 +942,6 @@ namespace Nikse.SubtitleEdit.Core.Common
             return maxLength;
         }
 
-        public static double GetCharactersPerSecond(Paragraph paragraph)
-        {
-            if (paragraph.DurationTotalMilliseconds < 1)
-            {
-                return 999;
-            }
-
-            return (double)paragraph.Text.CountCharacters(true) / paragraph.DurationTotalSeconds;
-        }
-
-        public static double GetCharactersPerSecond(Paragraph paragraph, double numberOfCharacters)
-        {
-            if (paragraph.DurationTotalMilliseconds < 1)
-            {
-                return 999;
-            }
-
-            return numberOfCharacters / paragraph.DurationTotalSeconds;
-        }
-
-
-        public static double GetCharactersPerSecond(Paragraph paragraph, ICalcLength calc)
-        {
-            if (paragraph.DurationTotalMilliseconds < 1)
-            {
-                return 999;
-            }
-
-            return (double)calc.CountCharacters(paragraph.Text, true) / paragraph.DurationTotalSeconds;
-        }
-
         public static bool IsRunningOnMono()
         {
             return Type.GetType("Mono.Runtime") != null;

--- a/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
@@ -31,7 +31,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     if (next == null || (p.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines) < next.StartTime.TotalMilliseconds)
                     {
                         var temp = new Paragraph(p) { EndTime = { TotalMilliseconds = p.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds } };
-                        if (Utilities.GetCharactersPerSecond(temp) <= Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                        if (temp.GetCharactersPerSecond() <= Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                         {
                             if (callbacks.AllowFix(p, fixAction))
                             {
@@ -66,12 +66,12 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     }
                 }
 
-                double charactersPerSecond = Utilities.GetCharactersPerSecond(p);
+                double charactersPerSecond = p.GetCharactersPerSecond();
                 if (!skip && charactersPerSecond > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                 {
                     var temp = new Paragraph(p);
                     var numberOfCharacters = (double)temp.Text.CountCharacters(true);
-                    while (Utilities.GetCharactersPerSecond(temp, numberOfCharacters) > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                    while (temp.GetCharactersPerSecond(numberOfCharacters) > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                     {
                         temp.EndTime.TotalMilliseconds++;
                     }
@@ -116,7 +116,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     }
                     // Make next subtitle duration shorter + make current subtitle duration longer
                     else if (diffMs < 1000 &&
-                             Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime && Utilities.GetCharactersPerSecond(new Paragraph(next.Text, p.StartTime.TotalMilliseconds + temp.DurationTotalMilliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines, next.EndTime.TotalMilliseconds)) < Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                             Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime && new Paragraph(next.Text, p.StartTime.TotalMilliseconds + temp.DurationTotalMilliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines, next.EndTime.TotalMilliseconds).GetCharactersPerSecond() < Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                     {
                         if (callbacks.AllowFix(p, fixAction))
                         {
@@ -130,7 +130,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     // Make next-next subtitle duration shorter + move next + make current subtitle duration longer
                     else if (diffMs < 500 &&
                              Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime && nextNext != null &&
-                             Utilities.GetCharactersPerSecond(new Paragraph(nextNext.Text, nextNext.StartTime.TotalMilliseconds + diffMs + Configuration.Settings.General.MinimumMillisecondsBetweenLines, nextNext.EndTime.TotalMilliseconds - (diffMs))) < Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                             new Paragraph(nextNext.Text, nextNext.StartTime.TotalMilliseconds + diffMs + Configuration.Settings.General.MinimumMillisecondsBetweenLines, nextNext.EndTime.TotalMilliseconds - (diffMs)).GetCharactersPerSecond() < Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                     {
                         if (callbacks.AllowFix(p, fixAction))
                         {

--- a/src/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMaxCps.cs
@@ -29,11 +29,11 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
                     calc = CalcFactory.MakeCalculator(nameof(CalcCjk));
                 }
 
-                var charactersPerSeconds = Utilities.GetCharactersPerSecond(jp, calc);
+                var charactersPerSeconds = jp.GetCharactersPerSecond(calc);
                 if (charactersPerSeconds > charactersPerSecond && !p.StartTime.IsMaxTime)
                 {
                     var fixedParagraph = new Paragraph(p, false);
-                    while (Utilities.GetCharactersPerSecond(fixedParagraph) > charactersPerSecond)
+                    while (fixedParagraph.GetCharactersPerSecond() > charactersPerSecond)
                     {
                         fixedParagraph.EndTime.TotalMilliseconds++;
                     }

--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -1084,7 +1084,7 @@ namespace Nikse.SubtitleEdit.Controls
 
                             if (Configuration.Settings.VideoControls.WaveformDrawCps)
                             {
-                                text = $"{Utilities.GetCharactersPerSecond(paragraph):0.00}" + Environment.NewLine + text;
+                                text = $"{paragraph.GetCharactersPerSecond():0.00}" + Environment.NewLine + text;
                             }
                         }
                         else
@@ -1096,7 +1096,7 @@ namespace Nikse.SubtitleEdit.Controls
 
                             if (Configuration.Settings.VideoControls.WaveformDrawCps)
                             {
-                                text = string.Format(LanguageSettings.Current.Waveform.CharsSecX, Utilities.GetCharactersPerSecond(paragraph)) + Environment.NewLine + text;
+                                text = string.Format(LanguageSettings.Current.Waveform.CharsSecX, paragraph.GetCharactersPerSecond()) + Environment.NewLine + text;
                             }
                         }
                     }

--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -1500,7 +1500,7 @@ namespace Nikse.SubtitleEdit.Controls
 
             if (_settings.Tools.ListViewSyntaxColorDurationSmall && !paragraph.StartTime.IsMaxTime)
             {
-                double charactersPerSecond = Utilities.GetCharactersPerSecond(paragraph);
+                double charactersPerSecond = paragraph.GetCharactersPerSecond();
                 if (charactersPerSecond > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                 {
                     if (ColumnIndexCps >= 0)
@@ -1654,7 +1654,7 @@ namespace Nikse.SubtitleEdit.Controls
                         item.SubItems.Add(GetDisplayDuration(paragraph));
                         break;
                     case SubtitleColumn.CharactersPerSeconds:
-                        item.SubItems.Add($"{Utilities.GetCharactersPerSecond(paragraph):0.00}");
+                        item.SubItems.Add($"{paragraph.GetCharactersPerSecond():0.00}");
                         break;
                     case SubtitleColumn.WordsPerMinute:
                         item.SubItems.Add($"{paragraph.WordsPerMinute:0.00}");
@@ -1927,7 +1927,7 @@ namespace Nikse.SubtitleEdit.Controls
         {
             if (ColumnIndexCps >= 0)
             {
-                item.SubItems[ColumnIndexCps].Text = $"{Utilities.GetCharactersPerSecond(paragraph):0.00}";
+                item.SubItems[ColumnIndexCps].Text = $"{paragraph.GetCharactersPerSecond():0.00}";
             }
             if (ColumnIndexWpm >= 0)
             {

--- a/src/ui/Forms/BinaryEdit/BinEdit.cs
+++ b/src/ui/Forms/BinaryEdit/BinEdit.cs
@@ -650,7 +650,7 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
 
                 if (_columnIndexCps >= 0)
                 {
-                    count = AddListViewSubItem(item, count, $"{Utilities.GetCharactersPerSecond(paragraph):0.00}");
+                    count = AddListViewSubItem(item, count, $"{paragraph.GetCharactersPerSecond():0.00}");
                 }
 
                 if (_columnIndexWpm >= 0)

--- a/src/ui/Forms/ErrorsGoTo.cs
+++ b/src/ui/Forms/ErrorsGoTo.cs
@@ -72,7 +72,7 @@ namespace Nikse.SubtitleEdit.Forms
                     errors.Add($"WPM: {paragraph.WordsPerMinute:#,###.00} > {Configuration.Settings.General.SubtitleMaximumWordsPerMinute}");
                 }
 
-                var charactersPerSecond = Utilities.GetCharactersPerSecond(paragraph);
+                var charactersPerSecond = paragraph.GetCharactersPerSecond();
                 if (charactersPerSecond > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                 {
                     errors.Add($"CPS: {charactersPerSecond:#,###.00} > {Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds}");

--- a/src/ui/Forms/ExportCustomTextFormat.cs
+++ b/src/ui/Forms/ExportCustomTextFormat.cs
@@ -347,7 +347,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         internal static string GetParagraph(string template, string start, string end, string text, string originalText, int number, string actor, TimeCode duration, string gap, string timeCodeTemplate, Paragraph p, string videoFileName)
         {
-            var cps = Utilities.GetCharactersPerSecond(p);
+            var cps = p.GetCharactersPerSecond();
             var d = duration.ToString();
             if (timeCodeTemplate == "ff" || timeCodeTemplate == "f")
             {

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -873,7 +873,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 var newDuration = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines - p.StartTime.TotalMilliseconds;
                                 if (newDuration >= Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                                 {
-                                    var cps = Utilities.GetCharactersPerSecond(p);
+                                    var cps = p.GetCharactersPerSecond();
                                     if (cps <= Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                                     {
                                         p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + newDuration;
@@ -11060,7 +11060,7 @@ namespace Nikse.SubtitleEdit.Forms
         {
             if (paragraph.DurationTotalSeconds > 0)
             {
-                double charactersPerSecond = Utilities.GetCharactersPerSecond(paragraph);
+                double charactersPerSecond = paragraph.GetCharactersPerSecond();
                 if (charactersPerSecond > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds &&
                     Configuration.Settings.Tools.ListViewSyntaxColorDurationSmall)
                 {
@@ -20164,7 +20164,7 @@ namespace Nikse.SubtitleEdit.Forms
                         var temp = new Paragraph(p);
                         temp.StartTime.TotalMilliseconds = newStartTimeMs;
                         if (temp.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds ||
-                            Utilities.GetCharactersPerSecond(temp) > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                            temp.GetCharactersPerSecond() > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                         {
                             var next = _subtitle.GetParagraphOrDefault(index + 1);
                             if (next == null ||

--- a/src/ui/Forms/ModifySelection.cs
+++ b/src/ui/Forms/ModifySelection.cs
@@ -435,7 +435,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     else if (comboBoxRule.SelectedIndex == FunctionCpsLessThan) // Cps less than
                     {
-                        if (Utilities.GetCharactersPerSecond(p) < (double)numericUpDownDuration.Value)
+                        if (p.GetCharactersPerSecond() < (double)numericUpDownDuration.Value)
                         {
                             listViewItems.Add(MakeListViewItem(p, i));
                         }

--- a/src/ui/Forms/Statistics.cs
+++ b/src/ui/Forms/Statistics.cs
@@ -143,7 +143,7 @@ https://github.com/SubtitleEdit/subtitleedit
                 maximumDuration = Math.Max(duration, maximumDuration);
                 totalDuration += duration;
 
-                var charsSec = Utilities.GetCharactersPerSecond(p);
+                var charsSec = p.GetCharactersPerSecond();
                 minimumCharsSec = Math.Min(charsSec, minimumCharsSec);
                 maximumCharsSec = Math.Max(charsSec, maximumCharsSec);
                 totalCharsSec += charsSec;
@@ -203,7 +203,7 @@ https://github.com/SubtitleEdit/subtitleedit
                     totalSingleLines++;
                 }
 
-                var cps = Utilities.GetCharactersPerSecond(p);
+                var cps = p.GetCharactersPerSecond();
                 if (cps > Configuration.Settings.General.SubtitleOptimalCharactersPerSeconds)
                 {
                     aboveOptimalCpsCount++;
@@ -343,7 +343,7 @@ https://github.com/SubtitleEdit/subtitleedit
             for (var i = 0; i < _subtitle.Paragraphs.Count; i++)
             {
                 var p = _subtitle.Paragraphs[i];
-                if (Math.Abs(Utilities.GetCharactersPerSecond(p) - cps) < 0.01)
+                if (Math.Abs(p.GetCharactersPerSecond() - cps) < 0.01)
                 {
                     if (indices.Count >= NumberOfLinesToShow)
                     {

--- a/src/ui/Forms/Translate/MergeAndSplitHelper.cs
+++ b/src/ui/Forms/Translate/MergeAndSplitHelper.cs
@@ -551,14 +551,14 @@ namespace Nikse.SubtitleEdit.Forms.Translate
                     }
 
                     // check max chars
-                    var cps1 = Utilities.GetCharactersPerSecond(new Paragraph(arr[0], item.Paragraphs[0].StartTime.TotalMilliseconds, item.Paragraphs[0].EndTime.TotalMilliseconds));
-                    var cps2 = Utilities.GetCharactersPerSecond(new Paragraph(arr[1], item.Paragraphs[1].StartTime.TotalMilliseconds, item.Paragraphs[1].EndTime.TotalMilliseconds));
+                    var cps1 = new Paragraph(arr[0], item.Paragraphs[0].StartTime.TotalMilliseconds, item.Paragraphs[0].EndTime.TotalMilliseconds).GetCharactersPerSecond();
+                    var cps2 = new Paragraph(arr[1], item.Paragraphs[1].StartTime.TotalMilliseconds, item.Paragraphs[1].EndTime.TotalMilliseconds).GetCharactersPerSecond();
 
-                    var cpsChar1 = Utilities.GetCharactersPerSecond(new Paragraph(pctCharArr[0], item.Paragraphs[0].StartTime.TotalMilliseconds, item.Paragraphs[0].EndTime.TotalMilliseconds));
-                    var cpsChar2 = Utilities.GetCharactersPerSecond(new Paragraph(pctCharArr[1], item.Paragraphs[1].StartTime.TotalMilliseconds, item.Paragraphs[1].EndTime.TotalMilliseconds));
+                    var cpsChar1 = new Paragraph(pctCharArr[0], item.Paragraphs[0].StartTime.TotalMilliseconds, item.Paragraphs[0].EndTime.TotalMilliseconds).GetCharactersPerSecond();
+                    var cpsChar2 = new Paragraph(pctCharArr[1], item.Paragraphs[1].StartTime.TotalMilliseconds, item.Paragraphs[1].EndTime.TotalMilliseconds).GetCharactersPerSecond();
 
-                    var cpsDuration1 = Utilities.GetCharactersPerSecond(new Paragraph(pctDurationArr[0], item.Paragraphs[0].StartTime.TotalMilliseconds, item.Paragraphs[0].EndTime.TotalMilliseconds));
-                    var cpsDuration2 = Utilities.GetCharactersPerSecond(new Paragraph(pctDurationArr[1], item.Paragraphs[1].StartTime.TotalMilliseconds, item.Paragraphs[1].EndTime.TotalMilliseconds));
+                    var cpsDuration1 = new Paragraph(pctDurationArr[0], item.Paragraphs[0].StartTime.TotalMilliseconds, item.Paragraphs[0].EndTime.TotalMilliseconds).GetCharactersPerSecond();
+                    var cpsDuration2 = new Paragraph(pctDurationArr[1], item.Paragraphs[1].StartTime.TotalMilliseconds, item.Paragraphs[1].EndTime.TotalMilliseconds).GetCharactersPerSecond();
 
                     if (pctCharArr[0].Length > 0 && pctCharArr[0].EndsWith(',') &&
                         cpsChar1 < Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds &&

--- a/src/ui/Forms/Tts/ReviewAudioClips.cs
+++ b/src/ui/Forms/Tts/ReviewAudioClips.cs
@@ -54,7 +54,7 @@ namespace Nikse.SubtitleEdit.Forms.Tts
                 var item = new ListViewItem { Tag = p, Checked = true };
                 item.SubItems.Add(p.Number.ToString(CultureInfo.InvariantCulture));
                 item.SubItems.Add(_textToSpeech.GetParagraphAudio(p));
-                item.SubItems.Add(Utilities.GetCharactersPerSecond(p).ToString("0.#", CultureInfo.InvariantCulture));
+                item.SubItems.Add(p.GetCharactersPerSecond().ToString("0.#", CultureInfo.InvariantCulture));
 
                 var pInfo = fileNames[subtitle.GetIndex(p)];
                 if (pInfo.Factor == 1)
@@ -299,7 +299,7 @@ namespace Nikse.SubtitleEdit.Forms.Tts
 
                     var number = p.Number.ToString(CultureInfo.InvariantCulture);
                     var voice = _textToSpeech.GetParagraphAudio(p);
-                    var cps = Utilities.GetCharactersPerSecond(p).ToString("0.#", CultureInfo.InvariantCulture);
+                    var cps = p.GetCharactersPerSecond().ToString("0.#", CultureInfo.InvariantCulture);
                     var factor = "-";
                     if (pInfo.Factor != 1)
                     {


### PR DESCRIPTION
Removed GetCharactersPerSecond method from the Utilities class and refactored all its references to use the equivalent method newly added in the Paragraph class. This refactoring resulted in cleaner, more object-oriented code and consolidated related logic in the Paragraph class.