### PR TITLE
Group speech-to-text backend variants

### DIFF
--- a/src/UI/Assets/Languages/English.json
+++ b/src/UI/Assets/Languages/English.json
@@ -40,6 +40,7 @@
     "autoContinue": "Auto-continue",
     "autoTranslate": "Auto-translate",
     "autodetect": "Autodetect",
+    "backend": "Backend",
     "background": "Background",
     "backgroundColor": "Background color",
     "backward": "Backward",

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrCanary.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrCanary.cs
@@ -98,7 +98,7 @@ public class CrispAsrCanary : CrispAsrEngineBase
 
     public override string ToString()
     {
-        return Name;
+        return CrispAsrEngine.GetBackendDisplayName(this);
     }
 
     public override string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
@@ -108,7 +108,7 @@ public class CrispAsrCohere : CrispAsrEngineBase
 
     public override string ToString()
     {
-        return Name;
+        return CrispAsrEngine.GetBackendDisplayName(this);
     }
 
     public override string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -1,0 +1,97 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+public class CrispAsrEngine : CrispAsrEngineBase
+{
+    private const string NamePrefix = "Crisp ASR ";
+    private readonly List<CrispAsrEngineBase> _backends;
+
+    public static string StaticName => "Crisp ASR";
+    public IReadOnlyList<CrispAsrEngineBase> Backends => _backends;
+    public CrispAsrEngineBase SelectedBackend { get; private set; }
+    public string SelectedBackendDisplay => GetBackendDisplayName(SelectedBackend);
+
+    public CrispAsrEngine()
+    {
+        _backends = new List<CrispAsrEngineBase>
+        {
+            new CrispAsrParakeet(),
+            new CrispAsrCanary(),
+            new CrispAsrCohere(),
+            new CrispAsrFireRed(),
+            new CrispAsrGlm(),
+            new CrispAsrGranite(),
+            new CrispAsrQwen3(),
+            new CrispAsrOmni(),
+        };
+
+        SelectedBackend = _backends[0];
+    }
+
+    public bool TrySelectBackendChoice(string choice)
+    {
+        var backend = _backends.FirstOrDefault(p =>
+            string.Equals(p.Choice, choice, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(p.Name, choice, StringComparison.OrdinalIgnoreCase));
+
+        if (backend == null)
+        {
+            return false;
+        }
+
+        SelectBackend(backend);
+        return true;
+    }
+
+    public void SelectBackend(CrispAsrEngineBase backend)
+    {
+        var match = _backends.FirstOrDefault(p => ReferenceEquals(p, backend) || string.Equals(p.Choice, backend.Choice, StringComparison.OrdinalIgnoreCase));
+        if (match != null)
+        {
+            SelectedBackend = match;
+        }
+    }
+
+    public static string GetBackendDisplayName(ICrispAsrEngine backend)
+    {
+        return backend.Name.StartsWith(NamePrefix, StringComparison.OrdinalIgnoreCase)
+            ? backend.Name[NamePrefix.Length..]
+            : backend.Name;
+    }
+
+    public override string Name => StaticName;
+    public override string Choice => SelectedBackend.Choice;
+    public override string Url => SelectedBackend.Url;
+    public override string BackendName => SelectedBackend.BackendName;
+    public override string DefaultLanguage => SelectedBackend.DefaultLanguage;
+    public override bool IncludeLanguage => SelectedBackend.IncludeLanguage;
+    public override List<WhisperLanguage> Languages => SelectedBackend.Languages;
+    public override List<WhisperModel> Models => SelectedBackend.Models;
+    public override string Extension => SelectedBackend.Extension;
+    public override string UnpackSkipFolder => SelectedBackend.UnpackSkipFolder;
+    public override string CommandLineParameter
+    {
+        get => SelectedBackend.CommandLineParameter;
+        set => SelectedBackend.CommandLineParameter = value;
+    }
+
+    public override bool IsEngineInstalled() => SelectedBackend.IsEngineInstalled();
+    public override bool CanBeDownloaded() => SelectedBackend.CanBeDownloaded();
+    public override string GetAndCreateWhisperFolder() => SelectedBackend.GetAndCreateWhisperFolder();
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => SelectedBackend.GetAndCreateWhisperModelFolder(whisperModel);
+    public override string GetExecutable() => SelectedBackend.GetExecutable();
+    public override bool IsModelInstalled(WhisperModel model) => SelectedBackend.IsModelInstalled(model);
+    public override string GetModelForCmdLine(string modelName) => SelectedBackend.GetModelForCmdLine(modelName);
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url) => SelectedBackend.GetWhisperModelDownloadFileName(whisperModel, url);
+    public override Task<string> GetHelpText() => SelectedBackend.GetHelpText();
+
+    public override string ToString()
+    {
+        return Name;
+    }
+}

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
@@ -29,7 +29,7 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
     public abstract string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url);
     public abstract string CommandLineParameter { get; set; }
 
