### PR TITLE
Fix logo preview hidden under video on Windows (airspace problem)

### DIFF
--- a/src/UI/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/UI/Features/Main/Layout/InitVideoPlayer.cs
@@ -9,6 +9,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.VideoPlayers;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
+using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
@@ -132,6 +133,28 @@ public static class InitVideoPlayer
         }
 
         throw new InvalidOperationException("Failed to create video player control.");
+    }
+
+    /// <summary>
+    /// Creates a video player that avoids native window embedding on Windows.
+    /// On Windows, NativeControlHost (used by mpv-wid and VLC) creates a Win32 HWND
+    /// that always renders on top of Avalonia overlays (the "airspace problem"),
+    /// making logo/overlay previews invisible. Using software rendering avoids this.
+    /// On non-Windows or when mpv is unavailable, falls back to the default player.
+    /// </summary>
+    public static VideoPlayerControl MakeVideoPlayerPreferNonNative()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var player = new LibMpvDynamicPlayer();
+            if (player.CanLoad())
+            {
+                var view = new LibMpvDynamicSoftwareControl(player);
+                return MakeVideoPlayerControl(player, view);
+            }
+        }
+
+        return MakeVideoPlayer();
     }
 
     private static VideoPlayerControl MakeVideoPlayerControl(IVideoPlayerInstance videoPlayer, Control view)

--- a/src/UI/Features/Video/BurnIn/BurnInLogoWindow.cs
+++ b/src/UI/Features/Video/BurnIn/BurnInLogoWindow.cs
@@ -117,7 +117,7 @@ public class BurnInLogoWindow : Window
         };
 
         // Video player control
-        var videoPlayerControl = InitVideoPlayer.MakeVideoPlayer();
+        var videoPlayerControl = InitVideoPlayer.MakeVideoPlayerPreferNonNative();
         videoPlayerControl.HorizontalAlignment = HorizontalAlignment.Stretch;
         videoPlayerControl.VerticalAlignment = VerticalAlignment.Stretch;
         vm.VideoPlayerControl = videoPlayerControl;


### PR DESCRIPTION
## Bug

In the **Burn-in Logo** dialog (`Video → Burn-in subtitles → Logo tab → Preview`), the logo overlay image is completely invisible — it renders behind the video surface and cannot be seen or positioned by the user.

**Affected platform:** Windows only (Linux/macOS are not affected).
**Affected players:** mpv (wid mode) and VLC — both use Avalonia's `NativeControlHost`, which embeds a Win32 HWND child window.

### Steps to reproduce
1. Open Subtitle Edit on Windows with mpv or VLC as the video player.
2. Load a video and go to **Video → Burn-in subtitles**.
3. Switch to the **Logo** tab and select a logo image.
4. Click **Preview** — the logo overlay is invisible (hidden behind the video).

### Root cause

On Windows, `NativeControlHost` creates a native Win32 HWND for the video surface. Native HWNDs always render on top of Avalonia/Skia-managed content regardless of z-order — this is the classic "airspace problem". As a result, any Avalonia `Image` overlay placed on top of the video is painted underneath the native window and becomes invisible.

### Fix

Introduce `InitVideoPlayer.MakeVideoPlayerPreferNonNative()` which, on Windows, creates an mpv player using **software rendering** (`LibMpvDynamicSoftwareControl`) instead of the native-window-embedded variant. Software rendering draws into an Avalonia `WriteableBitmap`, so the video and logo overlay share the same Avalonia render tree and z-order works correctly.

On non-Windows platforms or when mpv is unavailable, the method falls back to the default `MakeVideoPlayer()`.

### Changed files
- **`InitVideoPlayer.cs`** — new method `MakeVideoPlayerPreferNonNative()` that prefers software rendering on Windows.
- **`BurnInLogoWindow.cs`** — uses the new method instead of `MakeVideoPlayer()` for the logo preview.

### Before (logo hidden behind video):
<img width="2075" height="806" alt="qfeF0DxDTH" src="https://github.com/user-attachments/assets/c0e8bb44-8064-4da8-b996-bb27cf85fb3f"/>

### After fix:
<img width="1641" height="800" alt="{5F4790F6-17A8-4D36-8EFC-7868DBB88B05}" src="https://github.com/user-attachments/assets/7ae48496-b649-4453-947e-65453bd6587b"/>
