### PR TITLE
ci: stamp exe version from Se.cs in publish steps

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -40,6 +40,29 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Extract version from Se.cs
+        shell: pwsh
+        run: |
+          $seContent = Get-Content "src/UI/Logic/Config/Se.cs" -Raw
+          $m = [regex]::Match($seContent, 'public\s+static\s+string\s+Version\s*\{[^}]+\}\s*=\s*"v([^"]+)"')
+          if (-not $m.Success) { throw "Could not find Version in Se.cs" }
+          $versionString = $m.Groups[1].Value
+          $parts = $versionString -split '-', 2
+          $numericFields = $parts[0].Split('.')
+          $major = [int]$numericFields[0]
+          $minor = if ($numericFields.Length -gt 1) { [int]$numericFields[1] } else { 0 }
+          $build = if ($numericFields.Length -gt 2) { [int]$numericFields[2] } else { 0 }
+          $revision = 0
+          if ($parts.Length -gt 1) {
+            $rm = [regex]::Match($parts[1], '\d+$')
+            if ($rm.Success) { $revision = [int]$rm.Value }
+          }
+          $appVerFull = "$major.$minor.$build.$revision"
+          "APP_VER_DISPLAY=$versionString" >> $env:GITHUB_ENV
+          "APP_VER_FULL=$appVerFull"       >> $env:GITHUB_ENV
+          Write-Host "APP_VER_DISPLAY=$versionString"
+          Write-Host "APP_VER_FULL=$appVerFull"
+
       - name: Restore dependencies
         run: dotnet restore
 
@@ -60,6 +83,9 @@ jobs:
             -p:PublishSingleFile=true `
             -p:DebugSymbols=false `
             -p:DebugType=none `
+            -p:Version=$env:APP_VER_FULL `
+            -p:FileVersion=$env:APP_VER_FULL `
+            -p:InformationalVersion=$env:APP_VER_DISPLAY `
             -o ./publish/windows-x64
           Copy-Item "libmpv-temp/libmpv-2.dll" "./publish/windows-x64/"
 
@@ -69,6 +95,9 @@ jobs:
             -p:PublishSingleFile=true `
             -p:DebugSymbols=false `
             -p:DebugType=none `
+            -p:Version=$env:APP_VER_FULL `
+            -p:FileVersion=$env:APP_VER_FULL `
+            -p:InformationalVersion=$env:APP_VER_DISPLAY `
             -o ./publish/windows-arm64
 
       # - name: Setup WiX
@@ -105,6 +134,9 @@ jobs:
             -p:PublishSingleFile=true `
             -p:DebugSymbols=false `
             -p:DebugType=none `
+            -p:Version=$env:APP_VER_FULL `
+            -p:FileVersion=$env:APP_VER_FULL `
+            -p:InformationalVersion=$env:APP_VER_DISPLAY `
             -o ./src/ui/bin/Release/net10.0/publish
           Copy-Item "libmpv-temp/libmpv-2.dll" "./src/ui/bin/Release/net10.0/publish/"
 
@@ -166,6 +198,28 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
+      - name: Extract version from Se.cs
+        run: |
+          set -e
+          line=$(grep -E 'public[[:space:]]+static[[:space:]]+string[[:space:]]+Version[[:space:]]*\{' src/UI/Logic/Config/Se.cs)
+          version_string=$(printf '%s' "$line" | sed -E 's/.*"v([^"]+)".*/\1/')
+          numeric_part="${version_string%%-*}"
+          suffix=""
+          case "$version_string" in
+            *-*) suffix="${version_string#*-}" ;;
+          esac
+          dot_count=$(printf '%s' "$numeric_part" | tr -cd '.' | wc -c | tr -d ' ')
+          case "$dot_count" in
+            0) numeric_part="${numeric_part}.0.0" ;;
+            1) numeric_part="${numeric_part}.0" ;;
+          esac
+          revision=$(printf '%s' "$suffix" | grep -oE '[0-9]+$' || true)
+          revision=${revision:-0}
+          app_ver_full="${numeric_part}.${revision}"
+          echo "APP_VER_DISPLAY=$version_string" >> "$GITHUB_ENV"
+          echo "APP_VER_FULL=$app_ver_full" >> "$GITHUB_ENV"
+          echo "APP_VER_DISPLAY=$version_string"
+          echo "APP_VER_FULL=$app_ver_full"
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -291,6 +345,9 @@ jobs:
             -p:PublishSingleFile=true \
             -p:DebugSymbols=false \
             -p:DebugType=none \
+            -p:Version="$APP_VER_FULL" \
+            -p:FileVersion="$APP_VER_FULL" \
+            -p:InformationalVersion="$APP_VER_DISPLAY" \
             -o ./publish/macos-x64
 
           echo "Disk space after x64 publish:"; df -h /
