### PR TITLE
Feature/missing period

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="SevenZipExtractor" Version="1.0.17" />
     <PackageVersion Include="SharpCompress" Version="0.38.0" />
     <PackageVersion Include="System.Drawing.Common" Version="9.0.1" />

--- a/src/Tests/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Tests/FixCommonErrors/FixCommonErrorsTest.cs
@@ -8,6 +8,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Nikse.SubtitleEdit.Core.Interfaces;
+using NSubstitute;
+using NSubstitute.Extensions;
 
 namespace Tests.FixCommonErrors
 {
@@ -1421,6 +1424,33 @@ namespace Tests.FixCommonErrors
             s.Paragraphs.Add(new Paragraph("The house seemed desolate to me and", 0, 1000));
             s.Paragraphs.Add(new Paragraph("I wasn't sure if somebody lived in there...", 1000, 3000));
             new FixMissingPeriodsAtEndOfLine().Fix(s, new EmptyFixCallback());
+            Assert.AreEqual(s.Paragraphs[0].Text, "The house seemed desolate to me and");
+        }
+
+        [TestMethod]
+        public void FixMissingPeriodsAtEndOfLineNoPeriodForNameTest()
+        {
+            var context = Substitute.For<IFixCallbacks>();
+            context.Configure().IsName(Arg.Is("Bill Gates")).Returns(true);
+            context.Configure().AllowFix(Arg.Any<Paragraph>(), Arg.Any<string>()).Returns(true);
+
+            var s = new Subtitle();
+            s.Paragraphs.Add(new Paragraph("The house seemed desolate to me and", 0, 1000));
+            s.Paragraphs.Add(new Paragraph("Bill Gates wasn't sure if somebody lived in there...", 1000, 3000));
+            new FixMissingPeriodsAtEndOfLine().Fix(s, context);
+            Assert.AreEqual(s.Paragraphs[0].Text, "The house seemed desolate to me and");
+        }
+
+        [TestMethod]
+        public void FixMissingPeriodsAtEndOfLineNoPeriodForTitleTest()
+        {
+            var context = Substitute.For<IFixCallbacks>();
+            context.Configure().AllowFix(Arg.Any<Paragraph>(), Arg.Any<string>()).Returns(true);
+
+            var s = new Subtitle();
+            s.Paragraphs.Add(new Paragraph("The house seemed desolate to me and", 0, 1000));
+            s.Paragraphs.Add(new Paragraph("Mr. Bill Gates wasn't sure if somebody lived in there...", 1000, 3000));
+            new FixMissingPeriodsAtEndOfLine().Fix(s, context);
             Assert.AreEqual(s.Paragraphs[0].Text, "The house seemed desolate to me and");
         }
 

--- a/src/Tests/FixCommonErrors/FixCommonErrorsTest.cs
+++ b/src/Tests/FixCommonErrors/FixCommonErrorsTest.cs
@@ -1440,6 +1440,20 @@ namespace Tests.FixCommonErrors
             new FixMissingPeriodsAtEndOfLine().Fix(s, context);
             Assert.AreEqual(s.Paragraphs[0].Text, "The house seemed desolate to me and");
         }
+        
+        [TestMethod]
+        public void FixMissingPeriodsAtEndOfLinePeriodNextNotCloseForNameTest()
+        {
+            var context = Substitute.For<IFixCallbacks>();
+            context.Configure().IsName(Arg.Is("Bill Gates")).Returns(true);
+            context.Configure().AllowFix(Arg.Any<Paragraph>(), Arg.Any<string>()).Returns(true);
+
+            var s = new Subtitle();
+            s.Paragraphs.Add(new Paragraph("The house seemed desolate to me and", 0, 1000));
+            s.Paragraphs.Add(new Paragraph("Bill Gates wasn't sure if somebody lived in there...", 3000, 3000));
+            new FixMissingPeriodsAtEndOfLine().Fix(s, context);
+            Assert.AreEqual(s.Paragraphs[0].Text, "The house seemed desolate to me and.");
+        }
 
         [TestMethod]
         public void FixMissingPeriodsAtEndOfLineNoPeriodForTitleTest()

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest" />
+    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
@@ -83,19 +83,6 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             string oldText = p.Text;
                             AddPeriod(p, tempNoHtml);
 
