### PR TITLE
seconv: wire --FixCommonErrors and add BinaryOCR engine

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -149,6 +149,7 @@ into text. Four engines are supported:
 |---|---|---|
 | `tesseract` (default) | Subprocess | Install Tesseract (e.g. `apt install tesseract-ocr`, `brew install tesseract`, or the Windows installer); ensure it is on `PATH`. Pass `--ocrlanguage` as ISO 639-2 (`eng`, `deu`, `spa`, …). |
 | `nocr` | In-process | Built-in nOCR matcher. Required: `--ocrdb=<path-to-Latin.nocr>` (find these under `%AppData%\Subtitle Edit\Ocr\` or download via the SE UI). |
+| `binaryocr`, `binary` | In-process | Built-in BinaryOCR matcher (alternative to nOCR; different accuracy profile, similar speed). Required: `--ocrdb=<path-to-Latin.db>`. |
 | `ollama` | HTTP | Local Ollama server with a vision-capable model (e.g. `llama3.2-vision`, `qwen2.5vl`). Configure via `--ollama-url` (default `http://localhost:11434/api/chat`) and `--ollama-model` (default `llama3.2-vision`). Pass `--ocrlanguage` as a human name like `English`. |
 | `paddle`, `paddleocr` | Subprocess | Install via `pip install paddleocr`; ensure the `paddleocr` binary is on `PATH`. Pass `--ocrlanguage` as a short code (`en`, `de`, …). |
 
@@ -160,6 +161,9 @@ seconv movie.sup subrip --ocrengine tesseract --ocrlanguage eng
 
 # Same source via nOCR (no external dependency)
 seconv movie.sup subrip --ocrengine nocr --ocrdb "C:\Users\me\AppData\Roaming\Subtitle Edit\Ocr\Latin.nocr"
+
+# Or via BinaryOCR
+seconv movie.sup subrip --ocrengine binaryocr --ocrdb "C:\Users\me\AppData\Roaming\Subtitle Edit\Ocr\Latin.db"
 
 # MKV with image (PGS) tracks — OCR runs automatically
 seconv movie.mkv subrip --ocrengine tesseract --ocrlanguage eng

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -63,7 +63,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         public string? CustomFormat { get; init; }
 
         [CommandOption("--ocrengine")]
-        [Description("OCR engine: tesseract | nocr | ollama | paddle (default: tesseract)")]
+        [Description("OCR engine: tesseract | nocr | binaryocr | ollama | paddle (default: tesseract)")]
         public string? OcrEngine { get; init; }
 
         [CommandOption("--ocrlanguage")]
@@ -71,7 +71,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         public string? OcrLanguage { get; init; }
 
         [CommandOption("--ocrdb")]
-        [Description("Path to a .nocr database file (required when --ocrengine=nocr)")]
+        [Description("Path to a .nocr file (--ocrengine=nocr) or .db file (--ocrengine=binaryocr)")]
         public string? OcrDb { get; init; }
 
         [CommandOption("--ollama-url")]
@@ -235,8 +235,8 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 return 1;
             }
 
