### PR TITLE
Fixes wrong usage of ControlStyles flags

### DIFF
--- a/src/ui/Controls/VideoPlayerContainer.cs
+++ b/src/ui/Controls/VideoPlayerContainer.cs
@@ -18,9 +18,11 @@ namespace Nikse.SubtitleEdit.Controls
         {
             public DoubleBufferedPanel()
             {
-                this.DoubleBuffered = true;
-                this.SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
-                this.UpdateStyles();
+                DoubleBuffered = true;
+                SetStyle(ControlStyles.OptimizedDoubleBuffer |
+                         ControlStyles.AllPaintingInWmPaint |
+                         ControlStyles.UserPaint, true);
+                UpdateStyles();
             }
         }
 


### PR DESCRIPTION
See: https://learn.microsoft.com/en-us/dotnet/api/System.Windows.Forms.ControlStyles?view=netframework-4.8


> **AllPaintingInWmPaint**: 

    If true, the control ignores the window message WM_ERASEBKGND to reduce flicker. This style should only be applied if the 
    [UserPaint](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.controlstyles?view=netframework- 
    4.8#system-windows-forms-controlstyles-userpaint) bit is set to true.