### PR TITLE
Enhance video file detection

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -3000,6 +3000,66 @@ namespace Nikse.SubtitleEdit.Core.Common
             return fileName;
         }
 
+        private static readonly HashSet<string> CopyWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "copy",      // en
+            "نسخة",      // ar-EG - Arabic
+            "копие",     // bg-BG - Bulgarian
+            "còpia",     // br-FR - Breton
+            "còpia",     // ca-ES - Catalan
+            "kopie",     // cs-CZ - Czech
+            "kopi",      // da-DK - Danish
+            "kopie",     // de-DE - German
+            "αντίγραφο", // el-GR - Greek
+            "copia",     // es-AR, es-ES, es-MX - Spanish
+            "kopia",     // eu-ES - Basque
+            "کپی",       // fa-IR - Persian
+            "kopio",     // fi-FI - Finnish
+            "copie",     // fr-FR - French
+            "עותק",      // he-IL - Hebrew
+            "kopija",    // hr-HR - Croatian
+            "másolat",   // hu-HU - Hungarian
+            "salinan",   // id-ID - Indonesian
+            "copia",     // it-IT - Italian
+            "コピー",     // ja-JP - Japanese
+            "복사본",     // ko-KR - Korean
+            "копија",    // mk-MK - Macedonian
+            "kopi",      // nb-NO - Norwegian Bokmål
+            "kopie",     // nl-NL - Dutch
+            "kopia",     // pl-PL - Polish
+            "cópia",     // pt-BR, pt-PT - Portuguese
+            "copie",     // ro-RO - Romanian
+            "копия",     // ru-RU - Russian
+            "kopija",    // sl-SI - Slovenian
+            "копија",    // sr-Cyrl-RS - Serbian (Cyrillic)
+            "kopija",    // sr-Latn-RS - Serbian (Latin)
+            "kopia",     // sv-SE - Swedish
+            "สำเนา",     // th-TH - Thai
+            "kopya",     // tr-TR - Turkish
+            "нөсхә",     // tt-RU - Tatar
+            "копія",     // uk-UA - Ukrainian
+            "bản sao",   // vi-VN - Vietnamese
+            "复制",       // zh-Hans - Simplified Chinese
+            "複製",       // zh-TW - Traditional Chinese
+        };
+
+        public static string GetLenientPathAndFileNameWithoutExtension(string fileName)
+        {
+            var strictName = GetPathAndFileNameWithoutExtension(fileName);
+            var copyPattern = string.Join("|", CopyWords.Select(Regex.Escape));
+
+            // Remove common suffixes like " - Copy", " - Copy (2)"
+            while (Regex.IsMatch(strictName, @"(\s*[-_]?\s*({copyPattern})(?:\s*\(\d+\))?)$", RegexOptions.IgnoreCase))
+            {
+                strictName = Regex.Replace(strictName, @"(\s*[-_]?\s*({copyPattern})(?:\s*\(\d+\))?)$", "", RegexOptions.IgnoreCase);
+            }
+
+            // Remove common suffixes like "(2)", "(3)", etc.
+            strictName = Regex.Replace(strictName, @"\s*\(\d+\)$", "");
+
+            return strictName;
+        }
+
         public static string GetFileNameWithoutExtension(string fileName)
         {
             if (string.IsNullOrEmpty(fileName))

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -3049,9 +3049,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             var copyPattern = string.Join("|", CopyWords.Select(Regex.Escape));
 
             // Remove common suffixes like " - Copy", " - Copy (2)"
-            while (Regex.IsMatch(strictName, @"(\s*[-_]?\s*({copyPattern})(?:\s*\(\d+\))?)$", RegexOptions.IgnoreCase))
+            while (Regex.IsMatch(strictName, $@"(\s*[-_]?\s*({copyPattern})(?:\s*\(\d+\))?)$", RegexOptions.IgnoreCase))
             {
-                strictName = Regex.Replace(strictName, @"(\s*[-_]?\s*({copyPattern})(?:\s*\(\d+\))?)$", "", RegexOptions.IgnoreCase);
+                strictName = Regex.Replace(strictName, $@"(\s*[-_]?\s*({copyPattern})(?:\s*\(\d+\))?)$", "", RegexOptions.IgnoreCase);
             }
 
             // Remove common suffixes like "(2)", "(3)", etc.

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -4033,7 +4033,13 @@ namespace Nikse.SubtitleEdit.Forms
                         }
                         else if (!string.IsNullOrEmpty(fileName))
                         {
-                            TryToFindAndOpenVideoFile(Utilities.GetPathAndFileNameWithoutExtension(fileName));
+                            var baseName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
+
+                            if (!TryToFindAndOpenVideoFile(baseName))
+                            {
+                                var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(fileName);
+                                TryToFindAndOpenVideoFile(fallbackName);
+                            }
                         }
 
                         if (_videoFileName == null)
@@ -23163,7 +23169,13 @@ namespace Nikse.SubtitleEdit.Forms
                         ResetSubtitle();
                         if (!Configuration.Settings.General.DisableVideoAutoLoading)
                         {
-                            TryToFindAndOpenVideoFile(Utilities.GetPathAndFileNameWithoutExtension(importText.VideoFileName ?? fileName));
+                            var baseName = Utilities.GetPathAndFileNameWithoutExtension(importText.VideoFileName ?? fileName);
+
+                            if (!TryToFindAndOpenVideoFile(baseName))
+                            {
+                                var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(importText.VideoFileName ?? fileName);
+                                TryToFindAndOpenVideoFile(fallbackName);
+                            }
                         }
 
                         _fileName = Path.GetFileNameWithoutExtension(importText.VideoFileName);
