### PR TITLE
Add more Qwen3 ASR model options

### DIFF
--- a/src/UI/Assets/Whisper/Qwen3ASRCPP.txt
+++ b/src/UI/Assets/Whisper/Qwen3ASRCPP.txt
@@ -6,7 +6,7 @@ The Qwen3-Forced-Aligner-0.6B model can generate precise timestamps, making it u
 
 These models use GGUF quantization for efficient and fast inference, even on local machines.
 
-Advanced settings are appended before the required model/audio/output arguments.
+Advanced settings are prepended before the required model/audio/output arguments.
 
 Useful optional arguments:
 -t 8          Set number of CPU threads

--- a/src/UI/Assets/Whisper/Qwen3ASRCPP.txt
+++ b/src/UI/Assets/Whisper/Qwen3ASRCPP.txt
@@ -6,4 +6,14 @@ The Qwen3-Forced-Aligner-0.6B model can generate precise timestamps, making it u
 
 These models use GGUF quantization for efficient and fast inference, even on local machines.
 
+Advanced settings are appended before the required model/audio/output arguments.
+
+Useful optional arguments:
+-t 8          Set number of CPU threads
+--progress    Print progress during transcription
+--no-timing   Disable timing output
+
+GPU note:
+qwen3-asr.cpp uses ggml backends and can use GPU automatically when a compatible ggml backend plugin is available next to the executable (or via GGML_BACKEND_PATH). The bundled support-files package currently ships the basic engine binaries only, so GPU backends may need to be added separately.
+
 Project repository: https://github.com/woct0rdho/qwen3-asr.cpp

--- a/src/UI/Features/Video/SpeechToText/AudioToTextWhisperViewModel.cs
+++ b/src/UI/Features/Video/SpeechToText/AudioToTextWhisperViewModel.cs
@@ -1950,6 +1950,11 @@ public partial class AudioToTextWhisperViewModel : ObservableObject
             var alignerModel = qwen3Asr.ForcedAlignerModel;
             _qwen3AsrOutputJsonPath = Path.Combine(Path.GetTempPath(), $"qwen3_asr_{Guid.NewGuid():N}.json");
             var qwen3ExtraArgs = Se.Settings.Tools.AudioToText.WhisperCustomCommandLineArguments.Trim();
+            if (qwen3ExtraArgs == "--standard")
+            {
+                qwen3ExtraArgs = string.Empty;
+            }
+
             var qwen3Params = string.IsNullOrWhiteSpace(qwen3ExtraArgs)
                 ? $"-m \"{qwen3Asr.GetModelForCmdLine(model)}\" --aligner-model \"{qwen3Asr.GetModelForCmdLine(alignerModel.Name)}\" -f \"{waveFileName}\" --transcribe-align -o \"{_qwen3AsrOutputJsonPath}\""
                 : $"{qwen3ExtraArgs} -m \"{qwen3Asr.GetModelForCmdLine(model)}\" --aligner-model \"{qwen3Asr.GetModelForCmdLine(alignerModel.Name)}\" -f \"{waveFileName}\" --transcribe-align -o \"{_qwen3AsrOutputJsonPath}\"";

