### PR TITLE
Fix slight mistake and remove endundant line to define ProcessStartInfo

### DIFF
--- a/src/ui/Logic/Ocr/PaddleOcr.cs
+++ b/src/ui/Logic/Ocr/PaddleOcr.cs
@@ -190,11 +190,10 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     CreateNoWindow = true,
+                    StandardOutputEncoding = Encoding.UTF8,
                 },
             })
             {
-                process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
-                process.StartInfo.RedirectStandardOutput = true;
                 process.StartInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
                 process.StartInfo.EnvironmentVariables["PYTHONUTF8"] = "1";
 
@@ -207,16 +206,16 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                         return;
                     }
 
+                    _log.AppendLine(outLine.Data);
+
                     if (!processingStarted && outLine.Data.Contains("ppocr INFO: **********"))
                     {
                         processingStarted = true;
                         hasErrors = false;
-                        _log.Clear(); 
+                        _log.Clear();
+                        _log.AppendLine(outLine.Data);
                     }
-
-                    _log.AppendLine(outLine.Data);
-
-                    if (outLine.Data.Contains("ppocr WARNING: No text found in image"))
+                    else if (outLine.Data.Contains("ppocr WARNING: No text found in image"))
                     {
                         result = string.Empty;
                         return;
@@ -404,13 +403,16 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                             return;
                         }
 
+                        _log.AppendLine(outLine.Data);
+
                         if (outLine.Data.Contains("ppocr INFO: **********"))
                         {
                             if (!processingStarted)
                             {
                                 processingStarted = true;
                                 hasErrors = false;
-                                _log.Clear(); 
+                                _log.Clear();
+                                _log.AppendLine(outLine.Data);
                             }
 
                             if (!string.IsNullOrEmpty(oldFileName))
@@ -437,10 +439,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                                 results[fileName] = string.Empty;
                             }
                         }
-
-                        _log.AppendLine(outLine.Data);
-
-                        if (outLine.Data.Contains("ppocr WARNING: No text found in image"))
+                        else if (outLine.Data.Contains("ppocr WARNING: No text found in image"))
                         {
                             return;
                         }


### PR DESCRIPTION
I made a slight mistake yesterday. I split the if-else statement used when processing the process output into two if-statements but they were not mutually exclusive.
This caused an unnessecary match with the "PPOCR Info" if-statement.
It did not cause any errors because the Regex-Pattern did not match, but it was not how it should have been.

This PR reverts this logic back to the correct if-else statement.

I also noticed that we had one redundant line to define ProcessStartInfo in the Ocr() function. I removed it aswell.