### PR TITLE
docs: update Subtitle Edit 5 documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,7 +69,7 @@ You can also download FFmpeg in **Options → Settings**.
 ## Speech to Text
 
 ### What speech-to-text engines are supported?
-Subtitle Edit supports several Whisper-based engines:
+Subtitle Edit supports several local and downloadable speech-to-text engines:
 - **Whisper.cpp** — Cross-platform, CPU-based
 - **Whisper.cpp (cuBLAS)** — GPU-accelerated (Windows, NVIDIA)
 - **Whisper.cpp (Vulkan)** — GPU-accelerated via Vulkan (Windows)
@@ -77,7 +77,8 @@ Subtitle Edit supports several Whisper-based engines:
 - **CTranslate2** — Fast CPU/GPU-based 
 - **Const-me's Whisper** — DirectX-based (Windows)
 - **OpenAI Whisper** — Original Python implementation
-- **Chat LLM cpp** — LLM-based transcription (Windows, Linux)
+- **Chat LLM.cpp** — LLM-based transcription (Windows, Linux, macOS Apple Silicon)
+- **Qwen3 ASR CPP**, **Parakeet.cpp**, and **Crisp ASR** — Additional local engines with downloadable models
 
 ### How do I use Speech to Text?
 1. Open a video file

--- a/docs/features/audio-visualizer.md
+++ b/docs/features/audio-visualizer.md
@@ -10,6 +10,8 @@ The audio visualizer displays the audio waveform (and/or spectrogram) of the loa
 - **Waveform** — Shows audio amplitude over time
 - **Spectrogram** — Shows frequency distribution over time
 
+The spectrogram can be generated and toggled independently of the waveform. If you disable spectrogram generation, Subtitle Edit hides the spectrogram layer and keeps the waveform view available.
+
 ## Mouse Controls
 
 ### Navigation
@@ -25,9 +27,9 @@ The audio visualizer displays the audio waveform (and/or spectrogram) of the loa
 
 | Mouse Action | Effect |
 |--------------|--------|
-| **Click + Ctrl (cmd on mac) + Shift ** | Set start and offset the rest |
-| **Click + Shift ** | Set start of current |
-| **Click + Ctrl (cmd on mac) ** | Set end of current |
+| **Click + Ctrl (cmd on mac) + Shift** | Set start and offset the rest |
+| **Click + Shift** | Set start of current |
+| **Click + Ctrl (cmd on mac)** | Set end of current |
 | **Click** on empty area | Set video position |
 | **Click** on subtitle | Select the subtitle |
 | **Double-click** on subtitle | Set video position and select subtitle |
@@ -63,6 +65,18 @@ The waveform toolbar (when visible) provides buttons for:
 - Zoom in/out (horizontal and vertical)
 - Toggle waveform/spectrogram mode
 - Toggle grid lines
+- Navigate to previous/next shot change
+- Apply common subtitle timing actions
+
+The toolbar can be toggled from **Video → More → Toggle waveform toolbar**. Subtitle Edit 5 also supports waveform toolbar customization, including button visibility/order and import/export of toolbar settings.
+
+## Waveform Themes
+
+Waveform theme settings can be imported and exported. Use this to copy waveform colors and toolbar preferences between installations or share a timing workspace with another user.
+
+## Spectrogram
+
+The spectrogram view helps locate speech, music, and noise by frequency. It can be used together with the waveform when amplitude alone is not enough to identify a sound or silence boundary.
 
 ## Shot Changes
 
@@ -72,6 +86,8 @@ Shot changes (scene cuts) are displayed as vertical lines on the waveform. These
 - **Go to previous/next shot change** — Navigate between shot changes
 - **Snap to nearest shot change** — Align subtitle edges to nearby shot changes
 - **Extend to next shot change** — Extend subtitle to the next scene cut
+
+The shot change line color can be customized in Subtitle Edit 5, which is useful when your waveform or spectrogram theme makes the default color hard to see.
 
 ## Context Menu
 

--- a/docs/features/batch-convert.md
+++ b/docs/features/batch-convert.md
@@ -35,9 +35,29 @@ You can chain multiple conversion functions:
 - Auto translate
 - Delete lines
 
+## OCR in Batch Convert
+
+Batch Convert can OCR image-based subtitle files while converting them to text-based formats.
+
+Supported OCR workflows include:
+
+- Tesseract
+- nOCR
+- Binary OCR
+- Ollama OCR
+- PaddleOCR
+
+Subtitle Edit 5 can auto-detect language and pixels-are-space settings for nOCR/Binary OCR in many batch workflows. This reduces the amount of manual setup needed when converting many image-based subtitle files with similar fonts.
+
+## Speech to Text in Batch Mode
+
+Speech-to-text batch mode can transcribe multiple media files and save the results next to the source files. See [Speech to Text](speech-to-text.md) for engine setup and model details.
+
 ## Settings
 
 - **Output format** — Choose from 300+ subtitle formats
 - **Output folder** — Where converted files are saved
 - **Overwrite existing** — Whether to overwrite files
 - **Encoding** — Text encoding for output files
