### PR TITLE
Prompt before saving blank text for OCR character

### DIFF
--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddViewModel.cs
@@ -6,6 +6,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
@@ -13,6 +14,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.BinaryOcr;
 
@@ -241,12 +243,33 @@ public partial class BinaryOcrCharacterAddViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void Ok()
+    private async Task Ok()
     {
         if (BinaryOcrBitmap == null || _db.FindExactMatch(BinaryOcrBitmap) >= 0)
         {
             Close();
             return;
+        }
+
+        if (string.IsNullOrEmpty(NewText) && Se.Settings.Ocr.PromptForBlankOcrText)
+        {
+            var answer = await MessageBox.Show(
+                Window!,
+                Se.Language.Ocr.SaveBlankTextTitle,
+                Se.Language.Ocr.SaveBlankTextPrompt,
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question,
+                custom1: Se.Language.Ocr.YesAndNeverAskAgain);
+
+            if (answer == MessageBoxResult.No || answer == MessageBoxResult.None)
+            {
+                return;
+            }
+
+            if (answer == MessageBoxResult.Custom1)
+            {
+                Se.Settings.Ocr.PromptForBlankOcrText = false;
+            }
         }
 
         BinaryOcrBitmap.Text = NewText;
@@ -322,7 +345,7 @@ public partial class BinaryOcrCharacterAddViewModel : ObservableObject
         if (e.Key == Key.Enter && !string.IsNullOrWhiteSpace(TextBoxNew.Text))
         {
             e.Handled = true;
-            Ok();
+            _ = Ok();
         }
     }
 
@@ -331,7 +354,7 @@ public partial class BinaryOcrCharacterAddViewModel : ObservableObject
         if (SubmitOnFirstLetter && NewText.Length >= 1)
         {
             e.Handled = true;
-            Ok();
+            _ = Ok();
         }
     }
 

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterAddViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterAddViewModel.cs
@@ -282,8 +282,29 @@ public partial class NOcrCharacterAddViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void Ok()
+    private async Task Ok()
     {
+        if (string.IsNullOrEmpty(NewText) && Se.Settings.Ocr.PromptForBlankOcrText)
+        {
+            var answer = await MessageBox.Show(
+                Window!,
+                Se.Language.Ocr.SaveBlankTextTitle,
+                Se.Language.Ocr.SaveBlankTextPrompt,
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question,
+                custom1: Se.Language.Ocr.YesAndNeverAskAgain);
+
+            if (answer == MessageBoxResult.No || answer == MessageBoxResult.None)
+            {
+                return;
+            }
+
+            if (answer == MessageBoxResult.Custom1)
+            {
+                Se.Settings.Ocr.PromptForBlankOcrText = false;
+            }
+        }
+
         NOcrChar.Text = NewText;
         NOcrChar.Italic = IsNewTextItalic;
         OkPressed = true;
@@ -427,7 +448,7 @@ public partial class NOcrCharacterAddViewModel : ObservableObject
         if (e.Key == Key.Enter && !string.IsNullOrWhiteSpace(TextBoxNew.Text))
         {
             e.Handled = true;
-            Ok();
+            _ = Ok();
         }
     }
 
@@ -436,7 +457,7 @@ public partial class NOcrCharacterAddViewModel : ObservableObject
         if (SubmitOnFirstLetter && NewText.Length >= 1)
         {
             e.Handled = true;
-            Ok();
+            _ = Ok();
         }
     }
 

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -73,6 +73,9 @@ public class LanguageOcr
     public string DownloadingPaddleOcrModelsDotDotDot { get; set; }
     public string PaddleOcr { get; set; }
     public string BinaryImageCompareInspectImageMatches { get; set; }
+    public string SaveBlankTextTitle { get; set; }
+    public string SaveBlankTextPrompt { get; set; }
+    public string YesAndNeverAskAgain { get; set; }
 
     public LanguageOcr()
     {
@@ -145,5 +148,8 @@ public class LanguageOcr
         DownloadingPaddleOcrModelsDotDotDot = "Downloading Paddle OCR models...";
         PaddleOcr = "Paddle OCR";
         BinaryImageCompareInspectImageMatches = "\"Binary image compare\" - Inspect image matches";
+        SaveBlankTextTitle = "Save blank text?";
+        SaveBlankTextPrompt = "Save blank text for image?";
+        YesAndNeverAskAgain = "Yes and never ask again";
     }
 }

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -22,6 +22,7 @@ public class SeOcr
     public string MistralApiKey { get; set; }
     public bool IsNewLetterItalic { get; set; }
     public bool SubmitOnFirstLetter { get; set; }
+    public bool PromptForBlankOcrText { get; set; }
     public int NOcrNoOfLinesToAutoDraw { get; set; }
     public int NOcrZoomFactor { get; set; }
     public string PaddleOcrMode { get; set; }
@@ -81,5 +82,7 @@ public class SeOcr
         UseWordSplitList = true;
 
         CaptureAssaPosition = false;
+
+        PromptForBlankOcrText = true;
     }
 }


### PR DESCRIPTION
## Summary
- In the nOCR and Binary OCR "Add new character" dialogs, pressing OK with an empty text now prompts: **Save blank text for image?** with **Yes / No / Yes and never ask again**.
- Adds a shared `Se.Settings.Ocr.PromptForBlankOcrText` setting (default `true`) — picking "Yes and never ask again" turns it off so the prompt is suppressed in future sessions.
- New language strings: `SaveBlankTextTitle`, `SaveBlankTextPrompt`, `YesAndNeverAskAgain`.

## Test plan
- [ ] Open nOCR add-character dialog, leave text empty, press OK → prompt appears.
- [ ] Same for Binary OCR add-character dialog.
- [ ] "No" cancels OK and keeps the dialog open.
- [ ] "Yes" saves the blank entry and closes the dialog.
- [ ] "Yes and never ask again" saves the entry and prevents the prompt from showing on subsequent invocations (verify across app restart).
- [ ] Pressing OK with non-empty text still works as before (no prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)