### PR TITLE
Refactor directory creation logic

### DIFF
--- a/src/libse/Common/FileUtil.cs
+++ b/src/libse/Common/FileUtil.cs
@@ -935,5 +935,27 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             return string.Empty;
         }
+
+        /// <summary>
+        /// Tries to create a directory at the specified path if it does not already exist.
+        /// </summary>
+        /// <param name="path">The path where the directory is to be created.</param>
+        /// <returns>True if the directory was successfully created or already exists; otherwise, false.</returns>
+        public static bool TryCreateDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                try
+                {
+                    return Directory.CreateDirectory(path).Exists;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/libse/Common/ZipExtractor.cs
+++ b/src/libse/Common/ZipExtractor.cs
@@ -216,11 +216,9 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             // Make sure the parent directory exist
             string path = Path.GetDirectoryName(filename);
-            if (!Directory.Exists(path))
-            {
-                Directory.CreateDirectory(path);
-            }
-
+            
+            FileUtil.TryCreateDirectory(path);
+            
             // Check it is directory. If so, do nothing
             if (Directory.Exists(filename))
             {

--- a/src/ui/Forms/GenerateTransparentVideoWithSubtitles.cs
+++ b/src/ui/Forms/GenerateTransparentVideoWithSubtitles.cs
@@ -1339,20 +1339,7 @@ namespace Nikse.SubtitleEdit.Forms
 
         private void linkLabelSourceFolder_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            var path = linkLabelSourceFolder.Text;
-
-            if (!Directory.Exists(path))
-            {
-                try
-                {
-                    Directory.CreateDirectory(path);
-                }
-                catch
-                {
-                    return;
-                }
-            }
-
+            FileUtil.TryCreateDirectory(linkLabelSourceFolder.Text);
             UiUtil.OpenFolder(linkLabelSourceFolder.Text);
         }
 

--- a/src/ui/Forms/RestoreAutoBackup.cs
+++ b/src/ui/Forms/RestoreAutoBackup.cs
@@ -161,16 +161,9 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             var path = Path.Combine(Configuration.AutoBackupDirectory, "Settings");
-            if (!Directory.Exists(path))
+            if (!FileUtil.TryCreateDirectory(path))
             {
-                try
-                {
-                    Directory.CreateDirectory(path);
-                }
-                catch
-                {
-                    return false;
-                }
+                return false;
             }
 
             var fileName = $"{DateTime.Now.Year:0000}-{DateTime.Now.Month:00}-{DateTime.Now.Day:00}_{DateTime.Now.Hour:00}-{DateTime.Now.Minute:00}-{DateTime.Now.Second:00}Settings.xml";

--- a/src/ui/Logic/CommandLineConvert/CommandLineConverter.cs
+++ b/src/ui/Logic/CommandLineConvert/CommandLineConverter.cs
@@ -2092,11 +2092,8 @@ namespace Nikse.SubtitleEdit.Logic.CommandLineConvert
                         if (binaryParagraphs.Count > 0)
                         {
                             var path = Path.Combine(outputFolder, Path.GetFileNameWithoutExtension(fileName));
-                            if (!Directory.Exists(path))
-                            {
-                                Directory.CreateDirectory(path);
-                            }
-
+                            FileUtil.TryCreateDirectory(path);
+                            
                             targetFormatFound = true;
                             for (var i = 0; i < binaryParagraphs.Count; i++)
                             {


### PR DESCRIPTION
Replace direct directory creation with FileUtil.TryCreateDirectory throughout the code. This centralizes the logic for creating directories and handles potential exceptions uniformly. It enhances maintainability and error handling.