### PR TITLE
Add "Insert Line" feature and improve subtitle grid context menu logic

### DIFF
--- a/src/UI/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/UI/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -31,16 +31,18 @@ public static partial class InitListViewAndEditBox
             vm.SubtitleGrid.SelectionChanged -= vm.SubtitleGrid_SelectionChanged;
             vm.SubtitleGrid.Tapped -= vm.OnSubtitleGridSingleTapped;
             vm.SubtitleGrid.DoubleTapped -= vm.OnSubtitleGridDoubleTapped;
-            vm.SubtitleGrid.PointerPressed -= vm.SubtitleGrid_PointerPressed;
-            vm.SubtitleGrid.PointerReleased -= vm.SubtitleGrid_PointerReleased;
 
-            // Remove handlers added with AddHandler
-            vm.SubtitleGrid.RemoveHandler(InputElement.PointerPressedEvent, vm.SubtitleGrid_PointerPressed);
-            vm.SubtitleGrid.RemoveHandler(InputElement.PointerReleasedEvent, vm.SubtitleGrid_PointerReleased);
+            if (vm.SubtitleGridDropHost != null)
+            {
+                vm.SubtitleGridDropHost.PointerPressed -= vm.SubtitleGrid_PointerPressed;
+                vm.SubtitleGridDropHost.RemoveHandler(InputElement.PointerPressedEvent, vm.SubtitleGrid_PointerPressed);
+                vm.SubtitleGridDropHost.RemoveHandler(InputElement.PointerReleasedEvent, vm.SubtitleGrid_PointerReleased);
+                vm.SubtitleGridDropHost.ContextFlyout = null;
+                vm.SubtitleGridDropHost = null;
+            }
 
             // Clear the grid to help with garbage collection
             vm.SubtitleGrid.ItemsSource = null;
-            vm.SubtitleGrid.ContextFlyout = null;
         }
 
         // Unhook events from old text editors if they exist
@@ -100,6 +102,7 @@ public static partial class InitListViewAndEditBox
             Background = Brushes.Transparent,
             Child = vm.SubtitleGrid
         };
+        vm.SubtitleGridDropHost = dropHost;
         DragDrop.SetAllowDrop(dropHost, true);
         dropHost.AddHandler(DragDrop.DragOverEvent, vm.SubtitleGridOnDragOver, RoutingStrategies.Bubble);
         dropHost.AddHandler(DragDrop.DropEvent, vm.SubtitleGridOnDrop, RoutingStrategies.Bubble);
@@ -467,7 +470,7 @@ public static partial class InitListViewAndEditBox
         var flyout = new MenuFlyout();
 
         flyout.Opening += vm.SubtitleContextOpening;
-        vm.SubtitleGrid.PointerPressed += vm.SubtitleGrid_PointerPressed;
+        dropHost.PointerPressed += vm.SubtitleGrid_PointerPressed;
 
         var assaStylesMenuItem = new MenuItem
         {
@@ -638,19 +641,24 @@ public static partial class InitListViewAndEditBox
 
 
         var deleteMenuItem = new MenuItem { Header = Se.Language.General.Delete, DataContext = vm };
-        deleteMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        deleteMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         deleteMenuItem.Command = vm.DeleteSelectedLinesCommand;
         flyout.Items.Add(deleteMenuItem);
 
         var insertBeforeMenuItem = new MenuItem { Header = Se.Language.General.InsertBefore, DataContext = vm };
-        insertBeforeMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        insertBeforeMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         insertBeforeMenuItem.Command = vm.InsertLineBeforeCommand;
         flyout.Items.Add(insertBeforeMenuItem);
 
         var insertAfterMenuItem = new MenuItem { Header = Se.Language.General.InsertAfter, DataContext = vm };
-        insertAfterMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        insertAfterMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         insertAfterMenuItem.Command = vm.InsertLineAfterCommand;
         flyout.Items.Add(insertAfterMenuItem);
+
+        var insertLineMenuItem = new MenuItem { Header = Se.Language.General.InsertLine, DataContext = vm };
+        insertLineMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsInsertLineNoSelectionVisible)));
+        insertLineMenuItem.Command = vm.InsertLineAtEndCommand;
+        flyout.Items.Add(insertLineMenuItem);
 
         var copyOriginal = new MenuItem { Header = Se.Language.Main.CopyTextFromOriginalToCurrent, Command = vm.ColumnCopyTextFromOriginalToCurrentCommand };
         copyOriginal.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowColumnOriginalText)));
@@ -671,15 +679,15 @@ public static partial class InitListViewAndEditBox
                 new MenuItem { Header = Se.Language.Main.TextDown, Command = vm.ColumnTextDownCommand },
             }
         };
-        columnMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        columnMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(columnMenuItem);
 
         var sep1 = new Separator { DataContext = vm };
-        sep1.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        sep1.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(sep1);
 
         var splitMenuItem = new MenuItem { Header = Se.Language.General.SplitLine, DataContext = vm };