-    public async Task<string> GetHelpText()
+    public virtual async Task<string> GetHelpText()
     {
         var assetName = $"{Name.Replace(" ", string.Empty)}.txt";
         var uri = new Uri($"avares://SubtitleEdit/Assets/SpeechToText/{assetName}");

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrFireRed.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrFireRed.cs
@@ -119,7 +119,7 @@ public class CrispAsrFireRed : CrispAsrEngineBase
 
     public override string ToString()
     {
-        return Name;
+        return CrispAsrEngine.GetBackendDisplayName(this);
     }
 
     public override string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrGlm.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrGlm.cs
@@ -83,7 +83,7 @@ public class CrispAsrGlm : CrispAsrEngineBase
 
     public override string ToString()
     {
-        return Name;
+        return CrispAsrEngine.GetBackendDisplayName(this);
     }
 
     public override string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrGranite.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrGranite.cs
@@ -79,7 +79,7 @@ public class CrispAsrGranite : CrispAsrEngineBase
 
     public override string ToString()
     {
-        return Name;
+        return CrispAsrEngine.GetBackendDisplayName(this);
     }
 
     public override string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrOmni.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrOmni.cs
@@ -19,6 +19,8 @@ public class CrispAsrOmni : CrispAsrEngineBase
     public override List<WhisperLanguage> Languages =>
        new()
        {
+          new WhisperLanguage("auto", "Auto detect"),
+
             // Germanic
             new WhisperLanguage("eng_Latn", "english"),
             new WhisperLanguage("deu_Latn", "german"),
@@ -238,7 +240,7 @@ public class CrispAsrOmni : CrispAsrEngineBase
 
     public override string ToString()
     {
-        return Name;
+        return CrispAsrEngine.GetBackendDisplayName(this);
     }
 
     public override string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -87,7 +87,7 @@ public class CrispAsrParakeet : CrispAsrEngineBase
 
     public override string ToString()
     {
-        return Name;
+        return CrispAsrEngine.GetBackendDisplayName(this);
     }
 
     public override string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
@@ -105,7 +105,7 @@ public class CrispAsrQwen3 : CrispAsrEngineBase
 
     public override string ToString()
     {
-        return Name;
+        return CrispAsrEngine.GetBackendDisplayName(this);
     }
 
     public override string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/WhisperCppEngine.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/WhisperCppEngine.cs
@@ -1,0 +1,96 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+public class WhisperCppEngine : ISpeechToTextEngine
+{
+    private readonly List<ISpeechToTextEngine> _backends;
+
+    public static string StaticName => "Whisper CPP";
+    public IReadOnlyList<ISpeechToTextEngine> Backends => _backends;
+    public ISpeechToTextEngine SelectedBackend { get; private set; }
+
+    public WhisperCppEngine()
+    {
+        _backends = new List<ISpeechToTextEngine>
+        {
+            new WhisperEngineCpp(),
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            _backends.Add(new WhisperEngineCppCuBlas());
+            _backends.Add(new WhisperEngineCppVulkan());
+        }
+
+        SelectedBackend = _backends[0];
+    }
+
+    public bool TrySelectBackendChoice(string choice)
+    {
+        var backend = _backends.FirstOrDefault(p =>
+            string.Equals(p.Choice, choice, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(p.Name, choice, StringComparison.OrdinalIgnoreCase));
+
+        if (backend == null)
+        {
+            return false;
+        }
+
+        SelectBackend(backend);
+        return true;
+    }
+
+    public void SelectBackend(ISpeechToTextEngine backend)
+    {
+        var match = _backends.FirstOrDefault(p => ReferenceEquals(p, backend) || string.Equals(p.Choice, backend.Choice, StringComparison.OrdinalIgnoreCase));
+        if (match != null)
+        {
+            SelectedBackend = match;
+        }
+    }
+
+    public static string GetBackendDisplayName(ISpeechToTextEngine backend)
+    {
+        return backend switch
+        {
+            WhisperEngineCpp => "CPU",
+            WhisperEngineCppCuBlas => "cuBLAS",
+            WhisperEngineCppVulkan => "Vulkan",
+            _ => backend.Name,
+        };
+    }
+
+    public string Name => StaticName;
+    public string Choice => SelectedBackend.Choice;
+    public string Url => SelectedBackend.Url;
+    public List<WhisperLanguage> Languages => SelectedBackend.Languages;
+    public List<WhisperModel> Models => SelectedBackend.Models;
+    public string Extension => SelectedBackend.Extension;
+    public string UnpackSkipFolder => SelectedBackend.UnpackSkipFolder;
+    public string CommandLineParameter
+    {
+        get => SelectedBackend.CommandLineParameter;
+        set => SelectedBackend.CommandLineParameter = value;
+    }
+
+    public bool IsEngineInstalled() => SelectedBackend.IsEngineInstalled();
+    public bool CanBeDownloaded() => SelectedBackend.CanBeDownloaded();
+    public string GetAndCreateWhisperFolder() => SelectedBackend.GetAndCreateWhisperFolder();
+    public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => SelectedBackend.GetAndCreateWhisperModelFolder(whisperModel);
+    public string GetExecutable() => SelectedBackend.GetExecutable();
+    public bool IsModelInstalled(WhisperModel model) => SelectedBackend.IsModelInstalled(model);
+    public string GetModelForCmdLine(string modelName) => SelectedBackend.GetModelForCmdLine(modelName);
+    public Task<string> GetHelpText() => SelectedBackend.GetHelpText();
+    public string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url) => SelectedBackend.GetWhisperModelDownloadFileName(whisperModel, url);
+
+    public override string ToString()
+    {
+        return Name;
+    }
+}

--- a/src/UI/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
@@ -39,7 +39,7 @@ public class WhisperEngineCpp : ISpeechToTextEngine
 
     public override string ToString()
     {
-        return Name;
+        return WhisperCppEngine.GetBackendDisplayName(this);
     }
 
     public string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/WhisperEngineCppCuBlas.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/WhisperEngineCppCuBlas.cs
@@ -39,7 +39,7 @@ public class WhisperEngineCppCuBlas : ISpeechToTextEngine
 
     public override string ToString()
     {
-        return Name;
+        return WhisperCppEngine.GetBackendDisplayName(this);
     }
 
     public string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
+++ b/src/UI/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
@@ -39,7 +39,7 @@ public class WhisperEngineCppVulkan : ISpeechToTextEngine
 
     public override string ToString()
     {
-        return Name;
+        return WhisperCppEngine.GetBackendDisplayName(this);
     }
 
     public string GetAndCreateWhisperFolder()

--- a/src/UI/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/UI/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -60,6 +60,13 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private bool _isWhisperPurfviewXxlActive;
     [ObservableProperty] private bool _isTranscribeEnabled;
     [ObservableProperty] private bool _isTranslateVisible;
+    [ObservableProperty] private bool _isBackendSelectionVisible;
+    [ObservableProperty] private bool _isWhisperCppSelected;
+    [ObservableProperty] private ObservableCollection<ISpeechToTextEngine> _whisperCppBackends;
+    [ObservableProperty] private ISpeechToTextEngine? _selectedWhisperCppBackend;
+    [ObservableProperty] private bool _isCrispAsrSelected;
+    [ObservableProperty] private ObservableCollection<CrispAsrEngineBase> _crispAsrBackends;
+    [ObservableProperty] private CrispAsrEngineBase? _selectedCrispAsrBackend;
     [ObservableProperty] private double _progressOpacity;
 
     [ObservableProperty] private double _progressValue;
@@ -119,20 +126,19 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
+    private bool _isUpdatingWhisperCppBackend;
+    private bool _isUpdatingCrispAsrBackend;
 
     public SpeechToTextViewModel(IWindowService windowService, IFileHelper fileHelper)
     {
         _windowService = windowService;
         _fileHelper = fileHelper;
 
-        Engines = [new WhisperEngineCpp()];
+        Engines = [new WhisperCppEngine()];
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Engines.Add(new WhisperEngineCppCuBlas());
-            Engines.Add(new WhisperEngineCppVulkan());
             Engines.Add(new WhisperEnginePurfviewFasterWhisperXxl());
             Engines.Add(new WhisperEngineConstMe());
-            Engines.Add(new WhisperEngineCppCuBlas());
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
@@ -154,14 +160,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             Engines.Add(new Qwen3AsrCppEngine());
         }
 
-        Engines.Add(new CrispAsrParakeet());
-        Engines.Add(new CrispAsrCanary());
-        Engines.Add(new CrispAsrCohere());
-        Engines.Add(new CrispAsrFireRed());
-        Engines.Add(new CrispAsrGlm());
-        Engines.Add(new CrispAsrGranite());
-        Engines.Add(new CrispAsrQwen3());
-        Engines.Add(new CrispAsrOmni());
+        Engines.Add(new CrispAsrEngine());
 
         SelectedEngine = Engines[0];
 
@@ -171,20 +170,16 @@ public partial class SpeechToTextViewModel : ObservableObject
         Models = new ObservableCollection<SpeechToTextModelDisplay>();
 
         BatchItems = new ObservableCollection<SpeechToTextJobItem>();
+        WhisperCppBackends = new ObservableCollection<ISpeechToTextEngine>();
+        CrispAsrBackends = new ObservableCollection<CrispAsrEngineBase>();
 
         ResultAudioClips = new List<AudioClip>();
 
         IsTranscribeEnabled = true;
-        IsTranslateVisible = SelectedEngine is
-            not ChatLlmCppEngine and
-            not Qwen3AsrCppEngine and
-            not CrispAsrParakeet and
-            not CrispAsrCohere and
-            not CrispAsrQwen3 and
-            not CrispAsrFireRed and
-            not CrispAsrGlm and
-            not CrispAsrGranite and
-            not CrispAsrOmni;
+        IsTranslateVisible = IsTranslateAvailable(GetEffectiveSelectedEngine());
+        IsBackendSelectionVisible = false;
+        IsWhisperCppSelected = false;
+        IsCrispAsrSelected = false;
         Parameters = string.Empty;
         ConsoleLog = string.Empty;
         ProgressText = string.Empty;
@@ -212,13 +207,27 @@ public partial class SpeechToTextViewModel : ObservableObject
         DoAdjustTimings = Se.Settings.Tools.AudioToText.WhisperAutoAdjustTimings;
         DoPostProcessing = Se.Settings.Tools.AudioToText.PostProcessing;
 
-        var selectedEngine = Enumerable.FirstOrDefault<ISpeechToTextEngine>((IEnumerable<ISpeechToTextEngine>)Engines, p => p.Choice == Se.Settings.Tools.AudioToText.WhisperChoice);
-        if (selectedEngine != null)
+        var savedChoice = Se.Settings.Tools.AudioToText.WhisperChoice;
+        var whisperCppEngine = Engines.OfType<WhisperCppEngine>().FirstOrDefault();
+        var crispAsrEngine = Engines.OfType<CrispAsrEngine>().FirstOrDefault();
+        if (whisperCppEngine != null && whisperCppEngine.TrySelectBackendChoice(savedChoice))
         {
-            SelectedEngine = selectedEngine;
+            SelectedEngine = whisperCppEngine;
+        }
+        else if (crispAsrEngine != null && crispAsrEngine.TrySelectBackendChoice(savedChoice))
+        {
+            SelectedEngine = crispAsrEngine;
+        }
+        else
+        {
+            var selectedEngine = Enumerable.FirstOrDefault<ISpeechToTextEngine>((IEnumerable<ISpeechToTextEngine>)Engines, p => p.Choice == savedChoice);
+            if (selectedEngine != null)
+            {
+                SelectedEngine = selectedEngine;
+            }
         }
 
-        Parameters = SelectedEngine.CommandLineParameter;
+        Parameters = GetEffectiveSelectedEngine().CommandLineParameter;
 
         EngineChanged();
     }
@@ -227,12 +236,139 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         Se.Settings.Tools.AudioToText.WhisperAutoAdjustTimings = DoAdjustTimings;
         Se.Settings.Tools.AudioToText.PostProcessing = DoPostProcessing;
-        SelectedEngine.CommandLineParameter = Parameters;
-        Se.Settings.Tools.AudioToText.WhisperChoice = SelectedEngine.Choice;
+        var engine = GetEffectiveSelectedEngine();
+        engine.CommandLineParameter = Parameters;
+        Se.Settings.Tools.AudioToText.WhisperChoice = engine.Choice;
         Se.Settings.Tools.AudioToText.WhisperModel = SelectedModel?.Model.Name ?? string.Empty;
         Se.Settings.Tools.AudioToText.WhisperLanguageCode = SelectedLanguage?.Code ?? string.Empty;
 
         Se.SaveSettings();
+    }
+
+    private ISpeechToTextEngine GetEffectiveSelectedEngine()
+    {
+        return SelectedEngine switch
+        {
+            WhisperCppEngine whisperCppEngine => whisperCppEngine.SelectedBackend,
+            CrispAsrEngine crispAsrEngine => crispAsrEngine.SelectedBackend,
+            _ => SelectedEngine,
+        };
+    }
+
+    private static bool IsTranslateAvailable(ISpeechToTextEngine engine)
+    {
+        return engine is not ChatLlmCppEngine and not Qwen3AsrCppEngine and not ICrispAsrEngine;
+    }
+
+    private void UpdateBackendSelectionUi()
+    {
+        UpdateWhisperCppBackendUi();
+        UpdateCrispAsrBackendUi();
+        IsBackendSelectionVisible = IsWhisperCppSelected || IsCrispAsrSelected;
+    }
+
+    private void UpdateWhisperCppBackendUi()
+    {
+        if (SelectedEngine is WhisperCppEngine whisperCppEngine)
+        {
+            IsWhisperCppSelected = true;
+            _isUpdatingWhisperCppBackend = true;
+            try
+            {
+                WhisperCppBackends.Clear();
+                foreach (var backend in whisperCppEngine.Backends)
+                {
+                    WhisperCppBackends.Add(backend);
+                }
+
+                SelectedWhisperCppBackend = WhisperCppBackends.FirstOrDefault(p => p.Choice == whisperCppEngine.SelectedBackend.Choice);
+            }
+            finally
+            {
+                _isUpdatingWhisperCppBackend = false;
+            }
+
+            return;
+        }
+
+        IsWhisperCppSelected = false;
+        _isUpdatingWhisperCppBackend = true;
+        try
+        {
+            SelectedWhisperCppBackend = null;
+        }
+        finally
+        {
+            _isUpdatingWhisperCppBackend = false;
+        }
+    }
+
+    private void UpdateCrispAsrBackendUi()
+    {
+        if (SelectedEngine is CrispAsrEngine crispAsrEngine)
+        {
+            IsCrispAsrSelected = true;
+            _isUpdatingCrispAsrBackend = true;
+            try
+            {
+                CrispAsrBackends.Clear();
+                foreach (var backend in crispAsrEngine.Backends)
+                {
+                    CrispAsrBackends.Add(backend);
+                }
+
+                SelectedCrispAsrBackend = CrispAsrBackends.FirstOrDefault(p => p.Choice == crispAsrEngine.SelectedBackend.Choice);
+            }
+            finally
+            {
+                _isUpdatingCrispAsrBackend = false;
+            }
+
+            return;
+        }
+
+        IsCrispAsrSelected = false;
+        _isUpdatingCrispAsrBackend = true;
+        try
+        {
+            SelectedCrispAsrBackend = null;
+        }
+        finally
+        {
+            _isUpdatingCrispAsrBackend = false;
+        }
+    }
+
+    partial void OnSelectedWhisperCppBackendChanged(ISpeechToTextEngine? value)
+    {
+        if (_isUpdatingWhisperCppBackend || value == null || SelectedEngine is not WhisperCppEngine whisperCppEngine)
+        {
+            return;
+        }
+
+        if (string.Equals(whisperCppEngine.SelectedBackend.Choice, value.Choice, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        whisperCppEngine.SelectBackend(value);
+        EngineChanged();
+    }
+
+    partial void OnSelectedCrispAsrBackendChanged(CrispAsrEngineBase? value)
+    {
+        if (_isUpdatingCrispAsrBackend || value == null || SelectedEngine is not CrispAsrEngine crispAsrEngine)
+        {
+            return;
+        }
+
+        if (string.Equals(crispAsrEngine.SelectedBackend.Choice, value.Choice, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        crispAsrEngine.SelectBackend(value);
+        EngineChanged();
     }
 
     private void OnTimerWhisperOnElapsed(object? sender, ElapsedEventArgs args)
@@ -319,13 +455,15 @@ public partial class SpeechToTextViewModel : ObservableObject
             var settings = Se.Settings.Tools.AudioToText;
             _whisperProcess.Dispose();
 
-            if (SelectedEngine is ChatLlmCppEngine chatLlm)
+            var engine = GetEffectiveSelectedEngine();
+
+            if (engine is ChatLlmCppEngine chatLlm)
             {
                 ProcessChatLlmTranscription(settings, chatLlm);
                 return;
             }
 
-            if (SelectedEngine is Qwen3AsrCppEngine qwen3Asr)
+            if (engine is Qwen3AsrCppEngine)
             {
                 ProcessQwen3AsrCppTranscription(settings);
                 return;
@@ -965,11 +1103,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         Task.Delay(500);
 
-        if (SelectedEngine is not ISpeechToTextEngine engine)
-        {
-            resultTexts = new List<ResultText>();
-            return false;
-        }
+        var engine = GetEffectiveSelectedEngine();
 
         if (string.IsNullOrEmpty(waveFileName) && videoFileName.EndsWith(".wav", StringComparison.OrdinalIgnoreCase))
         {
@@ -1196,6 +1330,16 @@ public partial class SpeechToTextViewModel : ObservableObject
                 TranscribedSubtitle = transcribedSubtitle ?? new Subtitle();
                 Window?.Close();
             }
+            else if (GetEffectiveSelectedEngine() is ICrispAsrEngine)
+            {
+                await MessageBox.Show(Window!, "No transcription result",
+                    "Crisp ASR finished without generating subtitles. Please check the speech-to-text log for engine output.");
+
+                if (Window != null)
+                {
+                    FileHelper.OpenFileWithDefaultProgram(Se.GetSpeechToTextLogFilePath());
+                }
+            }
         }
     }
 
@@ -1306,12 +1450,12 @@ public partial class SpeechToTextViewModel : ObservableObject
     [RelayCommand]
     private void ShowWebLink()
     {
-        var engine = SelectedEngine;
-        if (Window == null || engine == null)
+        if (Window == null)
         {
             return;
         }
 
+        var engine = GetEffectiveSelectedEngine();
         UiUtil.OpenUrl(engine.Url);
     }
 
@@ -1328,12 +1472,12 @@ public partial class SpeechToTextViewModel : ObservableObject
     [RelayCommand]
     private async Task ReDownloadWhisperEngine()
     {
-        var engine = SelectedEngine;
-        if (Window == null || engine == null)
+        if (Window == null)
         {
             return;
         }
 
+        var engine = GetEffectiveSelectedEngine();
         var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
             Window, viewModel =>
             {
@@ -1341,24 +1485,6 @@ public partial class SpeechToTextViewModel : ObservableObject
                 viewModel.StartDownload();
             });
     }
-
-    [RelayCommand]
-    private async Task ReDownloadWhisperEngineVulkan()
-    {
-        var engine = SelectedEngine;
-        if (Window == null || engine == null)
-        {
-            return;
-        }
-
-        var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
-            Window, viewModel =>
-            {
-                viewModel.Engine = engine;
-                viewModel.StartDownload();
-            });
-    }
-
 
     [RelayCommand]
     private void SingleMode()
@@ -1463,7 +1589,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         if (vm.OkPressed)
         {
-            Parameters = SelectedEngine.CommandLineParameter;
+            Parameters = GetEffectiveSelectedEngine().CommandLineParameter;
         }
     }
 
