### PR TITLE
TTS Audio Quality Improvements: VAD Silence Compression, WSOLA Time-Stretching & Advanced Settings UI

### DIFF
--- a/src/UI/DependencyInjectionExtensions.cs
+++ b/src/UI/DependencyInjectionExtensions.cs
@@ -121,6 +121,7 @@ using Nikse.SubtitleEdit.Features.Video.OpenFromUrl;
 using Nikse.SubtitleEdit.Features.Video.ReEncodeVideo;
 using Nikse.SubtitleEdit.Features.Video.ShotChanges;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
@@ -208,6 +209,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<ILlamaCppDownloadService, LlamaCppDownloadService>();
 
         // Window view models
+        collection.AddTransient<AdvancedTtsSettingsViewModel>();
         collection.AddTransient<AddToNamesListViewModel>();
         collection.AddTransient<AddToOcrReplaceListViewModel>();
         collection.AddTransient<AddToUserDictionaryViewModel>();

--- a/src/UI/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsViewModel.cs
@@ -1,0 +1,81 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
+
+public partial class AdvancedTtsSettingsViewModel : ObservableObject
+{
+    [ObservableProperty] private bool _doProAudioChain;
+    [ObservableProperty] private bool _doAudioDucking;
+    [ObservableProperty] private string _audioDuckingVolume;
+    [ObservableProperty] private bool _doVadSilenceCompression;
+    [ObservableProperty] private string _vadMaxSilenceMs;
+    [ObservableProperty] private bool _doHighQualityTimeStretch;
+    [ObservableProperty] private string _silencePaddingMs;
+    [ObservableProperty] private string _outputSampleRate;
+    [ObservableProperty] private string _edgeTtsRate;
+    [ObservableProperty] private string _edgeTtsPitch;
+    [ObservableProperty] private string _edgeTtsVolume;
+    [ObservableProperty] private bool _isEdgeTtsEngine;
+    [ObservableProperty] private string _rubberbandStatus;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public AdvancedTtsSettingsViewModel()
+    {
+        RubberbandStatus = FfmpegGenerator.IsRubberbandAvailable() ? "(installed)" : "(not found in FFmpeg)";
+        var s = Se.Settings.Video.TextToSpeech;
+        DoProAudioChain = s.ProAudioChainEnabled;
+        DoAudioDucking = s.AudioDuckingEnabled;
+        AudioDuckingVolume = s.AudioDuckingOriginalVolume.ToString();
+        DoVadSilenceCompression = s.VadSilenceCompressionEnabled;
+        VadMaxSilenceMs = ((int)(s.VadMaxSilenceSeconds * 1000)).ToString();
+        DoHighQualityTimeStretch = s.HighQualityTimeStretchEnabled;
+        SilencePaddingMs = s.SilencePaddingMs.ToString();
+        OutputSampleRate = s.OutputSampleRate.ToString();
+        EdgeTtsRate = s.EdgeTtsRate;
+        EdgeTtsPitch = s.EdgeTtsPitch;
+        EdgeTtsVolume = s.EdgeTtsVolume;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        var s = Se.Settings.Video.TextToSpeech;
+        s.ProAudioChainEnabled = DoProAudioChain;
+        s.AudioDuckingEnabled = DoAudioDucking;
+        s.AudioDuckingOriginalVolume = int.TryParse(AudioDuckingVolume, out var dv) ? dv : 15;
+        s.VadSilenceCompressionEnabled = DoVadSilenceCompression;
+        s.VadMaxSilenceSeconds = int.TryParse(VadMaxSilenceMs, out var vadMs) ? vadMs / 1000.0 : 0.15;
+        s.HighQualityTimeStretchEnabled = DoHighQualityTimeStretch;
+        s.SilencePaddingMs = int.TryParse(SilencePaddingMs, out var sp) ? sp : 0;
+        s.OutputSampleRate = int.TryParse(OutputSampleRate, out var sr) ? sr : 0;
+        s.EdgeTtsRate = EdgeTtsRate;
+        s.EdgeTtsPitch = EdgeTtsPitch;
+        s.EdgeTtsVolume = EdgeTtsVolume;
+        Se.SaveSettings();
+
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/UI/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsWindow.cs
+++ b/src/UI/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsWindow.cs
@@ -1,0 +1,225 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
+
+public class AdvancedTtsSettingsWindow : Window
+{
+    private readonly AdvancedTtsSettingsViewModel _vm;
+
+    public AdvancedTtsSettingsWindow(AdvancedTtsSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "Advanced TTS settings";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MaxWidth = 550;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var content = new StackPanel
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+            Spacing = 5,
+            Children =
+            {
+                MakeSection(vm,
+                    "Pro audio post-processing",
+                    nameof(vm.DoProAudioChain),
+                    "Applies EQ warmth, noise gate, compression, loudness normalization (-16 LUFS), and fade in/out to each segment."),
+
+                MakeSection(vm,
+                    "Audio ducking",
+                    nameof(vm.DoAudioDucking),
+                    "Reduces the original video audio volume and mixes it with the TTS audio, so the original soundtrack is still faintly audible.",
+                    "Original volume %",
+                    nameof(vm.AudioDuckingVolume),
+                    50),
+
+                MakeSection(vm,
+                    "VAD silence compression",
+                    nameof(vm.DoVadSilenceCompression),
+                    "Shortens pauses between words before changing tempo. Uses Voice Activity Detection to compress only silence gaps " +
+                    "while keeping speech untouched. This is the preferred first step — it reduces duration without any quality loss.",
+                    "Max silence (ms)",
+                    nameof(vm.VadMaxSilenceMs),
+                    50),
+
+                MakeSectionWithStatus(vm,
+                    "High-quality time-stretch (WSOLA/rubberband)",
+                    nameof(vm.DoHighQualityTimeStretch),
+                    nameof(vm.RubberbandStatus),
+                    "Uses the rubberband algorithm (WSOLA) instead of the default atempo filter for pitch-preserving speed changes. " +
+                    "Produces more natural-sounding speech, especially at higher speed factors. " +
+                    "Requires librubberband in your FFmpeg build — falls back to atempo automatically if unavailable."),
+
+                MakeFieldRow(vm, "Silence padding (ms)", nameof(vm.SilencePaddingMs), 50,
+                    "Adds a short silence at the end of each segment. Useful for breathing room between sentences."),
+
+                MakeFieldRow(vm, "Output sample rate (0 = default)", nameof(vm.OutputSampleRate), 60,
+                    "Resamples all segments to the specified sample rate (e.g. 44100, 48000). Set to 0 to keep the original rate."),
+
+                MakeFieldRow(vm, "Edge-TTS rate", nameof(vm.EdgeTtsRate), 120,
+                    "Speech rate for Edge-TTS, e.g. \"+50%\", \"-30%\", or \"+0%\" for default.",
+                    nameof(vm.IsEdgeTtsEngine)),
+
+                MakeFieldRow(vm, "Edge-TTS pitch", nameof(vm.EdgeTtsPitch), 120,
+                    "Pitch adjustment for Edge-TTS, e.g. \"+10Hz\", \"-5Hz\", or \"+0Hz\" for default.",
+                    nameof(vm.IsEdgeTtsEngine)),
+
+                MakeFieldRow(vm, "Edge-TTS volume", nameof(vm.EdgeTtsVolume), 120,
+                    "Volume adjustment for Edge-TTS, e.g. \"+20%\", \"-10%\", or \"+0%\" for default.",
+                    nameof(vm.IsEdgeTtsEngine)),
+            }
+        };
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var mainPanel = new StackPanel
+        {
+            Children =
+            {
+                content,
+                panelButtons,
+            }
+        };
+
+        Content = mainPanel;
+
+        Activated += delegate { buttonOk.Focus(); };
+    }
+
+    private static StackPanel MakeSection(AdvancedTtsSettingsViewModel vm, string title, string checkBoxBinding, string description,
+        string? fieldLabel = null, string? fieldBinding = null, int fieldWidth = 50)
+    {
+        var checkBox = new CheckBox
+        {
+            Content = title,
+            FontWeight = FontWeight.SemiBold,
+            [!CheckBox.IsCheckedProperty] = new Binding(checkBoxBinding) { Mode = BindingMode.TwoWay },
+        };
+
+        var descBlock = new TextBlock
+        {
+            Text = description,
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+            Margin = new Thickness(26, 0, 0, 0),
+        };
+
+        var section = new StackPanel
+        {
+            Spacing = 2,
+            Margin = new Thickness(0, 0, 0, 10),
+            Children = { checkBox, descBlock },
+        };
+
+        if (fieldLabel != null && fieldBinding != null)
+        {
+            var fieldRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(26, 4, 0, 0),
+                Children =
+                {
+                    new Label { Content = fieldLabel, VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 5, 0) },
+                    UiUtil.MakeTextBox(fieldWidth, vm, fieldBinding),
+                }
+            };
+            section.Children.Add(fieldRow);
+        }
+
+        return section;
+    }
+
+    private static StackPanel MakeSectionWithStatus(AdvancedTtsSettingsViewModel vm, string title, string checkBoxBinding, string statusBinding, string description)
+    {
+        var checkBox = new CheckBox
+        {
+            Content = title,
+            FontWeight = FontWeight.SemiBold,
+            [!CheckBox.IsCheckedProperty] = new Binding(checkBoxBinding) { Mode = BindingMode.TwoWay },
+        };
+
+        var statusLabel = new Label
+        {
+            Opacity = 0.6,
+            FontStyle = FontStyle.Italic,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(5, 0, 0, 0),
+            [!Label.ContentProperty] = new Binding(statusBinding) { Mode = BindingMode.OneWay },
+        };
+
+        var headerRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { checkBox, statusLabel },
+        };
+
+        var descBlock = new TextBlock
+        {
+            Text = description,
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+            Margin = new Thickness(26, 0, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Spacing = 2,
+            Margin = new Thickness(0, 0, 0, 10),
+            Children = { headerRow, descBlock },
+        };
+    }
+
+    private static StackPanel MakeFieldRow(AdvancedTtsSettingsViewModel vm, string label, string binding, int fieldWidth, string description, string? isVisibleBinding = null)
+    {
+        var panel = new StackPanel
+        {
+            Spacing = 2,
+            Margin = new Thickness(0, 0, 0, 10),
+            Children =
+            {
+                new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Children =
+                    {
+                        new Label { Content = label, VerticalAlignment = VerticalAlignment.Center, FontWeight = FontWeight.SemiBold, Margin = new Thickness(0, 0, 5, 0) },
+                        UiUtil.MakeTextBox(fieldWidth, vm, binding),
+                    }
+                },
+                new TextBlock
+                {
+                    Text = description,
+                    TextWrapping = TextWrapping.Wrap,
+                    Opacity = 0.7,
+                    Margin = new Thickness(26, 0, 0, 0),
+                },
+            }
+        };
+
+        if (isVisibleBinding != null)
+        {
+            panel[!StackPanel.IsVisibleProperty] = new Binding(isVisibleBinding) { Mode = BindingMode.OneWay };
+        }
+
+        return panel;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -15,6 +15,7 @@ using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
@@ -641,12 +642,36 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var p = item.Paragraph;
         var index = Lines.IndexOf(row);
         var next = index + 1 < Lines.Count ? Lines[index + 1] : null;
