### PR TITLE
Fix merge cursor position and original text merge

### DIFF
--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -13027,7 +13027,7 @@ public partial class MainViewModel :
         _mergeManager.MergeSelectedLines(Subtitles,
             SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList());
 
-        SelectAndScrollToRow(index - 1);
+        SelectAndScrollToRow(index);
         Renumber();
     }
 

--- a/src/UI/Logic/MergeManager.cs
+++ b/src/UI/Logic/MergeManager.cs
@@ -136,6 +136,7 @@ namespace Nikse.SubtitleEdit.Logic
 
            // var subtitle = new Subtitle(inputSubtitle, false);
             var sb = new StringBuilder();
+            var sbOriginal = new StringBuilder();
             var deleteIndices = new List<int>();
             var first = true;
             var firstIndex = 0;
@@ -182,10 +183,12 @@ namespace Nikse.SubtitleEdit.Logic
                 if (breakMode == BreakMode.UnbreakNoSpace)
                 {
                     sb.Append(addText);
+                    sbOriginal.Append(inputSubtitle[index].OriginalText);
                 }
                 else
                 {
                     sb.AppendLine(addText);
+                    sbOriginal.AppendLine(inputSubtitle[index].OriginalText);
                 }
 
                 endMilliseconds = inputSubtitle[index].EndTime.TotalMilliseconds;
@@ -216,6 +219,29 @@ namespace Nikse.SubtitleEdit.Logic
 
             currentParagraph.Text = text;
 
+            var originalText = sbOriginal.ToString().TrimEnd();
+            if (!string.IsNullOrEmpty(originalText))
+            {
+                originalText = HtmlUtil.FixInvalidItalicTags(originalText);
+                if (breakMode == BreakMode.Unbreak)
+                {
+                    originalText = Utilities.UnbreakLine(originalText);
+                }
+                else if (breakMode == BreakMode.UnbreakNoSpace)
+                {
+                    originalText = originalText.Replace(" " + Environment.NewLine + " ", string.Empty)
+                        .Replace(Environment.NewLine + " ", string.Empty)
+                        .Replace(" " + Environment.NewLine, string.Empty)
+                        .Replace(Environment.NewLine, string.Empty);
+                }
+                else if (breakMode == BreakMode.KeepBreaks)
+                {
+                    originalText = Utilities.AutoBreakLine(originalText, inputSubtitle.AutoDetectGoogleLanguage());
+                }
+
+                currentParagraph.OriginalText = originalText;
+            }
+
             //display time
             currentParagraph.EndTime = TimeSpan.FromMilliseconds(endMilliseconds);
 
@@ -242,9 +268,11 @@ namespace Nikse.SubtitleEdit.Logic
 
             var currentParagraph = selectedItems[0];
             var currentText = Utilities.UnbreakLine(currentParagraph.Text);
+            var currentOriginalText = Utilities.UnbreakLine(currentParagraph.OriginalText);
 
             var nextParagraph = selectedItems[1];
             var nextText = Utilities.UnbreakLine(nextParagraph.Text);
+            var nextOriginalText = Utilities.UnbreakLine(nextParagraph.OriginalText);
 
             var subtitle = new Subtitle();
             subtitle.Paragraphs.AddRange(subtitles.Select(p=>new Paragraph(p.Text, p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds)));
@@ -252,6 +280,14 @@ namespace Nikse.SubtitleEdit.Logic
             var dialogHelper = new DialogSplitMerge { DialogStyle = Enum.Parse<DialogType>(Se.Settings.General.DialogStyle), TwoLetterLanguageCode = language };
             var dialogText = dialogHelper.FixDashes("- " + currentText.TrimStart(' ', '-') + Environment.NewLine + "- " + nextText.TrimStart(' ', '-'));
             currentParagraph.Text = dialogText;
