### PR TITLE
Add option to continuously retry DeepLX 

### DIFF
--- a/LanguageBaseEnglish.xml
+++ b/LanguageBaseEnglish.xml
@@ -1082,6 +1082,7 @@ We leverage the intrinsic rhythm of the image.</CreateSimpleChainingToolTip>
     <CopyPasteMaxSize>Max block size</CopyPasteMaxSize>
     <AutoCopyToClipboard>Auto-copy to clipboard</AutoCopyToClipboard>
     <AutoCopyLineSeparator>Line separator</AutoCopyLineSeparator>
+    <InfiniteRetries>Infinite retries</InfiniteRetries>
     <TranslateBlockXOfY>Translate block {0} of {1}</TranslateBlockXOfY>
     <TranslateBlockInfo>Go to translator and paste text, copy result back to clipboard and click the button below</TranslateBlockInfo>
     <TranslateBlockGetFromClipboard>Get translated text from clipboard

--- a/src/libse/Settings/Settings.cs
+++ b/src/libse/Settings/Settings.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Enums;
 using System;
 using System.Collections.Generic;
@@ -2129,6 +2129,18 @@ namespace Nikse.SubtitleEdit.Core.Settings
             if (subNode != null)
             {
                 settings.Tools.AutoTranslateDeepLUrl = subNode.InnerText;
+            }
+
+            subNode = node.SelectSingleNode("AutoTranslateDeepLXUrl");
+            if (subNode != null)
+            {
+                settings.Tools.AutoTranslateDeepLXUrl = subNode.InnerText;
+            }
+
+            subNode = node.SelectSingleNode("AutoTranslateDeepLXInfiniteRetry");
+            if (subNode != null && !string.IsNullOrWhiteSpace(subNode.InnerText))
+            {
+                settings.Tools.AutoTranslateDeepLXInfiniteRetry = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
             subNode = node.SelectSingleNode("AutoTranslatePapagoApiKeyId");
@@ -9218,6 +9230,8 @@ namespace Nikse.SubtitleEdit.Core.Settings
                 xmlWriter.WriteElementString("AutoTranslateSeamlessM4TUrl", settings.Tools.AutoTranslateSeamlessM4TUrl);
                 xmlWriter.WriteElementString("AutoTranslateDeepLApiKey", settings.Tools.AutoTranslateDeepLApiKey);
                 xmlWriter.WriteElementString("AutoTranslateDeepLUrl", settings.Tools.AutoTranslateDeepLUrl);
+                xmlWriter.WriteElementString("AutoTranslateDeepLXUrl", settings.Tools.AutoTranslateDeepLXUrl);
+                xmlWriter.WriteElementString("AutoTranslateDeepLXInfiniteRetry", settings.Tools.AutoTranslateDeepLXInfiniteRetry.ToString(CultureInfo.InvariantCulture));
                 xmlWriter.WriteElementString("AutoTranslatePapagoApiKeyId", settings.Tools.AutoTranslatePapagoApiKeyId);
                 xmlWriter.WriteElementString("AutoTranslatePapagoApiKey", settings.Tools.AutoTranslatePapagoApiKey);
                 xmlWriter.WriteElementString("AutoTranslateDeepLFormality", settings.Tools.AutoTranslateDeepLFormality);

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -60,6 +60,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string AutoTranslateDeepLUrl { get; set; }
         public string AutoTranslateDeepLFormality { get; set; }
         public string AutoTranslateDeepLXUrl { get; set; }
+        public bool AutoTranslateDeepLXInfiniteRetry { get; set; }
         public string AutoTranslatePapagoApiKeyId { get; set; }
         public string AutoTranslatePapagoApiKey { get; set; }
         public string AutoTranslateMistralApiKey { get; set; }
@@ -497,6 +498,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             AutoTranslateSeamlessM4TUrl = "http://localhost:5000/";
             AutoTranslateDeepLUrl = "https://api-free.deepl.com/";
             AutoTranslateDeepLXUrl = "http://localhost:1188";
+            AutoTranslateDeepLXInfiniteRetry = false;
             AutoTranslateMistralUrl = "https://api.mistral.ai/v1/chat/completions";
             AutoTranslateMistralModel = MistralTranslate.Models[0];
             AutoTranslateMistralPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";

--- a/src/ui/Forms/Translate/AutoTranslateSettings.Designer.cs
+++ b/src/ui/Forms/Translate/AutoTranslateSettings.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Nikse.SubtitleEdit.Forms.Translate
+namespace Nikse.SubtitleEdit.Forms.Translate
 {
     sealed partial class AutoTranslateSettings
     {
@@ -238,6 +238,17 @@
             0,
             0});
             // 
+            // checkBoxDeepLxInfiniteRetry
+            // 
+            this.checkBoxDeepLxInfiniteRetry = new System.Windows.Forms.CheckBox();
+            this.checkBoxDeepLxInfiniteRetry.AutoSize = true;
+            this.checkBoxDeepLxInfiniteRetry.Location = new System.Drawing.Point(21, 132);
+            this.checkBoxDeepLxInfiniteRetry.Name = "checkBoxDeepLxInfiniteRetry";
+            this.checkBoxDeepLxInfiniteRetry.Size = new System.Drawing.Size(91, 17);
+            this.checkBoxDeepLxInfiniteRetry.TabIndex = 35;
+            this.checkBoxDeepLxInfiniteRetry.Text = "Infinite retries";
+            this.checkBoxDeepLxInfiniteRetry.UseVisualStyleBackColor = true;
+            this.checkBoxDeepLxInfiniteRetry.Visible = false;
             // comboBoxParagraphHandling
             // 
             this.comboBoxParagraphHandling.BackColor = System.Drawing.SystemColors.Window;
@@ -269,6 +280,7 @@
             this.Controls.Add(this.nikseUpDownTemperature);
             this.Controls.Add(this.labelTemperature);
             this.Controls.Add(this.labelDelay);
+            this.Controls.Add(this.checkBoxDeepLxInfiniteRetry);
             this.Controls.Add(this.nikseUpDownDelay);
             this.Controls.Add(this.nikseTextBoxPrompt);
             this.Controls.Add(this.labelPrompt);
@@ -307,5 +319,6 @@
         private System.Windows.Forms.Label labelDelay;
         private Controls.NikseUpDown nikseUpDownTemperature;
         private System.Windows.Forms.Label labelTemperature;
+        private System.Windows.Forms.CheckBox checkBoxDeepLxInfiniteRetry;
     }
 }

