### PR TITLE
Fix duration cell not turning red on subtitle overlap

### DIFF
--- a/src/UI/Features/Main/SubtitleLineViewModel.cs
+++ b/src/UI/Features/Main/SubtitleLineViewModel.cs
@@ -282,7 +282,8 @@ public partial class SubtitleLineViewModel : ObservableObject
         get
         {
             if (Se.Settings.General.ColorDurationTooShort &&
-                Duration.TotalMilliseconds < Se.Settings.General.SubtitleMinimumDisplayMilliseconds || Se.Settings.General.ColorDurationTooLong && Duration.TotalMilliseconds > Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                Duration.TotalMilliseconds < Se.Settings.General.SubtitleMinimumDisplayMilliseconds || Se.Settings.General.ColorDurationTooLong && Duration.TotalMilliseconds > Se.Settings.General.SubtitleMaximumDisplayMilliseconds ||
+                Se.Settings.General.ColorTimeCodeOverlap && Gap < 0)
             {
                 return new SolidColorBrush(_errorColor);
             }
@@ -327,6 +328,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         }
 
         OnPropertyChanged(nameof(GapBackgroundBrush));
+        OnPropertyChanged(nameof(DurationBackgroundBrush));
     }
 
     public IBrush GapBackgroundBrush


### PR DESCRIPTION
## Summary
- `SubtitleLineViewModel.DurationBackgroundBrush`: now turns red on overlap when "Color time code overlap" is enabled (`Gap < 0`)
- `SubtitleLineViewModel.OnGapChanged`: added missing `DurationBackgroundBrush` notification so the duration cell color refreshes immediately when the gap changes

## Test plan
- [x] Create two overlapping subtitles and enable "Color time code overlap" in settings — verify the duration cell turns red
- [x] Adjust an end time to create an overlap — verify the duration cell turns red immediately
- [x] Resolve the overlap — verify the duration cell returns to its normal color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## UI Demo

### Before

![ShareX_rLCVm93YOG](https://github.com/user-attachments/assets/3a91909c-6de8-4a6d-997c-ba5e7b40fc18)

### After

![SubtitleEdit_Uk7J5p4Y9F](https://github.com/user-attachments/assets/978071f7-2ac7-4f99-9b11-1287e475992a)
