### PR TITLE
Persist Whisper Translate to English state

### DIFF
--- a/src/libse/Settings/Settings.cs
+++ b/src/libse/Settings/Settings.cs
@@ -4444,6 +4444,12 @@ namespace Nikse.SubtitleEdit.Core.Settings
                 settings.Tools.WhisperUseLineMaxChars = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
             }
 
+            subNode = node.SelectSingleNode("WhisperTranslateToEnglish");
+            if (subNode != null)
+            {
+                settings.Tools.WhisperTranslateToEnglish = Convert.ToBoolean(subNode.InnerText, CultureInfo.InvariantCulture);
+            }
+
             subNode = node.SelectSingleNode("AudioToTextLineMaxChars");
             if (subNode != null)
             {
@@ -9602,6 +9608,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
                 xmlWriter.WriteElementString("WhisperPostProcessingMergeLines", settings.Tools.WhisperPostProcessingMergeLines.ToString(CultureInfo.InvariantCulture));
                 xmlWriter.WriteElementString("WhisperPostProcessingFixCasing", settings.Tools.WhisperPostProcessingFixCasing.ToString(CultureInfo.InvariantCulture));
                 xmlWriter.WriteElementString("WhisperPostProcessingFixShortDuration", settings.Tools.WhisperPostProcessingFixShortDuration.ToString(CultureInfo.InvariantCulture));
+                xmlWriter.WriteElementString("WhisperTranslateToEnglish", settings.Tools.WhisperTranslateToEnglish.ToString(CultureInfo.InvariantCulture));
                 xmlWriter.WriteElementString("AudioToTextLineMaxChars", settings.Tools.AudioToTextLineMaxChars.ToString(CultureInfo.InvariantCulture));
                 xmlWriter.WriteElementString("AudioToTextLineMaxCharsJp", settings.Tools.AudioToTextLineMaxCharsJp.ToString(CultureInfo.InvariantCulture));
                 xmlWriter.WriteElementString("AudioToTextLineMaxCharsCn", settings.Tools.AudioToTextLineMaxCharsCn.ToString(CultureInfo.InvariantCulture));

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -453,6 +453,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public bool WhisperPostProcessingSplitLines { get; set; }
         public bool WhisperPostProcessingFixCasing { get; set; }
         public bool WhisperPostProcessingFixShortDuration { get; set; }
+        public bool WhisperTranslateToEnglish { get; set; }
         public int AudioToTextLineMaxChars { get; set; }
         public int AudioToTextLineMaxCharsJp { get; set; }
         public int AudioToTextLineMaxCharsCn { get; set; }
@@ -731,6 +732,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             WhisperPostProcessingSplitLines = true;
             WhisperPostProcessingFixCasing = false;
             WhisperPostProcessingFixShortDuration = true;
+            WhisperTranslateToEnglish = false;
             AudioToTextLineMaxChars = 86;
             AudioToTextLineMaxCharsJp = 32;
             AudioToTextLineMaxCharsCn = 36;

--- a/src/ui/Forms/AudioToText/WhisperAudioToText.cs
+++ b/src/ui/Forms/AudioToText/WhisperAudioToText.cs
@@ -193,6 +193,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
             labelFC.Text = string.Empty;
 
             removeTemporaryFilesToolStripMenuItem.Checked = Configuration.Settings.Tools.WhisperDeleteTempFiles;
+            checkBoxTranslateToEnglish.Checked = Configuration.Settings.Tools.WhisperTranslateToEnglish;
             ContextMenuStrip = contextMenuStripWhisperAdvanced;
         }
 
@@ -1489,6 +1490,7 @@ namespace Nikse.SubtitleEdit.Forms.AudioToText
 
             Configuration.Settings.Tools.VoskPostProcessing = checkBoxUsePostProcessing.Checked;
             Configuration.Settings.Tools.WhisperAutoAdjustTimings = checkBoxAutoAdjustTimings.Checked;
+            Configuration.Settings.Tools.WhisperTranslateToEnglish = checkBoxTranslateToEnglish.Checked;
 
             DeleteTemporaryFiles(_filesToDelete);
         }


### PR DESCRIPTION
Save and load the last chosen state of the Translate to English checkbox in the Whisper dialog box.