### PR TITLE
Switch PaddleOCR Standalone CUDA version to 11.8 for better compatibility

### DIFF
--- a/src/ui/Forms/Ocr/DownloadPaddleOCR.cs
+++ b/src/ui/Forms/Ocr/DownloadPaddleOCR.cs
@@ -12,7 +12,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
 {
     public sealed partial class DownloadPaddleOCR : Form
     {
-        public const string DownloadUrl = "https://github.com/timminator/PaddleOCR-Standalone/releases/download/v.1.0.0/PaddleOCR-GPU-v1.0.0.7z";
+        public const string DownloadUrl = "https://github.com/timminator/PaddleOCR-Standalone/releases/download/v.1.0.0/PaddleOCR-GPU-v1.0.0-CUDA-11.8.7z";
         private readonly CancellationTokenSource _cancellationTokenSource;
 
         private string _tempFileName;
@@ -83,7 +83,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
                 Directory.CreateDirectory(dictionaryFolder);
             }
 
-            Extract7Zip(downloadStream, dictionaryFolder, "PaddleOCR-GPU-v1.0.0");
+            Extract7Zip(downloadStream, dictionaryFolder, "PaddleOCR-GPU-v1.0.0-CUDA-11.8");
             Cursor = Cursors.Default;
             labelPleaseWait.Text = string.Empty;
             Cursor = Cursors.Default;

--- a/src/ui/Forms/Ocr/VobSubOcr.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.cs
@@ -339,8 +339,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         private int _tesseractOcrAutoFixes;
         private string Tesseract5Version = "5.5.0";
 
-        // Minimum driver version for CUDA 12.3 (PaddleOCR GPU version)
-        private static readonly string requiredDriverVersion = "545.84";
+        // Minimum driver version for CUDA 11.8 (PaddleOCR GPU version)
+        private static readonly string requiredDriverVersion = "522.25";
 
         // Last PaddleOCR version that does not support batch mode
         private static readonly Version lastPaddleOcrVersionWithoutBatchMode = new Version(2, 9, 1);


### PR DESCRIPTION
As described in my comment in #9536.
With this PR PaddleOCR in SubtitleEdit utilizes the standalone version compiled with CUDA 11.8 instead of the one with CUDA 12.3 that was used before. This ensures better compatibility with older GPUs (e.g. Pascal GPUs).

Fixes: https://github.com/timminator/PaddleOCR-Standalone/issues/1