### PR TITLE
Update PackageProjectUrl in LibSE.csproj

### DIFF
--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -6,7 +6,7 @@
 		<AssemblyName>libse</AssemblyName>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<PackageProjectUrl>https://github.com/SubtitleEdit/subtitleedit/tree/main/src/libse</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/SubtitleEdit/subtitleedit</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/SubtitleEdit/subtitleedit</RepositoryUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>subtitle subtitles subrip srt blu-ray sup</PackageTags>


### PR DESCRIPTION
The URL for the package project was modified to remove the subdirectory path. This change simplifies the link and ensures it points directly to the main repository page.