### PR TITLE
Use DI for AboutWindow in MainViewModel

### DIFF
--- a/src/UI/DependencyInjectionExtensions.cs
+++ b/src/UI/DependencyInjectionExtensions.cs
@@ -30,6 +30,7 @@ using Nikse.SubtitleEdit.Features.Files.RestoreAutoBackup;
 using Nikse.SubtitleEdit.Features.Files.Statistics;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Main.Layout;
+using Nikse.SubtitleEdit.Features.Help;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Ocr.BinaryOcr;
@@ -215,6 +216,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<AddToNamesListViewModel>();
         collection.AddTransient<AddToOcrReplaceListViewModel>();
         collection.AddTransient<AddToUserDictionaryViewModel>();
+        collection.AddTransient<AboutViewModel>();
         collection.AddTransient<AdjustAllTimesViewModel>();
         collection.AddTransient<AdjustDurationViewModel>();
         collection.AddTransient<AlignmentPickerViewModel>();

--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -21,6 +21,7 @@ using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.VobSub;
 using Nikse.SubtitleEdit.Features.Assa;
+using Nikse.SubtitleEdit.Features.Help;
 using Nikse.SubtitleEdit.Features.Assa.AssaApplyAdvancedEffect;
 using Nikse.SubtitleEdit.Features.Assa.AssaApplyCustomOverrideTags;
 using Nikse.SubtitleEdit.Features.Assa.AssaDraw;
@@ -1236,9 +1237,7 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ShowAbout()
     {
-        var newWindow = new AboutWindow(new AboutViewModel());
-        await newWindow.ShowDialog(Window!);
-        _shortcutManager.ClearKeys();
+        await ShowDialogAsync<AboutWindow, AboutViewModel>();
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- Register `AboutViewModel` in the DI container (`DependencyInjectionExtensions.cs`)
- Replace manual `new AboutWindow(new AboutViewModel())` + `ShowDialog` in `MainViewModel.ShowAbout` with the existing `ShowDialogAsync<AboutWindow, AboutViewModel>()` helper, consistent with how all other dialogs are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)