### PR TITLE
Fix batch convert remove line breaks

### DIFF
--- a/src/UI/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -160,6 +160,7 @@ public class BatchConvertConfig
     public class RemoveLineBreaksSettings
     {
         public bool IsActive { get; set; }
+        public bool OnlyShortLines { get; set; }
     }
 
     public class DeleteLinesSettings

--- a/src/UI/Features/Tools/BatchConvert/BatchConvertFunction.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertFunction.cs
@@ -39,6 +39,7 @@ public partial class BatchConvertFunction : ObservableObject
             MakeFunction(BatchConvertFunctionType.DeleteLines, Se.Language.General.DeleteLines, ViewDeleteLines.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.RemoveTextForHearingImpaired, Se.Language.General.RemoveTextForHearingImpaired, ViewRemoveTextForHearingImpaired.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.RemoveFormatting, Se.Language.General.RemoveFormatting, ViewRemoveFormatting.Make(vm) , activeFunctions),
+            MakeFunction(BatchConvertFunctionType.RemoveLineBreaks, Se.Language.General.UnbreakLines, ViewRemoveLineBreaks.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.AddFormatting, Se.Language.Tools.BatchConvert.AddFormatting, ViewAddFormatting.Make(vm) , activeFunctions),
             MakeFunction(BatchConvertFunctionType.SplitBreakLongLines,  Se.Language.Tools.SplitBreakLongLines.Title, ViewSplitBreakLongLines.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.OffsetTimeCodes,  Se.Language.General.OffsetTimeCodes, ViewOffsetTimeCodes.Make(vm), activeFunctions),

--- a/src/UI/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
@@ -20,4 +20,5 @@ public enum BatchConvertFunctionType
     BridgeGaps,
     ApplyMinGap,
     SplitBreakLongLines,
+    RemoveLineBreaks,
 }

--- a/src/UI/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -86,6 +86,9 @@ public partial class BatchConvertViewModel : ObservableObject
     [ObservableProperty] private bool _formattingRemoveAlignmentTags;
     [ObservableProperty] private bool _formattingRemoveColors;
 
+    // Remove line breaks
+    [ObservableProperty] private bool _removeLineBreaksOnlyShortLines;
+
     // Offset time codes
     [ObservableProperty] private bool _offsetTimeCodesForward;
     [ObservableProperty] private bool _offsetTimeCodesBack;
@@ -1356,6 +1359,12 @@ public partial class BatchConvertViewModel : ObservableObject
             RemoveTextForHearingImpaired = new BatchConvertConfig.RemoveTextForHearingImpairedSettings
             {
                 IsActive = activeFunctions.Contains(BatchConvertFunctionType.RemoveTextForHearingImpaired),
+            },
+
+            RemoveLineBreaks = new BatchConvertConfig.RemoveLineBreaksSettings
+            {
+                IsActive = activeFunctions.Contains(BatchConvertFunctionType.RemoveLineBreaks),
+                OnlyShortLines = RemoveLineBreaksOnlyShortLines,
             },
         };
     }

--- a/src/UI/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1504,14 +1504,16 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
     private Subtitle RemoveLineBreaks(Subtitle subtitle)
     {
-        if (!_config.OffsetTimeCodes.IsActive)
+        if (!_config.RemoveLineBreaks.IsActive)
         {
             return subtitle;
         }
 
         foreach (var paragraph in subtitle.Paragraphs)
         {
-            paragraph.Text = Utilities.UnbreakLine(paragraph.Text);
+            paragraph.Text = _config.RemoveLineBreaks.OnlyShortLines
+                ? Nikse.SubtitleEdit.Core.Forms.FixCommonErrors.Helper.FixShortLines(paragraph.Text, Language)
+                : Utilities.UnbreakLine(paragraph.Text);
         }
 
         return subtitle;

--- a/src/UI/Features/Tools/BatchConvert/FunctionViews/ViewRemoveLineBreaks.cs
+++ b/src/UI/Features/Tools/BatchConvert/FunctionViews/ViewRemoveLineBreaks.cs
@@ -1,0 +1,26 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert.FunctionViews;
+
+public static class ViewRemoveLineBreaks
+{
+    public static Control Make(BatchConvertViewModel vm)
+    {
+        var labelHeader = new Label
+        {
+            Content = Se.Language.General.UnbreakLines,
+            FontWeight = Avalonia.Media.FontWeight.Bold,
+            Margin = new Avalonia.Thickness(0, 0, 0, 10),
+        };
+
+        var checkBoxOnlyShortLines = UiUtil.MakeCheckBox(Se.Language.Tools.FixCommonErrors.RemoveLineBreaks, vm, nameof(vm.RemoveLineBreaksOnlyShortLines));
+
+        return new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Vertical,
+            Children = { labelHeader, checkBoxOnlyShortLines }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- `BatchConverter.RemoveLineBreaks`: was checking `OffsetTimeCodes.IsActive` instead of `RemoveLineBreaks.IsActive` (copy-paste bug) — caused the feature to activate/skip based on the wrong setting
- `BatchConvertFunctionType`, `BatchConvertFunction`, `BatchConvertViewModel`: `RemoveLineBreaks` was never registered in the batch convert UI — missing enum value, function list entry, and `IsActive` wiring, so it never appeared in the window and was never applied
- `ViewRemoveLineBreaks` (new): settings panel with an "Only short lines" checkbox — when checked, applies `Helper.FixShortLines` (single-sentence short subtitles only); when unchecked (default), applies `Utilities.UnbreakLine` to all subtitles
- `RemoveLineBreaksSettings`: added `OnlyShortLines` property to carry the checkbox state into the converter

## Test plan
- [x] In batch convert, verify "Unbreak lines" now appears in the function list
- [x] Enable "Unbreak lines" (checkbox unchecked) and run — verify line breaks are removed from all subtitles
- [x] Enable "Unbreak lines" with "Only short lines" checked — verify only short single-sentence subtitles are unbroken


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## UI Demo

<img width="1026" height="758" alt="image" src="https://github.com/user-attachments/assets/4804c592-a2d4-4677-b31e-d48abe08d668" />
