### PR TITLE
Normalize user dictionary words across Unicode forms

### DIFF
--- a/src/UI/Features/SpellCheck/SpellCheckWordLists.cs
+++ b/src/UI/Features/SpellCheck/SpellCheckWordLists.cs
@@ -91,7 +91,12 @@ public class SpellCheckWordLists
             {
                 foreach (XmlNode node in xmlNodeList)
                 {
-                    var word = node.InnerText.Trim().ToLowerInvariant();
+                    var word = Utilities.NormalizeUserDictionaryWord(node.InnerText);
+                    if (word.Length == 0)
+                    {
+                        continue;
+                    }
+
                     if (word.Contains(' '))
                     {
                         _userPhraseList.Add(word);
@@ -211,6 +216,7 @@ public class SpellCheckWordLists
 
     public void RemoveUserWord(string word)
     {
+        word = Utilities.NormalizeUserDictionaryWord(word);
         _userWordList.Remove(word);
         _userPhraseList.Remove(word);
         Utilities.RemoveFromUserDictionary(word, _languageName);
@@ -338,17 +344,17 @@ public class SpellCheckWordLists
 
     public bool IsWordInUserPhrases(int index, List<SpellCheckWord> words)
     {
-        string current = words[index].Text;
+        string current = Utilities.NormalizeUserDictionaryWord(words[index].Text);
         string prev = "-";
         if (index > 0)
         {
-            prev = words[index - 1].Text;
+            prev = Utilities.NormalizeUserDictionaryWord(words[index - 1].Text);
         }
 
         string next = "-";
         if (index < words.Count - 1)
         {
-            next = words[index + 1].Text;
+            next = Utilities.NormalizeUserDictionaryWord(words[index + 1].Text);
         }
 
         foreach (string userPhrase in _userPhraseList)
@@ -461,7 +467,7 @@ public class SpellCheckWordLists
             return false;
         }
 
-        word = word.Trim().ToLowerInvariant();
+        word = Utilities.NormalizeUserDictionaryWord(word);
         if (word.Length == 0 || _userWordList.Contains(word))
         {
             return false;
@@ -495,7 +501,7 @@ public class SpellCheckWordLists
 
     public bool HasUserWord(string word)
     {
-        string s = word.ToLowerInvariant();
+        string s = Utilities.NormalizeUserDictionaryWord(word);
         return _userWordList.Contains(s) || (s.StartsWith('\'') || s.EndsWith('\'')) && _userWordList.Contains(s.Trim('\''));
     }
 

--- a/src/UI/Logic/Dictionaries/UserWordsHelper.cs
+++ b/src/UI/Logic/Dictionaries/UserWordsHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Core.Common;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
@@ -34,8 +35,8 @@ public static class UserWordsHelper
                 {
                     foreach (XmlNode node in nodes)
                     {
-                        string s = node.InnerText.ToLowerInvariant();
-                        if (!userWordList.Contains(s))
+                        string s = Utilities.NormalizeUserDictionaryWord(node.InnerText);
+                        if (s.Length > 0 && !userWordList.Contains(s))
                         {
                             userWordList.Add(s);
                         }
@@ -54,7 +55,11 @@ public static class UserWordsHelper
             return false;
         }
 
-        word = word.Trim();
+        word = Utilities.NormalizeUserDictionaryWord(word);
+        if (word.Length == 0)
+        {
+            return false;
+        }
 
         var words = new List<string>();
         var userWordFileName = LoadUserWordList(words, languageName);
@@ -76,6 +81,12 @@ public static class UserWordsHelper
 
     public static bool RemoveWord(string word, string languageName)
     {
+        word = Utilities.NormalizeUserDictionaryWord(word);
+        if (word.Length == 0)
+        {
+            return false;
+        }
+
         var words = new List<string>();
         var userWordFileName = LoadUserWordList(words, languageName);
         if (!words.Contains(word))

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1048,9 +1048,63 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
+        private static string TrimUserDictionaryWord(string word)
+        {
+            if (word.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var start = 0;
+            var end = word.Length - 1;
+            while (start <= end && ShouldTrimUserDictionaryCharacter(word[start]))
+            {
+                start++;
+            }
+
+            while (end >= start && ShouldTrimUserDictionaryCharacter(word[end]))
+            {
+                end--;
+            }
+
+            if (start > end)
+            {
+                return string.Empty;
+            }
+
+            return word.Substring(start, end - start + 1);
+        }
+
+        private static bool ShouldTrimUserDictionaryCharacter(char ch)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                return true;
+            }
+
+            var category = CharUnicodeInfo.GetUnicodeCategory(ch);
+            return category == UnicodeCategory.Control || category == UnicodeCategory.Format;
+        }
+
+        public static string NormalizeUserDictionaryWord(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = TrimUserDictionaryWord(word);
+            if (trimmed.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return trimmed.Normalize(NormalizationForm.FormC).ToLowerInvariant();
+        }
+
         public static void RemoveFromUserDictionary(string word, string languageName)
         {
-            word = word.Trim();
+            word = NormalizeUserDictionaryWord(word);
             if (word.Length > 0)
             {
                 string userWordsXmlFileName = DictionaryFolder + languageName + "_user.xml";
@@ -1070,8 +1124,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     foreach (XmlNode node in nodes)
                     {
-                        string w = node.InnerText.Trim();
-                        if (w.Length > 0 && w != word)
+                        string w = NormalizeUserDictionaryWord(node.InnerText);
+                        if (w.Length > 0 && w != word && !words.Contains(w))
                         {
                             words.Add(w);
                         }
@@ -1097,7 +1151,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static void AddToUserDictionary(string word, string languageName)
         {
-            word = word.Trim();
+            word = NormalizeUserDictionaryWord(word);
             if (word.Length > 0)
             {
                 var userWordsXmlFileName = DictionaryFolder + languageName + "_user.xml";
@@ -1128,8 +1182,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                     {
                         foreach (XmlNode node in nodes)
                         {
-                            string w = node.InnerText.Trim();
-                            if (w.Length > 0)
+                            string w = NormalizeUserDictionaryWord(node.InnerText);
+                            if (w.Length > 0 && !words.Contains(w))
                             {
                                 words.Add(w);
                             }
@@ -1176,8 +1230,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 userWordDictionary.Load(userWordListXmlFileName);
                 foreach (XmlNode node in userWordDictionary.DocumentElement.SelectNodes("word"))
                 {
-                    string s = node.InnerText.ToLowerInvariant();
-                    if (!userWordList.Contains(s))
+                    string s = NormalizeUserDictionaryWord(node.InnerText);
+                    if (s.Length > 0 && !userWordList.Contains(s))
                     {
                         userWordList.Add(s);
                     }

--- a/tests/UI/Features/SpellCheck/UserDictionaryNormalizationTests.cs
+++ b/tests/UI/Features/SpellCheck/UserDictionaryNormalizationTests.cs
@@ -1,0 +1,56 @@
+using Nikse.SubtitleEdit.Core.Interfaces;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Dictionaries;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace UITests.Features.SpellCheck;
+
+public class UserDictionaryNormalizationTests : IDisposable
+{
+    private const string LanguageName = "en_US";
+    private const string HangulWord = "매트릭스의";
+    private readonly string _nfcWord = HangulWord.Normalize(NormalizationForm.FormC);
+    private readonly string _nfdWord = HangulWord.Normalize(NormalizationForm.FormD);
+
+    public UserDictionaryNormalizationTests()
+    {
+        Directory.CreateDirectory(Se.DictionariesFolder);
+        UserWordsHelper.RemoveWord(_nfcWord, LanguageName);
+        UserWordsHelper.RemoveWord(_nfdWord, LanguageName);
+    }
+
+    [Fact]
+    public void AddToUserDictionary_ShouldTreatVisuallyIdenticalHangulAsSameWordAcrossNormalizationForms()
+    {
+        Assert.True(UserWordsHelper.AddToUserDictionary(_nfdWord, LanguageName));
+        Assert.False(UserWordsHelper.AddToUserDictionary(_nfcWord, LanguageName));
+
+        var wordLists = new SpellCheckWordLists(LanguageName, new AlwaysMissSpellChecker());
+        Assert.True(wordLists.HasUserWord(_nfcWord));
+        Assert.True(wordLists.HasUserWord(_nfdWord));
+
+        var loadedWords = new List<string>();
+        UserWordsHelper.LoadUserWordList(loadedWords, LanguageName);
+
+        var storedWord = Assert.Single(loadedWords);
+        Assert.Equal(_nfcWord, storedWord);
+    }
+
+    public void Dispose()
+    {
+        UserWordsHelper.RemoveWord(_nfcWord, LanguageName);
+        UserWordsHelper.RemoveWord(_nfdWord, LanguageName);
+    }
+
+    private sealed class AlwaysMissSpellChecker : IDoSpell
+    {
+        public bool DoSpell(string word)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- normalize user dictionary words before loading, comparing, adding, and removing entries
- make visually identical words match across Unicode normalization forms
- add a regression test that covers the Hangul case reported in OCR work

## Problem
The user dictionary compared words by raw Unicode code points. That breaks cases where the same visible word is stored in different normalization forms, such as NFC vs NFD. A Korean example is `매트릭스의`, which can look identical on screen while still being treated as two different strings.

## Changes
- add a shared normalization helper for user dictionary words in `Utilities`
- use that normalization in `SpellCheckWordLists` and `UserWordsHelper`
- add a regression test that saves the Hangul word in one normalization form and verifies it is recognized in the other form

## Validation
- `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~UserDictionaryNormalizationTests" --no-build`
- `dotnet build src/UI/UI.csproj -c Debug --no-restore`

## Notes
- split out from `#10594` per review feedback so that OCR add-action behavior and Unicode normalization can be reviewed independently