### PR TITLE
Refactor async HTTP calls for improved await handling

### DIFF
--- a/src/libse/AutoTranslate/AnthropicTranslate.cs
+++ b/src/libse/AutoTranslate/AnthropicTranslate.cs
@@ -79,8 +79,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{ \"model\": \"" + model + "\", \"max_tokens\": 1024, \"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/AvalAi.cs
+++ b/src/libse/AutoTranslate/AvalAi.cs
@@ -112,8 +112,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libse/AutoTranslate/ChatGptTranslate.cs
@@ -99,8 +99,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/DeepLTranslate.cs
+++ b/src/libse/AutoTranslate/DeepLTranslate.cs
@@ -138,15 +138,15 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var postContent = MakeContent(text, sourceLanguageCode, targetLanguageCode);
-                result = await _httpClient.PostAsync("/v2/translate", postContent, cancellationToken);
-                resultContent = await result.Content.ReadAsStringAsync();
+                result = await _httpClient.PostAsync("/v2/translate", postContent, cancellationToken).ConfigureAwait(false);
+                resultContent = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (!ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {
                     break;
                 }
 
-                await Task.Delay(retryDelays[attempt], cancellationToken);
+                await Task.Delay(retryDelays[attempt], cancellationToken).ConfigureAwait(false);
             }
 
             if (!result.IsSuccessStatusCode)

--- a/src/libse/AutoTranslate/DeepLXTranslate.cs
+++ b/src/libse/AutoTranslate/DeepLXTranslate.cs
@@ -55,15 +55,15 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var postContent = MakeContent(text, sourceLanguageCode, targetLanguageCode);
-                result = await _httpClient.PostAsync("/translate", postContent, cancellationToken);
-                resultContent = await result.Content.ReadAsStringAsync();
+                result = await _httpClient.PostAsync("/translate", postContent, cancellationToken).ConfigureAwait(false);
+                resultContent = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (!DeepLTranslate.ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {
                     break;
                 }
 
-                await Task.Delay(retryDelays[attempt], cancellationToken);
+                await Task.Delay(retryDelays[attempt], cancellationToken).ConfigureAwait(false);
             }
 
             if (!result.IsSuccessStatusCode)
@@ -87,11 +87,9 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                     var resultTextWithFixedNewLines = ChatGptTranslate.FixNewLines(resultText);
                     return resultTextWithFixedNewLines.Trim();
                 }
-                else
-                {
-                    SeLogger.Error("DeepLXTranslate.Translate: " + resultContent);
-                    throw new Exception("DeepLXTranslate gave empty alternatives: StatusCode=" + result.StatusCode + Environment.NewLine + resultContent);
-                }
+
+                SeLogger.Error("DeepLXTranslate.Translate: " + resultContent);
+                throw new Exception("DeepLXTranslate gave empty alternatives: StatusCode=" + result.StatusCode + Environment.NewLine + resultContent);
             }
             catch (Exception ex)
             {

--- a/src/libse/AutoTranslate/DeepSeekTranslate.cs
+++ b/src/libse/AutoTranslate/DeepSeekTranslate.cs
@@ -80,15 +80,15 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             {
                 var content = new StringContent(input, Encoding.UTF8);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-                result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-                resultContent = await result.Content.ReadAsStringAsync();
+                result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
+                resultContent = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (!DeepLTranslate.ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {
                     break;
                 }
 
-                await Task.Delay(retryDelays[attempt], cancellationToken);
+                await Task.Delay(retryDelays[attempt], cancellationToken).ConfigureAwait(false);
             }
 
             if (!result.IsSuccessStatusCode)

--- a/src/libse/AutoTranslate/GeminiTranslate.cs
+++ b/src/libse/AutoTranslate/GeminiTranslate.cs
@@ -80,7 +80,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var content = MakeContent(text, sourceLanguageCode, targetLanguageCode);
-                result = await _httpClient.PostAsync(_baseUrl, content, cancellationToken);
+                result = await _httpClient.PostAsync(_baseUrl, content, cancellationToken).ConfigureAwait(false);
 
                 if (result.StatusCode == System.Net.HttpStatusCode.NotFound && !switchedBaseUrl)
                 {
@@ -98,14 +98,14 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                     continue;
                 }
 
-                resultContent = await result.Content.ReadAsStringAsync();
+                resultContent = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (!DeepLTranslate.ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {
                     break;
                 }
 
-                await Task.Delay(retryDelays[attempt], cancellationToken);
+                await Task.Delay(retryDelays[attempt], cancellationToken).ConfigureAwait(false);
             }
 
             if (!result.IsSuccessStatusCode)

--- a/src/libse/AutoTranslate/GoogleTranslateV1.cs
+++ b/src/libse/AutoTranslate/GoogleTranslateV1.cs
@@ -45,7 +45,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return GetTranslationPairs();
         }
 
-        public Task<string> Translate(string input, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string input, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             string jsonResultString;
 
@@ -54,8 +54,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 var text = input.Replace("\r'",string.Empty).Trim();
                 var url = $"translate_a/single?client=gtx&sl={sourceLanguageCode}&tl={targetLanguageCode}&dt=t&q={Utilities.UrlEncode(text)}";
 
-                var result = _httpClient.GetAsync(url).Result;
-                var bytes = result.Content.ReadAsByteArrayAsync().Result;
+                var result = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 jsonResultString = Encoding.UTF8.GetString(bytes).Trim();
 
                 if (!result.IsSuccessStatusCode)
@@ -70,7 +70,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
 
             var resultList = ConvertJsonObjectToStringLines(jsonResultString);
-            return Task.FromResult(string.Join(Environment.NewLine, resultList));
+            return string.Join(Environment.NewLine, resultList);
         }
 
         public static List<TranslationPair> GetTranslationPairs()

--- a/src/libse/AutoTranslate/GoogleTranslateV2.cs
+++ b/src/libse/AutoTranslate/GoogleTranslateV2.cs
@@ -1,5 +1,4 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Http;
 using Nikse.SubtitleEdit.Core.Translate;
 using System;
 using System.Collections.Generic;
@@ -46,7 +45,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return GoogleTranslateV1.GetTranslationPairs();
         }
 
