### PR TITLE
Add PaddleOCR-Standalone and Batch mode support

### DIFF
--- a/src/ui/Forms/Ocr/DownloadPaddleOCR.Designer.cs
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCR.Designer.cs
@@ -1,0 +1,78 @@
+﻿namespace Nikse.SubtitleEdit.Forms.Ocr
+{
+    sealed partial class DownloadPaddleOCR
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.labelDescription1 = new System.Windows.Forms.Label();
+            this.labelPleaseWait = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // labelDescription1
+            // 
+            this.labelDescription1.AutoSize = true;
+            this.labelDescription1.Location = new System.Drawing.Point(21, 27);
+            this.labelDescription1.Name = "labelDescription1";
+            this.labelDescription1.Size = new System.Drawing.Size(145, 13);
+            this.labelDescription1.TabIndex = 29;
+            this.labelDescription1.Text = "Downloading PaddleOCR";
+            // 
+            // labelPleaseWait
+            // 
+            this.labelPleaseWait.AutoSize = true;
+            this.labelPleaseWait.Location = new System.Drawing.Point(21, 59);
+            this.labelPleaseWait.Name = "labelPleaseWait";
+            this.labelPleaseWait.Size = new System.Drawing.Size(70, 13);
+            this.labelPleaseWait.TabIndex = 28;
+            this.labelPleaseWait.Text = "Please wait...";
+            // 
+            // DownloadPaddleOCR
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(320, 93);
+            this.Controls.Add(this.labelDescription1);
+            this.Controls.Add(this.labelPleaseWait);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "DownloadPaddleOCR";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Download Tesseract";
+            this.Shown += new System.EventHandler(this.DownloadTesseract5_Shown);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label labelDescription1;
+        private System.Windows.Forms.Label labelPleaseWait;
+    }
+}

