### PR TITLE
Refactor frame-to-milliseconds conversion

### DIFF
--- a/src/libse/Common/TimeCode.cs
+++ b/src/libse/Common/TimeCode.cs
@@ -354,7 +354,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         public TimeCode AlignToFrame()
         {
             var ts = TimeSpan.FromMilliseconds(Math.Round(TotalMilliseconds, MidpointRounding.AwayFromZero));
-            var frames = Math.Round(ts.Milliseconds / (TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate));
+            var frames = SubtitleFormat.MillisecondsToFrames(ts.Milliseconds);
             TimeSpan ts2;
             if (frames >= Configuration.Settings.General.CurrentFrameRate - 0.001)
             {

--- a/src/libse/SubtitleFormats/AQTitle.cs
+++ b/src/libse/SubtitleFormats/AQTitle.cs
@@ -131,11 +131,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return frames.ToString(CultureInfo.InvariantCulture);
         }
 
-        private static TimeCode DecodeTimeCode(string timePart)
-        {
-            int milliseconds = (int)Math.Round(TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate * int.Parse(timePart));
-            return new TimeCode(milliseconds);
-        }
-
+        private static TimeCode DecodeTimeCode(string timePart) => new TimeCode(FramesToMilliseconds(int.Parse(timePart)));
     }
 }

--- a/src/libse/SubtitleFormats/CaptionAssistant.cs
+++ b/src/libse/SubtitleFormats/CaptionAssistant.cs
@@ -24,14 +24,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var minutes = int.Parse(parts[1]);
             var seconds = int.Parse(parts[2]);
             var frames = int.Parse(parts[3]);
-
-            int milliseconds = (int)Math.Round(((TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate) * frames));
-            if (milliseconds > 999)
-            {
-                milliseconds = 999;
-            }
-
-            return new TimeCode(hour, minutes, seconds, milliseconds);
+            return new TimeCode(hour, minutes, seconds, FramesToMillisecondsMax999(frames));
         }
 
         public override string ToText(Subtitle subtitle, string title)

--- a/src/libse/SubtitleFormats/Cavena890.cs
+++ b/src/libse/SubtitleFormats/Cavena890.cs
@@ -1522,8 +1522,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static void WriteTime(Stream fs, TimeCode timeCode)
         {
-            double totalMilliseconds = timeCode.TotalMilliseconds;
-            int frames = (int)Math.Round(totalMilliseconds / (TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate));
+            int frames = MillisecondsToFrames(timeCode.TotalMilliseconds);
             fs.WriteByte((byte)(frames / 256 / 256));
             fs.WriteByte((byte)(frames / 256));
             fs.WriteByte((byte)(frames % 256));
@@ -1644,8 +1643,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else
                 {
                     subtitle.Paragraphs.Add(p);
-                    p.StartTime.TotalMilliseconds = (TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate) * startFrame;
-                    p.EndTime.TotalMilliseconds = (TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate) * endFrame;
+                    p.StartTime.TotalMilliseconds = FramesToMilliseconds(startFrame);
+                    p.EndTime.TotalMilliseconds = FramesToMilliseconds(endFrame);
                     p.Text = string.Join(Environment.NewLine, new[] { line1, line2 }.Select(l => l.TrimEnd()).Where(l => !string.IsNullOrWhiteSpace(l)));
                 }
                 if (boxType >= 0xa0 && boxType <= 0xa9 && !string.IsNullOrEmpty(p.Text)) // box

--- a/src/libse/SubtitleFormats/ElrPrint.cs
+++ b/src/libse/SubtitleFormats/ElrPrint.cs
@@ -48,7 +48,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             string s;
             var ts = p.Duration.TimeSpan;
-            var frames = Math.Round(ts.Milliseconds / (TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate));
+            var frames = MillisecondsToFrames(ts.Milliseconds);
             if (frames >= Configuration.Settings.General.CurrentFrameRate - 0.001)
             {
                 s = $"{ts.Seconds + 1:00}:{0:00}";

--- a/src/libse/SubtitleFormats/NciCaption.cs
+++ b/src/libse/SubtitleFormats/NciCaption.cs
@@ -62,14 +62,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             int minutes = buffer[index + 1];
             int seconds = buffer[index + 2];
             int frames = buffer[index + 3];
-
-            int milliseconds = (int)Math.Round(TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate * frames);
-            if (milliseconds > 999)
-            {
-                milliseconds = 999;
-            }
-
-            return new TimeCode(hour, minutes, seconds, milliseconds);
+            return new TimeCode(hour, minutes, seconds, FramesToMillisecondsMax999(frames));
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/libse/SubtitleFormats/UtxFrames.cs
+++ b/src/libse/SubtitleFormats/UtxFrames.cs
@@ -72,17 +72,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             subtitle.Renumber();
         }
 
-        private static string EncodeTimeCode(TimeCode time)
-        {
-            long frames = (long)(time.TotalMilliseconds / (TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate));
-            return frames.ToString();
-        }
+        private static string EncodeTimeCode(TimeCode time) => MillisecondsToFrames(time.TotalMilliseconds).ToString();
 
-        private static TimeCode DecodeTimeCode(string timePart)
-        {
-            int milliseconds = (int)Math.Round(TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate * int.Parse(timePart));
-            return new TimeCode(milliseconds);
-        }
-
+        private static TimeCode DecodeTimeCode(string timePart) => new TimeCode(FramesToMilliseconds(int.Parse(timePart)));
     }
 }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -13408,7 +13408,7 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 var seconds = (int)numericUpDownDuration.Value;
                 var frames = (int)Math.Round((Convert.ToDouble(numericUpDownDuration.Value) % 1.0 * 100.0));
-                return seconds * TimeCode.BaseUnit + frames * (TimeCode.BaseUnit / Configuration.Settings.General.CurrentFrameRate);
+                return seconds * TimeCode.BaseUnit + SubtitleFormat.FramesToMilliseconds(frames);
             }
 
             return ((double)numericUpDownDuration.Value * TimeCode.BaseUnit);


### PR DESCRIPTION
Replaced direct frame rate based conversions with reusable utility methods across multiple subtitle formats. This improves consistency, readability, and maintainability of the codebase.