@@ -368,11 +425,14 @@ jobs:
       - name: Publish macOS ARM64 app
         run: |
           echo "Disk space before ARM64 publish:"; df -h /
-          
+
           dotnet publish src/ui/UI.csproj -c ${{ inputs.build_configuration }} -r osx-arm64 --self-contained true \
             -p:PublishSingleFile=true \
             -p:DebugSymbols=false \
             -p:DebugType=none \
+            -p:Version="$APP_VER_FULL" \
+            -p:FileVersion="$APP_VER_FULL" \
+            -p:InformationalVersion="$APP_VER_DISPLAY" \
             -o ./publish/macos-arm64
 
           echo "Disk space after ARM64 publish:"; df -h /
@@ -502,7 +562,7 @@ jobs:
  
   build-linux:
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v5
 
@@ -510,6 +570,29 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
+
+      - name: Extract version from Se.cs
+        run: |
+          set -e
+          line=$(grep -E 'public[[:space:]]+static[[:space:]]+string[[:space:]]+Version[[:space:]]*\{' src/UI/Logic/Config/Se.cs)
+          version_string=$(printf '%s' "$line" | sed -E 's/.*"v([^"]+)".*/\1/')
+          numeric_part="${version_string%%-*}"
+          suffix=""
+          case "$version_string" in
+            *-*) suffix="${version_string#*-}" ;;
+          esac
+          dot_count=$(printf '%s' "$numeric_part" | tr -cd '.' | wc -c | tr -d ' ')
+          case "$dot_count" in
+            0) numeric_part="${numeric_part}.0.0" ;;
+            1) numeric_part="${numeric_part}.0" ;;
+          esac
+          revision=$(printf '%s' "$suffix" | grep -oE '[0-9]+$' || true)
+          revision=${revision:-0}
+          app_ver_full="${numeric_part}.${revision}"
+          echo "APP_VER_DISPLAY=$version_string" >> "$GITHUB_ENV"
+          echo "APP_VER_FULL=$app_ver_full" >> "$GITHUB_ENV"
+          echo "APP_VER_DISPLAY=$version_string"
+          echo "APP_VER_FULL=$app_ver_full"
 
       - name: Restore dependencies
         run: dotnet restore
@@ -526,6 +609,9 @@ jobs:
             -p:PublishSingleFile=true \
             -p:DebugSymbols=false \
             -p:DebugType=none \
+            -p:Version="$APP_VER_FULL" \
+            -p:FileVersion="$APP_VER_FULL" \
+            -p:InformationalVersion="$APP_VER_DISPLAY" \
             -o ./publish/linux-x64
 
       - name: Create Linux TAR package


### PR DESCRIPTION
## Summary

The published UI binary showed **File version 1.0.0.0** in Windows Properties because no `<Version>` is set in `src/ui/UI.csproj` and no `-p:Version=` was passed to `dotnet publish`. A user reported this and asked for a real build number.

This wires the version up in CI without touching the csproj.

- **Single source of truth:** `public static string Version = "v5.0.0-beta19";` in `src/UI/Logic/Config/Se.cs` (already used by the Inno Setup, Info.plist, and flatpak metainfo update scripts).
- **New extract step** in each of the three platform jobs (`pwsh` for Windows, `bash` for macOS/Linux) parses that line — same regex as `installer/WindowsInno/update-version.ps1` — and exports:
  - `APP_VER_DISPLAY` → e.g. `5.0.0-beta19` (free-form, used for `InformationalVersion` → "Product version")
  - `APP_VER_FULL` → e.g. `5.0.0.19` (numeric quad, used for `Version` and `FileVersion` → "File version")
- **Flags added to every `dotnet publish`** (3× Windows, 2× macOS, 1× Linux):
  ```
  -p:Version=$APP_VER_FULL
  -p:FileVersion=$APP_VER_FULL
  -p:InformationalVersion=$APP_VER_DISPLAY
  ```
- `AssemblyVersion` deliberately left at default to avoid breaking strong-name binding for any plugin/consumer.
- **Flatpak unchanged** — it builds via `flatpak-builder` rather than a direct `dotnet publish`, and Linux ELF binaries don't surface these properties the way Windows does.

## Test plan

- [ ] Verified locally: bash extractor against current `Se.cs` outputs `APP_VER_DISPLAY=5.0.0-beta19` / `APP_VER_FULL=5.0.0.19` (matches `update-version.ps1` exactly).
- [ ] YAML parses clean (Ruby `YAML.load_file`).
- [ ] Run the workflow → download `SubtitleEdit-Windows-x64-Setup.exe` (or the unzipped `SubtitleEdit.exe`) → right-click → Properties → Details should show File version `5.0.0.19` and Product version `5.0.0-beta19`.
- [ ] On macOS DMG and Linux tarball, verify the embedded assembly informational version with e.g. `monodis --assembly` or `Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)