### PR TITLE
Delete associated registry value when removing file association

### DIFF
--- a/src/ui/Logic/FileTypeAssociations.cs
+++ b/src/ui/Logic/FileTypeAssociations.cs
@@ -97,11 +97,23 @@ namespace Nikse.SubtitleEdit.Logic
 
         internal static void DeleteFileAssociationViaRegistry(string ext, string appName)
         {
+            var appExtensionRegKey = $"{appName}{ext}";
             using (var registryKey = Registry.CurrentUser.OpenSubKey(@"Software\Classes\", true))
             {
-                if (registryKey?.OpenSubKey($"{appName}{ext}") != null)
+                if (registryKey?.OpenSubKey(appExtensionRegKey) != null)
                 {
                     registryKey.DeleteSubKeyTree($"{appName}{ext}");
+                }
+            }
+
+            // (Default)
+            const string defaultRegValueName = "";
+            using (var registryKey = Registry.CurrentUser.OpenSubKey("Software\\Classes\\" + ext, true))
+            {
+                var registryValue = registryKey?.GetValue(defaultRegValueName);
+                if (appExtensionRegKey.Equals((string)registryValue, StringComparison.Ordinal))
+                {
+                    registryKey.DeleteValue(defaultRegValueName);
                 }
             }
         }


### PR DESCRIPTION
Enhanced the `DeleteFileAssociationViaRegistry` method to also delete the default registry value associated with the file extension if it matches the given application extension. This ensures a more thorough cleanup of file type associations in the registry.


![image](https://github.com/user-attachments/assets/93da7f64-8ea1-4e3a-ab74-b7dca7f2ca93)
