### PR TITLE
Initially browse for shot cuts in video folder

### DIFF
--- a/src/ui/Forms/ShotChanges/ImportShotChanges.cs
+++ b/src/ui/Forms/ShotChanges/ImportShotChanges.cs
@@ -94,6 +94,7 @@ namespace Nikse.SubtitleEdit.Forms.ShotChanges
                                      "|JSON shot changes file|*.json" +
                                      "|" + LanguageSettings.Current.General.AllFiles + "|*.*";
             openFileDialog1.FileName = string.Empty;
+            openFileDialog1.InitialDirectory = Path.GetDirectoryName(_videoFileName);
             if (openFileDialog1.ShowDialog() == DialogResult.OK)
             {
                 LoadTextFile(openFileDialog1.FileName);


### PR DESCRIPTION
After generating shot changes using an external tools, 99% of the times the tool will write the shot changes to a file in the same folder as the video.

The "Open file" button on the "Import shot changes" dialog didn't have an initial directory, so it just opens the last location.
Too many times, I imported the wrong shot changes (from a previous video) because of this.

This sets the initial directory to the location of the current video.