### PR TITLE
Improve video controls and menu behavior

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -142,9 +142,15 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             get => _isFullScreen;
             set
             {
+                if (_isFullScreen == value)
+                {
+                    return;
+                }
+
                 _buttonFullScreenCollapse.IsVisible = value;
                 _buttonFullScreen.IsVisible = !value;
                 _isFullScreen = value;
+                IsFullScreenChanged?.Invoke(value);
 
                 // Start or stop the auto-hide mechanism based on full screen state
                 if (value)
@@ -525,6 +531,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         public event Action? StopRequested;
         public event Action? FullscreenRequested;
         public event Action? FullscreenCollapseRequested;
+        public event Action<bool>? IsFullScreenChanged;
         public event Action<double>? PositionChanged;
         public event Action<double>? VolumeChanged;
         public event Action? ToggleDisplayProgressTextModeRequested;

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -261,6 +261,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Margin = new Thickness(0, 0, 3, 0),
             };
             Attached.SetIcon(_buttonPlay, "fa-solid fa-play");
+            ToolTip.SetTip(_buttonPlay, Se.Language.General.Play);
             _buttonPlay.Click += (_, _) =>
             {
                 _videoPlayerInstance.PlayOrPause();
@@ -285,6 +286,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Source = this
             });
             Attached.SetIcon(buttonStop, "fa-solid fa-stop");
+            ToolTip.SetTip(buttonStop, Se.Language.General.PlayFromStartOfVideo);
             buttonStop.Click += (_, _) =>
             {
                 _videoPlayerInstance.Stop();
@@ -308,6 +310,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Source = this
             });
             Attached.SetIcon(_buttonFullScreen, "fa-solid fa-expand");
+            ToolTip.SetTip(_buttonFullScreen, Se.Language.Options.Shortcuts.VideoFullScreen);
             _buttonFullScreen.Click += (_, _) => FullscreenRequested?.Invoke();
             stackPanel.Children.Add(_buttonFullScreen);
             _buttonFullScreen.Bind(Button.CommandProperty, new Binding
@@ -323,6 +326,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 IsVisible = false,
             };
             Attached.SetIcon(_buttonFullScreenCollapse, "fa-solid fa-compress");
+            ToolTip.SetTip(_buttonFullScreenCollapse, Se.Language.Options.Shortcuts.VideoFullScreen);
             _buttonFullScreenCollapse.Click += (_, _) => FullscreenCollapseRequested?.Invoke();
             stackPanel.Children.Add(_buttonFullScreenCollapse);
 
@@ -533,10 +537,12 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             if (isPlaying)
             {
                 Attached.SetIcon(_buttonPlay, "fa-solid fa-pause");
+                ToolTip.SetTip(_buttonPlay, Se.Language.General.Pause);
             }
             else
             {
                 Attached.SetIcon(_buttonPlay, "fa-solid fa-play");
+                ToolTip.SetTip(_buttonPlay, Se.Language.General.Play);
             }
         }
 

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -15,6 +15,7 @@ using Nikse.SubtitleEdit.Logic.VideoPlayers;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using Optris.Icons.Avalonia;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
@@ -136,8 +137,6 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
 
         private bool _isFullScreen = false;
 
-        public event Action<bool>? IsFullScreenChanged;
-
         public bool IsFullScreen
         {
             get => _isFullScreen;
@@ -157,8 +156,6 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                     StopAutoHideControls();
                     ShowControls();
                 }
-
-                IsFullScreenChanged?.Invoke(value);
             }
         }
 
@@ -181,6 +178,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         private DispatcherTimer? _autoHideTimer;
         private DateTime _lastActivityTime;
         private ContentPresenter? _contentPresenter;
+        private static readonly List<ShortCut> NoShortcuts = new();
 
         private void NotifyPositionChanged(double newPosition)
         {
@@ -261,7 +259,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Margin = new Thickness(0, 0, 3, 0),
             };
             Attached.SetIcon(_buttonPlay, "fa-solid fa-play");
-            ToolTip.SetTip(_buttonPlay, Se.Language.General.Play);
+            SetToolTip(_buttonPlay, Se.Language.General.Play);
             _buttonPlay.Click += (_, _) =>
             {
                 _videoPlayerInstance.PlayOrPause();
@@ -286,7 +284,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Source = this
             });
             Attached.SetIcon(buttonStop, "fa-solid fa-stop");
