### PR TITLE
Use IHttpClientFactory for CheckForUpdatesViewModel

### DIFF
--- a/src/UI/DependencyInjectionExtensions.cs
+++ b/src/UI/DependencyInjectionExtensions.cs
@@ -275,7 +275,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<ConvertActorsViewModel>();
         collection.AddTransient<ChangeFrameRateViewModel>();
         collection.AddTransient<ChangeSpeedViewModel>();
-        collection.AddTransient<CheckForUpdatesViewModel>();
+        collection.AddHttpClient<CheckForUpdatesViewModel>();
         collection.AddTransient<ColorPickerViewModel>();
         collection.AddTransient<ColumnPasteViewModel>();
         collection.AddTransient<CompareViewModel>();

--- a/src/UI/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
+++ b/src/UI/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
@@ -16,6 +16,14 @@ public partial class CheckForUpdatesViewModel : ObservableObject
     private const string ChangeLogUrl = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/ChangeLog.txt";
     private const string ReleasesUrl = "https://github.com/SubtitleEdit/subtitleedit/releases";
 
+    private readonly HttpClient _httpClient;
+
+    public CheckForUpdatesViewModel(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.Timeout = TimeSpan.FromSeconds(15);
+    }
+
     public Window? Window { get; set; }
 
     [ObservableProperty] private string _statusText = string.Empty;
@@ -31,9 +39,7 @@ public partial class CheckForUpdatesViewModel : ObservableObject
 
         try
         {
-            using var httpClient = new HttpClient();
-            httpClient.Timeout = TimeSpan.FromSeconds(15);
-            var content = await httpClient.GetStringAsync(ChangeLogUrl);
+            var content = await _httpClient.GetStringAsync(ChangeLogUrl);
 
             var latestVersion = ParseLatestVersion(content);
             ChangeLogText = ParseLatestChangeLog(content);


### PR DESCRIPTION
## Summary
- `CheckForUpdatesViewModel` was creating `new HttpClient()` on every update check, which risks socket exhaustion under repeated use
- Replaced with constructor-injected `HttpClient` via `AddHttpClient<T>()` to follow the pattern already used by all download services in the project
- Timeout is now set once at construction rather than per-request

## Test plan
- [x] Open Help → Check for updates — dialog appears and correctly reports current/new version
- [x] Confirm no regression: "Unable to check for updates" shown when offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)