### PR TITLE
Go to line: clamp out-of-range value to max subtitle count

### DIFF
--- a/src/UI/Features/Shared/GoToLineNumber/GoToLineNumberViewModel.cs
+++ b/src/UI/Features/Shared/GoToLineNumber/GoToLineNumberViewModel.cs
@@ -31,9 +31,13 @@ public partial class GoToLineNumberViewModel : ObservableObject
         MaxLineNumber = maxLineNumber;
     }
 
-    [RelayCommand]                   
-    private void Ok() 
+    [RelayCommand]
+    private void Ok()
     {
+        if (LineNumber > MaxLineNumber)
+        {
+            LineNumber = MaxLineNumber;
+        }
         OkPressed = LineNumber != null;
         Window?.Close();
     }

--- a/src/UI/Features/Shared/GoToLineNumber/GoToLineNumberWindow.cs
+++ b/src/UI/Features/Shared/GoToLineNumber/GoToLineNumberWindow.cs
@@ -27,10 +27,6 @@ public class GoToLineNumberWindow : Window
             {
                 Mode = BindingMode.TwoWay,
             },
-            [!NumericUpDown.MaximumProperty] = new Binding(nameof(vm.MaxLineNumber))
-            {
-                Mode = BindingMode.OneWay,
-            },
             Minimum = 1,
             Increment = 1,          // Only step in whole numbers
             FormatString = "F0",    // Show 0 decimal places


### PR DESCRIPTION
## Summary
- Remove `Maximum` binding from `NumericUpDown` so users can type values beyond the subtitle count
- Clamp any value exceeding `MaxLineNumber` to `MaxLineNumber` when OK is pressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)