+
+        var doVad = Se.Settings.Video.TextToSpeech.VadSilenceCompressionEnabled;
+        var vadMaxSilence = Se.Settings.Video.TextToSpeech.VadMaxSilenceSeconds;
+        var doHighQualityStretch = Se.Settings.Video.TextToSpeech.HighQualityTimeStretchEnabled;
+
+        // Step 1: Trim silence from start and end
         var outputFileNameTrim = Path.Combine(_waveFolder, Guid.NewGuid() + ".wav");
         var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileNameTrim);
 #pragma warning disable CA1416 // Validate platform compatibility
         _ = trimProcess.Start();
 #pragma warning restore CA1416 // Validate platform compatibility
         await trimProcess.WaitForExitAsync(_cancellationToken);
+
+        var currentFile = outputFileNameTrim;
+
+        // Step 2: VAD-based internal silence compression
+        if (doVad)
+        {
+            var vadOutput = Path.Combine(_waveFolder, $"vad_{Guid.NewGuid()}.wav");
+            var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence);
+#pragma warning disable CA1416 // Validate platform compatibility
+            _ = vadProcess.Start();
+#pragma warning restore CA1416 // Validate platform compatibility
+            await vadProcess.WaitForExitAsync(_cancellationToken);
+
+            if (File.Exists(vadOutput) && new FileInfo(vadOutput).Length > 0)
+            {
+                currentFile = vadOutput;
+            }
+        }
 
         var addDuration = 0d;
         if (next != null && p.EndTime.TotalMilliseconds < next.StepResult.Paragraph.StartTime.TotalMilliseconds)
