### PR TITLE
Add Kokoro TTS as a new TTS engine

### DIFF
--- a/src/UI/DependencyInjectionExtensions.cs
+++ b/src/UI/DependencyInjectionExtensions.cs
@@ -219,6 +219,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<ILlamaCppDownloadService, LlamaCppDownloadService>();
         collection.AddHttpClient<IQwen3AsrCppDownloadService, Qwen3AsrCppDownloadService>();
         collection.AddHttpClient<IQwen3TtsCppDownloadService, Qwen3TtsCppDownloadService>();
+        collection.AddHttpClient<IKokoroTtsCppDownloadService, KokoroTtsCppDownloadService>();
 
         // Window view models
         collection.AddTransient<AdvancedTtsSettingsViewModel>();

--- a/src/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -40,25 +40,32 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskQwen3TtsCpp;
     private Task? _downloadTaskQwen3TtsCppVoices;
     private Task? _downloadTaskQwen3TtsModels;
+    private Task? _downloadTaskKokoroTtsCpp;
+    private Task? _downloadTaskKokoroTtsModels;
     private readonly Timer _timer = new();
 
     private readonly ITtsDownloadService _ttsDownloadService;
     private readonly IQwen3TtsCppDownloadService _qwen3TtsCppDownloadService;
+    private readonly IKokoroTtsCppDownloadService _kokoroTtsCppDownloadService;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly MemoryStream _downloadStream;
     private readonly MemoryStream _downloadStreamModel;
     private readonly MemoryStream _downloadStreamConfig;
     private readonly MemoryStream _downloadStreamQwen3TtsCpp;
     private readonly MemoryStream _downloadStreamQwen3TtsCppVoices;
+    private readonly MemoryStream _downloadStreamKokoroTtsCpp;
     private readonly IZipUnpacker _zipUnpacker;
     private readonly object _lock = new();
     private string _modelFileName;
     private string _configFileName;
 
-    public DownloadTtsViewModel(ITtsDownloadService ttsDownloadService, IZipUnpacker zipUnpacker, IQwen3TtsCppDownloadService qwen3TtsCppDownloadService)
+    public DownloadTtsViewModel(ITtsDownloadService ttsDownloadService, IZipUnpacker zipUnpacker,
+        IQwen3TtsCppDownloadService qwen3TtsCppDownloadService,
+        IKokoroTtsCppDownloadService kokoroTtsCppDownloadService)
     {
         _ttsDownloadService = ttsDownloadService;
         _qwen3TtsCppDownloadService = qwen3TtsCppDownloadService;
+        _kokoroTtsCppDownloadService = kokoroTtsCppDownloadService;
         _zipUnpacker = zipUnpacker;
 
         _cancellationTokenSource = new CancellationTokenSource();
@@ -68,6 +75,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _downloadStreamConfig = new MemoryStream();
         _downloadStreamQwen3TtsCpp = new MemoryStream();
         _downloadStreamQwen3TtsCppVoices = new MemoryStream();
+        _downloadStreamKokoroTtsCpp = new MemoryStream();
 
         _modelFileName = string.Empty;
         _configFileName = string.Empty;
@@ -362,6 +370,90 @@ public partial class DownloadTtsViewModel : ObservableObject
                     Error = ex?.Message ?? "Unknown error";
                 }
             }
+
+            if (_downloadTaskKokoroTtsCpp is { IsCompleted: true })
+            {
+                _timer.Stop();
+
+                if (_downloadStreamKokoroTtsCpp.Length == 0)
+                {
+                    ProgressText = "Download failed";
+                    Error = "No data received";
+                    return;
+                }
+
+                var folder = KokoroTtsCpp.GetSetFolder();
+                try
+                {
+                    _downloadStreamKokoroTtsCpp.Position = 0;
+                    _zipUnpacker.UnpackZipStream(_downloadStreamKokoroTtsCpp, folder, string.Empty, false, new List<string>(), null);
+                    _downloadStreamKokoroTtsCpp.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    ProgressText = "Unpack failed: " + ex.Message;
+                    Error = ex.Message;
+                    Se.LogError(ex);
+                    return;
+                }
+
+                var exePath = KokoroTtsCpp.GetExecutableFileName();
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    if (File.Exists(exePath))
+                    {
+                        LinuxHelper.MakeExecutable(exePath);
+                    }
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    if (File.Exists(exePath))
+                    {
+                        MacHelper.MakeExecutable(exePath);
+                    }
+                }
+
+                _downloadTaskKokoroTtsCpp = null;
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskKokoroTtsCpp is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskKokoroTtsCpp.Exception?.InnerException ?? _downloadTaskKokoroTtsCpp.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
+
+            if (_downloadTaskKokoroTtsModels is { IsCompleted: true })
+            {
+                _timer.Stop();
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskKokoroTtsModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskKokoroTtsModels.Exception?.InnerException ?? _downloadTaskKokoroTtsModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
         }
     }
 
