### PR TITLE
Refactor OCR delay logic to use `Task.Delay` directly

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -2657,19 +2657,6 @@ namespace Nikse.SubtitleEdit.Core.Common
             return text;
         }
 
-        /// <summary>
-        /// Creates a task that will complete after a time delay.
-        /// </summary>
-        /// <param name="millisecondsDelay">The number of milliseconds to wait before completing the returned task.</param>
-        /// <returns>A task that represents the time delay.</returns>
-        public static Task TaskDelay(int millisecondsDelay)
-        {
-            var tcs = new TaskCompletionSource<object>();
-            var t = new System.Threading.Timer(_ => tcs.SetResult(null));
-            t.Change(millisecondsDelay, -1);
-            return tcs.Task;
-        }
-
         public static SubtitleFormat LoadMatroskaTextSubtitle(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska, List<MatroskaSubtitle> sub, Subtitle subtitle)
         {
             if (subtitle == null)

--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -8587,16 +8587,14 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             }
         }
 
-        internal void StartOcrFromDelayed()
+        internal async Task StartOcrFromDelayed()
         {
             if (_lastAdditions.Count > 0)
             {
                 var last = _lastAdditions[_lastAdditions.Count - 1];
                 numericUpDownStartNumber.Value = last.Index + 1;
-
-                // Simulate a click on ButtonStartOcr in 200ms.
-                var uiContext = TaskScheduler.FromCurrentSynchronizationContext();
-                Utilities.TaskDelay(200).ContinueWith(_ => ButtonStartOcrClick(null, null), uiContext);
+                await Task.Delay(200, CancellationToken.None);
+                ButtonStartOcrClick(null, null);
             }
         }
 

--- a/src/ui/Forms/Ocr/VobSubOcrCharacter.cs
+++ b/src/ui/Forms/Ocr/VobSubOcrCharacter.cs
@@ -231,7 +231,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             DialogResult = DialogResult.OK;
         }
 
-        private void buttonLastEdit_Click(object sender, EventArgs e)
+        private async void buttonLastEdit_Click(object sender, EventArgs e)
         {
             if (_additions.Count > 0)
             {
@@ -240,7 +240,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 if (result == DialogResult.OK)
                 {
                     _additions.RemoveAt(_additions.Count - 1);
-                    _vobSubForm.StartOcrFromDelayed();
+                    await _vobSubForm.StartOcrFromDelayed();
                     DialogResult = DialogResult.Abort;
                 }
             }


### PR DESCRIPTION
Replaced `Utilities.TaskDelay` with `Task.Delay` in `StartOcrFromDelayed` for cleaner and more modern asynchronous programming. Removed the custom `TaskDelay` implementation from `Utilities` as it is no longer needed. This simplifies the code and reduces dependency on custom utilities.