### PR TITLE
Add save support to CheetahCaptionOld format

### DIFF
--- a/src/libse/SubtitleFormats/CheetahCaptionOld.cs
+++ b/src/libse/SubtitleFormats/CheetahCaptionOld.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,7 +7,7 @@ using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
-    public class CheetahCaptionOld : SubtitleFormat
+    public class CheetahCaptionOld : SubtitleFormat, IBinaryPersistableSubtitle
     {
 
         public override string Extension => ".cap";
@@ -17,6 +18,53 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public static void Save(string fileName, Subtitle subtitle)
         {
+            using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+            {
+                new CheetahCaptionOld().Save(fileName, fs, subtitle, false);
+            }
+        }
+
+        public bool Save(string fileName, Stream stream, Subtitle subtitle, bool batchMode)
+        {
+            // 128-byte header: magic bytes 0xEA 0x10, rest zeros
+            var header = new byte[0x80];
+            header[0] = 0xEA;
+            header[1] = 0x10;
+            stream.Write(header, 0, header.Length);
+
+            var encoding = Encoding.ASCII;
+            foreach (var p in subtitle.Paragraphs)
+            {
+                var record = new byte[0xb2]; // 178 bytes per record
+
+                // Start timecode at offset 0
+                record[0] = (byte)p.StartTime.Hours;
+                record[1] = (byte)p.StartTime.Minutes;
+                record[2] = (byte)p.StartTime.Seconds;
+                record[3] = (byte)MillisecondsToFramesMaxFrameRate(p.StartTime.Milliseconds);
+
+                // End timecode at offset 4
+                record[4] = (byte)p.EndTime.Hours;
+                record[5] = (byte)p.EndTime.Minutes;
+                record[6] = (byte)p.EndTime.Seconds;
+                record[7] = (byte)MillisecondsToFramesMaxFrameRate(p.EndTime.Milliseconds);
+
+                // Write text lines - line 1 at 0x1a (38 bytes), line 2 at 0x40 (38 bytes)
+                var text = HtmlUtil.RemoveHtmlTags(p.Text);
+                var lines = text.SplitToLines();
+                WriteTextLine(record, 0x1a, lines.Count > 0 ? lines[0] : string.Empty, encoding);
+                WriteTextLine(record, 0x40, lines.Count > 1 ? lines[1] : string.Empty, encoding);
+
+                stream.Write(record, 0, record.Length);
+            }
+
+            return true;
+        }
+
+        private static void WriteTextLine(byte[] record, int offset, string text, Encoding encoding)
+        {
+            var bytes = encoding.GetBytes(text.Length > 38 ? text.Substring(0, 38) : text);
+            Array.Copy(bytes, 0, record, offset, bytes.Length);
         }
 
         public override bool IsMine(List<string> lines, string fileName)
@@ -51,12 +99,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return new TimeCode(buffer[index], buffer[index + 1], buffer[index + 2], FramesToMillisecondsMax999(buffer[index + 3]));
         }
 
-        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        public void LoadSubtitle(Subtitle subtitle, byte[] buffer)
         {
             _errorCount = 0;
             subtitle.Paragraphs.Clear();
             subtitle.Header = null;
-            byte[] buffer = FileUtil.ReadAllBytesShared(fileName);
             int i = 0x80;
             var sb = new StringBuilder();
             while (i < buffer.Length - 0xb1)
@@ -93,6 +140,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
             }
             subtitle.Renumber();
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            _errorCount = 0;
+            subtitle.Paragraphs.Clear();
+            subtitle.Header = null;
+            byte[] buffer = FileUtil.ReadAllBytesShared(fileName);
+            LoadSubtitle(subtitle, buffer);
         }
 
     }

