### PR TITLE
Add support for Google Lens OCR

### DIFF
--- a/src/libse/Common/Configuration.cs
+++ b/src/libse/Common/Configuration.cs
@@ -35,6 +35,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static readonly string TesseractDataDirectory = GetTesseractDataDirectory();
         public static readonly string Tesseract302DataDirectory = GetTesseract302DataDirectory();
         public static readonly string PaddleOcrDirectory = DataDirectory + "PaddleOCR3-1";
+        public static readonly string GoogleLensDirectory = DataDirectory + "Google-Lens";
 
         public static readonly string DefaultLinuxFontName = "DejaVu Serif";
 

--- a/src/libse/Settings/Settings.cs
+++ b/src/libse/Settings/Settings.cs
@@ -5964,6 +5964,12 @@ namespace Nikse.SubtitleEdit.Core.Settings
                 settings.VobSubOcr.OllamaModel = subNode.InnerText;
             }
 
+            subNode = node.SelectSingleNode("GoogleLensLanguage");
+            if (subNode != null)
+            {
+                settings.VobSubOcr.GoogleLensLanguage = subNode.InnerText;
+            }
+
             foreach (XmlNode groupNode in doc.DocumentElement.SelectNodes("MultipleSearchAndReplaceGroups/Group"))
             {
                 var group = new MultipleSearchAndReplaceGroup
@@ -9909,6 +9915,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
                 xmlWriter.WriteElementString("CloudVisionSendOriginalImages", settings.VobSubOcr.CloudVisionSendOriginalImages.ToString(CultureInfo.InvariantCulture));
                 xmlWriter.WriteElementString("OllamaLanguage", settings.VobSubOcr.OllamaLanguage);
                 xmlWriter.WriteElementString("OllamaModel", settings.VobSubOcr.OllamaModel);
+                xmlWriter.WriteElementString("GoogleLensLanguage", settings.VobSubOcr.GoogleLensLanguage);
 
                 xmlWriter.WriteEndElement();
 

--- a/src/libse/Settings/VobSubOcrSettings.cs
+++ b/src/libse/Settings/VobSubOcrSettings.cs
@@ -46,6 +46,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public bool CloudVisionSendOriginalImages { get; set; }
         public string OllamaLanguage { get; set; }
         public string OllamaModel { get; set; }
+        public string GoogleLensLanguage { get; set; }
 
 
         public VobSubOcrSettings()
@@ -81,6 +82,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             CloudVisionApiKey = string.Empty;
             CloudVisionLanguage = "en";
             CloudVisionSendOriginalImages = false;
+            GoogleLensLanguage = "en";
         }
     }
 }

--- a/src/ui/Forms/Ocr/DownloadChromeLensCLI.Designer.cs
+++ b/src/ui/Forms/Ocr/DownloadChromeLensCLI.Designer.cs
@@ -1,0 +1,78 @@
+﻿namespace Nikse.SubtitleEdit.Forms.Ocr
+{
+    sealed partial class DownloadChromeLensCLI
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.labelDescription1 = new System.Windows.Forms.Label();
+            this.labelPleaseWait = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // labelDescription1
+            // 
+            this.labelDescription1.AutoSize = true;
+            this.labelDescription1.Location = new System.Drawing.Point(21, 27);
+            this.labelDescription1.Name = "labelDescription1";
+            this.labelDescription1.Size = new System.Drawing.Size(145, 13);
+            this.labelDescription1.TabIndex = 29;
+            this.labelDescription1.Text = "Downloading Chrome Lens CLI";
+            // 
+            // labelPleaseWait
+            // 
+            this.labelPleaseWait.AutoSize = true;
+            this.labelPleaseWait.Location = new System.Drawing.Point(21, 59);
+            this.labelPleaseWait.Name = "labelPleaseWait";
+            this.labelPleaseWait.Size = new System.Drawing.Size(70, 13);
+            this.labelPleaseWait.TabIndex = 28;
+            this.labelPleaseWait.Text = "Please wait...";
+            // 
+            // DownloadChrome Lens CLO
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(320, 93);
+            this.Controls.Add(this.labelDescription1);
+            this.Controls.Add(this.labelPleaseWait);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "DownloadChromeLensCLI";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Download Chrome Lens CLI";
+            this.Shown += new System.EventHandler(this.DownloadChromeLensCLI_Shown);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label labelDescription1;
+        private System.Windows.Forms.Label labelPleaseWait;
+    }
+}

