### PR TITLE
Refactor text removal logic to simplify tag handling

### DIFF
--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -1405,22 +1405,18 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
             if (Settings.RemoveTextBetweenSquares)
             {
-                text = RemoveTextBetweenTags("[", "]:", text);
                 text = RemoveTextBetweenTags("[", "]", text);
             }
             if (Settings.RemoveTextBetweenBrackets)
             {
-                text = RemoveTextBetweenTags("{", "}:", text);
                 text = RemoveTextBetweenTags("{", "}", text);
             }
             if (Settings.RemoveTextBetweenParentheses)
             {
-                text = RemoveTextBetweenTags("(", "):", text);
                 text = RemoveTextBetweenTags("(", ")", text);
             }
             if (Settings.RemoveTextBetweenQuestionMarks)
             {
-                text = RemoveTextBetweenTags("?", "?:", text);
                 text = RemoveTextBetweenTags("?", "?", text);
             }
             if (Settings.RemoveTextBetweenCustomTags && Settings.CustomStart.Length > 0 && Settings.CustomEnd.Length > 0)


### PR DESCRIPTION
Removed unnecessary intermediate tag patterns (e.g., "]:" and "}:"), keeping only the primary tag pairs. This change improves code clarity and ensures consistent behavior for text removal settings.