### PR TITLE
Fixes plugin update not visible issue

### DIFF
--- a/src/ui/Logic/Plugins/InstalledPluginMetadataProvider.cs
+++ b/src/ui/Logic/Plugins/InstalledPluginMetadataProvider.cs
@@ -12,11 +12,13 @@ namespace Nikse.SubtitleEdit.Logic.Plugins
             var installedPlugins = new List<PluginInfoItem>();
             foreach (var pluginFileName in Configuration.GetPlugins())
             {
-                Main.GetPropertiesAndDoAction(pluginFileName, out var name, out _, out var version, out var description, out var actionType, out _, out var mi);
+                Main.GetPropertiesAndDoAction(pluginFileName, out var name, out var text, out var version,
+                    out var description, out var actionType, out _, out var mi);
                 if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(actionType) && mi != null)
                 {
                     installedPlugins.Add(new PluginInfoItem
                     {
+                        Text = text.Trim('.', ' '),
                         Name = name.Trim('.', ' '),
                         Description = description,
                         Version = version.ToString(CultureInfo.InvariantCulture),

--- a/src/ui/Logic/Plugins/OnlinePluginMetadataProvider.cs
+++ b/src/ui/Logic/Plugins/OnlinePluginMetadataProvider.cs
@@ -59,7 +59,7 @@ namespace Nikse.SubtitleEdit.Logic.Plugins
             var date = element.Element(nameof(PluginInfoItem.Date))?.Value;
             var url = element.Element(nameof(PluginInfoItem.Url))?.Value;
 
-            return new PluginInfoItem { Name = name, Description = description, Version = version, Date = date, Url = url };
+            return new PluginInfoItem { Text = name, Name = name, Description = description, Version = version, Date = date, Url = url };
         }
     }
 }

--- a/src/ui/Logic/Plugins/PluginInfoItem.cs
+++ b/src/ui/Logic/Plugins/PluginInfoItem.cs
@@ -2,6 +2,7 @@ namespace Nikse.SubtitleEdit.Logic.Plugins
 {
     public class PluginInfoItem
     {
+        public string Text { get; set; }
         public string Name { get; set;  }
         public string Version { get; set; }
         public string Description { get; set; }

--- a/src/ui/Logic/Plugins/PluginUpdateChecker.cs
+++ b/src/ui/Logic/Plugins/PluginUpdateChecker.cs
@@ -17,7 +17,8 @@ namespace Nikse.SubtitleEdit.Logic.Plugins
             var list = new List<PluginUpdate>();
             foreach (var installedPlugin in installedPlugins)
             {
-                var onlinePlugin = onlinePlugins.FirstOrDefault(p => p.Name == installedPlugin.Name);
+                var onlinePlugin = onlinePlugins.FirstOrDefault(p => 
+                    (p.Name == installedPlugin.Text) || (p.Name == installedPlugin.Name));
                 if (onlinePlugin != null &&
                     MakeComparableVersionNumber(installedPlugin.Version) < 
                     MakeComparableVersionNumber(onlinePlugin.Version))


### PR DESCRIPTION
Fixes issue where some plugins updates weren't visible.

Sometimes plugin name and text aren't equal for example

https://github.com/SubtitleEdit/plugins/blob/main/Plugins4.xml#L21 we are only storing name 
which is name equal to the actually plugin name "HI2UC" 