### PR TITLE
Switch to Central Package Management and update binding redirect

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,10 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
+        <PackageVersion Include="System.Drawing.Common" Version="8.0.8" />
+        <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+        <PackageVersion Include="UTF.Unknown" Version="2.5.1" />
+        <PackageVersion Include="zlib.net-mutliplatform" Version="1.0.6" />
         <PackageVersion Include="Microsoft.Net.Http" Version="2.2.29"/>
         <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0"/>
         <PackageVersion Include="NAudio.Core" Version="2.2.1"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,20 @@
+﻿<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.Net.Http" Version="2.2.29"/>
+        <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0"/>
+        <PackageVersion Include="NAudio.Core" Version="2.2.1"/>
+        <PackageVersion Include="NAudio.WinMM" Version="2.2.1"/>
+        <PackageVersion Include="ncalc" Version="1.3.8"/>
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageVersion Include="NHunspell" Version="1.2.5554.16953"/>
+        <PackageVersion Include="System.Security.AccessControl" Version="6.0.1"/>
+        <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0"/>
+        <PackageVersion Include="Vosk" Version="0.3.38"/>
+        <PackageVersion Include="NHunspell" Version="1.2.5554.16953"/>
+        <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0"/>
+        <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>
+    </ItemGroup>
+</Project>

--- a/SubtitleEdit.sln
+++ b/SubtitleEdit.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LanguageBaseEnglish.xml = LanguageBaseEnglish.xml
 		LICENSE.txt = LICENSE.txt
 		README.md = README.md
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibSE", "src\libse\LibSE.csproj", "{D6F64CD3-C3EA-4B36-B575-9B3B8A3CA13F}"

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -12,9 +12,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>Test</RootNamespace>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -201,18 +201,20 @@
         </ProjectReference>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="NHunspell" Version="1.2.5554.16953"/>
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0"/>
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>
+        <PackageReference Include="NHunspell"/>
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe"/>
+        <PackageReference Include="System.Threading.Tasks.Extensions"/>
     </ItemGroup>
     <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets"/>
     <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')"/>
+    
     <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
         <PropertyGroup>
             <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
         </PropertyGroup>
         <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))"/>
     </Target>
+    
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -208,13 +208,6 @@
     <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets"/>
     <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')"/>
     
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-        </PropertyGroup>
-        <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))"/>
-    </Target>
-    
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -43,9 +43,6 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
-    <Reference Include="NHunspell, Version=1.2.5554.16953, Culture=neutral, PublicKeyToken=1ac793ea843b4366, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NHunspell.1.2.5554.16953\lib\net\NHunspell.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
@@ -194,7 +191,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libse\LibSE.csproj">
@@ -205,6 +201,11 @@
       <Project>{511a5b59-1c35-4719-8536-23b19af9b21a}</Project>
       <Name>SubtitleEdit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NHunspell" Version="1.2.5554.16953" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -1,223 +1,223 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <AssemblyName>Test</AssemblyName>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <FileAlignment>512</FileAlignment>
