### PR TITLE
Try to fix bottom alignment not detected in some ttml 1.0 files

### DIFF
--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -1651,7 +1651,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 !string.IsNullOrEmpty(displayAlign))
             {
                 var yPos = Convert.ToDouble(originArr[1].TrimEnd('%'), CultureInfo.InvariantCulture);
-                if (yPos > 40 && displayAlign == "after")
+                var yExtent = Convert.ToDouble(extentArr[1].TrimEnd('%'), CultureInfo.InvariantCulture);
+                if (yPos + yExtent > 75 && displayAlign == "after")
                 {
                     return true;
                 }


### PR DESCRIPTION
Hey, it's been a while. :)

I was working on a dfxp file and noticed that when I try to remove the top alignment from a line, it just returns when I open the file again.

Looking into the file, which is extracted from an online platform, I saw it had:
```
      <region xml:id="region.after.center" tts:direction="rtl" tts:displayAlign="after" tts:textAlign="center" tts:origin="10% 10%" tts:extent="80% 80%" />
      <region xml:id="region.before.center" tts:direction="rtl" tts:displayAlign="before" tts:textAlign="center" tts:origin="10% 10%" tts:extent="80% 80%" />
```

The old code says that `yPos` has to be more than 40, which is not always the case, as you can see.
Given that you also have `extent`, shouldn't this be how it works? That `yPos + yExtent` is higher than a certain threshold that makes the text in the bottom area?