### PR TITLE
Add quick buttons for show earlier/later dialog and video sync where applicable

### DIFF
--- a/src/ui/Forms/BinaryEdit/BinEdit.cs
+++ b/src/ui/Forms/BinaryEdit/BinEdit.cs
@@ -2145,12 +2145,12 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 
             using (var form = new ShowEarlierLater())
             {
-                form.Initialize(ShowEarlierOrLater, subtitleListView1.SelectedItems.Count > 1);
+                form.Initialize(ShowEarlierOrLater, subtitleListView1.SelectedItems.Count > 1, false);
                 form.ShowDialog(this);
             }
         }
 
-        public void ShowEarlierOrLater(double adjustMilliseconds, SelectionChoice selection)
+        public void ShowEarlierOrLater(double adjustMilliseconds, SelectionChoice selection, bool syncWithPlayer)
         {
             if (subtitleListView1.SelectedItems.Count < 1)
             {
@@ -2529,7 +2529,7 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 
             using (var form = new ShowEarlierLater())
             {
-                form.Initialize(ShowEarlierOrLater, true);
+                form.Initialize(ShowEarlierOrLater, true, false);
                 form.ShowDialog(this);
             }
         }

--- a/src/ui/Forms/ExportPngXml.cs
+++ b/src/ui/Forms/ExportPngXml.cs
@@ -6224,12 +6224,12 @@ $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
         {
             using (var showEarlierOrLater = new ShowEarlierLater())
             {
-                showEarlierOrLater.Initialize(ShowEarlierOrLater, false);
+                showEarlierOrLater.Initialize(ShowEarlierOrLater, false, false);
                 showEarlierOrLater.ShowDialog(this);
             }
         }
 
-        public void ShowEarlierOrLater(double adjustMilliseconds, SelectionChoice selection)
+        public void ShowEarlierOrLater(double adjustMilliseconds, SelectionChoice selection, bool syncPlayer /* ignored */)
         {
             adjustMilliseconds /= TimeCode.BaseUnit;
             subtitleListView1.BeginUpdate();

--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -17043,7 +17043,7 @@ namespace Nikse.SubtitleEdit.Forms
                 _showEarlierOrLater.Left = Left + (Width / 2) - (_showEarlierOrLater.Width / 3);
             }
 
-            _showEarlierOrLater.Initialize(ShowEarlierOrLater, true);
+            _showEarlierOrLater.Initialize(ShowEarlierOrLater, true, true);
             MakeHistoryForUndo(_language.BeforeShowSelectedLinesEarlierLater);
             _showEarlierOrLater.Show(this);
 
@@ -19220,12 +19220,12 @@ namespace Nikse.SubtitleEdit.Forms
             }
             else if (_shortcuts.MainAdjustSelected100MsForward == e.KeyData)
             {
-                ShowEarlierOrLater(100, SelectionChoice.SelectionOnly);
+                ShowEarlierOrLater(100, SelectionChoice.SelectionOnly, false);
                 e.SuppressKeyPress = true;
             }
             else if (_shortcuts.MainAdjustSelected100MsBack == e.KeyData)
             {
-                ShowEarlierOrLater(-100, SelectionChoice.SelectionOnly);
+                ShowEarlierOrLater(-100, SelectionChoice.SelectionOnly, false);
                 e.SuppressKeyPress = true;
             }
 
@@ -19233,12 +19233,12 @@ namespace Nikse.SubtitleEdit.Forms
             // adjust
             else if (_shortcuts.MainAdjustSelected100MsForward == e.KeyData)
             {
-                ShowEarlierOrLater(100, SelectionChoice.SelectionOnly);
+                ShowEarlierOrLater(100, SelectionChoice.SelectionOnly, false);
                 e.SuppressKeyPress = true;
             }
             else if (_shortcuts.MainAdjustSelected100MsBack == e.KeyData)
             {
-                ShowEarlierOrLater(-100, SelectionChoice.SelectionOnly);
+                ShowEarlierOrLater(-100, SelectionChoice.SelectionOnly, false);
                 e.SuppressKeyPress = true;
             }
             else if (_shortcuts.MainAdjustAdjustStartXMsBack == e.KeyData)
@@ -25644,7 +25644,7 @@ namespace Nikse.SubtitleEdit.Forms
             audioVisualizer.WaveformAlpha = Math.Min(512 - opacity, 255);
         }
 
-        public void ShowEarlierOrLater(double adjustMilliseconds, SelectionChoice selection)
+        public void ShowEarlierOrLater(double adjustMilliseconds, SelectionChoice selection, bool syncPlayer)
         {
             var tc = new TimeCode(adjustMilliseconds);
             MakeHistoryForUndo(_language.BeforeShowSelectedLinesEarlierLater + ": " + tc);
@@ -25761,6 +25761,11 @@ namespace Nikse.SubtitleEdit.Forms
             RefreshSelectedParagraph();
             UpdateSourceView();
             UpdateListSyntaxColoring();
+
+            if (syncPlayer)
+            {
+                GotoSubPositionAndPause();
+            }
         }
 
         private void ShowEarlierOrLaterParagraph(double adjustMilliseconds, int i)
