### PR TITLE
Fix Flatpak HarfBuzz runtime mismatch

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -9,7 +9,7 @@ command: SubtitleEdit
 # Make the dotnet10 SDK tools available to every module at build time
 build-options:
   append-path: /usr/lib/sdk/dotnet10/bin
-  append-ld-library-path: /usr/lib/sdk/dotnet10/lib
+  append-ld-library-path: /app/lib:/usr/lib/sdk/dotnet10/lib
   no-debuginfo: true
   env:
     PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
@@ -37,11 +37,37 @@ cleanup:
 modules:
   # --- libmpv dependencies ---
 
+  - name: harfbuzz
+    buildsystem: meson
+    config-opts:
+      - -Ddocs=disabled
+      - -Dtests=disabled
+      - -Dintrospection=disabled
+      - -Dutilities=disabled
+      - -Dfreetype=enabled
+      - -Dglib=disabled
+      - -Dgobject=disabled
+      - -Dcairo=disabled
+      - -Dicu=disabled
+      - -Dgraphite2=disabled
+      - -Dc_link_args=-lstdc++
+    cleanup:
+      - /bin
+      - /include
+      - /lib/cmake
+      - /lib/libharfbuzz-subset.so*
+      - /lib/pkgconfig/harfbuzz-subset.pc
+      - /share
+    sources:
+      - type: git
+        url: https://github.com/harfbuzz/harfbuzz.git
+        tag: 8.3.1
+        commit: 985366b8b2a4e7e07413af918612334d6764a287
+
   - name: libass
     config-opts:
       - --disable-static
       - --enable-asm
-      - --enable-harfbuzz
       - --enable-fontconfig
     cleanup:
       - /include


### PR DESCRIPTION
## Summary
- Add a pinned HarfBuzz 8.3.1 Flatpak module before libass so the Flatpak ships a libharfbuzz version matching HarfBuzzSharp.NativeAssets.Linux 8.3.x.
- Include `/app/lib` in the Flatpak build linker path so subsequent modules prefer bundled libraries.
- Remove the unsupported libass `--enable-harfbuzz` configure flag; libass detects HarfBuzz through pkg-config.

## Why
Arabic text crashes reported around #10443/#10317 show `libHarfBuzzSharp.so` and `libharfbuzz.so.0` on the native stack. `libHarfBuzzSharp.so` bundles HarfBuzz 8.3.x symbols, while the Flatpak runtime can load a different platform `libharfbuzz.so.0` through libass/mpv. Shipping the matching HarfBuzz in `/app/lib` avoids that runtime mismatch and lets libass resolve to the bundled version.

## Validation
- `flatpak-builder --state-dir=/tmp/subtitleedit-flatpak-state --disable-cache --force-clean --disable-rofiles-fuse --disable-tests --stop-at=uchardet /tmp/subtitleedit-flatpak-harfbuzz installer/flatpak/dk.nikse.subtitleedit.yaml`
- Verified the staged libass resolves HarfBuzz from the Flatpak app prefix:
  `LD_LIBRARY_PATH=/tmp/subtitleedit-flatpak-harfbuzz/files/lib ldd /tmp/subtitleedit-flatpak-harfbuzz/files/lib/libass.so.9.4.1 | grep harfbuzz`
  -> `/tmp/subtitleedit-flatpak-harfbuzz/files/lib/libharfbuzz.so.0`
- `git diff --check`

Related to #10317 and #10443.