-            ToolTip.SetTip(buttonStop, Se.Language.General.PlayFromStartOfVideo);
+            SetToolTip(buttonStop, Se.Language.General.PlayFromStartOfVideo);
             buttonStop.Click += (_, _) =>
             {
                 _videoPlayerInstance.Stop();
@@ -310,7 +308,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Source = this
             });
             Attached.SetIcon(_buttonFullScreen, "fa-solid fa-expand");
-            ToolTip.SetTip(_buttonFullScreen, Se.Language.Options.Shortcuts.VideoFullScreen);
+            SetToolTip(_buttonFullScreen, Se.Language.Options.Shortcuts.VideoFullScreen);
             _buttonFullScreen.Click += (_, _) => FullscreenRequested?.Invoke();
             stackPanel.Children.Add(_buttonFullScreen);
             _buttonFullScreen.Bind(Button.CommandProperty, new Binding
@@ -326,7 +324,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 IsVisible = false,
             };
             Attached.SetIcon(_buttonFullScreenCollapse, "fa-solid fa-compress");
-            ToolTip.SetTip(_buttonFullScreenCollapse, Se.Language.Options.Shortcuts.VideoFullScreen);
+            SetToolTip(_buttonFullScreenCollapse, Se.Language.Options.Shortcuts.VideoFullScreen);
             _buttonFullScreenCollapse.Click += (_, _) => FullscreenCollapseRequested?.Invoke();
             stackPanel.Children.Add(_buttonFullScreenCollapse);
 
@@ -537,13 +535,18 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             if (isPlaying)
             {
                 Attached.SetIcon(_buttonPlay, "fa-solid fa-pause");
-                ToolTip.SetTip(_buttonPlay, Se.Language.General.Pause);
+                SetToolTip(_buttonPlay, Se.Language.General.Pause);
             }
             else
             {
                 Attached.SetIcon(_buttonPlay, "fa-solid fa-play");
-                ToolTip.SetTip(_buttonPlay, Se.Language.General.Play);
+                SetToolTip(_buttonPlay, Se.Language.General.Play);
             }
+        }
+
+        private static void SetToolTip(Control control, string hint)
+        {
+            ToolTip.SetTip(control, UiUtil.MakeToolTip(hint, NoShortcuts));
         }
 
         public void SetVolumeIcon(bool isMuted)

--- a/src/ui/Features/Files/ImportPlainText/PlainTextSplitter.cs
+++ b/src/ui/Features/Files/ImportPlainText/PlainTextSplitter.cs
@@ -121,7 +121,7 @@ public static class PlainTextSplitter
             var ch = text[i];
             var prevCh = i > 0 ? text[i - 1] : ' ';
 