@@ -659,14 +684,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
             }
         }
 
-        var mediaInfo = FfmpegMediaInfo.Parse(outputFileNameTrim);
+        var mediaInfo = FfmpegMediaInfo.Parse(currentFile);
         if (mediaInfo.Duration.TotalMilliseconds <= p.DurationTotalMilliseconds + addDuration)
         {
             return new TtsStepResult
             {
                 Paragraph = p,
                 Text = item.Text,
-                CurrentFileName = outputFileNameTrim,
+                CurrentFileName = currentFile,
                 SpeedFactor = 1.0f,
                 Voice = item.Voice,
             };
@@ -685,6 +710,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
             };
         }
 
+        // Step 3: Time-stretching
         var ext = ".wav";
         var factor = (decimal)mediaInfo.Duration.TotalMilliseconds / divisor;
         var outputFileName2 = Path.Combine(_waveFolder, $"{index}_{Guid.NewGuid()}{ext}");
@@ -694,11 +720,30 @@ public partial class ReviewSpeechViewModel : ObservableObject
             outputFileName2 = Path.Combine(_waveFolder, $"{Path.GetFileNameWithoutExtension(overrideFileName)}_{Guid.NewGuid()}{ext}");
         }
 
-        var mergeProcess = FfmpegGenerator.ChangeSpeed(outputFileNameTrim, outputFileName2, (float)factor);
+        // Use rubberband (WSOLA) for high-quality stretch, or atempo as fallback
+        Process speedProcess;
+        if (doHighQualityStretch)
+        {
+            speedProcess = FfmpegGenerator.ChangeSpeedHighQuality(currentFile, outputFileName2, (float)factor);
+        }
+        else
+        {
+            speedProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
+        }
 #pragma warning disable CA1416 // Validate platform compatibility
-        _ = mergeProcess.Start();
+        _ = speedProcess.Start();
 #pragma warning restore CA1416 // Validate platform compatibility