-        splitMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        splitMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         splitMenuItem.Command = vm.SplitCommand;
         flyout.Items.Add(splitMenuItem);
 
@@ -694,31 +702,31 @@ public static partial class InitListViewAndEditBox
         flyout.Items.Add(mergeNextMenuItem);
 
         var mergeSelectedMenuItem = new MenuItem { Header = Se.Language.General.MergeSelected, DataContext = vm };
-        mergeSelectedMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        mergeSelectedMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         mergeSelectedMenuItem.Command = vm.MergeSelectedLinesCommand;
         flyout.Items.Add(mergeSelectedMenuItem);
         vm.MenuItemMerge = mergeSelectedMenuItem;
 
         var mergeSelectedAsDialogMenuItem = new MenuItem { Header = Se.Language.General.MergeSelectedAsDialog, DataContext = vm };
-        mergeSelectedAsDialogMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        mergeSelectedAsDialogMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         mergeSelectedAsDialogMenuItem.Command = vm.MergeSelectedLinesDialogCommand;
         flyout.Items.Add(mergeSelectedAsDialogMenuItem);
         vm.MenuItemMergeAsDialog = mergeSelectedAsDialogMenuItem;
 
         var extendToLineBeforeMenuItem = new MenuItem { Header = Se.Language.General.ExtendBefore, DataContext = vm };
-        extendToLineBeforeMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        extendToLineBeforeMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         extendToLineBeforeMenuItem.Command = vm.ExtendSelectedToPreviousCommand;
         flyout.Items.Add(extendToLineBeforeMenuItem);
         vm.MenuItemExtendToLineBefore = extendToLineBeforeMenuItem;
 
         var extendToLineAfterMenuItem = new MenuItem { Header = Se.Language.General.ExtendAfter, DataContext = vm };
-        extendToLineAfterMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        extendToLineAfterMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         extendToLineAfterMenuItem.Command = vm.ExtendSelectedToPreviousCommand;
         flyout.Items.Add(extendToLineAfterMenuItem);
         vm.MenuItemExtendToLineAfter = extendToLineAfterMenuItem;
 
         var sep2 = new Separator { DataContext = vm };
-        sep2.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        sep2.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(sep2);
 
         var RemoveFormattingMenuItem = new MenuItem
@@ -771,7 +779,7 @@ public static partial class InitListViewAndEditBox
                 },
             }
         };
-        RemoveFormattingMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        RemoveFormattingMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(RemoveFormattingMenuItem);
 
 
@@ -781,7 +789,7 @@ public static partial class InitListViewAndEditBox
             Command = vm.ToggleLinesItalicCommand,
             DataContext = vm,
         };
-        italicMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        italicMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(italicMenuItem);
 
         var boldMenuItem = new MenuItem
@@ -790,7 +798,7 @@ public static partial class InitListViewAndEditBox
             Command = vm.ToggleLinesBoldCommand,
             DataContext = vm,
         };
-        boldMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        boldMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(boldMenuItem);
 
         var colorMenuItem = new MenuItem
@@ -799,7 +807,7 @@ public static partial class InitListViewAndEditBox
             Command = vm.ShowColorPickerCommand,
             DataContext = vm,
         };
-        colorMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        colorMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(colorMenuItem);
 
         var fontNameMenuItem = new MenuItem
@@ -808,7 +816,7 @@ public static partial class InitListViewAndEditBox
             Command = vm.ShowFontNamePickerCommand,
             DataContext = vm,
         };
-        fontNameMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        fontNameMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(fontNameMenuItem);
 
 
@@ -818,7 +826,7 @@ public static partial class InitListViewAndEditBox
             Command = vm.ShowAlignmentPickerCommand,
             DataContext = vm,
         };
-        alignmentMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        alignmentMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(alignmentMenuItem);
 
         var bookmarkMenuItem = new MenuItem
@@ -827,7 +835,7 @@ public static partial class InitListViewAndEditBox
             Command = vm.AddOrEditBookmarkCommand,
             DataContext = vm,
         };
-        bookmarkMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        bookmarkMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(bookmarkMenuItem);
 
         var menuItemSelectedLines = new MenuItem
@@ -906,14 +914,14 @@ public static partial class InitListViewAndEditBox
                 },
             }
         };
-        menuItemSelectedLines.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Converter = inverseBooleanConverter });
+        menuItemSelectedLines.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(menuItemSelectedLines);
 
 
-        // Set the ContextFlyout property
-        vm.SubtitleGrid.ContextFlyout = flyout;
-        vm.SubtitleGrid.AddHandler(InputElement.PointerPressedEvent, vm.SubtitleGrid_PointerPressed, RoutingStrategies.Tunnel);
-        vm.SubtitleGrid.AddHandler(InputElement.PointerReleasedEvent, vm.SubtitleGrid_PointerReleased, RoutingStrategies.Tunnel);
+        // Set the ContextFlyout on the drop host so right-clicks on empty space also show the menu
+        dropHost.ContextFlyout = flyout;
+        dropHost.AddHandler(InputElement.PointerPressedEvent, vm.SubtitleGrid_PointerPressed, RoutingStrategies.Tunnel);
+        dropHost.AddHandler(InputElement.PointerReleasedEvent, vm.SubtitleGrid_PointerReleased, RoutingStrategies.Tunnel);
 
         // Edit area - restructured with time controls on left, multiline text on right
         var editGrid = new Grid