@@ -25834,7 +25839,7 @@ namespace Nikse.SubtitleEdit.Forms
             }
 
             SaveSubtitleListviewIndices();
-            _showEarlierOrLater.Initialize(ShowEarlierOrLater, false);
+            _showEarlierOrLater.Initialize(ShowEarlierOrLater, false, true);
             _showEarlierOrLater.Show(this);
         }
 
@@ -26271,7 +26276,7 @@ namespace Nikse.SubtitleEdit.Forms
                 }
 
                 var offset = TimeCode.FromSeconds(videoPosition).TotalMilliseconds - p.StartTime.TotalMilliseconds;
-                ShowEarlierOrLater(offset, SelectionChoice.AllLines);
+                ShowEarlierOrLater(offset, SelectionChoice.AllLines, false);
             }
         }
 

--- a/src/ui/Forms/ShowEarlierLater.Designer.cs
+++ b/src/ui/Forms/ShowEarlierLater.Designer.cs
@@ -32,7 +32,7 @@ namespace Nikse.SubtitleEdit.Forms
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            Nikse.SubtitleEdit.Core.Common.TimeCode timeCode4 = new Nikse.SubtitleEdit.Core.Common.TimeCode();
+            Nikse.SubtitleEdit.Core.Common.TimeCode timeCode3 = new Nikse.SubtitleEdit.Core.Common.TimeCode();
             this.labelHourMinSecMilliSecond = new System.Windows.Forms.Label();
             this.buttonShowLater = new System.Windows.Forms.Button();
             this.buttonShowEarlier = new System.Windows.Forms.Button();
@@ -71,6 +71,7 @@ namespace Nikse.SubtitleEdit.Forms
             this.buttonQuick1msLater = new System.Windows.Forms.Button();
             this.buttonQuick1msEarlier = new System.Windows.Forms.Button();
             this.labelQuick1ms = new System.Windows.Forms.Label();
+            this.checkBoxSyncPlayer = new System.Windows.Forms.CheckBox();
             this.panelFooter.SuspendLayout();
             this.flowLayoutPanelMainContent.SuspendLayout();
             this.groupBoxSelection.SuspendLayout();
@@ -174,14 +175,14 @@ namespace Nikse.SubtitleEdit.Forms
             this.timeUpDownAdjust.Size = new System.Drawing.Size(105, 23);
             this.timeUpDownAdjust.TabIndex = 21;
             this.timeUpDownAdjust.TabStop = false;
-            timeCode4.Hours = 0;
-            timeCode4.Milliseconds = 0;
-            timeCode4.Minutes = 0;
-            timeCode4.Seconds = 0;
-            timeCode4.TimeSpan = System.TimeSpan.Parse("00:00:00");
-            timeCode4.TotalMilliseconds = 0D;
-            timeCode4.TotalSeconds = 0D;
-            this.timeUpDownAdjust.TimeCode = timeCode4;
+            timeCode3.Hours = 0;
+            timeCode3.Milliseconds = 0;
+            timeCode3.Minutes = 0;
+            timeCode3.Seconds = 0;
+            timeCode3.TimeSpan = System.TimeSpan.Parse("00:00:00");
+            timeCode3.TotalMilliseconds = 0D;
+            timeCode3.TotalSeconds = 0D;
+            this.timeUpDownAdjust.TimeCode = timeCode3;
             this.timeUpDownAdjust.UseVideoOffset = false;
             // 
             // radioButtonSelectedLineAndForward
@@ -200,7 +201,7 @@ namespace Nikse.SubtitleEdit.Forms
             // 
             this.panelFooter.Controls.Add(this.labelTotalAdjustment);
             this.panelFooter.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panelFooter.Location = new System.Drawing.Point(0, 266);
+            this.panelFooter.Location = new System.Drawing.Point(0, 350);
             this.panelFooter.Name = "panelFooter";
             this.panelFooter.Padding = new System.Windows.Forms.Padding(3);
             this.panelFooter.Size = new System.Drawing.Size(391, 24);
@@ -213,19 +214,20 @@ namespace Nikse.SubtitleEdit.Forms
             this.flowLayoutPanelMainContent.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanelMainContent.Location = new System.Drawing.Point(0, 0);
             this.flowLayoutPanelMainContent.Name = "flowLayoutPanelMainContent";
-            this.flowLayoutPanelMainContent.Size = new System.Drawing.Size(391, 266);
+            this.flowLayoutPanelMainContent.Size = new System.Drawing.Size(391, 350);
             this.flowLayoutPanelMainContent.TabIndex = 43;
             // 
             // groupBoxSelection
             // 
             this.groupBoxSelection.AutoSize = true;
+            this.groupBoxSelection.Controls.Add(this.checkBoxSyncPlayer);
             this.groupBoxSelection.Controls.Add(this.radioButtonAllLines);
             this.groupBoxSelection.Controls.Add(this.groupBoxCustomOffset);
             this.groupBoxSelection.Controls.Add(this.radioButtonSelectedLinesOnly);
             this.groupBoxSelection.Controls.Add(this.radioButtonSelectedLineAndForward);
             this.groupBoxSelection.Location = new System.Drawing.Point(3, 3);
             this.groupBoxSelection.Name = "groupBoxSelection";
