### PR TITLE
Fix Flatpak build: install xvfb on runner

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Update metainfo version/date from Se.cs
         run: bash installer/flatpak/update-metainfo-version.sh
 


### PR DESCRIPTION
## Summary
- The `flatpak-github-actions/flatpak-builder@v6` action calls `xvfb-run` internally, but `xvfb` is no longer pre-installed on `ubuntu-latest` runners
- This causes the build to fail with: `The process '/usr/bin/xvfb-run' failed with exit code 127`
- Adds a step to install `xvfb` before the Flatpak build

Fixes the failure in https://github.com/SubtitleEdit/subtitleedit/actions/runs/23449774069

Tested on: Debian GNU/Linux 13 (trixie) x86_64
Kernel: Linux 6.12.74+deb13+1-amd64
Flatpak package runs properly.

Known issues: App started on X11 but crashed on Wayland. (It's not related to this PR but I will prepare fix for that to make linux support better.)