-            // Validate --ocrengine: tesseract | nocr | ollama | paddle
-            var supportedEngines = new[] { "tesseract", "nocr", "ollama", "paddle", "paddleocr" };
+            // Validate --ocrengine: tesseract | nocr | binaryocr | ollama | paddle
+            var supportedEngines = new[] { "tesseract", "nocr", "binaryocr", "binary", "ollama", "paddle", "paddleocr" };
             if (!string.IsNullOrWhiteSpace(settings.OcrEngine) &&
                 !supportedEngines.Contains(settings.OcrEngine, StringComparer.OrdinalIgnoreCase))
             {

--- a/src/seconv/Core/BinaryOcrOcrEngine.cs
+++ b/src/seconv/Core/BinaryOcrOcrEngine.cs
@@ -1,0 +1,89 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using SkiaSharp;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// In-process OCR via Subtitle Edit's BinaryOCR matcher. Requires a <c>.db</c>
+/// database file (typically shipped with SE under <c>%AppData%\Subtitle Edit\Ocr\</c>;
+/// pass the path via <c>--ocrdb</c>). BinaryOCR uses fast bitmap-hash matching and
+/// is a useful alternative to nOCR — different accuracy profile, similar speed.
+/// </summary>
+internal sealed class BinaryOcrOcrEngine : IOcrEngine
+{
+    public string Name => "binaryocr";
+
+    private readonly BinaryOcrDb _db;
+    private readonly BinaryOcrMatcher _matcher;
+    private const int PixelsAreSpaceDefault = 12;
+    private const double MaxErrorPercent = 0.5;
+
+    public BinaryOcrOcrEngine(string dbPath)
+    {
+        if (!File.Exists(dbPath))
+        {
+            throw new FileNotFoundException(
+                $"BinaryOCR database not found: {dbPath}. Use --ocrdb to point to a .db file " +
+                "(typically %AppData%\\Subtitle Edit\\Ocr\\Latin.db or similar).", dbPath);
+        }
+        _db = new BinaryOcrDb(dbPath, loadCompareImages: true);
+        if (_db.AllCompareImages.Count == 0)
+        {
+            throw new InvalidOperationException($"BinaryOCR database is empty: {dbPath}");
+        }
+        _matcher = new BinaryOcrMatcher
+        {
+            IsLatinDb = Path.GetFileNameWithoutExtension(dbPath).Contains("Latin", StringComparison.OrdinalIgnoreCase),
+        };
+    }
+
+    public string Recognize(SKBitmap bitmap)
+    {
+        if (bitmap is null || bitmap.Width == 0 || bitmap.Height == 0)
+        {
+            return string.Empty;
+        }
+
+        var parent = new NikseBitmap2(bitmap);
+        parent.MakeTwoColor(200);
+        parent.CropTop(0, new SKColor(0, 0, 0, 0));
+        var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(
+            parent, PixelsAreSpaceDefault, rightToLeft: false, topToBottom: true, minLineHeight: 20, autoHeight: true);
+
+        var matches = new List<BinaryOcrMatcher.CompareMatch>();
+        var i = 0;
+        while (i < letters.Count)
+        {
+            var item = letters[i];
+            if (item.NikseBitmap == null)
+            {
+                if (item.SpecialCharacter != null)
+                {
+                    matches.Add(new BinaryOcrMatcher.CompareMatch(item.SpecialCharacter, false, 0, nameof(item.SpecialCharacter)));
+                }
+            }
+            else
+            {
+                var match = _matcher.GetCompareMatch(item, out _, letters, i, _db, MaxErrorPercent);
+                if (match is { ExpandCount: > 0 })
+                {
+                    i += match.ExpandCount - 1;
+                }
+
+                if (match == null)
+                {
+                    matches.Add(new BinaryOcrMatcher.CompareMatch("*", false, 0, null));
+                }
+                else
+                {
+                    matches.Add(new BinaryOcrMatcher.CompareMatch(match.Text, match.Italic, match.ExpandCount, match.Name));
+                }
+            }
+            i++;
+        }
+
+        return ItalicTextMerger.MergeWithItalicTags(matches).Trim();
+    }
+
+    public void Dispose() { /* no-op */ }
+}

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -1,0 +1,101 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+using Nikse.SubtitleEdit.Core.Interfaces;
+using SkiaSharp;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// Runs Subtitle Edit's full FixCommonErrors rule suite against a Subtitle. Each of the
+/// 39 rules in <see cref="Nikse.SubtitleEdit.Core.Forms.FixCommonErrors"/> is invoked
+/// once with an <see cref="EmptyFixCallback"/> (no UI reporting). Results mutate the
+/// passed <paramref name="subtitle"/> in place.
+/// </summary>
+internal static class FixCommonErrorsRunner
+{
+    public static void RunAll(Subtitle subtitle)
+    {
+        if (subtitle == null || subtitle.Paragraphs.Count == 0)
+        {
+            return;
+        }
+
+        var language = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle) ?? "en";
+        var callbacks = new EmptyFixCallback
+        {
+            Language = language,
+        };
+
+        foreach (var rule in BuildRules())
+        {
+            try
+            {
+                rule.Fix(subtitle, callbacks);
+            }
+            catch
+            {
+                // A rogue rule shouldn't kill the conversion. Skip and continue.
+            }
+        }
+    }
+
+    private static IEnumerable<IFixCommonError> BuildRules()
+    {
+        yield return new AddMissingQuotes();
+        yield return new Fix3PlusLines();
+        yield return new FixAloneLowercaseIToUppercaseI();
+        yield return new FixCommas();
+        yield return new FixContinuationStyle
+        {
+            FixAction = "Fix continuation style",
+        };
+        yield return new FixDanishLetterI();
+        yield return new FixDialogsOnOneLine();
+        yield return new FixDoubleApostrophes();
+        yield return new FixDoubleDash();
+        yield return new FixDoubleGreaterThan();
+        yield return new FixEllipsesStart();
+        yield return new FixEmptyLines();
+        yield return new FixHyphensInDialog();
+        yield return new FixHyphensRemoveDashSingleLine();
+        yield return new FixInvalidItalicTags();
+        yield return new FixLongDisplayTimes();
+        yield return new FixLongLines();
+        yield return new FixMissingOpenBracket();
+        yield return new FixMissingPeriodsAtEndOfLine();
+        yield return new FixMissingSpaces();
+        yield return new FixMusicNotation();
+        yield return new FixOverlappingDisplayTimes();
+        yield return new FixShortDisplayTimes();
+        yield return new FixShortGaps();
+        yield return new FixShortLines();
+        yield return new FixShortLinesAll();
+        yield return new FixShortLinesPixelWidth(MeasurePixelWidth);
+        yield return new FixSpanishInvertedQuestionAndExclamationMarks();
+        yield return new FixStartWithUppercaseLetterAfterColon();
+        yield return new FixStartWithUppercaseLetterAfterParagraph();
+        yield return new FixStartWithUppercaseLetterAfterPeriodInsideParagraph();
+        yield return new FixTurkishAnsiToUnicode();
+        yield return new FixUnnecessaryLeadingDots();
+        yield return new FixUnneededPeriods();
+        yield return new FixUnneededSpaces();
+        yield return new FixUppercaseIInsideWords();
+        yield return new NormalizeStrings();
+        yield return new RemoveDialogFirstLineInNonDialogs();
+        yield return new RemoveSpaceBetweenNumbers();
+        // FixCommonOcrErrors is intentionally omitted — it requires an UI-side IOcrFixEngine
+        // and SpellCheck setup that seconv doesn't carry. The other 38 rules cover most cleanup.
+    }
+
+    /// <summary>
+    /// Pixel-width measurer for FixShortLinesPixelWidth. Mirrors UI's implementation:
+    /// 14pt of the default Skia typeface. Headless contexts get the same numbers.
+    /// </summary>
+    private static int MeasurePixelWidth(string text)
+    {
+        using var typeface = SKTypeface.Default;
+        using var font = new SKFont(typeface, 14);
+        var width = font.MeasureText(text);
+        return (int)Math.Round(width, MidpointRounding.AwayFromZero);
+    }
+}

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -90,6 +90,10 @@ internal static class ListHelpers
             "in-process",
             "Pass --ocrdb=<path-to-Latin.nocr> (find under %AppData%\\\\Subtitle Edit\\\\Ocr\\\\)");
         table.AddRow(
+            "[green]binaryocr[/]",
+            "in-process",
+            "Pass --ocrdb=<path-to-Latin.db> (find under %AppData%\\\\Subtitle Edit\\\\Ocr\\\\)");
+        table.AddRow(
             "[green]ollama[/]",
             "HTTP",
             "Local Ollama with vision model. --ollama-url, --ollama-model");

