### PR TITLE
WebVTT: merge consecutive cues with identical time codes on load

### DIFF
--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -366,7 +366,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var current = subtitle.Paragraphs[i];
                 var nextParagraph = subtitle.Paragraphs[i + 1];
                 if (current.StartTime.TotalMilliseconds == nextParagraph.StartTime.TotalMilliseconds &&
-                    current.EndTime.TotalMilliseconds == nextParagraph.EndTime.TotalMilliseconds)
+                    current.EndTime.TotalMilliseconds == nextParagraph.EndTime.TotalMilliseconds &&
+                    current.Region == nextParagraph.Region)
                 {
                     current.Text = current.Text + Environment.NewLine + nextParagraph.Text;
                     subtitle.Paragraphs.RemoveAt(i + 1);

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -1,0 +1,55 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class WebVttTest
+{
+    private static Subtitle LoadWebVttSubtitle(string vttContent)
+    {
+        var subtitle = new Subtitle();
+        var format = new WebVTT();
+        var lines = new List<string>(vttContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None));
+        format.LoadSubtitle(subtitle, lines, null);
+        return subtitle;
+    }
+
+    [Fact]
+    public void LoadSubtitleMergesCuesWithIdenticalTimeCodes()
+    {
+        var vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:04.000\r\nHello\r\n\r\n00:00:01.000 --> 00:00:04.000\r\nWorld";
+        var subtitle = LoadWebVttSubtitle(vtt);
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello" + Environment.NewLine + "World", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void LoadSubtitleMergesThreeCuesWithIdenticalTimeCodes()
+    {
+        var vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:04.000\r\nLine1\r\n\r\n00:00:01.000 --> 00:00:04.000\r\nLine2\r\n\r\n00:00:01.000 --> 00:00:04.000\r\nLine3";
+        var subtitle = LoadWebVttSubtitle(vtt);
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Line1" + Environment.NewLine + "Line2" + Environment.NewLine + "Line3", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void LoadSubtitleDoesNotMergeCuesWithDifferentTimeCodes()
+    {
+        var vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:04.000\r\nHello\r\n\r\n00:00:05.000 --> 00:00:08.000\r\nWorld";
+        var subtitle = LoadWebVttSubtitle(vtt);
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+    }
+
+    [Fact]
+    public void LoadSubtitleDoesNotMergeCuesWithSameTimeCodesButDifferentRegions()
+    {
+        var vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:04.000 region:top\r\nHello\r\n\r\n00:00:01.000 --> 00:00:04.000 region:bottom\r\nWorld";
+        var subtitle = LoadWebVttSubtitle(vtt);
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("Hello", subtitle.Paragraphs[0].Text);
+        Assert.Equal("World", subtitle.Paragraphs[1].Text);
+    }
+}


### PR DESCRIPTION
Some WebVTT files split multi-line dialogue into separate cues with identical timestamps instead of using `<br />` line breaks within a single cue. For example:

```
9
00:00:41.166 --> 00:00:44.461 position:36.67%,start align:start size:36.67% line:79.29%
So you've come

10
00:00:41.166 --> 00:00:44.461 position:23.33%,start align:start size:61.43% line:84.62%
to the master for guidance?
```

This causes each line to appear as a separate subtitle entry when loaded in SubtitleEdit.

**Fix:** After loading WebVTT, merge consecutive cues that share exact start and end times by combining their text with a line break. This is a simple backward loop (to safely remove while iterating) — no new settings, no new dependencies.

Fixes #10444