### PR TITLE
Paragraph duration

### DIFF
--- a/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Test/FixCommonErrors/FixCommonErrorsTest.cs
@@ -3701,9 +3701,9 @@ A las 7, practicar por la mañana
 con Issa.".SplitToLines(), null);
                 target.Initialize(_subtitle, new SubRip(), System.Text.Encoding.UTF8);
                 new FixShortGaps().Fix(_subtitle, new EmptyFixCallback());
-                Assert.IsTrue(_subtitle.Paragraphs[0].Duration.TotalMilliseconds > 0, "Gap should not be negative");
-                Assert.IsTrue(_subtitle.Paragraphs[1].Duration.TotalMilliseconds > 0, "Gap should not be negative");
-                Assert.IsTrue(_subtitle.Paragraphs[2].Duration.TotalMilliseconds > 0, "Gap should not be negative");
+                Assert.IsTrue(_subtitle.Paragraphs[0].Duration.Milliseconds > 0, "Gap should not be negative");
+                Assert.IsTrue(_subtitle.Paragraphs[1].Duration.Milliseconds > 0, "Gap should not be negative");
+                Assert.IsTrue(_subtitle.Paragraphs[2].Duration.Milliseconds > 0, "Gap should not be negative");
             }
         }
 

--- a/src/Test/Logic/ParagraphTest.cs
+++ b/src/Test/Logic/ParagraphTest.cs
@@ -65,7 +65,7 @@ namespace Test.Logic
         public void TestDuration()
         {
             var p = new Paragraph { Text = string.Empty, StartTime = new TimeCode(0, 1, 0, 0), EndTime = new TimeCode(0, 1, 1, 1) };
-            Assert.AreEqual(p.DurationTotalMilliseconds, 1001);
+            Assert.AreEqual(p.Duration.Milliseconds, 1001);
         }
 
     }

--- a/src/Test/Logic/SplitLongLinesHelperTest.cs
+++ b/src/Test/Logic/SplitLongLinesHelperTest.cs
@@ -65,11 +65,11 @@ namespace Test.Logic
             Assert.AreEqual("and laugh it off to realise that\r\nlife isn’t so bad after all.", procSubtitle.Paragraphs[6].Text);
 
             // timing test
-            if (procSubtitle.Paragraphs[5].DurationTotalMilliseconds > procSubtitle.Paragraphs[6].DurationTotalMilliseconds)
+            if (procSubtitle.Paragraphs[5].Duration.Milliseconds > procSubtitle.Paragraphs[6].Duration.Milliseconds)
             {
                 Assert.IsTrue(procSubtitle.Paragraphs[5].Text.Length > procSubtitle.Paragraphs[6].Text.Length);
             }
-            if (procSubtitle.Paragraphs[5].DurationTotalMilliseconds < procSubtitle.Paragraphs[6].DurationTotalMilliseconds)
+            if (procSubtitle.Paragraphs[5].Duration.Milliseconds < procSubtitle.Paragraphs[6].Duration.Milliseconds)
             {
                 Assert.IsTrue(procSubtitle.Paragraphs[5].Text.Length < procSubtitle.Paragraphs[6].Text.Length);
             }

--- a/src/libse/AudioToText/AudioToTextPostProcessor.cs
+++ b/src/libse/AudioToText/AudioToTextPostProcessor.cs
@@ -521,12 +521,12 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
 
         private static double CalcDurationToMove(Paragraph oldCurrent, Paragraph current, Paragraph next)
         {
-            if (current.DurationTotalMilliseconds < 0 || next.DurationTotalMilliseconds < 0)
+            if (current.Duration.Milliseconds < 0 || next.Duration.Milliseconds < 0)
             {
                 return 0;
             }
 
-            var totalDuration = current.DurationTotalMilliseconds + next.DurationTotalMilliseconds;
+            var totalDuration = current.Duration.Milliseconds + next.Duration.Milliseconds;
             var totalChars = current.Text.Length + next.Text.Length;
             var durChar = totalDuration / totalChars;
 

--- a/src/libse/AudioToText/WhisperTimingFixer.cs
+++ b/src/libse/AudioToText/WhisperTimingFixer.cs
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                 var pctHere = FindPercentage(startPos - 0.05, startPos + 0.05, wavePeaks);
                 if (Math.Abs(pctHere - (-1)) < 0.01)
                 {
-                    if (p.DurationTotalMilliseconds < minDurationMs)
+                    if (p.Duration.Milliseconds < minDurationMs)
                     {
                         s.Paragraphs[index] = oldP;
                     }
@@ -78,7 +78,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                         var pct = FindPercentage(startPosBack - 0.05, startPosBack + 0.05, wavePeaks);
                         if (Math.Abs(pct - (-1)) < 0.01)
                         {
-                            if (p.DurationTotalMilliseconds < minDurationMs)
+                            if (p.Duration.Milliseconds < minDurationMs)
                             {
                                 s.Paragraphs[index] = oldP;
                             }
@@ -86,7 +86,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                             return s;
                         }
 
-                        if (pct < percentageMax + 1 && p.DurationTotalSeconds < 5)
+                        if (pct < percentageMax + 1 && p.Duration.Seconds < 5)
                         {
                             startPosBack -= 0.025;
                             var pct2 = FindPercentage(startPosBack - 0.05, startPosBack + 0.05, wavePeaks);
@@ -127,7 +127,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                         var pctF = FindPercentage(startPosForward - 0.05, startPosForward + 0.05, wavePeaks);
                         if (Math.Abs(pctF - (-1)) < 0.01)
                         {
-                            if (p.DurationTotalMilliseconds < minDurationMs)
+                            if (p.Duration.Milliseconds < minDurationMs)
                             {
                                 s.Paragraphs[index] = oldP;
                             }
@@ -160,7 +160,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                 pctHere = FindPercentage(startPos - 0.05, startPos + 0.05, wavePeaks);
                 if (Math.Abs(pctHere - (-1)) < 0.01)
                 {
-                    if (p.DurationTotalMilliseconds < minDurationMs)
+                    if (p.Duration.Milliseconds < minDurationMs)
                     {
                         s.Paragraphs[index] = oldP;
                     }
@@ -176,7 +176,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                         pctHere = FindPercentage(startPosForward - 0.05, startPosForward + 0.05, wavePeaks);
                         if (Math.Abs(pctHere - (-1)) < 0.01)
                         {
-                            if (p.DurationTotalMilliseconds < 1000)
+                            if (p.Duration.Milliseconds < 1000)
                             {
                                 s.Paragraphs[index] = oldP;
                             }
@@ -209,7 +209,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                     }
                 }
 
-                if (p.DurationTotalMilliseconds < minDurationMs)
+                if (p.Duration.Milliseconds < minDurationMs)
                 {
                     s.Paragraphs[index] = oldP;
                 }
@@ -224,7 +224,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
 
             foreach (var p in s.Paragraphs)
             {
-                if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (p.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     p.StartTime.TotalMilliseconds = p.EndTime.TotalMilliseconds - Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                 }

--- a/src/libse/Common/Duration.cs
+++ b/src/libse/Common/Duration.cs
@@ -1,0 +1,28 @@
+﻿namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Represents a duration of time.
+    /// </summary>
+    public readonly struct Duration
+    {
+        private readonly double _value;
+
+        public Duration(double value) => _value = value;
+
+        /// <summary>
+        /// Represents a duration of time in milliseconds.
+        /// </summary>
+        public double Milliseconds => _value;
+
+        /// <summary>
+        /// Represents a duration of time in seconds.
+        /// </summary>
+        public double Seconds => _value / TimeCode.BaseUnit;
+
+        /// <summary>
+        /// Converts the duration to a TimeCode object.
+        /// </summary>
+        /// <returns>A TimeCode object representing the duration.</returns>
+        public TimeCode ToTimeCode() => new TimeCode(_value);
+    }
+}

--- a/src/libse/Common/Duration.cs
+++ b/src/libse/Common/Duration.cs
@@ -5,24 +5,24 @@
     /// </summary>
     public readonly struct Duration
     {
-        private readonly double _value;
+        private readonly double _milliseconds;
 
-        public Duration(double value) => _value = value;
+        public Duration(double milliseconds) => _milliseconds = milliseconds;
 
         /// <summary>
         /// Represents a duration of time in milliseconds.
         /// </summary>
-        public double Milliseconds => _value;
+        public double Milliseconds => _milliseconds;
 
         /// <summary>
         /// Represents a duration of time in seconds.
         /// </summary>
-        public double Seconds => _value / TimeCode.BaseUnit;
+        public double Seconds => _milliseconds / TimeCode.BaseUnit;
 
         /// <summary>
         /// Converts the duration to a TimeCode object.
         /// </summary>
         /// <returns>A TimeCode object representing the duration.</returns>
-        public TimeCode ToTimeCode() => new TimeCode(_value);
+        public TimeCode ToTimeCode() => new TimeCode(_milliseconds);
     }
 }

--- a/src/libse/Common/FixDurationLimits.cs
+++ b/src/libse/Common/FixDurationLimits.cs
@@ -29,7 +29,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 var p = subtitle.Paragraphs[i];
-                var displayTime = p.DurationTotalMilliseconds;
+                var displayTime = p.Duration.Milliseconds;
                 if (displayTime < _minDurationMs)
                 {
                     var next = subtitle.GetParagraphOrDefault(i + 1);
@@ -65,7 +65,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 var p = subtitle.Paragraphs[i];
-                var displayTime = p.DurationTotalMilliseconds;
+                var displayTime = p.Duration.Milliseconds;
                 if (displayTime > _maxDurationMs)
                 {
                     p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + _maxDurationMs;

--- a/src/libse/Common/Paragraph.cs
+++ b/src/libse/Common/Paragraph.cs
@@ -13,9 +13,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public TimeCode EndTime { get; set; }
 
-        public TimeCode Duration => new TimeCode(EndTime.TotalMilliseconds - StartTime.TotalMilliseconds);
-        public double DurationTotalMilliseconds => EndTime.TotalMilliseconds - StartTime.TotalMilliseconds;
-        public double DurationTotalSeconds => (EndTime.TotalMilliseconds - StartTime.TotalMilliseconds) / TimeCode.BaseUnit;
+        public Duration Duration => new Duration(EndTime.TotalMilliseconds - StartTime.TotalMilliseconds);
 
         public bool Forced { get; set; }
 
@@ -121,38 +119,38 @@ namespace Nikse.SubtitleEdit.Core.Common
                     return 0;
                 }
 
-                return 60.0 / DurationTotalSeconds * Text.CountWords();
+                return 60.0 / Duration.Seconds * Text.CountWords();
             }
         }
 
         public double GetCharactersPerSecond()
         {
-            if (DurationTotalMilliseconds < 1)
+            if (Duration.Milliseconds < 1)
             {
                 return 999;
             }
 
-            return (double)Text.CountCharacters(true) / DurationTotalSeconds;
+            return (double)Text.CountCharacters(true) / Duration.Seconds;
         }
 
         public double GetCharactersPerSecond(double numberOfCharacters)
         {
-            if (DurationTotalMilliseconds < 1)
+            if (Duration.Milliseconds < 1)
             {
                 return 999;
             }
 
-            return numberOfCharacters / DurationTotalSeconds;
+            return numberOfCharacters / Duration.Seconds;
         }
 
         public double GetCharactersPerSecond(ICalcLength calc)
         {
-            if (DurationTotalMilliseconds < 1)
+            if (Duration.Milliseconds < 1)
             {
                 return 999;
             }
 
-            return (double)calc.CountCharacters(Text, true) / DurationTotalSeconds;
+            return (double)calc.CountCharacters(Text, true) / Duration.Seconds;
         }
     }
 }

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -80,7 +80,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// Get the paragraph of index, null if out of bounds
         /// </summary>
         /// <param name="index">Index of wanted paragraph</param>
-        /// <returns>Paragraph, null if index is index is out of bounds</returns>
+        /// <returns>Paragraph, null if index is out of bounds</returns>
         public Paragraph GetParagraphOrDefault(int index)
         {
             if (Paragraphs == null || Paragraphs.Count <= index || index < 0)
@@ -569,7 +569,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             
             p.EndTime.TotalMilliseconds = wantedEndMs <= bestEndMs ? wantedEndMs : bestEndMs;
 
-            if (p.DurationTotalMilliseconds <= 0)
+            if (p.Duration.Milliseconds <= 0)
             {
                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + 1;
             }
@@ -597,7 +597,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         bestEndMs = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                     }
 
