### PR TITLE
Fix multiple Binary image compare OCR bugs

### DIFF
--- a/src/UI/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
+++ b/src/UI/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
@@ -188,7 +188,7 @@ public partial class BinaryOcrDbEditViewModel : ObservableObject
         SelectedCharacter = characters.FirstOrDefault();
         CharactersChanged();
 
-        Title = string.Format(Se.Language.Ocr.EditNOcrDatabaseXWithYItems, imageCompareName, allImages.Count);
+        Title = string.Format(Se.Language.Ocr.EditBinaryOcrDatabaseXWithYItems, imageCompareName, allImages.Count);
     }
 
     internal void CharactersChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/UI/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
+++ b/src/UI/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
@@ -10,7 +10,7 @@ public class BinaryOcrDbEditWindow : Window
 {
     public BinaryOcrDbEditWindow(BinaryOcrDbEditViewModel vm)
     {
-        Title = Se.Language.Ocr.EditNOcrDatabase;
+        Title = Se.Language.Ocr.EditBinaryOcrDatabase;
         vm.Window = this;
         UiUtil.InitializeWindow(this, GetType().Name);
         CanResize = true;
@@ -52,12 +52,12 @@ public class BinaryOcrDbEditWindow : Window
 
         Content = grid;
 
-        Activated += delegate
-        {
-            buttonOk.Focus(); // hack to make OnKeyDown work
-        };
         KeyDown += (_, e) => vm.KeyDown(e);
-        Loaded += (_, _) => Title = vm.Title;
+        Loaded += (_, _) =>
+        {
+            Title = vm.Title;
+            buttonOk.Focus();
+        };
     }
 
     private static Border MakeCharacterControlsView(BinaryOcrDbEditViewModel vm)

--- a/src/UI/Features/Ocr/BinaryOcr/BinaryOcrInspectWindow.cs
+++ b/src/UI/Features/Ocr/BinaryOcr/BinaryOcrInspectWindow.cs
@@ -55,13 +55,13 @@ public class BinaryOcrInspectWindow : Window
 
         vm.TextBoxNew.KeyDown += vm.TextBoxNewOnKeyDown;
 
-        Activated += delegate
-        {
-            vm.TextBoxNew.Focus(); // hack to make OnKeyDown work
-        };
         KeyDown += (_, e) => vm.KeyDown(e);
         KeyUp += (_, e) => vm.KeyUp(e);
-        Loaded += (_, _) => vm.OnLoaded();
+        Loaded += (_, _) =>
+        {
+            vm.OnLoaded();
+            vm.TextBoxNew.Focus();
+        };
     }
 
     private static Border MakeLinesView(BinaryOcrInspectViewModel vm)

--- a/src/UI/Features/Ocr/FixEngine/OcrFixLineResult.cs
+++ b/src/UI/Features/Ocr/FixEngine/OcrFixLineResult.cs
@@ -27,6 +27,7 @@ public class OcrFixLineResult
         var sb = new System.Text.StringBuilder();
         foreach (var w in Words)
         {
+            w.WordIndex = sb.Length;
             sb.Append(string.IsNullOrEmpty(w.FixedWord) ? w.Word : w.FixedWord);
         }
 

--- a/src/UI/Features/Ocr/NOcr/NOcrDbEditWindow.cs
+++ b/src/UI/Features/Ocr/NOcr/NOcrDbEditWindow.cs
@@ -55,14 +55,14 @@ public class NOcrDbEditWindow : Window
 
         Content = grid;
 
-        Activated += delegate
-        {
-            buttonOk.Focus(); // hack to make OnKeyDown work
-        };
         PointerWheelChanged += vm.PointerWheelChanged;
         KeyDown += (_, e) => vm.KeyDown(e);
         KeyUp += (_, e) => vm.KeyUp(e);
-        Loaded += (_,_) => Title = vm.Title;    
+        Loaded += (_, _) =>
+        {
+            Title = vm.Title;
+            buttonOk.Focus();
+        };
     }
 
     private static Border MakeCharacterControlsView(NOcrDbEditViewModel vm)

--- a/src/UI/Features/Ocr/NOcr/NOcrInspectWindow.cs
+++ b/src/UI/Features/Ocr/NOcr/NOcrInspectWindow.cs
@@ -61,9 +61,9 @@ public class NOcrInspectWindow : Window
 
         vm.TextBoxNew.KeyDown += vm.TextBoxNewOnKeyDown;
 
-        Activated += delegate
+        Loaded += delegate
         {
-            vm.TextBoxNew.Focus(); // hack to make OnKeyDown work
+            vm.TextBoxNew.Focus();
         };
 
         PointerWheelChanged += vm.PointerWheelChanged;

--- a/src/UI/Features/Ocr/OcrViewModel.cs
+++ b/src/UI/Features/Ocr/OcrViewModel.cs
@@ -1151,6 +1151,7 @@ public partial class OcrViewModel : ObservableObject
             OcredSubtitle.Add(subtitleLine);
         }
 
+        _forceClose = true;
         Close();
     }
 
@@ -2313,6 +2314,7 @@ public partial class OcrViewModel : ObservableObject
                         }
                         else if (result.ChangeAllPressed)
                         {
+                            ChangeWord(item, unknownWord, result.Word);
                             _ocrFixEngine.ChangeAll(unknownWord.Word.Word, result.Word);
                         }
                         else if (result.SkipOncePressed)
