### PR TITLE
Qwen3 TTS: add 1.7B Base model option

### DIFF
--- a/src/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -497,9 +497,10 @@ public partial class DownloadTtsViewModel : ObservableObject
             _qwen3TtsCppDownloadService.DownloadEngine(_downloadStreamQwen3TtsCpp, downloadProgress, _cancellationTokenSource.Token);
     }
 
-    public void StartDownloadQwen3TtsModels()
+    public void StartDownloadQwen3TtsModels(string? modelKey = null)
     {
-        TitleText = "Downloading Qwen3 TTS models (~2.8 GB)";
+        var ttsModelFileName = Qwen3TtsCpp.GetModelFileName(Qwen3TtsCpp.ResolveModelKey(modelKey));
+        TitleText = $"Downloading Qwen3 TTS models ({ttsModelFileName})";
 
         var downloadProgress = new Progress<float>(number =>
         {
@@ -515,7 +516,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         });
 
         _downloadTaskQwen3TtsModels =
-            _qwen3TtsCppDownloadService.DownloadModels(Qwen3TtsCpp.GetSetModelsFolder(), downloadProgress, titleProgress, _cancellationTokenSource.Token);
+            _qwen3TtsCppDownloadService.DownloadModels(Qwen3TtsCpp.GetSetModelsFolder(), ttsModelFileName, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     internal void OnKeyDown(KeyEventArgs e)

--- a/src/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -24,11 +24,32 @@ public class Qwen3TtsCpp : ITtsEngine
     public bool HasLanguageParameter => false;
     public bool HasApiKey => false;
     public bool HasRegion => false;
-    public bool HasModel => false;
+    public bool HasModel => true;
     public bool HasKeyFile => false;
 
-    public const string TtsModelFileName = "qwen3-tts-0.6b-q8_0.gguf";
+    public const string ModelKey06B = "0.6B";
+    public const string ModelKey17BBase = "1.7B Base";
+    public const string DefaultModelKey = ModelKey06B;
+
+    public const string TtsModelFileName06B = "qwen3-tts-0.6b-q8_0.gguf";
+    public const string TtsModelFileName17BBase = "Qwen3-TTS-12Hz-1.7B-Base-q8_0.gguf";
     public const string TokenizerModelFileName = "qwen3-tts-tokenizer-q8_0.gguf";
+
+    public static string GetModelFileName(string? modelKey) => modelKey switch
+    {
+        ModelKey17BBase => TtsModelFileName17BBase,
+        _ => TtsModelFileName06B,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : saved;
+        }
+        return modelKey;
+    }
 
     private static readonly HttpClient HttpClient = new()
     {
@@ -37,6 +58,7 @@ public class Qwen3TtsCpp : ITtsEngine
     private static readonly SemaphoreSlim ServerLock = new(1, 1);
     private static Process? _serverProcess;
     private static int _serverPort;
+    private static string? _serverModelFileName;
     private static bool _processExitHooked;
 
     private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
@@ -46,10 +68,11 @@ public class Qwen3TtsCpp : ITtsEngine
         return Task.FromResult(File.Exists(GetExecutableFileName()));
     }
 
-    public static bool IsModelsInstalled()
+    public static bool IsModelsInstalled(string? modelKey = null)
     {
         var modelsFolder = GetSetModelsFolder();
-        return File.Exists(Path.Combine(modelsFolder, TtsModelFileName)) &&
+        var resolved = ResolveModelKey(modelKey);
+        return File.Exists(Path.Combine(modelsFolder, GetModelFileName(resolved))) &&
                File.Exists(Path.Combine(modelsFolder, TokenizerModelFileName));
     }
 
@@ -127,7 +150,7 @@ public class Qwen3TtsCpp : ITtsEngine
 
     public Task<string[]> GetModels()
     {
-        return Task.FromResult(Array.Empty<string>());
+        return Task.FromResult(new[] { ModelKey06B, ModelKey17BBase });
     }
 
     public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model)
@@ -154,7 +177,8 @@ public class Qwen3TtsCpp : ITtsEngine
             throw new ArgumentException("Voice is not a Qwen3TtsVoice");
         }
 
-        await EnsureServerRunningAsync(cancellationToken);
+        var modelFileName = GetModelFileName(ResolveModelKey(model));
+        await EnsureServerRunningAsync(modelFileName, cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
         var inputText = Utilities.UnbreakLine(text);
@@ -211,9 +235,9 @@ public class Qwen3TtsCpp : ITtsEngine
         }
     }
 
