### PR TITLE
Refactor method names for clarity in SpellCheckWordLists.

### DIFF
--- a/src/libse/SpellCheck/SpellCheckWordLists.cs
+++ b/src/libse/SpellCheck/SpellCheckWordLists.cs
@@ -161,12 +161,12 @@ namespace Nikse.SubtitleEdit.Core.SpellCheck
             return Path.Combine(_dictionaryFolder, _languageName + "_UseAlways.xml");
         }
 
-        public void UseAlwaysListAdd(string newKey, string newValue)
+        public void AddToUseAlwaysList(string newKey, string newValue)
         {
             SaveUseAlwaysList(newKey, newValue);
         }
 
-        public void UseAlwaysListRemove(string key)
+        public void RemoveFromUseAlwaysList(string key)
         {
             SaveUseAlwaysList(null, null, key);
         }

--- a/src/ui/Forms/SpellCheck.cs
+++ b/src/ui/Forms/SpellCheck.cs
@@ -802,7 +802,7 @@ namespace Nikse.SubtitleEdit.Forms
                     if (!_changeAllDictionary.ContainsKey(_currentWord))
                     {
                         _changeAllDictionary.Add(_currentWord, ChangeWord);
-                        _spellCheckWordLists.UseAlwaysListAdd(_currentWord, ChangeWord);
+                        _spellCheckWordLists.AddToUseAlwaysList(_currentWord, ChangeWord);
                     }
                     _mainWindow.CorrectWord(_prefix + ChangeWord + _postfix, _currentParagraph, _prefix + _currentWord + _postfix, ref _firstChange, -1);
                     break;
@@ -1725,7 +1725,7 @@ namespace Nikse.SubtitleEdit.Forms
                     case SpellCheckAction.ChangeAll:
                         _subtitle = _mainWindow.UndoFromSpellCheck(undo.Subtitle);
                         _changeAllDictionary.Remove(undo.CurrentWord);
-                        _spellCheckWordLists.UseAlwaysListRemove(undo.CurrentWord);
+                        _spellCheckWordLists.RemoveFromUseAlwaysList(undo.CurrentWord);
                         break;
                     case SpellCheckAction.Skip:
                         break;

--- a/src/ui/Logic/Ocr/OcrFixEngine.cs
+++ b/src/ui/Logic/Ocr/OcrFixEngine.cs
@@ -1843,7 +1843,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                         _ocrFixReplaceList.AddWordOrPartial(word, _spellCheck.Word);
                         if (!word.Contains(' '))
                         {
-                            _spellCheckWordLists?.UseAlwaysListAdd(word, _spellCheck.Word);
+                            _spellCheckWordLists?.AddToUseAlwaysList(word, _spellCheck.Word);
                         }
                     }
                     catch (Exception exception)


### PR DESCRIPTION
Renamed methods in SpellCheckWordLists to improve readability and align with naming conventions. Updated all references to these methods across the codebase to ensure consistency.