### PR TITLE
Improve nOcr quality in Batch Convert

### DIFF
--- a/src/UI/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/UI/Features/Tools/BatchConvert/BatchConverter.cs
@@ -663,9 +663,29 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     {
         var fileName = Path.Combine(Se.OcrFolder, Se.Settings.Ocr.NOcrDatabase + ".nocr");
         var nOcrDb = new NOcrDb(fileName);
-        item.Subtitle = new Subtitle();
-
         var totalCount = imageSubtitles.Count;
+        var maxWrongPixels = Se.Settings.Ocr.NOcrMaxWrongPixels > 0 ? Se.Settings.Ocr.NOcrMaxWrongPixels : 25;
+
+        // Pre-flight: detect pixels-is-space from a sample of images.
+        var sampleSize = Math.Min(OcrPreflightSampleSize, totalCount);
+        var pixelsAreSpace = Se.Settings.Ocr.NOcrPixelsAreSpace > 0 ? Se.Settings.Ocr.NOcrPixelsAreSpace : 12;
+        if (sampleSize > 0)
+        {
+            item.Status = Se.Language.General.OcrDotDotDot;
+            var detected = DetectPixelsIsSpace(imageSubtitles, sampleSize, cancellationToken);
+            if (detected.HasValue)
+            {
+                pixelsAreSpace = detected.Value;
+            }
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            item.Status = Se.Language.General.Cancelled;
+            return;
+        }
+
+        item.Subtitle = new Subtitle();
         var results = new Paragraph[totalCount];
         var processedCount = 0;
         var lockObj = new object();
@@ -676,47 +696,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             MaxDegreeOfParallelism = Environment.ProcessorCount
         }, i =>
         {
-            var bitmap = imageSubtitles.GetBitmap(i);
-            var parentBitmap = new NikseBitmap2(bitmap);
-            parentBitmap.MakeTwoColor(200);
-            parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
-            var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, 12,
-                false, true, 20, true);
-            int index = 0;
-            var matches = new List<NOcrChar>();
-            while (index < letters.Count)
-            {
-                var splitterItem = letters[index];
-                if (splitterItem.NikseBitmap == null)
-                {
-                    if (splitterItem.SpecialCharacter != null)
-                    {
-                        matches.Add(new NOcrChar { Text = splitterItem.SpecialCharacter });
-                    }
-                }
-                else
-                {
-                    var match = nOcrDb!.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, 100);
-                    if (match is { ExpandCount: > 0 })
-                    {
-                        index += match.ExpandCount - 1;
-                    }
-
-                    if (match == null)
-                    {
-                        matches.Add(new NOcrChar { Text = "*" });
-                    }
-                    else
-                    {
-                        matches.Add(new NOcrChar { Text = _nOcrCaseFixer.FixUppercaseLowercaseIssues(splitterItem, match), Italic = match.Italic });
-                    }
-                }
-
-                index++;
-            }
-
-            var text = ItalicTextMerger.MergeWithItalicTags(matches).Trim();
-            results[i] = new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
+            results[i] = OcrSingleNOcrImage(imageSubtitles, i, nOcrDb, pixelsAreSpace, maxWrongPixels);
 
             lock (lockObj)
             {
@@ -736,9 +716,110 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         {
             item.Subtitle.Paragraphs.Add(paragraph);
         }
+
+        // Detect language from the pre-flight sample so downstream functions get the right code.
+        if (sampleSize > 0)
+        {
+            var sampleSubtitle = new Subtitle();
+            for (var i = 0; i < sampleSize; i++)
+            {
+                sampleSubtitle.Paragraphs.Add(results[i]);
+            }
+
+            var detectedLanguage = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(sampleSubtitle);
+            if (!string.IsNullOrEmpty(detectedLanguage))
+            {
+                Language = detectedLanguage;
+            }
+        }
     }
 
