### PR TITLE
Fix two bugs in NextWordInDoNotBreakList

### DIFF
--- a/src/libse/Common/PlainTextImporter.cs
+++ b/src/libse/Common/PlainTextImporter.cs
@@ -141,9 +141,9 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private bool NextWordInDoNotBreakList(string text, int index)
         {
-            for (var i = index + 1; i < text.Length || i > 50; i++)
+            for (var i = index + 1; i < text.Length && i - index < 50; i++)
             {
-                var ch = text[index];
+                var ch = text[i];
                 if (ch == '\0')
                 {
                     return false;


### PR DESCRIPTION
## Summary

- Fix loop condition: `|| i > 50` changed to `&& i - index < 50` — the `||` made the condition nearly always true (once `i > 50`), causing out-of-bounds access on `text`
- Fix loop body: `text[index]` changed to `text[i]` — the fixed index meant the same character was inspected on every iteration, breaking the word scan entirely

## Test plan

- [ ] Import a plain text file containing phrases like "Mr. Smith goes to..." and verify no line break is inserted after "Mr."
- [ ] Verify no `IndexOutOfRangeException` is thrown during plain text import with long lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)