@@ -1501,7 +1627,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private async Task DownloadModel()
     {
         var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
-            Window!, viewModel => { viewModel.SetModels(Models, SelectedEngine, SelectedModel); });
+            Window!, viewModel => { viewModel.SetModels(Models, GetEffectiveSelectedEngine(), SelectedModel); });
 
         if (vm.OkPressed)
         {
@@ -1542,10 +1668,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             return;
         }
 
-        if (SelectedEngine is not { } engine)
-        {
-            return;
-        }
+        var engine = GetEffectiveSelectedEngine();
 
         _unknownArgument = false;
         _cudaOutOfMemory = false;
@@ -1659,7 +1782,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
                 Window!, viewModel =>
                 {
-                    viewModel.SetModels(Models, SelectedEngine, SelectedModel);
+                    viewModel.SetModels(Models, engine, SelectedModel);
                     viewModel.StartDownload();
                 });
 
@@ -1696,7 +1819,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                 var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
                     Window!, viewModel =>
                     {
-                        viewModel.SetModels(models, SelectedEngine, displayModelAligner);
+                        viewModel.SetModels(models, engine, displayModelAligner);
                         viewModel.StartDownload();
                     });
 
@@ -1737,7 +1860,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                 var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
                     Window!, viewModel =>
                     {
-                        viewModel.SetModels(models, SelectedEngine, displayModelAligner);
+                        viewModel.SetModels(models, engine, displayModelAligner);
                         viewModel.StartDownload();
                     });
 