+
+For headless batch conversion, see [Command Line (seconv)](../reference/command-line.md).

--- a/docs/features/embedded-subtitles.md
+++ b/docs/features/embedded-subtitles.md
@@ -1,0 +1,70 @@
+# Embedded Subtitles
+
+Add, remove, preview, and edit subtitle tracks embedded in a video file.
+
+- **Menu:** Video → More → Add/remove embedded subtitles...
+
+## Supported Video Files
+
+The embedded subtitle editor currently supports editing subtitle tracks in Matroska containers:
+
+- `.mkv`
+- `.webm`
+
+FFmpeg is required. If FFmpeg is not available, Subtitle Edit will prompt you to install or configure it before generating the output video.
+
+## What You Can Do
+
+- View existing subtitle tracks in the loaded video.
+- Add the current subtitle as a new embedded track.
+- Add an external subtitle file as a new embedded track.
+- Add Blu-ray SUP subtitles as image-based tracks.
+- Mark existing tracks for deletion.
+- Preview an embedded track before generating the new video.
+- Edit track metadata such as title/language, default flag, and forced flag.
+- Generate a new video file with the selected embedded subtitle track changes.
+
+## Add the Current Subtitle
+
+1. Open a video file.
+2. Open or create the subtitle you want to embed.
+3. Select **Video → More → Add/remove embedded subtitles...**.
+4. Click **Add current**.
+5. Edit the track metadata if needed.
+6. Click **Generate** and choose an output file name.
+
+If the current subtitle format is not suitable for Matroska embedding, Subtitle Edit converts it to ASSA for the generated output.
+
+## Add an External Subtitle File
+
+1. Open **Video → More → Add/remove embedded subtitles...**.
+2. Click **Add**.
+3. Choose a subtitle file.
+4. Review the detected language and title.
+5. Generate the output video.
+
+Common text formats such as SRT, WebVTT, ASSA, and SSA can be embedded. Unsupported text formats are converted to ASSA before embedding.
+
+## Remove or Edit Existing Tracks
+
+- Select a track and click **Delete** to mark it for removal.
+- Select a track and click **Edit** to change language/title, default, or forced flags.
+- Select a track and click **Preview** to inspect its contents.
+- Click **Clear** to mark all tracks for removal.
+
+Changes are applied only when you click **Generate** and create the new video file.
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Insert | Add an external subtitle file |
+| Delete | Mark the selected track for deletion / undo deletion mark |
+| Escape | Close or cancel generation |
+| F1 | Open help |
+
+## Notes
+
+- The original video is not overwritten unless you explicitly choose the same output file name.
+- Track editing is intended for Matroska/WebM files. Other containers may expose embedded subtitles elsewhere in Subtitle Edit, but this editor warns when the loaded file cannot be edited as a Matroska container.
+- Output naming follows the same output-folder and suffix preferences used by the video generation tools.

--- a/docs/features/empty-translation.md
+++ b/docs/features/empty-translation.md
@@ -1,0 +1,30 @@
+# Make Empty Translation
+
+Create an empty translation from the current subtitle.
+
+- **Menu:** Tools → Make new empty translation from current subtitle
+- **Shortcut:** Configurable
+
+## What It Does
+
+This command prepares the current subtitle for translation mode:
+
+- Copies the current subtitle text into the **Original text** column.
+- Clears the editable **Text** column.
+- Shows the original text column in the subtitle grid.
+- Clears the current file name so the translation can be saved as a new subtitle file.
+
+Timing, line order, and formatting metadata are preserved.
+
+## How to Use
+
+1. Open the source subtitle.
+2. Select **Tools → Make new empty translation from current subtitle**.
+3. Translate each line in the empty text column.
+4. Save the result as a new subtitle file.
+
+## Related Tools
+
+- [Auto Translate](auto-translate.md) - machine-translate subtitle text.
+- [Copy/Paste Translate](copy-paste-translate.md) - translate through an external web or desktop tool.
+- [Compare](compare.md) - compare the original and translated subtitle files.

