### PR TITLE
Enhancement: add -h and --help options for command line help

### DIFF
--- a/src/ui/Logic/CommandLineConvert/CommandLineConverter.cs
+++ b/src/ui/Logic/CommandLineConvert/CommandLineConverter.cs
@@ -75,7 +75,7 @@ namespace Nikse.SubtitleEdit.Logic.CommandLineConvert
                 {
                     action = Convert;
                 }
-                else if (firstArgument == "/help" || firstArgument == "-help" || firstArgument == "/?" || firstArgument == "-?")
+                else if (firstArgument == "-h" || firstArgument == "/help" || firstArgument == "-help" || firstArgument == "--help" || firstArgument == "/?" || firstArgument == "-?")
                 {
                     action = Help;
                 }


### PR DESCRIPTION
While I was looking at Issue #9381 I tried to run the help command and intuitively typed `-h` and because that didnt work I tried `--help` - also without success.

I thought adding these would be a nice enhancement. They are part of the GNU coding standard and are quite often used in other project aswell.