### PR TITLE
Add runtime dependencies to Flatpak and fix mpv video rendering

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -17,7 +17,7 @@ finish-args:
   # Display
   - --share=ipc
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   # Hardware acceleration
   - --device=dri
   # File access (subtitle files are typically in the home directory)

--- a/src/UI/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicNativeControl.cs
+++ b/src/UI/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicNativeControl.cs
@@ -161,8 +161,20 @@ public class LibMpvDynamicNativeControl : NativeControlHost
             System.Diagnostics.Debug.WriteLine($"Failed to set wid: {_mpvPlayer.GetErrorString(err)}");
         }
 
-        // Set video output to use the embedded window
-        _mpvPlayer.SetOptionString("vo", "gpu");
+        // Set video output for the embedded window.
+        // On Linux, use Xvideo (xv) rather than GPU-accelerated output.
+        // Avalonia (11.x) always uses X11/XWayland — GPU outputs (vo=gpu)
+        // cause flickering because the compositor redraws the area between
+        // mpv frames.  Xvideo renders directly via the X11 Xv extension
+        // without an OpenGL context, avoiding the compositing conflict.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            _mpvPlayer.SetOptionString("vo", "xv,x11,gpu");
+        }
+        else
+        {
+            _mpvPlayer.SetOptionString("vo", "gpu");
+        }
 
         // Keep subtitles off (we'll handle them separately)
         _mpvPlayer.SetOptionString("sid", "no");
@@ -170,11 +182,13 @@ public class LibMpvDynamicNativeControl : NativeControlHost
         // Keep the video paused at the end
         _mpvPlayer.SetOptionString("keep-open", "always");
 
-        // Platform-specific GPU context configuration
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            ConfigureLinuxGpuContext();
-        }
+        // Allow mpv to stay alive without a file loaded, and force it to
+        // create its rendering window immediately.  Without these the X11
+        // child window created by NativeControlHost has no content and the
+        // desktop shows through until a video file is opened.
+        _mpvPlayer.SetOptionString("idle", "yes");
+        _mpvPlayer.SetOptionString("force-window", "yes");
+        _mpvPlayer.SetOptionString("background-color", "#000000");
 
         // Initialize mpv
         err = _mpvPlayer.Initialize();
@@ -198,25 +212,13 @@ public class LibMpvDynamicNativeControl : NativeControlHost
             return;
         }
 
-        try
-        {
-            var sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE")?.ToLowerInvariant();
-            var waylandDisplay = Environment.GetEnvironmentVariable("WAYLAND_DISPLAY");
-            var x11Display = Environment.GetEnvironmentVariable("DISPLAY");
-
-            if (sessionType == "wayland" || (!string.IsNullOrEmpty(waylandDisplay) && sessionType == null))
-            {
-                _mpvPlayer.SetOptionString("gpu-context", "wayland");
-            }
-            else if (sessionType == "x11" || (!string.IsNullOrEmpty(x11Display) && sessionType == null))
-            {
-                _mpvPlayer.SetOptionString("gpu-context", "x11egl");
-            }
-        }
-        catch
-        {
-            // Ignore detection errors; fallback to mpv defaults
-        }
+        // Avalonia (11.x) has no native Wayland backend — it always renders
+        // through X11/XWayland even on Wayland sessions.  The wid handle we
+        // pass to mpv is therefore always an X11 window ID.
+        // Do NOT force gpu-context here: mpv will auto-detect the correct
+        // X11 context (GLX or EGL) from the wid window handle.
+        // Forcing gpu-context=wayland would cause a mismatch (Wayland surface
+        // for an X11 window), resulting in audio-only playback with no video.
     }
 
     private static string GetWindowIdString(IntPtr handle)
@@ -246,9 +248,10 @@ public class LibMpvDynamicNativeControl : NativeControlHost
 
     private void OnMpvRequestRender()
     {
-        // With native window embedding, mpv handles rendering automatically
-        // We just need to invalidate to trigger any UI updates if needed
-        Dispatcher.UIThread.Post(() => InvalidateVisual(), DispatcherPriority.Render);
+        // In wid mode mpv renders directly into its own X11 child window.
+        // Do NOT call InvalidateVisual() here — that would make Avalonia
+        // repaint the control area (with a black background) on every frame,
+        // causing flicker as Avalonia and mpv paint alternately.
     }
 
     public void LoadFile(string path)

--- a/src/UI/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/UI/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -415,31 +415,9 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayerInstance
         SetOptionString("vo", "libmpv");
         SetOptionString("gpu-api", "opengl");
 
