### PR TITLE
Fix flatpak CI restore (NU1101) and cache build state

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -640,6 +640,29 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Install flatpak
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak
+
+      # Cache the Freedesktop SDK + dotnet extension so we don't re-download
+      # ~6 GB of runtimes on every CI run. Bump the key suffix (-v1) to invalidate.
+      - name: Cache flatpak runtimes
+        id: flatpak-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/flatpak
+          key: flatpak-fd24.08-dotnet10-v1
+
+      - name: Install Freedesktop SDK + dotnet extension
+        if: steps.flatpak-cache.outputs.cache-hit != 'true'
+        run: |
+          flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak --user install -y --noninteractive flathub \
+            org.freedesktop.Platform//24.08 \
+            org.freedesktop.Sdk//24.08 \
+            org.freedesktop.Sdk.Extension.dotnet10//24.08
+
       - name: Regenerate nuget-sources.json
         run: bash installer/flatpak/generate-nuget-sources.sh
 
@@ -684,7 +707,7 @@ jobs:
         with:
           bundle: SubtitleEdit-linux-x64.flatpak
           manifest-path: installer/flatpak/dk.nikse.subtitleedit.yaml
-          cache-key: flatpak-builder-${{ github.sha }}
+          cache-key: flatpak-builder-${{ hashFiles('installer/flatpak/dk.nikse.subtitleedit.yaml', 'installer/flatpak/nuget-sources.json') }}
           arch: x86_64
 
       - name: Upload flatpak bundle artifact

--- a/installer/flatpak/generate-nuget-sources.sh
+++ b/installer/flatpak/generate-nuget-sources.sh
@@ -117,17 +117,10 @@ for sha_file in pkgs_dir.glob("**/*.nupkg.sha512"):
     version = sha_file.parent.name
     name    = sha_file.parent.parent.name
     filename = f"{name}.{version}.nupkg"
-    # The flatpak build targets linux-x64 / linux-arm64 only, but dotnet restore
-    # on a non-Linux host may drag in host-RID runtime packs (win-*, osx-*, etc.)
-    # Those are wasted bandwidth and bloat the offline cache, so drop them.
-    lower = name.lower()
-    if any(tag in lower for tag in (
-        ".win-", ".win10-", ".windowsdesktop.",
-        ".osx-", ".osx.", ".mac-", ".maccatalyst-",
-        ".android-", ".ios-", ".tvos-",
-        ".freebsd-",
-    )):
-        continue
+    # Don't filter by RID. Old PackageReferences (e.g. System.Net.Http 4.3.x)
+    # declare runtime.osx.*, runtime.win-*, etc. as transitive deps that NuGet
+    # must be able to resolve during restore even when targeting linux-x64.
+    # Stripping them by platform causes NU1101 inside the flatpak sandbox.
     url = f"https://api.nuget.org/v3-flatcontainer/{name}/{version}/{filename}"
     sha512_b64 = sha_file.read_text().strip()
     sha512_hex = binascii.hexlify(base64.b64decode(sha512_b64)).decode("ascii")


### PR DESCRIPTION
## Summary
- Regen job on `ubuntu-latest` was using Microsoft's .NET SDK, which preinstalls reference packs (e.g. `NETStandard.Library.Ref 2.1.0`) so they never landed in `nuget-sources.json`. The flatpak build runs inside the more minimal `org.freedesktop.Sdk.Extension.dotnet10` and failed with `NU1101` for those packages plus a couple of `runtime.osx.*` ones. Install flatpak + the matching SDK in the regen job so the JSON reflects what the actual build needs, and cache `~/.local/share/flatpak` to keep the runtime install off the critical path.
- Drop the platform-RID filter from `generate-nuget-sources.sh` fallback path. Old PackageReferences (`System.Net.Http 4.3.x`) declare `runtime.osx.*`, `runtime.win-*`, etc. as transitive deps that NuGet must resolve during restore, even when targeting linux-x64. Filtering them by name was causing `NU1101` inside the flatpak sandbox.
- Replace the per-commit `cache-key: flatpak-builder-${{ github.sha }}` with a hash of the manifest + nuget-sources, so `flatpak-builder`'s `.flatpak-builder/` cache (libmpv, ffmpeg, harfbuzz, etc.) is actually reused across commits instead of recompiling on every run.

## Test plan
- [ ] Trigger `Build and release UI` workflow; confirm `regenerate-flatpak-nuget-sources` regen step runs through the preferred (flatpak) path
- [ ] Confirm flatpak runtime cache miss on first run, hit on subsequent runs
- [ ] Confirm `Build flatpak bundle` step completes without `NU1101` errors
- [ ] Confirm the produced `SubtitleEdit-linux-x64.flatpak` installs and runs
- [ ] Confirm second run of the workflow on the same manifest is meaningfully faster (flatpak-builder cache reused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)