--- a/src/ui/Forms/Ocr/DownloadChromeLensCLI.cs
+++ b/src/ui/Forms/Ocr/DownloadChromeLensCLI.cs
@@ -1,0 +1,140 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Http;
+using Nikse.SubtitleEdit.Logic;
+using SevenZipExtractor;
+using System;
+using System.IO;
+using System.Threading;
+using System.Windows.Forms;
+using MessageBox = Nikse.SubtitleEdit.Forms.SeMsgBox.MessageBox;
+
+namespace Nikse.SubtitleEdit.Forms.Ocr
+{
+    public sealed partial class DownloadChromeLensCLI : Form
+    {
+        public const string DownloadUrl = "https://github.com/timminator/chrome-lens-py/releases/download/v3.3.0/Chrome-Lens-CLI-v3.3.0.7z";
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        private string _tempFileName;
+
+        public DownloadChromeLensCLI()
+        {
+            UiUtil.PreInitialize(this);
+            InitializeComponent();
+            UiUtil.FixFonts(this);
+            Text = LanguageSettings.Current.GetTesseractDictionaries.Download + " Chrome Lens CLI";
+            labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait;
+            labelDescription1.Text = LanguageSettings.Current.GetTesseractDictionaries.Download + " Chrome Lens CLI";
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        private void DownloadChromeLensCLI_Shown(object sender, EventArgs e)
+        {
+            try
+            {
+                _tempFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".7z");
+                using (var downloadStream = new FileStream(_tempFileName, FileMode.Create, FileAccess.Write))
+                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                {
+                    var downloadTask = httpClient.DownloadAsync(DownloadUrl, downloadStream, new Progress<float>((progress) =>
+                    {
+                        var pct = (int)Math.Round(progress * 100.0, MidpointRounding.AwayFromZero);
+                        labelPleaseWait.Text = LanguageSettings.Current.General.PleaseWait + "  " + pct + "%";
+                        labelPleaseWait.Refresh();
+                    }), _cancellationTokenSource.Token);
+
+                    while (!downloadTask.IsCompleted && !downloadTask.IsCanceled)
+                    {
+                        Application.DoEvents();
+                    }
+
+                    if (downloadTask.IsCanceled)
+                    {
+                        DialogResult = DialogResult.Cancel;
+                        labelPleaseWait.Refresh();
+                        return;
+                    }
+
+                }
+                CompleteDownload(_tempFileName);
+                return;
+            }
+            catch (Exception exception)
+            {
+                labelPleaseWait.Text = string.Empty;
+                Cursor = Cursors.Default;
+                MessageBox.Show($"Unable to download {DownloadUrl}!" + Environment.NewLine + Environment.NewLine +
+                                exception.Message + Environment.NewLine + Environment.NewLine + exception.StackTrace);
+                DialogResult = DialogResult.Cancel;
+            }
+        }
+
+        private void CompleteDownload(string downloadStream)
+        {
+            if (downloadStream.Length == 0)
+            {
+                throw new Exception("No content downloaded - missing file or no internet connection!" + Environment.NewLine  + 
+                                    $"For more info see: {Path.Combine(Configuration.DataDirectory, "error_log.txt")}");
+            }
+
+            var dictionaryFolder = Configuration.GoogleLensDirectory;
+            if (!Directory.Exists(dictionaryFolder))
+            {
+                Directory.CreateDirectory(dictionaryFolder);
+            }
+
+            Extract7Zip(downloadStream, dictionaryFolder, "Chrome-Lens-CLI-v3.3.0");
+            Cursor = Cursors.Default;
+            labelPleaseWait.Text = string.Empty;
+            Cursor = Cursors.Default;
+            DialogResult = DialogResult.OK;
+            File.Delete(_tempFileName);
+        }
+
+        private void Extract7Zip(string tempFileName, string dir, string skipFolderLevel)
+        {
+            Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, string.Empty);
+            labelDescription1.Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, "Chrome Lens CLI");
+            labelDescription1.Refresh();
+
+            using (var archiveFile = new ArchiveFile(tempFileName))
+            {
+                archiveFile.Extract(entry =>
+                {
+                    if (_cancellationTokenSource.IsCancellationRequested)
+                    {
+                        return null;
+                    }
+
+                    var entryFullName = entry.FileName;
+                    if (!string.IsNullOrEmpty(skipFolderLevel) && entryFullName.StartsWith(skipFolderLevel))
+                    {
+                        entryFullName = entryFullName.Substring(skipFolderLevel.Length);
+                    }
+
+                    entryFullName = entryFullName.Replace('/', Path.DirectorySeparatorChar);
+                    entryFullName = entryFullName.TrimStart(Path.DirectorySeparatorChar);
+
+                    var fullFileName = Path.Combine(dir, entryFullName);
+
+                    var fullPath = Path.GetDirectoryName(fullFileName);
+                    if (fullPath == null)
+                    {
+                        return null;
+                    }
+
+                    var displayName = entryFullName;
+                    if (displayName.Length > 30)
+                    {
+                        displayName = "..." + displayName.Remove(0, displayName.Length - 26).Trim();
+                    }
+
+                    labelPleaseWait.Text = string.Format(LanguageSettings.Current.Settings.ExtractingX, $"{displayName}");
+                    labelPleaseWait.Refresh();
+
+                    return fullFileName;
+                });
+            }
+        }
+    }
+}

--- a/src/ui/Forms/Ocr/VobSubOcr.Designer.cs
+++ b/src/ui/Forms/Ocr/VobSubOcr.Designer.cs
@@ -7,7 +7,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         /// <summary>
         /// Required designer variable.
         /// </summary>
-        private System.ComponentModel.IContainer components = null;       
+        private System.ComponentModel.IContainer components = null;
 
         #region Windows Form Designer generated code
 
