### PR TITLE
Add export for Cheetah Caption Old format

### DIFF
--- a/src/UI/Features/Main/Layout/InitMenu.cs
+++ b/src/UI/Features/Main/Layout/InitMenu.cs
@@ -185,6 +185,11 @@ public static class InitMenu
                         },
                         new MenuItem
                         {
+                            Header = CheetahCaptionOld.NameOfFormat,
+                            Command = vm.ExportCheetahCaptionOldCommand,
+                        },
+                        new MenuItem
+                        {
                             Header = Cavena890.NameOfFormat,
                             Command = vm.ExportCavena890Command,
                         },

--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -2110,6 +2110,37 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task ExportCheetahCaptionOld()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        var format = new CheetahCaptionOld();
+        using var ms = new MemoryStream();
+        format.Save(_subtitleFileName, ms, GetUpdateSubtitle(), false);
+
+        var fileName = await _fileHelper.PickSaveSubtitleFile(
+            Window!,
+            format,
+            GetNewFileName(),
+            $"Save {format.Name} file as");
+
+        if (!string.IsNullOrEmpty(fileName))
+        {
+            File.WriteAllBytes(fileName, ms.ToArray());
+            ShowStatus(string.Format(Se.Language.Main.FileExportedInFormatXToY, format.Name, fileName));
+        }
+    }
+
+    [RelayCommand]
     private async Task ExportCavena890()
     {
         if (Window == null)


### PR DESCRIPTION
## Summary
- Add `ExportCheetahCaptionOld` command to `MainViewModel` following the same pattern as `ExportCheetahCaption`
- Add "Cheetah Caption Old" menu item under File > Export, placed after the existing "Cheetah Caption" entry

## Test plan
- [x] Load a subtitle file
- [x] Go to File > Export > Cheetah Caption Old
- [x] Verify the save dialog appears with `.cap` extension
- [x] Save and verify the exported file can be re-opened as Cheetah Caption Old format

🤖 Generated with [Claude Code](https://claude.com/claude-code)