### PR TITLE
Preserve line breaks in compare HTML export

### DIFF
--- a/src/UI/Features/Files/Compare/CompareViewModel.cs
+++ b/src/UI/Features/Files/Compare/CompareViewModel.cs
@@ -805,7 +805,10 @@ public partial class CompareViewModel : ObservableObject
 
     private static string GetHtmlText(CompareItem p, string text)
     {
-        return p.IsDefault ? string.Empty : HtmlUtil.EncodeNamed(text);
+        return p.IsDefault ? string.Empty : HtmlUtil.EncodeNamed(text)
+            .Replace("\r\n", "<br />")
+            .Replace("\r", "<br />")
+            .Replace("\n", "<br />");
     }
 
     private static string GetHtmlBackgroundColor(IBrush brush)

--- a/tests/UI/Features/Files/Compare/CompareViewModelTests.cs
+++ b/tests/UI/Features/Files/Compare/CompareViewModelTests.cs
@@ -1,0 +1,19 @@
+using Nikse.SubtitleEdit.Features.Files.Compare;
+using System.Reflection;
+
+namespace UITests.Features.Files.Compare;
+
+public class CompareViewModelTests
+{
+    [Fact]
+    public void GetHtmlText_PreservesLineBreaks()
+    {
+        var method = typeof(CompareViewModel).GetMethod("GetHtmlText", BindingFlags.NonPublic | BindingFlags.Static);
+        var item = new CompareItem { Text = "not default" };
+
+        Assert.NotNull(method);
+        var html = (string)method!.Invoke(null, [item, "First\r\nSecond\nThird\rFourth <tag>"])!;
+
+        Assert.Equal("First<br />Second<br />Third<br />Fourth&nbsp;&lt;tag&gt;", html);
+    }
+}


### PR DESCRIPTION
## Summary
- Convert encoded CRLF/LF/CR text line breaks to `<br />` in Compare HTML export.
- Add a regression test covering all common newline forms.

Fixes #9699

## Tests
- `dotnet test tests/UI/UITests.csproj --no-restore`