### PR TITLE
Google lens sharp fix

### DIFF
--- a/src/UI/Features/Ocr/Engines/GoogleLensOcrSharp.cs
+++ b/src/UI/Features/Ocr/Engines/GoogleLensOcrSharp.cs
@@ -25,6 +25,8 @@ public class GoogleLensOcrSharp
 
         foreach (var bmpInput in input)
         {
+            if (cancellationToken.IsCancellationRequested) break;
+
             if (bmpInput.Bitmap == null)
             {
                 continue;

--- a/src/UI/Features/Ocr/Engines/GoogleLensOcrSharp.cs
+++ b/src/UI/Features/Ocr/Engines/GoogleLensOcrSharp.cs
@@ -33,7 +33,36 @@ public class GoogleLensOcrSharp
             }
 
             var result = await _lens.ScanByBitmap(bmpInput.Bitmap, language);
-            bmpInput.Text = string.Join(Environment.NewLine, result.Segments.Where(s => !string.IsNullOrWhiteSpace(s.Text)).Select(p => p.Text).ToList()).Trim();
+
+            var lines = result.Segments.Select(x => x.Text).ToList();
+
+            //join "-" with next line
+            for (int i = 0; i < lines.Count; i++)
+            {
+                if (lines[i] == "-" && i + 1 < lines.Count)
+                {
+                    lines[i] = $"- {lines[i + 1]}";
+                    lines.RemoveAt(i + 1);
+                }
+            }
+
+            //join "..." with line
+            for (int i = 0; i < lines.Count; i++)
+            {
+                //it has previous line not ending with .
+                if (lines[i] == "..." && i - 1 >= 0 && !lines[i-1].EndsWith("."))
+                {
+                    lines[i-1] = $"{lines[i - 1]} ...";
+                    lines.RemoveAt(i);
+                } 
+                else if (lines[i] == "..." && i + 1 < lines.Count)
+                {
+                    lines[i] = $"... {lines[i + 1]}";
+                    lines.RemoveAt(i + 1);
+                }
+            }
+
+            bmpInput.Text = string.Join(Environment.NewLine, lines).Trim();
             lock (_lockObject)
             {
                 var progressReport = new PaddleOcrBatchProgress


### PR DESCRIPTION
1) Bugfix of cancellation check was not used.
This causes ocr to continue even if "pause" button pressed or window closed.

2) dash and tripledot position fix

Dash problem example.
[input]
- line 1
- line 2
[output]
-
line 1
-
line 2

Tripledot example:

[input]
... line1 ...
... line 2
[output]
...
line1
...
...
line 2

Thou it's better to fix it based on rectangle coordinates. I don't know if they are returned. No data in parsed output.