### PR TITLE
Focus main textbox after inserting a line

### DIFF
--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -6540,6 +6540,7 @@ public partial class MainViewModel :
         _undoRedoManager.StopChangeDetection();
         InsertBeforeSelectedItem();
         _undoRedoManager.StartChangeDetection();
+        EditTextBox.Focus();
     }
 
     [RelayCommand]
@@ -6548,6 +6549,7 @@ public partial class MainViewModel :
         _undoRedoManager.StopChangeDetection();
         InsertAfterSelectedItem();
         _undoRedoManager.StartChangeDetection();
+        EditTextBox.Focus();
     }
 
     [RelayCommand]
@@ -6569,6 +6571,7 @@ public partial class MainViewModel :
         }
         _updateAudioVisualizer = true;
         _undoRedoManager.StartChangeDetection();
+        EditTextBox.Focus();
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- Focus the main edit textbox (`EditTextBox`) after inserting a line (before, after, or at end), so the user can start typing immediately without needing to click on the textbox.

## Test plan
- [x] Open Subtitle Edit, load a subtitle file
- [x] Right-click and select "Insert before" — verify the edit textbox gets focus
- [x] Right-click and select "Insert after" — verify the edit textbox gets focus
- [x] Insert a line when no selection exists (insert at end) — verify the edit textbox gets focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)