--- a/docs/features/find-double-lines.md
+++ b/docs/features/find-double-lines.md
@@ -1,0 +1,25 @@
+# Find Double Lines
+
+Find consecutive subtitle lines with the same text.
+
+- **Menu:** Spell check → Find double lines...
+- **Shortcut:** Configurable
+
+## How It Works
+
+Subtitle Edit compares each subtitle line with the next line. HTML/formatting tags are ignored for the comparison, and blank lines are skipped.
+
+When duplicate consecutive lines are found, they are listed in a results grid.
+
+## How to Use
+
+1. Open **Spell check → Find double lines...**.
+2. Select a duplicate line in the results grid.
+3. Click **Go to**, press **Enter**, or double-click the row to jump to that subtitle in the main grid.
+4. Edit, delete, or merge the duplicate lines as needed.
+
+## Related Tools
+
+- [Find Double Words](find-double-words.md) - finds repeated words inside subtitle text.
+- [Merge Lines with Same Text](merge-same-text.md) - can merge duplicate subtitle lines automatically.
+- [Fix Common Errors](fix-common-errors.md) - can detect and fix many repeated text issues.

--- a/docs/features/netflix-errors.md
+++ b/docs/features/netflix-errors.md
@@ -1,0 +1,45 @@
+# Check and Fix Netflix Errors
+
+Run Netflix-style quality checks and review proposed fixes before applying them.
+
+- **Menu:** Tools → Check and fix Netflix errors...
+
+## What It Checks
+
+The checker can report common Netflix delivery issues, including:
+
+- minimum and maximum duration
+- maximum characters per second
+- maximum line length
+- maximum number of lines
+- minimum two-frame gaps
+- shot change rules
+- dialog hyphen spacing
+- ellipsis style
+- whitespace issues
+- allowed glyphs
+- italics rules
+- HI/sound-effect bracket style
+- numbers that should be spelled out
+- Timed Text frame-rate issues
+
+## How to Use
+
+1. Open **Tools → Check and fix Netflix errors...**.
+2. Select the subtitle language.
+3. Enable the checks you want to run.
+4. Review the proposed fixes in the preview grid.
+5. Edit a proposed replacement if needed.
+6. Click **OK** to apply the selected text fixes.
+
+The tool does not blindly rewrite the subtitle. It shows the original and proposed text so you can review each change first.
+
+## Reports
+
+Click **Generate report** to save a CSV quality report. The report contains line number, time code, context, and comment columns, which makes it useful for handoff or QC review.
+
+## Notes
+
+- Some checks are report-only when a safe automatic text fix is not available.
+- Shot-change checks use video frame-rate information when a video is loaded.
+- Profile settings such as line length, duration, and reading-speed limits can still be configured in [Settings](settings.md).

--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -35,6 +35,7 @@ Built-in trainable OCR engine.
 Binary image comparison engine.
 - Compares against a database of known character images
 - Fast and accurate for known fonts
+- Supports database editing, character history, max error percentage, and pixels-are-space tuning
 
 ### Google Lens OCR
 Cloud-based OCR using Google Lens.
@@ -48,12 +49,32 @@ Cloud-based OCR using Google Cloud Vision API.
 Local LLM-based OCR using Ollama.
 - Requires Ollama installation
 
+### Llama.cpp OCR
+Local LLM-based OCR using a llama.cpp-compatible workflow.
+
 ### Mistral OCR
 Cloud-based OCR using Mistral API.
+- Requires a Mistral API key
 
 ### PaddleOCR
 Local OCR engine.
 - Download required
+
+### Azure Vision OCR
+Cloud-based OCR using Azure AI Vision.
+- Requires Azure credentials
+
+### Amazon Rekognition OCR
+Cloud-based OCR using Amazon Rekognition.
+- Requires AWS credentials
+
+## Engine Setup Notes
+
+- **nOCR** databases are stored in the Subtitle Edit OCR folder and can be created, renamed, edited, and deleted from the OCR window.
+- **Binary OCR** databases use image comparison and are edited separately from nOCR databases.
+- **PaddleOCR** can download standalone CPU/GPU builds and support files on Windows and Linux, or use a Python installation.
+- **Ollama OCR** and **Llama.cpp OCR** are useful when you want local AI-based OCR and have a vision-capable model available.
+- **Mistral OCR**, **Google Vision**, **Azure Vision**, and **Amazon Rekognition** require cloud credentials.
 
 ## How to Use
 
@@ -103,6 +124,12 @@ Before OCR, you can apply image pre-processing:
 - Binarize (convert to black/white)
 - Invert colors
 - Resize
+
+## Batch OCR
+
+Batch Convert can process image-based subtitle files with OCR. Subtitle Edit 5 includes Binary OCR in Batch Convert and can auto-detect several nOCR/Binary OCR settings such as language and pixels-are-space values.
+
+For command-line workflows, see [Command Line (seconv)](../reference/command-line.md), which documents OCR engines and options for headless conversion.
 
 <!-- Screenshot: OCR pre-processing -->
 ![OCR Pre-processing](../screenshots/ocr-preprocessing.png)