@@ -2362,10 +2364,21 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
+        var wordToFind = unknownWord.Word.FixedWord;
         var idx = unknownWord.Word.WordIndex;
-        if (item.Text.Substring(idx).StartsWith(unknownWord.Word.FixedWord))
+
+        // Try the pre-computed index first
+        if (idx >= 0 && idx < item.Text.Length && item.Text.Substring(idx).StartsWith(wordToFind))
         {
-            item.Text = item.Text.Remove(idx, unknownWord.Word.FixedWord.Length).Insert(idx, word);
+            item.Text = item.Text.Remove(idx, wordToFind.Length).Insert(idx, word);
+            return;
+        }
+
+        // Fallback: search for the word in the text (index may have shifted due to prior changes)
+        idx = item.Text.IndexOf(wordToFind, StringComparison.Ordinal);
+        if (idx >= 0)
+        {
+            item.Text = item.Text.Remove(idx, wordToFind.Length).Insert(idx, word);
         }
     }
 
@@ -3203,7 +3216,7 @@ public partial class OcrViewModel : ObservableObject
 
     internal async void OnClosing(WindowClosingEventArgs e)
     {
-        if (_forceClose || e.IsProgrammatic)
+        if (_forceClose)
         {
             SaveSettings();
             UiUtil.SaveWindowPosition(Window);

--- a/src/UI/Features/Ocr/OcrWindow.cs
+++ b/src/UI/Features/Ocr/OcrWindow.cs
@@ -427,7 +427,7 @@ public class OcrWindow : Window
             },
         };
         dataGridSubtitle.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedOcrSubtitleItem)) { Source = vm });
-        dataGridSubtitle.KeyDown += vm.SubtitleGridKeyDown;
+        dataGridSubtitle.AddHandler(KeyDownEvent, vm.SubtitleGridKeyDown, Avalonia.Interactivity.RoutingStrategies.Bubble, true);
         dataGridSubtitle.DoubleTapped += (s, e) => vm.SubtitleGridDoubleTapped();
         dataGridSubtitle.AddHandler(InputElement.PointerPressedEvent, vm.DataGridSubtitleMacPointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         dataGridSubtitle.AddHandler(InputElement.PointerReleasedEvent, vm.DataGridSubtitleMacPointerReleased, Avalonia.Interactivity.RoutingStrategies.Tunnel);

--- a/src/UI/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/UI/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -67,6 +67,7 @@ public class LanguageOcr
     public string DarknessThreshold { get; set; }
     public string EditExportDotDotDot { get; set; }
     public string EditBinaryOcrDatabase { get; set; }
+    public string EditBinaryOcrDatabaseXWithYItems { get; set; }
     public string BinaryImageCompareDatabase { get; set; }
     public string RemoveXFromUnknownWordsList { get; set; }
     public string DownloadingPaddleOcrEngineDotDotDot { get; set; }
@@ -139,6 +140,7 @@ public class LanguageOcr
         DarknessThreshold = "Darkness threshold";
         EditExportDotDotDot = "Edit/export...";
         EditBinaryOcrDatabase = "Edit \"Binary image compare\" database";
+        EditBinaryOcrDatabaseXWithYItems = "Edit \"Binary image compare\" database {0} with {1:#,###,##0} items";
         BinaryImageCompareDatabase = "\"Binary image compare\" database";
         RemoveXFromUnknownWordsList = "Remove \"{0}\" from unknown words list";
         DownloadingPaddleOcrEngineDotDotDot = "Downloading Paddle OCR engine...";


### PR DESCRIPTION
## Summary

- Fix Inspect Image Matches and Edit Database dialogs closing unexpectedly on Update/Delete by replacing `Activated` event handlers with `Loaded` handlers to prevent re-focus side effects when MessageBox closes
- Fix Edit Database title incorrectly referencing nOCR by adding `EditBinaryOcrDatabaseXWithYItems` language string and using correct Binary-specific strings
- Fix OCR window Esc key closing without confirmation by only checking `_forceClose` in `OnClosing` (not `e.IsProgrammatic`), and setting `_forceClose` in `Ok()` to bypass confirmation when accepting results
- Fix Home/End key navigation in OCR subtitle grid by subscribing with `handledEventsToo: true` so DataGrid's built-in handler doesn't consume events
- Fix spell check Change all/once buttons intermittently failing by updating `WordIndex` values in `GetText()` to reflect actual positions after `FixedWord` substitutions, adding fallback search in `ChangeWord`, and adding missing `ChangeWord` call in Binary OCR `ChangeAll` handler

## Test plan

- [ ] Open Binary image compare OCR, double-click a subtitle to open Inspect Image Matches — click Update/Delete and verify the dialog stays open
- [ ] Open Edit Database for Binary image compare — click Update/Delete and verify the dialog stays open, and the title says "Binary image compare" (not nOCR)
- [ ] During OCR, press Esc — verify a confirmation dialog appears asking to discard changes
- [ ] During OCR with items in the list, press Home/End — verify navigation to first/last item works repeatedly
- [ ] Run OCR with spell check enabled — verify Change once/all and Use once/always buttons correctly update the current line's text

🤖 Generated with [Claude Code](https://claude.com/claude-code)