-        await mergeProcess.WaitForExitAsync(_cancellationToken);
+        await speedProcess.WaitForExitAsync(_cancellationToken);
+
+        // Fallback: if rubberband failed, retry with atempo
+        if (doHighQualityStretch && (!File.Exists(outputFileName2) || new FileInfo(outputFileName2).Length == 0))
+        {
+            var fallbackProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
+#pragma warning disable CA1416 // Validate platform compatibility
+            _ = fallbackProcess.Start();
+#pragma warning restore CA1416 // Validate platform compatibility
+            await fallbackProcess.WaitForExitAsync(_cancellationToken);
+        }
 
         return new TtsStepResult
         {

--- a/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
@@ -20,6 +21,7 @@ using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -56,14 +58,6 @@ public partial class TextToSpeechViewModel : ObservableObject
     [ObservableProperty] private bool _isVoiceTestEnabled;
     [ObservableProperty] private bool _doReviewAudioClips;
     [ObservableProperty] private bool _doGenerateVideoFile;
-    [ObservableProperty] private bool _doProAudioChain;
-    [ObservableProperty] private bool _doAudioDucking;
-    [ObservableProperty] private string _audioDuckingVolume;
-    [ObservableProperty] private string _silencePaddingMs;
-    [ObservableProperty] private string _outputSampleRate;
-    [ObservableProperty] private string _edgeTtsRate;
-    [ObservableProperty] private string _edgeTtsPitch;
-    [ObservableProperty] private string _edgeTtsVolume;
     [ObservableProperty] private bool _isEdgeTtsEngine;
     [ObservableProperty] private bool _isGenerating;
     [ObservableProperty] private bool _isNotGenerating;
@@ -109,12 +103,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         ProgressText = string.Empty;
         ProgressText = string.Empty;
         DoneOrCancelText = string.Empty;
-        EdgeTtsRate = string.Empty;
-        EdgeTtsPitch = string.Empty;
-        EdgeTtsVolume = string.Empty;
-        AudioDuckingVolume = string.Empty;
-        SilencePaddingMs = string.Empty;
-        OutputSampleRate = string.Empty;
         IsVoiceTestEnabled = true;
         IsGenerating = false;
         IsNotGenerating = true;
@@ -177,14 +165,6 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         DoReviewAudioClips = Se.Settings.Video.TextToSpeech.ReviewAudioClips;
         DoGenerateVideoFile = Se.Settings.Video.TextToSpeech.GenerateVideoFile;
-        DoProAudioChain = Se.Settings.Video.TextToSpeech.ProAudioChainEnabled;
-        DoAudioDucking = Se.Settings.Video.TextToSpeech.AudioDuckingEnabled;
-        AudioDuckingVolume = Se.Settings.Video.TextToSpeech.AudioDuckingOriginalVolume.ToString();
-        SilencePaddingMs = Se.Settings.Video.TextToSpeech.SilencePaddingMs.ToString();
-        OutputSampleRate = Se.Settings.Video.TextToSpeech.OutputSampleRate.ToString();
-        EdgeTtsRate = Se.Settings.Video.TextToSpeech.EdgeTtsRate;
-        EdgeTtsPitch = Se.Settings.Video.TextToSpeech.EdgeTtsPitch;
-        EdgeTtsVolume = Se.Settings.Video.TextToSpeech.EdgeTtsVolume;
 
         if (SelectedEngine is AzureSpeech)
         {
@@ -212,14 +192,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         Se.Settings.Video.TextToSpeech.Voice = SelectedVoice?.Name ?? string.Empty;
         Se.Settings.Video.TextToSpeech.ReviewAudioClips = DoReviewAudioClips;
         Se.Settings.Video.TextToSpeech.GenerateVideoFile = DoGenerateVideoFile;
-        Se.Settings.Video.TextToSpeech.ProAudioChainEnabled = DoProAudioChain;
-        Se.Settings.Video.TextToSpeech.AudioDuckingEnabled = DoAudioDucking;
-        Se.Settings.Video.TextToSpeech.AudioDuckingOriginalVolume = int.TryParse(AudioDuckingVolume, out var dv) ? dv : 15;
-        Se.Settings.Video.TextToSpeech.SilencePaddingMs = int.TryParse(SilencePaddingMs, out var sp) ? sp : 0;
-        Se.Settings.Video.TextToSpeech.OutputSampleRate = int.TryParse(OutputSampleRate, out var sr) ? sr : 0;
-        Se.Settings.Video.TextToSpeech.EdgeTtsRate = EdgeTtsRate;
-        Se.Settings.Video.TextToSpeech.EdgeTtsPitch = EdgeTtsPitch;
-        Se.Settings.Video.TextToSpeech.EdgeTtsVolume = EdgeTtsVolume;
 
         if (SelectedEngine is AzureSpeech)
         {
@@ -439,6 +411,15 @@ public partial class TextToSpeechViewModel : ObservableObject
     private async Task ShowEncodingSettings()
     {
         await _windowService.ShowDialogAsync<EncodingSettingsWindow, EncodingSettingsViewModel>(Window!, vm => { });
+    }
+
+    [RelayCommand]
+    private async Task ShowAdvancedSettings()
+    {
+        await _windowService.ShowDialogAsync<AdvancedTtsSettingsWindow, AdvancedTtsSettingsViewModel>(Window!, vm =>
+        {
+            vm.IsEdgeTtsEngine = SelectedEngine is EdgeTts;
+        });
     }
 
     [RelayCommand]
@@ -937,6 +918,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             return null;
         }
 
+        var doVad = Se.Settings.Video.TextToSpeech.VadSilenceCompressionEnabled;
+        var vadMaxSilence = Se.Settings.Video.TextToSpeech.VadMaxSilenceSeconds;
+        var doHighQualityStretch = Se.Settings.Video.TextToSpeech.HighQualityTimeStretchEnabled;
+
         try
         {
             var resultList = new List<TtsStepResult>();
@@ -949,12 +934,34 @@ public partial class TextToSpeechViewModel : ObservableObject
                 var item = previousStepResult[index];
                 var p = item.Paragraph;
                 var next = index + 1 < previousStepResult.Length ? previousStepResult[index + 1] : null;
+
+                // Step 1: Trim silence from start and end
                 var outputFileName1 = Path.Combine(Path.GetDirectoryName(item.CurrentFileName)!, Guid.NewGuid() + ".wav");
                 var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileName1);
 #pragma warning disable CA1416 // Validate platform compatibility
                 _ = trimProcess.Start();
 #pragma warning restore CA1416 // Validate platform compatibility
                 await trimProcess.WaitForExitAsync(cancellationToken);
+
+                var currentFile = outputFileName1;
+
+                // Step 2: VAD-based internal silence compression
+                // Compress pauses between words/phrases before touching tempo.
+                // This preserves phoneme quality by only removing redundant silence.
+                if (doVad)
+                {
+                    var vadOutput = Path.Combine(Path.GetDirectoryName(item.CurrentFileName)!, $"vad_{Guid.NewGuid()}.wav");
+                    var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence);
+#pragma warning disable CA1416 // Validate platform compatibility
+                    _ = vadProcess.Start();
+#pragma warning restore CA1416 // Validate platform compatibility
+                    await vadProcess.WaitForExitAsync(cancellationToken);
+
+                    if (File.Exists(vadOutput) && new FileInfo(vadOutput).Length > 0)
+                    {
+                        currentFile = vadOutput;
+                    }
+                }
 
                 var addDuration = 0d;
                 if (next != null && p.EndTime.TotalMilliseconds < next.Paragraph.StartTime.TotalMilliseconds)
@@ -967,19 +974,20 @@ public partial class TextToSpeechViewModel : ObservableObject
                     }
                 }
 