+
+            if (!string.IsNullOrWhiteSpace(currentOriginalText) || !string.IsNullOrWhiteSpace(nextOriginalText))
+            {
+                var dialogOriginalText = dialogHelper.FixDashes("- " + currentOriginalText.TrimStart(' ', '-') 
+                                                                     + Environment.NewLine + "- " 
+                                                                     + nextOriginalText.TrimStart(' ', '-'));
+                currentParagraph.OriginalText = dialogOriginalText;
+            }
 
             currentParagraph.EndTime = TimeSpan.FromMilliseconds(nextParagraph.EndTime.TotalMilliseconds);
 

--- a/tests/UI/Logic/MergeManagerTests.cs
+++ b/tests/UI/Logic/MergeManagerTests.cs
@@ -1,0 +1,110 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.ObjectModel;
+
+namespace UITests.Logic;
+
+public class MergeManagerTests
+{
+    [Fact]
+    public void MergeSelectedLines_ShouldMergeOriginalText()
+    {
+        // Arrange
+        var mergeManager = new MergeManager();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Number = 1,
+                Text = "Translated one",
+                OriginalText = "Original one",
+                StartTime = TimeSpan.FromSeconds(1),
+                EndTime = TimeSpan.FromSeconds(2),
+            },
+            new()
+            {
+                Number = 2,
+                Text = "Translated two",
+                OriginalText = "Original two",
+                StartTime = TimeSpan.FromSeconds(2),
+                EndTime = TimeSpan.FromSeconds(3),
+            },
+        };
+
+        // Act
+        mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]]);
+
+        // Assert
+        Assert.Single(subtitles);
+        Assert.Equal($"Translated one{Environment.NewLine}Translated two", subtitles[0].Text);
+        Assert.Equal($"Original one{Environment.NewLine}Original two", subtitles[0].OriginalText);
+    }
+
+    [Fact]
+    public void MergeSelectedLinesAsDialog_ShouldMergeOriginalTextAsDialog()
+    {
+        // Arrange
+        Se.Settings.General.DialogStyle = "DashBothLinesWithSpace";
+        var mergeManager = new MergeManager();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Number = 1,
+                Text = "Hi there",
+                OriginalText = "Hej der",
+                StartTime = TimeSpan.FromSeconds(1),
+                EndTime = TimeSpan.FromSeconds(2),
+            },
+            new()
+            {
+                Number = 2,
+                Text = "How are you?",
+                OriginalText = "Hvordan gar det?",
+                StartTime = TimeSpan.FromSeconds(2),
+                EndTime = TimeSpan.FromSeconds(3),
+            },
+        };
+
+        mergeManager.MergeSelectedLinesAsDialog(subtitles, [subtitles[0], subtitles[1]]);
+
+        Assert.Single(subtitles);
+        Assert.Contains("Hej der", subtitles[0].OriginalText);
+        Assert.Contains("Hvordan gar det?", subtitles[0].OriginalText);
+    }
+
+    [Fact]
+    public void MergeSelectedLines_ShouldKeepOriginalTextEmpty_WhenBothOriginalTextsAreEmpty()
+    {
+        var mergeManager = new MergeManager();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Number = 1,
+                Text = "Translated one",
+                OriginalText = string.Empty,
+                StartTime = TimeSpan.FromSeconds(1),
+                EndTime = TimeSpan.FromSeconds(2),
+            },
+            new()
+            {
+                Number = 2,
+                Text = "Translated two",
+                OriginalText = string.Empty,
+                StartTime = TimeSpan.FromSeconds(2),
+                EndTime = TimeSpan.FromSeconds(3),
+            },
+        };
+
+        mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]]);
+
+        Assert.Single(subtitles);
+        Assert.Equal(string.Empty, subtitles[0].OriginalText);
+    }
+}
+
+
+
+


### PR DESCRIPTION
Currently, when merging subtitles, the cursor will move to the top subtitle of the merged subtitle and if there is original text, the merged original subtitle details will be removed:

https://github.com/user-attachments/assets/a5ff5e05-a477-4011-9110-2b90419f48b4

This commit aims to resolve this situation by aligning the cursor to the merged subtitle for any further edits and merge the original text too if they exist. This PR also adds a unit test for merging this code.

https://github.com/user-attachments/assets/92da04f0-7790-41d4-a2a8-fbd8e5d2d16c