--- a/docs/features/renumber.md
+++ b/docs/features/renumber.md
@@ -1,0 +1,28 @@
+# Renumber
+
+Renumber subtitle lines from a chosen start number.
+
+- **Menu:** Tools → Renumber...
+- **Shortcut:** Configurable
+
+## How to Use
+
+1. Open **Tools → Renumber...**.
+2. Enter the first subtitle number.
+3. Click **OK**.
+
+Subtitle Edit updates the visible subtitle numbers in order. Timing, text, formatting, and comments are not changed.
+
+## When to Use It
+
+- After deleting or merging lines.
+- After importing subtitles from a format with non-contiguous numbering.
+- Before exporting to formats or workflows that expect line numbers to start at a specific value.
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Enter | Apply |
+| Escape | Close / Cancel |
+| F1 | Open help |

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -38,6 +38,8 @@ Profiles store subtitle rules and limits. You can switch between profiles for di
 - **Remember window position and size** — Restore layout between sessions
 - **Use frame mode** — Display times as frame numbers instead of time codes
 - **Auto backup** — Enable automatic backups at a set interval
+- **Open file on start** — Choose whether Subtitle Edit reopens the previous file on startup
+- **Single-letter shortcuts in text boxes** — Control whether single-key shortcuts are active while editing text
 
 ## Subtitle Defaults
 
@@ -55,6 +57,13 @@ Profiles store subtitle rules and limits. You can switch between profiles for di
 - **Colors** — Primary, outline, and shadow colors
 - **Border style** — Outline or opaque box
 - **Outline/shadow width** — Border dimensions
+
+## Waveform and Audio Visualizer
+
+- **Waveform toolbar visibility** — Show or hide the waveform toolbar
+- **Waveform toolbar customization** — Choose which timing buttons are visible and how they are ordered
+- **Waveform theme import/export** — Reuse waveform color and toolbar preferences
+- **Shot change color** — Customize the color used for shot change markers
 
 ## Keyboard Shortcuts
 

--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -1,34 +1,52 @@
 # Speech to Text
 
-Subtitle Edit can automatically transcribe audio to text using Whisper-based speech recognition engines.
+Subtitle Edit can automatically transcribe audio to text using Whisper-based and other modern speech recognition engines.
 
-- **Menu:** Video → Speech to text (Whisper)...
+- **Menu:** Video → Speech to text...
 
 <!-- Screenshot: Speech to text window -->
 ![Speech to Text](../screenshots/speech-to-text.png)
 
 ## Supported Engines
 
-| Engine | Platform | GPU Support |
-|--------|----------|-------------|
-| Whisper.cpp | Windows, Linux, macOS | CPU only |
-| Whisper.cpp (cuBLAS) | Windows | NVIDIA CUDA |
-| Whisper.cpp (Vulkan) | Windows | Vulkan GPU |
-| Purfview's Faster Whisper XXL | Windows, Linux | NVIDIA CUDA |
-| Whisper CTranslate2 | Windows, Linux, macOs | CPU only / NVIDIA CUDA (requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive)) |
-| Const-me's Whisper | Windows | DirectX |
-| OpenAI Whisper | All (Python required) | NVIDIA CUDA |
-| Chat LLM cpp | Windows, Linux | CPU/GPU |
+| Engine | Platform | Notes |
+|--------|----------|-------|
+| Whisper.cpp | Windows, Linux, macOS | Local CPU engine |
+| Whisper.cpp (cuBLAS) | Windows | NVIDIA CUDA build |
+| Whisper.cpp (Vulkan) | Windows | Vulkan GPU build |
+| Purfview's Faster Whisper XXL | Windows, Linux | Fast local engine, often used with NVIDIA CUDA |
+| Whisper CTranslate2 | Windows, Linux, macOS | CPU / NVIDIA CUDA depending on installation; CUDA requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive) |
+| Const-me's Whisper | Windows | DirectX-based engine |
+| OpenAI Whisper | All | Python-based OpenAI Whisper workflow |
+| Chat LLM.cpp | Windows, Linux, macOS | Local LLM transcription workflow; macOS download is for Apple Silicon |
+| Qwen3 ASR CPP | Windows, Linux, macOS | Local Qwen3 ASR engine with downloadable GGUF models |
+| Parakeet.cpp | Windows, Linux, macOS | Local Parakeet engine; some models are English-only, larger models are multilingual |
+| Crisp ASR GLM | Windows, Linux, macOS | Crisp ASR backend |
+| Crisp ASR Qwen3 | Windows, Linux, macOS | Crisp ASR backend |
+| Crisp ASR Granite | Windows, Linux, macOS | Crisp ASR backend |
+| Crisp ASR Omni | Windows, Linux, macOS | Crisp ASR backend |
+| Crisp ASR Parakeet | Windows, Linux, macOS | Crisp ASR backend |
+| Crisp ASR Canary | Windows, Linux, macOS | Crisp ASR backend |
+| Crisp ASR Cohere | Windows, Linux, macOS | Crisp ASR backend |
+| Crisp ASR Fire Red | Windows, Linux, macOS | Crisp ASR backend |
 
 Engines and models are downloaded automatically on first use.