-                var mediaInfo = FfmpegMediaInfo.Parse(outputFileName1);
+                var mediaInfo = FfmpegMediaInfo.Parse(currentFile);
                 if (mediaInfo.Duration == null)
                 {
                     continue;
                 }
 
+                // If audio already fits after silence removal/compression, no time-stretching needed
                 if (mediaInfo.Duration.TotalMilliseconds <= p.DurationTotalMilliseconds + addDuration)
                 {
                     resultList.Add(new TtsStepResult
                     {
                         Paragraph = p,
                         Text = item.Text,
-                        CurrentFileName = outputFileName1,
+                        CurrentFileName = currentFile,
                         SpeedFactor = 1.0f,
                         Voice = item.Voice,
                     });
@@ -1002,6 +1010,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                     continue;
                 }
 
+                // Step 3: Time-stretching (only for audio that still exceeds subtitle duration)
                 var ext = ".wav";
                 var factor = (decimal)mediaInfo.Duration.TotalMilliseconds / divisor;
                 var outputFileName2 = Path.Combine(_waveFolder, $"{index}_{Guid.NewGuid()}{ext}");
@@ -1020,11 +1029,30 @@ public partial class TextToSpeechViewModel : ObservableObject
                     Voice = item.Voice,
                 });
 
-                var mergeProcess = FfmpegGenerator.ChangeSpeed(outputFileName1, outputFileName2, (float)factor);
+                // Use rubberband (WSOLA) for high-quality pitch-preserving stretch, or atempo as fallback
+                Process speedProcess;
+                if (doHighQualityStretch)
+                {
+                    speedProcess = FfmpegGenerator.ChangeSpeedHighQuality(currentFile, outputFileName2, (float)factor);
+                }
+                else
+                {
+                    speedProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
+                }
 #pragma warning disable CA1416 // Validate platform compatibility
-                _ = mergeProcess.Start();
+                _ = speedProcess.Start();
 #pragma warning restore CA1416 // Validate platform compatibility
-                await mergeProcess.WaitForExitAsync(cancellationToken);
+                await speedProcess.WaitForExitAsync(cancellationToken);
+
+                // Fallback: if rubberband failed (not available in FFmpeg build), retry with atempo
+                if (doHighQualityStretch && (!File.Exists(outputFileName2) || new FileInfo(outputFileName2).Length == 0))
+                {
+                    var fallbackProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
+#pragma warning disable CA1416 // Validate platform compatibility
+                    _ = fallbackProcess.Start();
+#pragma warning restore CA1416 // Validate platform compatibility
+                    await fallbackProcess.WaitForExitAsync(cancellationToken);
+                }
             }
             ProgressValue = 100;
 

--- a/src/UI/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/UI/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -286,105 +286,13 @@ public class TextToSpeechWindow : Window
             }
         };
 
-        var checkBoxProAudioChain = new CheckBox
-        {
-            Content = "Pro audio post-processing",
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, 0, 0, 10),
-            [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.DoProAudioChain)) { Mode = BindingMode.TwoWay }
-        };
-
-        var panelAudioDucking = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, 0, 0, 10),
-            Children =
-            {
-                new CheckBox
-                {
-                    Content = "Audio ducking",
-                    VerticalAlignment = VerticalAlignment.Center,
-                    [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.DoAudioDucking)) { Mode = BindingMode.TwoWay }
-                },
-                new Label { Content = "Vol %", VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(10, 0, 5, 0) },
-                UiUtil.MakeTextBox(50, vm, nameof(vm.AudioDuckingVolume)),
-            }
-        };
-
-        var panelSilencePadding = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, 0, 0, 10),
-            Children =
-            {
-                new Label { Content = "Silence padding (ms)", VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 5, 0) },
-                UiUtil.MakeTextBox(50, vm, nameof(vm.SilencePaddingMs)),
-            }
-        };
-
-        var panelSampleRate = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, 0, 0, 10),
-            Children =
-            {
-                new Label { Content = "Sample rate (0=default)", VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 5, 0) },
-                UiUtil.MakeTextBox(60, vm, nameof(vm.OutputSampleRate)),
-            }
-        };
-
-        var panelEdgeTtsRate = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, 0, 0, 5),
-            Children =
-            {
-                new Label { Content = "Edge-TTS rate", MinWidth = 110, VerticalAlignment = VerticalAlignment.Center },
-                UiUtil.MakeTextBox(120, vm, nameof(vm.EdgeTtsRate)),
-            },
-            [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.IsEdgeTtsEngine)) { Mode = BindingMode.OneWay },
-        };
-
-        var panelEdgeTtsPitch = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, 0, 0, 5),
-            Children =
-            {
-                new Label { Content = "Edge-TTS pitch", MinWidth = 110, VerticalAlignment = VerticalAlignment.Center },
-                UiUtil.MakeTextBox(120, vm, nameof(vm.EdgeTtsPitch)),
-            },
-            [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.IsEdgeTtsEngine)) { Mode = BindingMode.OneWay },
-        };
-
-        var panelEdgeTtsVolume = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, 0, 0, 5),
-            Children =
-            {
-                new Label { Content = "Edge-TTS volume", MinWidth = 110, VerticalAlignment = VerticalAlignment.Center },
-                UiUtil.MakeTextBox(120, vm, nameof(vm.EdgeTtsVolume)),
-            },
-            [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.IsEdgeTtsEngine)) { Mode = BindingMode.OneWay },
-        };
+        var buttonAdvanced = UiUtil.MakeButton("Advanced...", vm.ShowAdvancedSettingsCommand)
+            .WithMarginTop(5);
 
         var grid = new Grid
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
@@ -401,13 +309,7 @@ public class TextToSpeechWindow : Window
 
         grid.Add(checkBoxReviewAudioClips, 0, 0);
         grid.Add(panelAddAudioToVideoFile, 1, 0);