@@ -517,6 +609,43 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskQwen3TtsModels =
             _qwen3TtsCppDownloadService.DownloadModels(Qwen3TtsCpp.GetSetModelsFolder(), ttsModelFileName, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadKokoroTtsCpp()
+    {
+        TitleText = "Downloading Kokoro TTS";
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        _downloadTaskKokoroTtsCpp =
+            _kokoroTtsCppDownloadService.DownloadEngine(_downloadStreamKokoroTtsCpp, downloadProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadKokoroTtsModels()
+    {
+        TitleText = "Downloading Kokoro TTS models (~380 MB)";
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskKokoroTtsModels =
+            _kokoroTtsCppDownloadService.DownloadModels(KokoroTtsCpp.GetSetModelsFolder(), downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     internal void OnKeyDown(KeyEventArgs e)

--- a/src/UI/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/UI/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -1,0 +1,422 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+public class KokoroTtsCpp : ITtsEngine
+{
+    public string Name => "Kokoro TTS";
+    public string Description => "free/fast/multilingual";
+    public bool HasLanguageParameter => false;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => false;
+    public bool HasKeyFile => false;
+
+    public const string TtsModelFileName     = "kokoro-v1.1-zh.onnx";
+    public const string VoicesModelFileName  = "voices-v1.1-zh.bin";
+    public const string DefaultVoice         = "af_maple";
+
+    // The voices baked into voices-v1.1-zh.bin. Hard-coded so the dropdown is
+    // populated immediately without spinning up the server. RefreshVoices()
+    // syncs from /v1/speakers if the engine is installed.
+    private static readonly string[] BakedVoices =
+    {
+        "af_maple", "af_sol", "bf_vale",
+        "zf_001", "zf_002", "zf_003", "zf_004", "zf_005", "zf_006", "zf_007", "zf_008",
+        "zf_017", "zf_018", "zf_019", "zf_021", "zf_022", "zf_023", "zf_024", "zf_026",
+        "zf_027", "zf_028", "zf_032", "zf_036", "zf_038", "zf_039", "zf_040", "zf_042",
+        "zf_043", "zf_044", "zf_046", "zf_047", "zf_048", "zf_049", "zf_051", "zf_059",
+        "zf_060", "zf_067", "zf_070", "zf_071", "zf_072", "zf_073", "zf_074", "zf_075",
+        "zf_076", "zf_077", "zf_078", "zf_079", "zf_083", "zf_084", "zf_085", "zf_086",
+        "zf_087", "zf_088", "zf_090", "zf_092", "zf_093", "zf_094", "zf_099",
+        "zm_009", "zm_010", "zm_011", "zm_012", "zm_013", "zm_014", "zm_015", "zm_016",
+        "zm_020", "zm_025", "zm_029", "zm_030", "zm_031", "zm_033", "zm_034", "zm_035",
+        "zm_037", "zm_041", "zm_045", "zm_050", "zm_052", "zm_053", "zm_054", "zm_055",
+        "zm_056", "zm_057", "zm_058", "zm_061", "zm_062", "zm_063", "zm_064", "zm_065",
+        "zm_066", "zm_068", "zm_069", "zm_080", "zm_081", "zm_082", "zm_089", "zm_091",
+        "zm_095", "zm_096", "zm_097", "zm_098", "zm_100",
+    };
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(5),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static bool _processExitHooked;
+
+    private static List<string>? _cachedVoiceNames;
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetExecutableFileName()));
+    }
+
+    public static bool AreModelsInstalled()
+    {
+        var modelsFolder = GetSetModelsFolder();
+        return File.Exists(Path.Combine(modelsFolder, TtsModelFileName)) &&
+               File.Exists(Path.Combine(modelsFolder, VoicesModelFileName));
+    }
+
+    public override string ToString() => Name;
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "KokoroTtsCpp");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        var modelsFolder = Path.Combine(GetSetFolder(), "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetExecutableFileName()
+    {
+        return Path.Combine(GetSetFolder(), OperatingSystem.IsWindows() ? "kokoro-tts-server.exe" : "kokoro-tts-server");
+    }
+
+    public Task<Voice[]> GetVoices(string language)
+    {
+        var names = _cachedVoiceNames ?? new List<string>(BakedVoices);
+        var result = new List<Voice>(names.Count);
+        foreach (var name in names)
+        {
+            result.Add(new Voice(new KokoroTtsVoice(name)));
+        }
+        return Task.FromResult(result.ToArray());
+    }
+
+    public bool IsVoiceInstalled(Voice voice)
+    {
+        return true;
+    }
+
+    public Task<string[]> GetRegions()
+    {
+        return Task.FromResult(Array.Empty<string>());
+    }
+
+    public Task<string[]> GetModels()
+    {
+        return Task.FromResult(Array.Empty<string>());
+    }
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model)
+    {
+        return Task.FromResult(Array.Empty<TtsLanguage>());
+    }
+
+    // Refresh the voice cache from the running server (if available). Falls back
+    // to GetVoices() with the baked list if the server can't be reached.
+    public async Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (File.Exists(GetExecutableFileName()) && AreModelsInstalled())
+            {
+                await EnsureServerRunningAsync(cancellationToken);
+                using var resp = await HttpClient.GetAsync($"{ServerBaseUrl}/v1/speakers", cancellationToken);
+                if (resp.IsSuccessStatusCode)
+                {
+                    var json = await resp.Content.ReadAsStringAsync(cancellationToken);
+                    using var doc = JsonDocument.Parse(json);
+                    if (doc.RootElement.TryGetProperty("speakers", out var arr) && arr.ValueKind == JsonValueKind.Array)
+                    {
+                        var names = new List<string>(arr.GetArrayLength());
+                        foreach (var item in arr.EnumerateArray())
+                        {
+                            var s = item.GetString();
+                            if (!string.IsNullOrEmpty(s)) names.Add(s);
+                        }
+                        if (names.Count > 0)
+                        {
+                            _cachedVoiceNames = names;
+                        }
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Refresh is best-effort; fall through to GetVoices() with whatever cache we have.
+        }
+
+        return await GetVoices(language);
+    }
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not KokoroTtsVoice kokoroVoice)
+        {
+            throw new ArgumentException("Voice is not a KokoroTtsVoice");
+        }
+
+        await EnsureServerRunningAsync(cancellationToken);
+
+        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var inputText = Utilities.UnbreakLine(text);
+        var voiceName = string.IsNullOrEmpty(kokoroVoice.Voice) ? DefaultVoice : kokoroVoice.Voice;
+
+        var body = JsonSerializer.Serialize(new { text = inputText, voice = voiceName });
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/synthesize", content, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+            Se.LogError($"Kokoro TTS server error {(int)response.StatusCode} {response.StatusCode} - "
+                + $"Voice: {voiceName}, Text: {text}, Body: {errorBody}");
+            throw new InvalidOperationException(
+                $"Kokoro TTS synthesis failed ({(int)response.StatusCode}): {errorBody}");
+        }
+
+        await using (var fileStream = File.Create(outputFileName))
+        await using (var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken))
+        {
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(CancellationToken ct)
+    {
+        if (_serverProcess is { HasExited: false } && _serverPort != 0)
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0)
+            {
+                return;
+            }
+
+            var exe = GetExecutableFileName();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException("Kokoro TTS server executable not found.", exe);
+            }
+
+            var modelsFolder = GetSetModelsFolder();
+            var modelPath  = Path.Combine(modelsFolder, TtsModelFileName);
+            var voicesPath = Path.Combine(modelsFolder, VoicesModelFileName);
+            if (!File.Exists(modelPath) || !File.Exists(voicesPath))
+            {
+                throw new FileNotFoundException("Kokoro TTS model or voices file missing.",
+                    File.Exists(modelPath) ? voicesPath : modelPath);
+            }
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                // Working directory must be GetSetFolder() so the server can find dict/vocab.txt
+                // (relative path baked into the binary's default --vocab arg).
+                WorkingDirectory = GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(modelPath);
+            psi.ArgumentList.Add("-V");
+            psi.ArgumentList.Add(voicesPath);
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString());
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start kokoro-tts-server");
+
+            var stderrBuffer = new StringBuilder();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (stderrBuffer) stderrBuffer.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (stderrBuffer) stderrBuffer.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            HookProcessExitOnce();
+
+            var deadline = DateTime.UtcNow.AddSeconds(60);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotStderr(stderrBuffer);
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    throw new InvalidOperationException(
+                        $"kokoro-tts-server exited during startup (code {process.ExitCode}). Output: {tail}");
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(1), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromMilliseconds(500), ct);
+            }
+
+            var lastOutput = SnapshotStderr(stderrBuffer);
+            StopServerInternal();
+            throw new TimeoutException(
+                $"kokoro-tts-server did not report healthy within 60s. Last output: {lastOutput}");
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotStderr(StringBuilder buffer)
+    {
+        lock (buffer)
+        {
+            var s = buffer.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked) return;
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    public static void StopServer()
+    {
+        ServerLock.Wait();
+        try
+        {
+            StopServerInternal();
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        if (p == null) return;
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        // Kokoro uses fixed pre-trained voice style vectors; voice cloning is not supported.
+        return false;
+    }
+}

--- a/src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -256,6 +256,12 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 continue;
             }
 
