### PR TITLE
Switch PaddleOCR GPU parameter to true by default

### DIFF
--- a/src/libse/Settings/VobSubOcrSettings.cs
+++ b/src/libse/Settings/VobSubOcrSettings.cs
@@ -72,7 +72,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             LastBinaryImageCompareDb = "Latin+Latin";
             BinaryAutoDetectBestDb = true;
             PaddleOcrLanguageCode = "en";
-            PaddleOcrUseGpu = false;
+            PaddleOcrUseGpu = true;
             CaptureTopAlign = false;
             UnfocusedAttentionBlinkCount = 50;
             UnfocusedAttentionPlaySoundCount = 1;


### PR DESCRIPTION
Until now "Use GPU" was set to false by default. This meant if the user did not enable it manually it would not use the GPU. This can cause performance problems because running the GPU version on the CPU is slower than running the CPU version right away.
This PR switches this parameter to true by default.
This does also not cause any issues when using the CPU version. PaddleOCR just ignores the parameter being true in this case.