### PR TITLE
Clean up Program.cs startup code

### DIFF
--- a/src/UI/Program.cs
+++ b/src/UI/Program.cs
@@ -31,10 +31,16 @@ namespace Nikse.SubtitleEdit
             try
             {
                 // Global exception handling
-                AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
+                AppDomain.CurrentDomain.UnhandledException += (_, e) =>
                 {
-                    var exception = e.ExceptionObject as Exception;
-                    Se.LogError(exception ?? new Exception(), "Unhandled AppDomain Exception");
+                    if (e.ExceptionObject is Exception exception)
+                    {
+                        Se.LogError(exception, "Unhandled AppDomain Exception");
+                    }
+                    else
+                    {
+                        Se.LogError(new Exception(e.ExceptionObject?.ToString() ?? "Unknown error"), "Unhandled AppDomain Exception");
+                    }
                 };
 
                 // Setup application lifetime

--- a/src/UI/Program.cs
+++ b/src/UI/Program.cs
@@ -108,20 +108,20 @@ namespace Nikse.SubtitleEdit
             b.Instance.Styles.Add(UiTheme.FluentTheme);
 
             // Add DataGrid styles
-            b.Instance.Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml", UriKind.Absolute))
+            b.Instance.Styles.Add(new StyleInclude((Uri?)null)
             {
                 Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml")
             });
 
-            b.Instance.Styles.Add(new StyleInclude(new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml", UriKind.Absolute))
+            b.Instance.Styles.Add(new StyleInclude((Uri?)null)
             {
                 Source = new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml")
             });
 
             // Add ColorPicker styles
-            b.Instance.Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml", UriKind.Absolute))
+            b.Instance.Styles.Add(new StyleInclude((Uri?)null)
             {
-                Source = new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml", UriKind.Absolute)
+                Source = new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml")
             });
 
             // Set custom font

--- a/src/UI/Program.cs
+++ b/src/UI/Program.cs
@@ -100,54 +100,41 @@ namespace Nikse.SubtitleEdit
                 RegionColor = UiUtil.GetDarkThemeBackgroundColor(),
             });
 
-            if (b.Instance != null)
+            if (b.Instance == null)
             {
-                b.Instance.Styles.Add(UiTheme.FluentTheme);
+                return;
             }
+
+            b.Instance.Styles.Add(UiTheme.FluentTheme);
 
             // Add DataGrid styles
-            if (b.Instance != null)
+            b.Instance.Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml", UriKind.Absolute))
             {
-                b.Instance.Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml", UriKind.Absolute))
-                {
-                    Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml")
-                });
-            }
+                Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml")
+            });
 
-            if (b.Instance != null)
+            b.Instance.Styles.Add(new StyleInclude(new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml", UriKind.Absolute))
             {
-                b.Instance.Styles.Add(new StyleInclude(new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml", UriKind.Absolute))
-                {
-                    Source = new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml")
-                });
-            }
+                Source = new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml")
+            });
 
             // Add ColorPicker styles
-            if (b.Instance != null)
+            b.Instance.Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml", UriKind.Absolute))
             {
-                b.Instance.Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml", UriKind.Absolute))
-                {
-                    Source = new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml", UriKind.Absolute)
-                });
-            }
+                Source = new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml", UriKind.Absolute)
+            });
 
             // Set custom font
-            if (Application.Current != null && !string.IsNullOrEmpty(Se.Settings.Appearance.FontName))
+            if (!string.IsNullOrEmpty(Se.Settings.Appearance.FontName))
             {
                 UiUtil.SetFontName(Se.Settings.Appearance.FontName);
             }
 
             // Set application name
-            if (b.Instance != null)
-            {
-                b.Instance.Name = AppName;
-            }
+            b.Instance.Name = AppName;
 
             // Setup native menu
-            if (b.Instance != null)
-            {
-                SetupNativeMenu(b.Instance, lifetime);
-            }
+            SetupNativeMenu(b.Instance, lifetime);
         }
 
         private static void SetupNativeMenu(Application app, ClassicDesktopStyleApplicationLifetime lifetime)

--- a/src/UI/Program.cs
+++ b/src/UI/Program.cs
@@ -20,6 +20,8 @@ namespace Nikse.SubtitleEdit
 {
     internal class Program
     {
+        private const string AppName = "Subtitle Edit";
+
         public static string? PendingFileToOpen { get; set; }
         public static bool FileOpenedViaActivation { get; set; }
 
@@ -138,7 +140,7 @@ namespace Nikse.SubtitleEdit
             // Set application name
             if (b.Instance != null)
             {
-                b.Instance.Name = "Subtitle Edit";
+                b.Instance.Name = AppName;
             }
 
             // Setup native menu
@@ -216,7 +218,7 @@ namespace Nikse.SubtitleEdit
         {
             lifetime.MainWindow = new Window
             {
-                Title = "Subtitle Edit",
+                Title = AppName,
                 Name = "MainWindow",
                 Icon = UiUtil.GetSeIcon(),
                 MinWidth = 800,


### PR DESCRIPTION
## Summary
- Extract `AppName` constant to deduplicate the `\"Subtitle Edit\"` magic string used in two places
- Consolidate six repeated `b.Instance != null` null checks in `ConfigureApplication` into a single early return
- Remove redundant base URI argument from `StyleInclude` constructors (base URI is unused when `Source` is already an absolute `avares://` URI)
- Fix `UnhandledException` handler to preserve error info when the thrown object is not an `Exception` (previously used `?? new Exception()` which silently discarded native exception details)

## Test plan
- [x] Application starts and displays the main window with title \"Subtitle Edit\"
- [x] Fluent theme, DataGrid, AvaloniaEdit, and ColorPicker styles load correctly (no visual regressions)
- [ ] On macOS, the native menu \"About Subtitle Edit\" entry opens the About dialog
- [ ] On macOS, opening a file via Finder \"Send to\" / file association loads the subtitle
- [ ] Trigger an unhandled exception and confirm it is logged correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)