--- a/src/ui/Forms/Ocr/DownloadPaddleOCR.cs
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCR.cs
@@ -1,0 +1,140 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Http;
+using Nikse.SubtitleEdit.Logic;
+using SevenZipExtractor;
+using System;
+using System.IO;
+using System.Threading;
+using System.Windows.Forms;
+using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
+
+namespace Nikse.SubtitleEdit.Forms.Ocr
+{
+    public sealed partial class DownloadPaddleOCR : Form
+    {
+        public const string DownloadUrl = "https://github.com/timminator/PaddleOCR-Standalone/releases/download/v.1.0.0/PaddleOCR-GPU-v1.0.0.7z";
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        private string _tempFileName;
+
+        public DownloadPaddleOCR()
+        {
+            UiUtil.PreInitialize(this);
+            InitializeComponent();
+            UiUtil.FixFonts(this);
+            Text = LanguageSettings.Current.GetTesseractDictionaries.Download + " PaddleOCR";
+            labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait;
+            labelDescription1.Text = LanguageSettings.Current.GetTesseractDictionaries.Download + " PaddleOCR";
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        private void DownloadTesseract5_Shown(object sender, EventArgs e)
+        {
+            try
+            {
+                _tempFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".7z");
+                using (var downloadStream = new FileStream(_tempFileName, FileMode.Create, FileAccess.Write))
+                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                {
+                    var downloadTask = httpClient.DownloadAsync(DownloadUrl, downloadStream, new Progress<float>((progress) =>
+                    {
+                        var pct = (int)Math.Round(progress * 100.0, MidpointRounding.AwayFromZero);
+                        labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait + "  " + pct + "%";
+                        labelPleaseWait.Refresh();
+                    }), _cancellationTokenSource.Token);
+
+                    while (!downloadTask.IsCompleted && !downloadTask.IsCanceled)
+                    {
+                        Application.DoEvents();
+                    }
+
+                    if (downloadTask.IsCanceled)
+                    {
+                        DialogResult = DialogResult.Cancel;
+                        labelPleaseWait.Refresh();
+                        return;
+                    }
+
+                }
+                CompleteDownload(_tempFileName);
+                return;
+            }
+            catch (Exception exception)
+            {
+                labelPleaseWait.Text = string.Empty;
+                Cursor = Cursors.Default;
+                MessageBox.Show($"Unable to download {DownloadUrl}!" + Environment.NewLine + Environment.NewLine +
+                                exception.Message + Environment.NewLine + Environment.NewLine + exception.StackTrace);
+                DialogResult = DialogResult.Cancel;
+            }
+        }
+
+        private void CompleteDownload(string downloadStream)
+        {
+            if (downloadStream.Length == 0)
+            {
+                throw new Exception("No content downloaded - missing file or no internet connection!" + Environment.NewLine  + 
+                                    $"For more info see: {Path.Combine(Configuration.DataDirectory, "error_log.txt")}");
+            }
+
+            var dictionaryFolder = Configuration.PaddleOcrDirectory;
+            if (!Directory.Exists(dictionaryFolder))
+            {
+                Directory.CreateDirectory(dictionaryFolder);
+            }
+
+            Extract7Zip(downloadStream, dictionaryFolder, "PaddleOCR-GPU-v1.0.0");
+            Cursor = Cursors.Default;
+            labelPleaseWait.Text = string.Empty;
+            Cursor = Cursors.Default;
+            DialogResult = DialogResult.OK;
+            File.Delete(_tempFileName);
+        }
+
+        private void Extract7Zip(string tempFileName, string dir, string skipFolderLevel)
+        {
+            Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, string.Empty);
+            labelDescription1.Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, "PaddleOCR");
+            labelDescription1.Refresh();
+
+            using (var archiveFile = new ArchiveFile(tempFileName))
+            {
+                archiveFile.Extract(entry =>
+                {
+                    if (_cancellationTokenSource.IsCancellationRequested)
+                    {
+                        return null;
+                    }
+
+                    var entryFullName = entry.FileName;
+                    if (!string.IsNullOrEmpty(skipFolderLevel) && entryFullName.StartsWith(skipFolderLevel))
+                    {
+                        entryFullName = entryFullName.Substring(skipFolderLevel.Length);
+                    }
+
+                    entryFullName = entryFullName.Replace('/', Path.DirectorySeparatorChar);
+                    entryFullName = entryFullName.TrimStart(Path.DirectorySeparatorChar);
+
+                    var fullFileName = Path.Combine(dir, entryFullName);
+
+                    var fullPath = Path.GetDirectoryName(fullFileName);
+                    if (fullPath == null)
+                    {
+                        return null;
+                    }
+
+                    var displayName = entryFullName;
+                    if (displayName.Length > 30)
+                    {
+                        displayName = "..." + displayName.Remove(0, displayName.Length - 26).Trim();
+                    }
+
+                    labelPleaseWait.Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, $"{displayName}");
+                    labelPleaseWait.Refresh();
+
+                    return fullFileName;
+                });
+            }
+        }
+    }
+}

--- a/src/ui/Forms/Ocr/DownloadPaddleOCR.resx
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCR.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ui/Forms/Ocr/DownloadPaddleOCRCPU.Designer.cs
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCRCPU.Designer.cs
@@ -1,0 +1,78 @@
+﻿namespace Nikse.SubtitleEdit.Forms.Ocr
+{
+    sealed partial class DownloadPaddleOCRCPU
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.labelDescription1 = new System.Windows.Forms.Label();
+            this.labelPleaseWait = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // labelDescription1
+            // 
+            this.labelDescription1.AutoSize = true;
+            this.labelDescription1.Location = new System.Drawing.Point(21, 27);
+            this.labelDescription1.Name = "labelDescription1";
+            this.labelDescription1.Size = new System.Drawing.Size(145, 13);
+            this.labelDescription1.TabIndex = 29;
+            this.labelDescription1.Text = "Downloading PaddleOCR";
+            // 
+            // labelPleaseWait
+            // 
+            this.labelPleaseWait.AutoSize = true;
+            this.labelPleaseWait.Location = new System.Drawing.Point(21, 59);
+            this.labelPleaseWait.Name = "labelPleaseWait";
+            this.labelPleaseWait.Size = new System.Drawing.Size(70, 13);
+            this.labelPleaseWait.TabIndex = 28;
+            this.labelPleaseWait.Text = "Please wait...";
+            // 
+            // DownloadPaddleOCR
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(320, 93);
+            this.Controls.Add(this.labelDescription1);
+            this.Controls.Add(this.labelPleaseWait);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "DownloadPaddleOCR";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Download Tesseract";
+            this.Shown += new System.EventHandler(this.DownloadTesseract5_Shown);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label labelDescription1;
+        private System.Windows.Forms.Label labelPleaseWait;
+    }
+}