@@ -24620,7 +24632,13 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (mediaPlayer.VideoPlayer == null && !string.IsNullOrEmpty(_fileName) && string.IsNullOrEmpty(_videoFileName) && !Configuration.Settings.General.DisableVideoAutoLoading)
             {
-                TryToFindAndOpenVideoFile(Utilities.GetPathAndFileNameWithoutExtension(_fileName));
+                var baseName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
+
+                if (!TryToFindAndOpenVideoFile(baseName))
+                {
+                    var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(_fileName);
+                    TryToFindAndOpenVideoFile(fallbackName);
+                }
             }
 
             Main_Resize(null, null);
@@ -25593,7 +25611,13 @@ namespace Nikse.SubtitleEdit.Forms
                 !Configuration.Settings.General.DisableVideoAutoLoading &&
                 mediaPlayer.Visible)
             {
-                TryToFindAndOpenVideoFile(Utilities.GetPathAndFileNameWithoutExtension(_fileName));
+                var baseName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
+
+                if (!TryToFindAndOpenVideoFile(baseName))
+                {
+                    var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(_fileName);
+                    TryToFindAndOpenVideoFile(fallbackName);
+                }
             }
 
             if (_subtitleListViewIndex >= 0)

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -4033,13 +4033,7 @@ namespace Nikse.SubtitleEdit.Forms
                         }
                         else if (!string.IsNullOrEmpty(fileName))
                         {
-                            var baseName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
-
-                            if (!TryToFindAndOpenVideoFile(baseName))
-                            {
-                                var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(fileName);
-                                TryToFindAndOpenVideoFile(fallbackName);
-                            }
+                            TryToFindAndOpenVideoFile(Utilities.GetPathAndFileNameWithoutExtension(fileName));
                         }
 
                         if (_videoFileName == null)
@@ -23169,13 +23163,7 @@ namespace Nikse.SubtitleEdit.Forms
                         ResetSubtitle();
                         if (!Configuration.Settings.General.DisableVideoAutoLoading)
                         {
-                            var baseName = Utilities.GetPathAndFileNameWithoutExtension(importText.VideoFileName ?? fileName);
-
-                            if (!TryToFindAndOpenVideoFile(baseName))
-                            {
-                                var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(importText.VideoFileName ?? fileName);
-                                TryToFindAndOpenVideoFile(fallbackName);
-                            }
+                            TryToFindAndOpenVideoFile(Utilities.GetPathAndFileNameWithoutExtension(importText.VideoFileName ?? fileName));
                         }
 
                         _fileName = Path.GetFileNameWithoutExtension(importText.VideoFileName);
@@ -24320,6 +24308,12 @@ namespace Nikse.SubtitleEdit.Forms
                 }
             }
 
+            var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(fileNameNoExtension);
+            if (!string.Equals(fileNameNoExtension, fallbackName, StringComparison.OrdinalIgnoreCase))
+            {
+                return TryToFindAndOpenVideoFile(fallbackName);
+            }
+
             return false;
         }
 
@@ -24632,13 +24626,7 @@ namespace Nikse.SubtitleEdit.Forms
 
             if (mediaPlayer.VideoPlayer == null && !string.IsNullOrEmpty(_fileName) && string.IsNullOrEmpty(_videoFileName) && !Configuration.Settings.General.DisableVideoAutoLoading)
             {
-                var baseName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
-
-                if (!TryToFindAndOpenVideoFile(baseName))
-                {
-                    var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(_fileName);
-                    TryToFindAndOpenVideoFile(fallbackName);
-                }
+                TryToFindAndOpenVideoFile(Utilities.GetPathAndFileNameWithoutExtension(_fileName));
             }
 
             Main_Resize(null, null);
@@ -25611,13 +25599,7 @@ namespace Nikse.SubtitleEdit.Forms
                 !Configuration.Settings.General.DisableVideoAutoLoading &&
                 mediaPlayer.Visible)
             {
-                var baseName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
-
-                if (!TryToFindAndOpenVideoFile(baseName))
-                {
-                    var fallbackName = Utilities.GetLenientPathAndFileNameWithoutExtension(_fileName);
-                    TryToFindAndOpenVideoFile(fallbackName);
-                }
+                TryToFindAndOpenVideoFile(Utilities.GetPathAndFileNameWithoutExtension(_fileName));
             }
 
             if (_subtitleListViewIndex >= 0)


### PR DESCRIPTION
I implemented a solution for enhancing the video file detection logic. We still try to find a video file with the full title of the subtitle for example and when this does not return any matches, we try to clean the filename for duplicate naming styles and try again to open the corresponding video file.

The only thing that's not so clean is that Windows by default names copys in the system language like "test - Copy.srt" for english or "test - Kopie.srt" for german. I added a dictionary that contains these words for all supported languages by SubtitleEdit.

I'm interested in your feedback, in case you would like to handle this differently.

Fix #9679