### PR TITLE
fix: handle TTS server connection errors gracefully

### DIFF
--- a/src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -506,15 +506,25 @@ public partial class ReviewSpeechViewModel : ObservableObject
         }
         catch (HttpRequestException ex)
         {
-            IsRegenerateEnabled = true;
-            SeLogger.Error($"TTS server error during regeneration: {ex.Message}");
-            await MessageBox.Show(
-                Window!,
-                "TTS server error: " + ex.Message,
-                "Error",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Error);
+            SeLogger.Error(ex, "TTS server error during regeneration.");
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "TTS server error: " + ex.Message,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
             return;
+        }
+        finally
+        {
+            IsRegenerateEnabled = true;
+            if (engine is Murf && oldStyle != null)
+            {
+                Se.Settings.Video.TextToSpeech.MurfStyle = oldStyle;
+            }
         }
 
         line.AddHistory(voice, speakResult);
@@ -530,13 +540,6 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         _skipAutoContinue = true;
         await PlayAudio(line.StepResult.CurrentFileName);
-
-        IsRegenerateEnabled = true;
-
-        if (engine is Murf && oldStyle != null)
-        {
-            Se.Settings.Video.TextToSpeech.MurfStyle = oldStyle;
-        }
     }
 
     private static void SafeDelete(string fileName)

--- a/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -910,15 +910,18 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
         catch (HttpRequestException ex)
         {
-            SeLogger.Error($"TTS server error during speech generation: {ex.Message}");
+            SeLogger.Error(ex, "TTS server error during speech generation.");
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                await MessageBox.Show(
-                    Window!,
-                    "TTS server error: " + ex.Message,
-                    "Error",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
+                if (Window != null)
+                {
+                    await MessageBox.Show(
+                        Window,
+                        Se.Language.General.Error,
+                        "TTS server error: " + ex.Message,
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
             });
             return null;
         }

--- a/src/UI/Logic/Download/TtsDownloadService.cs
+++ b/src/UI/Logic/Download/TtsDownloadService.cs
@@ -121,7 +121,7 @@ public class TtsDownloadService : ITtsDownloadService
 
     public async Task<string> AllTalkVoiceSpeak(string inputText, AllTalkVoice voice, string language)
     {
-        var multipartContent = new MultipartFormDataContent();
+        using var multipartContent = new MultipartFormDataContent();
         var text = Utilities.UnbreakLine(inputText);
         multipartContent.Add(new StringContent(Json.EncodeJsonText(text)), "text_input");
         multipartContent.Add(new StringContent("standard"), "text_filtering");
@@ -142,26 +142,31 @@ public class TtsDownloadService : ITtsDownloadService
         }
         catch (HttpRequestException ex)
         {
-            SeLogger.Error($"AllTalk TTS server connection failed: {ex.Message}");
+            SeLogger.Error(ex, "AllTalk TTS server connection failed.");
             throw new HttpRequestException("AllTalk TTS server is not reachable. Please check that the server is running.", ex);
         }
         catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
         {
-            SeLogger.Error($"AllTalk TTS server request timed out: {ex.Message}");
+            SeLogger.Error(ex, "AllTalk TTS server request timed out.");
             throw new HttpRequestException("AllTalk TTS server request timed out. Please check that the server is running.", ex);
         }
 
-        var bytes = await result.Content.ReadAsByteArrayAsync();
-        var resultJson = Encoding.UTF8.GetString(bytes);
-
-        if (!result.IsSuccessStatusCode)
+        using (result)
         {
-            SeLogger.Error($"All Talk TTS failed calling API as base address {_httpClient.BaseAddress} : Status code={result.StatusCode}" + Environment.NewLine + resultJson);
-        }
+            if (!result.IsSuccessStatusCode)
+            {
+                var errorBody = await result.Content.ReadAsStringAsync();
+                SeLogger.Error($"AllTalk TTS failed calling API at {_httpClient.BaseAddress}: Status code={result.StatusCode}" + Environment.NewLine + errorBody);
+                throw new HttpRequestException($"AllTalk TTS server returned error {(int)result.StatusCode} ({result.StatusCode}).");
+            }
 
-        var jsonParser = new SeJsonParser();
-        var allTalkOutput = jsonParser.GetFirstObject(resultJson, "output_file_path");
-        return allTalkOutput.Replace("\\\\", "\\");
+            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var resultJson = Encoding.UTF8.GetString(bytes);
+
+            var jsonParser = new SeJsonParser();
+            var allTalkOutput = jsonParser.GetFirstObject(resultJson, "output_file_path");
+            return allTalkOutput.Replace("\\\\", "\\");
+        }
     }
 
     public async Task<bool> AllTalkIsInstalled()


### PR DESCRIPTION
## Fix: Handle TTS server connection errors gracefully

Closes #10401

### Problem
Application crashes with unhandled exception when the AllTalk TTS server becomes unavailable (shut down, network error) during audio generation. `AllTalkVoiceSpeak()` doesn't catch `HttpRequestException` or `TaskCanceledException` (timeout), and `GenerateSpeech()` / `RegenerateAudio()` only catch `OperationCanceledException`.

### Solution
1. **`TtsDownloadService.AllTalkVoiceSpeak()`** — wrap HTTP POST in try-catch for `HttpRequestException` and `TaskCanceledException` (timeout), log error and re-throw with descriptive message
2. **`TextToSpeechViewModel.GenerateSpeech()`** — catch `HttpRequestException` in the generation loop, show error dialog, return gracefully
3. **`ReviewSpeechViewModel.RegenerateAudio()`** — catch `HttpRequestException` around `engine.Speak()`, show error dialog, re-enable regenerate button

### Files changed
- `src/UI/Logic/Download/TtsDownloadService.cs`
- `src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs`
- `src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs`

### Tested
- Build succeeds with no new warnings