--- a/tests/libse/SubtitleFormats/CheetahCaptionOldTest.cs
+++ b/tests/libse/SubtitleFormats/CheetahCaptionOldTest.cs
@@ -1,0 +1,114 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.IO;
+
+namespace LibSETests.SubtitleFormats;
+
+public class CheetahCaptionOldTest
+{
+    [Fact]
+    public void SaveAndLoadSingleLine()
+    {
+        var target = new CheetahCaptionOld();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
+
+        var ms = new MemoryStream();
+        target.Save("test.cap", ms, subtitle, false);
+
+        var reload = new Subtitle();
+        target.LoadSubtitle(reload, ms.ToArray());
+
+        Assert.Single(reload.Paragraphs);
+        Assert.Equal("Hello world", reload.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void SaveAndLoadTwoLines()
+    {
+        var target = new CheetahCaptionOld();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Line one\nLine two", 2000, 5000));
+
+        var ms = new MemoryStream();
+        target.Save("test.cap", ms, subtitle, false);
+
+        var reload = new Subtitle();
+        target.LoadSubtitle(reload, ms.ToArray());
+
+        Assert.Single(reload.Paragraphs);
+        Assert.Contains("Line one", reload.Paragraphs[0].Text);
+        Assert.Contains("Line two", reload.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void SaveAndLoadTimecodes()
+    {
+        var target = new CheetahCaptionOld();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Test", 3_661_000, 3_662_000)); // 1:01:01 to 1:01:02
+
+        var ms = new MemoryStream();
+        target.Save("test.cap", ms, subtitle, false);
+
+        var reload = new Subtitle();
+        target.LoadSubtitle(reload, ms.ToArray());
+
+        Assert.Single(reload.Paragraphs);
+        Assert.Equal(1, reload.Paragraphs[0].StartTime.Hours);
+        Assert.Equal(1, reload.Paragraphs[0].StartTime.Minutes);
+        Assert.Equal(1, reload.Paragraphs[0].StartTime.Seconds);
+    }
+
+    [Fact]
+    public void SaveAndLoadMultipleParagraphs()
+    {
+        var target = new CheetahCaptionOld();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("First", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("Second", 2000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("Third", 4000, 5000));
+
+        var ms = new MemoryStream();
+        target.Save("test.cap", ms, subtitle, false);
+
+        var reload = new Subtitle();
+        target.LoadSubtitle(reload, ms.ToArray());
+
+        Assert.Equal(3, reload.Paragraphs.Count);
+        Assert.Equal("First", reload.Paragraphs[0].Text);
+        Assert.Equal("Second", reload.Paragraphs[1].Text);
+        Assert.Equal("Third", reload.Paragraphs[2].Text);
+    }
+
+    [Fact]
+    public void SaveWritesCorrectMagicBytes()
+    {
+        var target = new CheetahCaptionOld();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Test", 0, 1000));
+
+        var ms = new MemoryStream();
+        target.Save("test.cap", ms, subtitle, false);
+
+        var bytes = ms.ToArray();
+        Assert.Equal(0xEA, bytes[0]);
+        Assert.Equal(0x10, bytes[1]);
+    }
+
+    [Fact]
+    public void SaveHtmlTagsAreStripped()
+    {
+        var target = new CheetahCaptionOld();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("<i>Italic text</i>", 0, 1000));
+
+        var ms = new MemoryStream();
+        target.Save("test.cap", ms, subtitle, false);
+
+        var reload = new Subtitle();
+        target.LoadSubtitle(reload, ms.ToArray());
+
+        Assert.Equal("Italic text", reload.Paragraphs[0].Text);
+    }
+}


### PR DESCRIPTION
 ## Summary
  - Implement `IBinaryPersistableSubtitle` interface in `CheetahCaptionOld`
  - Add `Save(string, Stream, Subtitle, bool)` that writes the binary `.cap` format:
    128-byte header (`0xEA 0x10`) followed by 178-byte records with timecodes                                                                                                                                                     
    and two text lines per paragraph                                                                                                                                                                                              
  - Extract `LoadSubtitle(Subtitle, byte[])` overload so loading works directly                                                                                                                                                   
    from a byte array (required by the interface pattern and tests)                                                                                                                                                               
  - Add 6 unit tests covering: single-line roundtrip, two-line roundtrip,                                                                                                                                                         
    timecode preservation, multiple paragraphs, magic bytes, and HTML tag stripping 