-    <OutputType>Library</OutputType>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{7BE5B8E8-9469-4C7C-89D7-E8C884DEFC0E}</ProjectGuid>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <RootNamespace>Test</RootNamespace>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <RuntimeIdentifier>win</RuntimeIdentifier>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugType>pdbonly</DebugType>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Assa\TagHelperRemoveTagTest.cs" />
-    <Compile Include="Assa\ResamplerTest.cs" />
-    <Compile Include="Assa\AssaTimeCodes.cs" />
-    <Compile Include="Core\AudioToTextTest.cs" />
-    <Compile Include="Core\JsonTest.cs" />
-    <Compile Include="Core\MergeShortLinesUtilsTest.cs" />
-    <Compile Include="Core\CsvUtilTest.cs" />
-    <Compile Include="Core\WebVttHelperTest.cs" />
-    <Compile Include="Core\WebVttToAssaTest.cs" />
-    <Compile Include="Dictionaries\StringWithoutSpaceSplitToWordsTest.cs" />
-    <Compile Include="GoogleCloudVision\GoogleCloudVisionJsonToLinesTest.cs" />
-    <Compile Include="LanguageFiles\LanguageFileTest.cs" />
-    <Compile Include="Logic\AutoTranslate\MergeAndSplitHelperTest.cs" />
-    <Compile Include="Logic\BeautifyTimeCodesTest.cs" />
-    <Compile Include="Logic\ConvertColorsToDialogTest.cs" />
-    <Compile Include="Core\LanguageAutoDetectLanguagesTest.cs" />
-    <Compile Include="Logic\DimensionTest.cs" />
-    <Compile Include="Logic\NetflixHelperTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\EbuStlTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\NetflixTimedTextTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\LrcTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\PacTest.cs" />
-    <Compile Include="Core\UUEncodingTest.cs" />
-    <Compile Include="Core\CharUtilsTest.cs" />
-    <Compile Include="Core\DialogTypeTest.cs" />
-    <Compile Include="Core\SeJsonParserTest.cs" />
-    <Compile Include="Core\FixCasingTest.cs" />
-    <Compile Include="Core\LanguageAutoDetectTest.cs" />
-    <Compile Include="Core\PlainTextImporterTest.cs" />
-    <Compile Include="Core\StringExtensionsTest.cs" />
-    <Compile Include="Core\NikseBitmapTest.cs" />
-    <Compile Include="Core\SubtitleFormatTest.cs" />
-    <Compile Include="Core\SubtitleTest.cs" />
-    <Compile Include="Core\RichTextToPlainTextTest.cs" />
-    <Compile Include="Logic\BridgeGapsTest.cs" />
-    <Compile Include="Logic\Forms\MoveWordUpDownTest.cs" />
-    <Compile Include="Logic\NetflixQualityCheckTest.cs" />
-    <Compile Include="Logic\Ocr\BinaryOcrTest.cs" />
-    <Compile Include="Core\HtmlUtilTest.cs" />
-    <Compile Include="FixCommonErrors\FixCommonErrorsTest.cs" />
-    <Compile Include="Logic\LanguageTest.cs" />
-    <Compile Include="Logic\BluRaySup\BluRaySupParserTest.cs" />
-    <Compile Include="Logic\BluRaySup\ToolBoxTest.cs" />
-    <Compile Include="Logic\Dictionaries\NamesListTest.cs" />
-    <Compile Include="Logic\Dictionaries\OcrFixReplaceListTest.cs" />
-    <Compile Include="Logic\Mp4\Mp4Test.cs" />
-    <Compile Include="Logic\Ocr\MatchesToItalicStringConverterTest.cs" />
-    <Compile Include="Logic\SplitLongLinesHelperTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\Cea708Test.cs" />
-    <Compile Include="Logic\SubtitleFormats\SubtitleFormatFunctionsTest.cs" />
-    <Compile Include="Logic\TarFileTest.cs" />
-    <Compile Include="Logic\ProgressHelperTest.cs" />
-    <Compile Include="Logic\TransportStream\TransportStreamTest.cs" />
-    <Compile Include="Logic\ParagraphTest.cs" />
-    <Compile Include="Logic\StrippableTextTest.cs" />
-    <Compile Include="Logic\TimeCodeTest.cs" />
-    <Compile Include="Logic\UknownFormatImporterJsonTest.cs" />
-    <Compile Include="Logic\ContinuationUtilitiesTest.cs" />
-    <Compile Include="Logic\HtmlUtilTest.cs" />
-    <Compile Include="Logic\VideoFormats\MatroskaTest.cs" />
-    <Compile Include="Logic\VobSub\VobSubTest.cs" />
-    <Compile Include="Logic\Ocr\NOcrTest.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Logic\Forms\RemoveTextForHearImpairedTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\SubtitleFormatsTest.cs" />
-    <Compile Include="Logic\UtilitiesTest.cs" />
-    <Compile Include="Dictionaries\XmlDictionariesTest.cs" />
-    <Compile Include="UserControls\NikseComboBoxTests.cs" />
-    <Compile Include="UserControls\SeTextBoxTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Dictionaries\en_US.aff" />
-    <EmbeddedResource Include="Dictionaries\en_US.dic" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Dictionaries\names.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Files\sample.tar">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Files\sample_MKV_delayed.mkv">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Files\sample_MKV_SRT.mkv">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Files\sample_MKV_VobSub_PGS.mkv">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Files\sample_MP4.mp4">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Files\sample_TS_with_graphics.ts">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Files\sample_MP4_SRT.mp4">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Files\sample_BDSUP_multi_image.sup">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Files\auto_detect_Danish.srt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Files\auto_detect_Russian.srt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Files\auto_detect_windows-1250.srt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Files\auto_detect_windows-1251.srt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Files\sample_TS_with_teletext.ts">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\libse\LibSE.csproj">
-      <Project>{d6f64cd3-c3ea-4b36-b575-9b3b8a3ca13f}</Project>
-      <Name>LibSE</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\ui\SubtitleEdit.csproj">
-      <Project>{511a5b59-1c35-4719-8536-23b19af9b21a}</Project>
-      <Name>SubtitleEdit</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NHunspell" Version="1.2.5554.16953" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <AssemblyName>Test</AssemblyName>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <FileAlignment>512</FileAlignment>
+        <OutputType>Library</OutputType>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{7BE5B8E8-9469-4C7C-89D7-E8C884DEFC0E}</ProjectGuid>
+        <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+        <RootNamespace>Test</RootNamespace>
+        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+        <RuntimeIdentifier>win</RuntimeIdentifier>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <WarningLevel>4</WarningLevel>
+        <Prefer32Bit>false</Prefer32Bit>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+        <DebugType>pdbonly</DebugType>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <WarningLevel>4</WarningLevel>
+        <Prefer32Bit>false</Prefer32Bit>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="System"/>
+        <Reference Include="System.Configuration"/>
+        <Reference Include="System.Drawing"/>
+        <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+            <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+            <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+        </Reference>
+        <Reference Include="System.Windows.Forms"/>
+        <Reference Include="System.Xml"/>
+        <Reference Include="System.Xml.Linq"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="Assa\TagHelperRemoveTagTest.cs"/>
+        <Compile Include="Assa\ResamplerTest.cs"/>
+        <Compile Include="Assa\AssaTimeCodes.cs"/>
+        <Compile Include="Core\AudioToTextTest.cs"/>
+        <Compile Include="Core\JsonTest.cs"/>
+        <Compile Include="Core\MergeShortLinesUtilsTest.cs"/>
+        <Compile Include="Core\CsvUtilTest.cs"/>
+        <Compile Include="Core\WebVttHelperTest.cs"/>
+        <Compile Include="Core\WebVttToAssaTest.cs"/>
+        <Compile Include="Dictionaries\StringWithoutSpaceSplitToWordsTest.cs"/>
+        <Compile Include="GoogleCloudVision\GoogleCloudVisionJsonToLinesTest.cs"/>
+        <Compile Include="LanguageFiles\LanguageFileTest.cs"/>
+        <Compile Include="Logic\AutoTranslate\MergeAndSplitHelperTest.cs"/>
+        <Compile Include="Logic\BeautifyTimeCodesTest.cs"/>
+        <Compile Include="Logic\ConvertColorsToDialogTest.cs"/>
+        <Compile Include="Core\LanguageAutoDetectLanguagesTest.cs"/>
+        <Compile Include="Logic\DimensionTest.cs"/>
+        <Compile Include="Logic\NetflixHelperTest.cs"/>
+        <Compile Include="Logic\SubtitleFormats\EbuStlTest.cs"/>
+        <Compile Include="Logic\SubtitleFormats\NetflixTimedTextTest.cs"/>
+        <Compile Include="Logic\SubtitleFormats\LrcTest.cs"/>
+        <Compile Include="Logic\SubtitleFormats\PacTest.cs"/>
+        <Compile Include="Core\UUEncodingTest.cs"/>
+        <Compile Include="Core\CharUtilsTest.cs"/>
+        <Compile Include="Core\DialogTypeTest.cs"/>
+        <Compile Include="Core\SeJsonParserTest.cs"/>
+        <Compile Include="Core\FixCasingTest.cs"/>
+        <Compile Include="Core\LanguageAutoDetectTest.cs"/>
+        <Compile Include="Core\PlainTextImporterTest.cs"/>
+        <Compile Include="Core\StringExtensionsTest.cs"/>
+        <Compile Include="Core\NikseBitmapTest.cs"/>
+        <Compile Include="Core\SubtitleFormatTest.cs"/>
+        <Compile Include="Core\SubtitleTest.cs"/>
+        <Compile Include="Core\RichTextToPlainTextTest.cs"/>
+        <Compile Include="Logic\BridgeGapsTest.cs"/>
+        <Compile Include="Logic\Forms\MoveWordUpDownTest.cs"/>
+        <Compile Include="Logic\NetflixQualityCheckTest.cs"/>
+        <Compile Include="Logic\Ocr\BinaryOcrTest.cs"/>
+        <Compile Include="Core\HtmlUtilTest.cs"/>
+        <Compile Include="FixCommonErrors\FixCommonErrorsTest.cs"/>
+        <Compile Include="Logic\LanguageTest.cs"/>
+        <Compile Include="Logic\BluRaySup\BluRaySupParserTest.cs"/>
+        <Compile Include="Logic\BluRaySup\ToolBoxTest.cs"/>
+        <Compile Include="Logic\Dictionaries\NamesListTest.cs"/>
+        <Compile Include="Logic\Dictionaries\OcrFixReplaceListTest.cs"/>
+        <Compile Include="Logic\Mp4\Mp4Test.cs"/>
+        <Compile Include="Logic\Ocr\MatchesToItalicStringConverterTest.cs"/>
+        <Compile Include="Logic\SplitLongLinesHelperTest.cs"/>
+        <Compile Include="Logic\SubtitleFormats\Cea708Test.cs"/>
+        <Compile Include="Logic\SubtitleFormats\SubtitleFormatFunctionsTest.cs"/>
+        <Compile Include="Logic\TarFileTest.cs"/>
+        <Compile Include="Logic\ProgressHelperTest.cs"/>
+        <Compile Include="Logic\TransportStream\TransportStreamTest.cs"/>
+        <Compile Include="Logic\ParagraphTest.cs"/>
+        <Compile Include="Logic\StrippableTextTest.cs"/>
+        <Compile Include="Logic\TimeCodeTest.cs"/>
+        <Compile Include="Logic\UknownFormatImporterJsonTest.cs"/>
+        <Compile Include="Logic\ContinuationUtilitiesTest.cs"/>
+        <Compile Include="Logic\HtmlUtilTest.cs"/>
+        <Compile Include="Logic\VideoFormats\MatroskaTest.cs"/>
+        <Compile Include="Logic\VobSub\VobSubTest.cs"/>
+        <Compile Include="Logic\Ocr\NOcrTest.cs"/>
+        <Compile Include="Properties\AssemblyInfo.cs"/>
+        <Compile Include="Logic\Forms\RemoveTextForHearImpairedTest.cs"/>
+        <Compile Include="Logic\SubtitleFormats\SubtitleFormatsTest.cs"/>
+        <Compile Include="Logic\UtilitiesTest.cs"/>
+        <Compile Include="Dictionaries\XmlDictionariesTest.cs"/>
+        <Compile Include="UserControls\NikseComboBoxTests.cs"/>
+        <Compile Include="UserControls\SeTextBoxTests.cs"/>
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Dictionaries\en_US.aff"/>
+        <EmbeddedResource Include="Dictionaries\en_US.dic"/>
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Dictionaries\names.xml"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Files\sample.tar">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Files\sample_MKV_delayed.mkv">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="Files\sample_MKV_SRT.mkv">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="Files\sample_MKV_VobSub_PGS.mkv">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="Files\sample_MP4.mp4">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="Files\sample_TS_with_graphics.ts">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Files\sample_MP4_SRT.mp4">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Files\sample_BDSUP_multi_image.sup">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Files\auto_detect_Danish.srt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Files\auto_detect_Russian.srt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Files\auto_detect_windows-1250.srt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="Files\auto_detect_windows-1251.srt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Files\sample_TS_with_teletext.ts">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="app.config"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\libse\LibSE.csproj">
+            <Project>{d6f64cd3-c3ea-4b36-b575-9b3b8a3ca13f}</Project>
+            <Name>LibSE</Name>
+        </ProjectReference>
+        <ProjectReference Include="..\ui\SubtitleEdit.csproj">
+            <Project>{511a5b59-1c35-4719-8536-23b19af9b21a}</Project>
+            <Name>SubtitleEdit</Name>
+        </ProjectReference>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="NHunspell" Version="1.2.5554.16953"/>
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0"/>
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>
+    </ItemGroup>
+    <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets"/>
+    <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')"/>
+    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+        <PropertyGroup>
+            <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+        </PropertyGroup>
+        <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))"/>
+    </Target>
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
 </Project>

