### PR TITLE
Fix crash with Arabic text on Linux due to HarfBuzz ABI conflict

### DIFF
--- a/src/UI/Features/Main/SubtitleLineViewModel.cs
+++ b/src/UI/Features/Main/SubtitleLineViewModel.cs
@@ -171,6 +171,11 @@ public partial class SubtitleLineViewModel : ObservableObject
     {
         get
         {
+            if (!Se.Settings.General.ShowColumnPixelWidth && !Se.Settings.General.ColorTextTooWide)
+            {
+                return 0;
+            }
+
             var text = HtmlUtil.RemoveHtmlTags(Text, true);
             var lines = text.SplitToLines();
             var maxWidth = 0;


### PR DESCRIPTION
## Fix crash with Arabic text on Linux (Fedora 43)

Fixes #10443

### Root Cause

The crash is a **native segfault in HarfBuzz** text shaping, confirmed by the reporter's `coredumpctl` stack trace:

```
#0  n/a
#1  OT::GSUBGPOS::accelerator_t<OT::Layout::GPOS>  (libharfbuzz.so.0)
#2  get_gsubgpos_table                               (libharfbuzz.so.0)
#3  hb_ot_layout_language_find_feature               (libharfbuzz.so.0)
#4-#5  n/a                                           (libHarfBuzzSharp.so)
#6  hb_shape_plan_create2                            (libHarfBuzzSharp.so)
#7  hb_shape_plan_create_cached2                     (libHarfBuzzSharp.so)
#8  hb_shape_full                                    (libHarfBuzzSharp.so)
```

The bundled `libHarfBuzzSharp.so` (from SkiaSharp) resolves symbols from the **system** `libharfbuzz.so.0` (Fedora 43, harfbuzz 11.5.1). When processing Arabic OpenType GPOS tables, this ABI mismatch causes a segfault.

This is triggered by `SKFont.MeasureText()` in `CalculatePixelWidth()`, which was introduced in commit 064fb93 (pixel-width column). The `PixelWidth` getter is called on **every text change** via `OnPropertyChanged(nameof(PixelWidth))` in `OnTextChanged`, regardless of whether the pixel-width column or `ColorTextTooWide` are enabled.

### Fix

Skip `CalculatePixelWidth()` when neither `ShowColumnPixelWidth` nor `ColorTextTooWide` is enabled (both default to `false`):

```csharp
public int PixelWidth
{
    get
    {
        if (!Se.Settings.General.ShowColumnPixelWidth && !Se.Settings.General.ColorTextTooWide)
        {
            return 0;
        }
        // ... existing measurement code
    }
}
```

### Why this is sufficient

- The other two call sites for `CalculatePixelWidth` (`TextBackgroundBrush` and `GetErrors`) **already have** their own `ColorTextTooWide` guards
- The `PixelWidth` getter was the **only unguarded** call path to the HarfBuzz text shaping code
- Returning `0` is safe: the DataGrid column is hidden when `ShowColumnPixelWidth` is `false`, so the value is never displayed

### What this doesn't fix

If a user on an affected system **enables** `ShowColumnPixelWidth` or `ColorTextTooWide`, the crash could still occur. The underlying HarfBuzz ABI conflict is in SkiaSharp's bundled native libraries vs the system harfbuzz — that would need to be addressed upstream in SkiaSharp or by bundling a compatible harfbuzz.