### PR TITLE
Fix numpad vs non-numpad key ambiguity in shortcut binding

### DIFF
--- a/src/UI/Features/Options/Shortcuts/GetKeyViewModel.cs
+++ b/src/UI/Features/Options/Shortcuts/GetKeyViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Options.Shortcuts;
@@ -82,8 +83,9 @@ public partial class GetKeyViewModel : ObservableObject
         var shiftLabel = isMac ? Se.Language.Options.Shortcuts.ShiftMac : Se.Language.Options.Shortcuts.Shift;
         var winLabel = isMac ? Se.Language.Options.Shortcuts.WinMac : Se.Language.Options.Shortcuts.Win;
 
-        PressedKey = e.Key.ToString();
-        PressedKeyOnly = PressedKey;
+        var effectiveKey = ShortcutManager.GetEffectiveKeyName(e.Key, e.PhysicalKey);
+        PressedKey = effectiveKey;
+        PressedKeyOnly = effectiveKey;
         IsControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
         IsAltPressed = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
         IsShiftPressed = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
@@ -119,8 +121,8 @@ public partial class GetKeyViewModel : ObservableObject
             infoText += winLabel + " + ";       
         }
         
-        PressedKey += e.Key;
-        infoText += e.Key;    
+        PressedKey += effectiveKey;
+        infoText += effectiveKey;
 
         InfoText = string.Format(Se.Language.Options.Shortcuts.PressedKeyX, infoText);
     }

--- a/src/UI/Logic/ShortcutManager.cs
+++ b/src/UI/Logic/ShortcutManager.cs
@@ -11,11 +11,20 @@ namespace Nikse.SubtitleEdit.Logic;
 public class ShortcutManager : IShortcutManager
 {
     private readonly HashSet<Key> _activeKeys = [];
+    private readonly HashSet<string> _activeEffectiveNames = [];
     private readonly List<ShortCut> _shortcuts = [];
     private FrozenDictionary<string, ShortCut>? _lookupTable;
     private bool _isDirty = true;
     private bool _isControlPressed = false;
     private bool _isShiftPressed = false;
+
+    // When NumLock is off, numpad navigation keys (e.g. NumPad7) produce the same logical Key as
+    // their non-numpad counterparts (Key.Home). Use the PhysicalKey name to keep them distinct.
+    public static string GetEffectiveKeyName(Key logicalKey, PhysicalKey physicalKey)
+    {
+        var physicalName = physicalKey.ToString();
+        return physicalName.StartsWith("NumPad", StringComparison.Ordinal) ? physicalName : logicalKey.ToString();
+    }
 
     public static string GetKeyDisplayName(string key)
     {
@@ -51,6 +60,7 @@ public class ShortcutManager : IShortcutManager
             Key.LWin or Key.RWin))
         {
             _activeKeys.Add(e.Key);
+            _activeEffectiveNames.Add(GetEffectiveKeyName(e.Key, e.PhysicalKey));
         }
 
         _isControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
@@ -63,10 +73,12 @@ public class ShortcutManager : IShortcutManager
             Key.ImeAccept or Key.ImeModeChange or Key.DeadCharProcessed or Key.None)
         {
             _activeKeys.Clear();
+            _activeEffectiveNames.Clear();
         }
         else
         {
             _activeKeys.Remove(e.Key);
+            _activeEffectiveNames.Remove(GetEffectiveKeyName(e.Key, e.PhysicalKey));
         }
 
         _isControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
@@ -76,6 +88,7 @@ public class ShortcutManager : IShortcutManager
     public void ClearKeys()
     {
         _activeKeys.Clear();
+        _activeEffectiveNames.Clear();
         _isControlPressed = false;
         _isShiftPressed = false;
     }
@@ -125,11 +138,11 @@ public class ShortcutManager : IShortcutManager
         }
 
         // Build the current state key list with initial capacity
-        var currentInputKeys = new List<string>(_activeKeys.Count + 2);
+        var currentInputKeys = new List<string>(_activeEffectiveNames.Count + 2);
 
-        foreach (var key in _activeKeys)
+        foreach (var name in _activeEffectiveNames)
         {
-            currentInputKeys.Add(key.ToString());
+            currentInputKeys.Add(name);
         }
 
         // Add normalized modifiers based on the event state


### PR DESCRIPTION
## Summary
- Numpad navigation keys with NumLock off (e.g. NumPad7 → `Key.Home`) were indistinguishable from their non-numpad counterparts, making it impossible to bind different shortcuts to the two keys
- Added `GetEffectiveKeyName(Key, PhysicalKey)` helper in `ShortcutManager` that returns the `PhysicalKey` name when the physical key is a numpad key (all Avalonia numpad physical keys are prefixed with `"NumPad"`), falling back to the logical `Key` name otherwise
- `ShortcutManager` now tracks a parallel `_activeEffectiveNames: HashSet<string>` using the physical override; shortcut hash lookup in `CheckShortcuts` iterates this set instead of `_activeKeys`, while `_activeKeys` is preserved so existing callers (count checks, `AllowedSingleKeyShortcuts` filtering) are unaffected
- `GetKeyViewModel` uses `GetEffectiveKeyName()` when recording a key press so that numpad 7 (either NumLock state) is saved as `"NumPad7"` rather than `"Home"`, matching what `CheckShortcuts` sees at runtime

## Test plan
- [ ] Open Options → Shortcuts, click a shortcut, press the regular **Home** key — confirm it is recorded as `Home`
- [ ] With NumLock **off**, press **NumPad 7** — confirm it is recorded as `NumPad7` (not `Home`)
- [ ] With NumLock **on**, press **NumPad 7** — confirm it is still recorded as `NumPad7`
- [ ] Bind one shortcut to `Home` and a different shortcut to `NumPad7`; confirm each fires its own action independently
- [ ] Verify shortcuts using non-numpad keys (letters, F-keys, arrows) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)