### PR TITLE
fix(flatpak): restore release bundle publishing

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -544,36 +544,73 @@ jobs:
           name: linux-tar-package
           path: ./SubtitleEdit-Linux-x64.tar.gz
 
-  # build-linux-flatpak:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
-  #     options: --privileged
+  regenerate-flatpak-nuget-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
 
-  #   steps:
-  #     - uses: actions/checkout@v5
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
 
-  #     - name: Update metainfo version/date from Se.cs
-  #       run: bash installer/flatpak/update-metainfo-version.sh
+      - name: Regenerate nuget-sources.json
+        run: bash installer/flatpak/generate-nuget-sources.sh
 
-  #     - name: Build flatpak bundle
-  #       uses: flatpak/flatpak-github-actions/flatpak-builder@v6
-  #       with:
-  #         bundle: SubtitleEdit-linux-x64.flatpak
-  #         manifest-path: installer/flatpak/dk.nikse.subtitleedit.yaml
-  #         cache-key: flatpak-builder-${{ hashFiles('installer/flatpak/dk.nikse.subtitleedit.yaml', 'installer/flatpak/nuget-sources.json') }}
-  #         arch: x86_64
+      - name: Verify nuget-sources.json is consistent with UI.csproj
+        run: |
+          if ! git diff --quiet -- installer/flatpak/nuget-sources.json; then
+            echo "::notice::nuget-sources.json was stale and has been regenerated for this build."
+            git --no-pager diff --stat -- installer/flatpak/nuget-sources.json
+          else
+            echo "nuget-sources.json is already up to date."
+          fi
 
-  #     - name: Upload flatpak bundle artifact
-  #       uses: actions/upload-artifact@v5
-  #       with:
-  #         name: flatpak-bundle
-  #         path: SubtitleEdit-linux-x64.flatpak
-  #         overwrite: true
+      - name: Upload regenerated nuget-sources.json
+        uses: actions/upload-artifact@v5
+        with:
+          name: flatpak-nuget-sources
+          path: installer/flatpak/nuget-sources.json
+          if-no-files-found: error
+          overwrite: true
+
+  build-linux-flatpak:
+    needs: regenerate-flatpak-nuget-sources
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download regenerated nuget-sources.json
+        uses: actions/download-artifact@v5
+        with:
+          name: flatpak-nuget-sources
+          path: installer/flatpak/
+
+      - name: Update metainfo version/date from Se.cs
+        run: bash installer/flatpak/update-metainfo-version.sh
+
+      - name: Build flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: SubtitleEdit-linux-x64.flatpak
+          manifest-path: installer/flatpak/dk.nikse.subtitleedit.yaml
+          cache-key: flatpak-builder-${{ github.sha }}
+          arch: x86_64
+
+      - name: Upload flatpak bundle artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: flatpak-bundle
+          path: SubtitleEdit-linux-x64.flatpak
+          overwrite: true
 
   create-release:
     if: ${{ inputs.create_release }}
