### PR TITLE
Add error handling for PaddleOCR process start

### DIFF
--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -5240,6 +5240,11 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             else if (_ocrMethodIndex == _ocrMethodPaddle)
             {
                 text = OcrViaPaddle(bmp, i);
+                if (!string.IsNullOrEmpty(_paddleOcr.ProcessStartError))
+                {
+                    MessageBox.Show(_paddleOcr.ProcessStartError);
+                    return true;
+                }
             }
 
             _lastLine = text;
@@ -5407,6 +5412,11 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             while (!resetEvent.WaitOne(100))
             {
                 Application.DoEvents();
+            }
+
+            if (!string.IsNullOrEmpty(_paddleOcr.ProcessStartError))
+            {
+                MessageBox.Show(_paddleOcr.ProcessStartError);
             }
 
             return true;

--- a/src/ui/Logic/Ocr/PaddleOcr.cs
+++ b/src/ui/Logic/Ocr/PaddleOcr.cs
@@ -14,6 +14,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
     public class PaddleOcr
     {
         public string Error { get; set; }
+        public string ProcessStartError { get; set; }
         private List<PaddleOcrResultParser.TextDetectionResult> _textDetectionResults = new List<PaddleOcrResultParser.TextDetectionResult>();
         private string _paddingOcrPath;
         private string _clsPath;
@@ -106,6 +107,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
         public PaddleOcr()
         {
             Error = string.Empty;
+            ProcessStartError = string.Empty;
             _paddingOcrPath = Configuration.PaddleOcrDirectory;
             _clsPath = Path.Combine(_paddingOcrPath, "cls");
             _detPath = Path.Combine(_paddingOcrPath, "det");
@@ -191,9 +193,17 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                 process.OutputDataReceived += OutputHandler;
                 _textDetectionResults.Clear();
 
+                try
+                {
 #pragma warning disable CA1416 // Validate platform compatibility
-                process.Start();
+                    process.Start();
 #pragma warning restore CA1416 // Validate platform compatibility;
+                }
+                catch (Exception ex)
+                {
+                    ProcessStartError = ex.Message + Environment.NewLine + ex.StackTrace;
+                    return string.Empty;
+                }
 
                 process.BeginOutputReadLine();
 
@@ -382,9 +392,17 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                         }
                     };
 
+                    try
+                    {
 #pragma warning disable CA1416 // Validate platform compatibility
-                    process.Start();
+                        process.Start();
 #pragma warning restore CA1416 // Validate platform compatibility;
+                    }
+                    catch (Exception ex)
+                    {
+                        ProcessStartError = ex.Message + Environment.NewLine + ex.StackTrace;
+                        return;
+                    }
 
                     process.BeginOutputReadLine();
                     process.WaitForExit();


### PR DESCRIPTION
I added a try-catch block around the process.start command for both PaddleOCR functions. If it fails it displays a message box with the error and the stacktrace. This is now similar to the tesseractrunner.run function.

I hope this could help us understand what happens in #9286 aswell?