--- a/src/ui/Forms/Translate/AutoTranslateSettings.cs
+++ b/src/ui/Forms/Translate/AutoTranslateSettings.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core.AutoTranslate;
+using Nikse.SubtitleEdit.Core.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Settings;
 using Nikse.SubtitleEdit.Logic;
@@ -26,6 +26,9 @@ namespace Nikse.SubtitleEdit.Forms.Translate
             labelPrompt.Text = string.Format(LanguageSettings.Current.GoogleTranslate.PromptX, engineName);
             buttonOk.Text = LanguageSettings.Current.General.Ok;
             buttonCancel.Text = LanguageSettings.Current.General.Cancel;
+            checkBoxDeepLxInfiniteRetry.Text = LanguageSettings.Current.GoogleTranslate.InfiniteRetries;
+            checkBoxDeepLxInfiniteRetry.Checked = Configuration.Settings.Tools.AutoTranslateDeepLXInfiniteRetry;
+            checkBoxDeepLxInfiniteRetry.Visible = false;
 
             nikseUpDownDelay.Value = Configuration.Settings.Tools.AutoTranslateDelaySeconds;
 
@@ -148,6 +151,7 @@ namespace Nikse.SubtitleEdit.Forms.Translate
                 this.FormBorderStyle = FormBorderStyle.FixedSingle;
             }
 
+            checkBoxDeepLxInfiniteRetry.Visible = _engineType == typeof(DeepLXTranslate);
             comboBoxParagraphHandling.Items.Clear();
             comboBoxParagraphHandling.Items.Add(LanguageSettings.Current.GenerateVideoWithEmbeddedSubs.Default);
             comboBoxParagraphHandling.Items.Add(LanguageSettings.Current.GoogleTranslate.TranslateLinesSeparately);
@@ -228,6 +232,10 @@ namespace Nikse.SubtitleEdit.Forms.Translate
                 Configuration.Settings.Tools.GeminiPrompt = nikseTextBoxPrompt.Text;
             }
 
+            if (_engineType == typeof(DeepLXTranslate))
+            {
+                Configuration.Settings.Tools.AutoTranslateDeepLXInfiniteRetry = checkBoxDeepLxInfiniteRetry.Checked;
+            }
             if (comboBoxParagraphHandling.SelectedIndex == 1)
             {
                 Configuration.Settings.Tools.AutoTranslateStrategy = TranslateStrategy.TranslateEachLineSeparately.ToString();

--- a/src/ui/Logic/Language.cs
+++ b/src/ui/Logic/Language.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using System.Xml.Serialization;
@@ -1348,6 +1348,7 @@ namespace Nikse.SubtitleEdit.Logic
                 CopyPasteMaxSize = "Max block size",
                 AutoCopyToClipboard = "Auto-copy to clipboard",
                 AutoCopyLineSeparator = "Line separator",
+                InfiniteRetries = "Infinite retries",
                 TranslateBlockXOfY = "Translate block {0} of {1}",
                 TranslateBlockInfo = "Go to translator and paste text, copy result back to clipboard and click the button below",
                 TranslateBlockGetFromClipboard = "Get translated text from clipboard" + Environment.NewLine + "(Ctrl + V)",

--- a/src/ui/Logic/LanguageDeserializer.cs
+++ b/src/ui/Logic/LanguageDeserializer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Text;
 using System.Xml;
 
@@ -2856,6 +2856,9 @@ namespace Nikse.SubtitleEdit.Logic
                     break;
                 case "GoogleTranslate/AutoCopyLineSeparator":
                     language.GoogleTranslate.AutoCopyLineSeparator = reader.Value;
+                    break;
+                case "GoogleTranslate/InfiniteRetries":
+                    language.GoogleTranslate.InfiniteRetries = reader.Value;
                     break;
                 case "GoogleTranslate/TranslateBlockXOfY":
                     language.GoogleTranslate.TranslateBlockXOfY = reader.Value;

--- a/src/ui/Logic/LanguageStructure.cs
+++ b/src/ui/Logic/LanguageStructure.cs
@@ -1,4 +1,4 @@
-﻿namespace Nikse.SubtitleEdit.Logic
+namespace Nikse.SubtitleEdit.Logic
 {
     // The language classes are built for easy xml-serialization (makes save/load code simple)
     public static class LanguageStructure
@@ -1167,6 +1167,7 @@
             public string CopyPasteMaxSize { get; set; }
             public string AutoCopyToClipboard { get; set; }
             public string AutoCopyLineSeparator { get; set; }
+            public string InfiniteRetries { get; set; }
             public string TranslateBlockXOfY { get; set; }
             public string TranslateBlockInfo { get; set; }
             public string TranslateBlockGetFromClipboard { get; set; }


### PR DESCRIPTION
Depends on #9982.

Desperately needed because of janky nature of DeepLX. Optional (defaults to off) checkbox only shows when DeepLX is selected.