### PR TITLE
Add support for Unicode characters in MCC

### DIFF
--- a/src/libse/Cea708/Cea708.cs
+++ b/src/libse/Cea708/Cea708.cs
@@ -293,10 +293,10 @@ namespace Nikse.SubtitleEdit.Core.Cea708
                 {
                     //The EndOfText command is a Null Command which can be used to flush any buffered text to the current window. All commands force a flush of any buffered text to the current window, so this command is only needed when no other command is pending.
 
-                   if (DebugMode)
-                   {
-                       debugBuilder.Append("{EndOfText}");
-                   }
+                    if (DebugMode)
+                    {
+                        debugBuilder.Append("{EndOfText}");
+                    }
                 }
                 else if (b >= SetCurrentWindow.IdStart && b <= SetCurrentWindow.IdEnd)
                 {
@@ -517,6 +517,20 @@ namespace Nikse.SubtitleEdit.Core.Cea708
                         // GR Group: G3:  Future characters and icons
                     }
                 }
+
+                else if (b == 0x18 && i < bytes.Length - 2)
+                {
+                    // Unicode character
+                    char ch = Encoding.BigEndianUnicode.GetChars(bytes, i + 1, 2)[0];
+                    var text = new SetText(lineIndex, ch.ToString());
+                    state.Commands.Add(text);
+                    if (DebugMode)
+                    {
+                        debugBuilder.Append($"{{SetText CL Group Unicode:Text={text.Content}}}");
+                    }
+                    i += 2;
+                }
+
                 else if (b <= 0x1F)
                 {
                     // CL Group: C0: Subset of ASCII Control Codes


### PR DESCRIPTION
Hi,

I propose adding support for Unicode characters in the MCC format.

According to _ANSI-CTA-708-E+S-2023+++Errata+FINAL.pdf_, section 7.1.1:

> The code space may be extended further (for future use) to handle other character sets not included in
> the language sets listed in Section 7.1.7. This extension capability anticipates code sets which require 16-
> bit character code addressing, such as characters to implement Chinese and Japanese. The P16 code in
> the C0 Miscellaneous Control Code set is used for this purpose. When a decoder encounters the P16
> code, it uses the succeeding two bytes to address characters in a 16-bit code set.

Based on this specification, I’ve implemented processing of the P16 sequence, enabling proper handling of Unicode characters.