### PR TITLE
Remove redundant `return` and `continue` statements.

### DIFF
--- a/src/libse/SubtitleFormats/BelleNuitSubtitler.cs
+++ b/src/libse/SubtitleFormats/BelleNuitSubtitler.cs
@@ -232,7 +232,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 else if (RegexFileNum.IsMatch(line))
                 {
-                    continue; // skip Belle-Nuit's numbering lines ("/file 0001")
                 }
                 else if (paragraph != null)
                 {

--- a/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesManager.cs
+++ b/src/ui/Forms/Assa/SubStationAlphaStylesCategoriesManager.cs
@@ -381,7 +381,6 @@ namespace Nikse.SubtitleEdit.Forms.Assa
                 catch (Exception exception)
                 {
                     MessageBox.Show(exception.Message);
-                    return;
                 }
             }
         }

--- a/src/ui/Forms/AudioToText/WhisperAudioToText.cs
+++ b/src/ui/Forms/AudioToText/WhisperAudioToText.cs
@@ -1760,7 +1760,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 if (downloadForm.ShowDialog(this) != DialogResult.OK)
                                 {
                                     Configuration.Settings.Tools.WhisperIgnoreVersion = true;
-                                    return;
                                 }
                             }
                         }
@@ -1774,7 +1773,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                         {
                             if (downloadForm.ShowDialog(this) != DialogResult.OK)
                             {
-                                return;
                             }
                         }
                     }
@@ -1795,7 +1793,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 if (downloadForm.ShowDialog(this) != DialogResult.OK)
                                 {
                                     Configuration.Settings.Tools.WhisperIgnoreVersion = true;
-                                    return;
                                 }
                             }
                         }
@@ -1809,7 +1806,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                         {
                             if (downloadForm.ShowDialog(this) != DialogResult.OK)
                             {
-                                return;
                             }
                         }
                     }
@@ -1830,7 +1826,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 if (downloadForm.ShowDialog(this) != DialogResult.OK)
                                 {
                                     Configuration.Settings.Tools.WhisperIgnoreVersion = true;
-                                    return;
                                 }
                             }
                         }
@@ -1844,7 +1839,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                         {
                             if (downloadForm.ShowDialog(this) != DialogResult.OK)
                             {
-                                return;
                             }
                         }
                     }
@@ -1865,7 +1859,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                                 if (downloadForm.ShowDialog(this) != DialogResult.OK)
                                 {
                                     Configuration.Settings.Tools.WhisperIgnoreVersion = true;
-                                    return;
                                 }
                             }
                         }
@@ -1879,7 +1872,6 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
                         {
                             if (downloadForm.ShowDialog(this) != DialogResult.OK)
                             {
-                                return;
                             }
                         }
                     }

--- a/src/ui/Forms/ConvertActor.cs
+++ b/src/ui/Forms/ConvertActor.cs
@@ -212,7 +212,6 @@ namespace Nikse.SubtitleEdit.Forms
                 }
                 else
                 {
-                    continue;
                 }
             }
 

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -19569,7 +19569,6 @@ namespace Nikse.SubtitleEdit.Forms
                 }
                 catch
                 {
-                    return;
                 }
             }
             else if (mediaPlayer.VideoPlayer is LibVlcDynamic libVlc)
@@ -19595,7 +19594,6 @@ namespace Nikse.SubtitleEdit.Forms
                 }
                 catch
                 {
-                    return;
                 }
             }
         }
@@ -19619,7 +19617,6 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (form.ShowDialog(this) != DialogResult.OK)
                 {
-                    return;
                 }
             }
         }
@@ -33049,8 +33046,6 @@ namespace Nikse.SubtitleEdit.Forms
                         Configuration.Settings.SubtitleSettings.NuendoCharacterListFile = form.CharacterListFile;
                     }
                 }
-
-                return;
             }
         }
 
@@ -36479,7 +36474,6 @@ namespace Nikse.SubtitleEdit.Forms
             if (e.X > 72 && e.X <= (122 + textBoxListViewText.Height) && !textBoxListViewText.Enabled)
             {
                 InsertLineToolStripMenuItemClick(null, null);
-                return;
             }
         }
 
@@ -37243,7 +37237,6 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 if (form.ShowDialog(this) != DialogResult.OK)
                 {
-                    return;
                 }
             }
         }

--- a/src/ui/Forms/Ocr/DownloadPaddleOCR.cs
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCR.cs
@@ -57,7 +57,6 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
                 }
                 CompleteDownload(_tempFileName);
-                return;
             }
             catch (Exception exception)
             {

--- a/src/ui/Forms/Ocr/DownloadPaddleOCRCPU.cs
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCRCPU.cs
@@ -57,7 +57,6 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 
                 }
                 CompleteDownload(_tempFileName);
-                return;
             }
             catch (Exception exception)
             {

--- a/src/ui/Logic/Ocr/PaddleOcr.cs
+++ b/src/ui/Logic/Ocr/PaddleOcr.cs
@@ -218,7 +218,6 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
                     else if (outLine.Data.Contains("ppocr WARNING: No text found in image"))
                     {
                         result = string.Empty;
-                        return;
                     }
                     else if (outLine.Data.Contains("ppocr INFO:"))
                     {


### PR DESCRIPTION
Simplifies control flow by eliminating unnecessary `return` and `continue` statements across multiple files. This improves readability and maintains consistent coding practices without affecting functionality.