### PR TITLE
Added support for Myanmar (Burmese) language in translation pairs

### DIFF
--- a/src/libse/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libse/AutoTranslate/ChatGptTranslate.cs
@@ -196,6 +196,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                MakePair("Moldovan","ro"),
                MakePair("Mongolian","mn"),
                MakePair("Montenegrin",""),
+               MakePair("Myanmar(Burmese)", "my"),
                MakePair("Nepali","ne"),
                MakePair("Norwegian","no"),
                MakePair("Oriya","or"),

--- a/src/libse/AutoTranslate/GeminiTranslate.cs
+++ b/src/libse/AutoTranslate/GeminiTranslate.cs
@@ -215,6 +215,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                MakePair("Moldovan","ro"),
                MakePair("Mongolian","mn"),
                MakePair("Montenegrin",""),
+               MakePair("Myanmar(Burmese)", "my"),
                MakePair("Nepali","ne"),
                MakePair("Norwegian","no"),
                MakePair("Oriya","or"),


### PR DESCRIPTION
This pull request adds support for the Myanmar (Burmese) language in two translation-related methods across different files. I hope this would be cool for burmese subtitle editors.

Language additions:

* [`src/libse/AutoTranslate/ChatGptTranslate.cs`](diffhunk://#diff-7027f914d36c514b30290aba683359a57ffb840d792a7eeef06663219475f919R199): Added Myanmar (Burmese) language with the code `my` to the `ListLanguages` method.

* [`src/libse/AutoTranslate/GeminiTranslate.cs`](diffhunk://#diff-30ff218041a8e5759cdc1686072a54aa7c2d7b2663688aeb84e04c55abfc3050R218): Added Myanmar (Burmese) language with the code `my` to the `ListLanguages` method.