### PR TITLE
Fix typo in variable name 'ImportedSubitle' to 'ImportedSubtitle' 🔃

### DIFF
--- a/src/ui/Forms/ImportUnknownFormat.cs
+++ b/src/ui/Forms/ImportUnknownFormat.cs
@@ -10,7 +10,7 @@ namespace Nikse.SubtitleEdit.Forms
 {
     public partial class ImportUnknownFormat : Form
     {
-        public Subtitle ImportedSubitle { get; private set; }
+        public Subtitle ImportedSubtitle { get; private set; }
         private readonly Timer _refreshTimer = new Timer();
 
         public ImportUnknownFormat(string fileName)
@@ -47,10 +47,10 @@ namespace Nikse.SubtitleEdit.Forms
         private void GeneratePreviewReal()
         {
             var uknownFormatImporter = new UnknownFormatImporter { UseFrames = radioButtonTimeCodeFrames.Checked };
-            ImportedSubitle = uknownFormatImporter.AutoGuessImport(textBoxText.Lines.ToList());
-            groupBoxImportResult.Text = string.Format(LanguageSettings.Current.ImportText.PreviewLinesModifiedX, ImportedSubitle.Paragraphs.Count);
-            SubtitleListview1.Fill(ImportedSubitle);
-            if (ImportedSubitle.Paragraphs.Count > 0)
+            ImportedSubtitle = uknownFormatImporter.AutoGuessImport(textBoxText.Lines.ToList());
+            groupBoxImportResult.Text = string.Format(LanguageSettings.Current.ImportText.PreviewLinesModifiedX, ImportedSubtitle.Paragraphs.Count);
+            SubtitleListview1.Fill(ImportedSubtitle);
+            if (ImportedSubtitle.Paragraphs.Count > 0)
             {
                 SubtitleListview1.SelectIndexAndEnsureVisible(0);
             }

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -18638,9 +18638,9 @@ namespace Nikse.SubtitleEdit.Forms
                 {
                     if (form.ShowDialog(this) == DialogResult.OK)
                     {
-                        if (form.ImportedSubitle?.Paragraphs.Count > 0)
+                        if (form.ImportedSubtitle?.Paragraphs.Count > 0)
                         {
-                            _subtitle = form.ImportedSubitle;
+                            _subtitle = form.ImportedSubtitle;
                             _fileName = null;
                             SubtitleListview1.Fill(_subtitle, _subtitleOriginal);
                             SetTitle();


### PR DESCRIPTION
Corrected the misspelled variable name across both Main.cs and ImportUnknownFormat.cs files. Ensured consistent and accurate reference to 'ImportedSubtitle' for better code readability and functionality.