### PR TITLE
Add Select All, Invert, Select None to BatchConvert functions list

### DIFF
--- a/src/UI/Features/Tools/BatchConvert/BatchConvertFunction.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertFunction.cs
@@ -4,14 +4,18 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert;
 
-public class BatchConvertFunction
+public partial class BatchConvertFunction : ObservableObject
 {
     public BatchConvertFunctionType Type { get; set; }
     public string Name { get; set; }
-    public bool IsSelected { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsSelected { get; set; }
+
     public Control View { get; set; }
 
     public override string ToString()

--- a/src/UI/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1150,6 +1150,33 @@ public partial class BatchConvertViewModel : ObservableObject
         UpdateOutputProperties();
     }
 
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (BatchConvertFunction batchConvertFunction in BatchFunctions)
+        {
+            batchConvertFunction.IsSelected = true;
+        }
+    }
+
+    [RelayCommand]
+    private void InvertSelection()
+    {
+        foreach (BatchConvertFunction batchConvertFunction in BatchFunctions)
+        {
+            batchConvertFunction.IsSelected = !batchConvertFunction.IsSelected;
+        }
+    }
+
+    [RelayCommand]
+    private void SelectNone()
+    {
+        foreach (BatchConvertFunction batchConvertFunction in BatchFunctions)
+        {
+            batchConvertFunction.IsSelected = false;
+        }
+    }
+
     internal void OnKeyDown(KeyEventArgs e)
     {
         if (e.Key == Key.Escape)

--- a/src/UI/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -344,6 +344,27 @@ public class BatchConvertWindow : Window
             Height = 300,
             DataContext = vm,
             ItemsSource = vm.BatchFunctions,
+            ContextFlyout = new MenuFlyout()
+            {
+                Items =
+                {
+                    new MenuItem()
+                    {
+                        Header =Se.Language.General.SelectAll,
+                        Command = vm.SelectAllCommand,
+                    },
+                    new MenuItem()
+                    {
+                        Header = Se.Language.General.InvertSelection,
+                        Command = vm.InvertSelectionCommand,
+                    },
+                    new MenuItem()
+                    {
+                        Header =Se.Language.General.SelectNone,
+                        Command = vm.SelectNoneCommand,
+                    }
+                }
+            },
             Columns =
             {
                 new DataGridTemplateColumn


### PR DESCRIPTION
## Summary
- Added `SelectAll`, `InvertSelection`, and `SelectNone` relay commands to `BatchConvertViewModel`
- Made `BatchConvertFunction.IsSelected` an observable property so selection changes propagate to the UI
- Wired a right-click context menu on the functions `DataGrid` with the three selection commands

## Test plan
- [x] Open Batch Convert, right-click the functions list — context menu should appear with "Select All", "Invert Selection", "Select None"
- [x] "Select All" checks all functions
- [x] "Select None" unchecks all functions
- [x] "Invert Selection" flips each function's checked state

🤖 Generated with [Claude Code](https://claude.com/claude-code)