--- a/src/Test/app.config
+++ b/src/Test/app.config
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/Test/packages.config
+++ b/src/Test/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NHunspell" version="1.2.5554.16953" targetFramework="net40" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
-</packages>

--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -50,21 +50,19 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-		<PackageReference Include="System.Drawing.Common" Version="8.0.8" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="UTF.Unknown" Version="2.5.1" />
-		<PackageReference Include="zlib.net-mutliplatform" Version="1.0.6" />
+		<PackageReference Include="Microsoft.Win32.Registry"/>
+		<PackageReference Include="System.Drawing.Common"/>
+		<PackageReference Include="System.Net.Http"/>
+		<PackageReference Include="UTF.Unknown"/>
+		<PackageReference Include="zlib.net-mutliplatform"/>
 	</ItemGroup>
 
 	<ItemGroup>
 		<None Include="..\..\LICENSE.txt">
 			<Pack>True</Pack>
-			<PackagePath></PackagePath>
 		</None>
 		<None Include="Icon.png">
 			<Pack>True</Pack>
-			<PackagePath></PackagePath>
 		</None>
 	</ItemGroup>
 

--- a/src/ui/SubtitleEdit.csproj
+++ b/src/ui/SubtitleEdit.csproj
@@ -291,16 +291,16 @@
     </HunspellAssemblies>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="NAudio.Core" Version="2.2.1" />
