### PR TITLE
Update project metadata and repository URL in LibSE.csproj

### DIFF
--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -7,11 +7,12 @@
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<PackageProjectUrl>https://github.com/SubtitleEdit/subtitleedit/tree/main/src/libse</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/SubtitleEdit/subtitleedit/tree/main/src/libse</RepositoryUrl>
+		<RepositoryUrl>https://github.com/SubtitleEdit/subtitleedit</RepositoryUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>subtitle subtitles subrip srt blu-ray sup</PackageTags>
 		<Authors>Nikolaj Olsson</Authors>
 		<PackageIcon>Icon.png</PackageIcon>
+		<IsPackable>true</IsPackable>
 		<RepositoryType>git</RepositoryType>
 		<IncludeContentInPack>true</IncludeContentInPack>
 		<PackageReleaseNotes>SE 4.0.8</PackageReleaseNotes>


### PR DESCRIPTION
Modified the RepositoryUrl to point to the general SubtitleEdit repository and added an IsPackable property to allow the project to be included in packages. This ensures the updated repository URL is more accurate and the project is properly packable.

This is also a preparation for https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry#publishing-multiple-packages-to-the-same-repository