### PR TITLE
Fix PropertyChanged subscription leaks in OcrWindow and BeautifyTimeCodesViewModel

### DIFF
--- a/src/UI/Features/Ocr/OcrWindow.cs
+++ b/src/UI/Features/Ocr/OcrWindow.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
 using Projektanker.Icons.Avalonia;
 using System;
+using System.ComponentModel;
 using Avalonia.Input;
 using MenuItem = Avalonia.Controls.MenuItem;
 
@@ -68,7 +69,7 @@ public class OcrWindow : Window
         var savedHeight = (double)editViewHeight;
 
         // Collapse row when OCR is running, restore when stopped
-        vm.PropertyChanged += (s, e) =>
+        PropertyChangedEventHandler ocrRunningHandler = (s, e) =>
         {
             if (e.PropertyName == nameof(vm.IsOcrRunning))
             {
@@ -88,6 +89,7 @@ public class OcrWindow : Window
                             {
                                 savedHeight = editViewRow.Height.Value;
                             }
+
                             // Use Auto to collapse (content is hidden via binding)
                             editViewRow.Height = new GridLength(1, GridUnitType.Auto);
                             editViewRow.MinHeight = 0;
@@ -107,11 +109,8 @@ public class OcrWindow : Window
                 });
             }
         };
-
-
-
-
-
+        vm.PropertyChanged += ocrRunningHandler;
+        Closed += (_, _) => vm.PropertyChanged -= ocrRunningHandler;
 
         // Set initial state if OCR is already running when window opens
         if (vm.IsOcrRunning)

--- a/src/UI/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/UI/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -6,6 +6,7 @@ using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 
@@ -28,6 +29,7 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
     private List<double> _shotChanges;
     private double _frameRate = 25.0;
     private volatile bool _disposed;
+    private readonly PropertyChangedEventHandler _settingsChangedHandler;
 
     [ObservableProperty]
     private BeautifySettings _settings;
@@ -72,7 +74,8 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         };
 
         // Listen to settings changes
-        Settings.PropertyChanged += (s, e) => { _dirty = true; };
+        _settingsChangedHandler = (s, e) => { _dirty = true; };
+        Settings.PropertyChanged += _settingsChangedHandler;
     }
 
     private void UpdatePreview()
@@ -280,6 +283,7 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
 
         _disposed = true;
 
+        Settings.PropertyChanged -= _settingsChangedHandler;
         StopPositionTimer();
         _timerUpdatePreview.Stop();
         _timerUpdatePreview.Dispose();


### PR DESCRIPTION
## Summary
- `BeautifyTimeCodesViewModel`: stored the `Settings.PropertyChanged` handler as a field and unsubscribe it in `Dispose()`, preventing the lambda from rooting the VM after the window closes
- `OcrWindow`: stored the `vm.PropertyChanged` handler as a local and unsubscribe it on `Closed`, preventing the VM from holding window UI elements (grid rows, edit view) alive

## Test plan
- [ ] Open Beautify Time Codes dialog, interact with settings to confirm preview updates, close dialog — verify no errors
- [ ] Open OCR window, start OCR — confirm edit view row collapses; stop OCR — confirm row restores to saved height; close window — verify no errors
- [ ] Run both flows with a memory profiler and confirm VMs are collected after their windows close

🤖 Generated with [Claude Code](https://claude.com/claude-code)