### PR TITLE
Remove redundant property assignments in ChangeCasingViewModel ctor

### DIFF
--- a/src/UI/Features/Tools/ChangeCasing/ChangeCasingViewModel.cs
+++ b/src/UI/Features/Tools/ChangeCasing/ChangeCasingViewModel.cs
@@ -29,13 +29,6 @@ public partial class ChangeCasingViewModel : ObservableObject
     public ChangeCasingViewModel(IWindowService windowService)
     {
         _windowService = windowService;
-
-        NormalCasing = Se.Settings.Tools.ChangeCasing.NormalCasing;
-        NormalCasingFixNames = Se.Settings.Tools.ChangeCasing.NormalCasingFixNames;
-        NormalCasingOnlyUpper = Se.Settings.Tools.ChangeCasing.NormalCasingOnlyUpper;
-        FixNamesOnly = Se.Settings.Tools.ChangeCasing.FixNamesOnly;
-        AllUppercase = Se.Settings.Tools.ChangeCasing.AllUppercase;
-        AllLowercase = Se.Settings.Tools.ChangeCasing.AllLowercase;
         _subtitle = new Subtitle();
         Subtitle = new Subtitle();
         Info = string.Empty;


### PR DESCRIPTION
## Summary

- `ChangeCasingViewModel`'s constructor directly assigned all 6 casing settings properties, then immediately called `LoadSettings()` which sets the exact same properties again — redundant work with no effect.
- Removed the 6 duplicate assignments; `LoadSettings()` now handles initialization on its own.

## Test plan

- [ ] Open **Tools → Change Casing**, verify all option checkboxes load correctly from saved settings
- [ ] Change casing options, click OK, reopen — confirm settings are persisted