+
+## SE5 Engine Notes
+
+- **Qwen3 ASR CPP** includes 0.6B and 1.7B model options, plus a forced-aligner model used for timing workflows.
+- **Parakeet.cpp** stores each model in its own folder because a model needs both weights and a vocabulary file.
+- **Crisp ASR** engines share a common backend workflow and expose different model families such as GLM, Qwen3, Granite, Omni, Parakeet, Canary, Cohere, and Fire Red.
+- Several newer engines support automatic language selection.
+- Each engine can have separate advanced command-line parameters.
 
 ## How to Use
 
 1. Open a video file in Subtitle Edit
-2. Go to **Video → Speech to text (Whisper)...**
+2. Go to **Video → Speech to text...**
 3. Select an **Engine** from the dropdown
-4. Select a **Model** (larger models = better accuracy but slower)
-5. Select the **Language** of the audio
+4. Select a **Model** (larger models usually improve accuracy but take more time and disk space)
+5. Select the **Language** of the audio, or use auto-language when the selected engine supports it
 6. Optionally enable:
    - **Translate to English** — Translate non-English audio to English
    - **Adjust timings** — Post-process timing using waveform data
@@ -61,6 +79,8 @@ Click the **Advanced** button to configure custom command-line arguments for the
 - Highlight spoken words in the transcript
 - Adjust temperature or other model parameters
 
+Advanced settings are stored per engine, so you can keep separate parameters for Whisper.cpp, Qwen3 ASR, Parakeet.cpp, Crisp ASR, and other engines.
+
 ## Post-Processing Settings
 
 Click the **Post-processing** button to configure:
@@ -82,3 +102,4 @@ The console log at the bottom shows real-time output from the Whisper process, u
 - If you get "CUDA out of memory" errors, try a smaller model
 - The `--standard` parameter is automatically added for Purfview's Faster Whisper XXL
 - You can re-download an engine by right-clicking the engine area
+- If a new engine has no model installed yet, let Subtitle Edit download both the engine and the selected model before starting transcription

--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -20,11 +20,17 @@ Generate speech audio from subtitle text using various TTS engines.
 ## Supported Engines
 
 - **Piper** — Local, open-source TTS
+- **Edge-TTS** — Microsoft Edge online voices
 - **AllTalk** — Local TTS server
 - **ElevenLabs** — Cloud-based, high-quality voices (requires API key)
 - **Azure Cognitive Services** — Microsoft cloud TTS (requires API key and region)
+- **Mistral TTS** — Cloud-based Mistral speech generation (requires API key)
 - **Google Cloud** — Google cloud TTS (requires key file)
+- **Qwen3 TTS** — Local downloadable Qwen3 TTS server and models
+- **Kokoro TTS** — Local downloadable Kokoro TTS server and models
 - **Murf.ai** — Cloud TTS (requires API key)
+
+Local downloadable engines are installed into the Subtitle Edit data folder when you accept the download prompt.
 
 ## Engine Settings
 
@@ -34,6 +40,29 @@ Some engines require additional configuration:
 - **Region** — Select the Azure region (for Azure engine)
 - **Model** — Select the voice model
 - **Key file** — Browse for Google Cloud service account key file
+
+## Local SE5 Engines
+
+### Qwen3 TTS
+
+Qwen3 TTS runs a local server. Subtitle Edit can download the engine and the selected model on first use.
+
+- Available model choices include **0.6B** and **1.7B Base**.
+- The model download also requires the tokenizer model.
+- Qwen3 TTS supports imported reference WAV voices. Imported voices appear in the voice dropdown.
+- On Windows, Subtitle Edit can offer CPU or Vulkan builds depending on availability.
+
+### Kokoro TTS
+
+Kokoro TTS runs a local server with downloadable models.
+
+- Subtitle Edit downloads the engine and model files when needed.
+- Voice names are available immediately from the bundled voice list and can be refreshed from the running server.
+- It is a good choice when you want a local, multilingual TTS engine without an API key.
+
+### Mistral TTS
+
+Mistral TTS is configured with an API key and model selection. The selected model is remembered in settings.
 
 ## Review Audio Clips
 

--- a/docs/features/video-player.md
+++ b/docs/features/video-player.md
@@ -61,6 +61,14 @@ You can undock the video player into a separate window for multi-monitor setups:
 - **Undock video controls**
 - **Redock video controls**
 
+## Secondary Subtitles
+
+You can open a secondary subtitle on the video player and remove it again from the Video menu. This is useful when checking a translation against the original subtitle while previewing video playback.
+
+## Embedded Subtitles
+
+Use [Embedded Subtitles](embedded-subtitles.md) to add, remove, preview, and edit Matroska/WebM embedded subtitle tracks.
+
 ## Supported Video Players
 
 Configure the video player backend in **Options → Settings → Video Player**:
@@ -84,3 +92,11 @@ This displays:
 ## Audio Tracks
 
 If the video has multiple audio tracks, you can toggle between them via the video menu or a shortcut.
+
+## Video Menu Options
+
+The Video menu also includes:
+
+- **Toggle select subtitle while playing** - automatically select the current subtitle during playback.
+- **Set video offset** - shift video playback relative to the subtitle timing.
+- **SMPTE timing** - toggle SMPTE-style timing display when available.

--- a/docs/features/whats-new-in-se5.md
+++ b/docs/features/whats-new-in-se5.md
@@ -1,0 +1,69 @@
+# What's New in Subtitle Edit 5
+
+Subtitle Edit 5 is the Avalonia-based, cross-platform version of Subtitle Edit. It keeps the familiar subtitle editing workflow from the Windows Forms version, but many feature areas were rebuilt or expanded.
+
+## Application Platform
+
+- Cross-platform Avalonia UI for Windows, Linux, and macOS.
+- Updated video playback integration with libmpv/VLC support.
+- New Flatpak packaging work for Linux.
+- More windows remember their size and position.
+- More complete keyboard shortcut coverage, including single-key workflow settings.
+
+## Video and Waveform
+
+- Waveform toolbar visibility can be toggled from the Video menu.
+- Waveform toolbar buttons can be customized, sorted, imported, and exported.
+- Waveform themes can be imported and exported.
+- Spectrogram display can be generated and combined with the waveform view.
+- Shot change colors can be customized.
+- Embedded subtitle tracks can be added, removed, previewed, and edited for Matroska/WebM videos.
+- Video tools now include burn-in, transparent subtitle video, blank video generation, re-encode, cut, and embedded subtitle editing workflows.
+
+## Speech to Text
+
+Speech recognition is no longer limited to classic Whisper workflows. Subtitle Edit 5 includes a broader set of local and downloadable engines:
+
+- Whisper.cpp, cuBLAS, Vulkan, CTranslate2, Const-me's Whisper, OpenAI Whisper, and Purfview Faster-Whisper XXL.
+- Qwen3 ASR with multiple GGUF model sizes.
+- Parakeet.cpp models.
+- Crisp ASR variants including GLM, Qwen3, Granite, Omni, Parakeet, Canary, Cohere, and Fire Red.
+- Per-engine advanced parameters and batch transcription improvements.
+- Automatic language selection for several newer engines.
+
+See [Speech to Text](speech-to-text.md) for the current engine list and workflow.
+
+## Text to Speech
+
+Text to speech now includes more local and cloud engines:
+
+- Edge-TTS.
+- Mistral TTS.
+- Qwen3 TTS with downloadable local server builds and models.
+- Kokoro TTS with downloadable local server builds and models.
+- Review audio clips, regenerate individual lines, keep regeneration history, and export generated clips with metadata.
+
+See [Text to Speech](text-to-speech.md) for details.
+
+## OCR and Batch Conversion
+
+- nOCR and Binary OCR have improved matching and database workflows.
+- Batch Convert can use Binary OCR and can auto-detect several nOCR/Binary OCR settings.
+- PaddleOCR, Ollama OCR, Mistral OCR, Google Lens, Google Vision, Azure Vision, Amazon Rekognition, and Llama.cpp OCR are available in the OCR workflow.
+- The command-line converter `seconv` can run subtitle conversion and OCR without the GUI.
+
+See [OCR](ocr.md), [Batch Convert](batch-convert.md), and [Command Line (seconv)](../reference/command-line.md).
+
+## ASSA Tools
+
+- More ASSA advanced effects are available.
+- Custom override tags include history support.
+- ASSA background boxes, resolution resampling, drawing, positioning, style editing, attachments, and image color picking are available as dedicated feature pages.
+
+## Where to Look Next
+
+- [Main Window](main-window.md) - updated application layout.
+- [Audio Visualizer / Waveform](audio-visualizer.md) - waveform, spectrogram, and shot change tools.
+- [Embedded Subtitles](embedded-subtitles.md) - SE5 Matroska/WebM embedded track editor.
+- [Third-Party Components](../third-party-components.md) - component setup and data folder locations.
+- [Command Line (seconv)](../reference/command-line.md) - headless conversion and OCR.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 ## Getting Started
 
 - [Overview](overview.md) — What is Subtitle Edit and how to get started