-        grid.Add(checkBoxProAudioChain, 2, 0);
-        grid.Add(panelAudioDucking, 3, 0);
-        grid.Add(panelSilencePadding, 4, 0);
-        grid.Add(panelSampleRate, 5, 0);
-        grid.Add(panelEdgeTtsRate, 6, 0);
-        grid.Add(panelEdgeTtsPitch, 7, 0);
-        grid.Add(panelEdgeTtsVolume, 8, 0);
+        grid.Add(buttonAdvanced, 2, 0);
 
         return UiUtil.MakeBorderForControl(grid);
     }

--- a/src/UI/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/UI/Logic/Config/SeVideoTextToSpeech.cs
@@ -38,6 +38,13 @@ public class SeVideoTextToSpeech
     public string EdgeTtsPitch { get; set; }
     public string EdgeTtsVolume { get; set; }
 
+    // VAD-based internal silence compression (shorten pauses between words before time-stretching)
+    public bool VadSilenceCompressionEnabled { get; set; }
+    public double VadMaxSilenceSeconds { get; set; }
+
+    // High-quality time-stretching using rubberband (WSOLA) instead of atempo
+    public bool HighQualityTimeStretchEnabled { get; set; }
+
     // Silence padding between segments (ms)
     public int SilencePaddingMs { get; set; }
 
@@ -75,6 +82,9 @@ public class SeVideoTextToSpeech
         EdgeTtsRate = string.Empty;
         EdgeTtsPitch = string.Empty;
         EdgeTtsVolume = string.Empty;
+        VadSilenceCompressionEnabled = false;
+        VadMaxSilenceSeconds = 0.15;
+        HighQualityTimeStretchEnabled = false;
         SilencePaddingMs = 0;
         OutputSampleRate = 0;
     }

--- a/src/UI/Logic/Media/FfmpegGenerator.cs
+++ b/src/UI/Logic/Media/FfmpegGenerator.cs
@@ -418,6 +418,38 @@ public class FfmpegGenerator
         return ffmpegLocation;
     }
 
