### PR TITLE
Fix nOCR two-byte character load/save handling

### DIFF
--- a/src/UI/Logic/Ocr/NOcrChar.cs
+++ b/src/UI/Logic/Ocr/NOcrChar.cs
@@ -87,6 +87,7 @@ public class NOcrChar
             }
             else
             {
+                position++;
                 ExpandCount = file[position++];
                 Width = file[position++] << 8 | file[position++];
                 Height = file[position++] << 8 | file[position++];
@@ -179,7 +180,7 @@ public class NOcrChar
     {
         return Width <= byte.MaxValue && Height <= byte.MaxValue && ExpandCount < 16 &&
                LinesBackground.Count <= byte.MaxValue && LinesForeground.Count <= byte.MaxValue &&
-               IsAllPointByteValues(LinesForeground) && IsAllPointByteValues(LinesForeground);
+               IsAllPointByteValues(LinesForeground) && IsAllPointByteValues(LinesBackground);
     }
 
     private static bool IsAllPointByteValues(List<NOcrLine> lines)


### PR DESCRIPTION
This PR is split out from the broader changes discussed in #10542, per maintainer request to keep each fix separate.

What this fixes:
- skip the leading flags byte when loading two-byte/V2 `NOcrChar` records, so deserialization stays aligned before reading `ExpandCount`
- validate `LinesBackground` in `IsAllByteValues()` instead of checking `LinesForeground` twice, so entries with wide background coordinates are saved in the correct two-byte format

Repro / expected behavior:
- long-form `.nocr` entries should load with the correct `ExpandCount`, dimensions, `MarginTop`, text, and line coordinates
- entries where only background line coordinates exceed byte range should still save and reload correctly via the two-byte path

Local verification:
- built `src/UI/UI.csproj`
- verified a two-byte round-trip for a long-form `NOcrChar`
- verified a round-trip where only background coordinates forced the two-byte save path

No screenshot attached because this patch is a serialization/deserialization fix rather than a UI change.