### PR TITLE
Another small Beautify time codes improvement

### DIFF
--- a/src/libse/Forms/TimeCodesBeautifier.cs
+++ b/src/libse/Forms/TimeCodesBeautifier.cs
@@ -364,8 +364,20 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     }
                     else
                     {
-                        // Fallback when no shot changes were apparently found: just chain them
-                        newLeftOutCueFrame = newRightInCueFrame - Configuration.Settings.BeautifyTimeCodes.Profile.Gap;
+                        // Check if there are really no shot changes in between
+                        var firstShotChangeInBetween = GetFirstShotChangeFrameInBetween(bestLeftOutCueFrameInfo.cueFrame, bestRightInCueFrameInfo.cueFrame);
+                        var lastShotChangeInBetween = GetLastShotChangeFrameInBetween(bestLeftOutCueFrameInfo.cueFrame, bestRightInCueFrameInfo.cueFrame);
+
+                        if (firstShotChangeInBetween != null || lastShotChangeInBetween != null)
+                        {
+                            // There are, so snap to the one that is closest to either of the two cues
+                            AlignCuesAroundClosestShotChange(firstShotChangeInBetween ?? int.MinValue, lastShotChangeInBetween ?? int.MaxValue);
+                        } 
+                        else
+                        {
+                            // Fallback when no shot changes were apparently found: just chain them
+                            newLeftOutCueFrame = newRightInCueFrame - Configuration.Settings.BeautifyTimeCodes.Profile.Gap;
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
When using a very high "Tread as connected" setting, it could happen that there are shot changes in between the two cues (left out-cue & right in-cue). Those shot changes were being ignored, because the two cues were not affected by the red/green zones of the shot change(s).