### PR TITLE
fix: reimplement functionality to send copy-pasted translations to main window

### DIFF
--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -5563,16 +5563,16 @@ public partial class MainViewModel :
             return;
         }
 
-        //for (var i = 0; i < Subtitles.Count; i++)
-        //{
-        //    if (result.Rows.Count <= i)
-        //    {
-        //        break;
-        //    }
+        for (var i = 0; i < Subtitles.Count; i++)
+        {
+            if (result.Rows.Count <= i)
+            {
+                break;
+            }
 
-        //    Subtitles[i].OriginalText = Subtitles[i].Text;
-        //    Subtitles[i].Text = result.Rows[i].TranslatedText;
-        //}
+            Subtitles[i].OriginalText = Subtitles[i].Text;
+            Subtitles[i].Text = result.Rows[i].TranslatedText;
+        }
 
         _subtitleFileNameOriginal = _subtitleFileName;
         _subtitleFileName = string.Empty;

--- a/src/UI/Features/Translate/CopyPasteTranslateViewModel.cs
+++ b/src/UI/Features/Translate/CopyPasteTranslateViewModel.cs
@@ -17,6 +17,7 @@ namespace Nikse.SubtitleEdit.Features.Translate;
 
 public partial class CopyPasteTranslateViewModel : ObservableObject
 {
+    [ObservableProperty] private ObservableCollection<TranslateRow> _rows;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _subtitles;
     [ObservableProperty] private SubtitleLineViewModel? _selectedSubtitle;
     [ObservableProperty] private int? _maxBlockSize;
@@ -35,6 +36,7 @@ public partial class CopyPasteTranslateViewModel : ObservableObject
 
         SubtitleGrid = new DataGrid();
         Subtitles = new ObservableCollection<SubtitleLineViewModel>();
+        Rows = new ObservableCollection<TranslateRow>();
         MaxBlockSize = Se.Settings.AutoTranslate.CopyPasteMaxBlockSize;
         LineSeparator = Se.Settings.AutoTranslate.CopyPasteLineSeparator;
     }
@@ -144,6 +146,18 @@ public partial class CopyPasteTranslateViewModel : ObservableObject
             if (index < Subtitles.Count)
             {
                 var item = Subtitles[index];
+
+                TranslateRow row = new TranslateRow
+                {
+                    Number = item.Number,
+                    Show = item.StartTime,
+                    Hide = item.EndTime,
+                    Duration = item.Duration.ToString(),
+                    Text = item.Text,
+                    TranslatedText = s
+                };
+                Rows.Add(row);
+
                 item.Text = s;
             }
             index++;


### PR DESCRIPTION
The copy-paste translate window wasn't transferring translated lines to the current subtitle due to the relevant code being commented out. I uncommented those lines, added the Rows property to CopyPasteTranslateViewModel, and created those rows in FillTranslatedText.