### PR TITLE
Fix WebVTT STYLE class italic/bold/color loss on conversion (Apple TV)

### DIFF
--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -668,7 +668,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         var styles = GetStyles(match.Value);
                         var hasItalic = italicStyles.Any(st => styles.Contains(st));
                         var hasBold = boldStyles.Any(st => styles.Contains(st));
-                        var colorTag = FindBestColorTagOrDefault(styles.ToList());
+                        var colorTag = FindBestColorTagOrDefault(styles.ToList(), cueStyles);
                         if (hasItalic)
                         {
                             text = text.Insert(match.Index, "<i>");
@@ -784,14 +784,24 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var end = header.IndexOf('}', match.Index + match.Length);
                 if (end > 0)
                 {
-                    var content = header.Substring(match.Index + match.Length, end - (match.Index + match.Length));
+                    var content = header.Substring(match.Index + match.Length, end - (match.Index + match.Length))
+                        .Trim()
+                        .Replace(" ", string.Empty);
+
+                    // Ensure the last property is terminated with ';' so contains-matches like
+                    // "font-style:italic;" / "font-weight:bold;" hit when the source CSS omits
+                    // the trailing ';' (common in Apple TV WebVTT).
+                    if (content.Length > 0 && !content.EndsWith(';'))
+                    {
+                        content += ";";
+                    }
 
                     if (dic.ContainsKey(cueName))
                     {
                         dic.Remove(cueName);
                     }
 
-                    dic.Add(cueName, content.Trim().Replace(" ", string.Empty));
+                    dic.Add(cueName, content);
                 }
             }
 
@@ -803,7 +813,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return cTag.Replace("<c.", string.Empty).TrimEnd('>').Split('.');
         }
 
-        private static string FindBestColorTagOrDefault(List<string> tags)
+        private static string FindBestColorTagOrDefault(List<string> tags, Dictionary<string, string> cueStyles)
         {
             tags.Reverse();
             foreach (var s in tags)
@@ -818,6 +828,54 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     return "#" + l.Remove(0, 5);
                 }
