### PR TITLE
OCRSpellCheck text controls use defined SubtitleFont

### DIFF
--- a/src/ui/Forms/Ocr/OCRSpellCheck.cs
+++ b/src/ui/Forms/Ocr/OCRSpellCheck.cs
@@ -46,7 +46,12 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             UiUtil.PreInitialize(this);
             InitializeComponent();
             UiUtil.FixFonts(this);
-            _blinkForm = blinkForm;
+
+			UiUtil.InitializeSubtitleFont(richTextBoxParagraph);
+			UiUtil.InitializeSubtitleFont(textBoxWord);
+			UiUtil.InitializeSubtitleFont(listBoxSuggestions);
+
+			_blinkForm = blinkForm;
             Text = LanguageSettings.Current.SpellCheck.Title;
             buttonAddToDictionary.Text = LanguageSettings.Current.SpellCheck.AddToUserDictionary;
             buttonChange.Text = LanguageSettings.Current.SpellCheck.Change;
@@ -397,7 +402,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         {
             textBoxWholeText.Font = useLargerFontForThisWindowToolStripMenuItem.Checked ? new Font(textBoxWholeText.Font.FontFamily, textBoxWholeText.Font.Size - 2, FontStyle.Regular) : new Font(textBoxWholeText.Font.FontFamily, textBoxWholeText.Font.Size + 2, FontStyle.Regular);
             textBoxWord.Font = useLargerFontForThisWindowToolStripMenuItem.Checked ? new Font(textBoxWord.Font.FontFamily, textBoxWord.Font.Size - 2, FontStyle.Regular) : new Font(textBoxWord.Font.FontFamily, textBoxWord.Font.Size + 2, FontStyle.Regular);
-            richTextBoxParagraph.Font = useLargerFontForThisWindowToolStripMenuItem.Checked ? new Font(textBoxWholeText.Font.FontFamily, richTextBoxParagraph.Font.Size - 2, FontStyle.Regular) : new Font(textBoxWholeText.Font.FontFamily, richTextBoxParagraph.Font.Size + 2, FontStyle.Regular);
+            richTextBoxParagraph.Font = useLargerFontForThisWindowToolStripMenuItem.Checked ? new Font(richTextBoxParagraph.Font.FontFamily, richTextBoxParagraph.Font.Size - 2, FontStyle.Regular) : new Font(richTextBoxParagraph.Font.FontFamily, richTextBoxParagraph.Font.Size + 2, FontStyle.Regular);
             Font = useLargerFontForThisWindowToolStripMenuItem.Checked ? new Font(Font.FontFamily, Font.Size - 2, FontStyle.Regular) : new Font(Font.FontFamily, Font.Size + 2, FontStyle.Regular);
             useLargerFontForThisWindowToolStripMenuItem.Checked = !useLargerFontForThisWindowToolStripMenuItem.Checked;
             Configuration.Settings.Tools.SpellCheckUseLargerFont = useLargerFontForThisWindowToolStripMenuItem.Checked;

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -496,14 +496,11 @@ namespace Nikse.SubtitleEdit.Logic
             {
                 if (control is ListView)
                 {
-                    if (gs.SubtitleListViewFontBold)
-                    {
-                        control.Font = new Font(gs.SubtitleFontName, gs.SubtitleListViewFontSize, FontStyle.Bold);
-                    }
-                    else
-                    {
-                        control.Font = new Font(gs.SubtitleFontName, gs.SubtitleListViewFontSize);
-                    }
+                    SetControlSubtitleFont(control, gs.SubtitleFontName, gs.SubtitleListViewFontSize, gs.SubtitleListViewFontBold);
+                }
+                else if (control is ListBox)
+                {
+                    SetControlSubtitleFont(control, gs.SubtitleFontName, gs.SubtitleListViewFontSize, gs.SubtitleListViewFontBold);
                 }
                 else if (control is SETextBox seTextBox)
                 {
@@ -511,14 +508,11 @@ namespace Nikse.SubtitleEdit.Logic
                 }
                 else if (control is TextBox)
                 {
-                    if (gs.SubtitleTextBoxFontBold)
-                    {
-                        control.Font = new Font(gs.SubtitleFontName, gs.SubtitleTextBoxFontSize, FontStyle.Bold);
-                    }
-                    else
-                    {
-                        control.Font = new Font(gs.SubtitleFontName, gs.SubtitleTextBoxFontSize);
-                    }
+                    SetControlSubtitleFont(control, gs.SubtitleFontName, gs.SubtitleTextBoxFontSize, gs.SubtitleTextBoxFontBold);
+                }
+                else if (control is RichTextBox rtb)
+                {
+                    SetControlSubtitleFont(control, gs.SubtitleFontName, gs.SubtitleTextBoxFontSize, gs.SubtitleTextBoxFontBold);
                 }
 
                 control.BackColor = gs.SubtitleBackgroundColor;
@@ -527,6 +521,18 @@ namespace Nikse.SubtitleEdit.Logic
             catch
             {
                 // ignored
+            }
+        }
+
+        private static void SetControlSubtitleFont(Control control, string subtitleFontName, int subtitleFontSize, bool subtitleFontBold)
+        {
+            if (subtitleFontBold)
+            {
+                control.Font = new Font(subtitleFontName, subtitleFontSize, FontStyle.Bold);
+            }
+            else
+            {
+                control.Font = new Font(subtitleFontName, subtitleFontSize);
             }
         }
 


### PR DESCRIPTION
The text controls on the OCRSpellCheck form use the defined subtitle font rather than default font.

This makes the UI more consistent with other forms that use the subtitle font.

It also allows for easier differentiation between similar characters by letting the user choose a font they find easier to read.