### PR TITLE
Fix auto-backup timer not fully stopped when disabled

### DIFF
--- a/src/UI/Logic/AutoBackupService.cs
+++ b/src/UI/Logic/AutoBackupService.cs
@@ -58,6 +58,8 @@ public class AutoBackupService : IAutoBackupService
     public void StopAutobackup()
     {
         _timerAutoBackup?.Stop();
+        _timerAutoBackup?.Dispose();
+        _timerAutoBackup = null;
     }
 
     private static void SaveAutoBackup(Subtitle subtitle, SubtitleFormat saveFormat)


### PR DESCRIPTION
## Summary
- `StopAutobackup` now disposes and nulls the timer in addition to stopping it
- Ensures no `Elapsed` events can fire after the user disables auto-backup in settings
- When re-enabled, `StartAutoBackup` creates a fresh timer as before

## Test plan
- [ ] Enable auto-backup, verify backups are created on schedule
- [ ] Disable auto-backup in settings, verify no further backups are created
- [ ] Re-enable auto-backup, verify backups resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)