### PR TITLE
Fix typo in `InitializeLiveSpellCheck` method name

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -8598,11 +8598,11 @@ namespace Nikse.SubtitleEdit.Forms
         private void LiveSpellCheckTimer_Tick(object sender, EventArgs e)
         {
             _liveSpellCheckTimer.Stop();
-            InitializeLiveSpellChcek();
+            InitializeLiveSpellCheck();
             _liveSpellCheckTimer.Start();
         }
 
-        private void InitializeLiveSpellChcek()
+        private void InitializeLiveSpellCheck()
         {
             if (IsSubtitleLoaded)
             {


### PR DESCRIPTION
Corrected the method name from `InitializeLiveSpellChcek` to `InitializeLiveSpellCheck` for consistency and to prevent potential issues with method calls.