### PR TITLE
Fixes weird behavior with `AvaloniaProperty.UnsetValue`

### DIFF
--- a/src/UI/Features/Edit/Find/FindModeValueConverter.cs
+++ b/src/UI/Features/Edit/Find/FindModeValueConverter.cs
@@ -20,6 +20,6 @@ public class FindModeValueConverter : IValueConverter
             return parameter;
         }
 
-        return AvaloniaProperty.UnsetValue;
+        return FindService.FindMode.None;
     }
 }

--- a/src/UI/Logic/FindMode.cs
+++ b/src/UI/Logic/FindMode.cs
@@ -6,6 +6,7 @@ public partial class FindService
     {
         CaseSensitive,
         CaseInsensitive,
-        RegularExpression
+        RegularExpression,
+        None,
     }
 }


### PR DESCRIPTION
Fixes issue with `AvaloniaProperty.UnsetValue` that was suggest by copilot in code review

## Demo

![SubtitleEdit_VNskGEo6WA](https://github.com/user-attachments/assets/de8f3a95-e215-46fb-a92c-4e650c2e2cce)

Using `AvaloniaProperty.UnsetValue` is not a good candidate here as suggested by copilot review!

I think the root cause is that once `AvaloniaProperty.UnsetValue` is returned Avalonia will try to convert it to our Enum and it won't find the matching type in Enum so it will fallback to 0 which is `CaseSensitive` in our enum list