-    private static async Task EnsureServerRunningAsync(CancellationToken ct)
+    private static async Task EnsureServerRunningAsync(string modelFileName, CancellationToken ct)
     {
-        if (_serverProcess is { HasExited: false } && _serverPort != 0)
+        if (_serverProcess is { HasExited: false } && _serverPort != 0 && _serverModelFileName == modelFileName)
         {
             return;
         }
@@ -221,9 +245,15 @@ public class Qwen3TtsCpp : ITtsEngine
         await ServerLock.WaitAsync(ct);
         try
         {
-            if (_serverProcess is { HasExited: false } && _serverPort != 0)
+            if (_serverProcess is { HasExited: false } && _serverPort != 0 && _serverModelFileName == modelFileName)
             {
                 return;
+            }
+
+            // Different model selected, or server not running — (re)start with the requested model.
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
             }
 
             var exe = GetExecutableFileName();
@@ -245,7 +275,7 @@ public class Qwen3TtsCpp : ITtsEngine
             psi.ArgumentList.Add("-m");
             psi.ArgumentList.Add(GetSetModelsFolder());
             psi.ArgumentList.Add("--model-name");
-            psi.ArgumentList.Add(TtsModelFileName);
+            psi.ArgumentList.Add(modelFileName);
             psi.ArgumentList.Add("--host");
             psi.ArgumentList.Add("127.0.0.1");
             psi.ArgumentList.Add("--port");
@@ -268,6 +298,7 @@ public class Qwen3TtsCpp : ITtsEngine
 
             _serverProcess = process;
             _serverPort = port;
+            _serverModelFileName = modelFileName;
             HookProcessExitOnce();
 
             var deadline = DateTime.UtcNow.AddSeconds(120);
@@ -279,6 +310,7 @@ public class Qwen3TtsCpp : ITtsEngine
                     var tail = SnapshotStderr(stderrBuffer);
                     _serverProcess = null;
                     _serverPort = 0;
+                    _serverModelFileName = null;
                     throw new InvalidOperationException(
                         $"qwen3-tts-server exited during startup (code {process.ExitCode}). Output: {tail}");
                 }
@@ -363,6 +395,7 @@ public class Qwen3TtsCpp : ITtsEngine
         var p = _serverProcess;
         _serverProcess = null;
         _serverPort = 0;
+        _serverModelFileName = null;
         if (p == null) return;
         try
         {

--- a/src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -249,7 +249,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 continue;
             }
 
-            if (engineItem is Qwen3TtsCpp && (!File.Exists(Qwen3TtsCpp.GetExecutableFileName()) || !Qwen3TtsCpp.IsModelsInstalled()))
+            if (engineItem is Qwen3TtsCpp && (!File.Exists(Qwen3TtsCpp.GetExecutableFileName())
+                || (!Qwen3TtsCpp.IsModelsInstalled(Qwen3TtsCpp.ModelKey06B)
+                    && !Qwen3TtsCpp.IsModelsInstalled(Qwen3TtsCpp.ModelKey17BBase))))
             {
                 continue;
             }
@@ -914,6 +916,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Enumerable.First<string>(Models);
+                }
+            }
+            else if (engine is Qwen3TtsCpp)
+            {
+                SelectedModel = Enumerable.FirstOrDefault<string>(Models, p => p == Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Enumerable.FirstOrDefault<string>(Models);
                 }
             }
         });

--- a/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -229,6 +229,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             Se.Settings.Video.TextToSpeech.MistralApiKey = ApiKey;
             Se.Settings.Video.TextToSpeech.MistralModel = SelectedModel ?? "voxtral-mini-tts-2603";
         }
+        else if (SelectedEngine is Qwen3TtsCpp)
+        {
+            Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel = SelectedModel ?? Qwen3TtsCpp.DefaultModelKey;
+        }
         else if (SelectedEngine is Murf)
         {
             Se.Settings.Video.TextToSpeech.MurfApiKey = ApiKey;
@@ -633,12 +637,14 @@ public partial class TextToSpeechViewModel : ObservableObject
                 });
             }
 
-            if (!Qwen3TtsCpp.IsModelsInstalled())
+            var qwen3ModelKey = Qwen3TtsCpp.ResolveModelKey(SelectedModel);
+            if (!Qwen3TtsCpp.IsModelsInstalled(qwen3ModelKey))
             {
+                var sizeText = qwen3ModelKey == Qwen3TtsCpp.ModelKey17BBase ? "~2.7 GB" : "~1.6 GB";
                 var answer = await MessageBox.Show(
                     Window,
                     "Download Qwen3 TTS models?",
-                    $"{Environment.NewLine}\"Qwen3 TTS\" requires models (~1.6 GB).{Environment.NewLine}{Environment.NewLine}Download models?",
+                    $"{Environment.NewLine}\"Qwen3 TTS\" ({qwen3ModelKey}) requires models ({sizeText}).{Environment.NewLine}{Environment.NewLine}Download models?",
                     MessageBoxButtons.YesNoCancel,
                     MessageBoxIcon.Question);
 
@@ -647,8 +653,8 @@ public partial class TextToSpeechViewModel : ObservableObject
                     return false;
                 }
 
