### PR TITLE
Fix: Burn In dialog crash on Linux with Type1 fonts (GetTableData exception)

### DIFF
--- a/src/UI/Logic/FontHelper.cs
+++ b/src/UI/Logic/FontHelper.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Media;
+using Avalonia.Media;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -111,11 +111,23 @@ public static class FontHelper
 
     /// <summary>
     /// Reads name ID 1 (Win32/GDI family name) from the OpenType 'name' table.
-    /// Returns null when the table cannot be read.
+    /// Returns null when the table cannot be read (e.g. for Type1/PostScript fonts
+    /// that lack OpenType tables).
     /// </summary>
     private static string? ReadWin32FamilyName(SKTypeface typeface)
     {
-        var data = typeface.GetTableData(0x6E616D65u); // 'name' table tag
+        byte[]? data;
+        try
+        {
+            data = typeface.GetTableData(0x6E616D65u); // 'name' table tag
+        }
+        catch
+        {
+            // Type1 (.pfb) and other non-OpenType fonts do not have a 'name' table;
+            // SkiaSharp throws instead of returning null for these typefaces.
+            return null;
+        }
+
         if (data == null || data.Length < 6)
         {
             return null;


### PR DESCRIPTION
## What this PR does

Fixes #10314 — the Burn In dialog crashes immediately on Linux when legacy Type1 PostScript fonts (`.pfb`) are present on the system.

### The problem

`ReadWin32FamilyName()` in `FontHelper.cs` calls `SKTypeface.GetTableData(0x6E616D65u)` to read the OpenType `name` table. Type1 fonts do not have OpenType tables, and SkiaSharp **throws an exception** instead of returning `null`. The existing null-check never runs, and the exception propagates up through `BuildLibAssaFonts()` → `GetLibAssaFonts()` → `BurnInViewModel` constructor, crashing the dialog.

### The fix

Wrap the `GetTableData()` call in a `try/catch`, returning `null` on failure. The callers already have `?? typeface.FamilyName` fallbacks, so no other changes are needed.

```diff
     /// Reads name ID 1 (Win32/GDI family name) from the OpenType 'name' table.
-    /// Returns null when the table cannot be read.
+    /// Returns null when the table cannot be read (e.g. for Type1/PostScript fonts
+    /// that lack OpenType tables).
     private static string? ReadWin32FamilyName(SKTypeface typeface)
     {
-        var data = typeface.GetTableData(0x6E616D65u); // 'name' table tag
+        byte[]? data;
+        try
+        {
+            data = typeface.GetTableData(0x6E616D65u); // 'name' table tag
+        }
+        catch
+        {
+            // Type1 (.pfb) and other non-OpenType fonts do not have a 'name' table;
+            // SkiaSharp throws instead of returning null for these typefaces.
+            return null;
+        }
+
         if (data == null || data.Length < 6)
```

### Stack trace from the crash

```
Unable to read the data table.
Critical error during application startup
   at SkiaSharp.SKTypeface.GetTableData(UInt32 tag)
   at Nikse.SubtitleEdit.Logic.FontHelper.ReadWin32FamilyName(SKTypeface typeface)
   at Nikse.SubtitleEdit.Logic.FontHelper.BuildLibAssaFonts()
   at Nikse.SubtitleEdit.Logic.FontHelper.GetLibAssaFonts()
   at Nikse.SubtitleEdit.Features.Video.BurnIn.BurnInViewModel..ctor(...)
```

### Testing

- Verified on Debian 13 ("trixie") with Type1 fonts in `/usr/share/fonts/X11/Type1/`
- Before: dialog crashes immediately upon opening
- After: dialog opens successfully, all TrueType/OpenType fonts are shown, Type1 fonts gracefully fall back to `SKTypeface.FamilyName`

---

> **Note from the author:** I am not a professional programmer, and I used AI assistance to produce this fix. I truly appreciate the incredible work the SubtitleEdit team puts into this project — it's an amazing piece of software. I completely understand if you prefer to reject this commit and implement your own fix; no hard feelings at all. I did my best to ensure the change is minimal, correct, and consistent with the existing code style. Thank you for considering it! 🙏