+- [What's New in Subtitle Edit 5](features/whats-new-in-se5.md) — Major changes from the Windows Forms version to the Avalonia-based version
 - [Main Window](features/main-window.md) — Main window layout, areas, and interaction guide
 - [FAQ](faq.md) — Frequently Asked Questions
 
@@ -20,10 +21,12 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 
 ### Tools
 - [Fix Common Errors](features/fix-common-errors.md) — Automatic error detection and fixing
+- [Check and Fix Netflix Errors](features/netflix-errors.md) — Netflix quality checks, proposed fixes, and CSV reports
 - [Batch Convert](features/batch-convert.md) — Convert multiple subtitle files
 - [Change Casing](features/change-casing.md) — Fix casing issues
 - [Change Formatting](features/change-formatting.md) — Modify subtitle formatting
 - [Convert Actors](features/convert-actors.md) — Convert actor/voice labels between styles
+- [Make Empty Translation](features/empty-translation.md) — Create an empty translation column from the current subtitle
 - [Adjust Duration](features/adjust-duration.md) — Adjust subtitle display durations
 - [Apply Duration Limits](features/apply-duration-limits.md) — Enforce min/max duration rules
 - [Bridge Gaps](features/bridge-gaps.md) — Bridge gaps between subtitles
@@ -31,6 +34,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [Merge Short Lines](features/merge-short-lines.md) — Merge short subtitle lines
 - [Merge Lines with Same Text](features/merge-same-text.md) — Merge duplicate text lines
 - [Merge Lines with Same Time Codes](features/merge-same-timecodes.md) — Merge lines with identical timings
+- [Renumber](features/renumber.md) — Renumber subtitle lines from a chosen start number
 - [Split/Break Long Lines](features/split-break-long-lines.md) — Break overly long lines
 - [Split Subtitle](features/split-subtitle.md) — Split one subtitle file into multiple files
 - [Join Subtitles](features/join-subtitles.md) — Join multiple subtitle files
@@ -48,9 +52,10 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 ### Video
 - [Video Player](features/video-player.md) — Video playback controls
 - [Audio Visualizer / Waveform](features/audio-visualizer.md) — Waveform display and editing
-- [Speech to Text (Whisper)](features/speech-to-text.md) — Automatic speech recognition
+- [Speech to Text](features/speech-to-text.md) — Automatic speech recognition with Whisper, Qwen3, Parakeet, Crisp ASR, and related engines
 - [Text to Speech](features/text-to-speech.md) — Generate speech from subtitles
 - [Burn-In Subtitles](features/burn-in.md) — Hardcode subtitles into video
+- [Embedded Subtitles](features/embedded-subtitles.md) — Add, remove, preview, and edit subtitle tracks in Matroska/WebM files
 - [Transparent Subtitles](features/transparent-subtitles.md) — Generate transparent subtitle video
 - [Shot Changes](features/shot-changes.md) — Detect and manage shot changes
 - [Blank Video](features/blank-video.md) — Generate a blank video
@@ -64,6 +69,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 ### Spell Check
 - [Spell Check](features/spell-check.md) — Spell checking subtitles
 - [Find Double Words](features/find-double-words.md) — Find repeated words
+- [Find Double Lines](features/find-double-lines.md) — Find consecutive duplicate subtitle lines
 
 ### OCR (Optical Character Recognition)
 - [OCR](features/ocr.md) — Convert image-based subtitles to text (nOCR, Binary OCR, Tesseract)
@@ -107,4 +113,4 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [Keyboard Shortcuts Reference](reference/keyboard-shortcuts.md) — Complete list of keyboard shortcuts
 - [Mouse Controls Reference](reference/mouse-controls.md) — Mouse interactions
 - [Command Line (seconv)](reference/command-line.md) — Command-line converter
-- [Third-Party Components](third-party-components.md) — FFmpeg, MPV, Tesseract, Whisper setup guide
+- [Third-Party Components](third-party-components.md) — FFmpeg, MPV, OCR, speech-to-text, and text-to-speech setup guide

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -7,6 +7,8 @@ title: Third-Party Components
 
 Subtitle Edit uses several third-party tools for features like video playback, audio extraction, and OCR. While Subtitle Edit includes built-in downloaders for these components, you might want to use a specific version or a custom build.
 
+Subtitle Edit 5 also includes more downloadable AI components for speech-to-text, text-to-speech, and OCR. Prefer the in-app download prompts unless you need to install a specific build manually.
+
 > **⚠️ Warning**
 > Subtitle Edit is tested with specific versions of these components. Using other versions is **not officially supported** and may cause instability.
 >
@@ -37,6 +39,12 @@ Subtitle Edit stores these components in its **Data Folder**.
 | **Tesseract** | `tesseract.exe`, `tessdata/` folder | `[Data Folder]/Tesseract550` |
 | **Whisper CPP** | `whisper-cli.exe`, `Models/` folder | `[Data Folder]/SpeechToText/Cpp` |
 | **Purfview Faster-Whisper XXL** | `faster-whisper-xxl.exe`, `_models/` folder | `[Data Folder]/SpeechToText/Purfview-Faster-Whisper-XXL` |
+| **Crisp ASR** | `crispasr.exe`, `models/` folder | `[Data Folder]/SpeechToText/CrispASR` |
+| **Qwen3 ASR CPP** | `qwen3-asr-cli.exe`, `models/` folder | `[Data Folder]/Qwen3ASR` |
+| **Parakeet.cpp** | `parakeet.exe`, model folders | `[Data Folder]/parakeet.cpp` |
+| **PaddleOCR** | `paddleocr.exe`, `models/` folder | `[Data Folder]/OCR/PaddleOCR3-1` |
+| **Qwen3 TTS** | `qwen3-tts-server.exe`, `models/`, `voices/` | `[Data Folder]/TextToSpeech/Qwen3TtsCpp` |
+| **Kokoro TTS** | `kokoro-tts-server.exe`, `models/` | `[Data Folder]/TextToSpeech/KokoroTtsCpp` |
 
 ---
 
@@ -99,6 +107,30 @@ Used for GPU-accelerated AI-based speech recognition.
 *   **Files:** Download the Standalone Archive, extract contents so `faster-whisper-xxl.exe` is in the folder root.
 *   **Models:** Place model directories (e.g., `faster-whisper-medium`) inside the `_models` folder.
 
+### SE5 Speech-to-Text Engines
+Subtitle Edit 5 can download additional ASR engines directly from the **Speech to text** window.
+
+*   **Crisp ASR:** Stored in `[Data Folder]/SpeechToText/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, and Omni.
+*   **Qwen3 ASR CPP:** Stored in `[Data Folder]/Qwen3ASR`. Models go into `[Data Folder]/Qwen3ASR/models`.
+*   **Parakeet.cpp:** Stored in `[Data Folder]/parakeet.cpp`. Each model has its own folder because the model weights and `vocab.txt` must stay together.
+
+Use [Speech to Text](features/speech-to-text.md) for the current engine list and workflow.
+
+### PaddleOCR
+Used for OCR of image-based subtitles.
+
+*   **Destination:** `[Data Folder]/OCR/PaddleOCR3-1`
+*   **Models:** `[Data Folder]/OCR/PaddleOCR3-1/models`
+*   **Builds:** Subtitle Edit can download Windows CPU, Windows CUDA 11/12, Linux CPU, or Linux GPU builds when available.
+
+### Local Text-to-Speech Engines
+Subtitle Edit 5 can download local TTS servers and models from the **Text to speech** window.
+
+*   **Qwen3 TTS:** Stored in `[Data Folder]/TextToSpeech/Qwen3TtsCpp`. Models go into the `models` folder; imported reference voices go into the `voices` folder.
+*   **Kokoro TTS:** Stored in `[Data Folder]/TextToSpeech/KokoroTtsCpp`. Models go into the `models` folder.
+
+Use [Text to Speech](features/text-to-speech.md) for engine-specific options.
+
 ---
 
 ## Linux
@@ -152,6 +184,10 @@ Used for GPU-accelerated AI-based speech recognition.
 *   **Files:** Download the Linux Archive, extract so `faster-whisper-xxl` binary is present.
 *   **Models:** Place model directories (e.g., `faster-whisper-medium`) inside the `_models` folder.
 
+### SE5 Speech-to-Text, OCR, and TTS Engines
+
+The same data-folder layout is used on Linux. Prefer the in-app downloaders for Crisp ASR, Qwen3 ASR, Parakeet.cpp, PaddleOCR, Qwen3 TTS, and Kokoro TTS because the required files differ by build and model.
+
 ---
 
 ## macOS
@@ -196,3 +232,7 @@ Used for AI-based speech recognition.
 *   **Destination:** `[Data Folder]/SpeechToText/Cpp`
 *   **Files:** Download or build the binary and ensure it is named `whisper-cli`.
 *   **Models:** Models (`.bin` files) go into a `Models` subfolder: `[Data Folder]/SpeechToText/Cpp/Models`.
+
+### SE5 Speech-to-Text, OCR, and TTS Engines
+
+Some newer local engines are platform-specific or model-specific. Use the in-app downloaders where available, and check [Speech to Text](features/speech-to-text.md), [Text to Speech](features/text-to-speech.md), and [OCR](features/ocr.md) for current engine notes.


### PR DESCRIPTION
## Summary
- add a "What's New in Subtitle Edit 5" documentation page
- document missing SE5 feature pages for embedded subtitles, renumbering, Netflix checks, empty translation, and finding double lines
- update existing docs for speech-to-text, text-to-speech, OCR, waveform, batch conversion, video player, settings, and third-party components
- refresh the documentation index with the new pages and current SE5 feature names

## Validation
- `git diff --check`
- verified local markdown links resolve
- verified active `ShowHelp("features/...")` targets have docs files