### PR TITLE
Qwen3 TTS: prompt for CPU vs Vulkan build on Windows

### DIFF
--- a/src/UI/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/UI/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1311,40 +1311,6 @@ public partial class SpeechToTextViewModel : ObservableObject
                model.Name == "distil-large-v3";
     }
 
-    private static bool IsVulkanInstalled()
-    {
-        const string vulkanDll = "vulkan-1.dll";
-
-        var systemRoot = Environment.GetFolderPath(Environment.SpecialFolder.System);
-        if (File.Exists(Path.Combine(systemRoot, vulkanDll)))
-        {
-            return true;
-        }
-
-        var sysWow64 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "SysWOW64");
-        if (File.Exists(Path.Combine(sysWow64, vulkanDll)))
-        {
-            return true;
-        }
-
-        var pathVariable = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-        foreach (var folder in pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            try
-            {
-                if (File.Exists(Path.Combine(folder, vulkanDll)))
-                {
-                    return true;
-                }
-            }
-            catch
-            {
-                // ignore invalid/inaccessible path entries
-            }
-        }
-
-        return false;
-    }
 
 
     [RelayCommand]
@@ -1624,7 +1590,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                     _ => "vulkan",
                 };
 
-                if (crispVariant == "vulkan" && !IsVulkanInstalled())
+                if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
                 {
                     var vulkanAnswer = await MessageBox.Show(
                         Window!,

--- a/src/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -481,9 +481,9 @@ public partial class DownloadTtsViewModel : ObservableObject
             downloadProgressNull, _cancellationTokenSource.Token);
     }
 
