### PR TITLE
Fix Flatpak: launch on Wayland desktops (X11/XWayland)

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -14,10 +14,12 @@ build-options:
     PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
 
 finish-args:
-  # Display
+  # Display — Avalonia (11.x) has no native Wayland backend yet, so X11/XWayland
+  # is always required.  Keep --socket=wayland for future native support and for
+  # embedded components (e.g. libmpv) that can use Wayland directly.
   - --share=ipc
+  - --socket=x11
   - --socket=wayland
-  - --socket=fallback-x11
   # Hardware acceleration
   - --device=dri
   # File access (subtitle files are typically in the home directory)


### PR DESCRIPTION
## Summary
- Avalonia 11.x has no native Wayland backend — it always needs X11 (via XWayland on Wayland sessions)
- The manifest used `--socket=fallback-x11`, which denies X11 access when Wayland is available, causing a silent startup crash on Wayland desktops
- Changed to `--socket=x11` so X11/XWayland is always available; kept `--socket=wayland` for future native support and for embedded components (e.g. libmpv)

## Why this is not a breaking change
The original `wayland` + `fallback-x11` pattern is standard Flatpak boilerplate for apps with **native** Wayland support. Since Avalonia 11.x doesn't have a Wayland backend yet ([AvaloniaUI/Avalonia#1243](https://github.com/AvaloniaUI/Avalonia/issues/1243)), this pattern was incorrect for SubtitleEdit.

`--socket=x11` is actually **less restrictive** than `fallback-x11` — it simply ensures X11/XWayland is always available in the sandbox, which is what the [Flatpak docs](https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html) recommend for apps that require X11. No permissions are removed, no behavior changes on X11 sessions — it only fixes the Wayland session case where the app previously could not start.

When Avalonia eventually ships native Wayland support, this can be revisited to switch back to `fallback-x11`.

## Test environment
- **OS:** Q4OS 6 Andromeda (Debian 13 "trixie"), kernel 6.12.74
- **Desktop:** KDE Plasma 6, **native Wayland session** (`XDG_SESSION_TYPE=wayland`)
- **GPU:** NVIDIA RTX 4090, driver 550.163.01
- **Flatpak:** 1.16.3, flatpak-builder 1.4.4
- **Runtime:** org.freedesktop.Platform 24.08, .NET 10 SDK extension

## Test plan
- [x] Built Flatpak locally with `flatpak-builder`
- [x] Installed and launched on a **native Wayland session** — app starts and renders correctly via XWayland
- [x] Confirmed previous `--socket=fallback-x11` caused silent crash (exit code 1, no stderr output)
- [x] Confirmed `--socket=x11` fixes the issue
