### PR TITLE
Add BinaryOcr engine to Batch Convert OCR engines

### DIFF
--- a/src/UI/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.Ocr;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -38,9 +39,13 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _paddleOcrLanguages;
     [ObservableProperty] private OcrLanguage2? _selectedPaddleOcrLanguage;
 
+    [ObservableProperty] private ObservableCollection<string> _binaryOcrDatabases;
+    [ObservableProperty] private string? _selectedBinaryOcrDatabase;
+
     [ObservableProperty] bool _isOcrLanguageVisible;
     [ObservableProperty] bool _isTesseractOcrVisible;
     [ObservableProperty] bool _isPaddleOCrVisible;
+    [ObservableProperty] bool _isBinaryOcrVisible;
 
     public Window? Window { get; set; }
 
@@ -53,7 +58,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         var encodings = EncodingHelper.GetEncodings().Select(p => p.DisplayName).ToList();
         TargetEncodings = new ObservableCollection<string>(encodings);
 
-        OcrEngines = new ObservableCollection<string> { "nOcr", "Tesseract", "Ollama" };
+        OcrEngines = new ObservableCollection<string> { "nOcr", "BinaryOcr", "Tesseract", "Ollama" };
         if (OperatingSystem.IsWindows() && File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe")))
         {
             OcrEngines.Add("PaddleOCR");
@@ -75,6 +80,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
 
         PaddleOcrLanguages = new ObservableCollection<OcrLanguage2>(PaddleOcr.GetLanguages().OrderBy(p => p.ToString()));
         TesseractDictionaryItems = new ObservableCollection<TesseractDictionary>();
+        BinaryOcrDatabases = new ObservableCollection<string>(BinaryOcrDb.GetDatabases());
 
         _folderHelper = folderHelper;
 
@@ -148,6 +154,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             Se.Settings.Tools.BatchConvert.PaddleLanguage = SelectedPaddleOcrLanguage?.Code ?? "en";
         }
 
+        if (ocrEngine == "BinaryOcr")
+        {
+            Se.Settings.Tools.BatchConvert.BinaryOcrDatabase = SelectedBinaryOcrDatabase ?? "Latin";
+        }
+
         Se.SaveSettings();
     }
 
@@ -204,9 +215,10 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             return;
         }
 
-        IsOcrLanguageVisible = ocrEngine != "nOcr";
+        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr";
         IsTesseractOcrVisible = ocrEngine == "Tesseract";
         IsPaddleOCrVisible = ocrEngine == "PaddleOCR";
+        IsBinaryOcrVisible = ocrEngine == "BinaryOcr";
 
         if (ocrEngine == "Tesseract")
         {
@@ -218,6 +230,12 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         {
             SelectedPaddleOcrLanguage = PaddleOcrLanguages
                 .FirstOrDefault(p => p.Code == Se.Settings.Tools.BatchConvert.PaddleLanguage) ?? PaddleOcrLanguages.FirstOrDefault();
+        }
+
+        if (ocrEngine == "BinaryOcr")
+        {
+            SelectedBinaryOcrDatabase = BinaryOcrDatabases
+                .FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.BinaryOcrDatabase) ?? BinaryOcrDatabases.FirstOrDefault();
         }
     }
 }

--- a/src/UI/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -75,15 +75,18 @@ public class BatchConvertSettingsWindow : Window
         var labelOcrEngine = UiUtil.MakeLabel(Se.Language.Ocr.OcrEngine);
         var comboBoxOcrEngine = UiUtil.MakeComboBox(vm.OcrEngines, vm, nameof(vm.SelectedOcrEngine));
         var labelOcLanguage = UiUtil.MakeLabel(Se.Language.General.Language).WithBindVisible(vm, nameof(vm.IsOcrLanguageVisible)).WithMarginLeft(10);
