### PR TITLE
fix: atomic save and shared lock for NOcrDb

### DIFF
--- a/src/libuilogic/Ocr/NOcrDb.cs
+++ b/src/libuilogic/Ocr/NOcrDb.cs
@@ -29,102 +29,113 @@ public class NOcrDb
 
     public List<NOcrChar> OcrCharactersCombined => OcrCharacters.Concat(OcrCharactersExpanded).ToList();
 
-    private Lock SaveLock = new();
+    private readonly Lock _lock = new();
+
     public void Save()
     {
-        lock (SaveLock)
+        lock (_lock)
         {
-            if (File.Exists(FileName))
+            var tempFileName = FileName + ".tmp";
+
+            using (var gz = new GZipStream(File.Create(tempFileName), CompressionMode.Compress))
             {
-                File.Delete(FileName);
+                var versionBuffer = Encoding.ASCII.GetBytes(Version);
+                gz.Write(versionBuffer, 0, versionBuffer.Length);
+
+                foreach (var ocrChar in OcrCharacters)
+                {
+                    ocrChar.Save(gz);
+                }
+
+                foreach (var ocrChar in OcrCharactersExpanded)
+                {
+                    ocrChar.Save(gz);
+                }
             }
 
-            using Stream stream = new GZipStream(File.OpenWrite(FileName), CompressionMode.Compress);
-            var versionBuffer = Encoding.ASCII.GetBytes(Version);
-            stream.Write(versionBuffer, 0, versionBuffer.Length);
-
-            foreach (var ocrChar in OcrCharacters)
-            {
-                ocrChar.Save(stream);
-            }
-
-            foreach (var ocrChar in OcrCharactersExpanded)
-            {
-                ocrChar.Save(stream);
-            }
+            File.Move(tempFileName, FileName, overwrite: true);
         }
     }
 
     public void LoadOcrCharacters()
     {
-        var list = new List<NOcrChar>();
-        var listExpanded = new List<NOcrChar>();
-
-        if (!File.Exists(FileName))
+        lock (_lock)
         {
-            OcrCharacters = list;
-            OcrCharactersExpanded = listExpanded;
-            return;
-        }
+            var list = new List<NOcrChar>();
+            var listExpanded = new List<NOcrChar>();
 
-        byte[] buffer;
-        using (var stream = new MemoryStream())
-        {
-            using (var gz = new GZipStream(File.OpenRead(FileName), CompressionMode.Decompress))
+            if (!File.Exists(FileName))
             {
-                gz.CopyTo(stream);
+                OcrCharacters = list;
+                OcrCharactersExpanded = listExpanded;
+                return;
             }
 
-            buffer = stream.ToArray();
-        }
-
-        var position = 2;
-        var done = false;
-        while (!done)
-        {
-            var ocrChar = new NOcrChar(ref position, buffer);
-            if (ocrChar.LoadedOk)
+            byte[] buffer;
+            using (var stream = new MemoryStream())
             {
-                if (ocrChar.ExpandCount > 0)
+                using (var gz = new GZipStream(File.OpenRead(FileName), CompressionMode.Decompress))
                 {
-                    listExpanded.Add(ocrChar);
+                    gz.CopyTo(stream);
+                }
+
+                buffer = stream.ToArray();
+            }
+
+            var position = 2;
+            var done = false;
+            while (!done)
+            {
+                var ocrChar = new NOcrChar(ref position, buffer);
+                if (ocrChar.LoadedOk)
+                {
+                    if (ocrChar.ExpandCount > 0)
+                    {
+                        listExpanded.Add(ocrChar);
+                    }
+                    else
+                    {
+                        list.Add(ocrChar);
+                    }
                 }
                 else
                 {
-                    list.Add(ocrChar);
+                    done = true;
                 }
             }
-            else
-            {
-                done = true;
-            }
-        }
 
-        OcrCharacters = list;
-        OcrCharactersExpanded = listExpanded;
+            OcrCharacters = list;
+            OcrCharactersExpanded = listExpanded;
+        }
     }
 
     public void Add(NOcrChar ocrChar)
     {
-        if (ocrChar.ExpandCount > 0)
+        lock (_lock)
         {
-            OcrCharactersExpanded.Insert(0, ocrChar);
-        }
-        else
-        {
-            OcrCharacters.Insert(0, ocrChar);
+            if (ocrChar.ExpandCount > 0)
+            {
+                OcrCharactersExpanded.Insert(0, ocrChar);
+            }
+            else
+            {
+                OcrCharacters.Insert(0, ocrChar);
+            }
         }
     }
 
     public void Remove(NOcrChar ocrChar)
     {
-        if (ocrChar.ExpandCount > 0)
+        lock (_lock)
         {
-            OcrCharactersExpanded.Remove(ocrChar);
-        }
-        else
-        {
-            OcrCharacters.Remove(ocrChar);
+            if (ocrChar.ExpandCount > 0)
+            {
+                OcrCharactersExpanded.Remove(ocrChar);
+            }
+            else
+            {
+                OcrCharacters.Remove(ocrChar);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`NOcrDb.Save()` could leave the `.nocr` database empty or unreadable, and concurrent access could corrupt a save mid-write. This PR fixes both.

- **Atomic save.** `Save()` used to `File.Delete(FileName)` then `File.OpenWrite(FileName)`. A crash, exception, full disk, or power loss between those two calls left the file gone or with a truncated GZip trailer (won't decompress). It now writes to `<FileName>.tmp`, closes the GZip stream so the trailer is flushed, then `File.Move(..., overwrite: true)` onto the target — an atomic rename on POSIX (`rename(2)`) and on NTFS (`MoveFileEx`). A crash mid-write leaves a stray `.tmp` instead of corrupting the real file.
- **Shared lock.** The existing `SaveLock` was only held inside `Save()`. `LoadOcrCharacters`, `Add`, and `Remove` ignored it. So concurrent `Add`/`Remove` during a save could throw `InvalidOperationException: Collection was modified` *while writing the GZip stream*, and a `LoadOcrCharacters` running in the brief window after `File.Delete` but before `File.OpenWrite` could observe `File.Exists == false` and silently return empty lists — which a downstream save would then persist. The lock (renamed `_lock`, marked `readonly`) is now held in all four methods.

## Test plan

- [ ] Build with .NET 10 SDK (verified locally — `LibUiLogic` compiles, no warnings).
- [ ] Open Binary subtitle OCR, train a few characters, save, reopen — confirm characters round-trip.
- [ ] Train a glyph and force-quit Subtitle Edit before save completes — confirm the existing `.nocr` is still readable (no longer destroyed by the delete-before-write window). A `<name>.nocr.tmp` may be left behind and is harmless.
- [ ] Run an OCR session that adds characters while a save is in progress (or simulate by hammering `Add`/`Save` from threads) — should no longer throw mid-write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)