-        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var format = "text";
             var input = new StringBuilder();
@@ -55,13 +54,13 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             string content;
             try
             {
-                var result = _httpClient.PostAsync(uri, new StringContent(string.Empty)).Result;
+                var result = await _httpClient.PostAsync(uri, new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
 
                 if (!result.IsSuccessStatusCode)
                 {
                     try
                     {
-                        Error = result.Content.ReadAsStringAsync().Result;
+                        Error = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
                         SeLogger.Error($"Error in {StaticName}.Translate: " + Error);
                     }
                     catch
@@ -141,7 +140,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                     }
                 }
             }
-            return Task.FromResult(string.Join(Environment.NewLine, resultList));
+            return string.Join(Environment.NewLine, resultList);
         }
 
         public void Dispose() => _httpClient?.Dispose();

--- a/src/libse/AutoTranslate/GroqTranslate.cs
+++ b/src/libse/AutoTranslate/GroqTranslate.cs
@@ -81,8 +81,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/KoboldCppTranslate.cs
+++ b/src/libse/AutoTranslate/KoboldCppTranslate.cs
@@ -68,7 +68,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/LibreTranslate.cs
+++ b/src/libse/AutoTranslate/LibreTranslate.cs
@@ -59,8 +59,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{\"q\": \"" + Json.EncodeJsonText(text.Trim()) + "\", \"source\": \"" + sourceLanguageCode + "\", \"target\": \"" + targetLanguageCode + "\"" + apiKey + "}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = _httpClient.PostAsync("translate", content, cancellationToken).Result;
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync("translate", content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/LmStudioTranslate.cs
+++ b/src/libse/AutoTranslate/LmStudioTranslate.cs
@@ -61,8 +61,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{ " + modelJson + " \"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/MicrosoftTranslator.cs
+++ b/src/libse/AutoTranslate/MicrosoftTranslator.cs
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return GetTranslationPairs();
         }
 
-        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var url = string.Format(TranslateUrl, sourceLanguageCode, targetLanguageCode);
             if (!string.IsNullOrEmpty(_category))
@@ -79,9 +79,9 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var json = jsonBuilder.ToString();
             var content = new StringContent(json, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = httpClient.PostAsync(url, content).Result;
+            var result = await httpClient.PostAsync(url, content).ConfigureAwait(false);
             var parser = new JsonParser();
-            var jsonResult = result.Content.ReadAsStringAsync().Result;
+            var jsonResult = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (!result.IsSuccessStatusCode)
             {
@@ -111,7 +111,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 }
             }
 
-            return Task.FromResult(string.Join(Environment.NewLine, results));
+            return string.Join(Environment.NewLine, results);
         }
 
         private IDownloader GetTranslateClient()

--- a/src/libse/AutoTranslate/MistralTranslate.cs
+++ b/src/libse/AutoTranslate/MistralTranslate.cs
@@ -80,8 +80,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/MyMemoryApi.cs
+++ b/src/libse/AutoTranslate/MyMemoryApi.cs
@@ -204,7 +204,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return new TranslationPair(name, code, twoLetterIsoName);
         }
 
