### PR TITLE
Rename ColorUtils to ColorExtensions

### DIFF
--- a/src/libse/Common/ColorExtensions.cs
+++ b/src/libse/Common/ColorExtensions.cs
@@ -3,7 +3,7 @@ using System.Drawing;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public static class ColorUtils
+    public static class ColorExtensions
     {
         public static Color Blend(this Color baseColor, Color targetColor, double percentage = 0.5)
         {


### PR DESCRIPTION
Renamed the ColorUtils class to ColorExtensions to better reflect its purpose as an extension class for color-related functionalities. This change improves code readability and consistency within the project.