### PR TITLE
Fix incorrect asset filenames in UI.csproj

### DIFF
--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -87,7 +87,7 @@
 		<None Remove="Assets\Themes.zip" />
 		<None Remove="Assets\Whisper\PurfviewFasterWhisper.txt" />
 		<None Remove="Assets\Whisper\PurfviewFasterWhisperXXL.txt" />
-		<None Remove="Assets\Whisper\Qwen3ASRCPP.txt" />
+		<None Remove="Assets\Whisper\Qwen3AsrCPP.txt" />
 		<None Remove="Assets\Whisper\WhisperCPP.txt" />
 		<None Remove="Assets\Whisper\WhisperOpenAI.txt" />
 		<None Remove="Styles.xaml" />
@@ -121,7 +121,7 @@
 		<AvaloniaResource Include="Assets\Whisper\PurfviewFasterWhisperXXL.txt">
 			<CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\Whisper\Qwen3ASRCPP.txt" />
+		<AvaloniaResource Include="Assets\Whisper\Qwen3AsrCPP.txt" />
 		<AvaloniaResource Include="Assets\Whisper\WhisperConst-me.txt">
 			<CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>
@@ -145,7 +145,7 @@
 		<AvaloniaResource Include="Assets\Ocr.zip" />
 		<None Remove="Assets\about.png" />
 		<AvaloniaResource Include="Assets\about.png" />
-		<None Remove="Assets\Whisper\CTranslate2.txt" />
+		<None Remove="Assets\Whisper\WhisperCTranslate2.txt" />
 		<AvaloniaResource Include="Assets\Whisper\WhisperCTranslate2.txt" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary

- `Qwen3ASRCPP.txt` → `Qwen3AsrCPP.txt` in both `None Remove` and `AvaloniaResource Include` (matches actual filename on disk)
- `CTranslate2.txt` → `WhisperCTranslate2.txt` in `None Remove` (matches actual filename; the wrong name left `WhisperCTranslate2.txt` un-removed from the default `None` item group)

The casing mismatch for `Qwen3AsrCPP.txt` would cause a build failure on Linux (case-sensitive filesystem).

## Test plan

- [x] `dotnet build src/UI/UI.csproj` succeeds on Windows
- [ ] `dotnet build src/UI/UI.csproj` succeeds on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)