### PR TITLE
Fix subtitle grid double-click and drag selection conflict

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -36,6 +36,7 @@ public static partial class InitListViewAndEditBox
             if (vm.SubtitleGridDropHost != null)
             {
                 vm.SubtitleGridDropHost.PointerPressed -= vm.SubtitleGrid_PointerPressed;
+                vm.SubtitleGridDropHost.RemoveHandler(InputElement.DoubleTappedEvent, vm.SubtitleGridDropHost_DoubleTapped);
                 vm.SubtitleGridDropHost.RemoveHandler(InputElement.PointerPressedEvent, vm.SubtitleGrid_PointerPressed);
                 vm.SubtitleGridDropHost.RemoveHandler(InputElement.PointerReleasedEvent, vm.SubtitleGrid_PointerReleased);
                 vm.SubtitleGridDropHost.RemoveHandler(InputElement.PointerMovedEvent, vm.SubtitleGrid_PointerMoved);
@@ -109,8 +110,8 @@ public static partial class InitListViewAndEditBox
         dropHost.AddHandler(DragDrop.DragOverEvent, vm.SubtitleGridOnDragOver, RoutingStrategies.Bubble);
         dropHost.AddHandler(DragDrop.DropEvent, vm.SubtitleGridOnDrop, RoutingStrategies.Bubble);
 
-        vm.SubtitleGrid.DoubleTapped += vm.OnSubtitleGridDoubleTapped;
         vm.SubtitleGrid.Tapped += vm.OnSubtitleGridSingleTapped;
+        dropHost.AddHandler(InputElement.DoubleTappedEvent, vm.SubtitleGridDropHost_DoubleTapped, RoutingStrategies.Bubble, handledEventsToo: true);
 
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14200,10 +14200,27 @@ public partial class MainViewModel :
                 {
                     _dragSelectStartIndex = rowIndex;
                     _dragSelectLastIndex = rowIndex;
-                    e.Pointer.Capture(control);
                 }
             }
         }
+    }
+
+    public void SubtitleGridDropHost_DoubleTapped(object? sender, TappedEventArgs e)
+    {
+        var rowIndex = GetDataGridRowIndexFromPoint(e.GetPosition(SubtitleGrid));
+        if (rowIndex < 0 || rowIndex >= Subtitles.Count)
+        {
+            return;
+        }
+
+        StopSubtitleGridDragSelectAutoScroll();
+        _dragSelectStartIndex = -1;
+        _dragSelectLastIndex = -1;
+        _dragSelectHasMoved = false;
+
+        SubtitleGrid.SelectedItem = Subtitles[rowIndex];
+        OnSubtitleGridDoubleTapped(SubtitleGrid, e);
+        e.Handled = true;
     }
 
     private int GetDataGridRowIndexFromPoint(Avalonia.Point position)
@@ -14246,8 +14263,17 @@ public partial class MainViewModel :
             return;
         }
 
+        var wasDragging = _dragSelectHasMoved;
         DragSelectSubtitleGridToIndex(currentIndex);
-        e.Handled = _dragSelectHasMoved;
+        if (_dragSelectHasMoved)
+        {
+            if (!wasDragging && sender is Control control)
+            {
+                e.Pointer.Capture(control);
+            }
+
+            e.Handled = true;
+        }
     }
 
     private void DragSelectSubtitleGridToIndex(int currentIndex)


### PR DESCRIPTION
## Summary

Fixes a conflict between subtitle grid double-click actions and drag selection.

## Changes

- Delays pointer capture until drag selection has actually started.
- Handles subtitle grid double-tap events through the drop host.
- Clears drag selection state before running the existing double-click action.
- Removes the drop host double-tap handler when rebuilding the layout.

## Testing

- Verified the PR diff only contains the subtitle grid double-click / drag selection fix.
