### PR TITLE
Remove duplicate Icon.png pack entry in LibSE.csproj

### DIFF
--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -55,12 +55,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="Icon.png">
-			<Pack>True</Pack>
-		</None>
-	</ItemGroup>
-
-	<ItemGroup>
 		<None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Pack="true" PackagePath="" />
 		<None Include="$(MSBuildThisFileDirectory)Readme.md" Pack="true" PackagePath="" />
 		<None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="" />


### PR DESCRIPTION
## Summary

`Icon.png` was included twice for NuGet packing:

1. A standalone `<None Include="Icon.png"><Pack>True</Pack></None>` entry
2. `<None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="" />` in the shared pack assets group

Both resolve to the same file, causing a duplicate item during `dotnet pack`. Removed the first entry — the explicit one with `PackagePath=""` is sufficient and correctly satisfies `<PackageIcon>Icon.png</PackageIcon>`.

## Test plan

- [x] `dotnet pack src/libse/LibSE.csproj` succeeds without duplicate item warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)