-        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var apiKey = string.Empty;
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.AutoTranslateLibreApiKey))
@@ -213,7 +213,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
 
             var url = $"?langpair={sourceLanguageCode}|{targetLanguageCode}{apiKey}&q={Utilities.UrlEncode(text)}";
-            var jsonResultString = _httpClient.GetStringAsync(url).Result;
+            var jsonResultString = await _httpClient.GetStringAsync(url).ConfigureAwait(false);
             var textResult = _jsonParser.GetFirstObject(jsonResultString, "translatedText");
             var result = Json.DecodeJsonText(textResult);
 
@@ -226,7 +226,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 // ignore
             }
 
-            return Task.FromResult(result);
+            return result;
         }
 
         public void Dispose() => _httpClient?.Dispose();

--- a/src/libse/AutoTranslate/NoLanguageLeftBehindApi.cs
+++ b/src/libse/AutoTranslate/NoLanguageLeftBehindApi.cs
@@ -1,5 +1,4 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Http;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.Translate;
 using System;
@@ -44,10 +43,10 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var content = new StringContent("{ \"text\": \"" + Json.EncodeJsonText(text) + "\",  \"source\": \"" + sourceLanguageCode + "\", \"target\": \"" + targetLanguageCode + "\" }", Encoding.UTF8, "application/json");
-            var result = await _httpClient.PostAsync("translator", content);
+            var result = await _httpClient.PostAsync("translator", content, cancellationToken).ConfigureAwait(false);
             result.EnsureSuccessStatusCode();
 
-            var responseString = await result.Content.ReadAsStringAsync();
+            var responseString = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var validator = new SeJsonValidator();
             var isValidJson = validator.ValidateJson(responseString);

--- a/src/libse/AutoTranslate/NoLanguageLeftBehindServe.cs
+++ b/src/libse/AutoTranslate/NoLanguageLeftBehindServe.cs
@@ -55,9 +55,9 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
 
-            var result = _httpClient.PostAsync("translate", content).Result;
+            var result = await _httpClient.PostAsync("translate", content, cancellationToken).ConfigureAwait(false);
             result.EnsureSuccessStatusCode();
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
 
             var parser = new SeJsonParser();

--- a/src/libse/AutoTranslate/OllamaTranslate.cs
+++ b/src/libse/AutoTranslate/OllamaTranslate.cs
@@ -62,7 +62,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/OpenRouterTranslate.cs
+++ b/src/libse/AutoTranslate/OpenRouterTranslate.cs
@@ -80,8 +80,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/PapagoTranslate.cs
+++ b/src/libse/AutoTranslate/PapagoTranslate.cs
@@ -49,8 +49,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{\"text\": \"" + Json.EncodeJsonText(text.Trim()) + "\", \"source\": \"" + sourceLanguageCode + "\", \"target\": \"" + targetLanguageCode + "\"}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync("translation", content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var result = await _httpClient.PostAsync("translation", content, cancellationToken).ConfigureAwait(false);
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libse/AutoTranslate/SeamlessM4TTranslate.cs
+++ b/src/libse/AutoTranslate/SeamlessM4TTranslate.cs
@@ -65,9 +65,9 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{ \"input\": { \"task_name\":\"T2TT (Text to Text translation)\", \"input_text\": \"" + Json.EncodeJsonText(text.Trim()) + "\", \"input_text_language\": \"" + sourceLanguageCode + "\", \"target_language_text_only\": \"" + targetLanguageCode + "\" }}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = _httpClient.PostAsync("predictions", content).Result;
+            var result = await _httpClient.PostAsync("predictions", content, cancellationToken).ConfigureAwait(false);
             result.EnsureSuccessStatusCode();
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             var json = Encoding.UTF8.GetString(bytes).Trim();
 
             var parser = new SeJsonParser();


### PR DESCRIPTION
Revised HTTP client calls to use `ConfigureAwait(false)` and standardized asynchronous method return types for consistency and better thread management. Simplified unnecessary `Task.FromResult` returns to improve code clarity.