--- a/src/seconv/Core/OcrEngineFactory.cs
+++ b/src/seconv/Core/OcrEngineFactory.cs
@@ -13,26 +13,28 @@ internal static class OcrEngineFactory
         return engine switch
         {
             "tesseract" or "" => TesseractOcrEngine.Create(options.OcrLanguage),
-            "nocr" => new NOcrOcrEngine(ResolveNOcrDbPath(options)),
+            "nocr" => new NOcrOcrEngine(ResolveOcrDbPath(options, "nocr", ".nocr")),
+            "binaryocr" or "binary" => new BinaryOcrOcrEngine(ResolveOcrDbPath(options, "binaryocr", ".db")),
             "ollama" => new OllamaOcrEngine(options.OllamaUrl, options.OllamaModel, options.OcrLanguage),
             "paddle" or "paddleocr" => PaddleOcrEngine.Create(options.OcrLanguage),
             _ => throw new InvalidOperationException(
-                $"OCR engine '{options.OcrEngine}' is not supported. Use one of: tesseract, nocr, ollama, paddle.")
+                $"OCR engine '{options.OcrEngine}' is not supported. Use one of: tesseract, nocr, binaryocr, ollama, paddle.")
         };
     }
 
-    private static string ResolveNOcrDbPath(ConversionOptions options)
+    private static string ResolveOcrDbPath(ConversionOptions options, string engineName, string requiredExtension)
     {
         if (string.IsNullOrWhiteSpace(options.OcrDb))
         {
+            var displayExt = requiredExtension.TrimStart('.');
             throw new InvalidOperationException(
-                "nOCR engine requires --ocrdb=<path-to-Latin.nocr> (or another .nocr file). " +
-                "Find them in `%AppData%\\Subtitle Edit\\Ocr\\` or download from the SE UI.");
+                $"{engineName} engine requires --ocrdb=<path-to-Latin{requiredExtension}> (or another {requiredExtension} file). " +
+                $"Find them in `%AppData%\\Subtitle Edit\\Ocr\\` or download from the SE UI.");
         }
         var path = options.OcrDb;
