### PR TITLE
fix: reinitialize mpv player after first-launch download without restart

### DIFF
--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -11910,6 +11910,12 @@ public partial class MainViewModel :
 
                     var result =
                         await ShowDialogAsync<DownloadLibMpvWindow, DownloadLibMpvViewModel>();
+
+                    if (!string.IsNullOrEmpty(result.LibMpvFileName))
+                    {
+                        InitializeLibMpv();
+                        SetLayout(Se.Settings.General.LayoutNumber);
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
## Problem

On first launch on Windows, SE shows a prompt to download mpv. The download happens **after** `InitializeLibMpv()` has already run with no library present, so the video player stays broken for the entire session — the user must restart the app.

## Fix

After a successful download, call `InitializeLibMpv()` + `SetLayout()` to pick up the new library immediately:

```csharp
var result = await ShowDialogAsync<DownloadLibMpvWindow, DownloadLibMpvViewModel>();

if (!string.IsNullOrEmpty(result.LibMpvFileName))
{
    InitializeLibMpv();
    SetLayout(Se.Settings.General.LayoutNumber);
}
```

This is the same pattern already used after the Settings dialog closes (see `MainViewModel.cs` around line 5943/5995). No restart needed.

- **Over-engineered?** No — 6 lines reusing existing methods.
- **Duplication?** No — consistent with the post-Settings pattern.
- **Cross-platform?** Safe — the entire block is already guarded by `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)`.
