### PR TITLE
Small "Beautify time codes" improvement

### DIFF
--- a/src/libse/Forms/TimeCodesBeautifier.cs
+++ b/src/libse/Forms/TimeCodesBeautifier.cs
@@ -539,23 +539,24 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     bestRightInCueFrame = newRightInCueFrame;
                 }
 
-                // Check cases
-                var isLeftOutCueOnShotChange = IsCueOnShotChange(bestLeftOutCueFrame, false);
-                var isRightInCueOnShotChange = IsCueOnShotChange(bestRightInCueFrame, true);
-
-                var performGeneralChaining = false;
-
-                if (isLeftOutCueOnShotChange && isRightInCueOnShotChange 
-                    && bestLeftOutCueFrameInfo.result == FindBestCueResult.SnappedToRedZone && bestRightInCueFrameInfo.result == FindBestCueResult.SnappedToRedZone
-                    && bestLeftOutCueFrame == bestRightInCueFrame)
+                // Re-check if, with the new cues, the subtitles are actually connected
+                var newDistance = FramesToMilliseconds(bestRightInCueFrame) - FramesToMilliseconds(bestLeftOutCueFrame);
+                if (newDistance < Configuration.Settings.BeautifyTimeCodes.Profile.ConnectedSubtitlesTreatConnected)
                 {
-                    // If both cues are being snapped to the exact same shot change, the subtitles really are connected
-                    // So, handle using the designated function, ignoring the "treat connected" value (because otherwise it would have handled it before going into this function)
+                    // Yes, so handle using the designated function, ignoring its check connected check
+                    // (because otherwise it would have handled it before going into the FixChainableSubtitles function)
                     FixConnectedSubtitles(leftParagraph, rightParagraph, checkConnected: false);
 
                     return true;
                 }
-                else if (isRightInCueOnShotChange)
+
+                // Check cases
+                var isLeftOutCueOnShotChange = IsCueOnShotChange(bestLeftOutCueFrame, false);
+                var isRightInCueOnShotChange = IsCueOnShotChange(bestRightInCueFrame, true);
+
+                var performGeneralChaining = false;                              
+
+                if (isRightInCueOnShotChange)
                 {
                     // The right in cue is on a shot change
                     // Try to chain the subtitles

--- a/src/libse/Forms/TimeCodesBeautifier.cs
+++ b/src/libse/Forms/TimeCodesBeautifier.cs
@@ -554,7 +554,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 var isLeftOutCueOnShotChange = IsCueOnShotChange(bestLeftOutCueFrame, false);
                 var isRightInCueOnShotChange = IsCueOnShotChange(bestRightInCueFrame, true);
 
-                var performGeneralChaining = false;                              
+                var performGeneralChaining = false;
 
                 if (isRightInCueOnShotChange)
                 {


### PR DESCRIPTION
Sometimes, when chaining, due to red and green zones (when shot changes are imported), some cue pairs turn out to be connected after all.
Those should be handled by the `FixConnectedSubtitles` function to ensure the correct "In/out cue is closest" behavior is followed.