### PR TITLE
Add HunspellDictionaries.xml.gz as an embedded resource

### DIFF
--- a/src/ui/SubtitleEdit.csproj
+++ b/src/ui/SubtitleEdit.csproj
@@ -102,6 +102,7 @@
       <SubType>Designer</SubType>
     </None>
     <EmbeddedResource Include="Resources\SMPTE-428-7-2014-DCST.xsd.gz" />
+    <EmbeddedResource Include="Resources\HunspellDictionaries.xml.gz" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="DLLs\Voikkox64.dll" />


### PR DESCRIPTION
Wasn't showing dictionaries from "Get Dictionaries"