### PR TITLE
CrispASR: bump download URLs to v0.5.3

### DIFF
--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -19,11 +19,11 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.2/crispasr-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.2/crispasr-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.2/crispasr-windows-x86_64-cpu-legacy.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.2/crispasr-macos.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.2/crispasr-linux-x86_64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.3/crispasr-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.3/crispasr-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.3/crispasr-windows-x86_64-cpu-legacy.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.3/crispasr-macos.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.5.3/crispasr-linux-x86_64.tar.gz";
 
     public CrispAsrDownloadService(HttpClient httpClient)
     {


### PR DESCRIPTION
## Summary
- Bump CrispASR download URLs from v0.5.2 to v0.5.3 in `CrispAsrDownloadService.cs` (Windows CUDA/Vulkan/CPU, macOS, Linux)

## Test plan
- [ ] Trigger a CrispASR engine download from the Speech-to-Text UI on Windows and verify the v0.5.3 archive downloads and extracts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)