+
+                // Fallback: read `color:` from the CSS body of the matching STYLE block,
+                // e.g. `::cue(.styledotAB9216) { color:#AB9216;font-weight:bold }`.
+                if (cueStyles != null && cueStyles.TryGetValue(s, out var css))
+                {
+                    var color = ExtractColorFromCueCss(css);
+                    if (color != null)
+                    {
+                        return color;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static string ExtractColorFromCueCss(string css)
+        {
+            if (string.IsNullOrEmpty(css))
+            {
+                return null;
+            }
+
+            const string colorKey = "color:";
+            var idx = 0;
+            while ((idx = css.IndexOf(colorKey, idx, StringComparison.OrdinalIgnoreCase)) >= 0)
+            {
+                // Skip `background-color:` etc.
+                if (idx > 0 && (char.IsLetter(css[idx - 1]) || css[idx - 1] == '-'))
+                {
+                    idx += colorKey.Length;
+                    continue;
+                }
+
+                var start = idx + colorKey.Length;
+                var end = css.IndexOf(';', start);
+                if (end < 0)
+                {
+                    end = css.Length;
+                }
+
+                var value = css.Substring(start, end - start).Trim();
+                if (value.Length > 0)
+                {
+                    return value;
+                }
+
+                idx = end;
             }
 
             return null;

--- a/tests/libse/Files/sample_WebVTT_AppleTV.webvtt
+++ b/tests/libse/Files/sample_WebVTT_AppleTV.webvtt
@@ -1,0 +1,1799 @@
+WEBVTT
+X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000
+
+STYLE
+::cue(.styledotdefault) { font-weight:bold }
+::cue(.styledotAB9216) { color:#AB9216;font-weight:bold }
+::cue(.styledotAB9216dotitalic) { color:#AB9216;font-weight:bold;font-style:italic }
+
+1
+00:00:30.030 --> 00:00:34.243 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>SEVEROVÝCHODNÍ AUSTRÁLIE</c>
+
+2
+00:02:47.251 --> 00:02:49.378 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>INSPIROVÁNO MONSTREM GODZILLA</c>
+
+3
+00:02:57.678 --> 00:03:00.222 align:middle line:0%,start position:50%,middle
+<c.styledotAB9216>MONARCH: ODKAZ MONSTER</c>
+
+4
+00:03:23.996 --> 00:03:25.622 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>PŘÍCHOZÍ HOVOR
+MINISTR OBRANY</c>
+
+5
+00:03:28.917 --> 00:03:30.544 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ano, pane ministře.</c>
+
+6
+00:03:30.627 --> 00:03:32.671 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Situace se rychle vyvíjí.</c>
+
+7
+00:03:32.754 --> 00:03:35.299 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Jste mistr bagatelizace, Reddicku.</c>
+
+8
+00:03:35.382 --> 00:03:39.595 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Vzhledem k tomu, že se titán
+před 18 hodinami objevil na jejich prahu,</c>
+
+9
+00:03:39.678 --> 00:03:44.808 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>požaduje Austrálie, aby USA dodržely
+dohodu o obraně proti titánovi.</c>
+
+10
+00:03:44.892 --> 00:03:48.896 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Víte stejně jako já,
+že vojenskou silou jsme nic nezmohli.</c>
+
+11
+00:03:48.979 --> 00:03:50.814 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vyzkoušeli jsme na ně všechno.</c>
+
+12
+00:03:50.898 --> 00:03:53.525 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Všechno ne.</c>
+
+13
+00:03:54.860 --> 00:03:57.029 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To už jsme zkusili na atolu Bikini.</c>
+
+14
+00:03:57.112 --> 00:04:00.532 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Od Castle Bravo
+technologie značně pokročily.</c>
+
+15
+00:04:00.616 --> 00:04:02.910 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Je to taktická zbraň. Lokalizovaná.</c>
+
+16
+00:04:02.993 --> 00:04:03.994 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Lokalizovaná?</c>
+
+17
+00:04:04.077 --> 00:04:07.873 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tato možnost
+s sebou stále nese nedozírné následky.</c>
+
+18
+00:04:07.956 --> 00:04:10.250 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Kde je nejbližší obydlená oblast?</c>
+
+19
+00:04:14.004 --> 00:04:15.130 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Asi 15 km od moře.</c>
+
+20
+00:04:15.214 --> 00:04:18.050 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Lidi v okruhu 500 km nechám evakuovat.</c>
+
+21
+00:04:18.132 --> 00:04:20.802 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Dobře, ale rychle.
+Jednotky jsou již na cestě.</c>
+
+22
+00:04:20.886 --> 00:04:24.598 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Pane, chtěl bych říct…
+- </c><c.styledotAB9216dotitalic>Ne. Je to příležitost, Redde.</c>
+
+23
+00:04:24.681 --> 00:04:25.807 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Tak ji využijeme.</c>
+
+24
+00:04:27.017 --> 00:04:28.769 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Další možnosti už nejsou.</c>
+
+25
+00:04:31.396 --> 00:04:32.397 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Rozumím.</c>
+
+26
+00:04:40.489 --> 00:04:44.451 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- </c><c.styledotAB9216dotitalic>Přistáváme. Uvolněte heliport, prosím.</c>
+<c.styledotAB9216>- </c><c.styledotAB9216dotitalic>Rozumím. Je volný.</c>
+
+27
+00:05:09.101 --> 00:05:11.311 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tak jo. Buďte v klidu.</c>
+
+28
+00:05:11.395 --> 00:05:12.813 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Myslíš, že nám uvěří?</c>
+
+29
+00:05:12.896 --> 00:05:15.232 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Že jsi emocionálně napojená na monstrum?</c>
+
+30
+00:05:15.315 --> 00:05:16.358 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Začneme jinak.</c>
+
+31
+00:05:20.237 --> 00:05:21.446 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co je?</c>
+
+32
+00:05:24.199 --> 00:05:28.829 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Pane, přiletěl někdo,
+s kým byste si měl promluvit.</c>
+
+33
+00:05:31.456 --> 00:05:32.791 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ředitel Barris?</c>
+
+34
+00:05:34.668 --> 00:05:36.253 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vítejte na palubě.</c>
+
+35
+00:05:37.963 --> 00:05:42.176 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Paní doktorko, všude vás hledáme,
+a vy mi nakráčíte do kanceláře.</c>
+
+36
+00:05:42.259 --> 00:05:44.970 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Měl bych vás nechat odvést
+na správu zdrojů.</c>
+
+37
+00:05:45.053 --> 00:05:46.972 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne, měl byste je vyslechnout.</c>
+
+38
+00:05:47.055 --> 00:05:48.515 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Opravdu?
+- Ano.</c>
+
+39
+00:05:48.599 --> 00:05:49.975 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Stačí nám minuta.</c>
+
+40
+00:05:50.058 --> 00:05:53.228 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tu nemám.
+Titán dorazil na pobřeží Austrálie.</c>
+
+41
+00:05:53.312 --> 00:05:55.063 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To není váš největší problém.</c>
+
+42
+00:05:55.814 --> 00:05:56.857 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A co?</c>
+
+43
+00:05:56.940 --> 00:05:59.318 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Lee Shaw.
+- Ten s tím souvisí jak?</c>
+
+44
+00:05:59.401 --> 00:06:02.738 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Shaw má vlastní plán,
+jak titána zneškodnit.</c>
+
+45
+00:06:02.821 --> 00:06:05.949 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Což je u tak skvělého
+týmového hráče divné.</c>
+
+46
+00:06:06.033 --> 00:06:09.786 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Podle dr. Suzukiho použije
+koncentrované paprsky gama,</c>
+
+47
+00:06:09.870 --> 00:06:11.538 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>aby přilákal jiného titána.</c>
+
+48
+00:06:12.164 --> 00:06:13.373 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jiného titána?</c>
+
+49
+00:06:17.169 --> 00:06:18.170 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Godzillu.</c>
+
+50
+00:07:12.391 --> 00:07:13.392 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Charlie.</c>
+
+51
+00:07:14.184 --> 00:07:16.186 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vidíme něco na globální síti?</c>
+
+52
+00:07:16.270 --> 00:07:17.646 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Na G-TASS?</c>
+
+53
+00:07:17.729 --> 00:07:20.691 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jakoukoli aktivitu titánů mimo tuhle?</c>
+
+54
+00:07:20.774 --> 00:07:21.775 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne.</c>
+
+55
+00:07:21.859 --> 00:07:25.153 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Na radaru máme jen Titána X. Jinde nic.</c>
+
+56
+00:07:25.237 --> 00:07:28.490 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Může to fakt udělat?
+Může Shaw přivolat Godzillu?</c>
+
+57
+00:07:28.574 --> 00:07:30.450 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne. To je…</c>
+
+58
+00:07:30.534 --> 00:07:33.996 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Dr. Serizawa říkal,
+že Godzilla je králem monster.</c>
+
+59
+00:07:34.079 --> 00:07:35.956 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Udělá jen to, co sama chce.</c>
+
+60
+00:07:36.039 --> 00:07:39.710 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ale už se to jednou stalo.
+Godžira se ukázala na atolu Bikini</c>
+
+61
+00:07:39.793 --> 00:07:42.421 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>v důsledku radiace
+po výbuchu Castle Bravo.</c>
+
+62
+00:07:43.005 --> 00:07:46.425 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Lee má zařízení,
+které umí simulovat podobnou energii.</c>
+
+63
+00:07:47.009 --> 00:07:48.218 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Návnadu na titány.</c>
+
+64
+00:08:02.482 --> 00:08:04.776 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Už se titán někam přesunul?</c>
+
+65
+00:08:04.860 --> 00:08:08.572 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne, ale zaznamenali jsme u něj
+nárůst energie.</c>
+
+66
+00:08:08.655 --> 00:08:11.575 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Od chvíle, co dorazil na pobřeží,
+hodnoty rostou.</c>
+
+67
+00:08:11.658 --> 00:08:13.368 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Víš, co to znamená?</c>
+
+68
+00:08:13.452 --> 00:08:15.704 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Stejné výkyvy jsme zaznamenali,</c>
+
+69
+00:08:15.787 --> 00:08:19.458 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>když se Godzilla chystala zaútočit,
+takže to není nic moc.</c>
+
+70
+00:08:19.541 --> 00:08:22.878 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nemůže ten nárůst energie
+mít i jiný důvod?</c>
+
+71
+00:08:22.961 --> 00:08:25.088 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vykazuje i jiné známky agresivity?</c>
+
+72
+00:08:25.172 --> 00:08:29.593 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Za agresivní chování se považuje i to,
+že se usadil na pláži.</c>
+
+73
+00:08:29.676 --> 00:08:32.054 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Když počkáme, možná bude pozdě.</c>
+
+74
+00:08:32.136 --> 00:08:33.514 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Pozdě?</c>
+
+75
+00:08:34.890 --> 00:08:36.683 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co říkal ministr obrany?</c>
+
+76
+00:08:43.232 --> 00:08:49.154 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Právě teď k nám míří flotila 20 lodí
+se střelami Tomahawk s jadernou hlavicí.</c>
+
+77
+00:08:49.238 --> 00:08:51.865 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Jadernou?
+- Co to sakra…</c>
+
+78
+00:08:52.366 --> 00:08:56.578 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Víte, že ona na té pláži byla,
+když jsme to zkoušeli posledně?</c>
+
+79
+00:08:56.662 --> 00:08:58.747 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A jak to dopadlo?</c>
+
+80
+00:08:58.830 --> 00:09:00.874 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Budou tu ani ne za tři hodiny.</c>
+
+81
+00:09:02.918 --> 00:09:04.837 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Takže máme tři hodiny.</c>
+
+82
+00:09:05.420 --> 00:09:06.630 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Na co?</c>
+
+83
+00:09:07.339 --> 00:09:09.132 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Podle výzkumu mého muže</c>
+
+84
+00:09:09.216 --> 00:09:13.178 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Titán X po staletí sledoval
+stejnou migrační trasu kolem světa</c>
+
+85
+00:09:13.262 --> 00:09:15.222 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>bez jakýchkoli doložených útoků.</c>
+
+86
+00:09:15.305 --> 00:09:18.892 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Pak Apex zakročil na Santa Soledad
+a vychýlil ho z trasy.</c>
+
+87
+00:09:18.976 --> 00:09:22.312 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Když pochopíme, proč je mimo,
+a vrátíme ho na trasu,</c>
+
+88
+00:09:22.396 --> 00:09:25.357 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>zabráníme dalšímu útoku
+spíš než jadernou zbraní.</c>
+
+89
+00:09:25.440 --> 00:09:28.986 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Moment. Chci se ujistit,
+že chápu, co říkáte. Vy…</c>
+
+90
+00:09:29.069 --> 00:09:32.865 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Chcete titána zachránit?
+- Potřebuje naši pomoc.</c>
+
+91
+00:09:34.366 --> 00:09:37.995 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Můžu ho z té pláže dostat
+a vrátit na migrační trasu.</c>
+
+92
+00:09:44.668 --> 00:09:48.088 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Přistává Monarch 89.
+Na palubě je Kentaró Randa.</c>
+
+93
+00:09:53.927 --> 00:09:55.179 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Hej!</c>
+
+94
+00:09:55.762 --> 00:09:57.347 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsou tady Cate a Keiko.</c>
+
+95
+00:09:57.431 --> 00:09:59.183 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Zrovna mluví s Barrisem.</c>
+
+96
+00:09:59.266 --> 00:10:00.267 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Já vím.</c>
+
+97
+00:10:01.143 --> 00:10:02.811 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Řekneš mi něco o tom Thajsku?</c>
+
+98
+00:10:05.147 --> 00:10:06.315 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A co?</c>
+
+99
+00:10:06.982 --> 00:10:10.360 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nevím. Zničehonic jsi odletěl do Thajska</c>
+
+100
+00:10:11.153 --> 00:10:13.238 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>a co? S nikým ses tam neviděl?</c>
+
+101
+00:10:16.283 --> 00:10:17.492 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jmenuje se Isabel.</c>
+
+102
+00:10:20.287 --> 00:10:21.872 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A kdo to je? Měla bych…</c>
+
+103
+00:10:21.955 --> 00:10:23.290 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Isabel Simmonsová.</c>
+
+104
+00:10:24.875 --> 00:10:25.876 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co tím…</c>
+
+105
+00:10:26.460 --> 00:10:29.755 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jak to myslíš?
+Byls v Thajsku s Isabel Simmonsovou?</c>
+
+106
+00:10:30.255 --> 00:10:31.673 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A neřekl bys mi to?</c>
+
+107
+00:10:31.757 --> 00:10:33.634 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>S dcerou Waltera Simmonse?</c>
+
+108
+00:10:33.717 --> 00:10:35.969 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Zakladatele Apex Cybernetics.</c>
+
+109
+00:10:36.053 --> 00:10:37.095 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jo.</c>
+
+110
+00:10:37.179 --> 00:10:40.224 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Určitě bys totiž řekla,
+že tam jsem kvůli Apexu.</c>
+
+111
+00:10:40.307 --> 00:10:41.433 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>No a ne snad?</c>
+
+112
+00:10:41.517 --> 00:10:42.518 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne.</c>
+
+113
+00:10:43.644 --> 00:10:47.481 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Není zas tak hrozná.
+Ve skutečnosti Apex nesnáší jako my.</c>
+
+114
+00:10:51.026 --> 00:10:52.277 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Už to neřeš, jo?</c>
+
+115
+00:10:52.361 --> 00:10:54.238 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Byla to jen návštěva. Nic víc.</c>
+
+116
+00:11:00.786 --> 00:11:04.581 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Potřebuje pomoc?
+A to víte jak? Mluvila jste s ním?</c>
+
+117
+00:11:04.665 --> 00:11:07.626 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Neumím to vysvětlit,
+ale je to jakýsi pocit.</c>
+
+118
+00:11:07.709 --> 00:11:09.169 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Pocit?
+- Ano.</c>
+
+119
+00:11:09.253 --> 00:11:12.005 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Věděla, že je titán ztracený, dřív než my.</c>
+
+120
+00:11:12.089 --> 00:11:14.508 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Že se odklonil od trasy.</c>
+
+121
+00:11:14.591 --> 00:11:17.386 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Dřív než Monarch zjistil, že se ztratil.</c>
+
+122
+00:11:17.469 --> 00:11:20.138 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A to je fakt, který nebudu ignorovat.</c>
+
+123
+00:11:20.222 --> 00:11:22.683 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Poslouchejte. Víme o hrozbě.</c>
+
+124
+00:11:22.766 --> 00:11:24.226 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Víme, kde se nachází.</c>
+
+125
+00:11:24.726 --> 00:11:26.520 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Konečně máme možnost to řešit,</c>
+
+126
+00:11:26.603 --> 00:11:30.649 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>a vy nám v tom chcete zabránit
+kvůli pocitu, že potřebuje pomoc.</c>
+
+127
+00:11:30.732 --> 00:11:36.405 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Monarch odjakživa hledá
+nepravděpodobná řešení nemožných problémů.</c>
+
+128
+00:11:37.155 --> 00:11:40.117 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Zdá se mi, že tohle je ukázkový příklad.</c>
+
+129
+00:11:40.909 --> 00:11:42.953 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Říkáte, že máme tři hodiny.</c>
+
+130
+00:11:43.036 --> 00:11:47.249 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Riskujete jen dva lidi, které jste
+stejně chtěl poslat na správu zdrojů.</c>
+
+131
+00:11:47.332 --> 00:11:49.126 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Chtěl jste odpovědi.</c>
+
+132
+00:11:49.209 --> 00:11:53.589 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Říkal jste, že je v té situaci
+až moc neznámých.</c>
+
+133
+00:11:53.672 --> 00:11:55.674 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Třeba nám dokážou pomoct.</c>
+
+134
+00:11:55.757 --> 00:11:59.469 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nechejte ji, aby ho aspoň zkusila
+dostat zpět na tu trasu.</c>
+
+135
+00:11:59.553 --> 00:12:02.306 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Můžou tu situaci i zhoršit.</c>
+
+136
+00:12:02.389 --> 00:12:03.974 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To jste nezvážil?</c>
+
+137
+00:12:06.935 --> 00:12:09.646 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>„Riskujete jen dva lidi.“
+Snad do toho jdete.</c>
+
+138
+00:12:09.730 --> 00:12:11.773 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Chystáme pro vás vrtulník.</c>
+
+139
+00:12:11.857 --> 00:12:14.401 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Potrvá to asi 20 minut,
+půl hodiny poletíte,</c>
+
+140
+00:12:14.484 --> 00:12:16.486 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>takže vám zbydou dvě hodiny a něco.</c>
+
+141
+00:12:20.741 --> 00:12:21.992 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ahoj.</c>
+
+142
+00:12:25.370 --> 00:12:26.413 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ahoj.</c>
+
+143
+00:12:32.294 --> 00:12:33.462 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vřelá atmosféra.</c>
+
+144
+00:12:33.545 --> 00:12:36.548 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Připravte se. Vrtulník odlétá za 20 minut.</c>
+
+145
+00:12:36.632 --> 00:12:37.925 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ráda tě vidím.</c>
+
+146
+00:13:12.376 --> 00:13:13.460 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Kentaró?</c>
+
+147
+00:13:15.838 --> 00:13:17.130 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Jsi tam?</c>
+
+148
+00:13:18.048 --> 00:13:19.132 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsem.</c>
+
+149
+00:13:39.945 --> 00:13:41.572 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jen pojď, hochu!</c>
+
+150
+00:14:08.932 --> 00:14:10.684 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Kentaró, promluvíme si?</c>
+
+151
+00:14:11.768 --> 00:14:12.769 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jasně.</c>
+
+152
+00:14:14.897 --> 00:14:16.565 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To, cos řekl na tom pohřbu…</c>
+
+153
+00:14:18.275 --> 00:14:20.777 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Chápu, jestli ses na mě naštval.</c>
+
+154
+00:14:21.987 --> 00:14:24.489 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- To nic.
+- Třeba za to na Santa Soledad.</c>
+
+155
+00:14:24.573 --> 00:14:26.408 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Cate, to nic.</c>
+
+156
+00:14:32.873 --> 00:14:33.874 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jen…</c>
+
+157
+00:14:35.125 --> 00:14:37.419 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>se mi o tátovi občas zdá.</c>
+
+158
+00:14:38.795 --> 00:14:39.880 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Hezké sny?</c>
+
+159
+00:14:40.839 --> 00:14:41.840 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne.</c>
+
+160
+00:14:46.303 --> 00:14:47.804 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nemusíš to dělat.</c>
+
+161
+00:14:47.888 --> 00:14:49.806 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jít s námi za titánem.</c>
+
+162
+00:14:49.890 --> 00:14:51.225 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To neříkej.</c>
+
+163
+00:14:51.934 --> 00:14:52.935 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co?</c>
+
+164
+00:14:53.018 --> 00:14:55.145 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Neříkej, že ta mise není i moje.</c>
+
+165
+00:14:56.980 --> 00:15:00.859 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Musíme Titánovi X zabránit v tom,
+aby dál zabíjel. Dostat ho pryč.</c>
+
+166
+00:15:02.110 --> 00:15:05.113 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Takže ho zachránit. Nebo co.</c>
+
+167
+00:15:19.795 --> 00:15:20.838 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Rychle.</c>
+
+168
+00:15:29.429 --> 00:15:30.430 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Honem.</c>
+
+169
+00:15:34.142 --> 00:15:35.519 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Start povolen.</c>
+
+170
+00:15:35.602 --> 00:15:37.020 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Rozumím.</c>
+
+171
+00:15:59.168 --> 00:16:00.878 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Musím mluvit s Hollandovou.</c>
+
+172
+00:16:04.381 --> 00:16:05.632 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Apex něco chystá.</c>
+
+173
+00:16:08.552 --> 00:16:11.221 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>V Tokiu za Kentaróem
+přišla Isabel Simmonsová.</c>
+
+174
+00:16:12.681 --> 00:16:14.641 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A Kentaró říká, že o nic nejde.</c>
+
+175
+00:16:15.559 --> 00:16:18.437 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Teď se vrátil z Thajska,
+kde se s ní viděl.</c>
+
+176
+00:16:19.897 --> 00:16:20.898 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ty mu nevěříš?</c>
+
+177
+00:16:20.981 --> 00:16:21.982 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ale jo…</c>
+
+178
+00:16:23.483 --> 00:16:24.818 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nevěřím Simmonsovým.</c>
+
+179
+00:16:31.033 --> 00:16:33.243 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Myslím na to, co se jí stalo. Ona…</c>
+
+180
+00:16:34.786 --> 00:16:36.121 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Myslím na to pořád.</c>
+
+181
+00:16:39.374 --> 00:16:43.962 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Time, nemůžu sedět se založenýma rukama
+a čekat, co dalšího se pokazí.</c>
+
+182
+00:16:46.215 --> 00:16:49.510 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Víš, Hiroši říkával:</c>
+
+183
+00:16:50.219 --> 00:16:54.973 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>„Máme co dočinění s monstry,
+takže chyby budou monstrózní.</c>
+
+184
+00:16:58.560 --> 00:16:59.686 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ale nevzdáme to.</c>
+
+185
+00:17:00.562 --> 00:17:04.398 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Z chyb se poučíme
+a příště to uděláme líp.“</c>
+
+186
+00:17:07.986 --> 00:17:08.987 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne asi.</c>
+
+187
+00:17:09.988 --> 00:17:10.989 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Hele.</c>
+
+188
+00:17:11.740 --> 00:17:12.741 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne asi.</c>
+
+189
+00:17:14.701 --> 00:17:17.412 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jestli si myslíš, že tady něco hrozí,</c>
+
+190
+00:17:18.955 --> 00:17:20.290 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>tak to prověř.</c>
+
+191
+00:17:24.627 --> 00:17:25.628 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Budu tě krýt.</c>
+
+192
+00:17:32.594 --> 00:17:34.763 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Radši už běž. Zařídím to.</c>
+
+193
+00:17:40.269 --> 00:17:42.062 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Stanice 18, Monarch 55.</c>
+
+194
+00:17:43.021 --> 00:17:44.690 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Blížíme se k Titánovi X.</c>
+
+195
+00:17:44.773 --> 00:17:46.650 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Místo přistání máme na dohled.</c>
+
+196
+00:17:47.401 --> 00:17:48.402 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Rozumím.</c>
+
+197
+00:17:48.944 --> 00:17:50.571 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vidíte, jak je obří?</c>
+
+198
+00:18:29.902 --> 00:18:30.903 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co to sakra je?</c>
+
+199
+00:18:35.657 --> 00:18:36.658 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co je?</c>
+
+200
+00:18:38.577 --> 00:18:39.995 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Tam.
+- Ptáci!</c>
+
+201
+00:18:44.875 --> 00:18:46.084 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Mayday!
+- Padáme!</c>
+
+202
+00:18:54.843 --> 00:18:55.844 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ježíši.</c>
+
+203
+00:19:03.393 --> 00:19:05.062 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsou v pořádku? Přistáli?</c>
+
+204
+00:19:05.145 --> 00:19:06.730 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Monarchu 55, slyšíte?</c>
+
+205
+00:19:10.776 --> 00:19:16.031 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Monarchu 55, odpovězte.</c>
+
+206
+00:19:16.114 --> 00:19:18.200 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>ŽÁDNÝ SIGNÁL</c>
+
+207
+00:19:18.283 --> 00:19:20.369 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Tady Monarch 55.</c>
+
+208
+00:19:20.452 --> 00:19:22.162 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Měli jsme tvrdé přistání.</c>
+
+209
+00:19:22.246 --> 00:19:25.457 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Nacházíme se…
+Požadujeme okamžitou evakuaci…</c>
+
+210
+00:19:26.583 --> 00:19:29.044 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Rozumím, 55. Evakuační tým už letí.</c>
+
+211
+00:19:29.628 --> 00:19:32.589 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Poslouchejte,
+už s nimi nesmíte ztratit spojení.</c>
+
+212
+00:19:32.673 --> 00:19:34.299 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Rozumíte?
+- Ano.</c>
+
+213
+00:19:34.383 --> 00:19:35.384 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Dobrá práce.</c>
+
+214
+00:19:37.845 --> 00:19:39.638 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Proveďte evakuaci Monarchu 55.</c>
+
+215
+00:19:41.849 --> 00:19:46.478 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>NĚKDE V JIŽNÍM PACIFIKU</c>
+
+216
+00:20:35.360 --> 00:20:36.361 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Kei!</c>
+
+217
+00:20:37.863 --> 00:20:38.864 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Lee!</c>
+
+218
+00:20:41.575 --> 00:20:44.453 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ježíši! Co to má znamenat?</c>
+
+219
+00:20:46.538 --> 00:20:47.706 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsi v pořádku?</c>
+
+220
+00:20:48.749 --> 00:20:51.001 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsem v pořádku.</c>
+
+221
+00:20:51.585 --> 00:20:53.253 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co ti ostatní? Ahoj.</c>
+
+222
+00:20:57.257 --> 00:20:58.425 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nic se jim nestalo.</c>
+
+223
+00:20:58.926 --> 00:21:01.094 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Já nevěděl, že to jsi ty, jen jsem…</c>
+
+224
+00:21:01.929 --> 00:21:02.930 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Do háje.</c>
+
+225
+00:21:03.472 --> 00:21:04.473 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Já…</c>
+
+226
+00:21:05.849 --> 00:21:06.850 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Proč?</c>
+
+227
+00:21:10.479 --> 00:21:13.607 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Proč… Co tady děláš, Kei?</c>
+
+228
+00:21:16.276 --> 00:21:17.945 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co tady děláš ty, Lee?</c>
+
+229
+00:21:23.033 --> 00:21:24.660 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Hledám Brendu Hollandovou.</c>
+
+230
+00:21:24.743 --> 00:21:26.745 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Běžte dál, první dveře vpravo.</c>
+
+231
+00:21:33.627 --> 00:21:38.882 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>SPRÁVA ZDROJŮ MONARCHU
+TAJNÁ LOKALITA</c>
+
+232
+00:21:56.441 --> 00:21:57.609 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Déjà vu.</c>
+
+233
+00:21:58.735 --> 00:21:59.903 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsi rychlá.</c>
+
+234
+00:22:01.321 --> 00:22:05.826 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Trvalo ti asi dva dny,
+než ses v Monarchu propracovala nahoru.</c>
+
+235
+00:22:06.535 --> 00:22:09.246 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne. Dovolili mi si s tebou promluvit.</c>
+
+236
+00:22:13.458 --> 00:22:14.501 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsi v pořádku?</c>
+
+237
+00:22:16.420 --> 00:22:17.421 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsem.</c>
+
+238
+00:22:19.631 --> 00:22:20.632 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A ty?</c>
+
+239
+00:22:24.136 --> 00:22:25.137 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co potřebuješ?</c>
+
+240
+00:22:27.931 --> 00:22:31.059 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Četla jsem zápis tvojí výpovědi.</c>
+
+241
+00:22:31.935 --> 00:22:35.606 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tvrdila jsi v ní,
+žes porušila postupy Apexu.</c>
+
+242
+00:22:39.318 --> 00:22:40.777 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Brendo, proč jsi lhala?</c>
+
+243
+00:22:41.945 --> 00:22:45.866 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Mým úkolem je zajistit,
+aby měl Monarch všechny informace,</c>
+
+244
+00:22:46.575 --> 00:22:50.537 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>co potřebuje k posouzení událostí
+na Santa Soledad.</c>
+
+245
+00:22:51.830 --> 00:22:54.082 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Spolupracuji.
+- Prosím tě.</c>
+
+246
+00:22:54.750 --> 00:22:58.003 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>V takovéhle místnosti jsem už byla.
+A lhala jsem.</c>
+
+247
+00:22:59.129 --> 00:23:01.715 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Bála jsem se, co bude, když řeknu pravdu.</c>
+
+248
+00:23:02.758 --> 00:23:03.967 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Máš to stejně?</c>
+
+249
+00:23:04.593 --> 00:23:08.138 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Byla to podmínka,
+abys dostala zlatý padák?</c>
+
+250
+00:23:08.222 --> 00:23:09.806 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Měla jsi pravdu, Corah.</c>
+
+251
+00:23:11.350 --> 00:23:12.351 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Přehnala jsem to.</c>
+
+252
+00:23:13.185 --> 00:23:15.771 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Měla jsem přehnané ambice</c>
+
+253
+00:23:15.854 --> 00:23:19.441 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>a za to, co se stalo na Santa Soledad,
+nesu odpovědnost já.</c>
+
+254
+00:23:19.525 --> 00:23:21.276 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nejen ty.</c>
+
+255
+00:23:21.360 --> 00:23:24.112 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Já za své činy zodpovídám, Corah.</c>
+
+256
+00:23:28.450 --> 00:23:29.993 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Můžu poprosit o vodu?</c>
+
+257
+00:23:32.246 --> 00:23:33.705 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne z kohoutku. Děkuji.</c>
+
+258
+00:23:38.502 --> 00:23:41.171 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Prosím, nech to plavat.</c>
+
+259
+00:23:41.255 --> 00:23:44.800 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co chce dcera Waltera Simmonse
+po Kentaróovi Randovi?</c>
+
+260
+00:23:54.601 --> 00:23:55.727 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Je klidný.</c>
+
+261
+00:23:58.272 --> 00:24:01.733 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jenom říkám, že tady být nechcete.</c>
+
+262
+00:24:03.068 --> 00:24:04.319 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Proč?</c>
+
+263
+00:24:04.403 --> 00:24:08.115 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Protože jsem návnadu už aktivoval.
+Evakuační tým je na cestě?</c>
+
+264
+00:24:08.198 --> 00:24:10.200 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Snaží se sem poslat další vrtulník.</c>
+
+265
+00:24:10.284 --> 00:24:12.744 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Doufejte, že dorazí dřív než Godzilla.</c>
+
+266
+00:24:12.828 --> 00:24:15.455 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>S titánem si musí jít poradit i jinak.</c>
+
+267
+00:24:15.539 --> 00:24:18.000 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Určitě, Kei, ale já jsem pro Godzillu.</c>
+
+268
+00:24:18.584 --> 00:24:20.961 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ještě máme čas, než dorazí flotila, že?</c>
+
+269
+00:24:21.044 --> 00:24:22.462 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Ano.
+- Flotila?</c>
+
+270
+00:24:23.046 --> 00:24:24.339 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ano, Lee.</c>
+
+271
+00:24:24.423 --> 00:24:27.509 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Armáda USA chce titána taky zničit</c>
+
+272
+00:24:27.593 --> 00:24:30.762 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>a my s Cate uděláme, co chceme,
+než sem dorazí.</c>
+
+273
+00:24:30.846 --> 00:24:35.642 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Zavolejte Monarchu, ať flotila nejezdí,
+protože v přítomnosti Godzilly</c>
+
+274
+00:24:35.726 --> 00:24:39.938 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>titána nezničí, ať už plánují cokoliv.
+Natož aby zničili dva.</c>
+
+275
+00:24:40.022 --> 00:24:41.023 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Děkuju.</c>
+
+276
+00:24:42.524 --> 00:24:46.862 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A co ty a Cate vlastně přesně plánujete?</c>
+
+277
+00:24:47.946 --> 00:24:50.282 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vrátit Titána X na migrační trasu.</c>
+
+278
+00:24:50.365 --> 00:24:52.034 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>No jo. Zachránit ho.</c>
+
+279
+00:24:52.117 --> 00:24:53.952 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tvůj plán je snad lepší?</c>
+
+280
+00:24:54.036 --> 00:24:58.081 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Hele, Kei, nejsme v 50. letech.
+Svět se změnil.</c>
+
+281
+00:24:58.165 --> 00:25:02.336 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>V den G se vztah lidstva k titánům
+navždy změnil.</c>
+
+282
+00:25:02.920 --> 00:25:03.962 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jen ti to uniklo.</c>
+
+283
+00:25:04.046 --> 00:25:05.214 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Mně neuniklo nic.</c>
+
+284
+00:25:06.507 --> 00:25:09.676 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Já den G zažila.
+Přišla jsem o svoje blízké.</c>
+
+285
+00:25:11.553 --> 00:25:13.055 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ten titán ti zabil tátu.</c>
+
+286
+00:25:13.764 --> 00:25:14.765 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A tobě syna.</c>
+
+287
+00:25:15.349 --> 00:25:18.810 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tak vás prosím,
+abyste se od té pláže dostaly</c>
+
+288
+00:25:18.894 --> 00:25:22.314 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>co nejdál,
+než vás ten titán nebo Godzilla zabijí.</c>
+
+289
+00:25:26.944 --> 00:25:29.029 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Počkám na vás všechny v autě.</c>
+
+290
+00:25:37.955 --> 00:25:39.831 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jestli tam Cate chce jít, ať jde.</c>
+
+291
+00:25:40.999 --> 00:25:42.459 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Měla by to aspoň zkusit.</c>
+
+292
+00:25:43.210 --> 00:25:45.337 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Než dorazí loďstvo nebo Godzilla.</c>
+
+293
+00:25:51.510 --> 00:25:52.511 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To zvládneš.</c>
+
+294
+00:25:53.220 --> 00:25:54.221 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Běž.</c>
+
+295
+00:25:55.931 --> 00:25:57.683 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Já ji budu sledovat.</c>
+
+296
+00:26:00.143 --> 00:26:02.312 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Běž. Já zdržím Leeho.</c>
+
+297
+00:26:22.124 --> 00:26:23.375 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Kdy se to stalo?</c>
+
+298
+00:26:24.293 --> 00:26:26.044 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Den po Hirošiho pohřbu.</c>
+
+299
+00:26:26.128 --> 00:26:27.421 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Děkuju.</c>
+
+300
+00:26:27.504 --> 00:26:32.593 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To bylo od Isabel moc milé,
+že za ním šla a vyjádřila mu soustrast.</c>
+
+301
+00:26:33.093 --> 00:26:34.094 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nech toho.</c>
+
+302
+00:26:34.928 --> 00:26:36.346 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co po něm chce?</c>
+
+303
+00:26:36.430 --> 00:26:38.515 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>S Apexem nemá nic společného.</c>
+
+304
+00:26:38.599 --> 00:26:40.517 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vím, že to víš. Co dělají?</c>
+
+305
+00:26:40.601 --> 00:26:42.269 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Walter Simmons neskončil.</c>
+
+306
+00:26:42.352 --> 00:26:45.939 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Když jsem tě poznala, podcenila jsem tě.</c>
+
+307
+00:26:46.565 --> 00:26:50.068 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Myslela jsem, že vím,
+proč chceš dělat v AET.</c>
+
+308
+00:26:51.320 --> 00:26:54.781 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Spletla jsem se a zaplatila za to.</c>
+
+309
+00:26:55.449 --> 00:26:57.117 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jo, já za to taky zaplatila.</c>
+
+310
+00:26:57.201 --> 00:26:58.202 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jo.</c>
+
+311
+00:26:58.952 --> 00:27:01.955 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Protože sis myslela, že AET rozumíš.</c>
+
+312
+00:27:02.039 --> 00:27:03.457 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A spletla ses.</c>
+
+313
+00:27:03.540 --> 00:27:08.003 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jasně, klidně mi teď připomeň
+všechny moje chyby.</c>
+
+314
+00:27:08.670 --> 00:27:12.799 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Čeká mě
+ještě poslední schůzka s agenty Monarchu,</c>
+
+315
+00:27:12.883 --> 00:27:14.301 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>takže je možné,</c>
+
+316
+00:27:15.719 --> 00:27:17.638 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>že spolu mluvíme naposledy.</c>
+
+317
+00:27:19.723 --> 00:27:22.601 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Přeju ti hodně štěstí, Corah.</c>
+
+318
+00:27:25.562 --> 00:27:26.772 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Skončily jsme.</c>
+
+319
+00:28:36.717 --> 00:28:37.718 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Cate!</c>
+
+320
+00:28:38.510 --> 00:28:39.511 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>V pohodě.</c>
+
+321
+00:28:51.148 --> 00:28:52.566 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nemusíš to dělat.</c>
+
+322
+00:28:55.652 --> 00:28:56.653 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Musím.</c>
+
+323
+00:29:10.459 --> 00:29:11.543 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Lee!</c>
+
+324
+00:29:13.754 --> 00:29:14.755 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Přijdou?</c>
+
+325
+00:29:18.800 --> 00:29:20.511 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Měli bychom spolupracovat.</c>
+
+326
+00:29:21.762 --> 00:29:23.180 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Chceme oba to stejné.</c>
+
+327
+00:29:24.473 --> 00:29:26.141 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Až na to, že ne.</c>
+
+328
+00:29:26.225 --> 00:29:30.187 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To, co dělám, je v souladu s přírodou.
+Titáni tak fungují.</c>
+
+329
+00:29:30.270 --> 00:29:31.897 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ty víš, jak fungují?</c>
+
+330
+00:29:32.814 --> 00:29:34.358 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To neví nikdo, Lee.</c>
+
+331
+00:29:34.441 --> 00:29:38.570 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Billy mapu nakreslil před 60 lety,
+a my máme akorát víc zbraní.</c>
+
+332
+00:29:40.364 --> 00:29:43.242 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Lidstvo zachráníme tím,
+že titány pochopíme.</c>
+
+333
+00:29:43.909 --> 00:29:46.328 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Řekni mi jeden pádný důkaz,</c>
+
+334
+00:29:46.411 --> 00:29:50.832 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>cokoliv, cos zjistila a díky čemu
+tohle můžeš s jistotou říct. Jeden.</c>
+
+335
+00:29:52.793 --> 00:29:53.794 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Žádný nemám.</c>
+
+336
+00:29:57.923 --> 00:30:01.885 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vím jenom to, že Titána X
+musíme dostat zpátky na trasu,</c>
+
+337
+00:30:01.969 --> 00:30:03.470 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>jinak budou lidi umírat.</c>
+
+338
+00:30:06.473 --> 00:30:07.599 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To nestačí?</c>
+
+339
+00:30:07.683 --> 00:30:09.017 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne.</c>
+
+340
+00:30:09.101 --> 00:30:12.396 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne, když sebe, Cate a Kentaróa
+vystavuješ nebezpečí.</c>
+
+341
+00:30:13.146 --> 00:30:14.898 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Za to život titána nestojí.</c>
+
+342
+00:30:17.067 --> 00:30:20.320 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tvoje přesvědčení za ten risk stojí?</c>
+
+343
+00:30:20.404 --> 00:30:23.282 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Riskuju jen já, Kei.
+Ohrozil jsem jen sám sebe.</c>
+
+344
+00:30:23.365 --> 00:30:25.367 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A postavil nás do cesty Godžiře.</c>
+
+345
+00:30:25.450 --> 00:30:26.743 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ne, tos udělala ty.</c>
+
+346
+00:30:26.827 --> 00:30:28.662 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Já tady měl být sám.</c>
+
+347
+00:30:28.745 --> 00:30:32.624 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jen Godzilla, titán a já.
+Nikdo jinej. Nic!</c>
+
+348
+00:30:34.001 --> 00:30:35.836 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tys tady být neměla, Kei.</c>
+
+349
+00:30:39.089 --> 00:30:40.757 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>A kde bych měla být, Lee?</c>
+
+350
+00:30:40.841 --> 00:30:42.426 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Kdekoli jinde.</c>
+
+351
+00:31:21.882 --> 00:31:22.883 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Bože můj.</c>
+
+352
+00:31:25.636 --> 00:31:26.762 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co to je?</c>
+
+353
+00:31:34.061 --> 00:31:35.187 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Hnízdo.</c>
+
+354
+00:31:40.776 --> 00:31:41.902 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Proboha.</c>
+
+355
+00:31:42.986 --> 00:31:44.154 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Proto je tady.</c>
+
+356
+00:31:45.697 --> 00:31:46.698 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To je vejce.</c>
+
+357
+00:31:47.908 --> 00:31:49.785 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Titán si postavil hnízdo.</c>
+
+358
+00:32:06.885 --> 00:32:08.095 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Haló?</c>
+
+359
+00:32:08.178 --> 00:32:09.721 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Dochází nám čas, Kentaró.</c>
+
+360
+00:32:10.264 --> 00:32:11.974 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Už známe tvoji polohu.</c>
+
+361
+00:32:12.558 --> 00:32:14.142 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Celý tým čeká na rozkaz.</c>
+
+362
+00:32:14.685 --> 00:32:16.353 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Už jsi našel ty skaraby?</c>
+
+363
+00:32:17.312 --> 00:32:18.438 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Kentaró?</c>
+
+364
+00:32:18.522 --> 00:32:21.608 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jo, nevím, jestli by si to můj táta přál.</c>
+
+365
+00:32:21.692 --> 00:32:23.360 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Tvůj táta kvůli Cate umřel.</c>
+
+366
+00:32:25.821 --> 00:32:27.447 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ona není zlá.</c>
+
+367
+00:32:27.531 --> 00:32:29.199 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Ať má Cate v úmyslu cokoliv,</c>
+
+368
+00:32:29.283 --> 00:32:32.870 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>její přístup způsobí
+jen další úmrtí, další zkázu.</c>
+
+369
+00:32:37.040 --> 00:32:40.085 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Hele, jestli ten plán nevyjde,
+řekni mi to hned.</c>
+
+370
+00:32:44.923 --> 00:32:48.010 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Vyjde. Ten plán vyjde.</c>
+
+371
+00:32:48.594 --> 00:32:49.845 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216dotitalic>Skaraby neřeš.</c>
+
+372
+00:32:53.390 --> 00:32:55.142 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Řekni Trissopovi, že má vejce.</c>
+
+373
+00:32:56.894 --> 00:32:57.895 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Kde jsou?</c>
+
+374
+00:32:59.313 --> 00:33:00.314 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tak kde jsou?</c>
+
+375
+00:33:03.317 --> 00:33:05.277 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Dělá to, kvůli čemu přišla.</c>
+
+376
+00:33:06.945 --> 00:33:07.946 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Sakra.</c>
+
+377
+00:33:24.379 --> 00:33:27.007 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Skarabové postavili hnízdo
+pro titánovo mládě.</c>
+
+378
+00:33:27.090 --> 00:33:29.009 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jako že jich bude víc?</c>
+
+379
+00:33:29.092 --> 00:33:31.094 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Říkám, že nám nechce ublížit.</c>
+
+380
+00:33:31.178 --> 00:33:32.554 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tím se všechno mění.</c>
+
+381
+00:33:33.347 --> 00:33:36.642 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Z toho titána je matka.
+Proto teď nemůže odejít.</c>
+
+382
+00:33:57.496 --> 00:34:01.667 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Time! Je tady, pár minut od pobřeží.
+- Špatný… to je špatný.</c>
+
+383
+00:34:01.750 --> 00:34:03.126 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Mluvte.</c>
+
+384
+00:34:03.210 --> 00:34:06.505 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>V Pacifiku se objevila Godzilla
+a rychle míří sem.</c>
+
+385
+00:34:06.588 --> 00:34:07.589 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Kvůli Shawovi?</c>
+
+386
+00:34:07.673 --> 00:34:11.760 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Možná. Nebo si všimla, že je Titán X
+mimo trasu, a objevila se sama.</c>
+
+387
+00:34:12.553 --> 00:34:14.221 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Kdy tam bude záchranný tým?</c>
+
+388
+00:34:14.304 --> 00:34:15.389 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Za pět minut.</c>
+
+389
+00:34:15.472 --> 00:34:17.099 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To nestihnou. Honem!</c>
+
+390
+00:34:17.181 --> 00:34:18.183 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Pane?
+- Ano?</c>
+
+391
+00:34:18.266 --> 00:34:20.811 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Neznámá vozidla narušila
+perimetr Monarchu.</c>
+
+392
+00:34:20.893 --> 00:34:23.272 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Jaká? Viděli jste je?
+- Ne. Nereagují.</c>
+
+393
+00:34:23.355 --> 00:34:27.025 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Chci velitele flotily.
+Nikdo nebude blíž než 160 km od pobřeží.</c>
+
+394
+00:34:27.109 --> 00:34:28.652 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Musíme s tím počkat.</c>
+
+395
+00:34:42.541 --> 00:34:44.710 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Hej, Cate. Musíme jít.</c>
+
+396
+00:34:45.668 --> 00:34:46.670 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Dělej, Cate!</c>
+
+397
+00:35:00.851 --> 00:35:01.852 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Cate!</c>
+
+398
+00:35:19.578 --> 00:35:21.288 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Musíme je dostat pryč.</c>
+
+399
+00:35:27.377 --> 00:35:29.379 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Sakra. Možná tamtudy neprojedeme.</c>
+
+400
+00:35:30.130 --> 00:35:31.215 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Musíme pryč!</c>
+
+401
+00:35:39.306 --> 00:35:40.307 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Jsme na místě.</c>
+
+402
+00:35:41.225 --> 00:35:43.644 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tamhle je! Jdeme!</c>
+
+403
+00:36:00.285 --> 00:36:01.286 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>To je to vejce?</c>
+
+404
+00:36:04.957 --> 00:36:06.333 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Co dělají?</c>
+
+405
+00:36:07.000 --> 00:36:09.002 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Kentaró, co se sakra děje?</c>
+
+406
+00:36:12.464 --> 00:36:13.465 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Cate, musíme jít.</c>
+
+407
+00:36:17.469 --> 00:36:18.470 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Tys mi lhal!</c>
+
+408
+00:36:19.137 --> 00:36:20.764 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Jsi s nimi!
+- Nejsem.</c>
+
+409
+00:36:20.848 --> 00:36:22.474 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ale tohle se stát musí.</c>
+
+410
+00:36:25.853 --> 00:36:26.937 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Pohyb!</c>
+
+411
+00:36:27.020 --> 00:36:28.939 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Náklad máme na dohled.</c>
+
+412
+00:37:05.142 --> 00:37:08.020 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Můj tým tady zůstane,
+dokud cíl nebude zajištěn.</c>
+
+413
+00:37:08.103 --> 00:37:09.104 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Rozumím.</c>
+
+414
+00:37:09.771 --> 00:37:14.735 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Dvojko, trojko, odjezd!
+Jednička tady zůstane. Pohyb!</c>
+
+415
+00:37:34.421 --> 00:37:35.756 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Nelítejte před ně!</c>
+
+416
+00:37:57.027 --> 00:37:58.570 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Ježíši, nesejmulo je to?</c>
+
+417
+00:38:00.072 --> 00:38:01.073 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Dobrý.</c>
+
+418
+00:38:02.199 --> 00:38:04.826 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>- Mizíme. Rychle!
+- No tak!</c>
+
+419
+00:38:09.081 --> 00:38:10.999 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Oni to zvládnou. Rychle pryč.</c>
+
+420
+00:39:24.448 --> 00:39:26.450 align:middle line:85%,start position:50%,middle
+<c.styledotAB9216>Překlad titulků: Kristina Himmerová</c>
+

--- a/tests/libse/LibSETests.csproj
+++ b/tests/libse/LibSETests.csproj
@@ -63,6 +63,9 @@
     <Content Include="Files\sample_VodSub_windowStuffingWithoutPaddingStream.sub">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Files\sample_WebVTT_AppleTV.webvtt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -2,6 +2,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace LibSETests.SubtitleFormats;
@@ -15,6 +16,13 @@ public class WebVttTest
         var lines = new List<string>(vttContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None));
         format.LoadSubtitle(subtitle, lines, null);
         return subtitle;
+    }
+
+    private static Subtitle LoadWebVttFile(string fileName)
+    {
+        var path = Path.Combine(Directory.GetCurrentDirectory(), "Files", fileName);
+        var content = File.ReadAllText(path, System.Text.Encoding.UTF8);
+        return LoadWebVttSubtitle(content);
     }
 
     [Fact]
@@ -51,5 +59,86 @@ public class WebVttTest
         Assert.Equal(2, subtitle.Paragraphs.Count);
         Assert.Equal("Hello", subtitle.Paragraphs[0].Text);
         Assert.Equal("World", subtitle.Paragraphs[1].Text);
+    }
+
+    // Regression coverage for https://github.com/SubtitleEdit/subtitleedit/issues/10676
+    // Apple TV WebVTT files carry `X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000` (HLS segment metadata)
+    // and a STYLE block using class selectors like `.styledotAB9216dotitalic` for italic/bold/color.
+    // The sample file's first cue is `00:00:30.030 --> 00:00:34.243`.
+
+    [Fact]
+    public void AppleTVSample_XTimestampMap_Disabled_KeepsLocalTimeCodes()
+    {
+        var original = Configuration.Settings.SubtitleSettings.WebVttUseXTimestampMap;
+        try
+        {
+            Configuration.Settings.SubtitleSettings.WebVttUseXTimestampMap = false;
+
+            var subtitle = LoadWebVttFile("sample_WebVTT_AppleTV.webvtt");
+
+            Assert.NotEmpty(subtitle.Paragraphs);
+            Assert.Equal(30_030, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+            Assert.Equal(34_243, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        }
+        finally
+        {
+            Configuration.Settings.SubtitleSettings.WebVttUseXTimestampMap = original;
+        }
+    }
+
+    [Fact]
+    public void AppleTVSample_XTimestampMap_Enabled_ShiftsCuesByTenSeconds()
+    {
+        var original = Configuration.Settings.SubtitleSettings.WebVttUseXTimestampMap;
+        try
+        {
+            Configuration.Settings.SubtitleSettings.WebVttUseXTimestampMap = true;
+
+            var subtitle = LoadWebVttFile("sample_WebVTT_AppleTV.webvtt");
+
+            // MPEGTS 900000 / 90000 = 10s offset added to LOCAL 00:00:00.000.
+            Assert.NotEmpty(subtitle.Paragraphs);
+            Assert.Equal(40_030, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+            Assert.Equal(44_243, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        }
+        finally
+        {
+            Configuration.Settings.SubtitleSettings.WebVttUseXTimestampMap = original;
+        }
+    }
+
+    [Fact]
+    public void AppleTVSample_RemoveNativeFormatting_ConvertsStyleClassesToHtmlTags()
+    {
+        var subtitle = LoadWebVttFile("sample_WebVTT_AppleTV.webvtt");
+        var webVtt = new WebVTT();
+
+        // Cue 1: <c.styledotAB9216>...</c>  → bold + color (font-weight:bold; color:#AB9216)
+        // Cue 7: <c.styledotAB9216dotitalic>...</c>  → bold + italic + color
+        var cueAB9216 = subtitle.Paragraphs[0].Text;
+        var cueAB9216Italic = subtitle.Paragraphs[6].Text;
+
+        Assert.Contains("<c.styledotAB9216>", cueAB9216);
+        Assert.Contains("<c.styledotAB9216dotitalic>", cueAB9216Italic);
+
+        webVtt.RemoveNativeFormatting(subtitle, new SubRip());
+
+        var converted1 = subtitle.Paragraphs[0].Text;
+        var converted7 = subtitle.Paragraphs[6].Text;
+
+        // After conversion no class-based `<c...>` tags should remain.
+        Assert.DoesNotContain("<c.", converted1);
+        Assert.DoesNotContain("<c.", converted7);
+
+        // Cue 1 should carry bold + color from the STYLE block.
+        Assert.Contains("<b>", converted1);
+        Assert.Contains("</b>", converted1);
+        Assert.Contains("#AB9216", converted1);
+
+        // Cue 7 should additionally carry italic.
+        Assert.Contains("<i>", converted7);
+        Assert.Contains("</i>", converted7);
+        Assert.Contains("<b>", converted7);
+        Assert.Contains("#AB9216", converted7);
     }
 }


### PR DESCRIPTION
## Summary
  - `GetCueStyles`: ensure parsed CSS body ends with `;` so property matches    
  like `font-style:italic;` still hit when the source CSS omits the trailing `;`
   (common in Apple TV WebVTT).                                                 
  - `FindBestColorTagOrDefault`: fall back to reading `color:` from the matching
   STYLE block body when the class name itself doesn't encode a color (e.g.
  `.styledotAB9216`), and skip `background-color:` correctly.
  - New regression tests plus an Apple TV sample file covering the timestamp-map
   handling (on and off) and the class → `<i>`/`<b>`/`<font color>` conversion. 
   
  Fixes #10676                                                                  
                                                            
  ## Test plan                                                                  
  - [x] `dotnet test tests/libse/LibSETests.csproj --filter 
  "FullyQualifiedName~WebVtt"` → 16/16 pass                                     
  - [x] Full `LibSE` suite — no new failures (3 pre-existing `\r\n`/`\n`
  failures on macOS in unrelated tests)                                         
  - [x] `AppleTVSample_XTimestampMap_Disabled_KeepsLocalTimeCodes` — cue stays
  at `00:00:30.030`                                                             
  - [x] `AppleTVSample_XTimestampMap_Enabled_ShiftsCuesByTenSeconds` — cue
  shifted to `00:00:40.030` (HLS-spec behavior preserved)                       
  - [x] `AppleTVSample_RemoveNativeFormatting_ConvertsStyleClassesToHtmlTags` —
  `<c.styledotAB9216>` → `<font color="#AB9216"><b>…</b></font>`, combined class
   includes `<i>` too      