+    /// <summary>
+    /// Check if FFmpeg has rubberband filter support.
+    /// </summary>
+    public static bool IsRubberbandAvailable()
+    {
+        try
+        {
+            var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = GetFfmpegLocation(),
+                    Arguments = "-filters",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                }
+            };
+#pragma warning disable CA1416 // Validate platform compatibility
+            _ = process.Start();
+#pragma warning restore CA1416 // Validate platform compatibility
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(5000);
+            return output.Contains("rubberband");
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public static Process ChangeSpeed(string inputFileName, string outputFileName, float inputSpeed, DataReceivedEventHandler? dataReceivedHandler = null)
     {
         var speed = Math.Max(0.5f, inputSpeed);
@@ -448,6 +480,72 @@ public class FfmpegGenerator
             {
                 FileName = GetFfmpegLocation(),
                 Arguments = $"-i \"{inputFileName}\" -af \"areverse,atrim=start=0.1,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0.01,areverse,atrim=start=0.1,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0.01\" \"{outputFileName}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        SetupDataReceiveHandler(dataReceivedHandler, processMakeVideo);
+
+        return processMakeVideo;
+    }
+
+    /// <summary>
+    /// VAD-based internal silence compression: detects all silence gaps between words/phrases
+    /// and shortens them to a maximum duration, preserving speech segments untouched.
+    /// This is the first line of defense before time-stretching — it reduces audio duration
+    /// without affecting phonemes at all.
+    /// </summary>
+    /// <param name="maxSilenceSeconds">Maximum allowed silence duration between words (e.g. 0.15 for 150ms)</param>
+    public static Process CompressInternalSilence(string inputFileName, string outputFileName, double maxSilenceSeconds = 0.15, DataReceivedEventHandler? dataReceivedHandler = null)
+    {
+        var maxSilence = maxSilenceSeconds.ToString("0.00", CultureInfo.InvariantCulture);
+        // silenceremove: stop_periods=-1 processes ALL silence gaps (not just first)
+        // stop_duration = max allowed silence length; stop_threshold = silence detection level
+        // This keeps all speech intact and only compresses pauses between words
+        var filter = $"silenceremove=stop_periods=-1:stop_duration={maxSilence}:stop_threshold=-40dB";
+
+        var processMakeVideo = new Process
+        {
+            StartInfo =
+            {
+                FileName = GetFfmpegLocation(),
+                Arguments = $"-i \"{inputFileName}\" -af \"{filter}\" \"{outputFileName}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        SetupDataReceiveHandler(dataReceivedHandler, processMakeVideo);
+
+        return processMakeVideo;
+    }
+
+    /// <summary>
+    /// High-quality pitch-preserving time-stretch using FFmpeg's rubberband filter (WSOLA-based).
+    /// Rubberband produces significantly better speech quality than atempo, especially at higher
+    /// speed factors, because it uses a proper WSOLA algorithm designed for speech/music.
+    /// Falls back to atempo if rubberband is not available in the FFmpeg build.
+    /// </summary>
+    public static Process ChangeSpeedHighQuality(string inputFileName, string outputFileName, float inputSpeed, DataReceivedEventHandler? dataReceivedHandler = null)
+    {
+        var speed = Math.Max(0.5f, inputSpeed);
+        speed = Math.Min(100, speed);
+        speed = (float)Math.Round(speed, 3, MidpointRounding.AwayFromZero);
+
+        // rubberband filter: tempo parameter is the speed factor
+        // transients=smooth: smoother transient handling for speech
+        // engine=faster: use the faster engine (good enough for speech)
+        // window=short: short analysis window, better for speech than music
+        var speedStr = speed.ToString(CultureInfo.InvariantCulture);
+        var filter = $"rubberband=tempo={speedStr}:transients=smooth:engine=faster:window=short";
+
+        var processMakeVideo = new Process
+        {
+            StartInfo =
+            {
+                FileName = GetFfmpegLocation(),
+                Arguments = $"-i \"{inputFileName}\" -af \"{filter}\" \"{outputFileName}\"",
                 UseShellExecute = false,
                 CreateNoWindow = true
             }


### PR DESCRIPTION
## Context

This is a continuation of the Edge-TTS engine integration ([PR #10378](https://github.com/SubtitleEdit/subtitleedit/pull/10378)). While that PR added Edge-TTS support with basic prosody controls (rate/pitch/volume), pro audio chain, audio ducking, silence padding, and sample rate conversion, this PR focuses on solving a fundamental problem that affects **all** TTS engines: **what happens when generated audio doesn't fit the subtitle duration**.

### The Problem

When TTS generates speech for a subtitle segment, the audio often exceeds the available time window. This is especially common when translating between languages with different information density (e.g., English → Spanish or German translations are typically 20-40% longer).

The previous approach was:
1. Trim silence from start/end of the audio
2. Speed up the entire audio using FFmpeg's `atempo` filter

This worked, but had two significant quality issues:

- **Unnecessary speed-up**: The audio contained internal pauses between words/phrases that could be shortened first, reducing or eliminating the need for tempo changes
- **Chipmunk effect at high factors**: While `atempo` preserves pitch, its phase vocoder algorithm produces artifacts on speech at higher speed factors (1.3x+), making voices sound unnatural

## What This PR Adds

### 1. VAD-Based Internal Silence Compression (New)

**The idea**: Before touching the tempo of speech, first attack the silence. A Voice Activity Detection approach precisely identifies and shortens gaps between words/phrases. This is optimal because it doesn't distort any phonemes.

**Implementation**: New `CompressInternalSilence()` method in `FfmpegGenerator.cs` using FFmpeg's `silenceremove` filter:

```csharp
// silenceremove: stop_periods=-1 processes ALL silence gaps (not just first)
// stop_duration = max allowed silence length; stop_threshold = silence detection level
var filter = $"silenceremove=stop_periods=-1:stop_duration={maxSilence}:stop_threshold=-40dB";
```

Key parameters:
- `stop_periods=-1` — process ALL internal silence gaps, not just the first one
- `stop_duration` — configurable maximum silence duration (default: 150ms)
- `stop_threshold=-40dB` — silence detection threshold

**Why this filter configuration**: The existing `TrimSilenceStartAndEnd` only removes silence at the beginning and end of audio. By using `stop_periods=-1`, we target every pause inside the audio. The `-40dB` threshold is tuned for TTS output which has a clean noise floor. The configurable `stop_duration` parameter lets users control how much pause to keep — 150ms is a natural inter-word gap that still sounds comfortable.

**Example scenario**: A 5-second TTS clip needs to fit in 4 seconds. The audio has 1.2 seconds of internal pauses. After VAD compression (capping pauses at 150ms), the audio is 4.1 seconds — now only 1.025x speed-up is needed instead of 1.25x. The difference is barely audible vs. clearly noticeable.

### 2. High-Quality Time-Stretching via Rubberband/WSOLA (New)

**The idea**: When speed-up is still needed after silence compression, use a better algorithm than the default `atempo`. The rubberband library implements WSOLA (Waveform Similarity Overlap-Add), which cuts the audio waveform into overlapping micro-segments and "squeezes" them by removing redundant wave portions while preserving the original pitch.

**Implementation**: New `ChangeSpeedHighQuality()` method in `FfmpegGenerator.cs`:

```csharp
var filter = $"rubberband=tempo={speedStr}:transients=smooth:engine=faster:window=short";
```

Parameter choices explained:
- `transients=smooth` — smoother transient handling, better for speech than the default "crisp" mode which is designed for percussive music
- `engine=faster` — uses the faster processing engine (sufficient quality for speech, where the frequency content is simpler than music)
- `window=short` — short analysis window, better for speech which has rapidly changing formants vs. sustained musical notes

**Automatic fallback**: Not all FFmpeg builds include `librubberband`. The code handles this gracefully:

```csharp
// If rubberband output file wasn't created, fall back to atempo
if (doHighQualityStretch && (!File.Exists(outputFileName2) || new FileInfo(outputFileName2).Length == 0))
{
    var fallbackProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
    ...
}
```

**Rubberband detection**: A new `IsRubberbandAvailable()` method runs `ffmpeg -filters` and checks for rubberband presence. The result is displayed in the Advanced settings UI as "(installed)" or "(not found in FFmpeg)" next to the checkbox — similar to how Whisper models show installation status.

### 3. New Three-Stage Audio Pipeline

The `FixSpeed()` method in `TextToSpeechViewModel.cs` now implements a three-stage pipeline:

```
Stage 1: Trim silence from start/end (existing behavior, unchanged)
    ↓
Stage 2: VAD silence compression — shorten internal pauses (NEW, optional)
    ↓
  Check: does audio fit now? → YES → done, no speed change needed
    ↓ NO
Stage 3: Time-stretch to fit duration (improved: rubberband option)
```

This pipeline applies **uniformly to all TTS engines** (Edge-TTS, Piper, ElevenLabs, Azure, Google, AllTalk, Murf). This is correct because:

- **No engine does VAD or duration-fitting server-side** — all engines return raw audio of whatever duration they naturally generate
- **No engine does silence compression** — internal pauses are part of the TTS output
- **Engine-specific speed parameters** (Edge-TTS `rate`, ElevenLabs `speed`) control the base speaking rate at generation time, while our pipeline handles the post-generation timing adjustment — these are complementary, not duplicating

The same pipeline was also applied to `TrimAndAdjustSpeed()` in `ReviewSpeechViewModel.cs`, so that regenerated segments during review use the same processing.

### 4. Advanced TTS Settings Window (UI Refactor)


**The problem**: The main TTS window was becoming cluttered with too many controls (pro audio, ducking, VAD, time-stretch, silence padding, sample rate, Edge-TTS prosody). This made the UI intimidating for basic use.


**Solution**: Created a new `AdvancedTtsSettings` window (following the existing project pattern used by `EncodingSettings` and `VoiceSettings`), accessible via an "Advanced..." button.

The main TTS window now shows only:
- TTS - Review audio segments (checkbox)
- Add audio to video file (checkbox + encoding settings gear)
- Advanced... (button)

<img width="701" height="345" alt="image" src="https://github.com/user-attachments/assets/e8b05d7e-c9c6-4ed8-8aa1-5ef3638a35cd" />

The Advanced window groups all post-processing options with **descriptions explaining what each option does**:

<img width="552" height="983" alt="image" src="https://github.com/user-attachments/assets/3dce1106-075b-4764-87df-deaf9a336373" />

**Settings persistence**: All settings are saved via `Se.SaveSettings()` when the user clicks OK. Settings persist across sessions — the user configures once and all subsequent TTS generations use the same settings.

## Files Changed

### Modified Files

| File | Changes |
|------|---------|
| `src/UI/Logic/Media/FfmpegGenerator.cs` | Added 3 new methods: `IsRubberbandAvailable()`, `CompressInternalSilence()`, `ChangeSpeedHighQuality()` |
| `src/UI/Logic/Config/SeVideoTextToSpeech.cs` | Added 3 new settings: `VadSilenceCompressionEnabled`, `VadMaxSilenceSeconds`, `HighQualityTimeStretchEnabled` |
| `src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs` | Refactored `FixSpeed()` to 3-stage pipeline; moved advanced settings to new window; added `ShowAdvancedSettings` command |
| `src/UI/Features/Video/TextToSpeech/TextToSpeechWindow.cs` | Simplified UI — removed advanced controls, added "Advanced..." button |
| `src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs` | Updated `TrimAndAdjustSpeed()` to use same VAD + rubberband pipeline |
| `src/UI/DependencyInjectionExtensions.cs` | Registered `AdvancedTtsSettingsViewModel` in DI container |

### New Files

| File | Purpose |
|------|---------|
| `src/UI/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsViewModel.cs` | ViewModel for advanced settings dialog — loads/saves all post-processing settings |
| `src/UI/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsWindow.cs` | Avalonia Window with described settings sections, engine-specific visibility, rubberband status detection |

## Compatibility

- **Cross-platform**: All changes are pure C# .NET — no platform-specific code, no new NuGet dependencies
- **Linux/macOS**: `silenceremove` filter is standard FFmpeg, available everywhere. `rubberband` filter is optional with automatic fallback to `atempo`
- **Backwards compatible**: All new settings default to `false`/`0` — existing behavior is unchanged unless the user explicitly enables new features
- **All TTS engines**: VAD compression and time-stretching improvements apply to all 7 supported engines (Edge-TTS, Piper, ElevenLabs, Azure Speech, Google Speech, AllTalk, Murf)

## Testing

Tested on:

- **OS**: Windows 11 Home 64-bit (build 10.0.22631)
- **CPU**: AMD Ryzen 7 5800X3D 8-Core Processor
- **FFmpeg**: 8.0-full_build (gyan.dev Windows build — includes `librubberband`)
- **Runtime**: .NET 10.0.104

Scenarios verified:
- VAD silence compression shortens internal pauses without affecting speech
- High-quality rubberband time-stretch produces cleaner output than `atempo` at 1.3x–1.5x speed factors
- Automatic fallback to `atempo` when rubberband is unavailable
- Advanced settings window opens, all controls visible, settings persist after restart
- Edge-TTS-specific controls (rate/pitch/volume) show only when Edge-TTS engine is selected
- All existing TTS engines (Piper, ElevenLabs, Azure, Google, AllTalk, Murf) remain unaffected when new options are disabled