+        var labelBinaryOcrDatabase = UiUtil.MakeLabel(Se.Language.Ocr.Database).WithBindVisible(vm, nameof(vm.IsBinaryOcrVisible)).WithMarginLeft(10);
         var comboBoxTesseractLanguages = UiUtil.MakeComboBox(vm.TesseractDictionaryItems, vm, nameof(vm.SelectedTesseractDictionaryItem))
             .WithBindVisible(nameof(vm.IsTesseractOcrVisible));
         var comboBoxPaddleLanguages = UiUtil.MakeComboBox(vm.PaddleOcrLanguages, vm, nameof(vm.SelectedPaddleOcrLanguage))
             .WithBindVisible(nameof(vm.IsPaddleOCrVisible));
+        var comboBoxBinaryOcrDatabases = UiUtil.MakeComboBox(vm.BinaryOcrDatabases, vm, nameof(vm.SelectedBinaryOcrDatabase))
+            .WithBindVisible(nameof(vm.IsBinaryOcrVisible));
         var panelOcrEngine = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(0, 30, 0, 0),
-            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages }
+            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases }
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 

--- a/src/UI/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConverter.cs
@@ -65,10 +65,12 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     private readonly Dictionary<string, Regex> _compiledRegExList;
 
     private readonly INOcrCaseFixer _nOcrCaseFixer;
+    private readonly IBinaryOcrMatcher _binaryOcrMatcher;
 
