### PR TITLE
Fix build break and OriginalFormat regression in last few commits

### DIFF
--- a/src/UI/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/UI/Features/Options/Settings/SettingsViewModel.cs
@@ -62,7 +62,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private int _mpvPreviewFontSize;
     [ObservableProperty] private bool _mpvPreviewFontBold;
     [ObservableProperty] private ObservableCollection<AlignmentItem> __mpvPreviewFontAlignments;
-    [ObservableProperty] private AlignmentItem __mpvPreviewSelectedFontAlignment;
+    [ObservableProperty] private AlignmentItem _mpvPreviewSelectedFontAlignment;
     [ObservableProperty] private int _mpvPreviewMargin;
     [ObservableProperty] private Color _mpvPreviewColorPrimary;
     [ObservableProperty] private Color _mpvPreviewColorOutline;

--- a/src/UI/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/UI/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -199,7 +199,7 @@ public partial class CutVideoViewModel : ObservableObject
         }
         else if (SelectedVideoExtension == ".mp3" || SelectedVideoExtension == ".wav")
         {
-            SelectedVideoExtension = VideoExtensions[0];- 
+            SelectedVideoExtension = VideoExtensions[0];
         }
     }
 

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -183,6 +183,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 if (subtitleFormat.IsMine(lines, string.Empty))
                 {
                     subtitleFormat.LoadSubtitle(subtitle, lines, fileName);
+                    subtitle.OriginalFormat = subtitleFormat;
                     return subtitle;
                 }
             }


### PR DESCRIPTION
## Summary

Three independent fixes for issues introduced in recent commits to `main`:

- **Fix syntax error in `CutVideoViewModel`** — a stray `- ` after a statement-terminating semicolon (introduced in 4e94576) caused `CS1525`/`CS1002` and broke the build.
- **Set `OriginalFormat` in `Subtitle.Parse` fallback loop** — `Subtitle.Parse(List<string>, string)` (touched in 2cb54ed) only assigned `OriginalFormat` when a format matched on extension; the fallback loop returned a loaded subtitle without setting it.
- **Fix double-underscore typo** on the `_mpvPreviewSelectedFontAlignment` MVVM field in `SettingsViewModel` — long-standing typo, harmless because the source generator strips leading underscores, but inconsistent with the rest of the file.

Each fix is in its own commit so they can be reverted independently.

## Test plan

- [x] `dotnet build src/UI/UI.csproj` succeeds
- [x] `dotnet test tests/libse/LibSETests.csproj --filter "FullyQualifiedName~Subtitle"` — 86/86 pass
- [ ] Manually verify Cut Video flow with mp3/wav input/output
- [ ] Manually verify Settings → MPV preview alignment combo works

🤖 Generated with [Claude Code](https://claude.com/claude-code)