### PR TITLE
Reorder buttons in FindWindow to correct UI layout

### DIFF
--- a/src/UI/Features/Edit/Find/FindWindow.cs
+++ b/src/UI/Features/Edit/Find/FindWindow.cs
@@ -103,8 +103,8 @@ public class FindWindow : Window
             Margin = new Thickness(0, 0, 50, 0),
             Children =
             {
-                buttonFindPrevious,
                 buttonFindNext,
+                buttonFindPrevious,
                 buttonCount,
                 textBlockCountResult
             }


### PR DESCRIPTION
Move "Find next" on top since it's the button most like to be used also seems to be the standard 

<img width="436" height="260" alt="image" src="https://github.com/user-attachments/assets/490c381b-04a5-464a-8120-eea818383295" />