--- a/src/UI/Features/Video/SpeechToText/AudioToTextWhisperViewModel.cs
+++ b/src/UI/Features/Video/SpeechToText/AudioToTextWhisperViewModel.cs
@@ -503,6 +503,11 @@ public partial class AudioToTextWhisperViewModel : ObservableObject
             Dispatcher.UIThread.Invoke<Task>(async () =>
             {
                 LogToConsole($"Speech to text ({settings.WhisperChoice}) done in {_sw.Elapsed}{Environment.NewLine}");
+                if (_unknownArgument && !string.IsNullOrEmpty(settings.WhisperCustomCommandLineArguments))
+                {
+                    await MessageBox.Show(Window!, $"Unknown argument: {settings.WhisperCustomCommandLineArguments}",
+                        "Unknown argument. Please check the advanced settings.");
+                }
                 LogToConsole($"Speech to text: Could not find output JSON file{Environment.NewLine}");
                 ProgressValue = 100;
                 IsTranscribeEnabled = true;
@@ -1944,7 +1949,10 @@ public partial class AudioToTextWhisperViewModel : ObservableObject
             var exe = qwen3Asr.GetExecutable();
             var alignerModel = qwen3Asr.ForcedAlignerModel;
             _qwen3AsrOutputJsonPath = Path.Combine(Path.GetTempPath(), $"qwen3_asr_{Guid.NewGuid():N}.json");
-            var qwen3Params = $"-m \"{qwen3Asr.GetModelForCmdLine(model)}\" --aligner-model \"{qwen3Asr.GetModelForCmdLine(alignerModel.Name)}\" -f \"{waveFileName}\" --transcribe-align -o \"{_qwen3AsrOutputJsonPath}\"";
+            var qwen3ExtraArgs = Se.Settings.Tools.AudioToText.WhisperCustomCommandLineArguments.Trim();
+            var qwen3Params = string.IsNullOrWhiteSpace(qwen3ExtraArgs)
+                ? $"-m \"{qwen3Asr.GetModelForCmdLine(model)}\" --aligner-model \"{qwen3Asr.GetModelForCmdLine(alignerModel.Name)}\" -f \"{waveFileName}\" --transcribe-align -o \"{_qwen3AsrOutputJsonPath}\""
+                : $"{qwen3ExtraArgs} -m \"{qwen3Asr.GetModelForCmdLine(model)}\" --aligner-model \"{qwen3Asr.GetModelForCmdLine(alignerModel.Name)}\" -f \"{waveFileName}\" --transcribe-align -o \"{_qwen3AsrOutputJsonPath}\"";
 
             var p = new Process
             {

--- a/src/UI/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngine.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngine.cs
@@ -72,15 +72,33 @@ public class Qwen3AsrCppEngine : ISpeechToTextEngine
                         "https://huggingface.co/OpenVoiceOS/qwen3-asr-0.6b-f16/resolve/main/qwen3-asr-0.6b-f16.gguf"
                     ]
                 },
-                //new WhisperModel
-                //{
-                //    Name = "qwen3-asr-1.7b-q8_0.gguf",
-                //    Size = "2.5 GB",
-                //    Urls =
-                //    [
-                //        "https://huggingface.co/FlippyDora/qwen3-asr-1.7b-GGUF/resolve/main/qwen3-asr-1.7b-q8_0.gguf"
-                //    ]
-                //},
+                new WhisperModel
+                {
+                    Name = "qwen3-asr-0.6b-q8_0.gguf",
+                    Size = "1.3 GB",
+                    Urls =
+                    [
+                        "https://huggingface.co/OpenVoiceOS/qwen3-asr-0.6b-q8-0/resolve/main/qwen3-asr-0.6b-q8_0.gguf"
+                    ]
+                },
+                new WhisperModel
+                {
+                    Name = "qwen3-asr-1.7b-f16.gguf",
+                    Size = "4.4 GB",
+                    Urls =
+                    [
+                        "https://huggingface.co/FlippyDora/qwen3-asr-1.7b-GGUF/resolve/main/qwen3-asr-1.7b-f16.gguf"
+                    ]
+                },
+                new WhisperModel
+                {
+                    Name = "qwen3-asr-1.7b-q8_0.gguf",
+                    Size = "3.0 GB",
+                    Urls =
+                    [
+                        "https://huggingface.co/FlippyDora/qwen3-asr-1.7b-GGUF/resolve/main/qwen3-asr-1.7b-q8_0.gguf"
+                    ]
+                },
             }.ToList();
         }
     }

--- a/tests/UI/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngineTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngineTests.cs
@@ -1,0 +1,19 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+namespace UITests.Features.Video.SpeechToText.Engines;
+
+public class Qwen3AsrCppEngineTests
+{
+    [Fact]
+    public void Models_Includes_ExpectedQwen3Variants()
+    {
+        var engine = new Qwen3AsrCppEngine();
+        var modelNames = engine.Models.Select(x => x.Name).ToList();
+
+        Assert.Contains("qwen3-asr-0.6b-f16.gguf", modelNames);
+        Assert.Contains("qwen3-asr-0.6b-q8_0.gguf", modelNames);
+        Assert.Contains("qwen3-asr-1.7b-f16.gguf", modelNames);
+        Assert.Contains("qwen3-asr-1.7b-q8_0.gguf", modelNames);
+    }
+}


### PR DESCRIPTION
Summary:
- add more Qwen3 ASR model variants to the model list
- allow advanced CLI args to be passed through to qwen3-asr.cpp
- add a small regression test for expected model names
- clarify in the help text that GPU support depends on external ggml backend binaries

This addresses the model-options part of #10493.
GPU/Vulkan support is a separate follow-up because the current packaged qwen3-asr.cpp runtime does not include the required ggml GPU backend files.