### PR TITLE
Dispose of unused graphics objects and brushes

### DIFF
--- a/src/libse/VobSub/SubPicture.cs
+++ b/src/libse/VobSub/SubPicture.cs
@@ -240,9 +240,11 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             var bmp = new Bitmap(imageDisplayArea.Width + 1, imageDisplayArea.Height + 1);
             if (fourColors[0] != Color.Transparent)
             {
-                var gr = Graphics.FromImage(bmp);
-                gr.FillRectangle(new SolidBrush(fourColors[0]), new Rectangle(0, 0, bmp.Width, bmp.Height));
-                gr.Dispose();
+                using (var gr = Graphics.FromImage(bmp))
+                using (var brush = new SolidBrush(fourColors[0]))
+                {
+                    gr.FillRectangle(brush, new Rectangle(0, 0, bmp.Width, bmp.Height));
+                }
             }
             var fastBmp = new FastBitmap(bmp);
             fastBmp.LockImage();

--- a/src/ui/Logic/DarkTheme.cs
+++ b/src/ui/Logic/DarkTheme.cs
@@ -822,7 +822,10 @@ namespace Nikse.SubtitleEdit.Logic
             if (listView != null && !listView.Enabled)
             {
                 var disabledBackgroundImage = new Bitmap(listView.ClientSize.Width, listView.ClientSize.Height);
-                Graphics.FromImage(disabledBackgroundImage).Clear(Color.DimGray);
+                using (var g = Graphics.FromImage(disabledBackgroundImage))
+                {
+                    g.Clear(Color.DimGray);
+                }
                 listView.BackgroundImage = disabledBackgroundImage;
                 listView.BackgroundImageTiled = true;
             }

--- a/src/ui/Logic/TextDesigner.cs
+++ b/src/ui/Logic/TextDesigner.cs
@@ -104,6 +104,7 @@ namespace Nikse.SubtitleEdit.Logic
             path.Dispose();
             brush.Dispose();
             outlineImage.Dispose();
+            shadowImage.Dispose();
             gShadow.Dispose();
             gOutline.Dispose();
             g.Dispose();
@@ -297,6 +298,7 @@ namespace Nikse.SubtitleEdit.Logic
 
             newImage.Dispose();
             outlineImage.Dispose();
+            shadowImage.Dispose();
             gShadow.Dispose();
             gOutline.Dispose();
             g.Dispose();


### PR DESCRIPTION
Ensured proper disposal of `Graphics` and `Brush` objects using `using` statements to improve resource management and prevent memory leaks. Applied changes across TextDesigner, SubPicture, and DarkTheme components.