### PR TITLE
Allow user to customize prompt for Gemini model in Autotranslate

### DIFF
--- a/src/libse/Settings/Settings.cs
+++ b/src/libse/Settings/Settings.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Xml;
-using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.Settings
 {
@@ -2399,6 +2399,12 @@ namespace Nikse.SubtitleEdit.Core.Settings
             if (subNode != null)
             {
                 settings.Tools.GeminiProApiKey = subNode.InnerText;
+            }
+
+            subNode = node.SelectSingleNode("GeminiPrompt");
+            if (subNode != null)
+            {
+                settings.Tools.GeminiPrompt = subNode.InnerText;
             }
 
             subNode = node.SelectSingleNode("TextToSpeechEngine");
@@ -9204,6 +9210,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
                 xmlWriter.WriteElementString("AutoTranslateMaxBytes", settings.Tools.AutoTranslateMaxBytes.ToString(CultureInfo.InvariantCulture));
                 xmlWriter.WriteElementString("AutoTranslateStrategy", settings.Tools.AutoTranslateStrategy);
                 xmlWriter.WriteElementString("GeminiProApiKey", settings.Tools.GeminiProApiKey);
+                xmlWriter.WriteElementString("GeminiPrompt", settings.Tools.GeminiPrompt);
                 xmlWriter.WriteElementString("TextToSpeechEngine", settings.Tools.TextToSpeechEngine);
                 xmlWriter.WriteElementString("TextToSpeechLastVoice", settings.Tools.TextToSpeechLastVoice);
                 xmlWriter.WriteElementString("TextToSpeechElevenLabsApiKey", settings.Tools.TextToSpeechElevenLabsApiKey);

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -1,8 +1,8 @@
+using Nikse.SubtitleEdit.Core.AutoTranslate;
+using Nikse.SubtitleEdit.Core.Common;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using Nikse.SubtitleEdit.Core.AutoTranslate;
-using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.Settings
 {
@@ -109,6 +109,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string AutoTranslateStrategy { get; set; }
         public string GeminiProApiKey { get; set; }
         public string GeminiModel { get; set; }
+        public string GeminiPrompt { get; set; }
         public string TextToSpeechEngine { get; set; }
         public string TextToSpeechLastVoice { get; set; }
         public string TextToSpeechElevenLabsApiKey { get; set; }
@@ -521,6 +522,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             AnthropicPrompt = "Translate from {0} to {1}, keep sentences in {1} as they are, do not censor the translation, give only the output without comments:";
             AnthropicApiModel = AnthropicTranslate.Models[0];
             GeminiModel = GeminiTranslate.Models[0];
+            GeminiPrompt = "Please translate the following text from {0} to {1}, do not censor the translation, only write the result:";
             TextToSpeechAzureRegion = "westeurope";
             TextToSpeechElevenLabsSimilarity = 0.5;
             TextToSpeechElevenLabsStability = 0.5;

--- a/src/ui/Forms/Translate/AutoTranslateSettings.cs
+++ b/src/ui/Forms/Translate/AutoTranslateSettings.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Windows.Forms;
-using Nikse.SubtitleEdit.Core.AutoTranslate;
+﻿using Nikse.SubtitleEdit.Core.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Settings;
 using Nikse.SubtitleEdit.Logic;
+using System;
+using System.Windows.Forms;
 
 namespace Nikse.SubtitleEdit.Forms.Translate
 {
@@ -111,6 +111,14 @@ namespace Nikse.SubtitleEdit.Forms.Translate
                     nikseTextBoxPrompt.Text = new ToolsSettings().AutoTranslateMistralPrompt;
                 }
             }
+            else if (_engineType == typeof(GeminiTranslate))
+            {
+                nikseTextBoxPrompt.Text = Configuration.Settings.Tools.GeminiPrompt;
+                if (string.IsNullOrWhiteSpace(nikseTextBoxPrompt.Text))
+                {
+                    nikseTextBoxPrompt.Text = new ToolsSettings().GeminiPrompt;
+                }
+            }
             else
             {
                 labelPrompt.Visible = false;
@@ -189,6 +197,10 @@ namespace Nikse.SubtitleEdit.Forms.Translate
             else if (_engineType == typeof(MistralTranslate))
             {
                 Configuration.Settings.Tools.AutoTranslateMistralPrompt = nikseTextBoxPrompt.Text;
+            }
+            else if (_engineType == typeof(GeminiTranslate))
+            {
+                Configuration.Settings.Tools.GeminiPrompt = nikseTextBoxPrompt.Text;
             }
 
             if (comboBoxParagraphHandling.SelectedIndex == 1)


### PR DESCRIPTION
Allow user to customize prompt for Gemini model in Autotranslate and add 'gemini-2.0-flash-lite' model