### PR TITLE
Fix OCR user dictionary add-actions

### DIFF
--- a/src/UI/Features/Ocr/FixEngine/OcrFixEngine2.cs
+++ b/src/UI/Features/Ocr/FixEngine/OcrFixEngine2.cs
@@ -20,6 +20,7 @@ public interface IOcrFixEngine2
     void ChangeAll(string from, string to);
     void SkipAll(string word);
     void AddName(string name);
+    bool AddUserWord(string word);
 }
 
 public partial class OcrFixEngine2 : IOcrFixEngine2, IDoSpell
@@ -501,6 +502,16 @@ public partial class OcrFixEngine2 : IOcrFixEngine2, IDoSpell
         }
 
         _spellCheckWordLists.AddName(name);
+    }
+
+    public bool AddUserWord(string word)
+    {
+        if (string.IsNullOrWhiteSpace(word) || !_isLoaded)
+        {
+            return false;
+        }
+
+        return _spellCheckWordLists.AddUserWord(word);
     }
 }
 

--- a/src/UI/Features/Ocr/OcrViewModel.cs
+++ b/src/UI/Features/Ocr/OcrViewModel.cs
@@ -484,7 +484,7 @@ public partial class OcrViewModel : ObservableObject
         }
 
         var result = await _windowService.ShowDialogAsync<AddToNamesListWindow, AddToNamesListViewModel>(Window,
-            vm => { vm.Initialize(selectedWord.Word.Word, Dictionaries.ToList(), SelectedDictionary); });
+            vm => { vm.Initialize(selectedWord.DisplayWord, Dictionaries.ToList(), SelectedDictionary); });
         _isCtrlDown = false;
     }
 
@@ -497,15 +497,14 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var word = selectedWord.Word.Word;
         var result = await _windowService.ShowDialogAsync<AddToUserDictionaryWindow, AddToUserDictionaryViewModel>(Window!,
-            vm => { vm.Initialize(word, Dictionaries.ToList(), SelectedDictionary); });
+            vm => { vm.Initialize(selectedWord.DisplayWord, Dictionaries.ToList(), SelectedDictionary); });
         if (result.OkPressed)
         {
+            var word = selectedWord.ResolveSubmittedWord(result.Word);
             _ = _ocrFixEngine.AddUserWord(word);
-            RemoveUnknownWordsFromCurrentState(word);
+            RemoveUnknownWordsFromCurrentState(selectedWord.Word.Word);
         }
-
         _isCtrlDown = false;
     }
 