-    needs: [build-windows, build-macos, build-linux]
+    needs: [build-windows, build-macos, build-linux, build-linux-flatpak]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -605,6 +642,7 @@ jobs:
           cp ./artifacts/windows-zip-packages/*.zip ./release-assets/
           cp ./artifacts/macos-dmg-packages/*.dmg ./release-assets/
           cp ./artifacts/linux-tar-package/*.tar.gz ./release-assets/
+          cp ./artifacts/flatpak-bundle/*.flatpak ./release-assets/
 
           # List all files that will be uploaded
           echo "Release assets:"
@@ -633,6 +671,7 @@ jobs:
             - **macOS ARM64 (Apple Silicon - M1/M2/M3/M4 architecture):** [SubtitleEdit-macOS-ARM64.dmg](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-macOS-ARM64.dmg)
             - **macOS x64 (Intel 64-bit):** [SubtitleEdit-macOS-x64.dmg](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-macOS-x64.dmg)
             - **Linux x64 (tarball):** [SubtitleEdit-Linux-x64.tar.gz](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-Linux-x64.tar.gz)
+            - **Linux x64 (Flatpak):** [SubtitleEdit-linux-x64.flatpak](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-linux-x64.flatpak)
       
             ### Installation
             1. Read and fix requirements, please see [System Requirements](https://github.com/niksedk/subtitleedit-avalonia#system-requirements)
@@ -653,3 +692,4 @@ jobs:
             ./release-assets/SubtitleEdit-macOS-ARM64.dmg
             ./release-assets/SubtitleEdit-macOS-x64.dmg
             ./release-assets/SubtitleEdit-Linux-x64.tar.gz
+            ./release-assets/SubtitleEdit-linux-x64.flatpak

--- a/installer/flatpak/nuget-sources.json
+++ b/installer/flatpak/nuget-sources.json
@@ -78,10 +78,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.markup.declarative/12.0.1-preview1/avalonia.markup.declarative.12.0.1-preview1.nupkg",
-        "sha512": "2976e800be25c8b89d335d30907ef28ca3767695145bd36e50c68d688266e49e0c10add0516dc65239ce4cbbad2e8d7f47d23b6192c148e8fac7e887caa481ea",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.markup.declarative/12.0.1/avalonia.markup.declarative.12.0.1.nupkg",
+        "sha512": "363ce596cb49a33f5858c19069ff23059c4fc798f054c0b26dfcd2d6f1d3c00861fabb0d9034686abb209b934eab44d33e35057a205c42648265ee39466b6b69",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.markup.declarative.12.0.1-preview1.nupkg"
+        "dest-filename": "avalonia.markup.declarative.12.0.1.nupkg"
     },
     {
         "type": "file",
@@ -134,10 +134,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avaloniaui.diagnosticssupport/2.2.0/avaloniaui.diagnosticssupport.2.2.0.nupkg",
-        "sha512": "830a5f4083b26211ea0026dad6109eb3bbed61b91c93be6b5a73e577825cd27f6c0448a1986776993e041b712d1e7e91fde87ee2ffdadf9f9c6b634bedbcb31e",
+        "url": "https://api.nuget.org/v3-flatcontainer/avaloniaui.diagnosticssupport/2.2.1/avaloniaui.diagnosticssupport.2.2.1.nupkg",
+        "sha512": "564accf6dbdc3a6d322d90c9e912d0908821212294c7c3d97dfa68d5deba8cca860f693e778b0ecc5f24bbb8ad86bad994d80d5d554175a23143365227f1a776",
         "dest": "nuget-sources",
-        "dest-filename": "avaloniaui.diagnosticssupport.2.2.0.nupkg"
+        "dest-filename": "avaloniaui.diagnosticssupport.2.2.1.nupkg"
     },
     {
         "type": "file",
@@ -253,17 +253,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/8.3.1.2/harfbuzzsharp.8.3.1.2.nupkg",
-        "sha512": "8e3125def22e148286f0d597c80bb626bb5640c0cca4e72d58bfe8a31e2ba4dd12d44060c90537a2b32f05b76f321c8515d31fc164ad8b630cc22ac576debfc7",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.8.3.1.2.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/8.3.1.3/harfbuzzsharp.8.3.1.3.nupkg",
         "sha512": "8493b36e88beedfc80e12f13e3b986fb1e5560c4c8df86e672c1cad24a623fa36adc9a1a82f566fda3784f7a2d58975d10273ea65b7bcb119afc126b11a452c8",
         "dest": "nuget-sources",
         "dest-filename": "harfbuzzsharp.8.3.1.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/8.3.1.4-preview.1.1/harfbuzzsharp.8.3.1.4-preview.1.1.nupkg",
+        "sha512": "7ff0d706c5378fb8b1a6b18871040c912a4040d244ee28cdd8dbc076a5447e6eeede92ce40670dafa7b5a82c108a23e7f331a3eca17f78e81737bdea493f8977",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.8.3.1.4-preview.1.1.nupkg"
     },
     {
         "type": "file",
@@ -274,17 +274,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/8.3.1.2/harfbuzzsharp.nativeassets.macos.8.3.1.2.nupkg",
-        "sha512": "8ae0370c25c5e601cdbef019789a315c64dc4a44892762d4bb37c32d9f3cc1eddb14f29a4ab080245adde4d4b18f82a3a1710884e6890623fa3c62249b5c8299",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/8.3.1.4-preview.1.1/harfbuzzsharp.nativeassets.macos.8.3.1.4-preview.1.1.nupkg",
+        "sha512": "eab34e073dc7f28fe860b0fa8c45e97da8ecdfe624fb37fc80572b498b0249ef9be16ec2587706b00f93495903f0cde9d6fecd848473e08701fe7982cdc90ddd",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.8.3.1.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/8.3.1.3/harfbuzzsharp.nativeassets.macos.8.3.1.3.nupkg",
-        "sha512": "64222e104f945cc284c08fd98feaa4dbb355b92990eb77858d4179ab6ea112d1e6a127198075e9274745044fd41e99f691c4c68a138ddfd438c5ebdbb0571602",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.8.3.1.3.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.8.3.1.4-preview.1.1.nupkg"
     },
     {
         "type": "file",
@@ -295,17 +288,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/8.3.1.2/harfbuzzsharp.nativeassets.win32.8.3.1.2.nupkg",
-        "sha512": "6b3ae3a7d94cf5509c89aa6e61f287408885ee770ab895c3ae0b466f45fd0d0180b2b3f436ee8d17d9d062fb5305f3b85bac529819f1fcfcd6244d73c6066b5a",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/8.3.1.4-preview.1.1/harfbuzzsharp.nativeassets.win32.8.3.1.4-preview.1.1.nupkg",
+        "sha512": "74c8ae942da49ba5c630739272b48a764f767e0629ff8b409fdae47f190a6df679e15225d555a83d6a3ac0865d497a91e49b8ce9ce3c601c34e68b86ab681f31",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.8.3.1.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/8.3.1.3/harfbuzzsharp.nativeassets.win32.8.3.1.3.nupkg",
-        "sha512": "156ab246a79aeb509672b10c109a1fa29e59b3ad1eb9713ac331e2f11b6bac4b7a96bcb765a8e2da4d3f59bb54d5b648e870aeae4d22543baca28b17cb046fcf",
-        "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.8.3.1.3.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.8.3.1.4-preview.1.1.nupkg"
     },
     {
         "type": "file",
@@ -316,17 +302,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/10.0.6/microsoft.aspnetcore.app.runtime.linux-arm64.10.0.6.nupkg",
-        "sha512": "1b8febd42b92ceea0323d2ecc65352e285acc9bfce36f4df2256e5bb0a59ef2e49d62892156bd3d63ff360fb38f14c6fd00c1b35f7b259df81cbdc8e067b2975",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/10.0.7/microsoft.aspnetcore.app.runtime.linux-arm64.10.0.7.nupkg",
+        "sha512": "cafc92236965c07dc2e5226eee730f5dd88cb7d23c984eb261eda8eee19198b8a861d6af2fc2162537b4cfe787a941c124d19339e72ee225f27b01720675d151",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.10.0.6.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.10.0.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/10.0.6/microsoft.aspnetcore.app.runtime.linux-x64.10.0.6.nupkg",
-        "sha512": "10e53bcec9ea634a3e3244923dfba5d04e9c7af52a0b018099396c6281cf311e80c3307738b995bd9d4cf72449b5876103f0761aa9141fe3c99aa56397ab56f0",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/10.0.7/microsoft.aspnetcore.app.runtime.linux-x64.10.0.7.nupkg",
+        "sha512": "0188eda19b8bca9662d38b9f39ea371277f86ae0ae4e1fcefad7f795801c7fd77968af397881d7b5e39bb207f7f9bcd181557d43c66b359a86ce6a38113e91ac",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.10.0.6.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.10.0.7.nupkg"
     },
     {
         "type": "file",
@@ -449,38 +435,38 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/10.0.6/microsoft.net.illink.tasks.10.0.6.nupkg",
-        "sha512": "22ff081563e706c348c00f15e79e183803ae9a2a231b052cbbd35204834d52416810d8c77704b9c29740238ee618958208314833bd59bf78e40f9ec3c2a06926",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/10.0.7/microsoft.net.illink.tasks.10.0.7.nupkg",
+        "sha512": "7aa7f83a78680c287d79c0558118df6cbb71f20154d809bc6059f8bc6f5f252f9bc2d983807d3fa36ab92a30d886709c383a07b431850f3fab8f1fbac0a81ffb",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.net.illink.tasks.10.0.6.nupkg"
+        "dest-filename": "microsoft.net.illink.tasks.10.0.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/10.0.6/microsoft.netcore.app.host.linux-arm64.10.0.6.nupkg",
-        "sha512": "79c22614952d5ee4111f47e0dc1f10eb72700634472cfd83478e95584791dd27e6eed1a29ee76ab58fe06997e3f56b256dbe9f19b601146a640a51a01ff164fb",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/10.0.7/microsoft.netcore.app.host.linux-arm64.10.0.7.nupkg",
+        "sha512": "099b4c68e65904536750ccd3b7edf6bc848f77712794bcb64ac7801bbafeca328c093a02f1102d77f35be5badfe491b1a8693a3b45d9822b3f18b11d612f2cdc",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.linux-arm64.10.0.6.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.linux-arm64.10.0.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-x64/10.0.6/microsoft.netcore.app.host.linux-x64.10.0.6.nupkg",
-        "sha512": "006b2347f3133fd5bd25c8da7d2208a68fd861ab66d26452a1461c62e3494d65eb4b9956ec944147060cd851ebb2c58f09ec0684684d98432d04f208fe665da1",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-x64/10.0.7/microsoft.netcore.app.host.linux-x64.10.0.7.nupkg",
+        "sha512": "71ec17300c0c931cbbb49b1660322cfbf53cf9eda4e22581d2bad6b5e9e0b0fea02eb44ba0cc4f10a7e0a9c3d46fcc6a10a99ad767d78e51d2b0d439c3ca37fc",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.linux-x64.10.0.6.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.linux-x64.10.0.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/10.0.6/microsoft.netcore.app.runtime.linux-arm64.10.0.6.nupkg",
-        "sha512": "31214ea5f5cbe9bdf523bffe4b705c94bd7bf6ccb07b7500f7a023f7902ca419b60b4ae1860bb6d64e70b831a80f7dccf0ab0f00723df56537973070bb5270e0",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/10.0.7/microsoft.netcore.app.runtime.linux-arm64.10.0.7.nupkg",
+        "sha512": "97f334245cbe06a565d159a1ffb5d6fee4ad0b991c271b36d11417ac1f60b72d7fd7e8de30fb4d8cf3314215f897c2299efc492b11eb4304b87e61b17952dc93",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.10.0.6.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.10.0.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/10.0.6/microsoft.netcore.app.runtime.linux-x64.10.0.6.nupkg",
-        "sha512": "65caf9734669c02b0d2fabf00e4bb6bb65258241009c4574b28ccdf7dd3280f2fdcf019baa1ad12b258518583b709750d8196c3364392e85b4da9d99a5b504d6",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/10.0.7/microsoft.netcore.app.runtime.linux-x64.10.0.7.nupkg",
+        "sha512": "e8ce562c71206e4c11808ad54cd0a2c8a4591171ba35d4a930713a6b7132b5af5d7e7c0e46d4ee83fa8573f8b4947ccaa3b91c0ffa926b49fc6c8c2f562f1a94",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.10.0.6.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.10.0.7.nupkg"
     },
     {
         "type": "file",
@@ -519,6 +505,13 @@
     },
     {
         "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/netstandard.library.ref/2.1.0/netstandard.library.ref.2.1.0.nupkg",
+        "sha512": "26bd0eaa7aa4689246115ab7c3da0d42b204b5e0ffe1004d83760e87572f463c9dcf0a29d3bfb96968cefd27c462ee82c019fe75204a5e3f27884bd3372d9bac",
+        "dest": "nuget-sources",
+        "dest-filename": "netstandard.library.ref.2.1.0.nupkg"
+    },
+    {
+        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.4/newtonsoft.json.13.0.4.nupkg",
         "sha512": "6d1faff84ff227a83b195dae5f0d8ead44a36187e32e438b0bc243e24092db79ac2daa672ad7493c1240ef97f01c7fbe12b21f7de22acd82132f102eaf82805c",
         "dest": "nuget-sources",
@@ -533,24 +526,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia/12.0.4/optris.icons.avalonia.12.0.4.nupkg",
-        "sha512": "813524c3391db1c86c997eeb610b5997dd13009b49ee60d0ca656af9331f2b521b9fe8ea34b8d0f8db0605a453c23245b4e1fb859255a7e3adf29d6ba80a1c2d",
+        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia/12.0.6/optris.icons.avalonia.12.0.6.nupkg",
+        "sha512": "a052b6f884fad0adfe7965883b07da4672578af81b5f88dcb2c2c267858ddc60b16173feffb284e9638f6985c0ff08fb06301faf8f5153afcbad1a3c5b95e412",
         "dest": "nuget-sources",
-        "dest-filename": "optris.icons.avalonia.12.0.4.nupkg"
+        "dest-filename": "optris.icons.avalonia.12.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia.fontawesome/12.0.4/optris.icons.avalonia.fontawesome.12.0.4.nupkg",
-        "sha512": "7e0748f724b9211713fd5e942e47c8ca210630b58847cfc73a005ac2933b7c1a02df531902dbd614743f64512bcf4e0c0472876e31e303525328bfd27d9d9222",
+        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia.fontawesome/12.0.6/optris.icons.avalonia.fontawesome.12.0.6.nupkg",
+        "sha512": "81f417c1396c5c0b589edc9cbc137c163759776751568932b8ed9ce741f304833056c4f5852bb9f14763e54393f55410861fdfd4f507ff5223d21aba18fb3ab9",
         "dest": "nuget-sources",
-        "dest-filename": "optris.icons.avalonia.fontawesome.12.0.4.nupkg"
+        "dest-filename": "optris.icons.avalonia.fontawesome.12.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia.materialdesign/12.0.4/optris.icons.avalonia.materialdesign.12.0.4.nupkg",
-        "sha512": "e8b886578af978369cd7b9d6cba8bc71d7ebfa22545942e696be343ca4bcaa1372b620b05ee0b11c266e08cb454b523dbc545c45177f08d3bacca4e423ff6df8",
+        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia.materialdesign/12.0.6/optris.icons.avalonia.materialdesign.12.0.6.nupkg",
+        "sha512": "0998884fbbd9814ffec532cadf77d47f362db2e16321f17125f9468bf9fcc662722408ed7c9173c169d774a801d9a64331ccc300a68f52c52a5e0cacec439e41",
         "dest": "nuget-sources",
-        "dest-filename": "optris.icons.avalonia.materialdesign.12.0.4.nupkg"
+        "dest-filename": "optris.icons.avalonia.materialdesign.12.0.6.nupkg"
     },
     {
         "type": "file",
@@ -722,6 +715,20 @@
     },
     {
         "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+        "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "0a38f25e8773b58155b5d3f94f849b93353d0809da56228b8ebab5c976e6458ca50eb5a38acca4c8940678e6e9521fb57ae487337f7cbf2ea7893ae9e3f43935",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
         "sha512": "2ae9db4b719b31fa7e40c60f52c70038fc8668e029cf4e1d120fde8c295631d6b08207d7018a22937b79546016c560c894e27dd6ebc01d5e0f677567e6b2c4f2",
         "dest": "nuget-sources",
@@ -799,13 +806,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/3.119.1/skiasharp.3.119.1.nupkg",
-        "sha512": "179fc561c21ff05087fbe92cd7c720a87a189e415c2189c8e5eb8e3e14bbf4cf3eae68a61f35e1c335875787c20694ac847f4d2a9d1ea22ae9bc60af4ea088b9",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.3.119.1.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/3.119.3-preview.1.1/skiasharp.3.119.3-preview.1.1.nupkg",
         "sha512": "873b773e2179b1f0a16ed50790a98c6e3b38ed5a63c468ef334ce46155d230e2a92fc8adde014efb7233dae967207595a62c03b342945a602039e56f5916c011",
         "dest": "nuget-sources",
@@ -813,10 +813,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/3.119.1/skiasharp.harfbuzz.3.119.1.nupkg",
-        "sha512": "7cf1423c5b62d0f151af93747e7cece88228fd9f36ac876acdfaefcf3867f72e293e9b00f839a0427b66b1ddcea0cf8b6e035b7e5b136566ec39ce45fcb9db93",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/3.119.3-preview.1.1/skiasharp.harfbuzz.3.119.3-preview.1.1.nupkg",
+        "sha512": "19835423ad70dc06654787fd3cac5bb6ab7713b433cc0f6a11e0312c451ba837b404fe3ceedf5de5e902bf87486ea14b42bebe2903473a035c02b38f34524916",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.harfbuzz.3.119.1.nupkg"
+        "dest-filename": "skiasharp.harfbuzz.3.119.3-preview.1.1.nupkg"
     },
     {
         "type": "file",
@@ -824,13 +824,6 @@
         "sha512": "bfca2fe3939f38a13bf14b4b41a9b505a2f4257942657f6cf57a98f2fb931609130c71cf15ffd9318500ac7c6c7d024ab2be37c409e036c11fb601a733502a93",
         "dest": "nuget-sources",
         "dest-filename": "skiasharp.nativeassets.linux.3.119.3-preview.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/3.119.1/skiasharp.nativeassets.macos.3.119.1.nupkg",
-        "sha512": "3fa7655fbafaa26f8e3204c08fc73f2d99a6df56bad6339430476ea231dd2baa55e896e70beef2586db6a7ed1c419dac141ba4be3e4b93e1b0fc56593208b77c",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.macos.3.119.1.nupkg"
     },
     {
         "type": "file",
@@ -845,13 +838,6 @@
         "sha512": "c2b84b8662d6b7c2df34ea0e6befea7a08dace7115fbe1ee9c725727a3bd630445274f74bdb967333a8b529093ad0f12c4ec9b4fa12bab336a2f6f49689beb46",
         "dest": "nuget-sources",
         "dest-filename": "skiasharp.nativeassets.webassembly.3.119.3-preview.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/3.119.1/skiasharp.nativeassets.win32.3.119.1.nupkg",
-        "sha512": "2c27941c243a087ed8a1bd94d7de16efb3e152050efd50756c50343f259190f73204e879a85f25a3467daaf60b152e65b6fb55a80a59e15e1fe9abb650e8bcb1",
-        "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.win32.3.119.1.nupkg"
     },
     {
         "type": "file",
@@ -1181,6 +1167,13 @@
         "sha512": "7d488ff82cb20a3b3cef6380f2dae5ea9f7baa66bf75ad711aade1e3301b25993ccf2694e33c847ea5b9bdb90ff34c46fcd8a6ba7d6f95605ba0c124ed7c5d13",
         "dest": "nuget-sources",
         "dest-filename": "system.threading.tasks.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/taglibsharp/2.3.0/taglibsharp.2.3.0.nupkg",
+        "sha512": "9be37f6431f6ead36babe78dc6527340d7b4b0fe444736aaeae5aef3651191d4e0421d9d671106aea544888695d7841000fb12f8a44aab1b5fe93fb7c90d983f",
+        "dest": "nuget-sources",
+        "dest-filename": "taglibsharp.2.3.0.nupkg"
     },
     {
         "type": "file",


### PR DESCRIPTION
## Summary
- Re-enable Flatpak bundle generation in the main UI release workflow
- Regenerate Flatpak NuGet sources before the Flatpak build so release builds do not use stale offline package metadata
- Upload `SubtitleEdit-linux-x64.flatpak` as a release asset and restore the Flatpak download link in release notes
- Refresh `installer/flatpak/nuget-sources.json` for the current dependency graph and Flatpak dotnet10 runtime packs

Closes #10317
Related to #10625

## Overengineering check
- Kept the change scoped to the main release workflow and generated Flatpak NuGet source list
- Left the standalone manual Flatpak workflow unchanged, since release publishing is owned by `build-ui.yml`

## Validation
- `git diff --check`
- `npx --yes prettier --parser yaml .github/workflows/build-ui.yml >/dev/null`
- `dotnet restore src/UI/UI.csproj --locked-mode --verbosity minimal`
- `flatpak-spawn --host flatpak-builder --force-clean flatpak-build-dir installer/flatpak/dk.nikse.subtitleedit.yaml`
- `flatpak-spawn --host flatpak build-bundle flatpak-local-repo SubtitleEdit-linux-x64.flatpak dk.nikse.subtitleedit`