### PR TITLE
refactor: convert AutoTranslate Translate methods to async/await

### DIFF
--- a/src/libse/AutoTranslate/GoogleTranslateV1.cs
+++ b/src/libse/AutoTranslate/GoogleTranslateV1.cs
@@ -45,7 +45,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return GetTranslationPairs();
         }
 
-        public Task<string> Translate(string input, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string input, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             string jsonResultString;
 
@@ -54,8 +54,8 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 var text = input.Replace("\r'",string.Empty).Trim();
                 var url = $"translate_a/single?client=gtx&sl={sourceLanguageCode}&tl={targetLanguageCode}&dt=t&q={Utilities.UrlEncode(text)}";
 
-                var result = _httpClient.GetAsync(url).Result;
-                var bytes = result.Content.ReadAsByteArrayAsync().Result;
+                var result = await _httpClient.GetAsync(url, cancellationToken);
+                var bytes = await result.Content.ReadAsByteArrayAsync();
                 jsonResultString = Encoding.UTF8.GetString(bytes).Trim();
 
                 if (!result.IsSuccessStatusCode)
@@ -70,7 +70,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
 
             var resultList = ConvertJsonObjectToStringLines(jsonResultString);
-            return Task.FromResult(string.Join(Environment.NewLine, resultList));
+            return string.Join(Environment.NewLine, resultList);
         }
 
         public static List<TranslationPair> GetTranslationPairs()

--- a/src/libse/AutoTranslate/GoogleTranslateV2.cs
+++ b/src/libse/AutoTranslate/GoogleTranslateV2.cs
@@ -46,7 +46,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return GoogleTranslateV1.GetTranslationPairs();
         }
 
-        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var format = "text";
             var input = new StringBuilder();
@@ -55,13 +55,13 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             string content;
             try
             {
-                var result = _httpClient.PostAsync(uri, new StringContent(string.Empty)).Result;
+                var result = await _httpClient.PostAsync(uri, new StringContent(string.Empty), cancellationToken);
 
                 if (!result.IsSuccessStatusCode)
                 {
                     try
                     {
-                        Error = result.Content.ReadAsStringAsync().Result;
+                        Error = await result.Content.ReadAsStringAsync();
                         SeLogger.Error($"Error in {StaticName}.Translate: " + Error);
                     }
                     catch
@@ -72,7 +72,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 }
 
                 if ((int)result.StatusCode == 400)
-                {                   
+                {
                     throw new Exception("API key invalid (or perhaps billing is not enabled)?");
                 }
                 if ((int)result.StatusCode == 403)
@@ -85,7 +85,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                     throw new Exception($"An error occurred calling GT translate - status code: {result.StatusCode}");
                 }
 
-                content = result.Content.ReadAsStringAsync().Result;
+                content = await result.Content.ReadAsStringAsync();
             }
             catch (WebException webException)
             {
@@ -141,7 +141,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                     }
                 }
             }
-            return Task.FromResult(string.Join(Environment.NewLine, resultList));
+            return string.Join(Environment.NewLine, resultList);
         }
 
         public void Dispose() => _httpClient?.Dispose();

--- a/src/libse/AutoTranslate/LibreTranslate.cs
+++ b/src/libse/AutoTranslate/LibreTranslate.cs
@@ -59,7 +59,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{\"q\": \"" + Json.EncodeJsonText(text.Trim()) + "\", \"source\": \"" + sourceLanguageCode + "\", \"target\": \"" + targetLanguageCode + "\"" + apiKey + "}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = _httpClient.PostAsync("translate", content, cancellationToken).Result;
+            var result = await _httpClient.PostAsync("translate", content, cancellationToken);
             var bytes = await result.Content.ReadAsByteArrayAsync();
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)

--- a/src/libse/AutoTranslate/MicrosoftTranslator.cs
+++ b/src/libse/AutoTranslate/MicrosoftTranslator.cs
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return GetTranslationPairs();
         }
 
-        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var url = string.Format(TranslateUrl, sourceLanguageCode, targetLanguageCode);
             if (!string.IsNullOrEmpty(_category))
@@ -79,9 +79,9 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var json = jsonBuilder.ToString();
             var content = new StringContent(json, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = httpClient.PostAsync(url, content).Result;
+            var result = await httpClient.PostAsync(url, content);
             var parser = new JsonParser();
-            var jsonResult = result.Content.ReadAsStringAsync().Result;
+            var jsonResult = await result.Content.ReadAsStringAsync();
 
             if (!result.IsSuccessStatusCode)
             {
@@ -111,7 +111,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 }
             }
 
