### PR TITLE
Fix incorrect character check in tag detection logic

### DIFF
--- a/src/libse/Common/FixCasing.cs
+++ b/src/libse/Common/FixCasing.cs
@@ -207,7 +207,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     tagOn = true;
                 }
-                else if (ch == '<' || ch == '}')
+                else if (ch == '>' || ch == '}')
                 {
                     tagOn = false;
                 }


### PR DESCRIPTION
Changed the character check from '<' to '>' in the tag detection logic to properly toggle the tagOn variable. This corrects the behavior for closing tags, improving markup parsing accuracy.