### PR TITLE
Fixed: Wrong duration of DVB Subtitles, support for Stuffing type

### DIFF
--- a/src/libse/ContainerFormats/TransportStream/SubtitleSegment.cs
+++ b/src/libse/ContainerFormats/TransportStream/SubtitleSegment.cs
@@ -9,6 +9,7 @@
         public const int ObjectDataSegment = 0x13;
         public const int DisplayDefinitionSegment = 0x14;
         public const int EndOfDisplaySetSegment = 0x80;
+        public const int StuffingSegment = 0xFF;
 
         public int SyncByte { get; set; }
         public int SegmentType { get; set; }
@@ -62,6 +63,8 @@
                     break;
                 case DisplayDefinitionSegment:
                     DisplayDefinition = new DisplayDefinitionSegment(buffer, index + 6);
+                    break;           
+                case StuffingSegment:                    
                     break;
                 case EndOfDisplaySetSegment:
                     break;
@@ -80,6 +83,7 @@
                     case ObjectDataSegment: return "Object data segment";
                     case DisplayDefinitionSegment: return "Display definition segment";
                     case EndOfDisplaySetSegment: return "End of display set segment";
+                    case StuffingSegment: return "Stuffing segment";
                     default: return "Unknown";
                 }
             }

--- a/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
@@ -256,14 +256,30 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                     if (pes.ObjectDataList.Count > 0)
                     {
                         var sub = new TransportStreamSubtitle { StartMilliseconds = pes.PresentationTimestampToMilliseconds(), Pes = pes };
-                        if (i + 1 < list.Count && list[i + 1].PresentationTimestampToMilliseconds() > 25)
+                        if (i + 1 < list.Count)
                         {
-                            sub.EndMilliseconds = list[i + 1].PresentationTimestampToMilliseconds() - 25;
+                            var ndx = i + 1;
+                            while (ndx < list.Count)
+                            {
+                                var entry = list[ndx]; ndx++;
+                                if (entry.SubtitleSegments.Count == 0) continue;
+
+                                //we need EndOfDisplaySegment to stop the subtitle. In other case we can get Stuffing or something else
+                                if (!entry.SubtitleSegments.Any(p => p.SegmentType == SubtitleSegment.EndOfDisplaySetSegment)) continue;
+
+
+                                sub.EndMilliseconds = entry.PresentationTimestampToMilliseconds() ;
+                                break;
+                            }
+
                         }
+
+
                         if (sub.EndMilliseconds < sub.StartMilliseconds || sub.EndMilliseconds - sub.StartMilliseconds > (ulong)Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                         {
                             sub.EndMilliseconds = sub.StartMilliseconds + (ulong)Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds;
                         }
+
 
                         if (offset <= (long)sub.StartMilliseconds || offset < 0)
                         {


### PR DESCRIPTION
Support for stuffing segment and proper end time calculation of DVB Bitmap subtitles