### PR TITLE
fix: set LibVlcPath to VlcFolder so downloaded libVLC is found

### DIFF
--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -551,6 +551,7 @@ public partial class MainViewModel :
 
         InitializeFfmpeg();
         InitializeLibMpv();
+        LibVlcDynamicPlayer.LibVlcPath = Se.VlcFolder;
         LoadShortcuts();
 
         StartTimers();

--- a/src/UI/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/UI/Features/Options/Settings/SettingsViewModel.cs
@@ -1798,6 +1798,7 @@ public partial class SettingsViewModel : ObservableObject
             return;
         }
 
+        LibVlcDynamicPlayer.LibVlcPath = Se.VlcFolder;
         SetLibVlcStatus();
     }
 

--- a/src/UI/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
+++ b/src/UI/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
@@ -287,7 +287,6 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayerInstance
                 LibVlcPath,
                 Directory.GetCurrentDirectory(),
                 "/Applications/Subtitle Edit.app/Contents/Frameworks",
-                "/Users/nikolajolsson/Library/Application Support/Subtitle Edit",
                 "/opt/local/lib",
                 "/usr/local/lib",
                 "/opt/homebrew/lib",


### PR DESCRIPTION
## Problem

`LibVlcDynamicPlayer.LibVlcPath` was **never assigned** anywhere in the codebase (always empty string). After the user downloads libVLC via the UI, the file is extracted to `Se.VlcFolder` (`DataFolder/VLC/`), but that path is not included in `GetLibraryPaths()` — and since `LibVlcPath` is empty it is skipped. Result: `CanLoad()` returns false, status shows "Not installed", and video playback is broken until restart (and even then, only if the path happened to be in the system search list).

Reported in #10426 (macOS: "status shows as 'not installed', even after the UI says that libvlc.dylib has been downloaded and unpacked").

## Root cause

```csharp
// LibVlcPath is always "" — never set after download
public static string LibVlcPath = string.Empty;

private static string[] GetLibraryPaths() => [
    LibVlcPath,          // skipped (empty)
    ...                  // Se.VlcFolder not listed
];
```

## Fix

- **On startup:** set `LibVlcDynamicPlayer.LibVlcPath = Se.VlcFolder` so libraries downloaded in a previous session are found immediately
- **After download:** set `LibVlcDynamicPlayer.LibVlcPath = Se.VlcFolder` in `SettingsViewModel.DownloadLibVlc()` before calling `SetLibVlcStatus()` — no restart needed
- **Cleanup:** remove hardcoded developer home path `/Users/nikolajolsson/...` from macOS search paths

## Cross-platform

- The `LibVlcPath` assignment runs on all platforms; `Se.VlcFolder` is cross-platform
- macOS download is supported (x64); the fix makes it functional
- Linux is unaffected (no download UI, system paths cover it)

Closes #10426
