### PR TITLE
Add horizontal scrolling to the audio visualizer

### DIFF
--- a/src/UI/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/UI/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -605,7 +605,16 @@ public class AudioVisualizer : Control
         var delta = InvertMouseWheel ? -e.Delta.Y : e.Delta.Y;
 
         e.Handled = true;
-        var newStart = StartPositionSeconds + delta / 2;
+        // Handle both vertical (Y) and horizontal (X) trackpad scrolling
+        var scrollDelta = delta;
+        
+        // If Y delta is negligible but X delta is significant (trackpad horizontal scroll)
+        if (Math.Abs(delta) < 0.1 && Math.Abs(e.Delta.X) > 0.1)
+        {
+            scrollDelta = InvertMouseWheel ? -e.Delta.X : e.Delta.X;
+        }
+        
+        var newStart = StartPositionSeconds + scrollDelta / 2;
         if (newStart < 0)
         {
             newStart = 0;


### PR DESCRIPTION
This commit adds horizontal scrolling to the audio visualizer, making it more friendly to use on a laptop.

I'll also note that I am on a Mac and I have natural scrolling turned on so I have to turn on "invert mouse wheel" in settings. To me when I either swipe up or left, the visualizer should go right, and vice versa.