### PR TITLE
Fix "Save As" not appending format extension for language-coded filenames

### DIFF
--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -11606,6 +11606,8 @@ public partial class MainViewModel :
                              ?? SelectedSubtitleFormat;
         }
 
+        newFileName += subtitleFormat.Extension;
+
         var saveAsResult = await _fileHelper.PickSaveSubtitleFileAs(
             Window!,
             subtitleFormat,

--- a/src/UI/Logic/Media/FileHelper.cs
+++ b/src/UI/Logic/Media/FileHelper.cs
@@ -275,6 +275,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
                 SuggestedFileName = suggestedFileName,
                 FileTypeChoices = filePickerFileTypes,
                 SuggestedFileType = defaultChoice,
+                DefaultExtension = currentFormat.Extension.TrimStart('.'),
             };
 
             if (!string.IsNullOrEmpty(suggestedStartLocationPath))


### PR DESCRIPTION
## Summary
- When extracting subtitles from MKV with a two-letter language code (e.g., `.sv` for Swedish), the "Save As" dialog suggested a filename without the subtitle format extension (e.g., `.srt`)
- Windows treated the language code as the file extension, resulting in files saved as `name.sv` instead of `name.sv.srt`
- Added subtitle format extension to the suggested filename in `SaveSubtitleAs()`
- Added `DefaultExtension` to `FilePickerSaveOptions` in `PickSaveSubtitleFileAs()`, matching the existing behavior in `PickSaveSubtitleFile()`

## Test plan
- [ ] Open an MKV file containing multiple subtitle tracks with different languages (e.g., Swedish `.sv` and English `.en`)
- [ ] Select the Swedish subtitle track, press "Save As" — verify the suggested filename ends with `.sv.srt` (not just `.sv`)
- [ ] Select the English subtitle track, press "Save As" — verify the suggested filename ends with `.en.srt`
- [x] Open a regular `.srt` file, press "Save As" — verify the suggested filename still ends with `.srt` (no double extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)