### PR TITLE
Make update-checking process asynchronous

### DIFF
--- a/src/ui/Forms/CheckForUpdates.cs
+++ b/src/ui/Forms/CheckForUpdates.cs
@@ -66,7 +66,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        private void CheckForUpdates_Shown(object sender, EventArgs e)
+        private async void CheckForUpdates_Shown(object sender, EventArgs e)
         {
             if (!_performCheckOnShown)
             {
@@ -75,9 +75,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             _updatesHelper = new CheckForUpdatesHelper();
-            Application.DoEvents();
-            Refresh();
-            _updatesHelper.CheckForUpdates(true);
+            await _updatesHelper.CheckForUpdates(true);
             timerCheckForUpdates.Start();
 
             buttonOK.Focus();

--- a/src/ui/Logic/CheckForUpdatesHelper.cs
+++ b/src/ui/Logic/CheckForUpdatesHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Http;
 using Nikse.SubtitleEdit.Forms;
@@ -93,7 +94,7 @@ namespace Nikse.SubtitleEdit.Logic
             return sb.ToString();
         }
 
-        public void CheckForUpdates(bool manualCheck)
+        public async Task CheckForUpdates(bool manualCheck)
         {
             ManualCheck = manualCheck;
 
@@ -101,7 +102,7 @@ namespace Nikse.SubtitleEdit.Logic
             {
                 using (var httpClient = DownloaderFactory.MakeHttpClient())
                 {
-                    _changeLog = httpClient.GetStringAsync(ChangeLogUrl).Result;
+                    _changeLog = await httpClient.GetStringAsync(ChangeLogUrl).ConfigureAwait(false);
                 }
 
                 var installedPlugins = new InstalledPluginMetadataProvider().GetPlugins();


### PR DESCRIPTION
Converted update logic to use async/await for better responsiveness. This improves application performance and avoids blocking the UI during update checks.