### PR TITLE
Fix Pass 2 Generate video with burned-in subtitle in  if NUL exists

### DIFF
--- a/src/ui/Logic/VideoPreviewGenerator.cs
+++ b/src/ui/Logic/VideoPreviewGenerator.cs
@@ -275,7 +275,7 @@ namespace Nikse.SubtitleEdit.Logic
                 StartInfo =
                 {
                     FileName = GetFfmpegLocation(),
-                    Arguments = $"{cutStart}-i \"{inputVideoFileName}\"{cutEnd} -vf scale={width}:{height} -vf \"ass={Path.GetFileName(assaSubtitleFileName)}\" -g 30 -bf 2 -s {width}x{height} {videoEncodingSettings} {passSettings} {presetSettings} {crfSettings} {pixelFormat} {audioSettings}{tuneParameter} -use_editlist 0 -movflags +faststart {outputVideoFileName}".TrimStart(),
+                    Arguments = $"{cutStart}-i \"{inputVideoFileName}\"{cutEnd} -vf scale={width}:{height} -vf \"ass={Path.GetFileName(assaSubtitleFileName)}\" -g 30 -bf 2 -s {width}x{height} {videoEncodingSettings} {passSettings} {presetSettings} {crfSettings} {pixelFormat} {audioSettings}{tuneParameter} -use_editlist 0 -movflags +faststart -y {outputVideoFileName}".TrimStart(),
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     WorkingDirectory = Path.GetDirectoryName(assaSubtitleFileName) ?? string.Empty,


### PR DESCRIPTION
I use a lot the option Generate video with burned-in subtitles, but I couldn't use the Pass 2 option. (There were no progress bar running after clicking on Generate)

After checking the code for this option, I checked the arguments and everything looked great. Like the example below:
"-i \"What's Up Matador 1997.mp4\"  -vf scale=712:484 -vf \"ass=aaccddbeebfdb.ass\" -g 30 -bf 2 -s 712x484 -c:v libx264  -b:v 1638k -pass 1 -b:a 128k  -preset medium    -c:a aac -ar 48000 -ac 2 -use_editlist 0 -movflags +faststart -f mp4 NUL"

After running ffmpeg in the command line using these arguments, I got this message: File 'NUL' already exists. Overwrite?
So I added the -y flag and it worked. 

Maybe my computer had this issue, but it can help others who may experience the same problem in Windows.

![Captura de pantalla 2024-10-24 150020](https://github.com/user-attachments/assets/1e969314-88e2-4b92-8691-61603b59c7cd)

![Captura de pantalla 2024-10-24 150129](https://github.com/user-attachments/assets/717f087c-4f10-4b7f-86be-df01a48d2d2b)