@@ -1778,7 +1901,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                 var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
                     Window!, viewModel =>
                     {
-                        viewModel.SetModels(models, SelectedEngine, displayModelAligner);
+                        viewModel.SetModels(models, engine, displayModelAligner);
                         viewModel.StartDownload();
                     });
 
@@ -1888,10 +2011,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     public bool TranscribeViaWhisper(string waveFileName, string videoFileName)
     {
-        if (SelectedEngine is not { } engine)
-        {
-            return false;
-        }
+        var engine = GetEffectiveSelectedEngine();
 
         if (_videoFileName == null)
         {
@@ -2563,10 +2683,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     private void RefreshDownloadStatus(WhisperModel? result)
     {
-        if (SelectedEngine is not ISpeechToTextEngine engine)
-        {
-            return;
-        }
+        var engine = GetEffectiveSelectedEngine();
 
         if (SelectedModel is not SpeechToTextModelDisplay oldModel)
         {
@@ -2600,7 +2717,8 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     private void EngineChanged()
     {
-        var engine = SelectedEngine;
+        var engine = GetEffectiveSelectedEngine();
+        UpdateBackendSelectionUi();
 
         Languages.Clear();
         foreach (var l in engine.Languages)
@@ -2647,7 +2765,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         var isPurfview = engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName;
 
-        IsTranslateVisible = !(engine is ChatLlmCppEngine or Qwen3AsrCppEngine or CrispAsrParakeet or CrispAsrCohere or CrispAsrQwen3 or CrispAsrFireRed or CrispAsrGlm or CrispAsrGranite or CrispAsrOmni);
+        IsTranslateVisible = IsTranslateAvailable(engine);
 
         Parameters = engine.CommandLineParameter;
 
@@ -2714,8 +2832,8 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     internal void WindowContextMenuOpening(object? sender, EventArgs e)
     {
-        var engine = SelectedEngine;
-        if (engine == null || !engine.CanBeDownloaded())
+        var engine = GetEffectiveSelectedEngine();
+        if (!engine.CanBeDownloaded())
         {
             IsReDownloadVisible = false;
             return;

--- a/src/UI/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/UI/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -58,6 +58,19 @@ public class SpeechToTextWindow : Window
             }
         };
 
+        var labelBackend = UiUtil.MakeTextBlock(Se.Language.General.Backend).WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsBackendSelectionVisible));
+        var comboWhisperCppBackend = UiUtil.MakeComboBox(vm.WhisperCppBackends, vm, nameof(vm.SelectedWhisperCppBackend))
+            .WithMinWidth(220)
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
+            .WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsWhisperCppSelected));
+        var comboCrispAsrBackend = UiUtil.MakeComboBox(vm.CrispAsrBackends, vm, nameof(vm.SelectedCrispAsrBackend))
+            .WithMinWidth(220)
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
+            .WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsCrispAsrSelected));
+
         var labelLanguage = UiUtil.MakeTextBlock(Se.Language.Video.AudioToText.InputLanguage).WithMarginTop(10);
         var comboLanguage = UiUtil.MakeComboBox(vm.Languages, vm, nameof(vm.SelectedLanguage))
             .WithMinWidth(220)
