### PR TITLE
Refactor and test StartsAndEndsWithTag method

### DIFF
--- a/src/Test/Logic/UtilitiesTest.cs
+++ b/src/Test/Logic/UtilitiesTest.cs
@@ -1019,5 +1019,25 @@ namespace Test.Logic
 
             Assert.AreEqual("В отеле", s);
         }
+
+        [TestMethod]
+        public void StartsAndEndsWithTagTest()
+        {
+            const string italicOpen = "<i>";
+            const string italicClose = "</i>";
+            
+            // all variation of openings
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("<i>Hallo world!</i>", italicOpen, italicClose));
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("- <i>Hallo world!</i>", italicOpen, italicClose));
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("-<i>Hallo world!</i>", italicOpen, italicClose));
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("- ...<i>Hallo world!</i>", italicOpen, italicClose));
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("- <i>...Hallo world!</i>", italicOpen, italicClose));
+            
+            // all variations of closings
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("<i>Hallo world!</i>", italicOpen, italicClose));
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("<i>Hallo world?</i>", italicOpen, italicClose));
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("<i>Hallo world</i>...", italicOpen, italicClose));
+            Assert.IsTrue(Utilities.StartsAndEndsWithTag("<i>Hallo world</i>-", italicOpen, italicClose));
+        }
     }
 }

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1215,40 +1215,26 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return false;
             }
 
-            if (!text.Contains(startTag) || !text.Contains(endTag))
+            text = text.FixExtraSpaces();
+
+            string[] prefixFormats = { "{0}", "- {0}", "-{0}", "- ...{0}", "- {0}..." };
+            string[] suffixFormats = { "{0}", "{0}.", "{0}!", "{0}?", "{0}...", "{0}-" };
+
+            foreach (string prefixFormat in prefixFormats)
             {
-                return false;
+                if (text.StartsWith(string.Format(prefixFormat, startTag), StringComparison.Ordinal))
+                {
+                    foreach (string suffixFormat in suffixFormats)
+                    {
+                        if (text.EndsWith(string.Format(suffixFormat, endTag), StringComparison.Ordinal))
+                        {
+                            return true;
+                        }
+                    }
+                }
             }
 
-            while (text.Contains("  "))
-            {
-                text = text.Replace("  ", " ");
-            }
-
-            var s1 = "- " + startTag;
-            var s2 = "-" + startTag;
-            var s3 = "- ..." + startTag;
-            var s4 = "- " + startTag + "..."; // - <i>...
-
-            var e1 = endTag + ".";
-            var e2 = endTag + "!";
-            var e3 = endTag + "?";
-            var e4 = endTag + "...";
-            var e5 = endTag + "-";
-
-            bool isStart = false;
-            bool isEnd = false;
-            if (text.StartsWith(startTag, StringComparison.Ordinal) || text.StartsWith(s1, StringComparison.Ordinal) || text.StartsWith(s2, StringComparison.Ordinal) || text.StartsWith(s3, StringComparison.Ordinal) || text.StartsWith(s4, StringComparison.Ordinal))
-            {
-                isStart = true;
-            }
-
-            if (text.EndsWith(endTag, StringComparison.Ordinal) || text.EndsWith(e1, StringComparison.Ordinal) || text.EndsWith(e2, StringComparison.Ordinal) || text.EndsWith(e3, StringComparison.Ordinal) || text.EndsWith(e4, StringComparison.Ordinal) || text.EndsWith(e5, StringComparison.Ordinal))
-            {
-                isEnd = true;
-            }
-
-            return isStart && isEnd;
+            return false;
         }
 
         public static Paragraph GetOriginalParagraph(int index, Paragraph paragraph, List<Paragraph> originalParagraphs)


### PR DESCRIPTION
Simplified the logic in StartsAndEndsWithTag by using arrays for prefix and suffix formats. Added a unit test to ensure the method handles various tag formats correctly.