### PR TITLE
Fix Piper Linux espeak symlink

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -26,6 +26,13 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 
 public partial class DownloadTtsViewModel : ObservableObject
 {
+    internal static IReadOnlyList<(string SourceFilePattern, string LinkFileName)> PiperLinuxSymbolicLinks { get; } =
+        new[]
+        {
+            ("libpiper_phonemize.so.1.*", "libpiper_phonemize.so.1"),
+            ("libespeak-ng.so.1.*", "libespeak-ng.so.1"),
+        };
+
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
 
@@ -457,7 +464,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         }
     }
 
-    private void FixSymbolicLink(string path)
+    private static void FixSymbolicLink(string path)
     {
         var folder = Path.GetDirectoryName(path);
         if (string.IsNullOrEmpty(folder))
@@ -466,57 +473,73 @@ public partial class DownloadTtsViewModel : ObservableObject
             return;
         }
 
-        var sourcePath = Path.Combine(folder, "libpiper_phonemize.so.1.2.0");
-        var linkPath = Path.Combine(folder, "libpiper_phonemize.so.1");
+        foreach (var link in PiperLinuxSymbolicLinks)
+        {
+            var sourcePath = FindSymbolicLinkSource(folder, link.SourceFilePattern);
+            if (sourcePath == null)
+            {
+                Se.LogError("Source library file not found: " + Path.Combine(folder, link.SourceFilePattern));
+                continue;
+            }
 
+            var linkPath = Path.Combine(folder, link.LinkFileName);
+            CreateSymbolicLink(sourcePath, linkPath);
+        }
+    }
+
+    internal static string? FindSymbolicLinkSource(string folder, string sourceFilePattern)
+    {
+        return Directory
+            .GetFiles(folder, sourceFilePattern)
+            .OrderByDescending(Path.GetFileName, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
+    private static void CreateSymbolicLink(string sourcePath, string linkPath)
+    {
         try
         {
-            if (File.Exists(sourcePath))
+            var processStartInfo = CreateSymbolicLinkProcessStartInfo(sourcePath, linkPath);
+            using var process = Process.Start(processStartInfo);
+
+            if (process == null)
             {
-                // Check if the link exists and remove it if necessary
-                if (File.Exists(linkPath) || Directory.Exists(linkPath))
-                {
-                    File.Delete(linkPath); // Delete the existing link or file
-                }
-
-                // Create the symbolic link
-                var processStartInfo = new ProcessStartInfo
-                {
-                    FileName = "/bin/bash", // Use bash shell for command execution
-                    Arguments = $"-c \"ln -sf \\\"{sourcePath}\\\" \\\"{linkPath}\\\"\"",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-
-                var process = Process.Start(processStartInfo);
-
-                if (process != null)
-                {
-                    process.WaitForExit();
-
-                    // Check if the process completed successfully
-                    if (process.ExitCode != 0)
-                    {
-                        var error = process.StandardError.ReadToEnd();
-                        Se.LogError($"Error creating symlink: {error}");
-                    }
-                    else
-                    {
-                        Se.LogError("Symbolic link created successfully.");
-                    }
-                }
+                Se.LogError("Error creating symlink: Could not start /bin/bash");
+                return;
             }
-            else
+
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
             {
-                Se.LogError("Source library file not found!");
+                Se.LogError($"Error creating symlink: {error}");
             }
         }
         catch (Exception ex)
         {
             Se.LogError(ex);
         }
+    }
+
+    internal static ProcessStartInfo CreateSymbolicLinkProcessStartInfo(string sourcePath, string linkPath)
+    {
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        processStartInfo.ArgumentList.Add("-c");
+        processStartInfo.ArgumentList.Add($"ln -sfn -- {QuoteForBash(sourcePath)} {QuoteForBash(linkPath)}");
+        return processStartInfo;
+    }
+
+    private static string QuoteForBash(string value)
+    {
+        return "'" + value.Replace("'", "'\"'\"'") + "'";
     }
 
     private void Close()

--- a/tests/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModelTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModelTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
+
+namespace UITests.Features.Video.TextToSpeech.DownloadTts;
+
+public class DownloadTtsViewModelTests
+{
+    [Fact]
+    public void PiperLinuxSymbolicLinks_UsesVersionIndependentLibraryPatterns()
+    {
+        var links = DownloadTtsViewModel.PiperLinuxSymbolicLinks.ToList();
+
+        Assert.Contains(links, link =>
+            link.SourceFilePattern == "libpiper_phonemize.so.1.*" &&
+            link.LinkFileName == "libpiper_phonemize.so.1");
+        Assert.Contains(links, link =>
+            link.SourceFilePattern == "libespeak-ng.so.1.*" &&
+            link.LinkFileName == "libespeak-ng.so.1");
+    }
+
+    [Fact]
+    public void FindSymbolicLinkSource_FindsVersionedLibraryFile()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+
+        try
+        {
+            var sourcePath = Path.Combine(folder, "libespeak-ng.so.1.53.0.0");
+            File.WriteAllText(sourcePath, string.Empty);
+
+            var result = DownloadTtsViewModel.FindSymbolicLinkSource(folder, "libespeak-ng.so.1.*");
+
+            Assert.Equal(sourcePath, result);
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void CreateSymbolicLinkProcessStartInfo_UsesForceNoDereferenceLinkCommand()
+    {
+        var processStartInfo = DownloadTtsViewModel.CreateSymbolicLinkProcessStartInfo(
+            "/tmp/piper/libespeak-ng.so.1.53.0.0",
+            "/tmp/piper/libespeak-ng.so.1");
+
+        Assert.Equal("/bin/bash", processStartInfo.FileName);
+        Assert.Equal("-c", processStartInfo.ArgumentList[0]);
+        Assert.Contains("ln -sfn --", processStartInfo.ArgumentList[1]);
+        Assert.Contains("'/tmp/piper/libespeak-ng.so.1.53.0.0'", processStartInfo.ArgumentList[1]);
+        Assert.Contains("'/tmp/piper/libespeak-ng.so.1'", processStartInfo.ArgumentList[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add the missing Linux Piper symlink for `libespeak-ng.so.1` after unpacking Piper.
- Keep the existing `libpiper_phonemize.so.1` symlink behavior and use version-independent `*.so.1.*` source matching so future Piper archive bumps do not require exact filename updates.
- Preserve the previous `ln -sf` style behavior via `ln -sfn`, so existing or dangling symlinks are replaced instead of blocking setup.
- Add focused regression tests for the Piper Linux symlink patterns, versioned source discovery, and generated `ln -sfn` command.

Addresses discussion #10659.

## Verification
- Checked for existing PRs/fixes matching `#10659`, `libespeak-ng.so.1`, and Piper symlink wording; did not find an active duplicate.
- `dotnet test .\tests\UI\UITests.csproj -c Debug --no-restore --filter DownloadTtsViewModelTests -v minimal` passed: 3/3.
- `dotnet build .\src\ui\UI.csproj -c Debug --no-restore` succeeded.
- `dotnet test .\tests\UI\UITests.csproj -c Debug --no-restore -v minimal` passed: 127/127.

## Notes
- I verified this on Windows with unit/build tests; the actual symlink creation path is Linux-only and runs after Piper is unpacked.
- AI assistance was used to identify, implement, and verify this change.