### PR TITLE
fix: prevent portable mode from creating AppData\Subtitle Edit\Dictionaries folder

### DIFF
--- a/src/UI/Logic/Config/Se.cs
+++ b/src/UI/Logic/Config/Se.cs
@@ -81,6 +81,11 @@ public class Se
                 SeLogger.Error("Error creating data folder: " + DataFolder);
             }
         }
+
+        // Sync libse Configuration so it uses the same data folder as Se.
+        // Without this, Configuration.GetDataDirectory() uses its own heuristics and may
+        // create or return %AppData%\Subtitle Edit even when running in portable mode.
+        Configuration.DataDirectoryOverride = DataFolder;
     }
 
     public static string DictionariesFolder => Path.Combine(DataFolder, "Dictionaries");


### PR DESCRIPTION
## Problem

When running SE5 in portable mode (extracted from ZIP), the `%AppData%\Subtitle Edit\Dictionaries` folder was being created or used even though the app should be fully self-contained.

**Root cause:** `Se.DataFolder` (UI layer) and `Configuration.GetDataDirectory()` (libse) use independent heuristics to determine the data directory. In the common case where SE4 was previously installed (leaving `%AppData%\Subtitle Edit\Dictionaries` on disk), libse's `GetDataDirectory()` detects the existing AppData directory and returns it, while `Se.DataFolder` correctly returns the portable ExePath. This mismatch caused:

1. libse code (e.g. `Configuration.DictionariesDirectory`, used in spell-check and OCR features) to read/write from SE4's AppData folder instead of the portable folder
2. An empty `Dictionaries` folder appearing in AppData from SE5's perspective (the one SE5 creates vs the one SE4 left)
3. SE4's installed-vs-portable detection to fire incorrectly (SE4 treats presence of `%AppData%\Subtitle Edit\` as "installed mode")

## Fix

Set `Configuration.DataDirectoryOverride = Se.DataFolder` at the end of the `Se` static constructor, after `DataFolder` is resolved and the directory is created. This makes libse's `GetDataDirectory()` always return the same path as `Se.DataFolder` for all subsequent property calls (`DictionariesDirectory`, `SpectrogramsDirectory`, etc.), regardless of what SE4 left in AppData.

The fix is a single line in `Se.cs` — no changes to libse, no new files.

Fixes #10421

## Test plan
- [ ] Extract SE5 portable to a non-Program Files folder (e.g. Desktop) on a machine that has or had SE4 installed
- [ ] Launch SE5 portable
- [ ] Verify no new `%AppData%\Subtitle Edit\Dictionaries` folder is created
- [ ] Verify SE4 portable/installed detection is not broken (SE4 should not see a new AppData folder from SE5)
- [ ] Verify spell-check and OCR dictionaries load correctly from the portable folder