-    public void StartDownloadQwen3TtsCpp()
+    public void StartDownloadQwen3TtsCpp(string windowsVariant = Qwen3TtsCppDownloadService.WindowsVariantVulkan)
     {
-        TitleText = "Downloading Qwen3 TTS";
+        TitleText = $"Downloading Qwen3 TTS ({windowsVariant})";
 
         var downloadProgress = new Progress<float>(number =>
         {
@@ -494,7 +494,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         });
 
         _downloadTaskQwen3TtsCpp =
-            _qwen3TtsCppDownloadService.DownloadEngine(_downloadStreamQwen3TtsCpp, downloadProgress, _cancellationTokenSource.Token);
+            _qwen3TtsCppDownloadService.DownloadEngine(_downloadStreamQwen3TtsCpp, windowsVariant, downloadProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadQwen3TtsModels(string? modelKey = null)

--- a/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -613,24 +613,69 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             if (!await engine.IsInstalled(SelectedRegion))
             {
-                var answer = await MessageBox.Show(
-                    Window,
-                    "Download Qwen3 TTS?",
-                    $"{Environment.NewLine}\"Text to speech\" requires Qwen3 TTS.{Environment.NewLine}{Environment.NewLine}Download and use Qwen3 TTS?",
-                    MessageBoxButtons.YesNoCancel,
-                    MessageBoxIcon.Question);
-
-                if (answer != MessageBoxResult.Yes)
+                var qwen3Variant = Qwen3TtsCppDownloadService.WindowsVariantVulkan;
+                if (Configuration.IsRunningOnWindows)
                 {
-                    return false;
+                    var variantAnswer = await MessageBox.Show(
+                        Window,
+                        "Download Qwen3 TTS?",
+                        $"{Environment.NewLine}\"Text to speech\" requires Qwen3 TTS.{Environment.NewLine}{Environment.NewLine}Select a build to download:",
+                        MessageBoxButtons.Cancel,
+                        MessageBoxIcon.Question,
+                        "CPU",
+                        "Vulkan");
+
+                    if (variantAnswer == MessageBoxResult.None || variantAnswer == MessageBoxResult.Cancel)
+                    {
+                        return false;
+                    }
+
+                    qwen3Variant = variantAnswer == MessageBoxResult.Custom1
+                        ? Qwen3TtsCppDownloadService.WindowsVariantCpu
+                        : Qwen3TtsCppDownloadService.WindowsVariantVulkan;
+
+                    if (qwen3Variant == Qwen3TtsCppDownloadService.WindowsVariantVulkan && !VulkanHelper.IsInstalled())
+                    {
+                        var vulkanAnswer = await MessageBox.Show(
+                            Window,
+                            "Vulkan runtime may be required",
+                            $"The Vulkan version requires the Vulkan runtime (vulkan-1.dll) which usually ships with current GPU drivers, but was not detected on this system.{Environment.NewLine}{Environment.NewLine}You can install it from:{Environment.NewLine}https://vulkan.lunarg.com/sdk/home{Environment.NewLine}{Environment.NewLine}Continue with Vulkan download anyway?",
+                            MessageBoxButtons.YesNoCancel,
+                            MessageBoxIcon.Question);
+
+                        if (vulkanAnswer == MessageBoxResult.No)
+                        {
+                            UiUtil.OpenUrl("https://vulkan.lunarg.com/sdk/home");
+                            return false;
+                        }
+
+                        if (vulkanAnswer != MessageBoxResult.Yes)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    var answer = await MessageBox.Show(
+                        Window,
+                        "Download Qwen3 TTS?",
+                        $"{Environment.NewLine}\"Text to speech\" requires Qwen3 TTS.{Environment.NewLine}{Environment.NewLine}Download and use Qwen3 TTS?",
+                        MessageBoxButtons.YesNoCancel,
+                        MessageBoxIcon.Question);
+
+                    if (answer != MessageBoxResult.Yes)
+                    {
+                        return false;
+                    }
                 }
 
-                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window, vm => vm.StartDownloadQwen3TtsCpp());
+                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window, vm => vm.StartDownloadQwen3TtsCpp(qwen3Variant));
                 if (!dlResult.OkPressed)
                 {
                     return false;
                 }
-                
+
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
                     await RefreshVoices(engine);

--- a/src/UI/Logic/Download/Qwen3TtsCppDownloadService.cs
+++ b/src/UI/Logic/Download/Qwen3TtsCppDownloadService.cs
@@ -10,7 +10,7 @@ namespace Nikse.SubtitleEdit.Logic.Download;
 
 public interface IQwen3TtsCppDownloadService
 {
-    Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngine(Stream stream, string windowsVariant, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadVoices(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadModels(string modelsFolder, string ttsModelFileName, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
 }
@@ -19,11 +19,13 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.1/qwen3-tts-server-v0.4.1-windows-vulkan-x64.zip";
-    // Linux / macOS server builds are not yet published. The engine (Qwen3TtsCpp.cs)
-    // expects the qwen3-tts-server binary; the old CLI zips below will no longer work.
-    private const string MacUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.1/qwen3-tts-server-v0.4.1-macos-metal-arm64.zip";
-    private const string LinuxUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.1/qwen3-tts-server-v0.4.1-linux-vulkan-x64.zip";
+    public const string WindowsVariantVulkan = "vulkan";
+    public const string WindowsVariantCpu = "cpu";
+
+    private const string WindowsVulkanUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.2/qwen3-tts-server-v0.4.2-windows-vulkan-x64.zip";
+    private const string WindowsCpuUrl    = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.2/qwen3-tts-server-v0.4.2-windows-cpu-x64.zip";
+    private const string MacUrl           = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.2/qwen3-tts-server-v0.4.2-macos-metal-arm64.zip";
+    private const string LinuxUrl         = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.2/qwen3-tts-server-v0.4.2-linux-vulkan-x64.zip";
 
     private const string TokenizerModelFileName = "qwen3-tts-tokenizer-q8_0.gguf";
     private const string TokenizerModelUrl = "https://huggingface.co/koboldcpp/tts/resolve/main/qwen3-tts-tokenizer-q8_0.gguf";
@@ -43,9 +45,9 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
         _httpClient = httpClient;
     }
 
-    public async Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    public async Task DownloadEngine(Stream stream, string windowsVariant, IProgress<float>? progress, CancellationToken cancellationToken)
     {
-        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(), stream, progress, cancellationToken);
+        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(windowsVariant), stream, progress, cancellationToken);
     }
 
     public async Task DownloadVoices(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -81,11 +83,11 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
         }
     }
 
-    private static string GetUrl()
+    private static string GetUrl(string windowsVariant)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return WindowsUrl;
+            return windowsVariant == WindowsVariantCpu ? WindowsCpuUrl : WindowsVulkanUrl;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/src/UI/Logic/VulkanHelper.cs
+++ b/src/UI/Logic/VulkanHelper.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+public static class VulkanHelper
+{
+    public static bool IsInstalled()
+    {
+        const string vulkanDll = "vulkan-1.dll";
+
+        var systemRoot = Environment.GetFolderPath(Environment.SpecialFolder.System);
+        if (File.Exists(Path.Combine(systemRoot, vulkanDll)))
+        {
+            return true;
+        }
+
+        var sysWow64 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "SysWOW64");
+        if (File.Exists(Path.Combine(sysWow64, vulkanDll)))
+        {
+            return true;
+        }
+
+        var pathVariable = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        foreach (var folder in pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                if (File.Exists(Path.Combine(folder, vulkanDll)))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // ignore invalid/inaccessible path entries
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- When the user activates Qwen3 TTS for the first time on Windows, ask which `qwen3-tts-server` build to download — **Vulkan** (default, GPU-accelerated) or **CPU** (multi-variant, runs on anything from ~2008 SSE4.2 hardware up).
- Mirrors the existing CrispASR pattern (`SpeechToTextViewModel.cs:1601`) — same MessageBox layout, same Vulkan-detection warning if the user picks Vulkan but `vulkan-1.dll` isn't on disk.
- Bumps `qwen3-tts-server` to **v0.4.2**, which adds the new `qwen3-tts-server-vX.Y.Z-windows-cpu-x64.zip` asset alongside the existing Vulkan / Linux / macOS zips.

## Why
Some users hit cases where the Vulkan-only build fails to load on machines without a Vulkan loader (`vulkan-1.dll` missing — common on headless boxes, VMs without GPU passthrough, very old hardware). Letting them pick CPU at install time is the cleanest UX.

## What changed

| File | Change |
|------|--------|
| `src/UI/Logic/VulkanHelper.cs` *(new)* | Extracted the `IsVulkanInstalled` probe (System32 / SysWOW64 / PATH) into a shared static helper |
| `src/UI/Features/Video/SpeechToText/SpeechToTextViewModel.cs` | Removed the duplicate `IsVulkanInstalled` method; CrispASR flow now calls `VulkanHelper.IsInstalled()` |
| `src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs` | When prompting to download Qwen3 TTS, on Windows show a CPU/Vulkan picker; if user picks Vulkan but the loader isn't detected, show the LunarG warning. On non-Windows the existing yes/no prompt is preserved (macOS = Metal, Linux = Vulkan; no CPU asset for those platforms) |
| `src/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs` | `StartDownloadQwen3TtsCpp(string windowsVariant = "vulkan")` |
| `src/UI/Logic/Download/Qwen3TtsCppDownloadService.cs` | Added `WindowsCpuUrl`, split `WindowsUrl` into `WindowsVulkanUrl` + `WindowsCpuUrl`. `DownloadEngine(stream, windowsVariant, ...)` picks the right URL. All four URLs bumped from v0.4.1 → v0.4.2. Added `WindowsVariantVulkan` / `WindowsVariantCpu` constants. |

No persisted setting — the variant choice is one-shot at download time. The exe filename (`qwen3-tts-server.exe`) is identical for both builds, so once installed there's no further variant tracking needed. Users who later want to switch can delete the install folder and re-trigger the prompt.

## Test plan
- [x] `dotnet build src/UI/UI.csproj` clean (0 warnings, 0 errors).
- [x] `dotnet test --filter Qwen3TtsCpp` → 5/5 pass (existing tests untouched).
- [x] Verified the CPU build itself works end-to-end on Windows: built locally, started server with `--model-name qwen3-tts-0.6b-q8_0.gguf`, runtime picked `ggml-cpu-cascadelake.dll`, `/v1/synthesize` returned a valid 2.5 s WAV. Same for the 1.7B Base GGUF.
- [x] CrispASR Vulkan probe still works (called via `VulkanHelper.IsInstalled()` instead of the removed local method).
- [ ] Reviewer: please test the prompt UX on a fresh install (no existing `qwen3-tts-server.exe` on disk) — both branches of the picker, plus the "picked Vulkan but vulkan-1.dll missing" warning path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)