### PR TITLE
Fix incorrect bitmask for extracting EdgeColorRed

### DIFF
--- a/src/libse/Cea708/Commands/SetPenColor.cs
+++ b/src/libse/Cea708/Commands/SetPenColor.cs
@@ -54,7 +54,7 @@
 
             EdgeColorBlue = bytes[index + 2] & 0b00000011;
             EdgeColorGreen = (bytes[index + 2] & 0b00001100) >> 2;
-            EdgeColorRed = (bytes[index + 2] & 0b11110000) >> 4;
+            EdgeColorRed = (bytes[index + 2] & 0b00110000) >> 4;
         }
 
         public byte[] GetBytes()


### PR DESCRIPTION
The previous bitmask incorrectly included unused higher bits, causing potential inaccuracies in color decoding. Adjusted the mask to correctly isolate the red component from the byte data.