-                    // Then check for next shot change (if option is checked, and if any are supplied) -- keeping earliest time
+                    // Then check for next shot change (if option is checked, and if any are supplied) -- keeping the earliest time
                     if (shotChanges != null)
                     {
                         bestEndMs = Math.Min(bestEndMs, ShotChangeHelper.GetNextShotChangeMinusGapInMs(shotChanges, p.EndTime) ?? double.MaxValue);
@@ -605,7 +605,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                     p.EndTime.TotalMilliseconds = wantedEndMs <= bestEndMs ? wantedEndMs : bestEndMs;
 
-                    if (p.DurationTotalMilliseconds <= 0)
+                    if (p.Duration.Milliseconds <= 0)
                     {
                         p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + 1;
                     }
@@ -799,7 +799,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     Paragraphs = Paragraphs.OrderBy(p => p.EndTime.TotalMilliseconds).ThenBy(p => p.Number).ToList();
                     break;
                 case SubtitleSortCriteria.Duration:
-                    Paragraphs = Paragraphs.OrderBy(p => p.DurationTotalMilliseconds).ThenBy(p => p.Number).ToList();
+                    Paragraphs = Paragraphs.OrderBy(p => p.Duration.Milliseconds).ThenBy(p => p.Number).ToList();
                     break;
                 case SubtitleSortCriteria.Gap:
                     var lookupDictionary = new Dictionary<string, double>();

--- a/src/libse/Common/TextDraw.cs
+++ b/src/libse/Common/TextDraw.cs
@@ -6,7 +6,6 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     public static class TextDraw
     {
-
         public static double GetFontSize(double fontSize)
         {
             return fontSize * 0.895d; // font rendered in video players like vlc/mpv are a little smaller than .net, so we adjust font size a bit down

--- a/src/libse/Common/TextEffect/KaraokeEffect.cs
+++ b/src/libse/Common/TextEffect/KaraokeEffect.cs
@@ -17,7 +17,7 @@ namespace Nikse.SubtitleEdit.Core.Common.TextEffect
             var fontInsertIndex = CalculateColorInsertIndex(text);
             text = text.Insert(fontInsertIndex, GetColor(color));
             var result = _splitStrategy.Transform(text);
-            var duration = paragraph.DurationTotalMilliseconds - delay;
+            var duration = paragraph.Duration.Milliseconds - delay;
             var durationPerSentence = duration / result.Length;
             var baseStartTime = paragraph.StartTime.TotalMilliseconds;
 

--- a/src/libse/Common/TimeCode.cs
+++ b/src/libse/Common/TimeCode.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
 using System.Globalization;
+// ReSharper disable InconsistentNaming
 
 namespace Nikse.SubtitleEdit.Core.Common
 {

--- a/src/libse/Common/UnknownFormatImporter.cs
+++ b/src/libse/Common/UnknownFormatImporter.cs
@@ -44,13 +44,13 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     var sameLineSub = ImportTimeCodesInFramesAndTextOnSameLine(lines);
                     if (sameLineSub.Paragraphs.Count < 10 &&
-                        (sameLineSub.Paragraphs.Count(p => p.DurationTotalMilliseconds < 0) > 2 ||
+                        (sameLineSub.Paragraphs.Count(p => p.Duration.Milliseconds < 0) > 2 ||
                          sameLineSub.Paragraphs.Count(p => p.Text.Length > 100) > 1))
                     {
                         // probably not a subtitle
                     }
                     else if (sameLineSub.Paragraphs.Count < 20 &&
-                        (sameLineSub.Paragraphs.Count(p => p.DurationTotalMilliseconds < 0) > 8 ||
+                        (sameLineSub.Paragraphs.Count(p => p.Duration.Milliseconds < 0) > 8 ||
                          sameLineSub.Paragraphs.Count(p => p.Text.Length > 100) > 5))
                     {
                         // probably not a subtitle
@@ -764,7 +764,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             double averateDuration = 0;
             foreach (Paragraph a in subtitle.Paragraphs)
             {
-                double d = a.DurationTotalSeconds;
+                double d = a.Duration.Seconds;
                 if (d > 10)
                 {
                     d = 8;

--- a/src/libse/Common/UnknownFormatImporterJson.cs
+++ b/src/libse/Common/UnknownFormatImporterJson.cs
@@ -107,7 +107,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var msFound = 0;
             foreach (var p in subtitle.Paragraphs)
             {
-                totalDuration += p.DurationTotalMilliseconds;
+                totalDuration += p.Duration.Milliseconds;
                 if (p.Style.Contains("\"start\"") ||
                     p.Style.Contains("\"startMs\"") ||
                     p.Style.Contains("\"start_ms\"") ||

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1258,7 +1258,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return null;
             }
 
-            var middle = paragraph.StartTime.TotalMilliseconds + paragraph.DurationTotalMilliseconds / 2.0;
+            var middle = paragraph.StartTime.TotalMilliseconds + paragraph.Duration.Milliseconds / 2.0;
             if (index < originalParagraphs.Count)
             {
                 var o = originalParagraphs[index];
@@ -2758,7 +2758,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 subtitle.Paragraphs[i].Text = subtitle.Paragraphs[i].Text.TrimEnd();
-                if (subtitle.Paragraphs[i].DurationTotalMilliseconds < 1)
+                if (subtitle.Paragraphs[i].Duration.Milliseconds < 1)
                 {
                     // fix subtitles without duration
                     FixShortDisplayTime(subtitle, i);
@@ -2797,7 +2797,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             Paragraph p = s.Paragraphs[i];
             var minDisplayTime = Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
-            double displayTime = p.DurationTotalMilliseconds;
+            double displayTime = p.Duration.Milliseconds;
             if (displayTime < minDisplayTime)
             {
                 var next = s.GetParagraphOrDefault(i + 1);

--- a/src/libse/Forms/FixCommonErrors/FixLongDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixLongDisplayTimes.cs
@@ -22,7 +22,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     maxDisplayTime = Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                 }
 
-                double displayTime = p.DurationTotalMilliseconds;
+                double displayTime = p.Duration.Milliseconds;
 
                 bool allowFix = callbacks.AllowFix(p, Language.FixLongDisplayTime);
                 if (allowFix && displayTime > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)

--- a/src/libse/Forms/FixCommonErrors/FixOverlappingDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixOverlappingDisplayTimes.cs
@@ -26,7 +26,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             {
                 var p = subtitle.Paragraphs[i];
                 var oldP = new Paragraph(p);
-                if (p.DurationTotalMilliseconds < 0) // negative display time...
+                if (p.Duration.Milliseconds < 0) // negative display time...
                 {
                     bool isFixed = false;
                     string status = string.Format(Language.StartTimeLaterThanEndTime, i + 1, p.StartTime, p.EndTime, p.Text, Environment.NewLine);
@@ -100,18 +100,18 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 {
                     int diffHalf = (int)(diff / 2);
                     if (!Configuration.Settings.Tools.FixCommonErrorsFixOverlapAllowEqualEndStart && Math.Abs(p.StartTime.TotalMilliseconds - prev.EndTime.TotalMilliseconds) < 0.001 &&
-                        prev.DurationTotalMilliseconds > 100)
+                        prev.Duration.Milliseconds > 100)
                     {
                         if (callbacks.AllowFix(target, fixAction))
                         {
                             if (!canBeEqual)
                             {
                                 bool okEqual = true;
-                                if (prev.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                                if (prev.Duration.Milliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                                 {
                                     prev.EndTime.TotalMilliseconds--;
                                 }
-                                else if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                                else if (p.Duration.Milliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                                 {
                                     p.StartTime.TotalMilliseconds++;
                                 }
@@ -142,8 +142,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             callbacks.AddFixToListView(target, fixAction, oldPrevious, prev.ToString());
                         }
                     }
-                    else if (diff > 0 && currentOptimalDisplayTime <= p.DurationTotalMilliseconds - diffHalf &&
-                             prevOptimalDisplayTime <= prev.DurationTotalMilliseconds - diffHalf)
+                    else if (diff > 0 && currentOptimalDisplayTime <= p.Duration.Milliseconds - diffHalf &&
+                             prevOptimalDisplayTime <= prev.Duration.Milliseconds - diffHalf)
                     {
                         if (callbacks.AllowFix(p, fixAction))
                         {
@@ -167,8 +167,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             callbacks.AddFixToListView(p, fixAction, oldCurrent, p.ToString());
                         }
                     }
-                    else if (diff > 0 && currentWantedDisplayTime <= p.DurationTotalMilliseconds - diffHalf &&
-                             prevWantedDisplayTime <= prev.DurationTotalMilliseconds - diffHalf)
+                    else if (diff > 0 && currentWantedDisplayTime <= p.Duration.Milliseconds - diffHalf &&
+                             prevWantedDisplayTime <= prev.Duration.Milliseconds - diffHalf)
                     {
                         if (callbacks.AllowFix(p, fixAction))
                         {
@@ -206,7 +206,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             callbacks.AddFixToListView(p, fixAction, oldCurrent, p.ToString());
                         }
                     }
-                    else if (Math.Abs(p.StartTime.TotalMilliseconds - prev.EndTime.TotalMilliseconds) < 10 && p.DurationTotalMilliseconds > 1)
+                    else if (Math.Abs(p.StartTime.TotalMilliseconds - prev.EndTime.TotalMilliseconds) < 10 && p.Duration.Milliseconds > 1)
                     {
                         if (callbacks.AllowFix(p, fixAction))
                         {

--- a/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             {
                 Paragraph p = subtitle.Paragraphs[i];
                 var skip = p.StartTime.IsMaxTime || p.EndTime.IsMaxTime;
-                double displayTime = p.DurationTotalMilliseconds;
+                double displayTime = p.Duration.Milliseconds;
                 if (!skip && displayTime < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                 {
                     Paragraph next = subtitle.GetParagraphOrDefault(i + 1);
@@ -78,7 +78,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     Paragraph next = subtitle.GetParagraphOrDefault(i + 1);
                     Paragraph nextNext = subtitle.GetParagraphOrDefault(i + 2);
                     Paragraph prev = subtitle.GetParagraphOrDefault(i - 1);
-                    double diffMs = temp.DurationTotalMilliseconds - p.DurationTotalMilliseconds;
+                    double diffMs = temp.Duration.Milliseconds - p.Duration.Milliseconds;
 
                     // Normal - just make current subtitle duration longer
                     if (next == null || temp.EndTime.TotalMilliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines < next.StartTime.TotalMilliseconds)
@@ -93,7 +93,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     }
                     // Start current subtitle earlier (max 50 ms)
                     else if (Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime && p.StartTime.TotalMilliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds &&
-                             diffMs < 50 && (prev == null || prev.EndTime.TotalMilliseconds < p.EndTime.TotalMilliseconds - temp.DurationTotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines))
+                             diffMs < 50 && (prev == null || prev.EndTime.TotalMilliseconds < p.EndTime.TotalMilliseconds - temp.Duration.Milliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines))
                     {
                         noOfShortDisplayTimes = MoveStartTime(fixAction, noOfShortDisplayTimes, p, temp, next);
                     }
@@ -106,8 +106,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         if (callbacks.AllowFix(p, fixAction))
                         {
                             string oldCurrent = p.ToString();
-                            p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + temp.DurationTotalMilliseconds;
-                            var nextDurationMs = next.DurationTotalMilliseconds;
+                            p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + temp.Duration.Milliseconds;
+                            var nextDurationMs = next.Duration.Milliseconds;
                             next.StartTime.TotalMilliseconds = p.EndTime.TotalMilliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                             next.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds + nextDurationMs;
                             noOfShortDisplayTimes++;
@@ -116,12 +116,12 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     }
                     // Make next subtitle duration shorter + make current subtitle duration longer
                     else if (diffMs < 1000 &&
-                             Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime && new Paragraph(next.Text, p.StartTime.TotalMilliseconds + temp.DurationTotalMilliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines, next.EndTime.TotalMilliseconds).GetCharactersPerSecond() < Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                             Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime && new Paragraph(next.Text, p.StartTime.TotalMilliseconds + temp.Duration.Milliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines, next.EndTime.TotalMilliseconds).GetCharactersPerSecond() < Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                     {
                         if (callbacks.AllowFix(p, fixAction))
                         {
                             string oldCurrent = p.ToString();
-                            next.StartTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + temp.DurationTotalMilliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+                            next.StartTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + temp.Duration.Milliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                             p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                             noOfShortDisplayTimes++;
                             callbacks.AddFixToListView(p, fixAction, oldCurrent, p.ToString());
@@ -145,7 +145,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     }
                     // Start current subtitle earlier (max 200 ms)
                     else if (Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime && p.StartTime.TotalMilliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds &&
-                             diffMs < 200 && (prev == null || prev.EndTime.TotalMilliseconds < p.EndTime.TotalMilliseconds - temp.DurationTotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines))
+                             diffMs < 200 && (prev == null || prev.EndTime.TotalMilliseconds < p.EndTime.TotalMilliseconds - temp.Duration.Milliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines))
                     {
                         noOfShortDisplayTimes = MoveStartTime(fixAction, noOfShortDisplayTimes, p, temp, next);
                     }
@@ -182,7 +182,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                 }
 
-                p.StartTime.TotalMilliseconds = p.EndTime.TotalMilliseconds - temp.DurationTotalMilliseconds;
+                p.StartTime.TotalMilliseconds = p.EndTime.TotalMilliseconds - temp.Duration.Milliseconds;
                 noOfShortDisplayTimes++;
                 _callbacks.AddFixToListView(p, fixAction, oldCurrent, p.ToString());
             }

--- a/src/libse/Forms/SplitLongLinesHelper.cs
+++ b/src/libse/Forms/SplitLongLinesHelper.cs
@@ -84,7 +84,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 }
 
                 // calculate milliseconds per char
-                var millisecondsPerChar = oldParagraph.DurationTotalMilliseconds / (HtmlUtil.RemoveHtmlTags(text, true).Length - Environment.NewLine.Length);
+                var millisecondsPerChar = oldParagraph.Duration.Milliseconds / (HtmlUtil.RemoveHtmlTags(text, true).Length - Environment.NewLine.Length);
 
                 oldParagraph.Text = lines[firstLine];
 

--- a/src/libse/Forms/TimeCodesBeautifier.cs
+++ b/src/libse/Forms/TimeCodesBeautifier.cs
@@ -1077,7 +1077,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             }
 
             // Duration cannot be negative
-            if (paragraph.DurationTotalMilliseconds < 0)
+            if (paragraph.Duration.Milliseconds < 0)
             {
                 paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds;
             }

--- a/src/libse/NetflixQualityCheck/NetflixCheckMaxDuration.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMaxDuration.cs
@@ -11,7 +11,7 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
         {
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                if (p.DurationTotalMilliseconds > 7000)
+                if (p.Duration.Milliseconds > 7000)
                 {
                     var fixedParagraph = new Paragraph(p, false);
                     fixedParagraph.EndTime.TotalMilliseconds = fixedParagraph.StartTime.TotalMilliseconds + 7000;

--- a/src/libse/NetflixQualityCheck/NetflixCheckMinDuration.cs
+++ b/src/libse/NetflixQualityCheck/NetflixCheckMinDuration.cs
@@ -16,16 +16,16 @@ namespace Nikse.SubtitleEdit.Core.NetflixQualityCheck
 
                 if (controller.Language == "ja")
                 {
-                    if (p.DurationTotalMilliseconds < 500)
+                    if (p.Duration.Milliseconds < 500)
                     {
                         string comment = "Minimum duration: 0.5 second";
-                        controller.AddRecord(p, p.StartTime.ToHHMMSSFF(),  p.DurationTotalSeconds.ToString(CultureInfo.InvariantCulture), comment);
+                        controller.AddRecord(p, p.StartTime.ToHHMMSSFF(),  p.Duration.Seconds.ToString(CultureInfo.InvariantCulture), comment);
                     }
                     continue;
                 }
 
                 var next = subtitle.GetParagraphOrDefault(index + 1);
-                if (p.DurationTotalMilliseconds < 833 && !p.StartTime.IsMaxTime)
+                if (p.Duration.Milliseconds < 833 && !p.StartTime.IsMaxTime)
                 {
                     Paragraph fixedParagraph = null;
                     if (next == null || next.StartTime.TotalMilliseconds > p.StartTime.TotalMilliseconds + 834)

--- a/src/libse/SubtitleFormats/AdobeAfterEffectsFTME.cs
+++ b/src/libse/SubtitleFormats/AdobeAfterEffectsFTME.cs
@@ -33,7 +33,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             foreach (Paragraph p in subtitle.Paragraphs)
             {
                 XmlNode paragraph = xml.CreateElement("marker");
-                paragraph.InnerXml = string.Format(CultureInfo.InvariantCulture, innerXml, p.StartTime.TotalSeconds, p.DurationTotalSeconds);
+                paragraph.InnerXml = string.Format(CultureInfo.InvariantCulture, innerXml, p.StartTime.TotalSeconds, p.Duration.Seconds);
                 paragraph.SelectSingleNode("comment").Attributes["value"].InnerText = HtmlUtil.RemoveHtmlTags(p.Text, true).Replace(Environment.NewLine, "||");
                 root.AppendChild(paragraph);
             }

--- a/src/libse/SubtitleFormats/CaptionsInc.cs
+++ b/src/libse/SubtitleFormats/CaptionsInc.cs
@@ -252,7 +252,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                 }
             }
-            if (last != null && last.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+            if (last != null && last.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
             {
                 last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(last.Text);
             }

--- a/src/libse/SubtitleFormats/CheetahCaption.cs
+++ b/src/libse/SubtitleFormats/CheetahCaption.cs
@@ -266,7 +266,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 p.StartTime = DecodeTimestamp(buffer, i + 2);
                 p.EndTime = DecodeTimestamp(buffer, i + 6);
                 if (p.EndTime.Hours == 2 && p.EndTime.Minutes == 1 && p.EndTime.Seconds == 0 && p.EndTime.Milliseconds == 0 &&
-                    (p.DurationTotalMilliseconds < 0 || p.DurationTotalMilliseconds > 5000))
+                    (p.Duration.Milliseconds < 0 || p.Duration.Milliseconds > 5000))
                 {
                     usedBytes = 20 - 4;
                 }
@@ -345,7 +345,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 i += length;
             }
-            if (last != null && (last.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds || last.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds))
+            if (last != null && (last.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds || last.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds))
             {
                 last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(last.Text);
             }
@@ -355,7 +355,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var current = subtitle.Paragraphs[index];
                 var next = subtitle.Paragraphs[index + 1];
                 if (current.EndTime.Hours == 2 && current.EndTime.Minutes == 1 && current.EndTime.Seconds == 0 && current.EndTime.Milliseconds == 0 &&
-                    (current.DurationTotalMilliseconds < 0 || current.DurationTotalMilliseconds > 5000))
+                    (current.Duration.Milliseconds < 0 || current.Duration.Milliseconds > 5000))
                 {
                     current.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                 }

--- a/src/libse/SubtitleFormats/CheetahCaptionOld.cs
+++ b/src/libse/SubtitleFormats/CheetahCaptionOld.cs
@@ -76,17 +76,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 var paragraph = subtitle.Paragraphs[index];
                 var next = subtitle.GetParagraphOrDefault(index + 1);
-                if (paragraph.DurationTotalSeconds > 100)
+                if (paragraph.Duration.Seconds > 100)
                 {
                     _errorCount++;
                 }
-                if (Math.Abs(paragraph.EndTime.TotalMilliseconds) < 0.1 || paragraph.DurationTotalMilliseconds < 0.1)
+                if (Math.Abs(paragraph.EndTime.TotalMilliseconds) < 0.1 || paragraph.Duration.Milliseconds < 0.1)
                 {
                     if (next != null)
                     {
                         paragraph.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                     }
-                    if (next == null || paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                    if (next == null || paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                     {
                         paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                     }

--- a/src/libse/SubtitleFormats/Edius4Frames.cs
+++ b/src/libse/SubtitleFormats/Edius4Frames.cs
@@ -47,7 +47,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 marker.AppendChild(position);
 
                 XmlNode duration = xml.CreateElement("edius", "duration", "http://www.grassvalley.com/ns/edius/markerListInfo");
-                duration.InnerText = EncodeTimeCode(p.Duration);
+                duration.InnerText = EncodeTimeCode(p.Duration.ToTimeCode());
                 marker.AppendChild(duration);
 
                 XmlNode comment = xml.CreateElement("edius", "comment", "http://www.grassvalley.com/ns/edius/markerListInfo");

--- a/src/libse/SubtitleFormats/Edius4Ms.cs
+++ b/src/libse/SubtitleFormats/Edius4Ms.cs
@@ -47,7 +47,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 marker.AppendChild(position);
 
                 XmlNode duration = xml.CreateElement("edius", "duration", "http://www.grassvalley.com/ns/edius/markerListInfo");
-                duration.InnerText = EncodeTimeCode(p.Duration);
+                duration.InnerText = EncodeTimeCode(p.Duration.ToTimeCode());
                 marker.AppendChild(duration);
 
                 XmlNode comment = xml.CreateElement("edius", "comment", "http://www.grassvalley.com/ns/edius/markerListInfo");

--- a/src/libse/SubtitleFormats/EdiusMarkerList2Frames.cs
+++ b/src/libse/SubtitleFormats/EdiusMarkerList2Frames.cs
@@ -28,7 +28,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.Append(",\"");
                 sb.Append(EncodeTimeCode(p.StartTime));
                 sb.Append("\",\"");
-                sb.Append(EncodeTimeCode(p.Duration));
+                sb.Append(EncodeTimeCode(p.Duration.ToTimeCode()));
                 sb.Append("\",\"");
                 sb.Append(p.Text.Replace("\"", "\\\""));
                 sb.AppendLine("\"");

--- a/src/libse/SubtitleFormats/EdiusMarkerList2Ms.cs
+++ b/src/libse/SubtitleFormats/EdiusMarkerList2Ms.cs
@@ -28,7 +28,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.Append(",\"");
                 sb.Append(EncodeTimeCode(p.StartTime));
                 sb.Append("\",\"");
-                sb.Append(EncodeTimeCode(p.Duration));
+                sb.Append(EncodeTimeCode(p.Duration.ToTimeCode()));
                 sb.Append("\",\"");
                 sb.Append(p.Text.Replace("\"", "\\\""));
                 sb.AppendLine("\"");

--- a/src/libse/SubtitleFormats/EdiusMarkerList3Frames.cs
+++ b/src/libse/SubtitleFormats/EdiusMarkerList3Frames.cs
@@ -28,7 +28,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.Append(",\"ON\",\"");
                 sb.Append(EncodeTimeCode(p.StartTime));
                 sb.Append("\",\"");
-                sb.Append(EncodeTimeCode(p.Duration));
+                sb.Append(EncodeTimeCode(p.Duration.ToTimeCode()));
                 sb.Append("\",\"");
                 sb.Append(p.Text.Replace("\"", "\\\""));
                 sb.AppendLine("\"");

--- a/src/libse/SubtitleFormats/EdiusMarkerList3Ms.cs
+++ b/src/libse/SubtitleFormats/EdiusMarkerList3Ms.cs
@@ -28,7 +28,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.Append(",\"ON\",\"");
                 sb.Append(EncodeTimeCode(p.StartTime));
                 sb.Append("\",\"");
-                sb.Append(EncodeTimeCode(p.Duration));
+                sb.Append(EncodeTimeCode(p.Duration.ToTimeCode()));
                 sb.Append("\",\"");
                 sb.Append(p.Text.Replace("\"", "\\\""));
                 sb.AppendLine("\"");

--- a/src/libse/SubtitleFormats/ElrPrint.cs
+++ b/src/libse/SubtitleFormats/ElrPrint.cs
@@ -47,7 +47,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static object GetDuration(Paragraph p)
         {
             string s;
-            var ts = p.Duration.TimeSpan;
+            var ts = p.Duration.ToTimeCode().TimeSpan;
             var frames = Math.Round(ts.Milliseconds / (TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate));
             if (frames >= Configuration.Settings.General.CurrentFrameRate - 0.001)
             {
@@ -57,7 +57,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 s = $"{ts.Seconds:00}:{MillisecondsToFramesMaxFrameRate(ts.Milliseconds):00}";
             }
-            if (p.DurationTotalMilliseconds >= 0)
+            if (p.Duration.Milliseconds >= 0)
             {
                 return s;
             }

--- a/src/libse/SubtitleFormats/FLVCoreCuePoints.cs
+++ b/src/libse/SubtitleFormats/FLVCoreCuePoints.cs
@@ -52,7 +52,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 name = xml.CreateElement("Name");
                 name.InnerText = "duration";
                 value = xml.CreateElement("Value");
-                value.InnerText = p.DurationTotalMilliseconds.ToString();
+                value.InnerText = p.Duration.Milliseconds.ToString();
                 parameter.AppendChild(name);
                 parameter.AppendChild(value);
                 parameters.AppendChild(parameter);

--- a/src/libse/SubtitleFormats/FilmEditXml.cs
+++ b/src/libse/SubtitleFormats/FilmEditXml.cs
@@ -64,7 +64,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 paragraph.AppendChild(num);
 
                 XmlNode dur = xml.CreateElement("dur");
-                dur.InnerText = EncodeDuration(p.Duration);
+                dur.InnerText = EncodeDuration(p.Duration.ToTimeCode());
                 paragraph.AppendChild(dur);
 
                 XmlNode textNode = xml.CreateElement("text");

--- a/src/libse/SubtitleFormats/FinalCutProXCM.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXCM.cs
@@ -58,7 +58,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 XmlNode chapterMarker = xml.CreateElement("chapter-marker");
 
                 var attr = xml.CreateAttribute("duration");
-                attr.Value = Convert.ToInt64(p.DurationTotalSeconds * 2400000) + "/2400000s";
+                attr.Value = Convert.ToInt64(p.Duration.Seconds * 2400000) + "/2400000s";
                 chapterMarker.Attributes.Append(attr);
 
                 attr = xml.CreateAttribute("start");

--- a/src/libse/SubtitleFormats/FinalCutProXXml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXXml.cs
@@ -68,7 +68,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 attr = xml.CreateAttribute("duration");
                 //attr.Value = "9529520/2400000s";
-                attr.Value = Convert.ToInt64(p.DurationTotalSeconds * 2400000) + "/2400000s";
+                attr.Value = Convert.ToInt64(p.Duration.Seconds * 2400000) + "/2400000s";
                 clip.Attributes.Append(attr);
 
                 attr = xml.CreateAttribute("start");
@@ -81,7 +81,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 clip.Attributes.Append(attr);
 
                 attr = xml.CreateAttribute("audioDuration");
-                attr.Value = Convert.ToInt64(p.DurationTotalSeconds * 2400000) + "/2400000s";
+                attr.Value = Convert.ToInt64(p.Duration.Seconds * 2400000) + "/2400000s";
                 clip.Attributes.Append(attr);
 
                 attr = xml.CreateAttribute("tcFormat");
@@ -91,7 +91,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 XmlNode titleNode = clip.SelectSingleNode("title");
                 titleNode.Attributes["offset"].Value = Convert.ToInt64(p.StartTime.TotalSeconds * 60000) + "/60000s";
                 titleNode.Attributes["name"].Value = HtmlUtil.RemoveHtmlTags(p.Text);
-                titleNode.Attributes["duration"].Value = Convert.ToInt64(p.DurationTotalSeconds * 60000) + "/60000s";
+                titleNode.Attributes["duration"].Value = Convert.ToInt64(p.Duration.Seconds * 60000) + "/60000s";
                 titleNode.Attributes["start"].Value = Convert.ToInt64(p.StartTime.TotalSeconds * 60000) + "/60000s";
 
                 XmlNode text = clip.SelectSingleNode("title/text");

--- a/src/libse/SubtitleFormats/FinalCutProXml13.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml13.cs
@@ -66,7 +66,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 clip.Attributes.Append(attr);
 
                 attr = xml.CreateAttribute("duration");
-                attr.Value = Convert.ToInt64(p.DurationTotalSeconds * 2400000) + "/2400000s";
+                attr.Value = Convert.ToInt64(p.Duration.Seconds * 2400000) + "/2400000s";
                 clip.Attributes.Append(attr);
 
                 attr = xml.CreateAttribute("start");
@@ -78,7 +78,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 clip.Attributes.Append(attr);
 
                 attr = xml.CreateAttribute("audioDuration");
-                attr.Value = Convert.ToInt64(p.DurationTotalSeconds * 2400000) + "/2400000s";
+                attr.Value = Convert.ToInt64(p.Duration.Seconds * 2400000) + "/2400000s";
                 clip.Attributes.Append(attr);
 
                 attr = xml.CreateAttribute("tcFormat");
@@ -88,7 +88,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 XmlNode titleNode = clip.SelectSingleNode("video");
                 titleNode.Attributes["offset"].Value = Convert.ToInt64(p.StartTime.TotalSeconds * 60000) + "/60000s";
                 titleNode.Attributes["name"].Value = HtmlUtil.RemoveHtmlTags(p.Text);
-                titleNode.Attributes["duration"].Value = Convert.ToInt64(p.DurationTotalSeconds * 60000) + "/60000s";
+                titleNode.Attributes["duration"].Value = Convert.ToInt64(p.Duration.Seconds * 60000) + "/60000s";
                 titleNode.Attributes["start"].Value = Convert.ToInt64(p.StartTime.TotalSeconds * 60000) + "/60000s";
 
                 XmlNode param = clip.SelectSingleNode("video/param");

--- a/src/libse/SubtitleFormats/FinalCutProXml14.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml14.cs
@@ -76,7 +76,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 XmlNode generatorNode = video.SelectSingleNode("video");
                 generatorNode.Attributes["offset"].Value = Convert.ToInt64(p.StartTime.TotalSeconds * 2400000) + "/2400000s";
-                generatorNode.Attributes["duration"].Value = Convert.ToInt64(p.DurationTotalSeconds * 2400000) + "/2400000s";
+                generatorNode.Attributes["duration"].Value = Convert.ToInt64(p.Duration.Seconds * 2400000) + "/2400000s";
                 generatorNode.Attributes["start"].Value = Convert.ToInt64(p.StartTime.TotalSeconds * 2400000) + "/2400000s";
 
                 XmlNode param = video.SelectSingleNode("video/param");

--- a/src/libse/SubtitleFormats/FinalCutProXml14Text.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml14Text.cs
@@ -88,13 +88,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     generatorNode.Attributes["offset"].Value = FinalCutProXml15.GetFrameTime(p.StartTime);
                 }
 
-                if (IsNearleWholeNumber(p.DurationTotalSeconds))
+                if (IsNearleWholeNumber(p.Duration.Seconds))
                 {
-                    generatorNode.Attributes["duration"].Value = Convert.ToInt64(p.DurationTotalSeconds) + "s";
+                    generatorNode.Attributes["duration"].Value = Convert.ToInt64(p.Duration.Seconds) + "s";
                 }
                 else
                 {
-                    generatorNode.Attributes["duration"].Value = FinalCutProXml15.GetFrameTime(p.Duration);
+                    generatorNode.Attributes["duration"].Value = FinalCutProXml15.GetFrameTime(p.Duration.ToTimeCode());
                 }
 
                 if (IsNearleWholeNumber(p.StartTime.TotalSeconds))

--- a/src/libse/SubtitleFormats/FinalCutProXml15.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml15.cs
@@ -325,7 +325,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 WriteCurrentTextSegment(styles, styleTextPairs, video, number++, sbTrimmedTitle.ToString(), xml);
                 XmlNode generatorNode = video.SelectSingleNode("title");
                 generatorNode.Attributes["offset"].Value = GetFrameTime(p.StartTime);
-                generatorNode.Attributes["duration"].Value = GetFrameTime(p.Duration);
+                generatorNode.Attributes["duration"].Value = GetFrameTime(p.Duration.ToTimeCode());
                 generatorNode.Attributes["start"].Value = GetFrameTime(p.StartTime);
                 videoNode.AppendChild(generatorNode);
             }

--- a/src/libse/SubtitleFormats/FinalCutProXmlGap.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXmlGap.cs
@@ -66,7 +66,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 titleNode = titleNode.SelectSingleNode("title");
                 titleNode.Attributes["offset"].Value = Convert.ToInt64(p.StartTime.TotalSeconds * 60000) + "/60000s";
                 titleNode.Attributes["name"].Value = HtmlUtil.RemoveHtmlTags(p.Text);
-                titleNode.Attributes["duration"].Value = Convert.ToInt64(p.DurationTotalSeconds * 60000) + "/60000s";
+                titleNode.Attributes["duration"].Value = Convert.ToInt64(p.Duration.Seconds * 60000) + "/60000s";
                 titleNode.Attributes["start"].Value = Convert.ToInt64(p.StartTime.TotalSeconds * 60000) + "/60000s";
                 titleNode.SelectSingleNode("text").InnerText = HtmlUtil.RemoveHtmlTags(p.Text);
                 videoNode.AppendChild(titleNode);

--- a/src/libse/SubtitleFormats/FinalCutProXmlName.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXmlName.cs
@@ -84,7 +84,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 MakeTitleNodeWithText(video, text);
                 XmlNode generatorNode = video.SelectSingleNode("title");
                 generatorNode.Attributes["offset"].Value = FinalCutProXml15.GetFrameTime(p.StartTime);
-                generatorNode.Attributes["duration"].Value = FinalCutProXml15.GetFrameTime(p.Duration);
+                generatorNode.Attributes["duration"].Value = FinalCutProXml15.GetFrameTime(p.Duration.ToTimeCode());
                 generatorNode.Attributes["start"].Value = FinalCutProXml15.GetFrameTime(p.StartTime);
                 generatorNode.Attributes["name"].Value = text;
                 gapNode.AppendChild(generatorNode);

--- a/src/libse/SubtitleFormats/GooglePlayJson.cs
+++ b/src/libse/SubtitleFormats/GooglePlayJson.cs
@@ -21,7 +21,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 sb.AppendLine(count > 0 ? ", {" : "  {");
                 sb.AppendLine("    \"tStartMs\": " + p.StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture) + ",");
-                sb.AppendLine("    \"dDurationMs\": " + p.DurationTotalMilliseconds.ToString(CultureInfo.InvariantCulture) + ",");
+                sb.AppendLine("    \"dDurationMs\": " + p.Duration.Milliseconds.ToString(CultureInfo.InvariantCulture) + ",");
                 sb.AppendLine("    \"segs\": [ {");
                 sb.AppendLine("      \"utf8\": \"" + Json.EncodeJsonText(p.Text).Replace("<br />", "\\n") + "\"");
                 sb.AppendLine("    } ]");

--- a/src/libse/SubtitleFormats/JsonTed.cs
+++ b/src/libse/SubtitleFormats/JsonTed.cs
@@ -38,12 +38,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
 
                 sb.Append("{\"duration\":");
-                sb.Append(p.DurationTotalMilliseconds.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                sb.Append(p.Duration.Milliseconds.ToString(CultureInfo.InvariantCulture));
                 sb.Append(",\"content\":\"");
                 sb.Append(Json.EncodeJsonText(p.Text) + "\"");
                 sb.Append(",\"startOfParagraph\":true");
                 sb.Append(",\"startTime\":");
-                sb.Append(p.StartTime.TotalMilliseconds.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                sb.Append(p.StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
                 sb.Append('}');
                 count++;
             }
@@ -76,8 +76,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 string content = Json.ReadTag(s, "content");
                 if (start != null && duration != null && content != null)
                 {
-                    if (double.TryParse(start, System.Globalization.NumberStyles.AllowDecimalPoint, System.Globalization.CultureInfo.InvariantCulture, out var startSeconds) &&
-                        double.TryParse(duration, System.Globalization.NumberStyles.AllowDecimalPoint, System.Globalization.CultureInfo.InvariantCulture, out var durationSeconds))
+                    if (double.TryParse(start, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var startSeconds) &&
+                        double.TryParse(duration, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var durationSeconds))
                     {
                         subtitle.Paragraphs.Add(new Paragraph(Json.DecodeJsonText(content), startSeconds, startSeconds + durationSeconds));
                     }

--- a/src/libse/SubtitleFormats/JsonType13.cs
+++ b/src/libse/SubtitleFormats/JsonType13.cs
@@ -21,7 +21,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var last = subtitle.Paragraphs.LastOrDefault();
             if (last != null)
             {
-                duration = (last.StartTime.TotalSeconds + last.DurationTotalSeconds).ToString(CultureInfo.InvariantCulture);
+                duration = (last.StartTime.TotalSeconds + last.Duration.Seconds).ToString(CultureInfo.InvariantCulture);
             }
 
             var createdAt = "";
@@ -47,7 +47,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
 
                 sb.AppendLine("  {");
-                sb.AppendLine("    \"duration\": \"" + p.DurationTotalSeconds.ToString(CultureInfo.InvariantCulture) + "\",");
+                sb.AppendLine("    \"duration\": \"" + p.Duration.Seconds.ToString(CultureInfo.InvariantCulture) + "\",");
                 sb.AppendLine("    \"confidence\": null,");
                 sb.AppendLine("    \"name\": \"" + Json.EncodeJsonText(p.Text) + "\",");
                 sb.AppendLine("    \"time\": \"" + p.StartTime.TotalSeconds.ToString(CultureInfo.InvariantCulture) + "\"");

--- a/src/libse/SubtitleFormats/JsonType18.cs
+++ b/src/libse/SubtitleFormats/JsonType18.cs
@@ -26,7 +26,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.AppendLine();
                 sb.AppendLine("  {");
                 sb.AppendLine($"    \"s\": {p.StartTime.TotalSeconds.ToString(CultureInfo.InvariantCulture)},");
-                sb.AppendLine($"    \"d\": {p.DurationTotalSeconds.ToString(CultureInfo.InvariantCulture)},");
+                sb.AppendLine($"    \"d\": {p.Duration.Seconds.ToString(CultureInfo.InvariantCulture)},");
                 sb.AppendLine($"    \"n\": \"{Json.EncodeJsonText(p.Text, "\\n")}\"");
                 sb.Append("  }");
             }

--- a/src/libse/SubtitleFormats/JsonType19.cs
+++ b/src/libse/SubtitleFormats/JsonType19.cs
@@ -29,7 +29,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.AppendLine();
                 sb.AppendLine("  {");
                 sb.AppendLine($"    \"tStartMs\": {p.StartTime.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)},");
-                sb.AppendLine($"    \"dDurationMs\": {p.DurationTotalMilliseconds.ToString(CultureInfo.InvariantCulture)},");
+                sb.AppendLine($"    \"dDurationMs\": {p.Duration.Milliseconds.ToString(CultureInfo.InvariantCulture)},");
                 sb.AppendLine($"    \"segs\": [{{ \"utf8\": \"{Json.EncodeJsonText(p.Text, "\\n")}\" }} ]");
                 sb.Append("  }");
             }

--- a/src/libse/SubtitleFormats/JsonType23.cs
+++ b/src/libse/SubtitleFormats/JsonType23.cs
@@ -27,7 +27,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.AppendLine();
                 sb.AppendLine("    {");
                 sb.AppendLine($"      \"s\": {p.StartTime.TotalSeconds.ToString(CultureInfo.InvariantCulture)},");
-                sb.AppendLine($"      \"d\": {p.Duration.TotalSeconds.ToString(CultureInfo.InvariantCulture)},");
+                sb.AppendLine($"      \"d\": {p.Duration.Seconds.ToString(CultureInfo.InvariantCulture)},");
                 sb.AppendLine($"      \"n\": \"{Json.EncodeJsonText(p.Text, "\\n")}\"");
                 sb.Append("    }");
             }

--- a/src/libse/SubtitleFormats/JsonType3.cs
+++ b/src/libse/SubtitleFormats/JsonType3.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
 
                 sb.Append("{\"duration\":");
-                sb.Append(p.DurationTotalMilliseconds.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                sb.Append(p.Duration.Milliseconds.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 sb.Append(",\"content\":\"");
                 sb.Append(Json.EncodeJsonText(p.Text) + "\"");
                 sb.Append(",\"startOfParagraph\":false");

--- a/src/libse/SubtitleFormats/JsonType8.cs
+++ b/src/libse/SubtitleFormats/JsonType8.cs
@@ -20,7 +20,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 return false;
             }
-            var avgDurSecs = subtitle.Paragraphs.Average(p => p.DurationTotalSeconds);
+            var avgDurSecs = subtitle.Paragraphs.Average(p => p.Duration.Seconds);
             return avgDurSecs < 60;
         }
 

--- a/src/libse/SubtitleFormats/JsonType8b.cs
+++ b/src/libse/SubtitleFormats/JsonType8b.cs
@@ -20,7 +20,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 return false;
             }
-            var avgDurSecs = subtitle.Paragraphs.Average(p => p.DurationTotalSeconds);
+            var avgDurSecs = subtitle.Paragraphs.Average(p => p.Duration.Seconds);
             return avgDurSecs < 60 && avgDurSecs > 0.1;
         }
 

--- a/src/libse/SubtitleFormats/Lrc.cs
+++ b/src/libse/SubtitleFormats/Lrc.cs
@@ -299,7 +299,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                     }
-                    if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                    if (p.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                     {
                         double duration = Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                         p.EndTime = new TimeCode(p.StartTime.TotalMilliseconds + duration);

--- a/src/libse/SubtitleFormats/Lrc3DigitsMs.cs
+++ b/src/libse/SubtitleFormats/Lrc3DigitsMs.cs
@@ -300,7 +300,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                     }
-                    if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                    if (p.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                     {
                         double duration = Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                         p.EndTime = new TimeCode(p.StartTime.TotalMilliseconds + duration);

--- a/src/libse/SubtitleFormats/LrcNoEndTime.cs
+++ b/src/libse/SubtitleFormats/LrcNoEndTime.cs
@@ -280,7 +280,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (next != null && !p.StartTime.IsMaxTime && !next.StartTime.IsMaxTime)
                 {
                     p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
-                    if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                    if (p.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                     {
                         p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text + "!");
                     }

--- a/src/libse/SubtitleFormats/NVivoTranscript.cs
+++ b/src/libse/SubtitleFormats/NVivoTranscript.cs
@@ -98,7 +98,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Configuration.Settings.General.NewEmptyDefaultMs;
                 }
 
-                if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                 }

--- a/src/libse/SubtitleFormats/NciCaption.cs
+++ b/src/libse/SubtitleFormats/NciCaption.cs
@@ -233,7 +233,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 Paragraph p = subtitle.GetParagraphOrDefault(i);
                 Paragraph next = subtitle.GetParagraphOrDefault(i + 1);
-                if (p.DurationTotalMilliseconds <= 0 && next != null)
+                if (p.Duration.Milliseconds <= 0 && next != null)
                 {
                     p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - 1;
                 }

--- a/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
+++ b/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
@@ -113,7 +113,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             paragraph.Attributes.Append(start);
 
             XmlAttribute dur = xml.CreateAttribute("dur");
-            dur.InnerText = TimedText10.ConvertToTimeString(p.Duration);
+            dur.InnerText = TimedText10.ConvertToTimeString(p.Duration.ToTimeCode());
             paragraph.Attributes.Append(dur);
 
             XmlAttribute region = xml.CreateAttribute("region");

--- a/src/libse/SubtitleFormats/NkhCuePoints.cs
+++ b/src/libse/SubtitleFormats/NkhCuePoints.cs
@@ -53,7 +53,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 name = xml.CreateElement("Name");
                 name.InnerText = "duration";
                 value = xml.CreateElement("Value");
-                value.InnerText = p.DurationTotalMilliseconds.ToString();
+                value.InnerText = p.Duration.Milliseconds.ToString();
                 parameter.AppendChild(name);
                 parameter.AppendChild(value);
                 parameters.AppendChild(parameter);

--- a/src/libse/SubtitleFormats/Rtf2.cs
+++ b/src/libse/SubtitleFormats/Rtf2.cs
@@ -100,7 +100,7 @@ TimeCode Format: " + Configuration.Settings.General.CurrentFrameRate + @" frames
                 subtitle.Paragraphs.Add(p);
             }
 
-            if (subtitle.Paragraphs.Count > 0 && subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].DurationTotalMilliseconds < 0.01)
+            if (subtitle.Paragraphs.Count > 0 && subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].Duration.Milliseconds < 0.01)
             {
                 p = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);

--- a/src/libse/SubtitleFormats/SmilTimesheetData.cs
+++ b/src/libse/SubtitleFormats/SmilTimesheetData.cs
@@ -217,7 +217,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                 }
-                if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                 }

--- a/src/libse/SubtitleFormats/SonyDVDArchitectExplicitDuration.cs
+++ b/src/libse/SubtitleFormats/SonyDVDArchitectExplicitDuration.cs
@@ -22,11 +22,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 string text = HtmlUtil.RemoveHtmlTags(p.Text);
                 text = text.Replace(Environment.NewLine, "\r");
+                var dur = p.Duration.ToTimeCode();
                 sb.AppendLine(string.Format(writeFormat, p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, p.StartTime.Milliseconds,
-                                            p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, p.EndTime.Milliseconds,
-                                            p.Duration.Hours, p.Duration.Minutes, p.Duration.Seconds, p.Duration.Milliseconds,
-                                            text));
+                    p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, p.EndTime.Milliseconds,
+                    dur.Hours, dur.Minutes, dur.Seconds, dur.Milliseconds,
+                    text));
             }
+
             return sb.ToString().Trim() + Environment.NewLine + Environment.NewLine + Environment.NewLine;
         }
 

--- a/src/libse/SubtitleFormats/SonyDVDArchitectLineAndDuration.cs
+++ b/src/libse/SubtitleFormats/SonyDVDArchitectLineAndDuration.cs
@@ -44,15 +44,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var startFrame = MillisecondsToFramesMaxFrameRate(p.StartTime.Milliseconds);
                 var endFrame = MillisecondsToFramesMaxFrameRate(p.EndTime.Milliseconds);
                 var durationCalc = new Paragraph(
-                        new TimeCode(p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, FramesToMillisecondsMax999(startFrame)),
-                        new TimeCode(p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, FramesToMillisecondsMax999(endFrame)),
-                        string.Empty);
+                    new TimeCode(p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, FramesToMillisecondsMax999(startFrame)),
+                    new TimeCode(p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, FramesToMillisecondsMax999(endFrame)),
+                    string.Empty);
 
+                var dur = durationCalc.Duration.ToTimeCode();
                 sb.AppendLine(string.Format(writeFormat + Environment.NewLine,
-                                            p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, startFrame,
-                                            p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, endFrame,
-                                            durationCalc.Duration.Hours, durationCalc.Duration.Minutes, durationCalc.Duration.Seconds, MillisecondsToFramesMaxFrameRate(durationCalc.Duration.Milliseconds),
-                                            text, count));
+                    p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, startFrame,
+                    p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, endFrame,
+                    dur.Hours, dur.Minutes, dur.Seconds, MillisecondsToFramesMaxFrameRate(dur.Milliseconds),
+                    text, count));
             }
             return sb.ToString().Trim() + Environment.NewLine + Environment.NewLine + Environment.NewLine;
         }

--- a/src/libse/SubtitleFormats/SonyDVDArchitectLineDurationLength.cs
+++ b/src/libse/SubtitleFormats/SonyDVDArchitectLineDurationLength.cs
@@ -44,15 +44,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var startFrame = MillisecondsToFramesMaxFrameRate(p.StartTime.Milliseconds);
                 var endFrame = MillisecondsToFramesMaxFrameRate(p.EndTime.Milliseconds);
                 var durationCalc = new Paragraph(
-                        new TimeCode(p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, FramesToMillisecondsMax999(startFrame)),
-                        new TimeCode(p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, FramesToMillisecondsMax999(endFrame)),
-                        string.Empty);
+                    new TimeCode(p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, FramesToMillisecondsMax999(startFrame)),
+                    new TimeCode(p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, FramesToMillisecondsMax999(endFrame)),
+                    string.Empty);
 
+                var dur = durationCalc.Duration.ToTimeCode();
                 sb.AppendLine(string.Format(writeFormat + Environment.NewLine,
-                                            p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, startFrame,
-                                            p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, endFrame,
-                                            durationCalc.Duration.Hours, durationCalc.Duration.Minutes, durationCalc.Duration.Seconds, MillisecondsToFramesMaxFrameRate(durationCalc.Duration.Milliseconds),
-                                            text.Length, text, count));
+                    p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, startFrame,
+                    p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, endFrame,
+                    dur.Hours, dur.Minutes, dur.Seconds, MillisecondsToFramesMaxFrameRate(dur.Milliseconds),
+                    text.Length, text, count));
             }
             return sb.ToString().Trim() + Environment.NewLine + Environment.NewLine + Environment.NewLine;
         }

