### PR TITLE
Remove redundant GetCharactersPerSecond overload

### DIFF
--- a/src/libse/Common/Paragraph.cs
+++ b/src/libse/Common/Paragraph.cs
@@ -135,16 +135,6 @@ namespace Nikse.SubtitleEdit.Core.Common
             return (double)Text.CountCharacters(true) / DurationTotalSeconds;
         }
 
-        public double GetCharactersPerSecond(double numberOfCharacters)
-        {
-            if (DurationTotalMilliseconds < 1)
-            {
-                return 999;
-            }
-
-            return numberOfCharacters / DurationTotalSeconds;
-        }
-
         public double GetCharactersPerSecond(ICalcLength calc)
         {
             if (DurationTotalMilliseconds < 1)

--- a/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
@@ -70,8 +70,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 if (!skip && charactersPerSecond > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                 {
                     var temp = new Paragraph(p);
-                    var numberOfCharacters = (double)temp.Text.CountCharacters(true);
-                    while (temp.GetCharactersPerSecond(numberOfCharacters) > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                    while (temp.GetCharactersPerSecond() > Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
                     {
                         temp.EndTime.TotalMilliseconds++;
                     }


### PR DESCRIPTION
Simplified code by removing the GetCharactersPerSecond overload that accepted a character count parameter. Updated the usage to rely on the existing method, improving maintainability and reducing duplication.