### PR TITLE
Add initial test.runsettings file

### DIFF
--- a/SubtitleEdit.sln
+++ b/SubtitleEdit.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LanguageBaseEnglish.xml = LanguageBaseEnglish.xml
 		LICENSE.txt = LICENSE.txt
 		README.md = README.md
+		test.runsettings = test.runsettings
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibSE", "src\libse\LibSE.csproj", "{D6F64CD3-C3EA-4B36-B575-9B3B8A3CA13F}"

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>    
+    <ResultsDirectory>%temp%\TestResults</ResultsDirectory>    
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
This commit introduces a test.runsettings file to configure the test environment. It specifies the results directory for test outputs, setting it to the system's temporary folder. This aids in standardizing and managing test outputs centrally.


This will make sure the junks from test result will got to %temp%\TestResults 

Visual studio has feature to auto-select .runsettings file but in case it wasn't auto-selected there is also option to manually select.
For Rider you will have to select it manually.


Useful links

- https://superuser.com/questions/1267698/how-to-disable-testresults-folder-in-visual-studio
- https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2017/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2017