--- a/src/libse/SubtitleFormats/SubtitleEditorProject.cs
+++ b/src/libse/SubtitleFormats/SubtitleEditorProject.cs
@@ -62,7 +62,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 XmlNode paragraph = xml.CreateElement("subtitle");
 
                 XmlAttribute duration = xml.CreateAttribute("duration");
-                duration.InnerText = ((int)Math.Round(p.DurationTotalMilliseconds)).ToString(CultureInfo.InvariantCulture);
+                duration.InnerText = ((int)Math.Round(p.Duration.Milliseconds)).ToString(CultureInfo.InvariantCulture);
                 paragraph.Attributes.Append(duration);
 
                 XmlAttribute effect = xml.CreateAttribute("effect");

--- a/src/libse/SubtitleFormats/Ted20.cs
+++ b/src/libse/SubtitleFormats/Ted20.cs
@@ -102,17 +102,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
 
                 var next = subtitle.GetParagraphOrDefault(index + 1);
-                if (paragraph.DurationTotalSeconds > 100)
+                if (paragraph.Duration.Seconds > 100)
                 {
                     _errorCount++;
                 }
-                if (Math.Abs(paragraph.EndTime.TotalMilliseconds) < 0.1 || paragraph.DurationTotalMilliseconds < 0.1)
+                if (Math.Abs(paragraph.EndTime.TotalMilliseconds) < 0.1 || paragraph.Duration.Milliseconds < 0.1)
                 {
                     if (next != null)
                     {
                         paragraph.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                     }
-                    if (next == null || paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                    if (next == null || paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                     {
                         paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                     }

--- a/src/libse/SubtitleFormats/TimeCodesOnly1.cs
+++ b/src/libse/SubtitleFormats/TimeCodesOnly1.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             int index = 1;
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                sb.AppendLine($"{index}\t{EncodeTimeCode(p.StartTime)}\t{EncodeTimeCode(p.EndTime)}\t{p.Duration}");
+                sb.AppendLine($"{index}\t{EncodeTimeCode(p.StartTime)}\t{EncodeTimeCode(p.EndTime)}\t{p.Duration.ToTimeCode()}");
                 index++;
             }
             return sb.ToString();

--- a/src/libse/SubtitleFormats/TimeXml2.cs
+++ b/src/libse/SubtitleFormats/TimeXml2.cs
@@ -39,7 +39,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 paragraph.AppendChild(end);
 
                 XmlNode duration = xml.CreateElement("Duration");
-                duration.InnerText = p.Duration.ToShortString();
+                duration.InnerText = p.Duration.ToTimeCode().ToShortString();
                 paragraph.AppendChild(duration);
 
                 XmlNode text = xml.CreateElement("Text");

--- a/src/libse/SubtitleFormats/Titra.cs
+++ b/src/libse/SubtitleFormats/Titra.cs
@@ -43,7 +43,7 @@ ATTENTION : Pas plus de 40 caractères PAR LIGNE
             {
                 index++;
                 var text = HtmlUtil.RemoveHtmlTags(p.Text, true);
-                sb.AppendLine(string.Format(writeFormat, index, EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime), GetMaxCharsForDuration(p.DurationTotalSeconds) + "c", Environment.NewLine, text));
+                sb.AppendLine(string.Format(writeFormat, index, EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime), GetMaxCharsForDuration(p.Duration.Seconds) + "c", Environment.NewLine, text));
                 sb.AppendLine();
                 if (!text.Contains(Environment.NewLine))
                 {

--- a/src/libse/SubtitleFormats/Ultech130.cs
+++ b/src/libse/SubtitleFormats/Ultech130.cs
@@ -283,7 +283,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + 2500;
                 }
 
-                if (last.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (last.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(last.Text);
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle100.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle100.cs
@@ -26,7 +26,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string GetTimeCodeString(Paragraph paragraph)
         {
-            return $"#{paragraph.StartTime.TotalMilliseconds:00000000}{paragraph.DurationTotalMilliseconds:000000}";
+            return $"#{paragraph.StartTime.TotalMilliseconds:00000000}{paragraph.Duration.Milliseconds:000000}";
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/libse/SubtitleFormats/UnknownSubtitle104.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle104.cs
@@ -76,7 +76,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else
                 {
                     p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
-                    if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                    if (p.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                     {
                         p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                     }

--- a/src/libse/SubtitleFormats/UnknownSubtitle105.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle105.cs
@@ -18,10 +18,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (var index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
-                sb.AppendLine($"{EncodeTime(p.DurationTotalSeconds)}");
+                sb.AppendLine($"{EncodeTime(p.Duration.Seconds)}");
                 sb.AppendLine(p.Text);
 
-                seconds += p.DurationTotalSeconds;
+                seconds += p.Duration.Seconds;
                 var next = subtitle.GetParagraphOrDefault(index + 1);
                 if (next != null && (next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds) > 100)
                 {

--- a/src/libse/SubtitleFormats/UnknownSubtitle106.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle106.cs
@@ -82,7 +82,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Configuration.Settings.General.NewEmptyDefaultMs;
                 }
 
-                if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle25.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle25.cs
@@ -32,7 +32,7 @@ NOTE=
             Paragraph last = null;
             foreach (var p in subtitle.Paragraphs)
             {
-                sb.AppendLine($"{MakeTimeCode(p.StartTime, last)} {MakeTimeCode(p.DurationTotalSeconds)}\r\n{p.Text}\r\n");
+                sb.AppendLine($"{MakeTimeCode(p.StartTime, last)} {MakeTimeCode(p.Duration.Seconds)}\r\n{p.Text}\r\n");
                 last = p;
             }
             return sb.ToString().Trim().Replace(Environment.NewLine, "\n");

--- a/src/libse/SubtitleFormats/UnknownSubtitle27.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle27.cs
@@ -93,7 +93,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     current.EndTime.TotalMilliseconds = current.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(current.Text);
                 }
 
-                if (current.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (current.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     current.EndTime.TotalMilliseconds = current.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle44.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle44.cs
@@ -124,7 +124,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     current.EndTime.TotalMilliseconds = current.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(current.Text);
                 }
 
-                if (current.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (current.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     current.EndTime.TotalMilliseconds = current.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle46.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle46.cs
@@ -79,7 +79,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     paragraph.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - 1;
                 }
-                if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle47.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle47.cs
@@ -81,7 +81,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
 
 
-                if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle5.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle5.cs
@@ -30,7 +30,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 paragraph.Attributes.Append(start);
 
                 XmlAttribute duration = xml.CreateAttribute("dur");
-                duration.InnerText = $"{p.DurationTotalMilliseconds / 1000}".Replace(',', '.');
+                duration.InnerText = $"{p.Duration.Milliseconds / 1000}".Replace(',', '.');
                 paragraph.Attributes.Append(duration);
 
                 paragraph.InnerText = p.Text;

--- a/src/libse/SubtitleFormats/UnknownSubtitle52.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle52.cs
@@ -70,14 +70,17 @@ FILE_INFO_END";
 
                 // to avoid rounding errors in duration
                 var durationCalc = new Paragraph(
-                        new TimeCode(p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, FramesToMillisecondsMax999(startFrame)),
-                        new TimeCode(p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, FramesToMillisecondsMax999(endFrame)),
-                        string.Empty);
-                string duration = string.Format(timeFormat, durationCalc.Duration.Hours, durationCalc.Duration.Minutes, durationCalc.Duration.Seconds, MillisecondsToFramesMaxFrameRate(durationCalc.Duration.Milliseconds));
+                    new TimeCode(p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, FramesToMillisecondsMax999(startFrame)),
+                    new TimeCode(p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, FramesToMillisecondsMax999(endFrame)),
+                    string.Empty);
+
+                var dur = durationCalc.Duration.ToTimeCode();
+                string duration = string.Format(timeFormat, dur.Hours, dur.Minutes, dur.Seconds, MillisecondsToFramesMaxFrameRate(dur.Milliseconds));
 
                 sb.AppendLine(string.Format(paragraphWriteFormat, number, startTime, endTime, duration, HtmlUtil.RemoveHtmlTags(p.Text)));
                 number++;
             }
+
             return sb.ToString().Trim();
         }
 

--- a/src/libse/SubtitleFormats/UnknownSubtitle59.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle59.cs
@@ -176,7 +176,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             foreach (var p2 in subtitle.Paragraphs)
             {
-                if (p2.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (p2.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     p2.EndTime.TotalMilliseconds = p2.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle76.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle76.cs
@@ -53,7 +53,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 paragraph.InnerText = p.Text;
 
                 XmlAttribute dur = xml.CreateAttribute("d");
-                dur.InnerText = ConvertToTimeString(p.Duration);
+                dur.InnerText = ConvertToTimeString(p.Duration.ToTimeCode());
                 paragraph.Attributes.Append(dur);
 
                 XmlAttribute start = xml.CreateAttribute("t");

--- a/src/libse/SubtitleFormats/UnknownSubtitle82.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle82.cs
@@ -32,7 +32,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 paragraph.Attributes.Append(tAttribute);
 
                 XmlAttribute dAttribute = xml.CreateAttribute("d");
-                dAttribute.InnerText = Convert.ToInt64(p.DurationTotalMilliseconds).ToString();
+                dAttribute.InnerText = Convert.ToInt64(p.Duration.Milliseconds).ToString();
                 paragraph.Attributes.Append(dAttribute);
 
                 paragraphInsertNode.AppendChild(paragraph);

--- a/src/libse/SubtitleFormats/UnknownSubtitle83.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle83.cs
@@ -32,8 +32,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (int index = 0; index < subtitle.Paragraphs.Count;)
             {
                 var p = subtitle.Paragraphs[index++];
-                var lis = (int)Math.Round(MillisecondsToFrames(p.DurationTotalMilliseconds) / 2.0);
-                sb.AppendLine(string.Format(format, index, p.StartTime.ToHHMMSSFF(), p.EndTime.ToHHMMSSFF(), p.Duration.ToSSFF(), lis, p.Text.Length, p.Text));
+                var lis = (int)Math.Round(MillisecondsToFrames(p.Duration.Milliseconds) / 2.0);
+                sb.AppendLine(string.Format(format, index, p.StartTime.ToHHMMSSFF(), p.EndTime.ToHHMMSSFF(), p.Duration.ToTimeCode().ToSSFF(), lis, p.Text.Length, p.Text));
             }
             return sb.ToString().ToRtf();
         }

--- a/src/libse/SubtitleFormats/UnknownSubtitle85.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle85.cs
@@ -125,7 +125,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     if (next.StartTime.TotalMilliseconds < p.EndTime.TotalMilliseconds)
                     {
                         p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
-                        if (p.DurationTotalMilliseconds < 0)
+                        if (p.Duration.Milliseconds < 0)
                         {
                             _errorCount++;
                         }

--- a/src/libse/SubtitleFormats/UnknownSubtitle86.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle86.cs
@@ -74,7 +74,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                 }
 
-                if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (p.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle9.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle9.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             sb.AppendLine("    <div id=\"transcriptPanel\">");
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                sb.AppendLine($"      <a class=\"caption\" starttime=\"{((long)(Math.Round(p.StartTime.TotalMilliseconds))).ToString(CultureInfo.InvariantCulture)}\" duration=\"{((long)(Math.Round(p.DurationTotalMilliseconds))).ToString(CultureInfo.InvariantCulture)}\">{p.Text.Replace(Environment.NewLine, "<br />")}</a>");
+                sb.AppendLine($"      <a class=\"caption\" starttime=\"{((long)(Math.Round(p.StartTime.TotalMilliseconds))).ToString(CultureInfo.InvariantCulture)}\" duration=\"{((long)(Math.Round(p.Duration.Milliseconds))).ToString(CultureInfo.InvariantCulture)}\">{p.Text.Replace(Environment.NewLine, "<br />")}</a>");
             }
             sb.AppendLine("    </div>");
             sb.AppendLine("  </div>");

--- a/src/libse/SubtitleFormats/UnknownSubtitle90.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle90.cs
@@ -22,7 +22,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             const string writeFormat = "data_000001 1 {0:0.00} {1:0.00} {2}";
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, writeFormat, EncodeTimeCode(p.StartTime), EncodeTimeCode(p.Duration), HtmlUtil.RemoveHtmlTags(p.Text.Replace(Environment.NewLine, "<br>"))));
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, writeFormat, EncodeTimeCode(p.StartTime), EncodeTimeCode(p.Duration.ToTimeCode()), HtmlUtil.RemoveHtmlTags(p.Text.Replace(Environment.NewLine, "<br>"))));
             }
             return sb.ToString();
         }

--- a/src/libse/SubtitleFormats/UnknownSubtitle95.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle95.cs
@@ -27,7 +27,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (var index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
-                sb.AppendLine(string.Format(writeFormat, index + 1, p.StartTime.ToHHMMSSPeriodFF(), p.EndTime.ToHHMMSSPeriodFF(), p.Duration.ToHHMMSSPeriodFF(), Environment.NewLine, p.Text));
+                sb.AppendLine(string.Format(writeFormat, index + 1, p.StartTime.ToHHMMSSPeriodFF(), p.EndTime.ToHHMMSSPeriodFF(), p.Duration.ToTimeCode().ToHHMMSSPeriodFF(), Environment.NewLine, p.Text));
             }
 
             return sb.ToString().Trim();

--- a/src/libse/SubtitleFormats/UnknownSubtitle98.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle98.cs
@@ -85,7 +85,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     paragraph.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - 1;
                 }
