### PR TITLE
ci: remove signature from unsigned macOS builds before DMG creation

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -327,6 +327,9 @@ jobs:
             echo "Signing x64 app..."
             codesign --force --options runtime --timestamp --deep --entitlements "./installer/macBundle/Entitlements.plist" --sign "${{ secrets.MACOS_CERTIFICATE_NAME }}" "./SubtitleEdit-x64.app"
             codesign --verify --verbose "./SubtitleEdit-x64.app"
+          else
+            # Remove broken/conflicting signature from unsigned build (workaround for startup failures)
+            codesign --remove-signature "./SubtitleEdit-x64.app" 2>/dev/null || true
           fi
       
           # Create DMG for x64
@@ -444,6 +447,9 @@ jobs:
             echo "Signing ARM64 app..."
             codesign --force --options runtime --timestamp --deep --entitlements "./installer/macBundle/Entitlements.plist" --sign "${{ secrets.MACOS_CERTIFICATE_NAME }}" "./SubtitleEdit-ARM64.app"
             codesign --verify --verbose "./SubtitleEdit-ARM64.app"
+          else
+            # Remove broken/conflicting signature from unsigned build (workaround for startup failures)
+            codesign --remove-signature "./SubtitleEdit-ARM64.app" 2>/dev/null || true
           fi
       
           # Create DMG for ARM64


### PR DESCRIPTION
## Problem

When no Apple Developer certificate is available, the macOS app bundles are shipped with a broken/conflicting signature inherited from the build process. This causes startup failures on some systems — users in #10339 reported that running `codesign --remove-signature "Subtitle Edit.app"` manually fixes the issue.

## Fix

Add `codesign --remove-signature` in the `else` branch of the signing step (both x64 and ARM64), so unsigned builds ship without a signature rather than with a broken one:

```yaml
if [ "$SIGNING_AVAILABLE" = "true" ]; then
  codesign --force ... --sign "${{ secrets.MACOS_CERTIFICATE_NAME }}" "./SubtitleEdit-x64.app"
  codesign --verify --verbose "./SubtitleEdit-x64.app"
else
  # Remove broken/conflicting signature from unsigned build (workaround for startup failures)
  codesign --remove-signature "./SubtitleEdit-x64.app" 2>/dev/null || true
fi
```

## Scope

**Partial fix only.** This resolves the code-signing conflict for users with SIP enabled (the majority). It does not address the ARM64 `libcoreclr.dylib` initialization failure on systems with SIP disabled, which appears to be an upstream .NET runtime bug (dotnet/runtime#96247) outside of SE's control.

Relates to: #10339