### PR TITLE
Fix Find window "Count" resetting search text

### DIFF
--- a/src/UI/Features/Edit/Find/FindViewModel.cs
+++ b/src/UI/Features/Edit/Find/FindViewModel.cs
@@ -142,7 +142,10 @@ public partial class FindViewModel : ObservableObject
     {
         _findService = findService;
         _subs = subs;
-        SearchText = selectedText.Trim();
+        if (string.IsNullOrEmpty(SearchText))
+        {
+            SearchText = selectedText.Trim();
+        }
         _findResult = findResult;
 
         SearchHistory.Clear();


### PR DESCRIPTION
## Summary
- Preserve user-typed search text in `FindViewModel.InitializeFindData` when it is already non-empty, so clicking "Count" no longer overwrites the text box with the currently selected subtitle text.

## Test plan
- [x] Open Find dialog with subtitle text selected
- [x] Type a different search term in the search box
- [x] Click "Count" — verify the search box is NOT replaced by the selected text
- [x] Verify the count result reflects the typed term
- [x] Open Find dialog with an empty search box — verify it still pre-fills from selected text

🤖 Generated with [Claude Code](https://claude.com/claude-code)