-                if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                 }

--- a/src/libse/SubtitleFormats/UnknownSubtitle99.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle99.cs
@@ -104,7 +104,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     paragraph.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - 1;
                 }
-                if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                 }

--- a/src/libse/SubtitleFormats/Xmp.cs
+++ b/src/libse/SubtitleFormats/Xmp.cs
@@ -68,7 +68,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             li.AppendChild(comment);
 
             var duration = xml.CreateElement("xmpDM", "duration", NamespaceDescription);
-            duration.InnerText = MillisecondsToFrames(paragraph.DurationTotalMilliseconds).ToString(CultureInfo.InvariantCulture);
+            duration.InnerText = MillisecondsToFrames(paragraph.Duration.Milliseconds).ToString(CultureInfo.InvariantCulture);
             li.AppendChild(duration);
 
             var startTime = xml.CreateElement("xmpDM", "startTime", NamespaceDescription);

--- a/src/libse/VobSub/VobSubWriter.cs
+++ b/src/libse/VobSub/VobSubWriter.cs
@@ -124,7 +124,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
 
             // Control Sequence Table
             // Write delay - subtitle duration
-            WriteEndianWord(Convert.ToInt32(p.DurationTotalMilliseconds * 90.0) >> 10, ms);
+            WriteEndianWord(Convert.ToInt32(p.Duration.Milliseconds * 90.0) >> 10, ms);
 
             // next display control sequence table address (use current is last)
             WriteEndianWord(startDisplayControlSequenceTableAddress + 24, ms); // start of display control sequence table address