-        if (!path.EndsWith(".nocr", StringComparison.OrdinalIgnoreCase))
+        if (!path.EndsWith(requiredExtension, StringComparison.OrdinalIgnoreCase))
         {
-            path += ".nocr";
+            path += requiredExtension;
         }
         return path;
     }

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -40,9 +40,9 @@ internal static class HelpDisplay
         ShowParameter("--teletextonly", "Process teletext only");
         ShowParameter("--teletextonlypage:<page number>", "Teletext page number");
         ShowParameter("--track-number:<track list>", "Comma separated track number list");
-        ShowParameter("--ocrengine:<engine>", "OCR engine: tesseract | nocr | ollama | paddle");
+        ShowParameter("--ocrengine:<engine>", "OCR engine: tesseract | nocr | binaryocr | ollama | paddle");
         ShowParameter("--ocrlanguage:<lang>", "Language for OCR (e.g. eng, deu, spa)");
-        ShowParameter("--ocrdb:<path.nocr>", "nOCR database file (required for --ocrengine=nocr)");
+        ShowParameter("--ocrdb:<path>", ".nocr (--ocrengine=nocr) or .db (--ocrengine=binaryocr)");
         ShowParameter("--ollama-url:<url>", "Ollama API endpoint (default: http://localhost:11434/api/chat)");
         ShowParameter("--ollama-model:<model>", "Ollama vision model (default: llama3.2-vision)");
         ShowParameter("--multiplereplace:<path.xml>", "SE MultipleSearchAndReplaceGroups XML applied per paragraph");

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -9,7 +9,7 @@ operations, and OCR engines as the desktop UI — without an Avalonia / GUI depe
 - 300+ subtitle formats (text, binary, image-based)
 - Container input: Matroska (.mkv/.mks), MP4, MCC, transport stream teletext
 - OCR pipelines for image-based sources (Blu-Ray .sup, MKV PGS, DVB-sub)
-- Four OCR engines: Tesseract subprocess, nOCR (built-in), Ollama (HTTP), PaddleOCR subprocess
+- Five OCR engines: Tesseract subprocess, nOCR (built-in), BinaryOCR (built-in), Ollama (HTTP), PaddleOCR subprocess
 - Image-based output: Blu-Ray sup, BDN-XML, DOST, FCP, D-Cinema interop / SMPTE 2014, images-with-time-code
 - Full operation pipeline: offset, fps change, renumber, adjust-duration, fix-common-errors,
   merge/split, balance, redo casing, RTL fixes, multiple-replace, custom-text format, plain text
@@ -40,6 +40,7 @@ seconv *.sub subrip --fps:25 --outputfolder ./out              # frame-based →
 seconv movie.mkv subrip --track-number:3                       # extract MKV text track #3
 seconv movie.sup subrip --ocrengine:tesseract --ocrlanguage:eng  # OCR a Blu-Ray .sup
 seconv movie.sup subrip --ocrengine:nocr --ocrdb:Latin.nocr    # OCR via nOCR
+seconv movie.sup subrip --ocrengine:binaryocr --ocrdb:Latin.db # OCR via BinaryOCR
 seconv movie.sup subrip --ocrengine:ollama --ollama-model:llama3.2-vision
 
 seconv subs.srt bluraysup --resolution:1920x1080               # render text → Blu-Ray sup