-                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadQwen3TtsModels());
-                return dlResult.OkPressed && Qwen3TtsCpp.IsModelsInstalled();
+                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadQwen3TtsModels(qwen3ModelKey));
+                return dlResult.OkPressed && Qwen3TtsCpp.IsModelsInstalled(qwen3ModelKey);
             }
 
             return true;
@@ -1367,6 +1373,14 @@ public partial class TextToSpeechViewModel : ObservableObject
             {
                 ApiKey = Se.Settings.Video.TextToSpeech.MistralApiKey;
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.MistralModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+            }
+            else if (SelectedEngine is Qwen3TtsCpp)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/UI/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/UI/Logic/Config/SeVideoTextToSpeech.cs
@@ -25,6 +25,7 @@ public class SeVideoTextToSpeech
     public string MurfStyle { get; set; }
     public string MistralApiKey { get; set; }
     public string MistralModel { get; set; }
+    public string Qwen3TtsCppModel { get; set; }
     public string GoogleApiKey { get; set; }
     public string GoogleKeyFile { get; set; }
 
@@ -81,6 +82,7 @@ public class SeVideoTextToSpeech
         MurfStyle = "Conversational";
         MistralApiKey = string.Empty;
         MistralModel = "voxtral-mini-tts-2603";
+        Qwen3TtsCppModel = "0.6B";
         GoogleApiKey = string.Empty;
         GoogleKeyFile = string.Empty;
         ProAudioChainEnabled = false;