+            if (engineItem is KokoroTtsCpp && (!File.Exists(KokoroTtsCpp.GetExecutableFileName())
+                || !KokoroTtsCpp.AreModelsInstalled()))
+            {
+                continue;
+            }
+
             Engines.Add(engineItem);
         }
 

--- a/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -127,6 +127,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             new Murf(ttsDownloadService),
             new GoogleSpeech(ttsDownloadService),
             new Qwen3TtsCpp(),
+            new KokoroTtsCpp(),
         ];
 
         if (!OperatingSystem.IsMacOS())
@@ -232,6 +233,13 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is Qwen3TtsCpp)
         {
             Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel = SelectedModel ?? Qwen3TtsCpp.DefaultModelKey;
+        }
+        else if (SelectedEngine is KokoroTtsCpp)
+        {
+            if (SelectedVoice?.EngineVoice is Voices.KokoroTtsVoice kokoroVoice && !string.IsNullOrEmpty(kokoroVoice.Voice))
+            {
+                Se.Settings.Video.TextToSpeech.KokoroVoice = kokoroVoice.Voice;
+            }
         }
         else if (SelectedEngine is Murf)
         {
@@ -700,6 +708,55 @@ public partial class TextToSpeechViewModel : ObservableObject
 
                 var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadQwen3TtsModels(qwen3ModelKey));
                 return dlResult.OkPressed && Qwen3TtsCpp.IsModelsInstalled(qwen3ModelKey);