@@ -108,6 +108,9 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             this.labelOllamaModel = new System.Windows.Forms.Label();
             this.labelLanguageOllama = new System.Windows.Forms.Label();
             this.nikseComboBoxOllamaLanguages = new Nikse.SubtitleEdit.Controls.NikseComboBox();
+            this.groupBoxGoogleLens = new System.Windows.Forms.GroupBox();
+            this.labelLanguageGoogleLens = new System.Windows.Forms.Label();
+            this.nikseComboBoxGoogleLensLanguages = new Nikse.SubtitleEdit.Controls.NikseComboBox();
             this.groupBoxOCRControls = new System.Windows.Forms.GroupBox();
             this.labelStartFrom = new System.Windows.Forms.Label();
             this.numericUpDownStartNumber = new Nikse.SubtitleEdit.Controls.NikseUpDown();
@@ -195,6 +198,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             this.groupBoxNOCR.SuspendLayout();
             this.groupBoxImageCompareMethod.SuspendLayout();
             this.groupBoxOllama.SuspendLayout();
+            this.groupBoxGoogleLens.SuspendLayout();
             this.groupBoxOCRControls.SuspendLayout();
             this.groupBoxOcrAutoFix.SuspendLayout();
             this.tabControlLogs.SuspendLayout();
@@ -433,7 +437,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // ImagePreProcessingToolStripMenuItem
             // 
             this.ImagePreProcessingToolStripMenuItem.Name = "ImagePreProcessingToolStripMenuItem";
-            this.ImagePreProcessingToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.ImagePreProcessingToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift)
             | System.Windows.Forms.Keys.P)));
             this.ImagePreProcessingToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.ImagePreProcessingToolStripMenuItem.Text = "Image preprocessing...";
@@ -462,7 +466,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // progressBar1
             // 
-            this.progressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.progressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.progressBar1.Location = new System.Drawing.Point(12, 564);
             this.progressBar1.Name = "progressBar1";
@@ -513,6 +517,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             this.groupBoxOcrMethod.Controls.Add(this.GroupBoxTesseractMethod);
             this.groupBoxOcrMethod.Controls.Add(this.groupBoxModiMethod);
             this.groupBoxOcrMethod.Controls.Add(this.groupBoxCloudVision);
+            this.groupBoxOcrMethod.Controls.Add(this.groupBoxGoogleLens);
             this.groupBoxOcrMethod.Location = new System.Drawing.Point(13, 5);
             this.groupBoxOcrMethod.Name = "groupBoxOcrMethod";
             this.groupBoxOcrMethod.Size = new System.Drawing.Size(392, 192);
@@ -1515,6 +1520,49 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             this.nikseComboBoxOllamaLanguages.TabIndex = 1;
             this.nikseComboBoxOllamaLanguages.UsePopupWindow = false;
             // 
+            // groupBoxGoogleLens
+            // 
+            this.groupBoxGoogleLens.Controls.Add(this.labelLanguageGoogleLens);
+            this.groupBoxGoogleLens.Controls.Add(this.nikseComboBoxGoogleLensLanguages);
+            this.groupBoxGoogleLens.Location = new System.Drawing.Point(0, 41);
+            this.groupBoxGoogleLens.Name = "groupBoxGoogleLens";
+            this.groupBoxGoogleLens.Size = new System.Drawing.Size(366, 131);
+            this.groupBoxGoogleLens.TabIndex = 9;
+            this.groupBoxGoogleLens.TabStop = false;
+            this.groupBoxGoogleLens.Text = "Google Lens";
+            //
+            // labelLanguageGoogleLens
+            // 
+            this.labelLanguageGoogleLens.AutoSize = true;
+            this.labelLanguageGoogleLens.Location = new System.Drawing.Point(18, 22);
+            this.labelLanguageGoogleLens.Name = "labelLanguageGoogleLens";
+            this.labelLanguageGoogleLens.Size = new System.Drawing.Size(54, 13);
+            this.labelLanguageGoogleLens.TabIndex = 0;
+            this.labelLanguageGoogleLens.Text = "Language";
+            // 
+            // nikseComboBoxGoogleLensLanguages
+            // 
+            this.nikseComboBoxGoogleLensLanguages.BackColor = System.Drawing.SystemColors.Window;
+            this.nikseComboBoxGoogleLensLanguages.BackColorDisabled = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.nikseComboBoxGoogleLensLanguages.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(171)))), ((int)(((byte)(173)))), ((int)(((byte)(179)))));
+            this.nikseComboBoxGoogleLensLanguages.BorderColorDisabled = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(120)))), ((int)(((byte)(120)))));
+            this.nikseComboBoxGoogleLensLanguages.ButtonForeColor = System.Drawing.SystemColors.ControlText;
+            this.nikseComboBoxGoogleLensLanguages.ButtonForeColorDown = System.Drawing.Color.Orange;
+            this.nikseComboBoxGoogleLensLanguages.ButtonForeColorOver = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(120)))), ((int)(((byte)(215)))));
+            this.nikseComboBoxGoogleLensLanguages.DropDownHeight = 400;
+            this.nikseComboBoxGoogleLensLanguages.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.nikseComboBoxGoogleLensLanguages.DropDownWidth = 195;
+            this.nikseComboBoxGoogleLensLanguages.FormattingEnabled = true;
+            this.nikseComboBoxGoogleLensLanguages.Location = new System.Drawing.Point(98, 20);
+            this.nikseComboBoxGoogleLensLanguages.MaxLength = 32767;
+            this.nikseComboBoxGoogleLensLanguages.Name = "nikseComboBoxGoogleLensLanguages";
+            this.nikseComboBoxGoogleLensLanguages.SelectedIndex = -1;
+            this.nikseComboBoxGoogleLensLanguages.SelectedItem = null;
+            this.nikseComboBoxGoogleLensLanguages.SelectedText = "";
+            this.nikseComboBoxGoogleLensLanguages.Size = new System.Drawing.Size(195, 21);
+            this.nikseComboBoxGoogleLensLanguages.TabIndex = 1;
+            this.nikseComboBoxGoogleLensLanguages.UsePopupWindow = false;
+            // 
             // groupBoxOCRControls
             // 
             this.groupBoxOCRControls.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -1639,7 +1687,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // comboBoxDictionaries
             // 
