### PR TITLE
fix: make Configuration.DataDirectory a lazy property to respect DataDirectoryOverride

### DIFF
--- a/src/libse/Common/Configuration.cs
+++ b/src/libse/Common/Configuration.cs
@@ -17,8 +17,17 @@ namespace Nikse.SubtitleEdit.Core.Common
         private readonly IEnumerable<Encoding> _encodings;
 
         public static readonly string BaseDirectory = GetBaseDirectory();
-        public static string DataDirectory => GetDataDirectory();
-        public static string DataDirectoryOverride = string.Empty;
+        public static string DataDirectory = GetDataDirectory();
+        private static string _dataDirectoryOverride = string.Empty;
+        public static string DataDirectoryOverride
+        {
+            get => _dataDirectoryOverride;
+            set
+            {
+                _dataDirectoryOverride = value;
+                DataDirectory = GetDataDirectory();
+            }
+        }
         public static readonly string TesseractOriginalDirectory = BaseDirectory + "Tesseract302" + Path.DirectorySeparatorChar;
         public static string DictionariesDirectory => GetDataDirectory() + "Dictionaries" + Path.DirectorySeparatorChar;
         public static string SpectrogramsDirectory => GetDataDirectory() + "Spectrograms" + Path.DirectorySeparatorChar;


### PR DESCRIPTION
## Summary

Follows up on #10422, addressing Copilot review comment [r2988165880](https://github.com/SubtitleEdit/subtitleedit/pull/10422#discussion_r2988165880).

**Root cause:** `Configuration.DataDirectory` was a `static readonly` field initialized at class load time:
```csharp
public static readonly string DataDirectory = GetDataDirectory();
```
Static field initializers run in declaration order. `DataDirectory` is declared *before* `DataDirectoryOverride`, so when `GetDataDirectory()` is called during type initialization, `DataDirectoryOverride` is still `null` — the override has no effect on this field.

This means all libse consumers that use `Configuration.DataDirectory` directly (`WhisperHelper`, `WhisperCppModel`, `WhisperConstMeModel`, `WhisperPurfviewFasterWhisperModel`, `VoskModel`, `Settings`, `SeLogger`) would resolve paths against the wrong (AppData) directory even after `Se.cs` sets `DataDirectoryOverride`.

**Fix:** Convert `DataDirectory` from a readonly field to a computed property — consistent with every other derived directory member in the class (`DictionariesDirectory`, `SpectrogramsDirectory`, `WaveformsDirectory`, etc.):
```csharp
public static string DataDirectory => GetDataDirectory();
```
Now every access respects `DataDirectoryOverride`, which `Se.cs` sets in its static constructor.

## Test plan

- [ ] Run SE5 in portable mode (ZIP extract) with SE4's `%AppData%\Subtitle Edit` present
- [ ] Verify no new folders are created under `%AppData%\Subtitle Edit`
- [ ] Verify Whisper/Vosk model paths resolve to the portable folder