@@ -279,6 +292,7 @@ public class SpeechToTextWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Engine
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Backend
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Language
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Model
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Translate to English
@@ -333,12 +347,17 @@ public class SpeechToTextWindow : Window
         grid.Add(labelConsoleLog, row, 2, 2, 1);
         row++;
 
-        grid.Add(consoleLogAndBatchView, row, 2, 8);
-        grid.Add(consoleLogOnlyView, row, 2, 8);
+        grid.Add(consoleLogAndBatchView, row, 2, 9);
+        grid.Add(consoleLogOnlyView, row, 2, 9);
         row++;
 
         grid.Add(labelEngine, row, 0);
         grid.Add(panelEngineControls, row, 1);
+        row++;
+
+        grid.Add(labelBackend, row, 0);
+        grid.Add(comboWhisperCppBackend, row, 1);
+        grid.Add(comboCrispAsrBackend, row, 1);
         row++;
 
         grid.Add(labelLanguage, row, 0);

--- a/src/UI/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/UI/Logic/Config/Language/LanguageGeneral.cs
@@ -40,6 +40,7 @@ public class LanguageGeneral
     public string AutoContinue { get; set; }
     public string AutoTranslate { get; set; }
     public string Autodetect { get; set; }
+    public string Backend { get; set; }
     public string Background { get; set; }
     public string BackgroundColor { get; set; }
     public string Backward { get; set; }
