### PR TITLE
Unit test: Upgrade to .NET SDK Project style

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,12 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="MSTest" Version="3.6.0" />
-    <PackageVersion Include="MSTest.Analyzers" Version="3.6.0" />
     <PackageVersion Include="MSTest.Sdk" Version="3.6.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.8" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="UTF.Unknown" Version="2.5.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="MSTest" Version="3.6.0" />
+    <PackageVersion Include="MSTest.Analyzers" Version="3.6.0" />
+    <PackageVersion Include="MSTest.Sdk" Version="3.6.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="MSTest" Version="3.6.0" />
-    <PackageVersion Include="MSTest.Sdk" Version="3.6.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.8" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="UTF.Unknown" Version="2.5.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.8" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="UTF.Unknown" Version="2.5.1" />

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -14,16 +14,12 @@
   <ItemGroup>
     <EmbeddedResource Include="Dictionaries\en_US.aff" />
     <EmbeddedResource Include="Dictionaries\en_US.dic" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Dictionaries\names.xml" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Files\sample.tar">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Files\sample_MKV_delayed.mkv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -39,36 +35,24 @@
     <Content Include="Files\sample_TS_with_graphics.ts">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Files\sample_MP4_SRT.mp4">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Files\sample_BDSUP_multi_image.sup">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Files\auto_detect_Danish.srt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Files\auto_detect_Russian.srt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Files\auto_detect_windows-1250.srt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Files\auto_detect_windows-1251.srt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Files\sample_TS_with_teletext.ts">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -81,7 +81,7 @@
     <ProjectReference Include="..\ui\SubtitleEdit.csproj" />
   </ItemGroup>
   <ItemGroup>
-<!--    <PackageReference Include="MSTest.TestAdapter" />-->
+    <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest" />
     <PackageReference Include="MSTest.Analyzers">

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -81,7 +81,14 @@
     <ProjectReference Include="..\ui\SubtitleEdit.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" />
+<!--    <PackageReference Include="MSTest.TestAdapter" />-->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="MSTest.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="MSTest.Sdk" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="NHunspell" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -99,9 +99,6 @@
     <None Include="App.config" />
   </ItemGroup>
   
