### PR TITLE
Refactor RemoveEmptyTags to HtmlUtil for reuse

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -1527,5 +1527,20 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <param name="ch">The character to check.</param>
         /// <returns>True if the character is a start tag symbol; otherwise, false.</returns>
         public static bool IsStartTagSymbol(char ch) => ch == '<' || ch == '{';
+
+        public static string RemoveEmptyTags(string s)
+        {
+            var noTags = RemoveHtmlTags(s, true);
+            if (noTags.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return s
+                .Replace("<i></i>", string.Empty)
+                .Replace("<u></u>", string.Empty)
+                .Replace("<b></b>", string.Empty);
+        }
+
     }
 }

--- a/src/libse/Forms/MoveWordUpDown.cs
+++ b/src/libse/Forms/MoveWordUpDown.cs
@@ -83,7 +83,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             S1 = AddWordAfter(sbWord.ToString().Trim(), S1);
             S1 = AutoBreakIfNeeded(S1);
             S2 = sbS2.ToString().Trim();
-            S2 = RemoveEmptyTags(S2);
+            S2 = HtmlUtil.RemoveEmptyTags(S2);
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 }
             }
             S1 = string.Join(string.Empty, sbS1.ToString().Trim().ToCharArray().Reverse());
-            S1 = RemoveEmptyTags(S1);
+            S1 = HtmlUtil.RemoveEmptyTags(S1);
             S2 = AddWordBefore(string.Join(string.Empty, sbWord.ToString().Trim().ToCharArray().Reverse()), S2);
             S2 = AutoBreakIfNeeded(S2);
         }
@@ -178,20 +178,6 @@ namespace Nikse.SubtitleEdit.Core.Forms
             }
 
             return i >= indexOfFontTag && i <= indexOfEndFontTag;
-        }
-
-        private static string RemoveEmptyTags(string s)
-        {
-            var noTags = HtmlUtil.RemoveHtmlTags(s, true);
-            if (noTags.Length == 0)
-            {
-                return string.Empty;
-            }
-
-            return s
-                .Replace("<i></i>", string.Empty)
-                .Replace("<u></u>", string.Empty)
-                .Replace("<b></b>", string.Empty);
         }
 
         private static string AddWordBefore(string word, string input)


### PR DESCRIPTION
Moved the RemoveEmptyTags method from MoveWordUpDown to HtmlUtil to improve code reusability and maintainability. Updated references in MoveWordUpDown to use the HtmlUtil version. This change centralizes HTML utility functions into a common location.