### PR TITLE
Update ToString override declarations to align with C# conventions

### DIFF
--- a/src/UI/Features/Files/ExportImageBased/ExportAlignmentDisplay.cs
+++ b/src/UI/Features/Files/ExportImageBased/ExportAlignmentDisplay.cs
@@ -13,7 +13,7 @@ public class ExportAlignmentDisplay
         DisplayName = displayName;
     }
 
-    override public string ToString()
+    public override string ToString()
     {
         return DisplayName;
     }   

--- a/src/UI/Features/Files/ExportImageBased/ExportContentAlignmentDisplay.cs
+++ b/src/UI/Features/Files/ExportImageBased/ExportContentAlignmentDisplay.cs
@@ -13,7 +13,7 @@ public class ExportContentAlignmentDisplay
         DisplayName = displayName;
     }
 
-    override public string ToString()
+    public override string ToString()
     {
         return DisplayName;
     }   

--- a/src/UI/Features/Options/Settings/ProfileDisplay.cs
+++ b/src/UI/Features/Options/Settings/ProfileDisplay.cs
@@ -101,7 +101,7 @@ public partial class ProfileDisplay : ObservableObject
         };
     }
 
-    override public string ToString()
+    public override string ToString()
     {
         return Name;
     }

--- a/src/UI/Features/Tools/FixCommonErrors/ProfileDisplayItem.cs
+++ b/src/UI/Features/Tools/FixCommonErrors/ProfileDisplayItem.cs
@@ -14,7 +14,7 @@ public partial class ProfileDisplayItem : ObservableObject
         Name = string.Empty;
         FixRules = new ObservableCollection<FixRuleDisplayItem>();
     }
-    override public string ToString()
+    public override string ToString()
     {
         return Name;
     }

--- a/src/UI/Features/Video/TextToSpeech/EncodingSettings/EncodingDisplayItem.cs
+++ b/src/UI/Features/Video/TextToSpeech/EncodingSettings/EncodingDisplayItem.cs
@@ -14,7 +14,7 @@ public class EncodingDisplayItem
         Code = string.Empty;
     }
 
-    override public string ToString()
+    public override string ToString()
     {
         return Name;
     }


### PR DESCRIPTION
## Summary
- Refactored `override public` to `public override` across multiple `ToString()` declarations for consistency and adherence to C# coding standards.
- Files updated: `ExportAlignmentDisplay.cs`, `ExportContentAlignmentDisplay.cs`, `ProfileDisplay.cs`, `ProfileDisplayItem.cs`, `EncodingDisplayItem.cs`

## Test plan
- [x] Verify that the affected `ToString()` methods still function correctly
- [x] Confirm the project builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)