### PR TITLE
Add menu toggle for waveform toolbar

### DIFF
--- a/src/UI/Features/Main/Layout/InitMenu.cs
+++ b/src/UI/Features/Main/Layout/InitMenu.cs
@@ -550,6 +550,17 @@ public static class InitMenu
             },
             new MenuItem
             {
+                Header = Se.Language.Options.Shortcuts.ToggleWaveformToolbar,
+                Command = vm.ToggleIsWaveformToolbarVisibleCommand,
+                Icon = new Optris.Icons.Avalonia.Icon
+                {
+                    Value = IconNames.CheckBold,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsWaveformToolbarVisible)),
+                }
+            },
+            new MenuItem
+            {
                 Header = Se.Language.Main.Menu.SetVideoOffset,
                 [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SetVideoOffsetText)),
                 Command = vm.ShowVideoSetOffsetCommand,


### PR DESCRIPTION
## Summary
- Add a Video > More menu item that toggles the waveform toolbar.
- Show a check mark when the waveform toolbar is currently visible.

Fixes #10490

## Tests
- `dotnet test tests/UI/UITests.csproj`