### PR TITLE
Fix: persist ASSA storage styles to disk (Fixes #10428)

### DIFF
--- a/src/UI/Features/Assa/AssaStylesViewModel.cs
+++ b/src/UI/Features/Assa/AssaStylesViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Skia;
@@ -703,6 +703,8 @@ public partial class AssaStylesViewModel : ObservableObject
             var s = new SeAssaStyle(style);
             Se.Settings.Assa.StoredStyles.Add(s);
         }
+
+        Se.SaveSettings();
     }
 
     private void LoadSettings()


### PR DESCRIPTION
## Problem

Storage styles in the ASSA Styles dialog are not persisted after closing Subtitle Edit. Styles added to the "Storage" panel disappear on app restart.

Fixes #10428

## Root Cause

`AssaStylesViewModel.SaveSettings()` updates `Se.Settings.Assa.StoredStyles` in memory but never calls `Se.SaveSettings()` to write Settings.json to disk.

**Note:** This is not a regression — the `Se.SaveSettings()` call was never present in the Avalonia rewrite. The persistence was missing from the start.

## Fix

Added `Se.SaveSettings()` at the end of `SaveSettings()` in `AssaStylesViewModel.cs`, consistent with how other ViewModels in the project persist their settings.