### PR TITLE
Refactor OCR capitalization logic and enhance ellipses handling.

### DIFF
--- a/src/Tests/Core/StringExtensionsTest.cs
+++ b/src/Tests/Core/StringExtensionsTest.cs
@@ -453,5 +453,12 @@ namespace Tests.Core
             Assert.IsTrue("foobar;".HasSentenceEnding(greekCultureTwoLetter));
         }
 
+        [TestMethod]
+        public void HasSentenceEndingEllipsesTest()
+        {
+            Assert.IsFalse("Foobar...".HasSentenceEnding());
+            Assert.IsFalse("Foobar…".HasSentenceEnding());
+        }
+
     }
 }

--- a/src/Tests/Core/StringExtensionsTest.cs
+++ b/src/Tests/Core/StringExtensionsTest.cs
@@ -458,6 +458,10 @@ namespace Tests.Core
         {
             Assert.IsFalse("Foobar...".HasSentenceEnding());
             Assert.IsFalse("Foobar…".HasSentenceEnding());
+
+            // with formatting
+            Assert.IsFalse("Foobar…</i>".HasSentenceEnding());
+            Assert.IsFalse("Foobar...</font>".HasSentenceEnding());
         }
 
     }

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -803,7 +803,6 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return false;
             }
 
-
             var charAtIndex = value[checkIndex];
             // handles when sentence ending char is adjacent with html/assa closing tags e.g: </i>, </font>, {\\i0}...
             while (charAtIndex == '>' || charAtIndex == '}')
@@ -838,6 +837,24 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 // foobar—
                 return checkIndex > 0 && char.IsLetter(value[checkIndex - 1]);
+            }
+
+            // verify ellipses
+            if (charAtIndex == '…')
+            {
+                return false;
+            }
+
+            var l = checkIndex;
+            while (value[l] == '.')
+            {
+                l--;
+
+                // [...] 
+                if (checkIndex - l + 1 == 3)
+                {
+                    return false;
+                }
             }
 
             // evaluate culture type

--- a/src/ui/Logic/Ocr/OcrFixEngine.cs
+++ b/src/ui/Logic/Ocr/OcrFixEngine.cs
@@ -575,7 +575,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
             text = FixCommonOcrLineErrors(sb.ToString(), subtitle, index, prevLine, lastLastLine);
             if (Configuration.Settings.Tools.OcrFixUseHardcodedRules)
             {
-                text = FixLowercaseIToUppercaseI(text, prevLine);
+                text = CapitalizeInitialI(text, prevLine);
                 if (SpellCheckDictionaryName.StartsWith("en_", StringComparison.Ordinal) || _threeLetterIsoLanguageName == "eng")
                 {
                     var oldText = text;
@@ -898,7 +898,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
             return text;
         }
 
-        private string FixLowercaseIToUppercaseI(string input, string lastLine)
+        private string CapitalizeInitialI(string input, string previousLine)
         {
             var sb = new StringBuilder();
             var lines = input.SplitToLines();
@@ -908,27 +908,26 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
 
                 if (i > 0)
                 {
-                    lastLine = lines[i - 1];
+                    previousLine = lines[i - 1];
                 }
 
-                lastLine = HtmlUtil.RemoveHtmlTags(lastLine);
+                previousLine = HtmlUtil.RemoveHtmlTags(previousLine);
 
-                if (string.IsNullOrEmpty(lastLine) ||
-                    lastLine.EndsWith('.') ||
-                    lastLine.EndsWith('!') ||
-                    lastLine.EndsWith('?'))
+                if (string.IsNullOrEmpty(previousLine) || previousLine.HasSentenceEnding())
                 {
                     var st = new StrippableText(l);
-                    if (st.StrippedText.StartsWith('i') && !st.Pre.EndsWith('[') && !st.Pre.EndsWith('(') && !st.Pre.EndsWith("...", StringComparison.Ordinal))
+                    if (st.StrippedText.StartsWith('i') && !st.Pre.EndsWith('[') && !st.Pre.EndsWith('('))
                     {
-                        if (string.IsNullOrEmpty(lastLine) || (!lastLine.EndsWith("...", StringComparison.Ordinal) && !EndsWithAbbreviation(lastLine, _abbreviationList)))
+                        if (string.IsNullOrEmpty(previousLine) || !EndsWithAbbreviation(previousLine, _abbreviationList))
                         {
                             l = st.Pre + "I" + st.StrippedText.Remove(0, 1) + st.Post;
                         }
                     }
                 }
+
                 sb.AppendLine(l);
             }
+
             return sb.ToString().TrimEnd('\r', '\n');
         }
 


### PR DESCRIPTION
Renamed and optimized `FixLowercaseIToUppercaseI` to `CapitalizeInitialI` for clarity and maintainability. Improved `HasSentenceEnding` to handle ellipses properly, preventing false positives. Added corresponding unit tests to ensure coverage and correctness.