### PR TITLE
Refactor directory writable check to FileUtil

### DIFF
--- a/src/libse/Common/FileUtil.cs
+++ b/src/libse/Common/FileUtil.cs
@@ -935,5 +935,23 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             return string.Empty;
         }
+
+        /// <summary>
+        /// Checks if a directory is writable by attempting to create and delete a temporary file within it.
+        /// </summary>
+        /// <param name="dirPath">The directory path to check for write access.</param>
+        /// <returns>True if the directory is writable, false otherwise.</returns>
+        public static bool IsDirectoryWritable(string dirPath)
+        {
+            try
+            {
+                using (File.Create(Path.Combine(dirPath, Path.GetRandomFileName()), 1, FileOptions.DeleteOnClose)) { }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/ui/Forms/AudioToText/VoskAudioToText.cs
+++ b/src/ui/Forms/AudioToText/VoskAudioToText.cs
@@ -267,7 +267,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
             catch
             {
                 var dir = Path.GetDirectoryName(fileName);
-                if (!WhisperAudioToText.IsDirectoryWritable(dir))
+                if (!FileUtil.IsDirectoryWritable(dir))
                 {
                     MessageBox.Show($"SE does not have write access to the folder '{dir}'", MessageBoxIcon.Error);
                 }

--- a/src/ui/Forms/AudioToText/WhisperAudioToText.cs
+++ b/src/ui/Forms/AudioToText/WhisperAudioToText.cs
@@ -843,7 +843,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
             catch
             {
                 var dir = Path.GetDirectoryName(fileName);
-                if (!IsDirectoryWritable(dir))
+                if (!FileUtil.IsDirectoryWritable(dir))
                 {
                     MessageBox.Show($"SE does not have write access to the folder '{dir}'", MessageBoxIcon.Error);
                 }
@@ -852,20 +852,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
             }
         }
 
-        public static bool IsDirectoryWritable(string dirPath)
-        {
-            try
-            {
-                using (FileStream fs = File.Create(Path.Combine(dirPath, Path.GetRandomFileName()), 1, FileOptions.DeleteOnClose))
-                {
-                }
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
+
 
         internal static string GetLanguage(string name)
         {


### PR DESCRIPTION
Moved the method `IsDirectoryWritable` from `WhisperAudioToText` to `FileUtil` for better code reuse and maintainability. Adjusted references in `WhisperAudioToText` and `VoskAudioToText` accordingly.