-            this.groupBoxSelection.Size = new System.Drawing.Size(182, 235);
+            this.groupBoxSelection.Size = new System.Drawing.Size(182, 258);
             this.groupBoxSelection.TabIndex = 44;
             this.groupBoxSelection.TabStop = false;
             // 
@@ -538,11 +540,21 @@ namespace Nikse.SubtitleEdit.Forms
             this.labelQuick1ms.Text = "1ms";
             this.labelQuick1ms.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
+            // checkBoxSyncPlayer
+            // 
+            this.checkBoxSyncPlayer.AutoSize = true;
+            this.checkBoxSyncPlayer.Location = new System.Drawing.Point(16, 221);
+            this.checkBoxSyncPlayer.Name = "checkBoxSyncPlayer";
+            this.checkBoxSyncPlayer.Size = new System.Drawing.Size(105, 17);
+            this.checkBoxSyncPlayer.TabIndex = 46;
+            this.checkBoxSyncPlayer.Text = "Sync with player";
+            this.checkBoxSyncPlayer.UseVisualStyleBackColor = true;
+            // 
             // ShowEarlierLater
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(391, 290);
+            this.ClientSize = new System.Drawing.Size(391, 374);
             this.Controls.Add(this.flowLayoutPanelMainContent);
             this.Controls.Add(this.panelFooter);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -614,5 +626,6 @@ namespace Nikse.SubtitleEdit.Forms
         private System.Windows.Forms.Button buttonQuick1msLater;
         private System.Windows.Forms.Button buttonQuick1msEarlier;
         private System.Windows.Forms.Label labelQuick1ms;
+        private System.Windows.Forms.CheckBox checkBoxSyncPlayer;
     }
 }

--- a/src/ui/Forms/ShowEarlierLater.cs
+++ b/src/ui/Forms/ShowEarlierLater.cs
@@ -14,11 +14,13 @@ namespace Nikse.SubtitleEdit.Forms
             public bool AllowSelection { get; set; }
         }
 
-        public delegate void AdjustEventHandler(double adjustMilliseconds, SelectionChoice selection);
+        public delegate void AdjustEventHandler(double adjustMilliseconds, SelectionChoice selection, bool syncPlayer);
         public delegate void AllowSelectionHandler(object sender, ViewStatus viewStatus);
         public event AllowSelectionHandler AllowSelection;
         private TimeSpan _totalAdjustment;
         private AdjustEventHandler _adjustCallback;
+
+        private bool _canSyncPlayer;
 
         public ShowEarlierLater()
         {
@@ -72,8 +74,11 @@ namespace Nikse.SubtitleEdit.Forms
             }
         }
 
-        internal void Initialize(AdjustEventHandler adjustCallback, bool onlySelected)
+        internal void Initialize(AdjustEventHandler adjustCallback, bool onlySelected, bool canSyncPlayer)
         {
+            _canSyncPlayer = canSyncPlayer;
+            checkBoxSyncPlayer.Visible = canSyncPlayer;
+
             if (onlySelected)
             {
                 radioButtonSelectedLinesOnly.Checked = true;
@@ -200,7 +205,9 @@ namespace Nikse.SubtitleEdit.Forms
             {
                 durationMs = scale * durationMs;
 
-                _adjustCallback.Invoke(durationMs, GetSelectionChoice());
+                var shouldSyncWithPlayer = _canSyncPlayer && checkBoxSyncPlayer.Checked;
+
+                _adjustCallback.Invoke(durationMs, GetSelectionChoice(), shouldSyncWithPlayer);
                 _totalAdjustment = TimeSpan.FromMilliseconds(_totalAdjustment.TotalMilliseconds + durationMs);
                 ShowTotalAdjustment();
                 Configuration.Settings.General.DefaultAdjustMilliseconds = (int)Math.Abs(durationMs);


### PR DESCRIPTION
Hello!

I've added some quick buttons to the Show earlier/later tool to make it easier to sync up subtitles to each other.

For example a video might have a hardcoded subtitle which is perfectly synced, but I have a sub for another language which is out of sync. In this case all I have to do is to visually sync the new subtitle to the hardcoded one.

My process of doing this is to sync up roughly first, then adjusting step by step the sub until they appear at the same time, so they are in sync. In each refining step I have to manually change the offset in the dialog, which is quite cumbersome.

Also after moving the sub timing I usually double click on the sub line to force the player to move to the sub, so I can double check the exact time I need.
For this I've added a checkbox "Sync with player". The initiator sets if it supports this or not. If it supports the checkbox is shown, and the initiator can react to it on callback.

I moved the controls on the dialog a bit, to make room for the quick buttons, arranged them in panels and a little more proper containers. The tool window is now resizable, so the buttons can flow/break.

<img width="390" height="303" alt="image" src="https://github.com/user-attachments/assets/768280fa-6e41-48cd-b2b3-d7b4ec74a363" />

