### PR TITLE
Fix crash when aborting spellcheck in PaddleOCR Batch mode

### DIFF
--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -6843,7 +6843,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 {
                     ButtonPauseClick(null, null);
                     _ocrFixEngine.Abort = false;
-                    return processedText; // Return partial results if aborted
+                    
+                    return string.Empty;
                 }
 
                 // Log used word guesses


### PR DESCRIPTION
This PR fixes the issue I described in #9311.

Fixes #9311 