@@ -100,7 +101,7 @@ seconv --help                 # show help
 ### OCR
 | Option | Description |
 |---|---|
-| `--ocrengine:<engine>` | `tesseract` (default) \| `nocr` \| `ollama` \| `paddle` |
+| `--ocrengine:<engine>` | `tesseract` (default) \| `nocr` \| `binaryocr` \| `ollama` \| `paddle` |
 | `--ocrlanguage:<lang>` | Tesseract: ISO 639-2 (`eng`, `deu`); Paddle: short (`en`); Ollama: human (`English`) |
 | `--ocrdb:<path.nocr>` | nOCR database file (required for `--ocrengine=nocr`) |
 | `--ollama-url:<url>` | Default `http://localhost:11434/api/chat` |

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -1,0 +1,73 @@
+using Nikse.SubtitleEdit.Core.Common;
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+public class FixCommonErrorsRunnerTest
+{
+    [Fact]
+    public void RunAll_OnEmptySubtitle_NoThrow()
+    {
+        var sub = new Subtitle();
+        FixCommonErrorsRunner.RunAll(sub);
+        Assert.Empty(sub.Paragraphs);
+    }
+
+    [Fact]
+    public void RunAll_FixesMissingSpaceAfterComma()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("hello,world.", 0, 1000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.RunAll(sub);
+
+        // FixMissingSpaces adds a space after the comma; FixStartWithUppercaseLetter
+        // capitalises the leading 'h'. End result: "Hello, world."
+        Assert.Equal("Hello, world.", sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void RunAll_FixesUnneededSpaceBeforePeriod()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Hello world .", 0, 2000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.RunAll(sub);
+
+        Assert.DoesNotContain(" .", sub.Paragraphs[0].Text);
+        Assert.EndsWith(".", sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void RunAll_RemovesEmptyLines()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Hello world.", 0, 2000));
+        sub.Paragraphs.Add(new Paragraph(string.Empty, 3000, 5000));
+        sub.Paragraphs.Add(new Paragraph("Goodbye.", 6000, 8000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.RunAll(sub);
+
+        // FixEmptyLines drops the empty paragraph
+        Assert.Equal(2, sub.Paragraphs.Count);
+        Assert.Equal("Hello world.", sub.Paragraphs[0].Text);
+        Assert.Equal("Goodbye.", sub.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void RunAll_FixesAloneLowercaseI_InEnglish()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Yes, i went to the store.", 0, 2000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.RunAll(sub);
+
+        // FixAloneLowercaseIToUppercaseI fixes lowercase 'i' as a standalone word
+        Assert.Contains(" I ", sub.Paragraphs[0].Text);
+    }
+}

--- a/tests/seconv/Core/OcrEnginesTest.cs
+++ b/tests/seconv/Core/OcrEnginesTest.cs
@@ -53,12 +53,29 @@ public class OcrEnginesTest : IDisposable
     }
 
     [Fact]
+    public void Factory_BinaryOcrWithoutOcrDb_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => OcrEngineFactory.Create(Opts("binaryocr")));
+        Assert.Contains("--ocrdb", ex.Message);
+        Assert.Contains(".db", ex.Message);
+    }
+
+    [Fact]
+    public void Factory_BinaryOcrAutoAppendsDbExtension()
+    {
+        var ex = Assert.Throws<FileNotFoundException>(() =>
+            OcrEngineFactory.Create(Opts("binaryocr", Path.Combine(_tempRoot, "Latin"))));
+        Assert.Contains("Latin.db", ex.Message);
+    }
+
+    [Fact]
     public void Factory_UnknownEngine_Throws()
     {
         var ex = Assert.Throws<InvalidOperationException>(() => OcrEngineFactory.Create(Opts("nope")));
         Assert.Contains("nope", ex.Message);
         Assert.Contains("tesseract", ex.Message);
         Assert.Contains("nocr", ex.Message);
+        Assert.Contains("binaryocr", ex.Message);
         Assert.Contains("ollama", ex.Message);
         Assert.Contains("paddle", ex.Message);
     }


### PR DESCRIPTION
## Summary

Two cleanup features that were stubbed out in the initial seconv landing — both small, focused, fully tested.

## --FixCommonErrors

Was a `// TODO` no-op in `LibSEIntegration.ApplyOperation`. Now runs all 38 applicable rules from libse against the subtitle:

- `AddMissingQuotes`, `Fix3PlusLines`, `FixAloneLowercaseIToUppercaseI`, `FixCommas`, `FixContinuationStyle`, `FixDanishLetterI`, `FixDialogsOnOneLine`, `FixDoubleApostrophes`, `FixDoubleDash`, `FixDoubleGreaterThan`, `FixEllipsesStart`, `FixEmptyLines`, `FixHyphensInDialog`, `FixHyphensRemoveDashSingleLine`, `FixInvalidItalicTags`, `FixLongDisplayTimes`, `FixLongLines`, `FixMissingOpenBracket`, `FixMissingPeriodsAtEndOfLine`, `FixMissingSpaces`, `FixMusicNotation`, `FixOverlappingDisplayTimes`, `FixShortDisplayTimes`, `FixShortGaps`, `FixShortLines`, `FixShortLinesAll`, `FixShortLinesPixelWidth`, `FixSpanishInvertedQuestionAndExclamationMarks`, `FixStartWithUppercaseLetterAfterColon`/`AfterParagraph`/`AfterPeriodInsideParagraph`, `FixTurkishAnsiToUnicode`, `FixUnnecessaryLeadingDots`, `FixUnneededPeriods`, `FixUnneededSpaces`, `FixUppercaseIInsideWords`, `NormalizeStrings`, `RemoveDialogFirstLineInNonDialogs`, `RemoveSpaceBetweenNumbers`.

Implementation notes:

- Each rule's `Fix(subtitle, callbacks)` is invoked with libse's `EmptyFixCallback`, populated with the auto-detected Google language code so language-aware rules behave correctly.
- `FixShortLinesPixelWidth` gets a Skia-based pixel-width measurer (mirrors UI's implementation: 14pt default typeface).
- `FixContinuationStyle` gets a hardcoded English action label (UI passes a localised one; CLI doesn't carry the locale catalogue).
- A rogue rule that throws is caught and skipped so the conversion still completes.

`FixCommonOcrErrors` is intentionally **omitted** — it requires UI-side `IOcrFixEngine` + `SpellCheck` setup that seconv doesn't carry. The other 38 rules cover the bulk of the cleanup.

```bash
# Full cleanup pass
seconv *.srt subrip --FixCommonErrors --MergeSameTexts --SplitLongLines --overwrite

# Real input → output:
# Input:  hello,world.    →   Output: Hello, world.
#         (FixMissingSpaces adds the space; FixStartWithUppercaseLetter capitalises the lead)
```

## BinaryOCR engine

Wraps libuilogic's `BinaryOcrMatcher` (already moved during the seconv feature-complete work) as a fifth OCR engine. Fast bitmap-hash matching; an alternative accuracy profile to nOCR.

```bash
seconv movie.sup subrip --ocrengine binaryocr --ocrdb Latin.db
```

The `binary` alias is also accepted. `OcrEngineFactory.ResolveOcrDbPath` now auto-appends the right extension (`.nocr` for `nocr`, `.db` for `binaryocr`) when the user passes a bare name.

`seconv list-ocr-engines` gains a fifth row:

```
│ binaryocr           │ in-process │ Pass --ocrdb=<path-to-Latin.db>             │
```

## Test plan

- [x] `dotnet build SubtitleEdit.sln` — 0 errors
- [x] 110 seconv tests pass (was 103 → +7: 5 FixCommonErrorsRunner + 2 BinaryOCR factory)
- [x] 4 libuilogic tests pass
- [x] 332 libse tests pass
- [x] `seconv --FixCommonErrors` smoke-tested end-to-end
- [x] `seconv list-ocr-engines` lists five engines

## Test coverage

`FixCommonErrorsRunnerTest`:
- `RunAll_OnEmptySubtitle_NoThrow`
- `RunAll_FixesMissingSpaceAfterComma` (also exercises FixStartWithUppercaseLetter)
- `RunAll_FixesUnneededSpaceBeforePeriod`
- `RunAll_RemovesEmptyLines`
- `RunAll_FixesAloneLowercaseI_InEnglish`

`OcrEnginesTest` (additions):
- `Factory_BinaryOcrWithoutOcrDb_Throws`
- `Factory_BinaryOcrAutoAppendsDbExtension`

🤖 Generated with [Claude Code](https://claude.com/claude-code)