@@ -699,6 +700,7 @@ public class LanguageGeneral
         AutoContinue = "Auto-continue";
         AutoTranslate = "Auto-translate";
         Autodetect = "Autodetect";
+        Backend = "Backend";
         Background = "Background";
         BackgroundColor = "Background color";
         Backward = "Backward";

--- a/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineTests.cs
@@ -1,0 +1,52 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Video.SpeechToText.Engines;
+
+public class CrispAsrEngineTests
+{
+    [Theory]
+    [InlineData(WhisperChoice.CrispAsrOmni, typeof(CrispAsrOmni), "omniasr")]
+    [InlineData(WhisperChoice.CrispAsrQwen3, typeof(CrispAsrQwen3), "qwen3")]
+    public void TrySelectBackendChoice_SelectsPersistedCrispBackendChoice(string choice, Type backendType, string backendName)
+    {
+        var engine = new CrispAsrEngine();
+
+        Assert.True(engine.TrySelectBackendChoice(choice));
+
+        Assert.IsType(backendType, engine.SelectedBackend);
+        Assert.Equal(choice, engine.Choice);
+        Assert.Equal(backendName, engine.BackendName);
+    }
+
+    [Fact]
+    public void Members_DelegateToSelectedBackend()
+    {
+        var originalOmni = Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrOmni;
+
+        try
+        {
+            var engine = new CrispAsrEngine();
+            Assert.True(engine.TrySelectBackendChoice(WhisperChoice.CrispAsrOmni));
+
+            var expectedBackend = engine.SelectedBackend;
+            engine.CommandLineParameter = "--unit-test-crisp-asr";
+
+            Assert.Equal(expectedBackend.Choice, engine.Choice);
+            Assert.Equal(expectedBackend.Url, engine.Url);
+            Assert.Equal(expectedBackend.BackendName, engine.BackendName);
+            Assert.Equal(expectedBackend.DefaultLanguage, engine.DefaultLanguage);
+            Assert.Equal(expectedBackend.IncludeLanguage, engine.IncludeLanguage);
+            Assert.Equal(expectedBackend.Extension, engine.Extension);
+            Assert.Equal(expectedBackend.UnpackSkipFolder, engine.UnpackSkipFolder);
+            Assert.Equal(expectedBackend.CommandLineParameter, engine.CommandLineParameter);
+            Assert.Equal(expectedBackend.Models.Select(p => p.Name), engine.Models.Select(p => p.Name));
+            Assert.Equal(expectedBackend.Languages.Select(p => p.Code), engine.Languages.Select(p => p.Code));
+        }
+        finally
+        {
+            Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrOmni = originalOmni;
+        }
+    }
+}

