### PR TITLE
Delete temp files between batch speech-to-text items - Fix #10694

### DIFF
--- a/src/UI/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/UI/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -730,6 +730,10 @@ public partial class SpeechToTextViewModel : ObservableObject
             LastBatchSubtitleFileName = subtitleFileName;
         }
 
+        // Delete temp files from the just-finished item so disk usage doesn't grow across long batches
+        DeleteTempFiles();
+        _filesToDelete.Clear();
+
         _batchIndex++;
         if (_batchIndex < BatchItems.Count)
         {


### PR DESCRIPTION
## Summary
- In batch speech-to-text mode, each item adds the extracted WAV (and any intermediate JSON/SRT/VTT/ASS result files) to `_filesToDelete`, but `DeleteTempFiles()` was only invoked on window close.
- For long batches of long audio files (reported on macOS with Whisper CPP large-v3-turbo), this filled up the user's temp directory until Subtitle Edit ran out of disk space.
- Now `StartNext` clears the temp files for the just-finished item before starting the next one. The on-close cleanup remains as a fallback for cancelled runs.

Reported by @xjlin0; root cause analysis by @cookesan in https://github.com/SubtitleEdit/subtitleedit/discussions/10694.

## Test plan
- [ ] Run batch speech-to-text on multiple non-16 kHz MP3s with Whisper CPP and confirm the temp directory does not grow across iterations.
- [ ] Cancel a batch mid-run and confirm window-close cleanup still removes any remaining temp files.
- [ ] Single-file (non-batch) mode still cleans up temp files on window close as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)