### PR TITLE
Fix Arabic language name + Sync Hebrew translation version

### DIFF
--- a/src/ui/Languages/ar-EG.xml
+++ b/src/ui/Languages/ar-EG.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Language Name="arbic">
+<Language Name="العربية">
   <General>
     <Title>تحرير العنوان الفرعي</Title>
     <Version>4.0.13</Version>

--- a/src/ui/Languages/he-IL.xml
+++ b/src/ui/Languages/he-IL.xml
@@ -2,7 +2,7 @@
 <Language Name="עברית">
   <General>
     <Title>עריכת כתוביות</Title>
-    <Version>3.6.12</Version>
+    <Version>4.0.13</Version>
     <TranslatedBy>תורגם על ידי אלחנן</TranslatedBy>
     <CultureName>he-IL</CultureName>
     <HelpFile />


### PR DESCRIPTION
### Summary
This PR includes 2 internationalization improvements:
- [X] **Arabic (`ar-EG.xml`) Language name fixed** - Corrected the broken name (e.g. "Arbic") to the proper native form: `العربية`
- [X] **Hebrew (`he-IL.xml`) Version Synced** - Updated the version tag in the Hebrew translation file to match the current Subtitle Edit version for consistency across languages.

---
### Credits
- Contributed by **ArsenTech** (https://github.com/ArsenTech)

Let me know if any adjustments are needed!