--- a/src/ui/Controls/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizer.cs
@@ -458,7 +458,7 @@ namespace Nikse.SubtitleEdit.Controls
             foreach (var p in displayableParagraphs)
             {
                 if (displayableParagraphs.Count > 30 &&
-                    (p.DurationTotalMilliseconds < 0.01 || p.StartTime.TotalMilliseconds - lastStartTime < 90))
+                    (p.Duration.Milliseconds < 0.01 || p.StartTime.TotalMilliseconds - lastStartTime < 90))
                 {
                     continue;
                 }
@@ -1068,7 +1068,7 @@ namespace Nikse.SubtitleEdit.Controls
                 // paragraph number
                 if (n > 15)
                 {
-                    var text = "#" + paragraph.Number + "  " + paragraph.Duration.ToShortDisplayString();
+                    var text = "#" + paragraph.Number + "  " + paragraph.Duration.ToTimeCode().ToShortDisplayString();
                     if (n <= 51 || graphics.MeasureString(text, font).Width >= currentRegionWidth - padding - 1)
                     {
                         text = "#" + paragraph.Number;
@@ -1835,7 +1835,7 @@ namespace Nikse.SubtitleEdit.Controls
                         }
                         else if (_mouseDownParagraphType == MouseDownParagraphType.Whole)
                         {
-                            var durationMilliseconds = _mouseDownParagraph.DurationTotalMilliseconds;
+                            var durationMilliseconds = _mouseDownParagraph.Duration.Milliseconds;
                             var oldStart = _mouseDownParagraph.StartTime.TotalMilliseconds;
                             _mouseDownParagraph.StartTime.TotalMilliseconds = milliseconds - _moveWholeStartDifferenceMilliseconds;
                             _mouseDownParagraph.EndTime.TotalMilliseconds = _mouseDownParagraph.StartTime.TotalMilliseconds + durationMilliseconds;
@@ -2139,7 +2139,7 @@ namespace Nikse.SubtitleEdit.Controls
                         {
                             _oldParagraph = new Paragraph(SelectedParagraph);
                             _mouseDownParagraph = SelectedParagraph;
-                            var durationMilliseconds = _mouseDownParagraph.DurationTotalMilliseconds;
+                            var durationMilliseconds = _mouseDownParagraph.Duration.Milliseconds;
                             _mouseDownParagraph.StartTime.TotalMilliseconds = milliseconds;
                             _mouseDownParagraph.EndTime.TotalMilliseconds = _mouseDownParagraph.StartTime.TotalMilliseconds + durationMilliseconds;
                             OnTimeChanged?.Invoke(this, new ParagraphEventArgs(seconds, _mouseDownParagraph, _oldParagraph));

--- a/src/ui/Controls/SubtitleListView.cs
+++ b/src/ui/Controls/SubtitleListView.cs
@@ -1512,13 +1512,13 @@ namespace Nikse.SubtitleEdit.Controls
                         item.SubItems[ColumnIndexDuration].BackColor = Configuration.Settings.Tools.ListViewSyntaxErrorColor;
                     }
                 }
-                if (paragraph.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds && ColumnIndexDuration >= 0)
+                if (paragraph.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds && ColumnIndexDuration >= 0)
                 {
                     item.SubItems[ColumnIndexDuration].BackColor = Configuration.Settings.Tools.ListViewSyntaxErrorColor;
                 }
             }
             if (_settings.Tools.ListViewSyntaxColorDurationBig &&
-                paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds &&
+                paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds &&
                 ColumnIndexDuration >= 0)
             {
                 item.SubItems[ColumnIndexDuration].BackColor = Configuration.Settings.Tools.ListViewSyntaxErrorColor;
@@ -1694,7 +1694,7 @@ namespace Nikse.SubtitleEdit.Controls
                 return "-";
             }
 
-            return paragraph.Duration.ToShortDisplayString();
+            return paragraph.Duration.ToTimeCode().ToShortDisplayString();
         }
 
         public void SelectNone()

--- a/src/ui/Forms/ApplyDurationLimits.cs
+++ b/src/ui/Forms/ApplyDurationLimits.cs
@@ -162,7 +162,7 @@ namespace Nikse.SubtitleEdit.Forms
             for (int i = 0; i < _working.Paragraphs.Count; i++)
             {
                 var p = _working.Paragraphs[i];
-                var displayTime = p.DurationTotalMilliseconds;
+                var displayTime = p.Duration.Milliseconds;
                 if (displayTime < minDisplayTime)
                 {
                     var next = _working.GetParagraphOrDefault(i + 1);
@@ -215,9 +215,9 @@ namespace Nikse.SubtitleEdit.Forms
                 return;
             }
 
-            var before = p.StartTime.ToShortString() + " --> " + p.EndTime.ToShortString() + " - " + p.Duration.ToShortString();
+            var before = p.StartTime.ToShortString() + " --> " + p.EndTime.ToShortString() + " - " + p.Duration.ToTimeCode().ToShortString();
             p.EndTime.TotalMilliseconds = endMs;
-            var after = p.StartTime.ToShortString() + " --> " + p.EndTime.ToShortString() + " - " + p.Duration.ToShortString();
+            var after = p.StartTime.ToShortString() + " --> " + p.EndTime.ToShortString() + " - " + p.Duration.ToTimeCode().ToShortString();
             _totalFixes++;
             AddFixToListView(p, before, after, backgroundColor);
         }