--- a/src/ui/Forms/Ocr/DownloadPaddleOCRCPU.cs
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCRCPU.cs
@@ -1,0 +1,140 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Http;
+using Nikse.SubtitleEdit.Logic;
+using SevenZipExtractor;
+using System;
+using System.IO;
+using System.Threading;
+using System.Windows.Forms;
+using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
+
+namespace Nikse.SubtitleEdit.Forms.Ocr
+{
+    public sealed partial class DownloadPaddleOCRCPU : Form
+    {
+        public const string DownloadUrl = "https://github.com/timminator/PaddleOCR-Standalone/releases/download/v.1.0.0/PaddleOCR-CPU-v1.0.0.7z";
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        private string _tempFileName;
+
+        public DownloadPaddleOCRCPU()
+        {
+            UiUtil.PreInitialize(this);
+            InitializeComponent();
+            UiUtil.FixFonts(this);
+            Text = LanguageSettings.Current.GetTesseractDictionaries.Download + " PaddleOCR (CPU version)";
+            labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait;
+            labelDescription1.Text = LanguageSettings.Current.GetTesseractDictionaries.Download + " PaddleOCR (CPU version)";
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        private void DownloadTesseract5_Shown(object sender, EventArgs e)
+        {
+            try
+            {
+                _tempFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".7z");
+                using (var downloadStream = new FileStream(_tempFileName, FileMode.Create, FileAccess.Write))
+                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                {
+                    var downloadTask = httpClient.DownloadAsync(DownloadUrl, downloadStream, new Progress<float>((progress) =>
+                    {
+                        var pct = (int)Math.Round(progress * 100.0, MidpointRounding.AwayFromZero);
+                        labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait + "  " + pct + "%";
+                        labelPleaseWait.Refresh();
+                    }), _cancellationTokenSource.Token);
+
+                    while (!downloadTask.IsCompleted && !downloadTask.IsCanceled)
+                    {
+                        Application.DoEvents();
+                    }
+
+                    if (downloadTask.IsCanceled)
+                    {
+                        DialogResult = DialogResult.Cancel;
+                        labelPleaseWait.Refresh();
+                        return;
+                    }
+
+                }
+                CompleteDownload(_tempFileName);
+                return;
+            }
+            catch (Exception exception)
+            {
+                labelPleaseWait.Text = string.Empty;
+                Cursor = Cursors.Default;
+                MessageBox.Show($"Unable to download {DownloadUrl}!" + Environment.NewLine + Environment.NewLine +
+                                exception.Message + Environment.NewLine + Environment.NewLine + exception.StackTrace);
+                DialogResult = DialogResult.Cancel;
+            }
+        }
+
+        private void CompleteDownload(string downloadStream)
+        {
+            if (downloadStream.Length == 0)
+            {
+                throw new Exception("No content downloaded - missing file or no internet connection!" + Environment.NewLine  + 
+                                    $"For more info see: {Path.Combine(Configuration.DataDirectory, "error_log.txt")}");
+            }
+
+            var dictionaryFolder = Configuration.PaddleOcrDirectory;
+            if (!Directory.Exists(dictionaryFolder))
+            {
+                Directory.CreateDirectory(dictionaryFolder);
+            }
+
+            Extract7Zip(downloadStream, dictionaryFolder, "PaddleOCR-CPU-v1.0.0");
+            Cursor = Cursors.Default;
+            labelPleaseWait.Text = string.Empty;
+            Cursor = Cursors.Default;
+            DialogResult = DialogResult.OK;
+            File.Delete(_tempFileName);
+        }
+
+        private void Extract7Zip(string tempFileName, string dir, string skipFolderLevel)
+        {
+            Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, string.Empty);
+            labelDescription1.Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, "PaddleOCR");
+            labelDescription1.Refresh();
+
+            using (var archiveFile = new ArchiveFile(tempFileName))
+            {
+                archiveFile.Extract(entry =>
+                {
+                    if (_cancellationTokenSource.IsCancellationRequested)
+                    {
+                        return null;
+                    }
+
+                    var entryFullName = entry.FileName;
+                    if (!string.IsNullOrEmpty(skipFolderLevel) && entryFullName.StartsWith(skipFolderLevel))
+                    {
+                        entryFullName = entryFullName.Substring(skipFolderLevel.Length);
+                    }
+
+                    entryFullName = entryFullName.Replace('/', Path.DirectorySeparatorChar);
+                    entryFullName = entryFullName.TrimStart(Path.DirectorySeparatorChar);
+
+                    var fullFileName = Path.Combine(dir, entryFullName);
+
+                    var fullPath = Path.GetDirectoryName(fullFileName);
+                    if (fullPath == null)
+                    {
+                        return null;
+                    }
+
+                    var displayName = entryFullName;
+                    if (displayName.Length > 30)
+                    {
+                        displayName = "..." + displayName.Remove(0, displayName.Length - 26).Trim();
+                    }
+
+                    labelPleaseWait.Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, $"{displayName}");
+                    labelPleaseWait.Refresh();
+
+                    return fullFileName;
+                });
+            }
+        }
+    }
+}

