### PR TITLE
Handle original subtitle save failures

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11920,17 +11920,27 @@ public partial class MainViewModel :
 
         var text = GetUpdateSubtitleOriginal(true).ToText(SelectedSubtitleFormat);
 
-        if (SelectedEncoding.DisplayName == TextEncoding.Utf8WithBom)
+        try
         {
-            await File.WriteAllTextAsync(_subtitleFileNameOriginal, text, new UTF8Encoding(true));
+            if (SelectedEncoding.DisplayName == TextEncoding.Utf8WithBom)
+            {
+                await File.WriteAllTextAsync(_subtitleFileNameOriginal, text, new UTF8Encoding(true));
+            }
+            else if (SelectedEncoding.DisplayName == TextEncoding.Utf8WithoutBom)
+            {
+                await File.WriteAllTextAsync(_subtitleFileNameOriginal, text, new UTF8Encoding(false));
+            }
+            else
+            {
+                await File.WriteAllTextAsync(_subtitleFileNameOriginal, text, SelectedEncoding.Encoding);
+            }
         }
-        else if (SelectedEncoding.DisplayName == TextEncoding.Utf8WithoutBom)
+        catch (Exception ex)
         {
-            await File.WriteAllTextAsync(_subtitleFileNameOriginal, text, new UTF8Encoding(false));
-        }
-        else
-        {
-            await File.WriteAllTextAsync(_subtitleFileNameOriginal, text, SelectedEncoding.Encoding);
+            var message = string.Format(Se.Language.General.CouldNotSaveFileXErrorY, _subtitleFileNameOriginal, ex.Message);
+            await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return false;
         }
 
         _changeSubtitleHashOriginal = GetFastHashOriginal();
@@ -12129,13 +12139,24 @@ public partial class MainViewModel :
             return false;
         }
 
-        _subtitleFileNameOriginal = fileName;
+        var oldSubtitleFileNameOriginal = _subtitleFileNameOriginal;
+        var oldSubtitleOriginalFileName = _subtitleOriginal.FileName;
+        var oldLastOpenSaveFormat = _lastOpenSaveFormat;
 
+        _subtitleFileNameOriginal = fileName;
         _subtitleOriginal ??= new Subtitle();
         _subtitleOriginal.FileName = fileName;
 
         _lastOpenSaveFormat = SelectedSubtitleFormat;
-        await SaveSubtitleOriginal();
+        var result = await SaveSubtitleOriginal();
+        if (!result)
+        {
+            _subtitleFileNameOriginal = oldSubtitleFileNameOriginal;
+            _subtitleOriginal.FileName = oldSubtitleOriginalFileName;
+            _lastOpenSaveFormat = oldLastOpenSaveFormat;
+            return false;
+        }
+
         AddToRecentFiles(true);
         return true;
     }


### PR DESCRIPTION
## Summary
- Catch write failures when saving the original subtitle file, matching the existing behavior for the main subtitle save path.
- Show the localized "Could not save file" error instead of letting locked/read-only original files crash the app.
- Return the actual save result from "Save original as" and only update recent files after a successful write.

Addresses discussion #10477.

## Verification
- `dotnet build .\src\ui\UI.csproj -c Debug --no-restore` succeeded with the existing 3 nullability warnings in unrelated export/batch-convert files.
- `dotnet test .\tests\UI\UITests.csproj -c Debug --no-restore -v minimal` passed: 124/124.

## Notes
- I also checked nearby easy-looking candidates while triaging: #9961, discussion #10163, and discussion #10666 all appear to already be covered in the current code, so I left them alone.
- AI assistance was used to identify, implement, and verify this change.