-            if (prevCh == '.' || prevCh == '!' || prevCh == '?' || prevCh == '…')
+            if (prevCh == '.' || prevCh == '!' || prevCh == '?' || prevCh == '\u2026')
             {
                 if (char.IsWhiteSpace(ch) || i == text.Length - 1)
                 {
@@ -174,6 +174,6 @@ public static class PlainTextSplitter
         }
 
         var prevCh = text[position - 1];
-        return prevCh == '.' || prevCh == '!' || prevCh == '?' || prevCh == '…';
+        return prevCh == '.' || prevCh == '!' || prevCh == '?' || prevCh == '\u2026';
     }
 }

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -12,15 +12,22 @@ using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
 public static class InitMenu
 {
-    private static readonly HashSet<MenuItem> MenuItemsWaitingToClose = new();
+    private static readonly Dictionary<MenuItem, DispatcherTimer> MenuCloseTimers = new();
+    private static readonly PropertyInfo? IsPointerOverSubMenuProperty =
+        typeof(MenuItem)
+            .GetInterfaces()
+            .FirstOrDefault(p => p.FullName == "Avalonia.Controls.IMenuItem")
+            ?.GetProperty("IsPointerOverSubMenu");
 
     public static void Make(MainViewModel vm)
     {
+        StopMenuCloseTimers();
         var l = Se.Language.Main.Menu;
 
         vm.MenuReopen = new MenuItem
@@ -885,40 +892,63 @@ public static class InitMenu
 
     private static void CloseWhenPointerLeavesMenu(MenuItem item)
     {
-        if (!MenuItemsWaitingToClose.Add(item))
+        if (MenuCloseTimers.ContainsKey(item))
         {
             return;
         }
 
-        CheckPointerLeaveMenu(item);
+        var timer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(120),
+        };
+        timer.Tick += (_, _) => CheckPointerLeaveMenu(item);
+        MenuCloseTimers[item] = timer;
+        timer.Start();
     }
 
     private static void CheckPointerLeaveMenu(MenuItem item)
     {
-        DispatcherTimer.RunOnce(() =>
+        if (!MenuCloseTimers.ContainsKey(item))
         {
-            if (!item.IsSubMenuOpen)
-            {
-                MenuItemsWaitingToClose.Remove(item);
-                return;
-            }
+            return;
+        }
 
-            if (!item.IsPointerOver && !IsPointerOverSubMenu(item))
-            {
-                item.IsSubMenuOpen = false;
-                MenuItemsWaitingToClose.Remove(item);
-                return;
-            }
+        if (!item.IsSubMenuOpen)
+        {
+            StopMenuCloseTimer(item);
+            return;
+        }
 
-            CheckPointerLeaveMenu(item);
-        }, TimeSpan.FromMilliseconds(120));
+        if (!item.IsPointerOver && !IsPointerOverSubMenu(item))
+        {
+            item.IsSubMenuOpen = false;
+            StopMenuCloseTimer(item);
+        }
+    }
+
+    private static void StopMenuCloseTimer(MenuItem item)
+    {
+        if (!MenuCloseTimers.Remove(item, out var timer))
+        {
+            return;
+        }
+
+        timer.Stop();
+    }
+
+    private static void StopMenuCloseTimers()
+    {
+        foreach (var timer in MenuCloseTimers.Values)
+        {
+            timer.Stop();
+        }
+
+        MenuCloseTimers.Clear();
     }
 
     private static bool IsPointerOverSubMenu(MenuItem item)
     {
-        var menuItemInterface = item.GetType().GetInterfaces().FirstOrDefault(p => p.FullName == "Avalonia.Controls.IMenuItem");
-        var property = menuItemInterface?.GetProperty("IsPointerOverSubMenu");
-        return property?.GetValue(item) is true;
+        return IsPointerOverSubMenuProperty?.GetValue(item) is true;
     }
 
     public static void UpdateRecentFiles(MainViewModel vm)

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
@@ -16,6 +17,8 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
 public static class InitMenu
 {
+    private static readonly HashSet<MenuItem> MenuItemsWaitingToClose = new();
+
     public static void Make(MainViewModel vm)
     {
         var l = Se.Language.Main.Menu;
@@ -866,6 +869,56 @@ public static class InitMenu
         });
 
         menu.Items.Add(menuItemAssaTools);
+        InstallAutoCloseOnPointerLeave(menu);
+    }
+
+    private static void InstallAutoCloseOnPointerLeave(Menu menu)
+    {
+        foreach (var item in menu.Items.OfType<MenuItem>())
+        {
+            item.PointerExited += (_, _) =>
+            {
+                CloseWhenPointerLeavesMenu(item);
+            };
+        }
+    }
+
+    private static void CloseWhenPointerLeavesMenu(MenuItem item)
+    {
+        if (!MenuItemsWaitingToClose.Add(item))
+        {
+            return;
+        }
+
+        CheckPointerLeaveMenu(item);
+    }
+
+    private static void CheckPointerLeaveMenu(MenuItem item)
+    {
+        DispatcherTimer.RunOnce(() =>
+        {
+            if (!item.IsSubMenuOpen)
+            {
+                MenuItemsWaitingToClose.Remove(item);
+                return;
+            }
+
+            if (!item.IsPointerOver && !IsPointerOverSubMenu(item))
+            {
+                item.IsSubMenuOpen = false;
+                MenuItemsWaitingToClose.Remove(item);
+                return;
+            }
+
+            CheckPointerLeaveMenu(item);
+        }, TimeSpan.FromMilliseconds(120));
+    }
+
+    private static bool IsPointerOverSubMenu(MenuItem item)
+    {
+        var menuItemInterface = item.GetType().GetInterfaces().FirstOrDefault(p => p.FullName == "Avalonia.Controls.IMenuItem");
+        var property = menuItemInterface?.GetProperty("IsPointerOverSubMenu");
+        return property?.GetValue(item) is true;
     }
 
     public static void UpdateRecentFiles(MainViewModel vm)

--- a/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
+++ b/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
@@ -45,7 +45,7 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
         {
             string.Empty,
             "...",
-            "…",
+            "\u2026",
             "..",
             "-",
         });


### PR DESCRIPTION
## Summary

- Adds tooltips for video playback controls:
  - Play/Pause
  - Play from start
  - Full screen
- Updates the Play/Pause tooltip dynamically based on playback state.
- Auto-closes top-level menus when the pointer leaves the menu/submenu area.

## Testing

Built successfully with:

```powershell
dotnet build src\ui\UI.csproj --no-restore -p:RunAnalyzers=false -p:UseAppHost=false -p:OutDir=D:\subtitleedit\artifacts\verify-build\