-            return Task.FromResult(string.Join(Environment.NewLine, results));
+            return string.Join(Environment.NewLine, results);
         }
 
         private IDownloader GetTranslateClient()

--- a/src/libse/AutoTranslate/MicrosoftTranslator.cs
+++ b/src/libse/AutoTranslate/MicrosoftTranslator.cs
@@ -79,7 +79,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var json = jsonBuilder.ToString();
             var content = new StringContent(json, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await httpClient.PostAsync(url, content);
+            var result = await httpClient.PostAsync(url, content, cancellationToken);
             var parser = new JsonParser();
             var jsonResult = await result.Content.ReadAsStringAsync();
 

--- a/src/libse/AutoTranslate/MyMemoryApi.cs
+++ b/src/libse/AutoTranslate/MyMemoryApi.cs
@@ -204,7 +204,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             return new TranslationPair(name, code, twoLetterIsoName);
         }
 
-        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var apiKey = string.Empty;
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.AutoTranslateLibreApiKey))
@@ -213,7 +213,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
 
             var url = $"?langpair={sourceLanguageCode}|{targetLanguageCode}{apiKey}&q={Utilities.UrlEncode(text)}";
-            var jsonResultString = _httpClient.GetStringAsync(url).Result;
+            var jsonResultString = await _httpClient.GetStringAsync(url);
             var textResult = _jsonParser.GetFirstObject(jsonResultString, "translatedText");
             var result = Json.DecodeJsonText(textResult);
 
@@ -226,7 +226,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 // ignore
             }
 
-            return Task.FromResult(result);
+            return result;
         }
 
         public void Dispose() => _httpClient?.Dispose();

--- a/src/libse/AutoTranslate/NoLanguageLeftBehindServe.cs
+++ b/src/libse/AutoTranslate/NoLanguageLeftBehindServe.cs
@@ -55,7 +55,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
 
-            var result = _httpClient.PostAsync("translate", content).Result;
+            var result = await _httpClient.PostAsync("translate", content, cancellationToken);
             result.EnsureSuccessStatusCode();
             var bytes = await result.Content.ReadAsByteArrayAsync();
             var json = Encoding.UTF8.GetString(bytes).Trim();

--- a/src/libse/AutoTranslate/SeamlessM4TTranslate.cs
+++ b/src/libse/AutoTranslate/SeamlessM4TTranslate.cs
@@ -65,7 +65,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var input = "{ \"input\": { \"task_name\":\"T2TT (Text to Text translation)\", \"input_text\": \"" + Json.EncodeJsonText(text.Trim()) + "\", \"input_text_language\": \"" + sourceLanguageCode + "\", \"target_language_text_only\": \"" + targetLanguageCode + "\" }}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = _httpClient.PostAsync("predictions", content).Result;
+            var result = await _httpClient.PostAsync("predictions", content, cancellationToken);
             result.EnsureSuccessStatusCode();
             var bytes = await result.Content.ReadAsByteArrayAsync();
             var json = Encoding.UTF8.GetString(bytes).Trim();


### PR DESCRIPTION
## Summary

- Replace blocking `.Result` calls with `async`/`await` in 7 translator classes
- `GoogleTranslateV1`, `GoogleTranslateV2`, `MicrosoftTranslator`, `MyMemoryApi`: promoted `Translate` from sync-wrapping-Task to a proper `async Task<string>`, replacing `.Result` on HTTP calls and removing `Task.FromResult` on the return
- `LibreTranslate`: method was already `async` but was still calling `.Result` on the initial `PostAsync`; fixed
- `NoLanguageLeftBehindServe`, `SeamlessM4TTranslate`: same partial-async issue, now fully awaited and `CancellationToken` forwarded to the HTTP call

Note: `MicrosoftTranslator.GetAccessToken` and `GetTranslationPairs` call HTTP from sync interface methods (`Initialize`, `GetSupportedSourceLanguages/TargetLanguages`) and are left unchanged.

## Test plan

- [x] Build `LibSE.csproj` with no errors or warnings
- [ ] Translate a subtitle using Google Translate V1 and verify the result returns correctly
- [ ] Translate a subtitle using Google Translate V2 (API key required) and verify it succeeds
- [ ] Translate a subtitle using Microsoft Translator and verify it succeeds
- [ ] Translate a subtitle using LibreTranslate and verify it succeeds
- [ ] Translate a subtitle using MyMemory API and verify it succeeds
- [ ] Confirm cancellation (e.g. stop translation mid-way) propagates correctly and doesn't deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)