--- a/src/ui/Forms/Ocr/DownloadPaddleOCRCPU.resx
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCRCPU.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ui/Forms/Ocr/VobSubOcr.Designer.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.Designer.cs
@@ -2343,7 +2343,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             this.checkBoxPaddleOcrUseGpu.Name = "checkBoxPaddleOcrUseGpu";
             this.checkBoxPaddleOcrUseGpu.Size = new System.Drawing.Size(67, 17);
             this.checkBoxPaddleOcrUseGpu.TabIndex = 2;
-            this.checkBoxPaddleOcrUseGpu.Text = "Use GPU";
+            this.checkBoxPaddleOcrUseGpu.Text = "Use GPU (Only affects GPU version)";
             this.checkBoxPaddleOcrUseGpu.UseVisualStyleBackColor = true;
             // 
             // VobSubOcr

--- a/src/ui/Logic/Ocr/PaddleOcr.cs
+++ b/src/ui/Logic/Ocr/PaddleOcr.cs
@@ -159,11 +159,22 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
             var tempImage = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
             borderedBitmap.Save(tempImage, System.Drawing.Imaging.ImageFormat.Png);
             var parameters = $"--image_dir \"{tempImage}\" --ocr_version PP-OCRv4 --use_angle_cls true --use_gpu {useGpu.ToString().ToLowerInvariant()} --lang {language} --show_log false --det_model_dir \"{_detPath}\\{detFilePrefix}\" --rec_model_dir \"{_recPath}\\{recFilePrefix}\" --cls_model_dir \"{_clsPath}\\ch_ppocr_mobile_v2.0_cls_infer\"";
+            string PaddleOCRPath = null;
+
+            if (File.Exists(Path.Combine(Configuration.PaddleOcrDirectory, "paddleocr.exe")))
+            {
+                PaddleOCRPath = Path.GetFullPath(Path.Combine(Configuration.PaddleOcrDirectory, "paddleocr.exe"));
+            }
+            else
+            {
+                PaddleOCRPath = "paddleocr.exe";
+            }
+
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "paddleocr",
+                    FileName = PaddleOCRPath,
                     Arguments = parameters,
                     UseShellExecute = false,
                     RedirectStandardOutput = true,


### PR DESCRIPTION
This PR adds support for the PaddleOCR-Standalone version I have also made.

This enables the usage of PaddleOCR without requiring the user to install python, paddlepaddle and paddleocr. Instead it prompts the user to download the standalone version, similar to when using tesseract 5.5.0 for the first time.
The PR still detects if the user installed PaddleOCR beforehand and does not prompt the user in this case to download PaddleOCR again.
Furthermore it checks if the system supports the GPU version or not. If not, the CPU version is used instead.

This PR also adds one of two desired features mentioned in #9250. 

Edit: The second commit also adds Batch mode support when using PaddleOCR.

Fixes: #9250 