### PR TITLE
Remove duplicate entry for "O'neal" in names.xml

### DIFF
--- a/Dictionaries/names.xml
+++ b/Dictionaries/names.xml
@@ -4261,7 +4261,6 @@ This file is case sensitive.
   <name>Oman</name>
   <name>Omar</name>
   <name>Omni</name>
-  <name>O'neal</name>
   <name>O'Neal</name>
   <name>O'Neill</name>
   <name>Ontario</name>


### PR DESCRIPTION
The duplicate entry for "O'neal" was removed to maintain consistency in the dictionary. Only the properly capitalized version "O'Neal" is retained.