### PR TITLE
Add Renumber tool for subtitle paragraphs

### DIFF
--- a/src/UI/DependencyInjectionExtensions.cs
+++ b/src/UI/DependencyInjectionExtensions.cs
@@ -106,6 +106,7 @@ using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameText;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
+using Nikse.SubtitleEdit.Features.Tools.Renumber;
 using Nikse.SubtitleEdit.Features.Tools.SortBy;
 using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 using Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
@@ -361,6 +362,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<PromptUnknownWordViewModel>();
         collection.AddTransient<ReEncodeVideoViewModel>();
         collection.AddTransient<RemoveTextForHearingImpairedViewModel>();
+        collection.AddTransient<RenumberViewModel>();
         collection.AddTransient<ReplaceViewModel>();
         collection.AddTransient<RestoreAutoBackupViewModel>();
         collection.AddTransient<ReviewSpeechHistoryViewModel>();

--- a/src/UI/Features/Main/Layout/InitMenu.cs
+++ b/src/UI/Features/Main/Layout/InitMenu.cs
@@ -436,6 +436,11 @@ public static class InitMenu
             },
             new MenuItem
             {
+                Header = l.Renumber,
+                Command = vm.ShowToolsRenumberCommand,
+            },
+            new MenuItem
+            {
                 Header = l.RemoveTextForHearingImpaired,
                 Command = vm.ShowToolsRemoveTextForHearingImpairedCommand,
             },

--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -110,6 +110,7 @@ using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameText;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
+using Nikse.SubtitleEdit.Features.Tools.Renumber;
 using Nikse.SubtitleEdit.Features.Tools.SortBy;
 using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 using Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
@@ -3949,6 +3950,33 @@ public partial class MainViewModel :
         {
             SetSubtitles(result.FixedSubtitle);
             SelectAndScrollToRow(idx);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ShowToolsRenumber()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        var result = await ShowDialogAsync<RenumberWindow, RenumberViewModel>(vm => { vm.Initialize(Subtitles.ToList()); });
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        for (var i = 0; i < Subtitles.Count; i++)
+        {
+            Subtitles[i].Number = result.ResultSubtitles[i].Number;
         }
     }
 

--- a/src/UI/Features/Tools/Renumber/RenumberViewModel.cs
+++ b/src/UI/Features/Tools/Renumber/RenumberViewModel.cs
@@ -1,0 +1,65 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.Tools.Renumber;
+
+public partial class RenumberViewModel : ObservableObject
+{
+    [ObservableProperty] private int _startNumber;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+    public List<SubtitleLineViewModel> ResultSubtitles { get; private set; }
+
+    private List<SubtitleLineViewModel> _subtitles;
+
+    public RenumberViewModel()
+    {
+        _startNumber = 1;
+        _subtitles = new List<SubtitleLineViewModel>();
+        ResultSubtitles = new List<SubtitleLineViewModel>();
+    }
+
+    public void Initialize(List<SubtitleLineViewModel> subtitles)
+    {
+        _subtitles = subtitles;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        ResultSubtitles = new List<SubtitleLineViewModel>(_subtitles);
+        for (var i = 0; i < ResultSubtitles.Count; i++)
+        {
+            ResultSubtitles[i].Number = StartNumber + i;
+        }
+
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/renumber");
+        }
+    }
+}

