### PR TITLE
Add Central Kurdish (Sorani) support to Gemini translation

### DIFF
--- a/src/libse/AutoTranslate/GeminiTranslate.cs
+++ b/src/libse/AutoTranslate/GeminiTranslate.cs
@@ -201,6 +201,9 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                MakePair("Kannada","kn"),
                MakePair("Kashmiri","ks"),
                MakePair("Kazakh","kk"),
+               MakePair("Kurdish","ku"),
+               MakePair("Central Kurdish (Sorani)","ckb"),
+
                MakePair("Konkani",""),
                MakePair("Korean","ko"),
                MakePair("Kyrgyz","ky"),


### PR DESCRIPTION
This PR adds Central Kurdish (Sorani) (ckb) to the Google Gemini
auto-translation language list in Subtitle Edit.

Google Gemini already supports ckb, and this change exposes it
in both source and target language dropdowns.

ISO code: ckb
