### PR TITLE
Disable start time rebasing by default

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic.cs
@@ -745,6 +745,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers
                 _mpvSetOptionString(_mpvHandle, GetUtf8Bytes("no-sub"), GetUtf8Bytes(string.Empty)); // don't load subtitles (does not seem to work anymore)
                 _mpvSetOptionString(_mpvHandle, GetUtf8Bytes("sid"), GetUtf8Bytes("no")); // don't load subtitles
                 _mpvSetOptionString(_mpvHandle, GetUtf8Bytes("hr-seek"), GetUtf8Bytes("yes")); // don't load subtitles
+                _mpvSetOptionString(_mpvHandle, GetUtf8Bytes("rebase-start-time"), GetUtf8Bytes("no")); // don't adjust timestamps to start at zero
 
                 if (videoFileName.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
                     videoFileName.StartsWith("https://", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
This PR fixes issue #9828 by disabling start time rebasing by default. This enables subtitles to appear at the right time when a video has a start time offset.

Fixes #9828 