### PR TITLE
Fix toolbar separator visibility not updating when setting changes

### DIFF
--- a/src/UI/Features/Main/MainView.cs
+++ b/src/UI/Features/Main/MainView.cs
@@ -75,10 +75,9 @@ public class MainView : ViewBase
         InitMenu.Make(_vm);
         root.Children.Add(_vm.Menu.Dock(Dock.Top));
 
-        if (Se.Settings.Appearance.ShowHorizontalLineAboveToolbar)
-        {
-            root.Children.Add(UiUtil.MakeHorizontalSeparator(0.5, 0.5, new Thickness(0, 0, 0, 0)).Dock(Dock.Top));
-        }
+        _vm.ToolbarTopSeparator = UiUtil.MakeHorizontalSeparator(0.5, 0.5, new Thickness(0, 0, 0, 0));
+        _vm.ToolbarTopSeparator.IsVisible = Se.Settings.Appearance.ShowHorizontalLineAboveToolbar;
+        root.Children.Add(_vm.ToolbarTopSeparator.Dock(Dock.Top));
 
         // Toolbar
         _vm.Toolbar = InitToolbar.Make(_vm);

--- a/src/UI/Features/Main/MainViewModel.cs
+++ b/src/UI/Features/Main/MainViewModel.cs
@@ -335,6 +335,7 @@ public partial class MainViewModel :
     public VideoPlayerControl? VideoPlayerControl { get; internal set; }
     public Menu Menu { get; internal set; }
     public Border Toolbar { get; internal set; }
+    public Separator? ToolbarTopSeparator { get; internal set; }
     public StackPanel PanelSingleLineLengths { get; internal set; }
     public MenuItem MenuItemMergeAsDialog { get; internal set; }
     public MenuItem MenuItemExtendToLineBefore { get; internal set; }
@@ -5953,6 +5954,11 @@ public partial class MainViewModel :
     {
         UiUtil.SetFontName(Se.Settings.Appearance.FontName);
         UiTheme.SetCurrentTheme();
+
+        if (ToolbarTopSeparator != null)
+        {
+            ToolbarTopSeparator.IsVisible = Se.Settings.Appearance.ShowHorizontalLineAboveToolbar;
+        }
 
         if (Toolbar is Border toolbarBorder)
         {


### PR DESCRIPTION
## Summary
- Store toolbar top separator in `ToolbarTopSeparator` VM property instead of conditionally adding it
- Always add the separator to the visual tree but control visibility via `IsVisible`
- Update separator visibility in the settings-apply method so toggling the setting takes effect immediately without restart

## Test plan
- [x] Open Settings > Appearance, toggle "Show horizontal line above toolbar" on → separator appears above toolbar
- [x] Toggle it off → separator disappears immediately
- [x] Restart the app → setting is preserved correctly

## Visual demo

![SubtitleEdit_gcgnQ2aVzB](https://github.com/user-attachments/assets/5991619f-d36b-4fc5-8e7a-d87493cbc031)



🤖 Generated with [Claude Code](https://claude.com/claude-code)