-        // Platform-specific GPU context configuration
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            // On Linux, configure gpu-context based on display server
-            try
-            {
-                var sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE")?.ToLowerInvariant();
-                var waylandDisplay = Environment.GetEnvironmentVariable("WAYLAND_DISPLAY");
-                var x11Display = Environment.GetEnvironmentVariable("DISPLAY");
-
-                if (sessionType == "wayland" || (!string.IsNullOrEmpty(waylandDisplay) && sessionType == null))
-                {
-                    SetOptionString("gpu-context", "wayland");
-                }
-                else if (sessionType == "x11" || (!string.IsNullOrEmpty(x11Display) && sessionType == null))
-                {
-                    SetOptionString("gpu-context", "x11");
-                }
-                // else: don't force gpu-context, mpv will autodetect
-            }
-            catch
-            {
-                // Ignore detection errors; fallback to mpv defaults
-            }
-        }
+        // On Linux, do NOT force gpu-context.  Avalonia (11.x) has no native
+        // Wayland backend — it always provides an X11/XWayland OpenGL context,
+        // so let mpv auto-detect from the context it receives.
 
         // Initialize mpv first
         var err = _mpvInitialize(_mpv);


### PR DESCRIPTION
## Summary

I'm sorry — in PR #10385 I fixed the Flatpak build system so that it compiles from source, but I overlooked the fact that SubtitleEdit loads several native libraries at runtime that are **not** included in the `org.freedesktop.Platform 24.08` runtime. This caused video playback and audio processing features to silently fail inside the Flatpak sandbox.

This PR:
1. Adds all missing runtime dependencies as build modules in the Flatpak manifest
2. Fixes the library search path so libmpv can be found in the sandbox
3. Fixes multiple mpv video rendering issues on Linux (flickering, no video, transparent background)
4. Fixes Flatpak X11 socket policy so the app launches on Wayland desktops

---

## Part 1: Flatpak manifest — add runtime dependency modules

| Module | Version | Why SubtitleEdit needs it |
|--------|---------|---------------------------|
| **libmpv** | 0.41.0 | Primary video player — loaded via `NativeLibrary.TryLoad("libmpv.so.2")` in `LibMpvDynamicPlayer.cs` |
| **ffmpeg** | 7.1.2 | Audio/video processing — wave extraction, subtitle burn-in, TTS speed adjustment, blank video generation |
| **rubberband** | 4.0.0 | High-quality pitch-preserving audio time-stretching — used by ffmpeg's `rubberband` filter for TTS speed adjustment (`FfmpegGenerator.cs:525-548`); platform ffmpeg 7.0.3 lacks this filter |
| **x264** | latest | H.264 encoding — used for subtitle burn-in (`-c:v libx264`) and blank video generation; not in platform ffmpeg |
| **libass** | 0.17.4 | Subtitle rendering — needed by both ffmpeg (`-vf ass=`, `-vf subtitles=`) and mpv |
| **uchardet** | 0.0.8 | Character encoding detection — needed by mpv |
| **libplacebo** | 7.360.1 | GPU shader library — needed by mpv for rendering |
| **mujs** | 1.3.8 | JavaScript engine — needed by mpv |
| **libXpresent** | 1.0.2 | X11 Present extension — needed by mpv |
| **hwdata** | 0.394 | PCI/USB ID database — needed by libdisplay-info |
| **libdisplay-info** | 0.2.0 | Display EDID parsing — needed by mpv |

### Why the custom ffmpeg build

The platform's ffmpeg 7.0.3 is built with `--disable-encoders` and **no librubberband**. SubtitleEdit needs:
- **rubberband filter** — for pitch-preserving TTS audio speed adjustment (falls back to `atempo` but with lower quality)
- **libx264 encoder** — for subtitle burn-in and blank video generation
- **libass filter** — for ASS subtitle rendering in burn-in

The custom ffmpeg 7.1.2 at `/app/bin/ffmpeg` overrides the platform version for the sandboxed app only.

### Module sources

