### PR TITLE
Fix adjust duration percent calculation

### DIFF
--- a/src/UI/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
+++ b/src/UI/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
@@ -106,8 +106,8 @@ public partial class AdjustDurationViewModel : ObservableObject
             var nextSubtitle = subtitles.GetOrNull(i + 1);
 
             var originalDuration = subtitle.EndTime - subtitle.StartTime;
-            var adjustment = originalDuration.TotalSeconds * (AdjustPercent / 100.0);
-            var newEndTime = subtitle.EndTime + TimeSpan.FromSeconds(adjustment);
+            var newDuration = originalDuration.TotalSeconds * (AdjustPercent / 100.0);
+            var newEndTime = subtitle.StartTime + TimeSpan.FromSeconds(newDuration);
 
             if (nextSubtitle != null && newEndTime > nextSubtitle.StartTime)
             {

--- a/tests/UI/Features/Tools/AdjustDuration/AdjustDurationViewModelTests.cs
+++ b/tests/UI/Features/Tools/AdjustDuration/AdjustDurationViewModelTests.cs
@@ -1,0 +1,37 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.AdjustDuration;
+using System.Collections.ObjectModel;
+
+namespace UITests.Features.Tools.AdjustDuration;
+
+public class AdjustDurationViewModelTests
+{
+    [Fact]
+    public void AdjustDuration_Percent_ScalesDurationFromStartTime()
+    {
+        var vm = new AdjustDurationViewModel
+        {
+            SelectedAdjustType = new AdjustDurationDisplay { Type = AdjustDurationType.Percent },
+            AdjustPercent = 120,
+        };
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Text = "First",
+                StartTime = TimeSpan.FromSeconds(1),
+                EndTime = TimeSpan.FromSeconds(3),
+            },
+            new()
+            {
+                Text = "Second",
+                StartTime = TimeSpan.FromSeconds(10),
+                EndTime = TimeSpan.FromSeconds(11),
+            },
+        };
+
+        vm.AdjustDuration(subtitles);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(3400), subtitles[0].EndTime);
+    }
+}


### PR DESCRIPTION
## Summary
- Scale subtitle duration from the original start time in Adjust durations percent mode.
- Add a regression test for 120% duration scaling.

Fixes #9616

## Tests
- `dotnet test tests/UI/UITests.csproj --no-restore`