### PR TITLE
Add ReplaceNullWithSpace method and refactor usages

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -909,5 +909,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                 .Replace("\u202B", string.Empty) // &rlm;
                 .Replace("\u202A", string.Empty); // &lmr;
         }
+
+        /// <summary>
+        /// Replaces all null characters ('\0') in the input string with space characters (' ').
+        /// </summary>
+        /// <param name="input">The string in which null characters are to be replaced.</param>
+        /// <returns>A new string with all null characters replaced by spaces.</returns>
+        public static string ReplaceNullWithSpace(this string input) => input.Replace('\0', ' ');
     }
 }

--- a/src/libse/SubtitleFormats/SubRip.cs
+++ b/src/libse/SubtitleFormats/SubRip.cs
@@ -245,7 +245,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             _paragraph.Text += Environment.NewLine;
                         }
 
-                        _paragraph.Text += RemoveBadChars(line).TrimEnd();
+                        _paragraph.Text += line.ReplaceNullWithSpace().TrimEnd();
                     }
                     else if (string.IsNullOrEmpty(line) && string.IsNullOrEmpty(_paragraph.Text))
                     {
@@ -260,7 +260,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                     else if (string.IsNullOrEmpty(line) && string.IsNullOrEmpty(next))
                     {
-                        _paragraph.Text += Environment.NewLine + RemoveBadChars(line).TrimEnd();
+                        _paragraph.Text += Environment.NewLine + line.ReplaceNullWithSpace().TrimEnd();
                     }
                     else
                     {
@@ -281,11 +281,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private bool IsText(string text)
         {
             return !(string.IsNullOrWhiteSpace(text) || Utilities.IsInteger(text) || TryReadTimeCodesLine(text.Trim(), null, false));
-        }
-
-        private static string RemoveBadChars(string line)
-        {
-            return line.Replace('\0', ' ');
         }
 
         private bool TryReadTimeCodesLine(string input, Paragraph paragraph, bool validate)

--- a/src/libse/SubtitleFormats/YouTubeSbv.cs
+++ b/src/libse/SubtitleFormats/YouTubeSbv.cs
@@ -110,7 +110,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             _paragraph.Text += Environment.NewLine;
                         }
 
-                        _paragraph.Text += RemoveBadChars(line).TrimEnd();
+                        _paragraph.Text += line.ReplaceNullWithSpace().TrimEnd();
                     }
                     else if (IsText(next))
                     {
@@ -119,7 +119,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             _paragraph.Text += Environment.NewLine;
                         }
 
-                        _paragraph.Text += RemoveBadChars(line).TrimEnd();
+                        _paragraph.Text += line.ReplaceNullWithSpace().TrimEnd();
                     }
                     else
                     {
@@ -139,11 +139,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             return true;
-        }
-
-        private static string RemoveBadChars(string line)
-        {
-            return line.Replace('\0', ' ');
         }
 
         private static bool TryReadTimeCodesLine(string inputLine, Paragraph paragraph)


### PR DESCRIPTION
Introduce a new StringExtensions method, ReplaceNullWithSpace, to replace null characters with spaces. Refactor YouTubeSbv and SubRip classes to use this method, removing the redundant RemoveBadChars method for improved clarity and reusability.