### PR TITLE
Fixes edge cases for parsing milliseconds.

### DIFF
--- a/src/libse/Common/TimeCode.cs
+++ b/src/libse/Common/TimeCode.cs
@@ -24,6 +24,19 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 if (int.TryParse(parts[0], out var hours) && int.TryParse(parts[1], out var minutes) && int.TryParse(parts[2], out var seconds) && int.TryParse(parts[3], out var milliseconds))
                 {
+                	// Fixes edge cases where the millisecond portion doesn't have three digits
+                	if (parts[3].Length < 3)
+                	{
+                		for (int msLength = parts[3].Length; msLength < 3; msLength ++)
+                		{
+                			milliseconds *= 10;
+                		}
+                	} else {
+                		for (int msLength = parts[3].Length; msLength > 3; msLength --)
+                		{
+                			milliseconds /= 10;
+                		}
+                	}
                     return new TimeSpan(0, hours, minutes, seconds, milliseconds).TotalMilliseconds;
                 }
             }
@@ -32,6 +45,19 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 if (int.TryParse(parts[0], out var minutes) && int.TryParse(parts[1], out var seconds) && int.TryParse(parts[2], out var milliseconds))
                 {
+                	// Fixes edge cases where the millisecond portion doesn't have three digits
+                	if (parts[3].Length < 3)
+                	{
+                		for (int msLength = parts[3].Length; msLength < 3; msLength ++)
+                		{
+                			milliseconds *= 10;
+                		}
+                	} else {
+                		for (int msLength = parts[3].Length; msLength > 3; msLength --)
+                		{
+                			milliseconds /= 10;
+                		}
+                	}
                     return new TimeSpan(0, 0, minutes, seconds, milliseconds).TotalMilliseconds;
                 }
             }


### PR DESCRIPTION
Discovered by @Jirehlov, this PR aims to fix edge cases where parsing the millisecond portion of the time codes doesn't have three digits.

Cannot install Visual Studio Community on Linux, and cannot compile SubtitleEdit on Linux due to a lack of WinForm, so this PR is not tested.