### PR TITLE
Remove outdated .NET Framework bootstrapper packages

### DIFF
--- a/src/ui/SubtitleEdit.csproj
+++ b/src/ui/SubtitleEdit.csproj
@@ -242,32 +242,8 @@
     <Content Include="Icons\VisualSync.png" />
     <Content Include="Icons\WaveformToggle.png" />
   </ItemGroup>
+  
   <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 2.0 %28x86%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.0 %28x86%29</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Visual.C++.10.0.x86">
       <Visible>False</Visible>
       <ProductName>Visual C++ 2010 Runtime Libraries %28x86%29</ProductName>
@@ -279,6 +255,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\libse\LibSE.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Deleted deprecated bootstrapper packages for older .NET Framework versions (2.0, 3.0, 3.5). This cleanup reduces project clutter and aligns with current dependency requirements.