### PR TITLE
Fix Intermittent DeepLX Exception

### DIFF
--- a/src/libse/AutoTranslate/DeepLXTranslate.cs
+++ b/src/libse/AutoTranslate/DeepLXTranslate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
@@ -81,17 +81,24 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                     data = alternatives[0];
                 }
 
+                if (string.IsNullOrEmpty(data))
+                {
+                    var dataValues = parser.GetAllTagsByNameAsStrings(resultContent, "data");
+                    if (dataValues.Count > 0)
+                    {
+                        data = dataValues[0];
+                    }
+                }
+
                 if (!string.IsNullOrEmpty(data))
                 {
                     var resultText = Json.DecodeJsonText(data);
                     var resultTextWithFixedNewLines = ChatGptTranslate.FixNewLines(resultText);
                     return resultTextWithFixedNewLines.Trim();
                 }
-                else
-                {
-                    SeLogger.Error("DeepLXTranslate.Translate: " + resultContent);
-                    throw new Exception("DeepLXTranslate gave empty alternatives: StatusCode=" + result.StatusCode + Environment.NewLine + resultContent);
-                }
+
+                SeLogger.Error("DeepLXTranslate.Translate: " + resultContent);
+                throw new Exception("DeepLXTranslate gave empty alternatives: StatusCode=" + result.StatusCode + Environment.NewLine + resultContent);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Implements fallback to use the data field when alternatives array is null. Not exactly sure if this is a recent change to DeepLX or what.

`
DeepLXTranslate gave empty alternatives: StatusCode=OK {"alternatives":null,"code":200,"data":"OUTPUT.","id":123,"method":"Free","source_lang":"JA","target_lang":"en"} at Nikse.SubtitleEdit.Core.AutoTranslate.DeepLXTranslate.<Translate>d__20.MoveNext() in [Redacted]\subtitleedit\src\libse\AutoTranslate\DeepLXTranslate.cs:line 99 --- End of stack trace from previous location where exception was thrown --- at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() at Nikse.SubtitleEdit.Forms.Translate.AutoTranslate.<buttonTranslate_Click>d__33.MoveNext() in [Redacted]\subtitleedit\src\ui\Forms\Translate\AutoTranslate.cs:line 1023
`

```
{
  "alternatives": null,
  "code": 200,
  "data": "OUTPUT.",
  "id": 123,
  "method": "Free",
  "source_lang": "JA",
  "target_lang": "en"
}
```

