### PR TITLE
Fix Remove Text for Hearing Impaired not working in batch convert

### DIFF
--- a/src/UI/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1324,6 +1324,11 @@ public partial class BatchConvertViewModel : ObservableObject
             {
                 IsActive = activeFunctions.Contains(BatchConvertFunctionType.MultipleReplace),
             },
+
+            RemoveTextForHearingImpaired = new BatchConvertConfig.RemoveTextForHearingImpairedSettings
+            {
+                IsActive = activeFunctions.Contains(BatchConvertFunctionType.RemoveTextForHearingImpaired),
+            },
         };
     }
 

--- a/src/UI/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1654,7 +1654,6 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         var list = interjections?.Interjections ?? new List<string>();
         var skipList = interjections?.SkipStartList ?? new List<string>();
 
-
         removeTextForHiLib.ReloadInterjection(list, skipList);
 
         for (var index = 0; index < subtitle.Paragraphs.Count; index++)
@@ -1667,6 +1666,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
         }
 
+        subtitle.RemoveEmptyLines();
         return subtitle;
     }
 


### PR DESCRIPTION
## Summary
- Add missing `RemoveTextForHearingImpaired` config initialization in `MakeBatchConvertConfig()`, which caused the feature to silently skip execution during batch conversion (`IsActive` always defaulted to `false`)

Fixes #10379

🤖 Generated with [Claude Code](https://claude.com/claude-code)