-    <PackageReference Include="NAudio.WinMM" Version="2.2.1" />
-    <PackageReference Include="ncalc" Version="1.3.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NHunspell" Version="1.2.5554.16953" />
-    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
-    <PackageReference Include="Vosk" Version="0.3.38" />
+    <PackageReference Include="Microsoft.Net.Http"/>
+    <PackageReference Include="Microsoft.Win32.Registry"/>
+    <PackageReference Include="NAudio.Core"/>
+    <PackageReference Include="NAudio.WinMM"/>
+    <PackageReference Include="ncalc"/>
+    <PackageReference Include="Newtonsoft.Json"/>
+    <PackageReference Include="NHunspell"/>
+    <PackageReference Include="System.Security.AccessControl"/>
+    <PackageReference Include="System.Security.Principal.Windows"/>
+    <PackageReference Include="Vosk"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Logic\VideoPlayers\DirectShowLib2005.cs" />


### PR DESCRIPTION
~Replaced `packages.config` with `PackageReference` in `Test.csproj` for streamlined package management. Also updated the `System.Net.Http` binding redirect in `app.config` from version `4.2.0.0` to `4.1.2.0`.~


~### [Benefits of using package references (Click here)](https://learn.microsoft.com/en-us/nuget/consume-packages/migrate-packages-config-to-package-reference#benefits-of-using-packagereference)~

Update to central package management