### PR TITLE
Add drag selection support to subtitle grid

### DIFF
--- a/src/UI/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/UI/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -37,6 +37,7 @@ public static partial class InitListViewAndEditBox
                 vm.SubtitleGridDropHost.PointerPressed -= vm.SubtitleGrid_PointerPressed;
                 vm.SubtitleGridDropHost.RemoveHandler(InputElement.PointerPressedEvent, vm.SubtitleGrid_PointerPressed);
                 vm.SubtitleGridDropHost.RemoveHandler(InputElement.PointerReleasedEvent, vm.SubtitleGrid_PointerReleased);
+                vm.SubtitleGridDropHost.RemoveHandler(InputElement.PointerMovedEvent, vm.SubtitleGrid_PointerMoved);
                 vm.SubtitleGridDropHost.ContextFlyout = null;
                 vm.SubtitleGridDropHost = null;
             }
@@ -943,6 +944,7 @@ public static partial class InitListViewAndEditBox
         dropHost.ContextFlyout = flyout;
         dropHost.AddHandler(InputElement.PointerPressedEvent, vm.SubtitleGrid_PointerPressed, RoutingStrategies.Tunnel);
         dropHost.AddHandler(InputElement.PointerReleasedEvent, vm.SubtitleGrid_PointerReleased, RoutingStrategies.Tunnel);
+        dropHost.AddHandler(InputElement.PointerMovedEvent, vm.SubtitleGrid_PointerMoved, RoutingStrategies.Tunnel);
 
         // Edit area - restructured with time controls on left, multiline text on right
         var editGrid = new Grid

--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -13476,12 +13476,14 @@ public partial class MainViewModel :
     private bool _subtitleGridIsRightClick = false;
     private bool _subtitleGridIsLeftClick = false;
     private bool _subtitleGridIsControlPressed = false;
+    private int _dragSelectStartIndex = -1;
 
     public void SubtitleGrid_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         _subtitleGridIsControlPressed = false;
         _subtitleGridIsLeftClick = false;
         _subtitleGridIsRightClick = false;
+        _dragSelectStartIndex = -1;
         IsSubtitleGridFlyoutHeaderVisible = false;
 
         if (sender is Control { ContextFlyout: not null } control)
@@ -13504,11 +13506,76 @@ public partial class MainViewModel :
 
                 current = current.Parent as Control;
             }
+
+            if (_subtitleGridIsLeftClick && !_subtitleGridIsControlPressed)
+            {
+                var rowIndex = GetDataGridRowIndexFromPoint(e.GetPosition(SubtitleGrid));
+                if (rowIndex >= 0)
+                {
+                    _dragSelectStartIndex = rowIndex;
+                }
+            }
         }
+    }
+
+    private int GetDataGridRowIndexFromPoint(Avalonia.Point position)
+    {
+        var hitTest = SubtitleGrid.InputHitTest(position);
+        var current = hitTest as Control;
+        while (current != null)
+        {
+            if (current is DataGridRow row)
+            {
+                return row.Index;
+            }
+
+            current = current.Parent as Control;
+        }
+
+        return -1;
+    }
+
+    public void SubtitleGrid_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_dragSelectStartIndex < 0 || !_subtitleGridIsLeftClick)
+        {
+            return;
+        }
+
+        var props = e.GetCurrentPoint(SubtitleGrid).Properties;
+        if (!props.IsLeftButtonPressed)
+        {
+            _dragSelectStartIndex = -1;
+            return;
+        }
+
+        var currentIndex = GetDataGridRowIndexFromPoint(e.GetPosition(SubtitleGrid));
+        if (currentIndex < 0 || currentIndex == _dragSelectStartIndex)
+        {
+            return;
+        }
+
+        var startIdx = Math.Min(_dragSelectStartIndex, currentIndex);
+        var endIdx = Math.Max(_dragSelectStartIndex, currentIndex);
+
+        _subtitleGridSelectionChangedSkip = true;
+        SubtitleGrid.SelectedItems.Clear();
+        for (var i = startIdx; i <= endIdx; i++)
+        {
+            if (i < Subtitles.Count)
+            {
+                SubtitleGrid.SelectedItems.Add(Subtitles[i]);
+            }
+        }
+        _subtitleGridSelectionChangedSkip = false;
+
+        SubtitleGridSelectionChanged();
     }
 
     public void SubtitleGrid_PointerReleased(object? sender, PointerReleasedEventArgs e)
     {
+        _dragSelectStartIndex = -1;
+
         if (sender is Control { ContextFlyout: MenuFlyout menuFlyout } control)
         {
             if (_subtitleGridIsRightClick)


### PR DESCRIPTION
## Summary
- Implement drag selection on the main subtitle DataGrid, allowing users to click and drag to select a contiguous range of rows
- Adds `PointerMoved` event handler that tracks the drag start row and selects all rows between the start and current pointer position
- Existing selection modes (Ctrl+Click, Shift+Click) continue to work as before

## Test plan
- [x] Open a subtitle file with multiple lines
- [x] Click on a row and drag up/down — verify contiguous rows get selected
- [x] Verify Ctrl+Click still toggles individual row selection
- [x] Verify Shift+Click still extends selection
- [x] Verify right-click context menu still works
- [x] Verify double-click action still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>