-    public BatchConverter(INOcrCaseFixer nOcrCaseFixer)
+    public BatchConverter(INOcrCaseFixer nOcrCaseFixer, IBinaryOcrMatcher binaryOcrMatcher)
     {
         _nOcrCaseFixer = nOcrCaseFixer;
+        _binaryOcrMatcher = binaryOcrMatcher;
         _config = new BatchConvertConfig();
         _subtitleFormats = new List<SubtitleFormat>();
         _compiledRegExList = new Dictionary<string, Regex>();
@@ -274,6 +276,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("nOcr", StringComparison.OrdinalIgnoreCase))
             {
                 RunNOcr(imageSubtitle, item, cancellationToken);
+            }
+            else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("BinaryOcr", StringComparison.OrdinalIgnoreCase))
+            {
+                RunBinaryOcr(imageSubtitle, item, cancellationToken);
             }
             else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("PaddleOCR", StringComparison.OrdinalIgnoreCase))
             {
@@ -703,6 +709,96 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                     else
                     {
                         matches.Add(new NOcrChar { Text = _nOcrCaseFixer.FixUppercaseLowercaseIssues(splitterItem, match), Italic = match.Italic });
+                    }
+                }
+
+                index++;
+            }
+
+            var text = ItalicTextMerger.MergeWithItalicTags(matches).Trim();
+            results[i] = new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
+
+            lock (lockObj)
+            {
+                processedCount++;
+                var pct = processedCount * 100 / totalCount;
+                item.Status = string.Format(Se.Language.General.OcrPercentX, pct);
+            }
+        });
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            item.Status = Se.Language.General.Cancelled;
+            return;
+        }
+
+        foreach (var paragraph in results)
+        {
+            item.Subtitle.Paragraphs.Add(paragraph);
+        }
+    }
+
+    private void RunBinaryOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
+    {
+        var dbName = string.IsNullOrEmpty(Se.Settings.Tools.BatchConvert.BinaryOcrDatabase)
+            ? "Latin"
+            : Se.Settings.Tools.BatchConvert.BinaryOcrDatabase;
+        var fileName = Path.Combine(Se.OcrFolder, dbName + BinaryOcrDb.Extension);
+        if (!File.Exists(fileName))
+        {
+            item.Status = "BinaryOcr database not found: " + dbName;
+            return;
+        }
+
+        var binaryOcrDb = new BinaryOcrDb(fileName, true);
+        _binaryOcrMatcher.IsLatinDb = dbName.Contains("Latin", StringComparison.OrdinalIgnoreCase);
+        var pixelsAreSpace = Se.Settings.Ocr.BinaryOcrPixelsAreSpace;
+        var maxErrorPercent = Se.Settings.Ocr.BinaryOcrMaxErrorPercent;
+
+        item.Subtitle = new Subtitle();
+        var totalCount = imageSubtitles.Count;
+        var results = new Paragraph[totalCount];
+        var processedCount = 0;
+        var lockObj = new object();
+
+        Parallel.For(0, totalCount, new ParallelOptions
+        {
+            CancellationToken = cancellationToken,
+            MaxDegreeOfParallelism = Environment.ProcessorCount
+        }, i =>
+        {
+            var bitmap = imageSubtitles.GetBitmap(i);
+            var parentBitmap = new NikseBitmap2(bitmap);
+            parentBitmap.MakeTwoColor(200);
+            parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
+            var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, pixelsAreSpace, false, true, 20, true);
+            var index = 0;
+            var matches = new List<BinaryOcrMatcher.CompareMatch>();
+            while (index < letters.Count)
+            {
+                var splitterItem = letters[index];
+                if (splitterItem.NikseBitmap == null)
+                {
+                    if (splitterItem.SpecialCharacter != null)
+                    {
+                        matches.Add(new BinaryOcrMatcher.CompareMatch(splitterItem.SpecialCharacter, false, 0, nameof(splitterItem.SpecialCharacter)));
+                    }
+                }
+                else
+                {
+                    var match = _binaryOcrMatcher.GetCompareMatch(splitterItem, out _, letters, index, binaryOcrDb, maxErrorPercent);
+                    if (match is { ExpandCount: > 0 })
+                    {
+                        index += match.ExpandCount - 1;
+                    }
+
+                    if (match == null)
+                    {
+                        matches.Add(new BinaryOcrMatcher.CompareMatch("*", false, 0, null));
+                    }
+                    else
+                    {
+                        matches.Add(new BinaryOcrMatcher.CompareMatch(match.Text, match.Italic, match.ExpandCount, match.Name));
                     }
                 }
 

--- a/src/UI/Logic/Config/SeBatchConvert.cs
+++ b/src/UI/Logic/Config/SeBatchConvert.cs
@@ -12,6 +12,7 @@ public class SeBatchConvert
     public string OcrEngine { get; set; }
     public string TesseractLanguage { get; set; }
     public string PaddleLanguage { get; set; }
+    public string BinaryOcrDatabase { get; set; }
 
     public bool FormattingRemoveAll { get; set; }
     public bool FormattingRemoveItalic { get; set; }
@@ -59,6 +60,7 @@ public class SeBatchConvert
         OcrEngine = "Tesseract";
         TesseractLanguage = "eng";
         PaddleLanguage = "en";
+        BinaryOcrDatabase = "Latin";
         OffsetTimeCodesForward = true;
         AdjustVia = "Seconds"; 
         AdjustDurationSeconds = 0.1;


### PR DESCRIPTION
## Summary
- Add `BinaryOcr` to the OCR engines available in Batch Convert (alongside nOcr, Tesseract, Ollama, PaddleOCR).
- Add a `RunBinaryOcr` method to `BatchConverter` that loads the configured `.db` from the OCR folder and runs the binary image-compare matcher in parallel over each subtitle image.
- Add a `BinaryOcrDatabase` property to `SeBatchConvert` (default `Latin`) and persist the chosen database from the Batch Convert settings dialog.
- Surface a database picker in `BatchConvertSettingsWindow` that is shown only when BinaryOcr is the selected engine.

## Test plan
- [ ] Open Batch Convert settings, select `BinaryOcr` as the OCR engine, pick a database, click OK and reopen — selection should persist.
- [ ] Run a batch conversion of an image-based subtitle (e.g. Blu-ray sup) to a text format with BinaryOcr selected and verify recognised text is written.
- [ ] Verify other engines (nOcr, Tesseract, Ollama, PaddleOCR) still work after the dispatch change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)