### PR TITLE
Replace `ContainsVisibleChars` with `IsFormattingOnly` for clearer in…

### DIFF
--- a/src/libse/AudioToText/AudioToTextPostProcessor.cs
+++ b/src/libse/AudioToText/AudioToTextPostProcessor.cs
@@ -595,8 +595,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
             foreach (var paragraph in subtitle.Paragraphs)
             {
                 var text = paragraph.Text;
-                var textNoTags = HtmlUtil.RemoveHtmlTags(text, true);
-                if (textNoTags != textNoTags.ToUpperInvariant() && !string.IsNullOrEmpty(text))
+                if (!text.IsFormattingOnly())
                 {
                     var st = new StrippableText(text);
                     st.FixCasing(nameListInclMulti, true, engine == Engine.Vosk, engine == Engine.Vosk, lastLine);

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -909,5 +909,22 @@ namespace Nikse.SubtitleEdit.Core.Common
                 .Replace("\u202B", string.Empty) // &rlm;
                 .Replace("\u202A", string.Empty); // &lmr;
         }
+
+        /// <summary>
+        /// Determines whether a given string contains only formatting elements such as HTML tags,
+        /// control characters, or whitespace, and does not include any textual letters.
+        /// </summary>
+        /// <param name="input">The input string to be checked.</param>
+        /// <returns>True if the input string contains only formatting characters or whitespace; otherwise, false.</returns>
+        public static bool IsFormattingOnly(this string input)
+        {
+            string noFormattingText = HtmlUtil.RemoveHtmlTags(input, true);
+            if (string.IsNullOrWhiteSpace(noFormattingText))
+            {
+                return true;
+            }
+
+            return !noFormattingText.ContainsLetter();
+        }
     }
 }

--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -178,7 +178,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                         {
                             if (count == 1 && newText.Length > 1 && removedInFirstLine &&
                                 !".?!♪♫".Contains(newTextNoHtml[newTextNoHtml.Length - 1]) && newText.LineEndsWithHtmlTag(true) &&
-                                line != line.ToUpperInvariant())
+                                !line.IsFormattingOnly())
                             {
                                 newText += Environment.NewLine;
                                 if (pre.Contains("<i>") && line.Contains("</i>") && !line.Contains("<i>"))
@@ -208,7 +208,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                             }
                             else if (count == 1 && newTextNoHtml.Length > 1 && indexOfColon > 15 && line.Substring(0, indexOfColon).Contains(' ') &&
                                      !".?!♪♫".Contains(newTextNoHtml[newTextNoHtml.Length - 1]) && newText.LineEndsWithHtmlTag(true) &&
-                                     line != line.ToUpperInvariant())
+                                     !line.IsFormattingOnly())
                             {
                                 newText += Environment.NewLine;
                                 if (pre.Contains("<i>") && line.Contains("</i>") && !line.Contains("<i>"))
@@ -302,11 +302,11 @@ namespace Nikse.SubtitleEdit.Core.Forms
                                                 content = content.Remove(0, "</b>".Length);
                                             }
 
-                                            if (count == 0 && !string.IsNullOrEmpty(content) && content[0].ToString() != content[0].ToString().ToUpperInvariant())
+                                            if (count == 0 && !content.IsFormattingOnly())
                                             {
                                                 content = content[0].ToString().ToUpperInvariant() + content.Remove(0, 1);
                                             }
-                                            else if (count == 1 && !string.IsNullOrEmpty(content) && content[0].ToString() != content[0].ToString().ToUpperInvariant())
+                                            else if (count == 1 && !content.IsFormattingOnly())
                                             {
                                                 content = content[0].ToString().ToUpperInvariant() + content.Remove(0, 1);
                                             }
@@ -1555,7 +1555,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             foreach (var line in text.SplitToLines())
             {
                 var lineNoHtml = HtmlUtil.RemoveHtmlTags(line, true);
-                if (lineNoHtml == lineNoHtml.ToUpperInvariant() && lineNoHtml != lineNoHtml.ToLowerInvariant())
+                if (lineNoHtml == lineNoHtml.ToUpperInvariant() && !lineNoHtml.IsFormattingOnly())
                 {
                     var temp = lineNoHtml.TrimEnd(endTrimChars).Trim().Trim(trimChars);
                     if (temp.Length == 1 || temp == "YES" || temp == "NO" || temp == "WHY" || temp == "HI" || temp == "OK")

--- a/src/libse/GermanNouns.cs
+++ b/src/libse/GermanNouns.cs
@@ -30,8 +30,7 @@ namespace Nikse.SubtitleEdit.Core
 
         public string UppercaseNouns(string text)
         {
-            var textNoTags = HtmlUtil.RemoveHtmlTags(text, true);
-            if (textNoTags != textNoTags.ToUpperInvariant() && !string.IsNullOrEmpty(text))
+            if (!text.IsFormattingOnly())
             {
                 var st = new StrippableText(text);
 


### PR DESCRIPTION
…tent

Replaced the `ContainsVisibleChars` extension method with the new `IsFormattingOnly` method to improve clarity and correctness when checking text content. Updated all references accordingly.