### PR TITLE
Refactor WebVTT parsing to replace <v> tags with narrator text.

### DIFF
--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -682,7 +682,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         match = regexRemoveCTags.Match(text, start);
                     }
 
-                    text = RemoveTag("v", text);
+                    text = VoiceToNarrator(text);
                     text = RemoveTag("rt", text);
                     text = RemoveTag("ruby", text);
                     text = RemoveTag("span", text);
@@ -692,6 +692,33 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     p.Text = text;
                 }
             }
+        }
+
+        private string VoiceToNarrator(string text)
+        {
+            var voiceIdx = text.IndexOf("<v ", StringComparison.OrdinalIgnoreCase);
+            while (voiceIdx >= 0)
+            {
+                var voiceEndIdx = text.IndexOf(">", voiceIdx + 3, StringComparison.OrdinalIgnoreCase);
+                if (voiceEndIdx < 0)
+                {
+                    break;
+                }
+
+                // voice no tag
+                string voice = text.Substring(voiceIdx + 2, voiceEndIdx - (voiceIdx + 2)).Trim();
+                text = text.Remove(voiceIdx, voiceEndIdx - voiceIdx + 1);
+
+                // remove empty voice
+                if (voice.Length != 0)
+                {
+                    text = text.Insert(voiceIdx, voice + ": ");
+                }
+
+                voiceIdx = text.IndexOf("<v ", voiceIdx, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return text;
         }
 
         /// <summary>


### PR DESCRIPTION
Replaced the `RemoveTag("v")` logic with a new `VoiceToNarrator` method to handle `<v>` tags in WebVTT subtitles. This ensures that voice annotations are preserved as narrator text instead of being removed entirely. The change improves subtitle readability by maintaining contextual speaker information.