### PR TITLE
Fix shortcuts not responding after using IME input methods

### DIFF
--- a/src/UI/Logic/ShortcutManager.cs
+++ b/src/UI/Logic/ShortcutManager.cs
@@ -34,7 +34,16 @@ public class ShortcutManager : IShortcutManager
 
     public void OnKeyPressed(object? sender, KeyEventArgs e)
     {
-        // Avoid adding modifier keys to the active keys set to prevent redundancy 
+        // When IME is processing input, clear all active keys to prevent stale keys
+        // from corrupting shortcut hash lookups (e.g., after using Chinese input methods)
+        if (e.Key is Key.ImeProcessed or Key.ImeConvert or Key.ImeNonConvert or
+            Key.ImeAccept or Key.ImeModeChange or Key.DeadCharProcessed or Key.None)
+        {
+            _activeKeys.Clear();
+            return;
+        }
+
+        // Avoid adding modifier keys to the active keys set to prevent redundancy
         // with KeyEventArgs.KeyModifiers
         if (e.Key is not (Key.LeftCtrl or Key.RightCtrl or
             Key.LeftShift or Key.RightShift or
@@ -50,7 +59,15 @@ public class ShortcutManager : IShortcutManager
 
     public void OnKeyReleased(object? sender, KeyEventArgs e)
     {
-        _activeKeys.Remove(e.Key);
+        if (e.Key is Key.ImeProcessed or Key.ImeConvert or Key.ImeNonConvert or
+            Key.ImeAccept or Key.ImeModeChange or Key.DeadCharProcessed or Key.None)
+        {
+            _activeKeys.Clear();
+        }
+        else
+        {
+            _activeKeys.Remove(e.Key);
+        }
 
         _isControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
         _isShiftPressed = e.KeyModifiers.HasFlag(KeyModifiers.Shift);


### PR DESCRIPTION
## Summary
- Fix shortcut keys becoming unresponsive after using IME input methods (e.g., Sogou Chinese)
- Clear `_activeKeys` when IME-related key events are detected in `ShortcutManager.OnKeyPressed` and `OnKeyReleased`
- Prevents stale IME keys from corrupting the shortcut hash lookup

## Root Cause
When an IME is active, key events arrive with special values like `Key.ImeProcessed`. These were added to `_activeKeys` but never properly removed (the KeyUp may arrive with a different key value). The stale keys corrupted the hash in `CheckShortcuts()`, causing no shortcut to match.

## Test plan
- [ ] Set shortcuts: Space → Play/Pause, Alt+Q → Merge to next, Alt+W → Split long lines
- [ ] Use a Chinese IME (e.g., Sogou) to type/edit subtitles
- [ ] Verify all shortcuts still respond after switching back from the IME
- [ ] Verify shortcuts work normally without IME usage (no regression)

Closes #10360

🤖 Generated with [Claude Code](https://claude.com/claude-code)