-            this.comboBoxDictionaries.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.comboBoxDictionaries.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxDictionaries.BackColor = System.Drawing.SystemColors.Window;
             this.comboBoxDictionaries.BackColorDisabled = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
@@ -1677,8 +1725,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // tabControlLogs
             // 
-            this.tabControlLogs.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.tabControlLogs.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControlLogs.ContextMenuStrip = this.contextMenuStripAllFixes;
             this.tabControlLogs.Controls.Add(this.tabPageUnknownWords);
@@ -1768,8 +1816,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // listBoxUnknownWords
             // 
-            this.listBoxUnknownWords.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.listBoxUnknownWords.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.listBoxUnknownWords.ContextMenuStrip = this.contextMenuStripUnknownWords;
             this.listBoxUnknownWords.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -1915,7 +1963,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // groupBoxImagePalette
             // 
-            this.groupBoxImagePalette.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxImagePalette.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxImagePalette.Controls.Add(this.checkBoxBackgroundTransparent);
             this.groupBoxImagePalette.Controls.Add(this.pictureBoxBackground);
@@ -2035,7 +2083,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // groupBoxSubtitleImage
             // 
-            this.groupBoxSubtitleImage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxSubtitleImage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxSubtitleImage.Controls.Add(this.labelMinAlpha);
             this.groupBoxSubtitleImage.Controls.Add(this.numericUpDownAutoTransparentAlphaMax);
@@ -2103,7 +2151,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // groupBoxTransportStream
             // 
-            this.groupBoxTransportStream.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxTransportStream.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxTransportStream.Controls.Add(this.checkBoxTransportStreamGetColorAndSplit);
             this.groupBoxTransportStream.Controls.Add(this.checkBoxTransportStreamGrayscale);
@@ -2139,8 +2187,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // pictureBoxSubtitleImage
             // 
-            this.pictureBoxSubtitleImage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.pictureBoxSubtitleImage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.pictureBoxSubtitleImage.BackColor = System.Drawing.Color.DimGray;
             this.pictureBoxSubtitleImage.ContextMenuStrip = this.contextMenuStripImage;
@@ -2190,7 +2238,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // imagePreprocessingToolStripMenuItem1
             // 
             this.imagePreprocessingToolStripMenuItem1.Name = "imagePreprocessingToolStripMenuItem1";
-            this.imagePreprocessingToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.imagePreprocessingToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift)
             | System.Windows.Forms.Keys.P)));
             this.imagePreprocessingToolStripMenuItem1.Size = new System.Drawing.Size(266, 22);
             this.imagePreprocessingToolStripMenuItem1.Text = "Image preprocessing...";
@@ -2246,8 +2294,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // 
             // splitContainerBottom
             // 
-            this.splitContainerBottom.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.splitContainerBottom.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.splitContainerBottom.Location = new System.Drawing.Point(15, 199);
             this.splitContainerBottom.Name = "splitContainerBottom";
@@ -2273,7 +2321,7 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // textBoxCurrentText
             // 
             this.textBoxCurrentText.AllowDrop = true;
-            this.textBoxCurrentText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.textBoxCurrentText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxCurrentText.BackColor = System.Drawing.SystemColors.WindowFrame;
             this.textBoxCurrentText.ContextMenuStrip = this.contextMenuStripTextBox;
@@ -2401,8 +2449,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             // subtitleListView1
             // 
             this.subtitleListView1.AllowColumnReorder = true;
-            this.subtitleListView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.subtitleListView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.subtitleListView1.ContextMenuStrip = this.contextMenuStripListview;
             this.subtitleListView1.FirstVisibleIndex = -1;
@@ -2473,6 +2521,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
             this.groupBoxImageCompareMethod.PerformLayout();
             this.groupBoxOllama.ResumeLayout(false);
             this.groupBoxOllama.PerformLayout();