@@ -228,7 +228,7 @@ namespace Nikse.SubtitleEdit.Forms
             for (int i = 0; i < _working.Paragraphs.Count; i++)
             {
                 var p = _working.Paragraphs[i];
-                var displayTime = p.DurationTotalMilliseconds;
+                var displayTime = p.Duration.Milliseconds;
                 if (displayTime > maxDisplayTime)
                 {
                     AddFix(p, p.StartTime.TotalMilliseconds + maxDisplayTime, DefaultBackColor);

--- a/src/ui/Forms/AudioClipsGet.cs
+++ b/src/ui/Forms/AudioClipsGet.cs
@@ -59,7 +59,7 @@ namespace Nikse.SubtitleEdit.Forms
                         }
 
                         var start = $"{item.StartTime.TotalSeconds:0.000}".Replace(",", ".");
-                        var duration = $"{item.DurationTotalSeconds:0.000}".Replace(",", ".");
+                        var duration = $"{item.Duration.Seconds:0.000}".Replace(",", ".");
                         var fFmpegWaveTranscodeSettings = "-ss " + start + " -t " + duration + " -i \"{0}\" -vn -ar 16000 -ac 1 -ab 32k -af volume=1.75 -f wav {2} \"{1}\"";
                         if (useCenterChannelOnly)
                         {

--- a/src/ui/Forms/BatchConvert.cs
+++ b/src/ui/Forms/BatchConvert.cs
@@ -1358,7 +1358,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                         if (fromFormat != null && fromFormat.GetType() == typeof(MicroDvd))
                         {
-                            if (sub != null && sub.Paragraphs.Count > 0 && sub.Paragraphs[0].DurationTotalMilliseconds < 1001)
+                            if (sub != null && sub.Paragraphs.Count > 0 && sub.Paragraphs[0].Duration.Milliseconds < 1001)
                             {
                                 if (sub.Paragraphs[0].Text.StartsWith("29.", StringComparison.Ordinal) || sub.Paragraphs[0].Text.StartsWith("23.", StringComparison.Ordinal) ||
                                 sub.Paragraphs[0].Text.StartsWith("29,", StringComparison.Ordinal) || sub.Paragraphs[0].Text.StartsWith("23,", StringComparison.Ordinal) ||
@@ -2114,10 +2114,10 @@ namespace Nikse.SubtitleEdit.Forms
                     if (pes == null && subtitle.Paragraphs.Count > 0)
                     {
                         var last = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
-                        if (last.DurationTotalMilliseconds < 100)
+                        if (last.Duration.Milliseconds < 100)
                         {
                             last.EndTime.TotalMilliseconds = msub.Start;
-                            if (last.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                            if (last.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                             {
                                 last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + 3000;
                             }
@@ -2145,7 +2145,7 @@ namespace Nikse.SubtitleEdit.Forms
             for (var index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
-                if (p.DurationTotalMilliseconds < 200)
+                if (p.Duration.Milliseconds < 200)
                 {
                     p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + 3000;
                 }
@@ -2921,7 +2921,7 @@ namespace Nikse.SubtitleEdit.Forms
                     var current = p.Subtitle.GetParagraphOrDefault(i);
                     var next = p.Subtitle.GetParagraphOrDefault(i + 1);
                     var gapsBetween = next.StartTime.TotalMilliseconds - current.EndTime.TotalMilliseconds;
-                    if (gapsBetween < minimumMillisecondsBetweenLines && current.DurationTotalMilliseconds > minimumMillisecondsBetweenLines)
+                    if (gapsBetween < minimumMillisecondsBetweenLines && current.Duration.Milliseconds > minimumMillisecondsBetweenLines)
                     {
                         current.EndTime.TotalMilliseconds -= (minimumMillisecondsBetweenLines - gapsBetween);
                     }

--- a/src/ui/Forms/BinaryEdit/BinEdit.cs
+++ b/src/ui/Forms/BinaryEdit/BinEdit.cs
@@ -640,7 +640,7 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
 
                 if (_columnIndexDuration >= 0)
                 {
-                    count = AddListViewSubItem(item, count, paragraph.Duration.ToShortDisplayString());
+                    count = AddListViewSubItem(item, count, paragraph.Duration.ToTimeCode().ToShortDisplayString());
                 }
 
                 if (_columnIndexGap >= 0)
@@ -732,11 +732,11 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
 
             if (_columnIndexDuration >= 0)
             {
-                if (paragraph.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds && _columnIndexDuration >= 0)
+                if (paragraph.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds && _columnIndexDuration >= 0)
                 {
                     colorDuration = true;
                 }
-                else if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                else if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     colorDuration = true;
                 }
@@ -838,7 +838,7 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
 
             if (_columnIndexDuration >= 0)
             {
-                item.SubItems[_columnIndexDuration].Text = paragraph.Duration.ToShortDisplayString();
+                item.SubItems[_columnIndexDuration].Text = paragraph.Duration.ToTimeCode().ToShortDisplayString();
             }
 
             if (_columnIndexGap >= 0 && _subtitle != null)
@@ -1087,10 +1087,10 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
                     if (pes == null && subtitle.Paragraphs.Count > 0)
                     {
                         var last = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
-                        if (last.DurationTotalMilliseconds < 100)
+                        if (last.Duration.Milliseconds < 100)
                         {
                             last.EndTime.TotalMilliseconds = msub.Start;
-                            if (last.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                            if (last.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                             {
                                 last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + 3000;
                             }
@@ -1118,7 +1118,7 @@ namespace Nikse.SubtitleEdit.Forms.BinaryEdit
             for (var index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
-                if (p.DurationTotalMilliseconds < 200)
+                if (p.Duration.Milliseconds < 200)
                 {
                     p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + 3000;
                 }
@@ -1666,7 +1666,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                 ntsc = "TRUE";
             }
 
-            var duration = SubtitleFormat.MillisecondsToFrames(p.DurationTotalMilliseconds, _frameRate);
+            var duration = SubtitleFormat.MillisecondsToFrames(p.Duration.Milliseconds, _frameRate);
             var start = SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds, _frameRate);
             var end = SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds, _frameRate);
 
@@ -4046,11 +4046,11 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 
             if (string.IsNullOrEmpty(errorText))
             {
-                if (paragraph.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds && _columnIndexDuration >= 0)
+                if (paragraph.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds && _columnIndexDuration >= 0)
                 {
                     errorText = "Duration too small";
                 }
-                else if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds && _columnIndexDuration >= 0)
+                else if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds && _columnIndexDuration >= 0)
                 {
                     errorText = "Duration too large";
                 }

--- a/src/ui/Forms/BookmarksGoTo.cs
+++ b/src/ui/Forms/BookmarksGoTo.cs
@@ -131,7 +131,7 @@ namespace Nikse.SubtitleEdit.Forms
             sb.Append(paragraph.Number + separator);
             sb.Append(ToCsvText(paragraph.StartTime.ToDisplayString()) + separator);
             sb.Append(ToCsvText(paragraph.EndTime.ToDisplayString()) + separator);
-            sb.Append(ToCsvText(paragraph.Duration.ToShortDisplayString()) + separator);
+            sb.Append(ToCsvText(paragraph.Duration.ToTimeCode().ToShortDisplayString()) + separator);
             sb.Append(ToCsvText(paragraph.Text) + separator);
             sb.Append(ToCsvText(paragraph.Bookmark) + separator);
             return sb.ToString();

--- a/src/ui/Forms/Compare.cs
+++ b/src/ui/Forms/Compare.cs
@@ -382,7 +382,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 subtitleListView2.SetBackgroundColor(index, ListViewGreen, subtitleListView2.ColumnIndexEnd);
                             }
                             // Duration
-                            if (!IsTimeEqual(p1.Duration, p2.Duration))
+                            if (!IsTimeEqual(p1.Duration.ToTimeCode(), p2.Duration.ToTimeCode()))
                             {
                                 subtitleListView1.SetBackgroundColor(index, ListViewGreen, subtitleListView1.ColumnIndexDuration);
                                 subtitleListView2.SetBackgroundColor(index, ListViewGreen, subtitleListView2.ColumnIndexDuration);
@@ -581,7 +581,7 @@ namespace Nikse.SubtitleEdit.Forms
                 columnsEqual++;
             }
 
-            if (IsTimeEqual(p1.Duration, p2.Duration))
+            if (IsTimeEqual(p1.Duration.ToTimeCode(), p2.Duration.ToTimeCode()))
             {
                 columnsEqual++;
             }

--- a/src/ui/Forms/EffectKaraoke.cs
+++ b/src/ui/Forms/EffectKaraoke.cs
@@ -55,8 +55,8 @@ namespace Nikse.SubtitleEdit.Forms
 
             AddToPreview(richTextBoxPreview, paragraph.Text);
             RefreshPreview();
-            labelTotalMilliseconds.Text = $"{paragraph.DurationTotalMilliseconds / TimeCode.BaseUnit:#,##0.000}";
-            numericUpDownDelay.Maximum = (decimal)((paragraph.DurationTotalMilliseconds - 500) / TimeCode.BaseUnit);
+            labelTotalMilliseconds.Text = $"{paragraph.Duration.Milliseconds / TimeCode.BaseUnit:#,##0.000}";
+            numericUpDownDelay.Maximum = (decimal)((paragraph.Duration.Milliseconds - 500) / TimeCode.BaseUnit);
             numericUpDownDelay.Minimum = 0;
 
             numericUpDownDelay.Left = labelEndDelay.Left + labelEndDelay.Width + 5;
@@ -113,7 +113,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void MakeAnimation()
         {
             _animation = new List<Paragraph>();
-            if (HtmlUtil.RemoveHtmlTags(_paragraph.Text, true).Length == 0 || _paragraph.DurationTotalMilliseconds < 0.001)
+            if (HtmlUtil.RemoveHtmlTags(_paragraph.Text, true).Length == 0 || _paragraph.Duration.Milliseconds < 0.001)
             {
                 _animation.Add(new Paragraph(_paragraph));
                 return;

--- a/src/ui/Forms/EffectTypewriter.cs
+++ b/src/ui/Forms/EffectTypewriter.cs
@@ -59,8 +59,8 @@ namespace Nikse.SubtitleEdit.Forms
             AddToPreview(richTextBoxPreview, paragraph.Text);
             RefreshPreview();
 
-            labelTotalMilliseconds.Text = $"{paragraph.DurationTotalMilliseconds / TimeCode.BaseUnit:#,##0.000}";
-            numericUpDownDelay.Maximum = (decimal)((paragraph.DurationTotalMilliseconds - 500) / TimeCode.BaseUnit);
+            labelTotalMilliseconds.Text = $"{paragraph.Duration.Milliseconds / TimeCode.BaseUnit:#,##0.000}";
+            numericUpDownDelay.Maximum = (decimal)((paragraph.Duration.Milliseconds - 500) / TimeCode.BaseUnit);
             numericUpDownDelay.Minimum = 0;
 
             numericUpDownDelay.Left = labelEndDelay.Left + labelEndDelay.Width + 5;
@@ -273,7 +273,7 @@ namespace Nikse.SubtitleEdit.Forms
         public void MakeAnimation()
         {
             TypewriterParagraphs = new List<Paragraph>();
-            var duration = _paragraph.DurationTotalMilliseconds - (double)numericUpDownDelay.Value * TimeCode.BaseUnit;
+            var duration = _paragraph.Duration.Milliseconds - (double)numericUpDownDelay.Value * TimeCode.BaseUnit;
             var stepsLength = CalculateStepLength(_paragraph.Text, duration);
             double startMilliseconds;
             double endMilliseconds;

--- a/src/ui/Forms/ErrorsGoTo.cs
+++ b/src/ui/Forms/ErrorsGoTo.cs
@@ -78,14 +78,14 @@ namespace Nikse.SubtitleEdit.Forms
                     errors.Add($"CPS: {charactersPerSecond:#,###.00} > {Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds}");
                 }
 
-                if (paragraph.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                 {
-                    errors.Add($"Min duration: {paragraph.DurationTotalMilliseconds:#,###.00} < {Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds}");
+                    errors.Add($"Min duration: {paragraph.Duration.Milliseconds:#,###.00} < {Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds}");
                 }
 
-                if (paragraph.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (paragraph.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
-                    errors.Add($"Max duration: {paragraph.DurationTotalMilliseconds:#,###.00} > {Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds}");
+                    errors.Add($"Max duration: {paragraph.Duration.Milliseconds:#,###.00} > {Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds}");
                 }
 
                 if (i > 0 && i < paragraphs.Count)
@@ -232,7 +232,7 @@ namespace Nikse.SubtitleEdit.Forms
             sb.Append(paragraph.Number + separator);
             sb.Append(ToCsvText(paragraph.StartTime.ToDisplayString()) + separator);
             sb.Append(ToCsvText(paragraph.EndTime.ToDisplayString()) + separator);
-            sb.Append(ToCsvText(paragraph.Duration.ToShortDisplayString()) + separator);
+            sb.Append(ToCsvText(paragraph.Duration.ToTimeCode().ToShortDisplayString()) + separator);
             sb.Append(ToCsvText(paragraph.Text.Replace(Environment.NewLine, "<br />")) + separator);
             sb.Append(ToCsvText(paragraph.Bookmark) + separator);
             return sb.ToString();

--- a/src/ui/Forms/ExportCustomText.cs
+++ b/src/ui/Forms/ExportCustomText.cs
@@ -308,7 +308,7 @@ namespace Nikse.SubtitleEdit.Forms
                         originalText = originalParagraph.Text;
                     }
                 }
-                var paragraph = ExportCustomTextFormat.GetParagraph(template, start, end, text, originalText, i, p.Actor, p.Duration, gap, arr[3], p, videoFileName);
+                var paragraph = ExportCustomTextFormat.GetParagraph(template, start, end, text, originalText, i, p.Actor, p.Duration.ToTimeCode(), gap, arr[3], p, videoFileName);
                 sb.Append(paragraph);
             }
             sb.Append(ExportCustomTextFormat.GetHeaderOrFooter(title, videoFileName, subtitle, arr[5]));

--- a/src/ui/Forms/ExportCustomTextFormat.cs
+++ b/src/ui/Forms/ExportCustomTextFormat.cs
@@ -106,8 +106,8 @@ namespace Nikse.SubtitleEdit.Forms
                 var template = GetParagraphTemplate(textBoxParagraph.Text);
                 var videoFileName = "C:\\Video\\MyVideo.mp4";
                 textBoxPreview.Text = GetHeaderOrFooter("Demo", videoFileName, subtitle, textBoxHeader.Text) +
-                                      GetParagraph(template, start1, end1, GetText(p1.Text, newLine), GetText("Line 1a." + Environment.NewLine + "Line 1b.", newLine), 0, p1.Actor, p1.Duration, gap1, comboBoxTimeCode.Text, p1, videoFileName) +
-                                      GetParagraph(template, start2, end2, GetText(p2.Text, newLine), GetText("Line 2a." + Environment.NewLine + "Line 2b.", newLine), 1, p2.Actor, p2.Duration, gap2, comboBoxTimeCode.Text, p2, videoFileName) +
+                                      GetParagraph(template, start1, end1, GetText(p1.Text, newLine), GetText("Line 1a." + Environment.NewLine + "Line 1b.", newLine), 0, p1.Actor, p1.Duration.ToTimeCode(), gap1, comboBoxTimeCode.Text, p1, videoFileName) +
+                                      GetParagraph(template, start2, end2, GetText(p2.Text, newLine), GetText("Line 2a." + Environment.NewLine + "Line 2b.", newLine), 1, p2.Actor, p2.Duration.ToTimeCode(), gap2, comboBoxTimeCode.Text, p2, videoFileName) +
                                       GetHeaderOrFooter("Demo", videoFileName, subtitle, textBoxFooter.Text);
             }
             catch (Exception ex)

--- a/src/ui/Forms/ExportPngXml.cs
+++ b/src/ui/Forms/ExportPngXml.cs
@@ -1949,7 +1949,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                         fullSize.Save(fileName2, ImageFormat.Png);
                         fullSize.Dispose();
 
-                        string line = $"{i:000}  {fileName1}  V     C        {new TimeCode().ToHHMMSSFF()} {param.P.Duration.ToHHMMSSFF()} {param.P.StartTime.ToHHMMSSFF()} {param.P.EndTime.ToHHMMSSFF()}";
+                        string line = $"{i:000}  {fileName1}  V     C        {new TimeCode().ToHHMMSSFF()} {param.P.Duration.ToTimeCode().ToHHMMSSFF()} {param.P.StartTime.ToHHMMSSFF()} {param.P.EndTime.ToHHMMSSFF()}";
                         sb.AppendLine(line);
                         if (_exportType == ExportFormats.EdlClipName)
                         {
@@ -2141,7 +2141,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
                 ntsc = "TRUE";
             }
 
-            var duration = SubtitleFormat.MillisecondsToFrames(param.P.DurationTotalMilliseconds, param.FramesPerSeconds);
+            var duration = SubtitleFormat.MillisecondsToFrames(param.P.Duration.Milliseconds, param.FramesPerSeconds);
             var start = SubtitleFormat.MillisecondsToFrames(param.P.StartTime.TotalMilliseconds, param.FramesPerSeconds);
             var end = SubtitleFormat.MillisecondsToFrames(param.P.EndTime.TotalMilliseconds, param.FramesPerSeconds);
 
@@ -5771,7 +5771,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
             subItem = new ListViewItem.ListViewSubItem(item, paragraph.EndTime.ToDisplayString());
             item.SubItems.Add(subItem);
 
-            subItem = new ListViewItem.ListViewSubItem(item, paragraph.Duration.ToShortDisplayString());
+            subItem = new ListViewItem.ListViewSubItem(item, paragraph.Duration.ToTimeCode().ToShortDisplayString());
             item.SubItems.Add(subItem);
 
             subItem = new ListViewItem.ListViewSubItem(item, UiUtil.GetListViewTextFromString(paragraph.Text));
@@ -6270,7 +6270,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
             }
             subtitleListView1.Items[index].SubItems[startIndex].Text = _subtitle.Paragraphs[index].StartTime.ToDisplayString();
             subtitleListView1.Items[index].SubItems[startIndex + 1].Text = _subtitle.Paragraphs[index].EndTime.ToDisplayString();
-            subtitleListView1.Items[index].SubItems[startIndex + 2].Text = _subtitle.Paragraphs[index].Duration.ToShortDisplayString();
+            subtitleListView1.Items[index].SubItems[startIndex + 2].Text = _subtitle.Paragraphs[index].Duration.ToTimeCode().ToShortDisplayString();
         }
 
         private void contextMenuStripListView_Opening(object sender, System.ComponentModel.CancelEventArgs e)

--- a/src/ui/Forms/FixCommonErrors.cs
+++ b/src/ui/Forms/FixCommonErrors.cs
@@ -1238,7 +1238,7 @@ namespace Nikse.SubtitleEdit.Forms
             timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBox_TextChanged;
 
             numericUpDownDuration.ValueChanged -= NumericUpDownDurationValueChanged;
-            numericUpDownDuration.Value = (decimal)(p.DurationTotalMilliseconds / TimeCode.BaseUnit);
+            numericUpDownDuration.Value = (decimal)(p.Duration.Milliseconds / TimeCode.BaseUnit);
             numericUpDownDuration.ValueChanged += NumericUpDownDurationValueChanged;
         }
 
@@ -1791,7 +1791,7 @@ namespace Nikse.SubtitleEdit.Forms
                     startFactor = 0.80;
                 }
 
-                double middle = currentParagraph.StartTime.TotalMilliseconds + (currentParagraph.DurationTotalMilliseconds * startFactor);
+                double middle = currentParagraph.StartTime.TotalMilliseconds + (currentParagraph.Duration.Milliseconds * startFactor);
                 if (splitSeconds.HasValue && splitSeconds.Value > (currentParagraph.StartTime.TotalSeconds + 0.2) && splitSeconds.Value < (currentParagraph.EndTime.TotalSeconds - 0.2))
                 {
                     middle = splitSeconds.Value * TimeCode.BaseUnit;

--- a/src/ui/Forms/ImportImages.cs
+++ b/src/ui/Forms/ImportImages.cs
@@ -86,7 +86,7 @@ namespace Nikse.SubtitleEdit.Forms
             SetEndTimeAndStartTime(name, p);
             item.SubItems.Add(p.StartTime.ToString());
             item.SubItems.Add(p.EndTime.ToString());
-            item.SubItems.Add(p.Duration.ToShortString());
+            item.SubItems.Add(p.Duration.ToTimeCode().ToShortString());
         }
 
         public static void SetEndTimeAndStartTime(string name, Paragraph p)

--- a/src/ui/Forms/ImportText.cs
+++ b/src/ui/Forms/ImportText.cs
@@ -561,7 +561,7 @@ namespace Nikse.SubtitleEdit.Forms
             double millisecondsIndex = millisecondsInterval;
             foreach (Paragraph p in FixedSubtitle.Paragraphs)
             {
-                p.EndTime.TotalMilliseconds = millisecondsIndex + p.DurationTotalMilliseconds;
+                p.EndTime.TotalMilliseconds = millisecondsIndex + p.Duration.Milliseconds;
                 p.StartTime.TotalMilliseconds = millisecondsIndex;
                 millisecondsIndex += (p.EndTime.TotalMilliseconds - p.StartTime.TotalMilliseconds) + millisecondsInterval;
             }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -1362,17 +1362,17 @@ namespace Nikse.SubtitleEdit.Forms
                 { // so we don't get weird rounds we'll use whole frames when moving start time
                     double fr = TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate;
                     if (e.BeforeParagraph != null && e.BeforeParagraph.StartTime.TotalMilliseconds != e.Paragraph.StartTime.TotalMilliseconds &&
-                        e.BeforeParagraph.DurationTotalMilliseconds == e.Paragraph.DurationTotalMilliseconds)
+                        e.BeforeParagraph.Duration.Milliseconds == e.Paragraph.Duration.Milliseconds)
                     {
                         // move paragraph
                         paragraph.StartTime.TotalMilliseconds = ((int)Math.Round(paragraph.StartTime.TotalMilliseconds / fr)) * fr;
-                        paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + e.BeforeParagraph.DurationTotalMilliseconds;
+                        paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + e.BeforeParagraph.Duration.Milliseconds;
                     }
                     else if (e.BeforeParagraph != null && e.BeforeParagraph.EndTime.TotalMilliseconds == e.Paragraph.EndTime.TotalMilliseconds)
                     {
                         paragraph.EndTime.TotalMilliseconds = ((int)Math.Round(paragraph.EndTime.TotalMilliseconds / fr)) * fr;
                         int end = SubtitleFormat.MillisecondsToFrames(paragraph.EndTime.TotalMilliseconds);
-                        int dur = SubtitleFormat.MillisecondsToFrames(paragraph.DurationTotalMilliseconds);
+                        int dur = SubtitleFormat.MillisecondsToFrames(paragraph.Duration.Milliseconds);
                         paragraph.StartTime.TotalMilliseconds = SubtitleFormat.FramesToMilliseconds(end - dur);
                     }
                 }
@@ -1382,7 +1382,7 @@ namespace Nikse.SubtitleEdit.Forms
                 timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
                 SubtitleListview1.SetStartTimeAndDurationBackground(index, paragraph, _subtitle.GetParagraphOrDefault(index + 1), _subtitle.GetParagraphOrDefault(index - 1));
 
-                var durationInSeconds = (decimal)paragraph.DurationTotalSeconds;
+                var durationInSeconds = (decimal)paragraph.Duration.Seconds;
                 if (durationInSeconds >= numericUpDownDuration.Minimum && durationInSeconds <= numericUpDownDuration.Maximum)
                 {
                     SetDurationInSeconds((double)durationInSeconds);
@@ -1426,7 +1426,7 @@ namespace Nikse.SubtitleEdit.Forms
                             timeUpDownStartTime.MaskedTextBox.TextChanged -= MaskedTextBoxTextChanged;
                             timeUpDownStartTime.TimeCode = paragraph.StartTime;
                             timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
-                            var durationInSeconds = (decimal)(paragraph.DurationTotalSeconds);
+                            var durationInSeconds = (decimal)(paragraph.Duration.Seconds);
                             if (durationInSeconds >= numericUpDownDuration.Minimum && durationInSeconds <= numericUpDownDuration.Maximum)
                             {
                                 SetDurationInSeconds((double)durationInSeconds);
@@ -1503,7 +1503,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void MoveSelectedLines(AudioVisualizer.ParagraphEventArgs e, Paragraph paragraph, int index, int[] selectedIndices)
         {
             // calculate move min/max values related to current idx
-            var newMultiMoveHash = paragraph.DurationTotalMilliseconds.GetHashCode() + index.GetHashCode() + selectedIndices.Length.GetHashCode();
+            var newMultiMoveHash = paragraph.Duration.Milliseconds.GetHashCode() + index.GetHashCode() + selectedIndices.Length.GetHashCode();
             if (newMultiMoveHash != _lastMultiMoveHash)
             {
                 var currentStart = _subtitle.Paragraphs[index].StartTime.TotalMilliseconds;
@@ -1536,7 +1536,7 @@ namespace Nikse.SubtitleEdit.Forms
                 if (p != paragraph)
                 {
                     var oldParagraph = new Paragraph(p, false);
-                    var dur = p.DurationTotalMilliseconds;
+                    var dur = p.Duration.Milliseconds;
                     p.StartTime.TotalMilliseconds += e.AdjustMs;
                     p.EndTime.TotalMilliseconds += e.AdjustMs;
                     SubtitleListview1.SetStartTimeAndDurationBackground(idx, p, _subtitle.GetParagraphOrDefault(idx + 1), _subtitle.GetParagraphOrDefault(idx - 1));
@@ -1581,7 +1581,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                         if (curIdx == index - 1)
                         {
-                            var durationInSeconds = (decimal)(prev.DurationTotalSeconds);
+                            var durationInSeconds = (decimal)(prev.Duration.Seconds);
                             if (durationInSeconds >= numericUpDownDuration.Minimum && durationInSeconds <= numericUpDownDuration.Maximum)
                             {
                                 SetDurationInSeconds((double)durationInSeconds);
@@ -1612,7 +1612,7 @@ namespace Nikse.SubtitleEdit.Forms
                         if (curIdx == index + 1)
                         {
                             timeUpDownStartTime.TimeCode = next.StartTime;
-                            var durationInSeconds = (decimal)(next.DurationTotalSeconds);
+                            var durationInSeconds = (decimal)(next.Duration.Seconds);
                             if (durationInSeconds >= numericUpDownDuration.Minimum && durationInSeconds <= numericUpDownDuration.Maximum)
                             {
                                 SetDurationInSeconds((double)durationInSeconds);
@@ -6322,7 +6322,7 @@ namespace Nikse.SubtitleEdit.Forms
                 for (var index = 0; index < _subtitle.Paragraphs.Count; index++)
                 {
                     var p = _subtitle.Paragraphs[index];
-                    if (p.DurationTotalMilliseconds < 0 && !p.StartTime.IsMaxTime && !p.EndTime.IsMaxTime)
+                    if (p.Duration.Milliseconds < 0 && !p.StartTime.IsMaxTime && !p.EndTime.IsMaxTime)
                     {
                         if (sb.Length < 20)
                         {
@@ -7716,7 +7716,7 @@ namespace Nikse.SubtitleEdit.Forms
                 _makeHistoryPaused = true;
                 var idx = SubtitleListview1.SelectedItems[0].Index;
                 _subtitle.RecalculateDisplayTime(Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds, idx, Configuration.Settings.General.SubtitleOptimalCharactersPerSeconds, onlyOptimal: onlyOptimal);
-                SetDurationInSeconds(_subtitle.Paragraphs[idx].DurationTotalSeconds);
+                SetDurationInSeconds(_subtitle.Paragraphs[idx].Duration.Seconds);
                 _makeHistoryPaused = false;
             }
         }
@@ -7729,7 +7729,7 @@ namespace Nikse.SubtitleEdit.Forms
                 _makeHistoryPaused = true;
                 var idx = SubtitleListview1.SelectedItems[0].Index;
                 _subtitle.RecalculateDisplayTime(Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds, idx, Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds);
-                SetDurationInSeconds(_subtitle.Paragraphs[idx].DurationTotalSeconds);
+                SetDurationInSeconds(_subtitle.Paragraphs[idx].Duration.Seconds);
                 _makeHistoryPaused = false;
             }
         }
@@ -9858,7 +9858,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             var audioClips = GetAudioClips();
 
-            if (audioClips.Count == 1 && audioClips[0].Paragraph.DurationTotalMilliseconds > 10_000)
+            if (audioClips.Count == 1 && audioClips[0].Paragraph.Duration.Milliseconds > 10_000)
             {
                 using (var form = new VoskAudioToText(audioClips[0].AudioFileName, _videoAudioTrackNumber, this))
                 {
@@ -9922,7 +9922,7 @@ namespace Nikse.SubtitleEdit.Forms
                               _subtitleOriginal != null &&
                               SubtitleListview1.IsOriginalTextColumnVisible;
             var audioClips = GetAudioClips();
-            if (audioClips.Count == 1 && audioClips[0].Paragraph.DurationTotalMilliseconds > 8_000)
+            if (audioClips.Count == 1 && audioClips[0].Paragraph.Duration.Milliseconds > 8_000)
             {
                 var s = new Subtitle();
                 s.Paragraphs.Add(audioClips[0].Paragraph);
@@ -10646,7 +10646,7 @@ namespace Nikse.SubtitleEdit.Forms
                     newParagraph.StartTime.TotalMilliseconds = prev.EndTime.TotalMilliseconds + 1;
                 }
 
-                if (newParagraph.DurationTotalMilliseconds < 100)
+                if (newParagraph.Duration.Milliseconds < 100)
                 {
                     newParagraph.EndTime.TotalMilliseconds += 100;
                 }
@@ -10697,14 +10697,14 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 newParagraph.StartTime.TotalMilliseconds = 1000;
                 newParagraph.EndTime.TotalMilliseconds = 3000;
-                if (newParagraph.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                if (newParagraph.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                 {
                     newParagraph.EndTime.TotalMilliseconds = newParagraph.StartTime.TotalMilliseconds +
                                                              Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
                 }
             }
 
-            if (newParagraph.Duration.TotalMilliseconds < 100)
+            if (newParagraph.Duration.Milliseconds < 100)
             {
                 newParagraph.EndTime.TotalMilliseconds = newParagraph.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
             }
@@ -10826,14 +10826,14 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 newParagraph.StartTime.TotalMilliseconds = 1000;
                 newParagraph.EndTime.TotalMilliseconds = 3000;
-                if (newParagraph.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                if (newParagraph.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                 {
                     newParagraph.EndTime.TotalMilliseconds = newParagraph.StartTime.TotalMilliseconds +
                                                              Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
                 }
             }
 
-            if (newParagraph.Duration.TotalMilliseconds < 100)
+            if (newParagraph.Duration.Milliseconds < 100)
             {
                 newParagraph.EndTime.TotalMilliseconds = newParagraph.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
             }
@@ -10968,7 +10968,7 @@ namespace Nikse.SubtitleEdit.Forms
                     if (startTime != null && last != null && _subtitle != null &&
                         Math.Abs(last.StartTime.TotalMilliseconds - startTime.TotalMilliseconds) > 0.5)
                     {
-                        var dur = last.DurationTotalMilliseconds;
+                        var dur = last.Duration.Milliseconds;
                         last.StartTime.TotalMilliseconds = startTime.TotalMilliseconds;
                         last.EndTime.TotalMilliseconds = startTime.TotalMilliseconds + dur;
                         SubtitleListview1.SetStartTimeAndDuration(_subtitleListViewIndex, last, _subtitle.GetParagraphOrDefault(_subtitleListViewIndex + 1), _subtitle.GetParagraphOrDefault(_subtitleListViewIndex - 1));
@@ -10976,7 +10976,7 @@ namespace Nikse.SubtitleEdit.Forms
                     }
 
                     var duration = GetDurationInMilliseconds();
-                    if (last != null && duration > 0 && duration < 100000 && Math.Abs(duration - last.DurationTotalMilliseconds) > 0.5 && _subtitle != null)
+                    if (last != null && duration > 0 && duration < 100000 && Math.Abs(duration - last.Duration.Milliseconds) > 0.5 && _subtitle != null)
                     {
                         last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + duration;
                         SubtitleListview1.SetDuration(_subtitleListViewIndex, last, _subtitle.GetParagraphOrDefault(_subtitleListViewIndex + 1));
@@ -11058,7 +11058,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void UpdateListViewTextCharactersPerSeconds(Label charsPerSecond, Paragraph paragraph)
         {
-            if (paragraph.DurationTotalSeconds > 0)
+            if (paragraph.Duration.Seconds > 0)
             {
                 double charactersPerSecond = paragraph.GetCharactersPerSecond();
                 if (charactersPerSecond > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds &&
@@ -12441,7 +12441,7 @@ namespace Nikse.SubtitleEdit.Forms
                 if (_networkSession != null)
                 {
                     _networkSession.TimerStop();
-                    SetDurationInSeconds(currentParagraph.DurationTotalSeconds);
+                    SetDurationInSeconds(currentParagraph.Duration.Seconds);
                     _networkSession.UpdateLine(_subtitle.GetIndex(currentParagraph), currentParagraph);
                     NetworkGetSendUpdates(new List<int>(), firstSelectedIndex + 1, newParagraph);
                 }
@@ -12584,7 +12584,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void SetSplitTime(double? splitSeconds, Paragraph currentParagraph, Paragraph newParagraph, string oldText)
         {
-            double middle = currentParagraph.StartTime.TotalMilliseconds + (currentParagraph.DurationTotalMilliseconds / 2);
+            double middle = currentParagraph.StartTime.TotalMilliseconds + (currentParagraph.Duration.Milliseconds / 2);
             if (!string.IsNullOrWhiteSpace(HtmlUtil.RemoveHtmlTags(oldText)))
             {
                 var lineOneTextNoHtml = HtmlUtil.RemoveHtmlTags(currentParagraph.Text, true).Replace(Environment.NewLine, string.Empty);
@@ -12604,7 +12604,7 @@ namespace Nikse.SubtitleEdit.Forms
                         startFactor = 0.75;
                     }
 
-                    middle = currentParagraph.StartTime.TotalMilliseconds + (currentParagraph.DurationTotalMilliseconds * startFactor);
+                    middle = currentParagraph.StartTime.TotalMilliseconds + (currentParagraph.Duration.Milliseconds * startFactor);
                 }
             }
 
@@ -12613,7 +12613,7 @@ namespace Nikse.SubtitleEdit.Forms
                 newParagraph.StartTime.TotalMilliseconds = TimeCode.MaxTimeTotalMilliseconds;
                 newParagraph.EndTime.TotalMilliseconds = TimeCode.MaxTimeTotalMilliseconds;
             }
-            else if (currentParagraph.DurationTotalMilliseconds <= 1)
+            else if (currentParagraph.Duration.Milliseconds <= 1)
             {
                 newParagraph.StartTime.TotalMilliseconds = currentParagraph.EndTime.TotalMilliseconds;
                 newParagraph.EndTime.TotalMilliseconds = currentParagraph.EndTime.TotalMilliseconds;
@@ -12713,7 +12713,7 @@ namespace Nikse.SubtitleEdit.Forms
                         }
                     }
 
-                    durationMilliseconds += p.DurationTotalMilliseconds;
+                    durationMilliseconds += p.Duration.Milliseconds;
                 }
 
                 if (sb1.Length > 150 || sb2.Length > 150)
@@ -13249,7 +13249,7 @@ namespace Nikse.SubtitleEdit.Forms
                 if (_networkSession != null)
                 {
                     _networkSession.TimerStop();
-                    SetDurationInSeconds(currentParagraph.DurationTotalSeconds);
+                    SetDurationInSeconds(currentParagraph.Duration.Seconds);
                     _networkSession.UpdateLine(_subtitle.GetIndex(currentParagraph), currentParagraph);
                     var deleteIndices = new List<int> { _subtitle.GetIndex(nextParagraph) };
                     NetworkGetSendUpdates(deleteIndices, 0, null);
@@ -13581,13 +13581,13 @@ namespace Nikse.SubtitleEdit.Forms
             timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
 
             numericUpDownDuration.ValueChanged -= NumericUpDownDurationValueChanged;
-            if (p.DurationTotalSeconds > (double)numericUpDownDuration.Maximum)
+            if (p.Duration.Seconds > (double)numericUpDownDuration.Maximum)
             {
                 SetDurationInSeconds((double)numericUpDownDuration.Maximum);
             }
             else
             {
-                SetDurationInSeconds(p.DurationTotalSeconds);
+                SetDurationInSeconds(p.Duration.Seconds);
             }
 
             numericUpDownDuration.ValueChanged += NumericUpDownDurationValueChanged;
@@ -13612,13 +13612,13 @@ namespace Nikse.SubtitleEdit.Forms
             timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
 
             numericUpDownDuration.ValueChanged -= NumericUpDownDurationValueChanged;
-            if (p.DurationTotalSeconds > (double)numericUpDownDuration.Maximum)
+            if (p.Duration.Seconds > (double)numericUpDownDuration.Maximum)
             {
                 SetDurationInSeconds((double)numericUpDownDuration.Maximum);
             }
             else
             {
-                SetDurationInSeconds(p.DurationTotalSeconds);
+                SetDurationInSeconds(p.Duration.Seconds);
             }
 
             numericUpDownDuration.ValueChanged += NumericUpDownDurationValueChanged;
@@ -15360,10 +15360,10 @@ namespace Nikse.SubtitleEdit.Forms
                     if (pes == null && subtitle.Paragraphs.Count > 0)
                     {
                         var last = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
-                        if (last.DurationTotalMilliseconds < 100)
+                        if (last.Duration.Milliseconds < 100)
                         {
                             last.EndTime.TotalMilliseconds = msub.Start;
-                            if (last.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                            if (last.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                             {
                                 last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + 3000;
                             }
@@ -15390,7 +15390,7 @@ namespace Nikse.SubtitleEdit.Forms
             for (int index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
-                if (p.DurationTotalMilliseconds < 200)
+                if (p.Duration.Milliseconds < 200)
                 {
                     p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + 3000;
                 }
@@ -18908,7 +18908,7 @@ namespace Nikse.SubtitleEdit.Forms
                         p.EndTime = newEndTime;
 
                         SubtitleListview1.SetStartTimeAndDuration(index, _subtitle.Paragraphs[index], _subtitle.GetParagraphOrDefault(index + 1), _subtitle.GetParagraphOrDefault(index - 1));
-                        SetDurationInSeconds(_subtitle.Paragraphs[index].DurationTotalSeconds);
+                        SetDurationInSeconds(_subtitle.Paragraphs[index].Duration.Seconds);
                         var newP = InsertNewParagraphAtPosition(newEndTime.TotalMilliseconds + MinGapBetweenLines, false);
                         if (audioVisualizer.WavePeaks != null && newP.EndTime.TotalSeconds >= audioVisualizer.EndPositionSeconds - 0.1)
                         {
@@ -19432,7 +19432,7 @@ namespace Nikse.SubtitleEdit.Forms
                         p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - MinGapBetweenLines;
                     }
 
-                    if (p.DurationTotalMilliseconds < 0)
+                    if (p.Duration.Milliseconds < 0)
                     {
                         p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds;
                     }
@@ -19461,7 +19461,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 original.EndTime.TotalMilliseconds = originalNext.StartTime.TotalMilliseconds - MinGapBetweenLines;
                             }
 
-                            if (original.DurationTotalMilliseconds < 0)
+                            if (original.Duration.Milliseconds < 0)
                             {
                                 original.EndTime.TotalMilliseconds = original.StartTime.TotalMilliseconds;
                             }
@@ -19532,7 +19532,7 @@ namespace Nikse.SubtitleEdit.Forms
                                     original.StartTime.TotalMilliseconds = originalPrevious.EndTime.TotalMilliseconds + MinGapBetweenLines;
                                 }
 
-                                if (original.DurationTotalMilliseconds < 0)
+                                if (original.Duration.Milliseconds < 0)
                                 {
                                     original.StartTime.TotalMilliseconds = original.EndTime.TotalMilliseconds;
                                 }
@@ -19555,7 +19555,7 @@ namespace Nikse.SubtitleEdit.Forms
                         p.StartTime.TotalMilliseconds = previous.EndTime.TotalMilliseconds + MinGapBetweenLines;
                     }
 
-                    if (p.DurationTotalMilliseconds < 0)
+                    if (p.Duration.Milliseconds < 0)
                     {
                         p.StartTime.TotalMilliseconds = p.EndTime.TotalMilliseconds;
                     }
@@ -20163,14 +20163,14 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         var temp = new Paragraph(p);
                         temp.StartTime.TotalMilliseconds = newStartTimeMs;
-                        if (temp.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds ||
+                        if (temp.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds ||
                             temp.GetCharactersPerSecond() > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                         {
                             var next = _subtitle.GetParagraphOrDefault(index + 1);
                             if (next == null ||
-                                next.StartTime.TotalMilliseconds > newStartTimeMs + p.DurationTotalMilliseconds + MinGapBetweenLines)
+                                next.StartTime.TotalMilliseconds > newStartTimeMs + p.Duration.Milliseconds + MinGapBetweenLines)
                             {
-                                newEndTimeMs = newStartTimeMs + p.DurationTotalMilliseconds;
+                                newEndTimeMs = newStartTimeMs + p.Duration.Milliseconds;
                             }
                         }
                     }
@@ -20605,7 +20605,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     isClose = true;
                     prevGap = p.StartTime.TotalMilliseconds - prev.EndTime.TotalMilliseconds;
-                    if (ms < 0 && prev.DurationTotalMilliseconds + ms < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                    if (ms < 0 && prev.Duration.Milliseconds + ms < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                     {
                         return;
                     }
@@ -20623,7 +20623,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else
             {
-                if (p.DurationTotalMilliseconds + Math.Abs(ms) > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (p.Duration.Milliseconds + Math.Abs(ms) > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     return;
                 }
@@ -20651,7 +20651,7 @@ namespace Nikse.SubtitleEdit.Forms
             timeUpDownStartTime.MaskedTextBox.TextChanged -= MaskedTextBoxTextChanged;
             timeUpDownStartTime.TimeCode = p.StartTime;
             timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
-            SetDurationInSeconds(p.DurationTotalSeconds);
+            SetDurationInSeconds(p.Duration.Seconds);
 
             if (keepGapPrevIfClose && isClose && prev != null)
             {
@@ -20718,7 +20718,7 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     isClose = true;
                     nextGap = next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds;
-                    if (ms > 0 && next.DurationTotalMilliseconds + ms < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                    if (ms > 0 && next.Duration.Milliseconds + ms < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                     {
                         return;
                     }
@@ -20727,7 +20727,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (ms > 0)
             {
-                if (p.DurationTotalMilliseconds + ms > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (p.Duration.Milliseconds + ms > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     return;
                 }
@@ -20759,7 +20759,7 @@ namespace Nikse.SubtitleEdit.Forms
             timeUpDownStartTime.MaskedTextBox.TextChanged -= MaskedTextBoxTextChanged;
             timeUpDownStartTime.TimeCode = p.StartTime;
             timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
-            SetDurationInSeconds(p.DurationTotalSeconds);
+            SetDurationInSeconds(p.Duration.Seconds);
 
             if (keepGapNextIfClose && isClose && next != null)
             {
@@ -24830,7 +24830,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 timeUpDownStartTime.TimeCode = TimeCode.FromSeconds(videoPosition);
 
-                var duration = p.DurationTotalMilliseconds;
+                var duration = p.Duration.Milliseconds;
 
                 p.StartTime.TotalMilliseconds = videoPosition * TimeCode.BaseUnit;
                 if (adjustEndTime)
@@ -24849,7 +24849,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 if (!adjustEndTime)
                 {
-                    SetDurationInSeconds(p.DurationTotalSeconds);
+                    SetDurationInSeconds(p.Duration.Seconds);
                 }
 
                 UpdateOriginalTimeCodes(oldParagraph);
@@ -24924,7 +24924,7 @@ namespace Nikse.SubtitleEdit.Forms
                 }
 
                 SubtitleListview1.SetStartTimeAndDuration(index, _subtitle.Paragraphs[index], _subtitle.GetParagraphOrDefault(index + 1), _subtitle.GetParagraphOrDefault(index - 1));
-                SetDurationInSeconds(_subtitle.Paragraphs[index].DurationTotalSeconds);
+                SetDurationInSeconds(_subtitle.Paragraphs[index].Duration.Seconds);
                 UpdateSourceView();
             }
         }
@@ -25054,7 +25054,7 @@ namespace Nikse.SubtitleEdit.Forms
                         }
                     }
 
-                    if (duration == currentParagraph.Duration.TotalMilliseconds)
+                    if (duration == currentParagraph.Duration.Milliseconds)
                     {
                         return;
                     }
@@ -25900,7 +25900,7 @@ namespace Nikse.SubtitleEdit.Forms
                 _subtitle.Paragraphs[index].EndTime.TotalSeconds = videoPosition;
                 SubtitleListview1.SetDuration(index, _subtitle.Paragraphs[index], _subtitle.GetParagraphOrDefault(index + 1));
                 checkBoxSyncListViewWithVideoWhilePlaying.Checked = oldSync;
-                numericUpDownDuration.Value = (decimal)_subtitle.Paragraphs[index].DurationTotalSeconds;
+                numericUpDownDuration.Value = (decimal)_subtitle.Paragraphs[index].Duration.Seconds;
                 numericUpDownDuration.ValueChanged += NumericUpDownDurationValueChanged;
                 RefreshSelectedParagraph();
 
@@ -25989,7 +25989,7 @@ namespace Nikse.SubtitleEdit.Forms
                 }
 
                 SubtitleListview1.SetDuration(index, _subtitle.Paragraphs[index], _subtitle.GetParagraphOrDefault(index + 1));
-                SetDurationInSeconds(_subtitle.Paragraphs[index].DurationTotalSeconds);
+                SetDurationInSeconds(_subtitle.Paragraphs[index].Duration.Seconds);
 
                 if (index + 1 < _subtitle.Paragraphs.Count)
                 {
@@ -26264,8 +26264,8 @@ namespace Nikse.SubtitleEdit.Forms
                 if (!string.IsNullOrEmpty(_videoFileName) &&
                     audioVisualizer.WavePeaks != null &&
                     audioVisualizer.NewSelectionParagraph != null &&
-                    audioVisualizer.NewSelectionParagraph.Duration.TotalMilliseconds > 100 &&
-                    audioVisualizer.NewSelectionParagraph.Duration.TotalMilliseconds < 10_000)
+                    audioVisualizer.NewSelectionParagraph.Duration.Milliseconds > 100 &&
+                    audioVisualizer.NewSelectionParagraph.Duration.Milliseconds < 10_000)
                 {
                     AddParagraphHereToolStripMenuItemClick(null, null);
                     return;
@@ -30245,7 +30245,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             timeUpDownStartTime.TimeCode = p.StartTime;
-            var durationInSeconds = (decimal)p.DurationTotalSeconds;
+            var durationInSeconds = (decimal)p.Duration.Seconds;
             if (durationInSeconds >= numericUpDownDuration.Minimum && durationInSeconds <= numericUpDownDuration.Maximum)
             {
                 SetDurationInSeconds((double)durationInSeconds);
@@ -30311,7 +30311,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             timeUpDownStartTime.TimeCode = p.StartTime;
-            var durationInSeconds = (decimal)p.DurationTotalSeconds;
+            var durationInSeconds = (decimal)p.Duration.Seconds;
             if (durationInSeconds >= numericUpDownDuration.Minimum && durationInSeconds <= numericUpDownDuration.Maximum)
             {
                 SetDurationInSeconds((double)durationInSeconds);
@@ -30365,7 +30365,7 @@ namespace Nikse.SubtitleEdit.Forms
             //}
 
             // current movie Position
-            double durationTotalMilliseconds = p.DurationTotalMilliseconds;
+            double durationTotalMilliseconds = p.Duration.Milliseconds;
             double totalMillisecondsEnd = mediaPlayer.CurrentPosition * TimeCode.BaseUnit;
 
             var tc = new TimeCode(totalMillisecondsEnd - durationTotalMilliseconds);
@@ -30384,7 +30384,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             timeUpDownStartTime.TimeCode = p.StartTime;
-            var durationInSeconds = (decimal)(p.DurationTotalSeconds);
+            var durationInSeconds = (decimal)(p.Duration.Seconds);
             if (durationInSeconds >= numericUpDownDuration.Minimum && durationInSeconds <= numericUpDownDuration.Maximum)
             {
                 SetDurationInSeconds((double)durationInSeconds);
@@ -30507,14 +30507,14 @@ namespace Nikse.SubtitleEdit.Forms
                 timeUpDownStartTime.MaskedTextBox.TextChanged += MaskedTextBoxTextChanged;
             }
 
-            if (p.DurationTotalSeconds < 0)
+            if (p.Duration.Seconds < 0)
             {
                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);
             }
 
             SubtitleListview1.SetStartTimeAndDuration(index, p, _subtitle.GetParagraphOrDefault(index + 1), _subtitle.GetParagraphOrDefault(index - 1));
 
-            SetDurationInSeconds(_subtitle.Paragraphs[index].DurationTotalSeconds + 0.001);
+            SetDurationInSeconds(_subtitle.Paragraphs[index].Duration.Seconds + 0.001);
             if (next != null)
             {
                 int addMilliseconds = MinGapBetweenLines;
@@ -30523,7 +30523,7 @@ namespace Nikse.SubtitleEdit.Forms
                     addMilliseconds = 1;
                 }
 
-                var oldDuration = next.DurationTotalMilliseconds;
+                var oldDuration = next.Duration.Milliseconds;
                 if (next.StartTime.IsMaxTime || next.EndTime.IsMaxTime)
                 {
                     oldDuration = Utilities.GetOptimalDisplayMilliseconds(p.Text);
@@ -31606,7 +31606,7 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         // current sub
                     }
-                    else if (p.DurationTotalSeconds < 10 && p.StartTime.TotalMilliseconds > ms)
+                    else if (p.Duration.Seconds < 10 && p.StartTime.TotalMilliseconds > ms)
                     {
                         mediaPlayer.CurrentPosition = p.StartTime.TotalSeconds;
                         SubtitleListview1.SelectIndexAndEnsureVisible(_subtitle.GetIndex(p), true);
@@ -31629,7 +31629,7 @@ namespace Nikse.SubtitleEdit.Forms
                     {
                         // current sub
                     }
-                    else if (p.DurationTotalSeconds < 10 && p.StartTime.TotalMilliseconds < ms)
+                    else if (p.Duration.Seconds < 10 && p.StartTime.TotalMilliseconds < ms)
                     {
                         mediaPlayer.CurrentPosition = p.StartTime.TotalSeconds;
                         SubtitleListview1.SelectIndexAndEnsureVisible(_subtitle.GetIndex(p), true);
@@ -36844,7 +36844,7 @@ namespace Nikse.SubtitleEdit.Forms
                 else
                 {
                     var mp4Parser = new MP4Parser(_videoFileName);
-                    if (mp4Parser.Duration.TotalMilliseconds > 0)
+                    if (mp4Parser.Duration.Milliseconds > 0)
                     {
                         sb.AppendLine($"Container: MP4");
                     }

--- a/src/ui/Forms/ModifySelection.cs
+++ b/src/ui/Forms/ModifySelection.cs
@@ -421,14 +421,14 @@ namespace Nikse.SubtitleEdit.Forms
                     }
                     else if (comboBoxRule.SelectedIndex == FunctionDurationLessThan) // Duration less than
                     {
-                        if (p.DurationTotalMilliseconds < (double)numericUpDownDuration.Value)
+                        if (p.Duration.Milliseconds < (double)numericUpDownDuration.Value)
                         {
                             listViewItems.Add(MakeListViewItem(p, i));
                         }
                     }
                     else if (comboBoxRule.SelectedIndex == FunctionDurationGreaterThan) // Duration greater than
                     {
-                        if (p.DurationTotalMilliseconds > (double)numericUpDownDuration.Value)
+                        if (p.Duration.Milliseconds > (double)numericUpDownDuration.Value)
                         {
                             listViewItems.Add(MakeListViewItem(p, i));
                         }

--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -1481,7 +1481,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                     Paragraph p = new Paragraph(string.Empty, x.StartTime.TotalMilliseconds, x.EndTime.TotalMilliseconds);
                     if (checkBoxUseTimeCodesFromIdx.Checked && x.IdxLine != null)
                     {
-                        double durationMilliseconds = p.DurationTotalMilliseconds;
+                        double durationMilliseconds = p.Duration.Milliseconds;
                         p.StartTime = new TimeCode(x.IdxLine.StartTime.TotalMilliseconds);
                         p.EndTime = new TimeCode(x.IdxLine.StartTime.TotalMilliseconds + durationMilliseconds);
                     }
@@ -7517,7 +7517,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 foreach (var old in oldSubtitle.Paragraphs)
                 {
                     if (Math.Abs(current.StartTime.TotalMilliseconds - old.StartTime.TotalMilliseconds) < 0.01 &&
-                        Math.Abs(current.DurationTotalMilliseconds - old.DurationTotalMilliseconds) < 0.01)
+                        Math.Abs(current.Duration.Milliseconds - old.Duration.Milliseconds) < 0.01)
                     {
                         current.Text = old.Text;
                         break;

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -425,7 +425,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                 if (imageSub == null)
                 {
-                    var mean = _currentParagraph.StartTime.TotalMilliseconds + _currentParagraph.DurationTotalMilliseconds / 2;
+                    var mean = _currentParagraph.StartTime.TotalMilliseconds + _currentParagraph.Duration.Milliseconds / 2;
                     imageSub = _binSubtitles.FirstOrDefault(p => mean >= p.StartTimeCode.TotalMilliseconds && mean <= _currentParagraph.EndTime.TotalMilliseconds);
                 }
 

--- a/src/ui/Forms/SplitLongLines.cs
+++ b/src/ui/Forms/SplitLongLines.cs
@@ -206,7 +206,7 @@ namespace Nikse.SubtitleEdit.Forms
                             var newParagraph2 = new Paragraph(p);
                             newParagraph1.Text = Utilities.AutoBreakLine(arr[0], language);
 
-                            var middle = p.StartTime.TotalMilliseconds + p.DurationTotalMilliseconds / 2;
+                            var middle = p.StartTime.TotalMilliseconds + p.Duration.Milliseconds / 2;
                             if (!string.IsNullOrWhiteSpace(oldText))
                             {
                                 var startFactor = (double)HtmlUtil.RemoveHtmlTags(newParagraph1.Text).Length / oldText.Length;
@@ -220,7 +220,7 @@ namespace Nikse.SubtitleEdit.Forms
                                     startFactor = 0.75;
                                 }
 
-                                middle = p.StartTime.TotalMilliseconds + p.DurationTotalMilliseconds * startFactor;
+                                middle = p.StartTime.TotalMilliseconds + p.Duration.Milliseconds * startFactor;
                             }
 
                             newParagraph1.EndTime.TotalMilliseconds = middle - spacing1;
@@ -305,7 +305,7 @@ namespace Nikse.SubtitleEdit.Forms
                         }
                         else
                         {
-                            var durationMs = p.DurationTotalMilliseconds / arr.Count;
+                            var durationMs = p.Duration.Milliseconds / arr.Count;
                             for (var index = 0; index < arr.Count; index++)
                             {
                                 var line = arr[index];
@@ -321,7 +321,7 @@ namespace Nikse.SubtitleEdit.Forms
                                 {
                                     var minGap = Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                                     if (minGap > 0 &&
-                                        newParagraph.DurationTotalMilliseconds - minGap > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                                        newParagraph.Duration.Milliseconds - minGap > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                                     {
                                         newParagraph.EndTime.TotalMilliseconds -= minGap;
                                     }
@@ -424,7 +424,7 @@ namespace Nikse.SubtitleEdit.Forms
                                     var newParagraph2 = new Paragraph(p);
                                     newParagraph1.Text = Utilities.AutoBreakLine(arr[0], language);
 
-                                    var middle = p.StartTime.TotalMilliseconds + p.DurationTotalMilliseconds / 2;
+                                    var middle = p.StartTime.TotalMilliseconds + p.Duration.Milliseconds / 2;
                                     if (!string.IsNullOrWhiteSpace(oldText))
                                     {
                                         var startFactor = (double)HtmlUtil.RemoveHtmlTags(newParagraph1.Text).Length / oldText.Length;
@@ -438,7 +438,7 @@ namespace Nikse.SubtitleEdit.Forms
                                             startFactor = 0.75;
                                         }
 
-                                        middle = p.StartTime.TotalMilliseconds + p.DurationTotalMilliseconds * startFactor;
+                                        middle = p.StartTime.TotalMilliseconds + p.Duration.Milliseconds * startFactor;
                                     }
 
                                     newParagraph1.EndTime.TotalMilliseconds = middle - spacing1;
@@ -545,7 +545,7 @@ namespace Nikse.SubtitleEdit.Forms
 
                                 newParagraph1.Text = Utilities.AutoBreakLine(p.Text.Substring(0, splitPos + 1), language);
 
-                                var middle = p.StartTime.TotalMilliseconds + p.DurationTotalMilliseconds / 2;
+                                var middle = p.StartTime.TotalMilliseconds + p.Duration.Milliseconds / 2;
                                 if (!string.IsNullOrWhiteSpace(oldText))
                                 {
                                     var startFactor = (double)HtmlUtil.RemoveHtmlTags(newParagraph1.Text).Length / oldText.Length;
@@ -559,7 +559,7 @@ namespace Nikse.SubtitleEdit.Forms
                                         startFactor = 0.75;
                                     }
 
-                                    middle = p.StartTime.TotalMilliseconds + p.DurationTotalMilliseconds * startFactor;
+                                    middle = p.StartTime.TotalMilliseconds + p.Duration.Milliseconds * startFactor;
                                 }
 
                                 newParagraph1.EndTime.TotalMilliseconds = middle - spacing1;

--- a/src/ui/Forms/Statistics.cs
+++ b/src/ui/Forms/Statistics.cs
@@ -138,7 +138,7 @@ https://github.com/SubtitleEdit/subtitleedit
                 maximumLineLength = Math.Max(len, maximumLineLength);
                 totalLineLength += len;
 
-                var duration = p.DurationTotalMilliseconds;
+                var duration = p.Duration.Milliseconds;
                 minimumDuration = Math.Min(duration, minimumDuration);
                 maximumDuration = Math.Max(duration, maximumDuration);
                 totalDuration += duration;
@@ -218,11 +218,11 @@ https://github.com/SubtitleEdit/subtitleedit
                     aboveMaximumWpmCount++;
                 }
 
-                if (p.DurationTotalMilliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
+                if (p.Duration.Milliseconds < Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                 {
                     belowMinimumDurationCount++;
                 }
-                if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                if (p.Duration.Milliseconds > Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
                     aboveMaximumDurationCount++;
                 }
@@ -324,7 +324,7 @@ https://github.com/SubtitleEdit/subtitleedit
             for (var i = 0; i < _subtitle.Paragraphs.Count; i++)
             {
                 var p = _subtitle.Paragraphs[i];
-                if (Math.Abs(p.DurationTotalMilliseconds - duration) < 0.01)
+                if (Math.Abs(p.Duration.Milliseconds - duration) < 0.01)
                 {
                     if (indices.Count >= NumberOfLinesToShow)
                     {

--- a/src/ui/Forms/SyncPointsSync.cs
+++ b/src/ui/Forms/SyncPointsSync.cs
@@ -150,7 +150,7 @@ namespace Nikse.SubtitleEdit.Forms
                 if (_synchronizationPoints.ContainsKey(i))
                 {
                     var p = new Paragraph { StartTime = { TotalMilliseconds = _synchronizationPoints[i].Time.TotalMilliseconds } };
-                    p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + _subtitle.Paragraphs[i].DurationTotalMilliseconds;
+                    p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + _subtitle.Paragraphs[i].Duration.Milliseconds;
                     subtitleListView1.SetStartTimeAndDuration(i, p, _subtitle.GetParagraphOrDefault(i + 1), _subtitle.GetParagraphOrDefault(i - 1));
 
                     var item = new ListBoxSyncPoint { Index = i, Text = _subtitle.Paragraphs[i].Number + " - " + p.StartTime };
@@ -533,7 +533,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             var selectedLocation = syncParagraph.StartTime.TotalMilliseconds;
-            var selectedDuration = syncParagraph.DurationTotalMilliseconds;
+            var selectedDuration = syncParagraph.Duration.Milliseconds;
             if (selectedDuration == 0)
                 selectedDuration = 1000;
 

--- a/src/ui/Forms/Translate/MergeAndSplitHelper.cs
+++ b/src/ui/Forms/Translate/MergeAndSplitHelper.cs
@@ -536,9 +536,9 @@ namespace Nikse.SubtitleEdit.Forms.Translate
                     var pctCharArr = GetTwoPartsByPct(text, pctCharLength1, pctCharLength2);
 
                     // test using duration for percentage
-                    var totalDurationLength = item.Paragraphs[0].DurationTotalMilliseconds + item.Paragraphs[1].DurationTotalMilliseconds + 1;
-                    var pctDurationLength1 = item.Paragraphs[0].DurationTotalMilliseconds * 100.0 / totalDurationLength;
-                    var pctDurationLength2 = item.Paragraphs[1].DurationTotalMilliseconds * 100.0 / totalDurationLength;
+                    var totalDurationLength = item.Paragraphs[0].Duration.Milliseconds + item.Paragraphs[1].Duration.Milliseconds + 1;
+                    var pctDurationLength1 = item.Paragraphs[0].Duration.Milliseconds * 100.0 / totalDurationLength;
+                    var pctDurationLength2 = item.Paragraphs[1].Duration.Milliseconds * 100.0 / totalDurationLength;
                     var pctDurationArr = GetTwoPartsByPct(text, pctDurationLength1, pctDurationLength2);
 
 

--- a/src/ui/Forms/Tts/ReviewAudioClips.cs
+++ b/src/ui/Forms/Tts/ReviewAudioClips.cs
@@ -194,7 +194,7 @@ namespace Nikse.SubtitleEdit.Forms.Tts
 
             var idx = listViewAudioClips.SelectedItems[0].Index;
             var p = _subtitle.Paragraphs[idx];
-            labelParagraphInfo.Text = p.StartTime.ToDisplayString() + " --> " + p.EndTime.ToDisplayString() + " : " + p.Duration.ToShortDisplayString();
+            labelParagraphInfo.Text = p.StartTime.ToDisplayString() + " --> " + p.EndTime.ToDisplayString() + " : " + p.Duration.ToTimeCode().ToShortDisplayString();
         }
 
         private void buttonPlay_Click(object sender, EventArgs e)

--- a/src/ui/Forms/Tts/TextToSpeech.cs
+++ b/src/ui/Forms/Tts/TextToSpeech.cs
@@ -516,13 +516,13 @@ namespace Nikse.SubtitleEdit.Forms.Tts
                 }
 
                 var waveInfo = UiUtil.GetVideoInfo(outputFileName1);
-                if (waveInfo.TotalMilliseconds <= p.DurationTotalMilliseconds + addDuration)
+                if (waveInfo.TotalMilliseconds <= p.Duration.Milliseconds + addDuration)
                 {
                     fileNames.Add(new FileNameAndSpeedFactor { Filename = outputFileName1, Factor = 1 });
                     continue;
                 }
 
-                var factor = (decimal)waveInfo.TotalMilliseconds / (decimal)(p.DurationTotalMilliseconds + addDuration);
+                var factor = (decimal)waveInfo.TotalMilliseconds / (decimal)(p.Duration.Milliseconds + addDuration);
                 var outputFileName2 = Path.Combine(_waveFolder, $"{index}_{Guid.NewGuid()}{ext}");
                 if (!string.IsNullOrEmpty(overrideFileName) && File.Exists(Path.Combine(_waveFolder, overrideFileName)))
                 {

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -85,7 +85,7 @@ namespace Nikse.SubtitleEdit.Logic
                 if (p.StartTime.TotalMilliseconds <= positionInMilliseconds + 0.01 && p.EndTime.TotalMilliseconds >= positionInMilliseconds - 0.01)
                 {
                     string text = p.Text.Replace("|", Environment.NewLine);
-                    bool isInfo = p == subtitle.Paragraphs[0] && (Math.Abs(p.StartTime.TotalMilliseconds) < 0.01 && Math.Abs(p.DurationTotalMilliseconds) < 0.01 || Math.Abs(p.StartTime.TotalMilliseconds - Pac.PacNullTime.TotalMilliseconds) < 0.01);
+                    bool isInfo = p == subtitle.Paragraphs[0] && (Math.Abs(p.StartTime.TotalMilliseconds) < 0.01 && Math.Abs(p.Duration.Milliseconds) < 0.01 || Math.Abs(p.StartTime.TotalMilliseconds - Pac.PacNullTime.TotalMilliseconds) < 0.01);
                     if (!isInfo)
                     {
                         if (videoPlayerContainer.LastParagraph != p)


### PR DESCRIPTION
Introduce new type (value type) `Duration` which will help avoiding allocation that happens 
with the TimeCode type since it is a struct-type

Note: Regarding to the formatting that is only available through the TimeCode class, an method is 
also introduced in Duration which will help with the conversion between Duration => TimeCode to facilitate 
with the formatting. This will change in the future though to allow Duration type to also 
support self formatting to string