--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -193,7 +193,9 @@ public partial class MainViewModel :
 
     [ObservableProperty] private bool _isWaveformToolbarVisible;
     [ObservableProperty] private bool _isSubtitleGridFlyoutHeaderVisible;
+    [ObservableProperty] private bool _isSubtitleGridDataMenuVisible;
     [ObservableProperty] private bool _isMergeWithNextOrPreviousVisible;
+    [ObservableProperty] private bool _isInsertLineNoSelectionVisible;
     [ObservableProperty] private bool _showColumnOriginalText;
     [ObservableProperty] private bool _showColumnEndTime;
     [ObservableProperty] private bool _showColumnGap;
@@ -246,6 +248,7 @@ public partial class MainViewModel :
     [ObservableProperty] private bool _isSubtitleSecondaryVisible;
 
     public DataGrid SubtitleGrid { get; set; }
+    public Border? SubtitleGridDropHost { get; set; }
     public Window? Window { get; set; }
     public Grid ContentGrid { get; set; }
     public MainView? MainView { get; set; }
@@ -6465,6 +6468,27 @@ public partial class MainViewModel :
     {
         _undoRedoManager.StopChangeDetection();
         InsertAfterSelectedItem();
+        _undoRedoManager.StartChangeDetection();
+    }
+
+    [RelayCommand]
+    private void InsertLineAtEnd()
+    {
+        _undoRedoManager.StopChangeDetection();
+        if (Subtitles.Count == 0)
+        {
+            _insertService.InsertBefore(SelectedSubtitleFormat, _subtitle, Subtitles, 0, string.Empty);
+            Renumber();
+            SelectAndScrollToRow(0);
+        }
+        else
+        {
+            var lastIndex = Subtitles.Count - 1;
+            _insertService.InsertAfter(SelectedSubtitleFormat, _subtitle, Subtitles, lastIndex, string.Empty);
+            Renumber();
+            SelectAndScrollToRow(lastIndex + 1);
+        }
+        _updateAudioVisualizer = true;
         _undoRedoManager.StartChangeDetection();
     }
 
@@ -13055,11 +13079,21 @@ public partial class MainViewModel :
 
         if (IsSubtitleGridFlyoutHeaderVisible)
         {
+            IsSubtitleGridDataMenuVisible = false;
             IsMergeWithNextOrPreviousVisible = false;
+            IsInsertLineNoSelectionVisible = false;
+        }
+        else if (Subtitles.Count == 0)
+        {
+            IsSubtitleGridDataMenuVisible = false;
+            IsMergeWithNextOrPreviousVisible = false;
+            IsInsertLineNoSelectionVisible = true;
         }
         else
         {
+            IsSubtitleGridDataMenuVisible = true;
             IsMergeWithNextOrPreviousVisible = SubtitleGrid.SelectedItems.Count == 1;
+            IsInsertLineNoSelectionVisible = false;
 
             if (IsFormatAssa || IsFormatSsa)
             {

--- a/src/UI/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/UI/Logic/Config/Language/LanguageGeneral.cs
@@ -247,6 +247,7 @@ public class LanguageGeneral
     public string InsertAtPositionAndFocusTextBox { get; set; }
     public string InsertAtPositionNoFocusTextBox { get; set; }
     public string InsertBefore { get; set; }
+    public string InsertLine { get; set; }
     public string InsertNewSelection { get; set; }
     public string InsertSubtitleAfterCurrentLine { get; set; }
     public string InsertSubtitleFileAtVideoPositionDotDotDot { get; set; }
@@ -888,6 +889,7 @@ public class LanguageGeneral
         InsertAtPositionAndFocusTextBox = "Insert subtitle at video position and focus text box";
         InsertAtPositionNoFocusTextBox = "Insert subtitle at video position (no focus text box)";
         InsertBefore = "Insert before";
+        InsertLine = "Insert line";
         InsertNewSelection = "Insert new selection";
         InsertSubtitleAfterCurrentLine = "Insert subtitle after current line...";
         InsertSubtitleFileAtVideoPositionDotDotDot = "Insert subtitle file at video position...";


### PR DESCRIPTION
Extended functionality with a new "Insert Line" command targeting empty grids. Adjusted the subtitle grid context menu binding to replace redundant checks with state-specific visibility logic. Enhanced empty area interactivity by setting the context menu on the drop host.

Closes #10351