### PR TITLE
Simplify AddRange logic and improve type handling.

### DIFF
--- a/src/ui/Controls/NikseComboBoxCollection.cs
+++ b/src/ui/Controls/NikseComboBoxCollection.cs
@@ -18,15 +18,7 @@ namespace Nikse.SubtitleEdit.Controls
 
         public List<object> ToList() => _items;
 
-        public void AddRange(object[] items)
-        {
-            _items.AddRange(items);
-        }
-
-        public void AddRange(string[] items)
-        {
-            _items.AddRange(items);
-        }
+        public void AddRange<T>(IEnumerable<T> items) where T : class => _items.AddRange(items);
 
         public IEnumerator GetEnumerator()
         {

--- a/src/ui/Forms/Translate/AutoTranslate.cs
+++ b/src/ui/Forms/Translate/AutoTranslate.cs
@@ -142,7 +142,7 @@ namespace Nikse.SubtitleEdit.Forms.Translate
             };
 
             nikseComboBoxEngine.Items.Clear();
-            nikseComboBoxEngine.Items.AddRange(_autoTranslatorEngines.Select(p => p.Name).ToArray<object>());
+            nikseComboBoxEngine.Items.AddRange(_autoTranslatorEngines);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.AutoTranslateLastName))
             {
@@ -752,12 +752,12 @@ namespace Nikse.SubtitleEdit.Forms.Translate
                     }
                 }
 
-                comboBox.Items.AddRange(languagesToAdd.OrderBy(p => p.Name).ToArray<object>());
+                comboBox.Items.AddRange(languagesToAdd.OrderBy(p => p.Name));
             }
 
             if (!languagesFilled)
             {
-                comboBox.Items.AddRange(languages.OrderBy(p => p.Name).ToArray<object>());
+                comboBox.Items.AddRange(languages.OrderBy(p => p.Name));
             }
 
             comboBox.Items.Add(LanguageSettings.Current.General.ChangeLanguageFilter);
@@ -1393,7 +1393,7 @@ namespace Nikse.SubtitleEdit.Forms.Translate
 
         private IAutoTranslator GetCurrentEngine()
         {
-            return _autoTranslatorEngines.First(p => p.Name == nikseComboBoxEngine.Text);
+            return (IAutoTranslator)nikseComboBoxEngine.SelectedItem;
         }
 
         private void buttonCancel_Click(object sender, EventArgs e)


### PR DESCRIPTION
Replaced duplicate AddRange methods with a generic implementation to reduce redundancy. Updated code to pass typed collections directly instead of casting, improving clarity and type safety. This change ensures better maintainability and consistency in handling items.