### PR TITLE
fix: use flathub container for Flatpak CI build

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -12,15 +12,12 @@ on:
 jobs:
   build-flatpak:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
+      options: --privileged
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install Flatpak build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder xvfb
-          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Update metainfo version/date from Se.cs
         run: bash installer/flatpak/update-metainfo-version.sh


### PR DESCRIPTION
## Problem

The `Build Flatpak` workflow fails on `ubuntu-latest` runners (Ubuntu 24.04) because:

1. PR #10392 added `xvfb` installation, fixing the initial `exit code 127`
2. However, `flatpak-builder` itself is also no longer pre-installed, causing `xvfb-run` to fail with `exit code 127` (the wrapped command not found)
3. Even after installing `flatpak` + `flatpak-builder` + `xvfb` manually, the build fails with `exit code 1` because `flatpak --system install` is not allowed for unprivileged users on the runner (`Flatpak system operation Deploy not allowed for user`)

See failed run: https://github.com/SubtitleEdit/subtitleedit/actions/runs/23476723098

## Solution

Use the official flathub container image as recommended by the [flatpak-github-actions README](https://github.com/flatpak/flatpak-github-actions#how-to-use):

```yaml
container:
  image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
  options: --privileged
```

This container has `flatpak`, `flatpak-builder`, `xvfb`, and the flathub remote pre-configured with correct permissions.

## Verified

Successfully tested in fork: https://github.com/Ironship/subtitleedit/actions/runs/23487145291 ✅
