### PR TITLE
Normalize language codes to lowercase when retrieving them

### DIFF
--- a/src/ui/Forms/Translate/AutoTranslate.cs
+++ b/src/ui/Forms/Translate/AutoTranslate.cs
@@ -792,10 +792,11 @@ namespace Nikse.SubtitleEdit.Forms.Translate
                 {
                     continue;
                 }
-                var iso639 = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(layoutName);
+
+                var iso639 = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(layoutName)?.ToLowerInvariant();
                 if (!string.IsNullOrEmpty(iso639) && !installedLanguages.Contains(iso639))
                 {
-                    installedLanguages.Add(iso639.ToLowerInvariant());
+                    installedLanguages.Add(iso639);
                 }
             }
 


### PR DESCRIPTION
The two-letter language code is now explicitly converted to lowercase when retrieved to ensure consistency. This change eliminates redundant `.ToLowerInvariant()` calls and ensures `installedLanguages` contains uniformly formatted codes.