### PR TITLE
feat: add "Merge selected lines bilingual" shortcut

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6846,6 +6846,12 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void MergeSelectedLinesBilingual()
+    {
+        MergeLinesSelectedBilingual();
+    }
+
+    [RelayCommand]
     private void ToggleCasing()
     {
         if (IsSubtitleGridFocused())
@@ -13395,6 +13401,72 @@ public partial class MainViewModel :
         _mergeManager.MergeSelectedLinesAsDialog(Subtitles, selectedItems);
         SelectAndScrollToRow(index);
         Renumber();
+    }
+
+    private void MergeLinesSelectedBilingual()
+    {
+        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        if (selectedItems.Count < 2)
+        {
+            return;
+        }
+
+        var ordered = selectedItems
+            .Select(item => (Item: item, Index: Subtitles.IndexOf(item)))
+            .Where(p => p.Index >= 0)
+            .OrderBy(p => p.Index)
+            .ToList();
+
+        if (ordered.Count != selectedItems.Count)
+        {
+            return;
+        }
+
+        for (var i = 1; i < ordered.Count; i++)
+        {
+            if (ordered[i].Index != ordered[i - 1].Index + 1)
+            {
+                return; // selection must be contiguous
+            }
+        }
+
+        var firstIndex = ordered[0].Index;
+        var first = ordered[0].Item;
+        var last = ordered[ordered.Count - 1].Item;
+
+        first.Text = MergeBilingualLines(ordered.Select(p => p.Item.Text));
+        if (ordered.Any(p => !string.IsNullOrEmpty(p.Item.OriginalText)))
+        {
+            first.OriginalText = MergeBilingualLines(ordered.Select(p => p.Item.OriginalText));
+        }
+
+        first.EndTime = last.EndTime;
+
+        for (var i = ordered.Count - 1; i >= 1; i--)
+        {
+            Subtitles.Remove(ordered[i].Item);
+        }
+
+        Renumber();
+        SelectAndScrollToRow(firstIndex);
+        _updateAudioVisualizer = true;
+    }
+
+    private static string MergeBilingualLines(IEnumerable<string> texts)
+    {
+        var split = texts.Select(t => (t ?? string.Empty).SplitToLines()).ToList();
+        var maxLines = split.Count == 0 ? 0 : split.Max(lines => lines.Count);
+        var resultLines = new List<string>(maxLines);
+        for (var i = 0; i < maxLines; i++)
+        {
+            var parts = split
+                .Select(lines => i < lines.Count ? lines[i].Trim() : string.Empty)
+                .Where(s => s.Length > 0);
+            resultLines.Add(string.Join(" ", parts));
+        }
+
+        var merged = string.Join(Environment.NewLine, resultLines);
+        return HtmlUtil.FixInvalidItalicTags(merged);
     }
 
     private void ToggleItalic()

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -253,6 +253,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.MergeWithLineAfterKeepBreaksCommand), Se.Language.General.MergeWithLineAfterKeepBreaks },
         { nameof(MainViewModel.MergeSelectedLinesCommand), Se.Language.General.MergeSelectedLines },
         { nameof(MainViewModel.MergeSelectedLinesDialogCommand), Se.Language.General.MergeSelectedLinesDialog },
+        { nameof(MainViewModel.MergeSelectedLinesBilingualCommand), Se.Language.Options.Shortcuts.GeneralMergeSelectedLinesBilingual },
         { nameof(MainViewModel.ShowColorPickerCommand), Se.Language.General.ChooseColorDotDotDot },
         { nameof(MainViewModel.FetchFirstWordFromNextSubtitleCommand), Se.Language.Options.Shortcuts.FetchFirstWordFromNextSubtitle },
         { nameof(MainViewModel.WaveformSetEndAndStartOfNextAfterGapCommand), Se.Language.Options.Shortcuts.WaveformSetEndAndStartOfNextAfterGap },
@@ -546,6 +547,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.MergeWithLineAfterKeepBreaksCommand, nameof(vm.MergeWithLineAfterKeepBreaksCommand), ShortcutCategory.General);
 
         AddShortcut(shortcuts, vm.MergeSelectedLinesDialogCommand, nameof(vm.MergeSelectedLinesDialogCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.MergeSelectedLinesBilingualCommand, nameof(vm.MergeSelectedLinesBilingualCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowColorPickerCommand, nameof(vm.ShowColorPickerCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.FetchFirstWordFromNextSubtitleCommand, nameof(vm.FetchFirstWordFromNextSubtitleCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MoveLastWordToNextSubtitleCommand, nameof(vm.MoveLastWordToNextSubtitleCommand), ShortcutCategory.General);


### PR DESCRIPTION
## Summary

Adds a new `MergeSelectedLinesBilingual` shortcut that merges adjacent multi-line subtitles **line-by-line** instead of stacking text blocks. This is useful for bilingual subtitles where each subtitle stores both languages on separate lines and the existing "Merge selected lines" command produces the wrong shape.

**Example** (issue #10685):

Before:
- `00:00:01,000 --> 00:00:02,000` &nbsp; `I need a feature\n我需要一个功能`
- `00:00:02,500 --> 00:00:03,500` &nbsp; `to merge bilingual lines.\n来合并双语字幕。`

After (with the new shortcut):
- `00:00:01,000 --> 00:00:03,500` &nbsp; `I need a feature to merge bilingual lines.\n我需要一个功能来合并双语字幕。`

## Implementation

- `MainViewModel.MergeSelectedLinesBilingual()` (`[RelayCommand]`) — the shortcut entry point.
- `MainViewModel.MergeLinesSelectedBilingual()` — does the work: validates contiguous selection, splits each line by `Environment.NewLine`, joins line *i* of each subtitle with a single space, then writes the result back to the first item and removes the rest.
- `OriginalText` is merged with the same rule when at least one selected line has an original text.
- Registered in `ShortcutsMain` (both the display-name dictionary and `RegisterShortcuts`) using the existing `GeneralMergeSelectedLinesBilingual` language string.

## Notes

- I couldn't build locally — the project targets .NET 10 and only the .NET 9 SDK is installed on this machine. The change follows the same patterns as the surrounding merge commands (`MergeSelectedLinesDialog`, `MergeSelectedLines`), so it should compile cleanly in CI.
- No keyboard shortcut is bound by default — users assign one via **Options → Shortcuts** as with the other merge commands.

Closes #10685

## Test plan
- [ ] Build the UI project in CI.
- [ ] In the running app, select 2+ contiguous bilingual lines, run **Merge selected lines bilingual**, and verify the output joins line-by-line with a single space and uses the first start time / last end time.
- [ ] With non-contiguous selection, verify the command is a no-op.
- [ ] With translation mode enabled (so lines have `OriginalText`), verify `OriginalText` is also merged line-by-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)