+            }
+
+            return true;
+        }
+
+        if (engine is KokoroTtsCpp)
+        {
+            if (!await engine.IsInstalled(SelectedRegion))
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download Kokoro TTS?",
+                    $"{Environment.NewLine}\"Text to speech\" requires Kokoro TTS.{Environment.NewLine}{Environment.NewLine}Download and use Kokoro TTS?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window, vm => vm.StartDownloadKokoroTtsCpp());
+                if (!dlResult.OkPressed)
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await RefreshVoices(engine);
+                });
+            }
+
+            if (!KokoroTtsCpp.AreModelsInstalled())
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download Kokoro TTS models?",
+                    $"{Environment.NewLine}\"Kokoro TTS\" requires models (~380 MB).{Environment.NewLine}{Environment.NewLine}Download models?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadKokoroTtsModels());
+                return dlResult.OkPressed && KokoroTtsCpp.AreModelsInstalled();
             }
 
             return true;
@@ -1429,6 +1486,18 @@ public partial class TextToSpeechViewModel : ObservableObject
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();
+                }
+            }
+            else if (SelectedEngine is KokoroTtsCpp)
+            {
+                var savedVoice = Se.Settings.Video.TextToSpeech.KokoroVoice;
+                if (!string.IsNullOrEmpty(savedVoice))
+                {
+                    var match = Voices.FirstOrDefault(v => v.Name == savedVoice);
+                    if (match != null)
+                    {
+                        SelectedVoice = match;
+                    }
                 }
             }
             else if (SelectedEngine is Murf)