-<!--  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />-->
-<!--  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />-->
-<!--  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />-->
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -1,123 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <AssemblyName>Test</AssemblyName>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{7BE5B8E8-9469-4C7C-89D7-E8C884DEFC0E}</ProjectGuid>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <RootNamespace>Test</RootNamespace>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <RuntimeIdentifier>win</RuntimeIdentifier>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugType>pdbonly</DebugType>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Assa\TagHelperRemoveTagTest.cs" />
-    <Compile Include="Assa\ResamplerTest.cs" />
-    <Compile Include="Assa\AssaTimeCodes.cs" />
-    <Compile Include="Core\AudioToTextTest.cs" />
-    <Compile Include="Core\JsonTest.cs" />
-    <Compile Include="Core\MergeShortLinesUtilsTest.cs" />
-    <Compile Include="Core\CsvUtilTest.cs" />
-    <Compile Include="Core\WebVttHelperTest.cs" />
-    <Compile Include="Core\WebVttToAssaTest.cs" />
-    <Compile Include="Dictionaries\StringWithoutSpaceSplitToWordsTest.cs" />
-    <Compile Include="GoogleCloudVision\GoogleCloudVisionJsonToLinesTest.cs" />
-    <Compile Include="LanguageFiles\LanguageFileTest.cs" />
-    <Compile Include="Logic\AutoTranslate\MergeAndSplitHelperTest.cs" />
-    <Compile Include="Logic\BeautifyTimeCodesTest.cs" />
-    <Compile Include="Logic\ConvertColorsToDialogTest.cs" />
-    <Compile Include="Core\LanguageAutoDetectLanguagesTest.cs" />
-    <Compile Include="Logic\DimensionTest.cs" />
-    <Compile Include="Logic\NetflixHelperTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\EbuStlTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\NetflixTimedTextTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\LrcTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\PacTest.cs" />
-    <Compile Include="Core\UUEncodingTest.cs" />
-    <Compile Include="Core\CharUtilsTest.cs" />
-    <Compile Include="Core\DialogTypeTest.cs" />
-    <Compile Include="Core\SeJsonParserTest.cs" />
-    <Compile Include="Core\FixCasingTest.cs" />
-    <Compile Include="Core\LanguageAutoDetectTest.cs" />
-    <Compile Include="Core\PlainTextImporterTest.cs" />
-    <Compile Include="Core\StringExtensionsTest.cs" />
-    <Compile Include="Core\NikseBitmapTest.cs" />
-    <Compile Include="Core\SubtitleFormatTest.cs" />
-    <Compile Include="Core\SubtitleTest.cs" />
-    <Compile Include="Core\RichTextToPlainTextTest.cs" />
-    <Compile Include="Logic\BridgeGapsTest.cs" />
-    <Compile Include="Logic\Forms\MoveWordUpDownTest.cs" />
-    <Compile Include="Logic\NetflixQualityCheckTest.cs" />
-    <Compile Include="Logic\Ocr\BinaryOcrTest.cs" />
-    <Compile Include="Core\HtmlUtilTest.cs" />
-    <Compile Include="FixCommonErrors\FixCommonErrorsTest.cs" />
-    <Compile Include="Logic\LanguageTest.cs" />
-    <Compile Include="Logic\BluRaySup\BluRaySupParserTest.cs" />
-    <Compile Include="Logic\BluRaySup\ToolBoxTest.cs" />
-    <Compile Include="Logic\Dictionaries\NamesListTest.cs" />
-    <Compile Include="Logic\Dictionaries\OcrFixReplaceListTest.cs" />
-    <Compile Include="Logic\Mp4\Mp4Test.cs" />
-    <Compile Include="Logic\Ocr\MatchesToItalicStringConverterTest.cs" />
-    <Compile Include="Logic\SplitLongLinesHelperTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\Cea708Test.cs" />
-    <Compile Include="Logic\SubtitleFormats\SubtitleFormatFunctionsTest.cs" />
-    <Compile Include="Logic\TarFileTest.cs" />
-    <Compile Include="Logic\ProgressHelperTest.cs" />
-    <Compile Include="Logic\TransportStream\TransportStreamTest.cs" />
-    <Compile Include="Logic\ParagraphTest.cs" />
-    <Compile Include="Logic\StrippableTextTest.cs" />
-    <Compile Include="Logic\TimeCodeTest.cs" />
-    <Compile Include="Logic\UknownFormatImporterJsonTest.cs" />
-    <Compile Include="Logic\ContinuationUtilitiesTest.cs" />
-    <Compile Include="Logic\HtmlUtilTest.cs" />
-    <Compile Include="Logic\VideoFormats\MatroskaTest.cs" />
-    <Compile Include="Logic\VobSub\VobSubTest.cs" />
-    <Compile Include="Logic\Ocr\NOcrTest.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Logic\Forms\RemoveTextForHearImpairedTest.cs" />
-    <Compile Include="Logic\SubtitleFormats\SubtitleFormatsTest.cs" />
-    <Compile Include="Logic\UtilitiesTest.cs" />
-    <Compile Include="Dictionaries\XmlDictionariesTest.cs" />
-    <Compile Include="UserControls\NikseComboBoxTests.cs" />
-    <Compile Include="UserControls\SeTextBoxTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Dictionaries\en_US.aff" />
@@ -182,25 +77,24 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\libse\LibSE.csproj">
-      <Project>{d6f64cd3-c3ea-4b36-b575-9b3b8a3ca13f}</Project>
-      <Name>LibSE</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\ui\SubtitleEdit.csproj">
-      <Project>{511a5b59-1c35-4719-8536-23b19af9b21a}</Project>
-      <Name>SubtitleEdit</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\libse\LibSE.csproj" />
+    <ProjectReference Include="..\ui\SubtitleEdit.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="NHunspell" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  
+<!--  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />-->
+<!--  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />-->
+<!--  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />-->
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -9,9 +9,6 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
@@ -81,15 +78,7 @@
     <ProjectReference Include="..\ui\SubtitleEdit.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest" />
-    <PackageReference Include="MSTest.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="MSTest.Sdk" />
-    <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="NHunspell" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />

--- a/src/libse/Common/InterjectionsRepository.cs
+++ b/src/libse/Common/InterjectionsRepository.cs
@@ -87,6 +87,11 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
+            if (!Directory.Exists(Configuration.DictionariesDirectory))
+            {
+                Directory.CreateDirectory(Configuration.DictionariesDirectory);
+            }
+
             var fullFileName = Path.Combine(Configuration.DictionariesDirectory, userFileName);
             xmlDocument.Save(fullFileName);
         }


### PR DESCRIPTION
Upgrading  unit-test project to new sdk style

Removes all the legacy visual studio testing and now using MSTest (https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-getting-started)