--- a/tests/UI/Features/Video/SpeechToText/Engines/WhisperCppEngineTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/WhisperCppEngineTests.cs
@@ -1,0 +1,64 @@
+using System.Runtime.InteropServices;
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Video.SpeechToText.Engines;
+
+public class WhisperCppEngineTests
+{
+    [Fact]
+    public void TrySelectBackendChoice_SelectsPersistedWindowsBackendChoice()
+    {
+        var engine = new WhisperCppEngine();
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.False(engine.TrySelectBackendChoice(WhisperChoice.CppCuBlas));
+            Assert.IsType<WhisperEngineCpp>(engine.SelectedBackend);
+            return;
+        }
+
+        Assert.True(engine.TrySelectBackendChoice(WhisperChoice.CppCuBlas));
+        Assert.IsType<WhisperEngineCppCuBlas>(engine.SelectedBackend);
+        Assert.Equal(WhisperChoice.CppCuBlas, engine.Choice);
+
+        Assert.True(engine.TrySelectBackendChoice(WhisperChoice.CppVulkan));
+        Assert.IsType<WhisperEngineCppVulkan>(engine.SelectedBackend);
+        Assert.Equal(WhisperChoice.CppVulkan, engine.Choice);
+    }
+
+    [Fact]
+    public void Members_DelegateToSelectedBackend()
+    {
+        var originalCpp = Se.Settings.Tools.AudioToText.CommandLineParameterCpp;
+        var originalVulkan = Se.Settings.Tools.AudioToText.CommandLineParameterCppVulkan;
+
+        try
+        {
+            var engine = new WhisperCppEngine();
+            var expectedBackend = engine.SelectedBackend;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.True(engine.TrySelectBackendChoice(WhisperChoice.CppVulkan));
+                expectedBackend = engine.SelectedBackend;
+            }
+
+            engine.CommandLineParameter = "--unit-test-whisper-cpp";
+
+            Assert.Equal(expectedBackend.Choice, engine.Choice);
+            Assert.Equal(expectedBackend.Url, engine.Url);
+            Assert.Equal(expectedBackend.Extension, engine.Extension);
+            Assert.Equal(expectedBackend.UnpackSkipFolder, engine.UnpackSkipFolder);
+            Assert.Equal(expectedBackend.CommandLineParameter, engine.CommandLineParameter);
+            Assert.Equal(expectedBackend.Models.Select(p => p.Name), engine.Models.Select(p => p.Name));
+            Assert.Equal(expectedBackend.Languages.Select(p => p.Code), engine.Languages.Select(p => p.Code));
+        }
+        finally
+        {
+            Se.Settings.Tools.AudioToText.CommandLineParameterCpp = originalCpp;
+            Se.Settings.Tools.AudioToText.CommandLineParameterCppVulkan = originalVulkan;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Group Crisp ASR into one top-level engine with an inline Backend dropdown for Parakeet, Canary, Cohere, FireRed, GLM, Granite, Qwen3, and Omni.
- Group only the whisper.cpp CPU/cuBLAS/Vulkan variants under one top-level Whisper CPP entry with a Backend dropdown.
- Preserve the existing persisted `WhisperChoice` values by delegating all engine/model/download/command-line behavior to the selected backend.
- Add `Auto detect` to Crisp ASR Omni and show the speech-to-text log when a Crisp ASR run finishes without producing subtitles.
- Address Copilot review feedback by localizing the Backend label, removing an unused Vulkan re-download command, and adding wrapper-engine tests.

## UI cleanup and readability

The speech-to-text engine list had become hard to scan because implementation variants were shown as independent engines. This keeps the main engine dropdown focused on the user's engine family choice, then exposes implementation variants in a compact Backend dropdown only when that choice has variants.

Crisp ASR is grouped because these entries are all backends of the same CrispASR executable and are selected by passing `--backend ...`; grouping them matches the underlying runtime model and avoids repeating `Crisp ASR` in the main engine list.

Whisper is different: most Whisper-related entries are separate projects, executables, install folders, options, or providers, such as Const-me, Purfview Faster Whisper XXL, CTranslate2/OpenAI-style providers, and Qwen3 ASR CPP. Those remain top-level engines. Only Whisper CPP CPU, cuBLAS, and Vulkan are grouped because they are build/backend variants of the whisper.cpp engine family and share the same general model flow.

## Note on #10723

Related to #10723. This PR addresses the Subtitle Edit integration-side pieces that are visible from the issue:

- Crisp ASR Omni now exposes `Auto detect` in the language dropdown.
- The current main branch already contains the related `-l auto` command-line behavior for Crisp ASR when auto-detect is selected.
- If Crisp ASR exits without generating subtitles, Subtitle Edit no longer treats it as a silent success; it shows a message and opens the speech-to-text log so dependency/model/runtime errors are visible.

Confidence: medium. The UI and command-line integration paths are covered by code review and build/tests, but I did not reproduce the exact Serbian audio + CPU + `omniasr-llm-300m-v2-q4_k.gguf` scenario from the issue. If the root cause is inside the CrispASR executable or an external runtime dependency, this PR should expose it through the log rather than fully fixing it.

## Verification

- `dotnet build ./src/UI/UI.csproj -c Debug`
- `dotnet test ./tests/UI/UITests.csproj -c Debug -v minimal` (94 passed)
- `dotnet test ./tests/libse/LibSETests.csproj -c Debug -v minimal` (332 passed)
- `dotnet build ./src/UI/UI.csproj -c Release`

## Compiled branch demo
<img width="1377" height="864" alt="9W8yT3bJGk" src="https://github.com/user-attachments/assets/84850c01-0cc6-4a18-a886-7ef14ff6d04d"/>


<img width="1904" height="1009" alt="JO6xCeIx4p" src="https://github.com/user-attachments/assets/31e975e7-3e17-45ac-aa5a-fea2110b751c"/>