--- a/src/UI/Features/Video/TextToSpeech/Voices/KokoroTtsVoice.cs
+++ b/src/UI/Features/Video/TextToSpeech/Voices/KokoroTtsVoice.cs
@@ -1,0 +1,24 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+public class KokoroTtsVoice
+{
+    // Kokoro voice id, e.g. "af_maple", "bf_vale", "zf_001". Maps directly to a
+    // pre-trained 256-dim style vector inside voices-v1.1-zh.bin; Kokoro does
+    // not support voice cloning, so this is the only voice handle.
+    public string Voice { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public KokoroTtsVoice()
+    {
+        Voice = string.Empty;
+    }
+
+    public KokoroTtsVoice(string voice)
+    {
+        Voice = voice;
+    }
+}

--- a/src/UI/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/UI/Logic/Config/SeVideoTextToSpeech.cs
@@ -26,6 +26,7 @@ public class SeVideoTextToSpeech
     public string MistralApiKey { get; set; }
     public string MistralModel { get; set; }
     public string Qwen3TtsCppModel { get; set; }
+    public string KokoroVoice { get; set; }
     public string GoogleApiKey { get; set; }
     public string GoogleKeyFile { get; set; }
 
@@ -83,6 +84,7 @@ public class SeVideoTextToSpeech
         MistralApiKey = string.Empty;
         MistralModel = "voxtral-mini-tts-2603";
         Qwen3TtsCppModel = "0.6B";
+        KokoroVoice = "af_maple";
         GoogleApiKey = string.Empty;
         GoogleKeyFile = string.Empty;
         ProAudioChainEnabled = false;

--- a/src/UI/Logic/Download/KokoroTtsCppDownloadService.cs
+++ b/src/UI/Logic/Download/KokoroTtsCppDownloadService.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IKokoroTtsCppDownloadService
+{
+    Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadModels(string modelsFolder, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+public class KokoroTtsCppDownloadService : IKokoroTtsCppDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    private const string WindowsUrl = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.0/kokoro-tts-server-v0.1.0-windows-x64.zip";
+    private const string MacUrl     = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.0/kokoro-tts-server-v0.1.0-macos-arm64.zip";
+    private const string LinuxUrl   = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.0/kokoro-tts-server-v0.1.0-linux-x64.zip";
+
+    private const string TtsModelFileName    = "kokoro-v1.1-zh.onnx";
+    private const string VoicesModelFileName = "voices-v1.1-zh.bin";
+    private const string TtsModelUrl     = "https://github.com/koth/kokoro.cpp/releases/download/voices_model_files/kokoro-v1.1-zh.onnx";
+    private const string VoicesModelUrl  = "https://github.com/koth/kokoro.cpp/releases/download/voices_model_files/voices-v1.1-zh.bin";
+
+    public KokoroTtsCppDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(), stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadModels(string modelsFolder, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var ttsPath    = Path.Combine(modelsFolder, TtsModelFileName);
+        var voicesPath = Path.Combine(modelsFolder, VoicesModelFileName);
+        var needTts    = !File.Exists(ttsPath);
+        var needVoices = !File.Exists(voicesPath);
+        var total      = (needTts ? 1 : 0) + (needVoices ? 1 : 0);
+        var step       = 0;
+
+        if (needTts)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Kokoro TTS models ({step}/{total}): {TtsModelFileName}");
+            await DownloadHelper.DownloadFileAsync(_httpClient, TtsModelUrl, ttsPath, progress, cancellationToken);
+        }
+        if (needVoices)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Kokoro TTS models ({step}/{total}): {VoicesModelFileName}");
+            await DownloadHelper.DownloadFileAsync(_httpClient, VoicesModelUrl, voicesPath, progress, cancellationToken);
+        }
+    }
+
+    private static string GetUrl()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return WindowsUrl;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return LinuxUrl;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return MacUrl;
+        }
+
+        throw new PlatformNotSupportedException();
+    }
+}

--- a/tests/UI/Features/Video/TextToSpeech/Engines/KokoroTtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/KokoroTtsCppTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+public class KokoroTtsCppTests
+{
+    [Fact]
+    public async Task GetVoices_Returns_BakedVoiceList()
+    {
+        var engine = new KokoroTtsCpp();
+        var voices = await engine.GetVoices(string.Empty);
+
+        Assert.NotEmpty(voices);
+        // The baked list ships with all 103 voices that live in voices-v1.1-zh.bin.
+        Assert.Equal(103, voices.Length);
+
+        // Spot-check the default + one each of American Female, British Female,
+        // Mandarin Female, Mandarin Male.
+        var voiceNames = voices.Select(v => ((KokoroTtsVoice)v.EngineVoice!).Voice).ToList();
+        Assert.Contains(KokoroTtsCpp.DefaultVoice, voiceNames);
+        Assert.Contains("af_maple", voiceNames);
+        Assert.Contains("bf_vale", voiceNames);
+        Assert.Contains("zf_001", voiceNames);
+        Assert.Contains("zm_009", voiceNames);
+    }
+
+    [Fact]
+    public void Engine_HasNoApiKey_NoRegion_NoModelDropdown()
+    {
+        var engine = new KokoroTtsCpp();
+        Assert.False(engine.HasApiKey);
+        Assert.False(engine.HasRegion);
+        Assert.False(engine.HasModel);
+        Assert.False(engine.HasLanguageParameter);
+        Assert.False(engine.HasKeyFile);
+    }
+
+    [Fact]
+    public void ImportVoice_NotSupported()
+    {
+        // Kokoro uses fixed pre-trained voice style vectors and cannot clone.
+        var engine = new KokoroTtsCpp();
+        Assert.False(engine.ImportVoice("anything.wav"));
+    }
+}


