### PR TITLE
Append missing extension on save as

### DIFF
--- a/src/UI/Logic/Media/FileHelper.cs
+++ b/src/UI/Logic/Media/FileHelper.cs
@@ -300,13 +300,25 @@ namespace Nikse.SubtitleEdit.Logic.Media
             {
                 return null;
             }
+
+            var subtitleFormat = SubtitleFormat.AllSubtitleFormats
+                .FirstOrDefault(f => result.SelectedFileType?.Name == f.Name) ?? currentFormat;
             
             return new FileHelperSubtitleSavePickerResult
             {
-                FileName = result.File.Path.LocalPath,
-                SubtitleFormat = SubtitleFormat.AllSubtitleFormats
-                    .FirstOrDefault(f => result.SelectedFileType?.Name == f.Name) ?? new SubRip(),
+                FileName = AddMissingExtension(result.File.Path.LocalPath, subtitleFormat.Extension),
+                SubtitleFormat = subtitleFormat,
             };
+        }
+
+        private static string AddMissingExtension(string fileName, string extension)
+        {
+            if (string.IsNullOrEmpty(fileName) || Path.HasExtension(fileName))
+            {
+                return fileName;
+            }
+
+            return fileName + (extension.StartsWith('.') ? extension : "." + extension);
         }
 
         public async Task<string> PickSaveSubtitleFile(

--- a/tests/UI/Logic/Media/FileHelperTests.cs
+++ b/tests/UI/Logic/Media/FileHelperTests.cs
@@ -1,0 +1,17 @@
+using Nikse.SubtitleEdit.Logic.Media;
+using System.Reflection;
+
+namespace UITests.Logic.Media;
+
+public class FileHelperTests
+{
+    [Fact]
+    public void AddMissingExtension_AppendsExtensionOnlyWhenFileNameHasNoExtension()
+    {
+        var method = typeof(FileHelper).GetMethod("AddMissingExtension", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        Assert.Equal("subtitle.srt", method!.Invoke(null, ["subtitle", ".srt"]));
+        Assert.Equal("subtitle.ass", method.Invoke(null, ["subtitle.ass", ".srt"]));
+    }
+}


### PR DESCRIPTION
## Summary
- Append the selected subtitle format extension when Save As returns a file name without one.
- Keep user-provided extensions unchanged.
- Add a small regression test for the helper.

Fixes #10349

## Tests
- `dotnet test tests/UI/UITests.csproj --no-restore`