### PR TITLE
Fix CrispASR '--split-on-punct' passing 'true' as input file

### DIFF
--- a/src/UI/Logic/Config/SeAudioToText.cs
+++ b/src/UI/Logic/Config/SeAudioToText.cs
@@ -43,13 +43,13 @@ public class SeAudioToText
     public string CommandLineParameterQwen3AsrCpp { get; set; } = string.Empty;
     public string CommandLineParameterParakeetCpp { get; set; } = string.Empty;
     public string CommandLineParameterChatLlm { get; set; } = string.Empty;
-    public string CommandLineParameterCrispAsrCanary { get; set; } = "--max-len 50 --split-on-punct true";
-    public string CommandLineParameterCrispAsrCohere { get; set; } = "--max-len 50 --split-on-punct true";
-    public string CommandLineParameterCrispAsrFireRed { get; set; } = "--max-len 50 --split-on-punct true";
-    public string CommandLineParameterCrispAsrGlm { get; set; } = "--max-len 50 --split-on-punct true";
-    public string CommandLineParameterCrispAsrGranite { get; set; } = "--max-len 50 --split-on-punct true";
-    public string CommandLineParameterCrispAsrParakeet { get; set; } = "--max-len 50 --split-on-punct true";
-    public string CommandLineParameterCrispAsrQwen3 { get; set; } = "--max-len 50 --split-on-punct true";
+    public string CommandLineParameterCrispAsrCanary { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrCohere { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrFireRed { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrGlm { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrGranite { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrParakeet { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrQwen3 { get; set; } = "--max-len 50 --split-on-punct";
 
     public string WhisperExtraSettingsHistory { get; set; } = string.Empty;
 


### PR DESCRIPTION
## Summary
- `--split-on-punct` is a boolean flag (no argument) per the CrispASR help text (`[false] split subtitle lines at sentence-ending punctuation`).
- The default command lines appended ` true`, so the parser treated `true` as a positional arg (input file), producing `error: input file not found 'true'`.
- Removed the trailing `true` from all seven CrispASR defaults (Canary, Cohere, FireRed, GLM, Granite, Parakeet, Qwen3).

Fixes #10672

## Test plan
- [ ] Launch Audio-to-Text with a CrispASR backend on a fresh config and confirm the error no longer appears in the output.
- [ ] Confirm sentence-punctuation splitting still takes effect (segments split on `.`/`?`/`!`).
- [ ] Existing users who already saved the buggy value in settings will need to either reset the command-line field or edit out the trailing `true` manually — a settings migration could be added as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)