### PR DESCRIPTION
## Summary
Adds **Kokoro TTS** ([hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M), Apache 2.0) as a new TTS engine alongside Qwen3 TTS, wrapping the [niksedk/kokoro.cpp](https://github.com/niksedk/kokoro.cpp) v0.1.0 HTTP server. Kokoro is a fast 82M-parameter multilingual TTS with **103 pre-trained voices** spanning American/British English and Mandarin Chinese.

## User flow
1. "Kokoro TTS" appears in the engine dropdown.
2. First selection prompts to download the engine (~70 MB platform zip — Win / Linux / macOS) into `TextToSpeechFolder/KokoroTtsCpp/`.
3. Second prompt downloads the model + voices files (~380 MB total) into `KokoroTtsCpp/models/`.
4. Voice dropdown is populated immediately from a baked list of all 103 voice ids; `RefreshVoices()` syncs from the running server's `/v1/speakers` if the engine is up.
5. Selected voice is persisted in `Se.Settings.Video.TextToSpeech.KokoroVoice` (default `af_maple`).

## Engine implementation
- HTTP shim mirrors `qwen3-tts-server`'s API (`/health`, `/v1/synthesize`) so SE's "start server, probe health, POST text, receive WAV" state machine reuses the same shape that already works for `Qwen3TtsCpp.cs`.
- Voice cloning is intentionally not exposed — Kokoro uses fixed pre-trained 256-dim style vectors and cannot clone from a reference clip; `ImportVoice` returns `false`.
- Single-process server, mutex-serialized synthesis. Process-exit hook tears the server down on app close.

## Files

| File | Change |
|------|--------|
| `src/UI/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs` *(new)* | Engine implementation (`ITtsEngine`) |
| `src/UI/Features/Video/TextToSpeech/Voices/KokoroTtsVoice.cs` *(new)* | Voice POCO (just a voice id string) |
| `src/UI/Logic/Download/KokoroTtsCppDownloadService.cs` *(new)* | Download URLs + per-platform engine zip + model files |
| `tests/UI/Features/Video/TextToSpeech/Engines/KokoroTtsCppTests.cs` *(new)* | Unit tests for voice list, engine flags, ImportVoice |
| `src/UI/DependencyInjectionExtensions.cs` | DI registration of `IKokoroTtsCppDownloadService` |
| `src/UI/Logic/Config/SeVideoTextToSpeech.cs` | New `KokoroVoice` setting (default `"af_maple"`) |
| `src/UI/Features/Video/TextToSpeech/TextToSpeechViewModel.cs` | Engine list + install/download flow + save/load voice |
| `src/UI/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs` | Drop Kokoro from picker if not installed |
| `src/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs` | New `_downloadTaskKokoroTtsCpp` / `_downloadTaskKokoroTtsModels` plumbing + `StartDownloadKokoroTtsCpp` / `StartDownloadKokoroTtsModels` methods |

## Test plan
- [x] `dotnet build src/UI/UI.csproj` clean (0 warnings, 0 errors).
- [x] `dotnet test --filter Qwen3TtsCpp|KokoroTtsCpp` → **8/8 pass** (3 new + 5 existing Qwen3).
- [x] End-to-end on Windows: dropped the v0.1.0 release zip + model files into `TextToSpeech/KokoroTtsCpp/`, server starts (~1 s), `/health` and `/v1/speakers` respond, `POST /v1/synthesize {"text":"Hello world, this is a test.","voice":"af_maple"}` returns a 122 KB RIFF WAV (2.55 s of audio in ~1.9 s wall time).
- [x] Existing Qwen3 TTS engine path untouched.
- [ ] Reviewer: please test the install dialog flow on a fresh machine (no existing `KokoroTtsCpp/` folder), and verify the voice dropdown shows all 103 voices once the engine is set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)