### PR TITLE
Refactor string capitalization to use helper method

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
@@ -137,8 +137,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 return Helper.GetTurkishUppercaseLetter(text[0], callbacks.Encoding) + text.Substring(1);
             }
 
-            text = char.ToUpper(text[0]) + text.Substring(1);
-            return text;
+            return text.CapitalizeFirstLetter();
         }
 
     }


### PR DESCRIPTION
Simplified logic by replacing manual string manipulation with a call to the `CapitalizeFirstLetter` helper method. This improves code clarity and reduces duplication by reusing existing utilities.