-    private const int BinaryOcrPreflightSampleSize = 50;
+    private Paragraph OcrSingleNOcrImage(IOcrSubtitle imageSubtitles, int i, NOcrDb nOcrDb, int pixelsAreSpace, int maxWrongPixels)
+    {
+        var bitmap = imageSubtitles.GetBitmap(i);
+        var parentBitmap = new NikseBitmap2(bitmap);
+        parentBitmap.MakeTwoColor(200);
+        parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
+        var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, pixelsAreSpace,
+            false, true, 20, true);
+        var index = 0;
+        var matches = new List<NOcrChar>();
+        while (index < letters.Count)
+        {
+            var splitterItem = letters[index];
+            if (splitterItem.NikseBitmap == null)
+            {
+                if (splitterItem.SpecialCharacter != null)
+                {
+                    matches.Add(new NOcrChar { Text = splitterItem.SpecialCharacter, ImageSplitterItem = splitterItem });
+                }
+            }
+            else
+            {
+                var match = nOcrDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, maxWrongPixels);
+                if (match is { ExpandCount: > 0 })
+                {
+                    index += match.ExpandCount - 1;
+                }
+
+                if (match == null)
+                {
+                    matches.Add(new NOcrChar { Text = "*", ImageSplitterItem = splitterItem });
+                }
+                else
+                {
+                    matches.Add(new NOcrChar
+                    {
+                        Text = _nOcrCaseFixer.FixUppercaseLowercaseIssues(splitterItem, match),
+                        Italic = match.Italic,
+                        ExpandCount = match.ExpandCount,
+                        ImageSplitterItem = splitterItem,
+                    });
+                }
+            }
+
+            index++;
+        }
+
+        matches = RemoveSpacesAfter1(matches, pixelsAreSpace);
+
+        var text = ItalicTextMerger.MergeWithItalicTags(matches).Trim();
+        return new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
+    }
+
+    private static List<NOcrChar> RemoveSpacesAfter1(List<NOcrChar> matches, int pixelsAreSpace)
+    {
+        var deleteItems = new List<NOcrChar>();
+        for (var i = 0; i < matches.Count - 1; i++)
+        {
+            var match = matches[i];
+            if (match.Text.EndsWith("1", StringComparison.Ordinal) && !match.Italic)
+            {
+                var pixelsLess = 0;
+                if (pixelsAreSpace > 7)
+                {
+                    pixelsLess = (int)Math.Round(pixelsAreSpace * 0.3m, MidpointRounding.AwayFromZero);
+                }
+
+                var nextMatch = matches[i + 1];
+                if (nextMatch.ImageSplitterItem != null &&
+                    nextMatch.ImageSplitterItem.SpecialCharacter == " " &&
+                    nextMatch.ImageSplitterItem.SpacePixels - pixelsLess < pixelsAreSpace)
+                {
+                    deleteItems.Add(nextMatch);
+                }
+            }
+        }
+
+        foreach (var deleteItem in deleteItems)
+        {
+            matches.Remove(deleteItem);
+        }
+
+        return matches;
+    }
+
+    private const int OcrPreflightSampleSize = 50;
 
     private void RunBinaryOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
@@ -758,12 +839,12 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         var totalCount = imageSubtitles.Count;
 
         // Pre-flight: detect pixels-is-space from a sample of images.
-        var sampleSize = Math.Min(BinaryOcrPreflightSampleSize, totalCount);
+        var sampleSize = Math.Min(OcrPreflightSampleSize, totalCount);
         var pixelsAreSpace = Se.Settings.Ocr.BinaryOcrPixelsAreSpace;
         if (sampleSize > 0)
         {
             item.Status = Se.Language.General.OcrDotDotDot;
-            var detected = DetectBinaryOcrPixelsIsSpace(imageSubtitles, sampleSize, cancellationToken);
+            var detected = DetectPixelsIsSpace(imageSubtitles, sampleSize, cancellationToken);
             if (detected.HasValue)
             {
                 pixelsAreSpace = detected.Value;
@@ -869,7 +950,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         return new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
     }
 
-    private static int? DetectBinaryOcrPixelsIsSpace(IOcrSubtitle imageSubtitles, int sampleSize, CancellationToken cancellationToken)
+    private static int? DetectPixelsIsSpace(IOcrSubtitle imageSubtitles, int sampleSize, CancellationToken cancellationToken)
     {
         var gaps = new List<int>(1024);
         for (var i = 0; i < sampleSize; i++)


### PR DESCRIPTION
## Summary
nOcr in Batch Convert produced noticeably worse output than the OCR window's nOcr. Three fixes:

- **Use `Se.Settings.Ocr.NOcrMaxWrongPixels`** (default 25) for `nOcrDb.GetMatch` instead of the hardcoded `100`. At 100 the looser tiers in `NOcrDb.GetMatch` — including the `deepSeek` branch with `IsMatch(bitmap, oc, 100)` — accept many false matches; 25 is what the OCR window uses by default.
- **Add the same pre-flight pass that BinaryOcr has**: sample the first ~50 image subtitles, run the splitter, and use Otsu's method on the gap-width distribution to pick `pixels-is-space` (fallback `Se.Settings.Ocr.NOcrPixelsAreSpace`, or 12). After OCR, detect language from the same sample and write to `BatchConverter.Language`. The helper constants and methods dropped their `BinaryOcr` prefix since the analysis is engine-agnostic.
- **Port `RemoveSpacesAfter1`** from `OcrViewModel`: drops a spurious space after a `"1"` when the gap is below threshold, mirroring the post-processing of the normal nOcr loop. Per-image OCR was factored into `OcrSingleNOcrImage` so the loop stays readable.

## Note
PR #10698 (nOcr autodetect) was opened with `binaryocr-batch-autodetect` as its base and ended up merged into that branch rather than `main`, so its changes never reached `main`. This PR re-applies them on top of `main` and adds the `maxWrongPixels` and `RemoveSpacesAfter1` fixes that were missing.

## Test plan
- [ ] Run Batch Convert with nOcr engine on the same Blu-ray sup that previously produced poor output; verify quality matches the OCR window's nOcr.
- [ ] Verify words containing `"1"` no longer get a spurious space after them.
- [ ] Confirm language is detected correctly and downstream functions act on it.
- [ ] Cancel mid-pre-flight: bails cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)