### PR TITLE
Fix RestoreXFromY format string placeholder

### DIFF
--- a/src/UI/Logic/Config/Language/File/LanguageRestoreAutoBackup.cs
+++ b/src/UI/Logic/Config/Language/File/LanguageRestoreAutoBackup.cs
@@ -14,7 +14,7 @@ public class LanguageRestoreAutoBackup
         Title = "Restore auto-backup";
         OpenAutoBackupFolder = "Open auto-backup folder";
         RestoreAutoBackupFile = "Restore auto-backup file";
-        RestoreXFromY = "Do you want to restore \"{0}\" from {0}?";
+        RestoreXFromY = "Do you want to restore \"{0}\" from {1}?";
         DeleteAllSubtitleBackups = "Do you want to delete all subtitle backup files?";
         DeleteAll = "Delete all";
     }


### PR DESCRIPTION
## Summary
- `RestoreXFromY` format string used `{0}` twice: `"Do you want to restore \"{0}\" from {0}?"`.
- The caller passes two args (`file.FileName`, `file.DateAndTime`), so the dialog showed the filename twice instead of filename + date.
- Fixed second placeholder to `{1}`.

## Test plan
- [x] `dotnet build src/UI/UI.csproj` succeeds with no warnings or errors.
- [ ] Restore-auto-backup dialog shows filename and date correctly.