--- a/src/UI/Logic/Download/Qwen3TtsCppDownloadService.cs
+++ b/src/UI/Logic/Download/Qwen3TtsCppDownloadService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -11,21 +12,29 @@ public interface IQwen3TtsCppDownloadService
 {
     Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadVoices(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
-    Task DownloadModels(string modelsFolder, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+    Task DownloadModels(string modelsFolder, string ttsModelFileName, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
 }
 
 public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.0/qwen3-tts-server-v0.4.0-windows-vulkan-x64.zip";
+    private const string WindowsUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.1/qwen3-tts-server-v0.4.1-windows-vulkan-x64.zip";
     // Linux / macOS server builds are not yet published. The engine (Qwen3TtsCpp.cs)
     // expects the qwen3-tts-server binary; the old CLI zips below will no longer work.
-    private const string MacUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.0/qwen3-tts-server-v0.4.0-macos-metal-arm64.zip";
-    private const string LinuxUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.0/qwen3-tts-server-v0.4.0-linux-vulkan-x64.zip";
+    private const string MacUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.1/qwen3-tts-server-v0.4.1-macos-metal-arm64.zip";
+    private const string LinuxUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.1/qwen3-tts-server-v0.4.1-linux-vulkan-x64.zip";
 
-    private const string TtsModelUrl = "https://huggingface.co/koboldcpp/tts/resolve/main/qwen3-tts-0.6b-q8_0.gguf";
+    private const string TokenizerModelFileName = "qwen3-tts-tokenizer-q8_0.gguf";
     private const string TokenizerModelUrl = "https://huggingface.co/koboldcpp/tts/resolve/main/qwen3-tts-tokenizer-q8_0.gguf";
+
+    private static readonly Dictionary<string, string> TtsModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["qwen3-tts-0.6b-q8_0.gguf"] = "https://huggingface.co/koboldcpp/tts/resolve/main/qwen3-tts-0.6b-q8_0.gguf",
+        // khimaros' rebuild includes the projection tensor (named code_pred.mtp_proj.*) that
+        // qwen3-tts.cpp needs for the 1.7B variant. The koboldcpp upload predates that change.
+        ["Qwen3-TTS-12Hz-1.7B-Base-q8_0.gguf"] = "https://huggingface.co/khimaros/Qwen3-TTS-12Hz-1.7B-Base-GGUF/resolve/main/Qwen3-TTS-12Hz-1.7B-Base-Q8_0.gguf",
+    };
 
     private const string VoicesUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-tts-cpp-2026-4/voices.zip";
 
@@ -44,12 +53,32 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
         await DownloadHelper.DownloadFileAsync(_httpClient, VoicesUrl, stream, progress, cancellationToken);
     }
 
-    public async Task DownloadModels(string modelsFolder, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    public async Task DownloadModels(string modelsFolder, string ttsModelFileName, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
     {
-        titleProgress?.Invoke("Downloading Qwen3 TTS models (1/2): qwen3-tts-0.6b-q8_0.gguf");
-        await DownloadHelper.DownloadFileAsync(_httpClient, TtsModelUrl, Path.Combine(modelsFolder, "qwen3-tts-0.6b-q8_0.gguf"), progress, cancellationToken);
-        titleProgress?.Invoke("Downloading Qwen3 TTS models (2/2): qwen3-tts-tokenizer-q8_0.gguf");
-        await DownloadHelper.DownloadFileAsync(_httpClient, TokenizerModelUrl, Path.Combine(modelsFolder, "qwen3-tts-tokenizer-q8_0.gguf"), progress, cancellationToken);
+        if (!TtsModelUrls.TryGetValue(ttsModelFileName, out var ttsModelUrl))
+        {
+            throw new ArgumentException($"Unknown Qwen3 TTS model: {ttsModelFileName}", nameof(ttsModelFileName));
+        }
+
+        var ttsModelPath = Path.Combine(modelsFolder, ttsModelFileName);
+        var tokenizerPath = Path.Combine(modelsFolder, TokenizerModelFileName);
+        var needTts = !File.Exists(ttsModelPath);
+        var needTokenizer = !File.Exists(tokenizerPath);
+        var total = (needTts ? 1 : 0) + (needTokenizer ? 1 : 0);
+        var step = 0;
+
+        if (needTts)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Qwen3 TTS models ({step}/{total}): {ttsModelFileName}");
+            await DownloadHelper.DownloadFileAsync(_httpClient, ttsModelUrl, ttsModelPath, progress, cancellationToken);
+        }
+        if (needTokenizer)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Qwen3 TTS models ({step}/{total}): {TokenizerModelFileName}");
+            await DownloadHelper.DownloadFileAsync(_httpClient, TokenizerModelUrl, tokenizerPath, progress, cancellationToken);
+        }
     }
 
     private static string GetUrl()

--- a/tests/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCppTests.cs
@@ -1,0 +1,25 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+public class Qwen3TtsCppTests
+{
+    [Fact]
+    public async Task GetModels_Returns_BothVariants()
+    {
+        var engine = new Qwen3TtsCpp();
+        var models = await engine.GetModels();
+
+        Assert.Equal(new[] { Qwen3TtsCpp.ModelKey06B, Qwen3TtsCpp.ModelKey17BBase }, models);
+    }
+
+    [Theory]
+    [InlineData(Qwen3TtsCpp.ModelKey06B, Qwen3TtsCpp.TtsModelFileName06B)]
+    [InlineData(Qwen3TtsCpp.ModelKey17BBase, Qwen3TtsCpp.TtsModelFileName17BBase)]
+    [InlineData("unknown", Qwen3TtsCpp.TtsModelFileName06B)]
+    [InlineData(null, Qwen3TtsCpp.TtsModelFileName06B)]
+    public void GetModelFileName_MapsKeyToFile(string? key, string expected)
+    {
+        Assert.Equal(expected, Qwen3TtsCpp.GetModelFileName(key));
+    }
+}


### PR DESCRIPTION
## Summary
- Lets users pick between **Qwen3-TTS 0.6B** (existing default) and **Qwen3-TTS-12Hz-1.7B-Base** in the standard model dropdown.
- Bumps the bundled `qwen3-tts-server` to **v0.4.1**, which accepts the alternate `code_pred.mtp_proj.*` tensor naming used by khimaros' GGUFs (see niksedk/qwen3-tts.cpp#11).
- Each variant downloads only its own ~1.3–2.5 GB weights file; the ~261 MB tokenizer/vocoder is shared across both.

## What changed
- `Qwen3TtsCpp` now reports `HasModel = true` and exposes two options: `"0.6B"` and `"1.7B Base"`.
- The local HTTP server is restarted on the fly when the user switches between models.
- `IsModelsInstalled(modelKey)` lets the install/download flow only download the missing variant.
- User's choice is persisted in `Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel` (default `"0.6B"` — backward-compatible).
- `ReviewSpeechViewModel` keeps Qwen3 in its engine picker when *either* variant is installed.
- 1.7B URL points to `khimaros/Qwen3-TTS-12Hz-1.7B-Base-GGUF` Q8_0 (the koboldcpp upload predates the projection-tensor change in qwen3-tts.cpp). 0.6B URL unchanged.
- 5 new xUnit tests for the model-key / filename mapping.

## Test plan
- [x] `dotnet build src/UI/UI.csproj` clean (0 warnings, 0 errors).
- [x] `dotnet test --filter Qwen3TtsCpp` → 5/5 pass.
- [x] Verified end-to-end on Windows: 0.6B server starts, synthesizes a 2.2 s WAV; 1.7B Base server starts (with v0.4.1 binary), synthesizes a 3.9 s WAV. Switching between models in the UI restarts the server cleanly.
- [x] Tokenizer file is correctly skipped when already present (no double-download when switching variants).
- [ ] Linux/macOS server zips updated to v0.4.1 same as Windows — please sanity-check on those platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)