@@ -2009,11 +2008,11 @@ public partial class OcrViewModel : ObservableObject
                         }
                         else if (result.AddToNamesListPressed)
                         {
-                            _ocrFixEngine.AddName(unknownWord.Word.Word);
+                            _ocrFixEngine.AddName(unknownWord.ResolveSubmittedWord(result.Word));
                         }
                         else if (result.AddToUserDictionaryPressed)
                         {
-                            if (_ocrFixEngine.AddUserWord(unknownWord.Word.Word))
+                            if (_ocrFixEngine.AddUserWord(unknownWord.ResolveSubmittedWord(result.Word)))
                             {
                                 RemoveUnknownWordsFromCurrentState(unknownWord.Word.Word);
                                 RemovePendingUnknownWords(ocrFixResultTemp.UnknownWords, unknownWordIndex, unknownWord.Word.Word);
@@ -2371,11 +2370,11 @@ public partial class OcrViewModel : ObservableObject
                         }
                         else if (result.AddToNamesListPressed)
                         {
-                            _ocrFixEngine.AddName(unknownWord.Word.Word);
+                            _ocrFixEngine.AddName(unknownWord.ResolveSubmittedWord(result.Word));
                         }
                         else if (result.AddToUserDictionaryPressed)
                         {
-                            if (_ocrFixEngine.AddUserWord(unknownWord.Word.Word))
+                            if (_ocrFixEngine.AddUserWord(unknownWord.ResolveSubmittedWord(result.Word)))
                             {
                                 RemoveUnknownWordsFromCurrentState(unknownWord.Word.Word);
                                 RemovePendingUnknownWords(unknownWords, unknownWordIndex, unknownWord.Word.Word);

--- a/src/UI/Features/Ocr/OcrViewModel.cs
+++ b/src/UI/Features/Ocr/OcrViewModel.cs
@@ -34,7 +34,6 @@ using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.Dictionaries;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Ocr;
 using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
@@ -409,6 +408,11 @@ public partial class OcrViewModel : ObservableObject
     private void UnknownWordsRemoveCurrent()
     {
         var word = SelectedUnknownWord?.Word.Word ?? string.Empty;
+        RemoveUnknownWordsFromCurrentState(word);
+    }
+
+    private void RemoveUnknownWordsFromCurrentState(string word)
+    {
         if (string.IsNullOrEmpty(word))
         {
             return;
@@ -420,7 +424,28 @@ public partial class OcrViewModel : ObservableObject
             UnknownWords.Remove(item);
         }
 
+        if (SelectedUnknownWord?.Word.Word.Equals(word, StringComparison.Ordinal) == true)
+        {
+            SelectedUnknownWord = null;
+        }
+
         IsUnknownWordSelected = false;
+    }
+
+    private static void RemovePendingUnknownWords(List<UnknownWordItem> unknownWords, int startIndex, string word)
+    {
+        if (string.IsNullOrEmpty(word))
+        {
+            return;
+        }
+
+        for (var i = unknownWords.Count - 1; i >= startIndex; i--)
+        {
+            if (unknownWords[i].Word.Word.Equals(word, StringComparison.Ordinal))
+            {
+                unknownWords.RemoveAt(i);
+            }
+        }
     }
 
     [RelayCommand]
@@ -472,8 +497,15 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
+        var word = selectedWord.Word.Word;
         var result = await _windowService.ShowDialogAsync<AddToUserDictionaryWindow, AddToUserDictionaryViewModel>(Window!,
-            vm => { vm.Initialize(selectedWord.Word.Word, Dictionaries.ToList(), SelectedDictionary); });
+            vm => { vm.Initialize(word, Dictionaries.ToList(), SelectedDictionary); });
+        if (result.OkPressed)
+        {
+            _ = _ocrFixEngine.AddUserWord(word);
+            RemoveUnknownWordsFromCurrentState(word);
+        }
+
         _isCtrlDown = false;
     }
 
@@ -1945,8 +1977,9 @@ public partial class OcrViewModel : ObservableObject
                 var tcs = new TaskCompletionSource<bool>();
                 Dispatcher.UIThread.Post(async () =>
                 {
-                    foreach (var unknownWord in ocrFixResultTemp.UnknownWords)
+                    for (var unknownWordIndex = 0; unknownWordIndex < ocrFixResultTemp.UnknownWords.Count; unknownWordIndex++)
                     {
+                        var unknownWord = ocrFixResultTemp.UnknownWords[unknownWordIndex];
                         var suggestions = _ocrFixEngine.GetSpellCheckSuggestions(unknownWord.Word.FixedWord);
                         var result = await _windowService.ShowDialogAsync<PromptUnknownWordWindow, PromptUnknownWordViewModel>(Window!,
                             vm => { vm.Initialize(item.GetBitmap(), item.Text, unknownWord, suggestions); });
@@ -1980,9 +2013,11 @@ public partial class OcrViewModel : ObservableObject
                         }
                         else if (result.AddToUserDictionaryPressed)
                         {
-                            if (SelectedDictionary != null)
+                            if (_ocrFixEngine.AddUserWord(unknownWord.Word.Word))
                             {
-                                UserWordsHelper.AddToUserDictionary(unknownWord.Word.Word, SelectedDictionary.GetFiveLetterLanguageName() ?? "en_US");
+                                RemoveUnknownWordsFromCurrentState(unknownWord.Word.Word);
+                                RemovePendingUnknownWords(ocrFixResultTemp.UnknownWords, unknownWordIndex, unknownWord.Word.Word);
+                                unknownWordIndex--;
                             }
                         }
                         else
@@ -2306,8 +2341,9 @@ public partial class OcrViewModel : ObservableObject
                 var tcs = new TaskCompletionSource<bool>();
                 Dispatcher.UIThread.Post(async () =>
                 {
-                    foreach (var unknownWord in unknownWords)
+                    for (var unknownWordIndex = 0; unknownWordIndex < unknownWords.Count; unknownWordIndex++)
                     {
+                        var unknownWord = unknownWords[unknownWordIndex];
                         var suggestions = _ocrFixEngine.GetSpellCheckSuggestions(unknownWord.Word.FixedWord);
                         var result = await _windowService.ShowDialogAsync<PromptUnknownWordWindow, PromptUnknownWordViewModel>(Window!,
                             vm => { vm.Initialize(item.GetBitmap(), item.Text, unknownWord, suggestions); });
@@ -2339,9 +2375,11 @@ public partial class OcrViewModel : ObservableObject
                         }
                         else if (result.AddToUserDictionaryPressed)
                         {
-                            if (SelectedDictionary != null)
+                            if (_ocrFixEngine.AddUserWord(unknownWord.Word.Word))
                             {
-                                UserWordsHelper.AddToUserDictionary(unknownWord.Word.Word, SelectedDictionary.GetFiveLetterLanguageName() ?? "en_US");
+                                RemoveUnknownWordsFromCurrentState(unknownWord.Word.Word);
+                                RemovePendingUnknownWords(unknownWords, unknownWordIndex, unknownWord.Word.Word);
+                                unknownWordIndex--;
                             }
                         }
                         else

--- a/src/UI/Features/Ocr/UnknownWordItem.cs
+++ b/src/UI/Features/Ocr/UnknownWordItem.cs
@@ -7,12 +7,23 @@ public class UnknownWordItem
     public OcrSubtitleItem Item { get; set; }
     public OcrFixLineResult Result { get; set; }
     public OcrFixLinePartResult Word { get; set; }
+    public string DisplayWord => string.IsNullOrWhiteSpace(Word.FixedWord) ? Word.Word : Word.FixedWord;
 
     public UnknownWordItem(OcrSubtitleItem item, OcrFixLineResult result, OcrFixLinePartResult word)
     {
         Item = item;
         Result = result;
         Word = word;
+    }
+
+    public string ResolveSubmittedWord(string? submittedWord)
+    {
+        if (!string.IsNullOrWhiteSpace(submittedWord))
+        {
+            return submittedWord.Trim();
+        }
+
+        return DisplayWord;
     }
 
     public override string ToString()

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineUserDictionaryTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineUserDictionaryTests.cs
@@ -1,0 +1,77 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Dictionaries;
+using System;
+using System.IO;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+public class OcrFixEngineUserDictionaryTests : IDisposable
+{
+    private const string LanguageName = "en_US";
+    private readonly string _testWord = $"zzzxqvnonceword{Guid.NewGuid():N}".ToLowerInvariant();
+
+    public OcrFixEngineUserDictionaryTests()
+    {
+        Directory.CreateDirectory(Se.DictionariesFolder);
+        UserWordsHelper.RemoveWord(_testWord, LanguageName);
+    }
+
+    [Fact]
+    public void AddUserWord_ShouldMakeWordCorrectWithoutReinitializingEngine()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(new TimeCode(0), new TimeCode(1000), _testWord));
+
+        var ocrSubtitle = new OcrSubtitleDummy(subtitle);
+        var items = ocrSubtitle.MakeOcrSubtitleItems();
+        items[0].Text = _testWord;
+
+        var spellCheckManager = new SpellCheckManager();
+        IOcrFixEngine2 ocrFixEngine = new OcrFixEngine2(spellCheckManager);
+        ocrFixEngine.Initialize(items, "eng", new SpellCheckDictionaryDisplay
+        {
+            Name = "English [en_US]",
+            DictionaryFileName = GetEnglishDictionaryFileName(),
+        });
+
+        var beforeAddResult = ocrFixEngine.FixOcrErrors(0, items[0], doTryToGuessUnknownWords: false);
+        var beforeAddWord = Assert.Single(beforeAddResult.Words, w => w.LinePartType == OcrFixLinePartType.Word);
+        Assert.False(beforeAddWord.IsSpellCheckedOk);
+
+        Assert.True(ocrFixEngine.AddUserWord(_testWord));
+
+        var afterAddResult = ocrFixEngine.FixOcrErrors(0, items[0], doTryToGuessUnknownWords: false);
+        var afterAddWord = Assert.Single(afterAddResult.Words, w => w.LinePartType == OcrFixLinePartType.Word);
+        Assert.True(afterAddWord.IsSpellCheckedOk);
+    }
+
+    public void Dispose()
+    {
+        UserWordsHelper.RemoveWord(_testWord, LanguageName);
+    }
+
+    private static string GetEnglishDictionaryFileName()
+    {
+        var repoRoot = FindRepoRoot();
+        var dictionaryFileName = Path.Combine(repoRoot, "Dictionaries", "en_US.dic");
+        Assert.True(File.Exists(dictionaryFileName), $"Dictionary file not found: {dictionaryFileName}");
+        return dictionaryFileName;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SubtitleEdit.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory!.FullName;
+    }
+}

--- a/tests/UI/Features/Ocr/UnknownWordItemTests.cs
+++ b/tests/UI/Features/Ocr/UnknownWordItemTests.cs
@@ -1,0 +1,55 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+
+namespace UITests.Features.Ocr;
+
+public class UnknownWordItemTests
+{
+    [Fact]
+    public void DisplayWord_ShouldPreferFixedWordOverRawOcrToken()
+    {
+        var unknownWord = MakeUnknownWordItem("recuérdaIo", "recuérdalo");
+
+        Assert.Equal("recuérdalo", unknownWord.DisplayWord);
+    }
+
+    [Fact]
+    public void ResolveSubmittedWord_ShouldPreferEditedPopupWord()
+    {
+        var unknownWord = MakeUnknownWordItem("recuérdaIo", "recuérdalo");
+
+        var result = unknownWord.ResolveSubmittedWord("  recuérdame  ");
+
+        Assert.Equal("recuérdame", result);
+    }
+
+    [Fact]
+    public void ResolveSubmittedWord_ShouldFallbackToDisplayWordWhenPopupWordIsEmpty()
+    {
+        var unknownWord = MakeUnknownWordItem("recuérdaIo", "recuérdalo");
+
+        var result = unknownWord.ResolveSubmittedWord("   ");
+
+        Assert.Equal("recuérdalo", result);
+    }
+
+    private static UnknownWordItem MakeUnknownWordItem(string rawWord, string fixedWord)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(new TimeCode(0), new TimeCode(1000), fixedWord));
+
+        var item = new OcrSubtitleDummy(subtitle).MakeOcrSubtitleItems()[0];
+        var lineResult = new OcrFixLineResult(0, fixedWord);
+        var word = new OcrFixLinePartResult
+        {
+            LinePartType = OcrFixLinePartType.Word,
+            Word = rawWord,
+            FixedWord = fixedWord,
+            WordIndex = 0,
+        };
+
+        return new UnknownWordItem(item, lineResult, word);
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes two related OCR dictionary issues in the unknown-word flow.

1. `Add to user dictionary` did write the word to the runtime `*_user.xml`, but OCR could still ask for the same word again in the same session because the OCR runtime dictionary state was stale.
2. Some OCR add-actions used the raw OCR token (`Word.Word`) instead of the displayed/corrected word (`FixedWord` or the edited popup text), so the saved value could differ from what the user actually confirmed.

These two bugs are related in the UI, but they have different root causes:
- fix 1 updates OCR runtime state immediately after adding a user word
- fix 2 makes OCR add-actions submit the displayed word instead of the raw OCR token

## Root Cause
### 1. Stale OCR runtime state after `Add to user dictionary`
`OcrFixEngine2` loaded user words into `SpellCheckWordLists2` during initialization and then kept using that in-memory state for the current OCR run.

When the user pressed `Add to user dictionary`, the XML file was updated, but the current OCR engine state was not. The unknown-word list that had already been built for the session was also not cleaned up. As a result, words such as `recuérdalo` could already be present in the runtime dictionary file and still be prompted again immediately.

### 2. Raw OCR token used instead of displayed word
In several OCR add-action paths, the value sent to the user dictionary or names list was `Word.Word`.

That is the internal OCR token, not necessarily the same word shown to the user in the popup. In cases where OCR had already normalized or corrected the token for display, the saved value could be different from the visible word the user approved.

## What Changed
### Fix 1: refresh OCR session state after adding a user word
- Added `AddUserWord(string word)` to `IOcrFixEngine2` and `OcrFixEngine2`.
- Routed OCR `Add to user dictionary` through `_ocrFixEngine.AddUserWord(...)` instead of only updating XML directly.
- Reused `SpellCheckWordLists2.AddUserWord(...)` so one call both:
  - writes the word to `Se.DictionariesFolder`
  - updates the current OCR engine's in-memory word lists
- Removed the just-added word from the current OCR unknown-word state and from the pending popup traversal list so it is not shown again in the same OCR run.

### Fix 2: use the displayed/edited OCR word for add-actions
- Added `DisplayWord` and `ResolveSubmittedWord(...)` to `UnknownWordItem`.
- Changed side-panel `Add to user dictionary` / `Add to names` to initialize from the displayed OCR word instead of the raw token.
- Changed popup `Add to user dictionary` / `Add to names list` to use:
  - the edited popup text first
  - otherwise the displayed fixed word
  - and only then fall back to the raw token
- Left raw-token-specific paths alone where that behavior is still intentional, such as OCR pair and Google search actions.

## User Impact
After this change:
- adding a word to the user dictionary in OCR takes effect immediately in the current OCR session
- the same word is not prompted again from stale OCR state in that run
- words saved through OCR add-actions match the word the user sees and confirms in the UI

## Validation
Ran locally:

```powershell
dotnet build SubtitleEdit.sln -c Debug --no-restore
dotnet test tests\UI\UITests.csproj --filter "FullyQualifiedName~UITests.Features.Ocr.FixEngine" --no-restore
dotnet test tests\UI\UITests.csproj --filter "FullyQualifiedName~UITests.Features.Ocr" --no-restore
```

## Tests Added
- `OcrFixEngineUserDictionaryTests`
  - verifies that `AddUserWord(...)` makes a new word valid without reinitializing the OCR engine
- `UnknownWordItemTests`
  - verifies that OCR add-actions prefer the displayed/fixed word and edited popup text over the raw OCR token

## Example Scenario
Reported example:

`Escucha lo que te digo, chico, y recuérdalo bien.`

Confirmed behavior before fix:
- `recuérdalo` could already be written correctly to `es_ES_user.xml`
- OCR still prompted it again because the current OCR runtime state had not been refreshed

With this PR:
- the add-action updates both the runtime dictionary file and the OCR in-memory state
- the current unknown-word session state is cleaned up immediately
- the saved word matches the displayed/confirmed word