+            this.groupBoxGoogleLens.ResumeLayout(false);
+            this.groupBoxGoogleLens.PerformLayout();
             this.groupBoxOCRControls.ResumeLayout(false);
             this.groupBoxOCRControls.PerformLayout();
             this.groupBoxOcrAutoFix.ResumeLayout(false);
@@ -2677,5 +2727,8 @@ namespace Nikse.SubtitleEdit.Forms.Ocr
         private System.Windows.Forms.Label labelOllamaModel;
         private System.Windows.Forms.Label labelLanguageOllama;
         private NikseComboBox nikseComboBoxOllamaLanguages;
+        private System.Windows.Forms.GroupBox groupBoxGoogleLens;
+        private System.Windows.Forms.Label labelLanguageGoogleLens;
+        private NikseComboBox nikseComboBoxGoogleLensLanguages;
     }
 }

--- a/src/ui/Logic/Ocr/GoogleLens.cs
+++ b/src/ui/Logic/Ocr/GoogleLens.cs
@@ -1,0 +1,408 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using static Nikse.SubtitleEdit.Forms.Ocr.VobSubOcr;
+
+namespace Nikse.SubtitleEdit.Logic.Ocr
+{
+    public class GoogleLens
+    {
+        public string Error { get; set; }
+        private bool hasErrors = false;
+        private StringBuilder _log = new StringBuilder();
+
+        public GoogleLens()
+        {
+            Error = string.Empty;
+        }
+
+        private object LockObject = new object();
+
+        public void OcrBatch(List<OcrInput> input, string language, Action<OcrInput> progressCallback, Func<bool> abortCheck)
+        {
+            _log.Clear();
+            hasErrors = false;
+
+            var tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempFolder);
+
+            try
+            {
+                var imagePaths = new List<string>();
+                var width = input.Count.ToString().Length; // Determine the number of digits for file name padding
+
+                for (var i = 0; i < input.Count; i++)
+                {
+                    var imagePath = Path.Combine(tempFolder, string.Format("{0:D" + width + "}.png", i));
+                    input[i].Bitmap.Save(imagePath, System.Drawing.Imaging.ImageFormat.Png);
+                    input[i].FileName = imagePath;
+                    imagePaths.Add(imagePath);
+                }
+
+                var parameters = $"\"{tempFolder}\" {language}";
+
+                string GoogleLensPath = "GoogleLens";
+                if (File.Exists(Path.Combine(Configuration.GoogleLensDirectory, "Chrome-Lens-CLI.exe")))
+                {
+                    GoogleLensPath = Path.GetFullPath(Path.Combine(Configuration.GoogleLensDirectory, "Chrome-Lens-CLI.exe"));
+                }
+
+                using (var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = GoogleLensPath,
+                        Arguments = parameters,
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        CreateNoWindow = true,
+                        StandardOutputEncoding = Encoding.UTF8,
+                    }
+                })
+                {
+                    process.StartInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
+                    process.StartInfo.EnvironmentVariables["PYTHONUTF8"] = "1";
+
+                    var results = new Dictionary<string, string>();
+                    string currentFileName = null;
+                    bool canCollectText = false;
+
+                    if (input.Count == 1)
+                    {
+                        currentFileName = Path.GetFileName(input[0].FileName);
+                        results[currentFileName] = string.Empty;
+                    }
+
+                    process.OutputDataReceived += (sendingProcess, outLine) =>
+                    {
+                        if (string.IsNullOrWhiteSpace(outLine.Data))
+                        {
+                            return;
+                        }
+
+                        _log.AppendLine(outLine.Data);
+
+                        var fileMarkerMatch = Regex.Match(outLine.Data, @"- \(\d+/\d+\) Result for: (.*) -");
+                        if (fileMarkerMatch.Success)
+                        {
+                            if (currentFileName != null)
+                            {
+                                var existingInput = input.FirstOrDefault(p => Path.GetFileName(p.FileName) == currentFileName);
+                                if (existingInput != null && results.ContainsKey(currentFileName))
+                                {
+                                    existingInput.Text = results[currentFileName].Trim();
+                                    lock (LockObject)
+                                    {
+                                        progressCallback?.Invoke(existingInput);
+                                    }
+                                }
+                            }
+
+                            currentFileName = fileMarkerMatch.Groups[1].Value.Trim();
+                            if (!results.ContainsKey(currentFileName))
+                            {
+                                results[currentFileName] = string.Empty;
+                            }
+                            canCollectText = false;
+                            return;
+                        }
+
+                        if (outLine.Data.StartsWith("OCR Results:"))
+                        {
+                            canCollectText = true;
+                            return;
+                        }
+
+                        if (canCollectText && currentFileName != null)
+                        {
+                            if (!outLine.Data.Equals("No OCR text found.", StringComparison.OrdinalIgnoreCase))
+                            {
+                                results[currentFileName] += outLine.Data + Environment.NewLine;
+                            }
+                        }
+
+                        if (abortCheck != null && abortCheck.Invoke())
+                        {
+                            try
+                            {
+                                process.CancelOutputRead();
+                                process.Kill(); // Terminate GoogleLens process
+                                process.WaitForExit(1000);
+                            }
+                            catch (Exception ex)
+                            {
+                                Error = $"Error terminating GoogleLens: {ex.Message}";
+                                SeLogger.Error(ex, "Log: " + _log.ToString());
+                            }
+                        }
+                    };
+
+                    process.ErrorDataReceived += (sendingProcess, errorLine) =>
+                    {
+                        if (errorLine == null || string.IsNullOrWhiteSpace(errorLine.Data))
+                        {
+                            return;
+                        }
+                        Error = errorLine.Data;
+
+                        hasErrors = true;
+                        _log.AppendLine(errorLine.Data);
+                    };
+
+#pragma warning disable CA1416 // Validate platform compatibility
+                    process.Start();
+#pragma warning restore CA1416 // Validate platform compatibility;
+
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
+
+                    process.WaitForExit();
+
+                    if (hasErrors)
+                    {
+                        SeLogger.Error("GoogleLensError: " + _log.ToString());
+                    }
+
+                    if (currentFileName != null)
+                    {
+                        var existingInput = input.FirstOrDefault(p => Path.GetFileName(p.FileName) == currentFileName);
+                        if (existingInput != null && results.ContainsKey(currentFileName))
+                        {
+                            existingInput.Text = results[currentFileName].Trim();
+                            lock (LockObject)
+                            {
+                                progressCallback?.Invoke(existingInput);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                SeLogger.Error(ex, "Log: " + _log.ToString());
+                throw;
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(tempFolder))
+                    {
+                        Directory.Delete(tempFolder, true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Error = $"An unexpected error occurred during cleanup: {ex.Message}";
+                }
+            }
+        }
+
+        public static List<OcrLanguage3> GetLanguages()
+        {
+            return new List<OcrLanguage3>
+            {
+                new OcrLanguage3("ab", "Abkhaz"),
+                new OcrLanguage3("ace", "Acehnese"),
+                new OcrLanguage3("ach", "Acholi"),
+                new OcrLanguage3("af", "Afrikaans"),
+                new OcrLanguage3("ak", "Twi (Akan)"),
+                new OcrLanguage3("sq", "Albanian"),
+                new OcrLanguage3("alz", "Alur"),
+                new OcrLanguage3("am", "Amharic"),
+                new OcrLanguage3("ar", "Arabic"),
+                new OcrLanguage3("hy", "Armenian"),
+                new OcrLanguage3("as", "Assamese"),
+                new OcrLanguage3("awa", "Awadhi"),
+                new OcrLanguage3("ay", "Aymara"),
+                new OcrLanguage3("az", "Azerbaijani"),
+                new OcrLanguage3("ban", "Balinese"),
+                new OcrLanguage3("bm", "Bambara"),
+                new OcrLanguage3("ba", "Bashkir"),
+                new OcrLanguage3("eu", "Basque"),
+                new OcrLanguage3("btx", "Batak Karo"),
+                new OcrLanguage3("bts", "Batak Simalungun"),
+                new OcrLanguage3("bbc", "Batak Toba"),
+                new OcrLanguage3("be", "Belarusian"),
+                new OcrLanguage3("bem", "Bemba"),
+                new OcrLanguage3("bn", "Bengali"),
+                new OcrLanguage3("bew", "Betawi"),
+                new OcrLanguage3("bho", "Bhojpuri"),
+                new OcrLanguage3("bik", "Bikol"),
+                new OcrLanguage3("bs", "Bosnian"),
+                new OcrLanguage3("br", "Breton"),
+                new OcrLanguage3("bg", "Bulgarian"),
+                new OcrLanguage3("bua", "Buryat"),
+                new OcrLanguage3("yue", "Cantonese"),
+                new OcrLanguage3("ca", "Catalan"),
+                new OcrLanguage3("ceb", "Cebuano"),
+                new OcrLanguage3("ny", "Chichewa (Nyanja)"),
+                new OcrLanguage3("zh-CN", "Chinese (Simplified)"),
+                new OcrLanguage3("zh-TW", "Chinese (Traditional)"),
+                new OcrLanguage3("cv", "Chuvash"),
+                new OcrLanguage3("co", "Corsican"),
+                new OcrLanguage3("crh", "Crimean Tatar"),
+                new OcrLanguage3("hr", "Croatian"),
+                new OcrLanguage3("cs", "Czech"),
+                new OcrLanguage3("da", "Danish"),
+                new OcrLanguage3("din", "Dinka"),
+                new OcrLanguage3("dv", "Divehi"),
+                new OcrLanguage3("doi", "Dogri"),
+                new OcrLanguage3("dov", "Dombe"),
+                new OcrLanguage3("nl", "Dutch"),
+                new OcrLanguage3("dz", "Dzongkha"),
+                new OcrLanguage3("en", "English"),
+                new OcrLanguage3("eo", "Esperanto"),
+                new OcrLanguage3("et", "Estonian"),
+                new OcrLanguage3("ee", "Ewe"),
+                new OcrLanguage3("fj", "Fijian"),
+                new OcrLanguage3("fil", "Filipino (Tagalog)"),
+                new OcrLanguage3("fi", "Finnish"),
+                new OcrLanguage3("fr", "French"),
+                new OcrLanguage3("fr-CA", "French (Canadian)"),
+                new OcrLanguage3("fr-FR", "French (French)"),
+                new OcrLanguage3("fy", "Frisian"),
+                new OcrLanguage3("ff", "Fulfulde"),
+                new OcrLanguage3("gaa", "Ga"),
+                new OcrLanguage3("gl", "Galician"),
+                new OcrLanguage3("lg", "Ganda (Luganda)"),
+                new OcrLanguage3("ka", "Georgian"),
+                new OcrLanguage3("de", "German"),
+                new OcrLanguage3("el", "Greek"),
+                new OcrLanguage3("gn", "Guarani"),
+                new OcrLanguage3("gu", "Gujarati"),
+                new OcrLanguage3("ht", "Haitian Creole"),
+                new OcrLanguage3("cnh", "Hakha Chin"),
+                new OcrLanguage3("ha", "Hausa"),
+                new OcrLanguage3("haw", "Hawaiian"),
+                new OcrLanguage3("iw", "Hebrew"),
+                new OcrLanguage3("hil", "Hiligaynon"),
+                new OcrLanguage3("hi", "Hindi"),
+                new OcrLanguage3("hmn", "Hmong"),
+                new OcrLanguage3("hu", "Hungarian"),
+                new OcrLanguage3("hrx", "Hunsrik"),
+                new OcrLanguage3("is", "Icelandic"),
+                new OcrLanguage3("ig", "Igbo"),
+                new OcrLanguage3("ilo", "Iloko"),
+                new OcrLanguage3("id", "Indonesian"),
+                new OcrLanguage3("ga", "Irish"),
+                new OcrLanguage3("it", "Italian"),
+                new OcrLanguage3("ja", "Japanese"),
+                new OcrLanguage3("jw", "Javanese"),
+                new OcrLanguage3("kn", "Kannada"),
+                new OcrLanguage3("pam", "Kapampangan"),
+                new OcrLanguage3("kk", "Kazakh"),
+                new OcrLanguage3("km", "Khmer"),
+                new OcrLanguage3("cgg", "Kiga"),
+                new OcrLanguage3("rw", "Kinyarwanda"),
+                new OcrLanguage3("ktu", "Kituba"),
+                new OcrLanguage3("gom", "Konkani"),
+                new OcrLanguage3("ko", "Korean"),
+                new OcrLanguage3("kri", "Krio"),
+                new OcrLanguage3("ku", "Kurdish (Kurmanji)"),
+                new OcrLanguage3("ckb", "Kurdish (Sorani)"),
+                new OcrLanguage3("ky", "Kyrgyz"),
+                new OcrLanguage3("lo", "Lao"),
+                new OcrLanguage3("ltg", "Latgalian"),
+                new OcrLanguage3("la", "Latin"),
+                new OcrLanguage3("lv", "Latvian"),
+                new OcrLanguage3("lij", "Ligurian"),
+                new OcrLanguage3("li", "Limburgan"),
+                new OcrLanguage3("ln", "Lingala"),
+                new OcrLanguage3("lt", "Lithuanian"),
+                new OcrLanguage3("lmo", "Lombard"),
+                new OcrLanguage3("luo", "Luo"),
+                new OcrLanguage3("lb", "Luxembourgish"),
+                new OcrLanguage3("mk", "Macedonian"),
+                new OcrLanguage3("mai", "Maithili"),
+                new OcrLanguage3("mak", "Makassar"),
+                new OcrLanguage3("mg", "Malagasy"),
+                new OcrLanguage3("ms", "Malay"),
+                new OcrLanguage3("ms-Arab", "Malay (Jawi)"),
+                new OcrLanguage3("ml", "Malayalam"),
+                new OcrLanguage3("mt", "Maltese"),
+                new OcrLanguage3("mi", "Maori"),
+                new OcrLanguage3("mr", "Marathi"),
+                new OcrLanguage3("chm", "Meadow Mari"),
+                new OcrLanguage3("mni-Mtei", "Meiteilon (Manipuri)"),
+                new OcrLanguage3("min", "Minang"),
+                new OcrLanguage3("lus", "Mizo"),
+                new OcrLanguage3("mn", "Mongolian"),
+                new OcrLanguage3("my", "Myanmar (Burmese)"),
+                new OcrLanguage3("nr", "Ndebele (South)"),
+                new OcrLanguage3("new", "Nepalbhasa (Newari)"),
+                new OcrLanguage3("ne", "Nepali"),
+                new OcrLanguage3("nso", "Northern Sotho (Sepedi)"),
+                new OcrLanguage3("no", "Norwegian"),
+                new OcrLanguage3("nus", "Nuer"),
+                new OcrLanguage3("oc", "Occitan"),
+                new OcrLanguage3("or", "Odia (Oriya)"),
+                new OcrLanguage3("om", "Oromo"),
+                new OcrLanguage3("pag", "Pangasinan"),
+                new OcrLanguage3("pap", "Papiamento"),
+                new OcrLanguage3("ps", "Pashto"),
+                new OcrLanguage3("fa", "Persian"),
+                new OcrLanguage3("pl", "Polish"),
+                new OcrLanguage3("pt", "Portuguese"),
+                new OcrLanguage3("pt-BR", "Portuguese (Brazil)"),
+                new OcrLanguage3("pt-PT", "Portuguese (Portugal)"),
+                new OcrLanguage3("pa", "Punjabi"),
+                new OcrLanguage3("pa-Arab", "Punjabi (Shahmukhi)"),
+                new OcrLanguage3("qu", "Quechua"),
+                new OcrLanguage3("rom", "Romani"),
+                new OcrLanguage3("ro", "Romanian"),
+                new OcrLanguage3("rn", "Rundi"),
+                new OcrLanguage3("ru", "Russian"),
+                new OcrLanguage3("sm", "Samoan"),
+                new OcrLanguage3("sg", "Sango"),
+                new OcrLanguage3("sa", "Sanskrit"),
+                new OcrLanguage3("gd", "Scots Gaelic"),
+                new OcrLanguage3("sr", "Serbian"),
+                new OcrLanguage3("st", "Sesotho"),
+                new OcrLanguage3("crs", "Seychellois Creole"),
+                new OcrLanguage3("shn", "Shan"),
+                new OcrLanguage3("sn", "Shona"),
+                new OcrLanguage3("scn", "Sicilian"),
+                new OcrLanguage3("szl", "Silesian"),
+                new OcrLanguage3("sd", "Sindhi"),
+                new OcrLanguage3("si", "Sinhala (Sinhalese)"),
+                new OcrLanguage3("sk", "Slovak"),
+                new OcrLanguage3("sl", "Slovenian"),
+                new OcrLanguage3("so", "Somali"),
+                new OcrLanguage3("es", "Spanish"),
+                new OcrLanguage3("su", "Sundanese"),
+                new OcrLanguage3("sw", "Swahili"),
+                new OcrLanguage3("ss", "Swati"),
+                new OcrLanguage3("sv", "Swedish"),
+                new OcrLanguage3("tg", "Tajik"),
+                new OcrLanguage3("ta", "Tamil"),
+                new OcrLanguage3("tt", "Tatar"),
+                new OcrLanguage3("te", "Telugu"),
+                new OcrLanguage3("tet", "Tetum"),
+                new OcrLanguage3("th", "Thai"),
+                new OcrLanguage3("ti", "Tigrinya"),
+                new OcrLanguage3("ts", "Tsonga"),
+                new OcrLanguage3("tn", "Tswana"),
+                new OcrLanguage3("tr", "Turkish"),
+                new OcrLanguage3("tk", "Turkmen"),
+                new OcrLanguage3("uk", "Ukrainian"),
+                new OcrLanguage3("ur", "Urdu"),
+                new OcrLanguage3("ug", "Uyghur"),
+                new OcrLanguage3("uz", "Uzbek"),
+                new OcrLanguage3("vi", "Vietnamese"),
+                new OcrLanguage3("cy", "Welsh"),
+                new OcrLanguage3("xh", "Xhosa"),
+                new OcrLanguage3("yi", "Yiddish"),
+                new OcrLanguage3("yo", "Yoruba"),
+                new OcrLanguage3("yua", "Yucatec Maya"),
+                new OcrLanguage3("zu", "Zulu"),
+            }.OrderBy(p => p.Name).ToList();
+        }
+    }
+}

--- a/src/ui/Logic/Ocr/OcrLanguage3.cs
+++ b/src/ui/Logic/Ocr/OcrLanguage3.cs
@@ -1,0 +1,19 @@
+﻿namespace Nikse.SubtitleEdit.Logic.Ocr
+{
+    public class OcrLanguage3
+    {
+        public string Name { get; set; }
+        public string Code { get; set; }
+
+        public OcrLanguage3(string code, string name)
+        {
+            Code = code;
+            Name = name;
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/src/ui/Logic/Ocr/PaddleOcr.cs
+++ b/src/ui/Logic/Ocr/PaddleOcr.cs
@@ -134,7 +134,7 @@ namespace Nikse.SubtitleEdit.Logic.Ocr
 
         private object LockObject = new object();
 
-        public void OcrBatch(List<PaddleOcrInput> input, string language, bool useGpu, string mode, Action<PaddleOcrInput> progressCallback, Func<bool> abortCheck)
+        public void OcrBatch(List<OcrInput> input, string language, bool useGpu, string mode, Action<OcrInput> progressCallback, Func<bool> abortCheck)
         {
             _log.Clear();
             hasErrors = false;


### PR DESCRIPTION
This PR adds support for the Google Lens API.

It is now possible to interact with the Google Lens API available in the Chrome Browser or on Android/Iphone directly.
More info can be found here:
https://github.com/timminator/chrome-lens-py

I made a standalone version again and integrated it into SubtitleEdit now.
The OCR accuracy and capability from Google Lens is highly impressive. It's the best I've ever seen.
It is not as fast as PaddleOCR though and of course all images are send to Google - the OCR process is not performed locally.