--- a/src/UI/Features/Tools/Renumber/RenumberWindow.cs
+++ b/src/UI/Features/Tools/Renumber/RenumberWindow.cs
@@ -1,0 +1,54 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.Renumber;
+
+public class RenumberWindow : Window
+{
+    public RenumberWindow(RenumberViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Tools.Renumber.Title;
+        CanResize = false;
+        Width = 350;
+        Height = 180;
+        vm.Window = this;
+        DataContext = vm;
+
+        var label = UiUtil.MakeLabel(Se.Language.Tools.Renumber.StartFromNumber);
+        var numericUpDown = UiUtil.MakeNumericUpDownInt(0, 99999, 1, 150, vm, nameof(vm.StartNumber));
+
+        var panelInput = UiUtil.MakeVerticalPanel(label, numericUpDown);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 10,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(panelInput, 0);
+        grid.Add(panelButtons, 2);
+
+        Content = grid;
+
+        Loaded += delegate { numericUpDown.Focus(); };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/UI/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/UI/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -52,6 +52,7 @@ public class LanguageMainMenu
     public string MergeLinesWithSameTimeCodes { get; set; }
     public string SplitBreakLongLines { get; set; }
     public string MergeShortLines { get; set; }
+    public string Renumber { get; set; }
     public string RemoveTextForHearingImpaired { get; set; }
     public string ConvertActors { get; set; }
     public string JoinSubtitles { get; set; }
@@ -167,6 +168,7 @@ public class LanguageMainMenu
         MergeLinesWithSameTimeCodes = "Merge lines with same time codes...";
         SplitBreakLongLines = "Split/rebalance long lines...";
         MergeShortLines = "Merge short lines...";
+        Renumber = "Renumber...";
         RemoveTextForHearingImpaired = "_Remove text for hearing impaired...";
         ConvertActors = "Convert actors...";
         ChangeCasing = "_Change casing...";

--- a/src/UI/Logic/Config/Language/Tools/LanguageRenumber.cs
+++ b/src/UI/Logic/Config/Language/Tools/LanguageRenumber.cs
@@ -1,0 +1,13 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language.Tools;
+
+public class LanguageRenumber
+{
+    public string Title { get; set; }
+    public string StartFromNumber { get; set; }
+
+    public LanguageRenumber()
+    {
+        Title = "Renumber";
+        StartFromNumber = "Start from number:";
+    }
+}

--- a/src/UI/Logic/Config/Language/Tools/LanguageTools.cs
+++ b/src/UI/Logic/Config/Language/Tools/LanguageTools.cs
@@ -8,6 +8,7 @@ public class LanguageTools
     public LanguageApplyMinGaps ApplyMinGaps { get; set; } = new();
     public LanguageBeautifyTimeCodes BeautifyTimeCodes { get; set; } = new();
     public LanguageBridgeGaps BridgeGaps { get; set; } = new();
+    public LanguageRenumber Renumber { get; set; } = new();
     public LanguageSortBy SortBy { get; set; } = new();
     public LanguageBatchConvert BatchConvert { get; set; } = new();
     public LanguageChangeCasing ChangeCasing { get; set; } = new();

--- a/src/UI/Logic/WindowsService.cs
+++ b/src/UI/Logic/WindowsService.cs
@@ -149,7 +149,7 @@ namespace Nikse.SubtitleEdit.Logic
             UiTheme.ApplyScaleToWindow(window);
 
             await window.ShowDialog(owner);
-
+            
             return viewModel;
         }
 


### PR DESCRIPTION
## Summary
- Add new **Renumber** tool under the Tools menu that allows renumbering subtitle paragraphs starting from a user-specified number
- Includes a simple dialog window with a numeric input ("Start from number:") and OK/Cancel buttons
- Integrated with the existing tool window patterns (MVVM, DI, language support)

## New files
- `src/ui/Features/Tools/Renumber/RenumberViewModel.cs`
- `src/ui/Features/Tools/Renumber/RenumberWindow.cs`
- `src/ui/Logic/Config/Language/Tools/LanguageRenumber.cs`

## Test plan
- [x] Open a subtitle file with multiple lines
- [x] Go to Tools > Renumber
- [x] Verify the dialog appears with "Start from number:" label and numeric input defaulting to 1
- [x] Change the number to a custom value (e.g. 5) and click OK
- [x] Verify all subtitle paragraphs are renumbered starting from 5
- [x] Reopen the dialog, click Cancel, and verify no changes are made

🤖 Generated with [Claude Code](https://claude.com/claude-code)