All module versions and build configurations are based on the [official mpv Flathub manifest](https://github.com/flathub/io.mpv.Mpv) (`io.mpv.Mpv`), adapted for SubtitleEdit's needs (library-only mpv build with `-Dlibmpv=true -Dcplayer=false`).

---

## Part 2: LibMpvDynamicPlayer.cs — add `/app/lib` to search paths

`LoadLibraryInternal()` iterates a hardcoded list of Linux library directories and checks `File.Exists()` before calling `dlopen`. The Flatpak sandbox installs libraries to `/app/lib`, which was not in the list, so libmpv was present but never found. Added `/app/lib` to `GetLibraryPaths()`.

---

## Part 3: Fix mpv video rendering on Linux

### Problem 1: No video output (audio only) on Wayland desktops

**Root cause:** `LibMpvDynamicNativeControl.ConfigureLinuxGpuContext()` and `LibMpvDynamicPlayer` both detected the session type via `$XDG_SESSION_TYPE` / `$WAYLAND_DISPLAY` and forced `gpu-context=wayland` when Wayland was detected. However, **Avalonia 11.x has no native Wayland backend** — it always renders through X11/XWayland, even on Wayland sessions (see [AvaloniaUI/Avalonia#1243](https://github.com/AvaloniaUI/Avalonia/issues/1243)). The `wid` handle passed to mpv is therefore always an X11 window ID. Forcing `gpu-context=wayland` created a Wayland surface for an X11 window — a fatal mismatch that resulted in audio-only playback with no video.

**Fix:** Removed all `gpu-context` forcing logic from both `LibMpvDynamicNativeControl.cs` and `LibMpvDynamicPlayer.cs`. mpv auto-detects the correct X11 context (GLX or EGL) from the `wid` window handle. This is safe because:
- On X11 sessions: mpv auto-detects X11 context (same behavior as before for X11 users)
- On Wayland sessions: Avalonia still provides X11/XWayland handles, so mpv correctly auto-detects X11 context instead of incorrectly using Wayland

### Problem 2: Video flickering during playback

**Root cause:** Two separate issues combined to cause flickering:

1. **`vo=gpu` + compositor conflict:** With `vo=gpu`, mpv uses an OpenGL context to render into the embedded window. On XWayland, the compositor (KWin) redraws the window area between mpv frames, creating a visible flicker as the compositor and mpv paint alternately.

2. **`InvalidateVisual()` in `OnMpvRequestRender()`:** Every time mpv requested a render, the code called `Dispatcher.UIThread.Post(() => InvalidateVisual())`, which triggered Avalonia to repaint the `NativeControlHost` area (with a blank/black background) on every single frame. This created a constant flicker as Avalonia and mpv painted alternately into the same area.

**Fix:**
- Changed `vo` to `xv,x11,gpu` on Linux — Xvideo renders directly via the X11 Xv extension without an OpenGL context, completely bypassing the compositor conflict. Falls back to `x11` then `gpu` if Xvideo is unavailable.
- Removed the `InvalidateVisual()` call from `OnMpvRequestRender()` — in `wid` mode mpv renders directly into its own X11 child window and does not need Avalonia to trigger repaints.

### Problem 3: Transparent player area before video loads

**Root cause:** The `NativeControlHost` creates an X11 child window for mpv to embed into. Before mpv loads a video file, this window has no content — the X11 window has no background attribute set, so it's transparent and the desktop shows through.

**Fix:** Added three mpv options before `Initialize()`:
- `idle=yes` — keeps mpv alive without a file loaded, waiting for commands
- `force-window=yes` — forces mpv to create its rendering window and start its render loop immediately, even without a video file
- `background-color=#000000` — paints a black background in the idle state

Together these make mpv paint a solid black background into the embedded window as soon as it initializes, eliminating the transparency.

---

## Part 4: Fix Flatpak X11 socket for Wayland desktops

Changed `--socket=fallback-x11` to `--socket=x11` in the Flatpak manifest.

**Why this is needed:** `fallback-x11` grants X11 access **only when Wayland is unavailable**. On Wayland desktops, it actively denies X11 access. But Avalonia 11.x has no native Wayland backend — it always needs X11/XWayland to function. With `fallback-x11`, the app silently crashes on launch on any Wayland desktop.

**Why this is not a breaking change:** The `--socket=wayland` permission is still present, so Wayland-aware subsystems can use it. The `--socket=x11` simply ensures X11/XWayland is always available as Avalonia requires. Once Avalonia adds native Wayland support in a future version, this can be revisited.

(Same fix as PR #10387, included here so this branch is self-contained and testable.)

---

## Test environment
- **OS:** Q4OS 6 Andromeda (Debian 13 "trixie"), kernel 6.12.74
- **Desktop:** KDE Plasma 6, **native Wayland session** (not X11)
- **GPU:** NVIDIA RTX 4090, driver 550.163.01
- **Flatpak:** 1.16.3, flatpak-builder 1.4.4
- **Runtime:** org.freedesktop.Platform 24.08, .NET 10 SDK extension

## Test plan
- [x] Flatpak builds successfully with all modules
- [x] `libmpv.so.2` present and loadable in sandbox (`/app/lib/libmpv.so.2.5.0`)
- [x] `ffmpeg -filters` shows `rubberband` filter
- [x] `ffmpeg -encoders` shows `libx264` encoder
- [x] `ffmpeg -filters` shows `ass` and `subtitles` filters
- [x] Application launches on native Wayland session
- [x] Video playback works — no audio-only issue
- [x] No flickering during video playback
- [x] Player area shows black background (not transparent) before video is loaded
- [ ] Verify TTS audio speed adjustment uses rubberband

🤖 Generated with [Claude Code](https://claude.com/claude-code)