-                            // ATTENTION: `next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > 2000` is already handled with isNextClose
-                            // if (callbacks.IsName(next.Text.Split(WordSplitChars)[0]))
-                            // {
-                            //     if (next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > 2000)
-                            //     {
-                            //         AddPeriod(p, tempNoHtml);
-                            //     }
-                            // }
-                            // else
-                            // {
-                            //     AddPeriod(p, tempNoHtml);
-                            // }
-
                             if (p.Text != oldText)
                             {
                                 missingPeriodsAtEndOfLine++;

--- a/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
@@ -15,6 +15,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
         private static readonly char[] WordSplitChars = { ' ', '.', ',', '-', '?', '!', ':', ';', '"', '(', ')', '[', ']', '{', '}', '|', '<', '>', '/', '+', '\r', '\n' };
 
+        private static readonly string[] UrlPrefixes = { "http://", "https://", "www." };
+
         private static bool IsOneLineUrl(string s)
         {
             if (s.Contains(' ') || s.Contains(Environment.NewLine))
@@ -22,17 +24,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 return false;
             }
 
-            if (s.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            if (s.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            if (s.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+            if (UrlPrefixes.Any(prefix => s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
             {
                 return true;
             }

--- a/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
@@ -76,7 +76,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     var tempTrimmed = tempNoHtml.TrimEnd().TrimEnd('\'', '"', '“', '”').TrimEnd();
                     if (tempTrimmed.Length > 0 && !ExpectedString2.Contains(tempTrimmed[tempTrimmed.Length - 1]) && p.Text != p.Text.ToUpperInvariant())
                     {
-                        if (callbacks.AllowFix(p, fixAction) && isNextClose && !IsKnownUppercasePrefix(nextText, callbacks))
+                        if (callbacks.AllowFix(p, fixAction) &&
+                            (!isNextClose || !IsKnownUppercasePrefix(nextText, callbacks)))
                         {
                             //test to see if the first word of the next line is a name
                             string oldText = p.Text;
@@ -235,7 +236,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             }
 
             // known title
-            if (_titles.Any(title => text.StartsWith(title, StringComparison.OrdinalIgnoreCase)))
+            if (_titles.Any(title => text.StartsWith(title, StringComparison.Ordinal)))
             {
                 return true;
             }

--- a/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
@@ -76,29 +76,29 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     var tempTrimmed = tempNoHtml.TrimEnd().TrimEnd('\'', '"', '“', '”').TrimEnd();
                     if (tempTrimmed.Length > 0 && !ExpectedString2.Contains(tempTrimmed[tempTrimmed.Length - 1]) && p.Text != p.Text.ToUpperInvariant())
                     {
-                        if (isNextClose && !IsKnownUppercasePrefix(nextText, callbacks))
+                        if (callbacks.AllowFix(p, fixAction) && isNextClose && !IsKnownUppercasePrefix(nextText, callbacks))
                         {
                             //test to see if the first word of the next line is a name
-                            if (callbacks.AllowFix(p, fixAction))
-                            {
-                                string oldText = p.Text;
-                                if (callbacks.IsName(next.Text.Split(WordSplitChars)[0]))
-                                {
-                                    if (next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > 2000)
-                                    {
-                                        AddPeriod(p, tempNoHtml);
-                                    }
-                                }
-                                else
-                                {
-                                    AddPeriod(p, tempNoHtml);
-                                }
+                            string oldText = p.Text;
+                            AddPeriod(p, tempNoHtml);
 
-                                if (p.Text != oldText)
-                                {
-                                    missingPeriodsAtEndOfLine++;
-                                    callbacks.AddFixToListView(p, fixAction, oldText, p.Text);
-                                }
+                            // ATTENTION: `next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > 2000` is already handled with isNextClose
+                            // if (callbacks.IsName(next.Text.Split(WordSplitChars)[0]))
+                            // {
+                            //     if (next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > 2000)
+                            //     {
+                            //         AddPeriod(p, tempNoHtml);
+                            //     }
+                            // }
+                            // else
+                            // {
+                            //     AddPeriod(p, tempNoHtml);
+                            // }
+
+                            if (p.Text != oldText)
+                            {
+                                missingPeriodsAtEndOfLine++;
+                                callbacks.AddFixToListView(p, fixAction, oldText, p.Text);
                             }
                         }
                     }
@@ -227,7 +227,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         /// <returns>True if the text is a known uppercase prefix, otherwise false.</returns>
         private bool IsKnownUppercasePrefix(string text, IFixCallbacks context)
         {
-            // known pronoun
+            // known pronouns
             // don't end the sentence if the next word is an I word as they're always capped.
             if (text.StartsWith("I ", StringComparison.Ordinal) || text.StartsWith("I'", StringComparison.Ordinal))
             {
@@ -243,19 +243,19 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             // Bill Gates
             var nameSegmentCount = 0;
             var len = text.Length;
-            for (int r = 0; r < len + 1 && nameSegmentCount < 2; r++)
+            for (int i = 0; i < len + 1 && nameSegmentCount < 2; i++)
             {
                 // when an entire text is a name
-                if (r == len)
+                if (i == len)
                 {
                     return context.IsName(text);
                 }
 
                 // handles both single word and multiple word name
-                if (char.IsWhiteSpace(text[r]))
+                if (char.IsWhiteSpace(text[i]))
                 {
                     nameSegmentCount++;
-                    if (context.IsName(text.Substring(0, r)))
+                    if (context.IsName(text.Substring(0, i)))
                     {
                         return true;
                     }


### PR DESCRIPTION
This commit improves the `FixMissingPeriodsAtEndOfLine` logic through multiple enhancements. It introduces a new test case to ensure that names, such as "Bill Gates," are handled correctly when they appear in subsequent lines, avoiding invalid period insertions. The handling of uppercase prefixes (like pronouns, titles, or names) is refactored into a dedicated `IsKnownUppercasePrefix` method, improving readability and reuse while maintaining functionality. Additionally, redundant and outdated commented logic for handling names is removed to streamline the code and reduce clutter. Other refinements include more precise title matching and better handling of URL prefixes through a centralized list for improved maintainability.