### PR TITLE
Add forced aligner picker for CrispASR

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCanary.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCanary.cs
@@ -15,6 +15,7 @@ public class CrispAsrCanary : CrispAsrEngineBase
     public override string BackendName => "canary";
     public override string DefaultLanguage => "en";
     public override bool IncludeLanguage => true;
+    public override bool HasNativeTimestamps => true;
 
     public override List<WhisperLanguage> Languages =>
        new()

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
@@ -15,6 +15,7 @@ public class CrispAsrCohere : CrispAsrEngineBase
     public override string BackendName => "cohere";
     public override string DefaultLanguage => "en";
     public override bool IncludeLanguage => true;
+    public override bool HasNativeTimestamps => true;
 
     public override List<WhisperLanguage> Languages =>
        new()

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -71,6 +71,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
     public override string BackendName => SelectedBackend.BackendName;
     public override string DefaultLanguage => SelectedBackend.DefaultLanguage;
     public override bool IncludeLanguage => SelectedBackend.IncludeLanguage;
+    public override bool HasNativeTimestamps => SelectedBackend.HasNativeTimestamps;
     public override List<WhisperLanguage> Languages => SelectedBackend.Languages;
     public override List<WhisperModel> Models => SelectedBackend.Models;
     public override string Extension => SelectedBackend.Extension;

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
@@ -15,6 +15,7 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
     public abstract string BackendName { get; }
     public abstract string DefaultLanguage { get; }
     public abstract bool IncludeLanguage { get; }
+    public virtual bool HasNativeTimestamps => false;
     public abstract List<WhisperLanguage> Languages { get; }
     public abstract List<WhisperModel> Models { get; }
     public abstract string Extension { get; }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -15,6 +15,7 @@ public class CrispAsrParakeet : CrispAsrEngineBase
     public override string BackendName => "parakeet";
     public override string DefaultLanguage => "en";
     public override bool IncludeLanguage => false;
+    public override bool HasNativeTimestamps => true;
 
     public override List<WhisperLanguage> Languages =>
        new()

--- a/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
@@ -1,0 +1,72 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using System;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+public class ForcedAlignerOption
+{
+    public const string BuiltInChoice = "built-in";
+    public const string CanaryCtcChoice = "canary-ctc";
+    public const string Qwen3Choice = "qwen3-forced";
+
+    public string Display { get; }
+    public string Choice { get; }
+    public string FileName { get; }
+    public string Url { get; }
+    public string Size { get; }
+
+    public bool IsBuiltIn => Choice == BuiltInChoice;
+
+    public ForcedAlignerOption(string display, string choice, string fileName, string url, string size)
+    {
+        Display = display;
+        Choice = choice;
+        FileName = fileName;
+        Url = url;
+        Size = size;
+    }
+
+    public override string ToString() => Display;
+
+    public WhisperModel ToWhisperModel() => new()
+    {
+        Name = FileName,
+        Size = Size,
+        Urls = string.IsNullOrEmpty(Url) ? Array.Empty<string>() : new[] { Url },
+    };
+
+    public static ForcedAlignerOption BuiltIn() =>
+        new("Built-in aligner", BuiltInChoice, string.Empty, string.Empty, string.Empty);
+
+    public static ForcedAlignerOption CanaryCtc() =>
+        new("Canary CTC aligner",
+            CanaryCtcChoice,
+            "canary-ctc-aligner-q8_0.gguf",
+            "https://huggingface.co/cstr/canary-ctc-aligner-GGUF/resolve/main/canary-ctc-aligner-q8_0.gguf",
+            "650 MB");
+
+    public static ForcedAlignerOption Qwen3() =>
+        new("Qwen3 forced aligner",
+            Qwen3Choice,
+            "qwen3-forced-aligner-0.6b-q8_0.gguf",
+            "https://huggingface.co/cstr/qwen3-forced-aligner-0.6b-GGUF/resolve/main/qwen3-forced-aligner-0.6b-q8_0.gguf",
+            "986 MB");
+
+    public static IReadOnlyList<ForcedAlignerOption> All() => new[]
+    {
+        BuiltIn(),
+        CanaryCtc(),
+        Qwen3(),
+    };
+
+    public static ForcedAlignerOption FromChoice(string? choice)
+    {
+        return choice switch
+        {
+            CanaryCtcChoice => CanaryCtc(),
+            Qwen3Choice => Qwen3(),
+            _ => BuiltIn(),
+        };
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
@@ -10,7 +10,8 @@ public class ForcedAlignerOption
     public const string CanaryCtcChoice = "canary-ctc";
     public const string Qwen3Choice = "qwen3-forced";
 
-    public string Display { get; }
+    public string BaseDisplay { get; }
+    public string Display { get; set; }
     public string Choice { get; }
     public string FileName { get; }
     public string Url { get; }
@@ -20,6 +21,7 @@ public class ForcedAlignerOption
 
     public ForcedAlignerOption(string display, string choice, string fileName, string url, string size)
     {
+        BaseDisplay = display;
         Display = display;
         Choice = choice;
         FileName = fileName;

--- a/src/ui/Features/Video/SpeechToText/Engines/ICrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ICrispAsrEngine.cs
@@ -10,5 +10,8 @@ public interface ICrispAsrEngine : ISpeechToTextEngine
 
     /// <summary>Whether the -l (language) flag should be included in the command line.</summary>
     bool IncludeLanguage { get; }
+
+    /// <summary>Whether the backend produces native word/segment timestamps without an external CTC aligner.</summary>
+    bool HasNativeTimestamps { get; }
 }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -290,15 +290,15 @@ public partial class SpeechToTextViewModel : ObservableObject
         newOptions.Add(ForcedAlignerOption.CanaryCtc());
         newOptions.Add(ForcedAlignerOption.Qwen3());
 
-        var sameList = ForcedAligners.Count == newOptions.Count
-                       && ForcedAligners.Zip(newOptions, (a, b) => a.Choice == b.Choice).All(eq => eq);
-        if (!sameList)
+        foreach (var opt in newOptions)
         {
-            ForcedAligners.Clear();
-            foreach (var opt in newOptions)
-            {
-                ForcedAligners.Add(opt);
-            }
+            opt.Display = BuildAlignerDisplay(opt, crispEngine);
+        }
+
+        ForcedAligners.Clear();
+        foreach (var opt in newOptions)
+        {
+            ForcedAligners.Add(opt);
         }
 
         if (crispEngine == null)
@@ -316,6 +316,40 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             SelectedForcedAligner = match;
         }
+    }
+
+    private static string BuildAlignerDisplay(ForcedAlignerOption option, ICrispAsrEngine? crispEngine)
+    {
+        if (option.IsBuiltIn || string.IsNullOrEmpty(option.FileName))
+        {
+            return option.BaseDisplay;
+        }
+
+        var installed = false;
+        if (crispEngine is CrispAsrEngineBase baseEngine)
+        {
+            var path = baseEngine.GetModelForCmdLine(option.FileName);
+            if (File.Exists(path) && new FileInfo(path).Length > 10_000_000)
+            {
+                installed = true;
+            }
+        }
+
+        var size = string.IsNullOrEmpty(option.Size) ? string.Empty : option.Size;
+        if (installed && !string.IsNullOrEmpty(size))
+        {
+            return $"{option.BaseDisplay} ({size})";
+        }
+        if (installed)
+        {
+            return option.BaseDisplay;
+        }
+        if (!string.IsNullOrEmpty(size))
+        {
+            return $"{option.BaseDisplay} ({size}, not installed)";
+        }
+
+        return $"{option.BaseDisplay} (not installed)";
     }
 
     private void UpdateWhisperCppBackendUi()
@@ -1727,7 +1761,6 @@ public partial class SpeechToTextViewModel : ObservableObject
             displays.Add(new SpeechToTextModelDisplay
             {
                 Model = aligner.ToWhisperModel(),
-                Display = aligner.Display + " (" + aligner.FileName + ")",
                 Engine = engine,
             });
         }
@@ -1750,6 +1783,8 @@ public partial class SpeechToTextViewModel : ObservableObject
             {
                 viewModel.SetModels(displays, engine, preSelected);
             });
+
+        UpdateForcedAlignerUi();
     }
 
     private static string GetForcedAlignerPath(ICrispAsrEngine crispEngine, ForcedAlignerOption aligner)
@@ -2050,13 +2085,12 @@ public partial class SpeechToTextViewModel : ObservableObject
                 var displayAligner = new SpeechToTextModelDisplay
                 {
                     Model = alignerWhisperModel,
-                    Display = SelectedForcedAligner.Display + " (" + SelectedForcedAligner.FileName + ")",
                     Engine = engine,
                 };
                 var answer = await MessageBox.Show(
                                 Window!,
-                                $"Download {SelectedForcedAligner.Display}?",
-                                $"'{SelectedForcedAligner.Display}' is selected but not installed.\nDownload and use {SelectedForcedAligner.FileName}?",
+                                $"Download {SelectedForcedAligner.BaseDisplay}?",
+                                $"'{SelectedForcedAligner.BaseDisplay}' is selected but not installed.\nDownload and use {SelectedForcedAligner.FileName}?",
                                 MessageBoxButtons.YesNoCancel,
                                 MessageBoxIcon.Question);
 
@@ -2077,6 +2111,8 @@ public partial class SpeechToTextViewModel : ObservableObject
                 {
                     return;
                 }
+
+                UpdateForcedAlignerUi();
             }
         }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -68,6 +68,9 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private bool _isCrispAsrSelected;
     [ObservableProperty] private ObservableCollection<CrispAsrEngineBase> _crispAsrBackends;
     [ObservableProperty] private CrispAsrEngineBase? _selectedCrispAsrBackend;
+    [ObservableProperty] private bool _isForcedAlignerVisible;
+    [ObservableProperty] private ObservableCollection<ForcedAlignerOption> _forcedAligners;
+    [ObservableProperty] private ForcedAlignerOption? _selectedForcedAligner;
     [ObservableProperty] private double _progressOpacity;
 
     [ObservableProperty] private double _progressValue;
@@ -174,6 +177,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         BatchItems = new ObservableCollection<SpeechToTextJobItem>();
         WhisperCppBackends = new ObservableCollection<ISpeechToTextEngine>();
         CrispAsrBackends = new ObservableCollection<CrispAsrEngineBase>();
+        ForcedAligners = new ObservableCollection<ForcedAlignerOption>();
 
         ResultAudioClips = new List<AudioClip>();
 
@@ -243,6 +247,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         Se.Settings.Tools.AudioToText.WhisperChoice = engine.Choice;
         Se.Settings.Tools.AudioToText.WhisperModel = SelectedModel?.Model.Name ?? string.Empty;
         Se.Settings.Tools.AudioToText.WhisperLanguageCode = SelectedLanguage?.Code ?? string.Empty;
+        Se.Settings.Tools.AudioToText.CrispAsrForcedAligner = SelectedForcedAligner?.Choice ?? ForcedAlignerOption.BuiltInChoice;
 
         Se.SaveSettings();
     }
@@ -266,7 +271,51 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         UpdateWhisperCppBackendUi();
         UpdateCrispAsrBackendUi();
+        UpdateForcedAlignerUi();
         IsBackendSelectionVisible = IsWhisperCppSelected || IsCrispAsrSelected;
+        IsForcedAlignerVisible = IsCrispAsrSelected;
+    }
+
+    private void UpdateForcedAlignerUi()
+    {
+        var engine = GetEffectiveSelectedEngine();
+        var crispEngine = engine as ICrispAsrEngine;
+        var hasNative = crispEngine?.HasNativeTimestamps == true;
+
+        var newOptions = new List<ForcedAlignerOption>();
+        if (hasNative)
+        {
+            newOptions.Add(ForcedAlignerOption.BuiltIn());
+        }
+        newOptions.Add(ForcedAlignerOption.CanaryCtc());
+        newOptions.Add(ForcedAlignerOption.Qwen3());
+
+        var sameList = ForcedAligners.Count == newOptions.Count
+                       && ForcedAligners.Zip(newOptions, (a, b) => a.Choice == b.Choice).All(eq => eq);
+        if (!sameList)
+        {
+            ForcedAligners.Clear();
+            foreach (var opt in newOptions)
+            {
+                ForcedAligners.Add(opt);
+            }
+        }
+
+        if (crispEngine == null)
+        {
+            return;
+        }
+
+        var preferredChoice = hasNative
+            ? ForcedAlignerOption.BuiltInChoice
+            : (crispEngine is CrispAsrQwen3 ? ForcedAlignerOption.Qwen3Choice : ForcedAlignerOption.CanaryCtcChoice);
+
+        var match = ForcedAligners.FirstOrDefault(p => p.Choice == preferredChoice)
+                    ?? ForcedAligners.FirstOrDefault();
+        if (!ReferenceEquals(SelectedForcedAligner, match))
+        {
+            SelectedForcedAligner = match;
+        }
     }
 
     private void UpdateWhisperCppBackendUi()
@@ -277,13 +326,20 @@ public partial class SpeechToTextViewModel : ObservableObject
             _isUpdatingWhisperCppBackend = true;
             try
             {
-                WhisperCppBackends.Clear();
-                foreach (var backend in whisperCppEngine.Backends)
+                if (WhisperCppBackends.Count != whisperCppEngine.Backends.Count)
                 {
-                    WhisperCppBackends.Add(backend);
+                    WhisperCppBackends.Clear();
+                    foreach (var backend in whisperCppEngine.Backends)
+                    {
+                        WhisperCppBackends.Add(backend);
+                    }
                 }
 
-                SelectedWhisperCppBackend = WhisperCppBackends.FirstOrDefault(p => p.Choice == whisperCppEngine.SelectedBackend.Choice);
+                var match = WhisperCppBackends.FirstOrDefault(p => p.Choice == whisperCppEngine.SelectedBackend.Choice);
+                if (!ReferenceEquals(SelectedWhisperCppBackend, match))
+                {
+                    SelectedWhisperCppBackend = match;
+                }
             }
             finally
             {
@@ -313,13 +369,20 @@ public partial class SpeechToTextViewModel : ObservableObject
             _isUpdatingCrispAsrBackend = true;
             try
             {
-                CrispAsrBackends.Clear();
-                foreach (var backend in crispAsrEngine.Backends)
+                if (CrispAsrBackends.Count != crispAsrEngine.Backends.Count)
                 {
-                    CrispAsrBackends.Add(backend);
+                    CrispAsrBackends.Clear();
+                    foreach (var backend in crispAsrEngine.Backends)
+                    {
+                        CrispAsrBackends.Add(backend);
+                    }
                 }
 
-                SelectedCrispAsrBackend = CrispAsrBackends.FirstOrDefault(p => p.Choice == crispAsrEngine.SelectedBackend.Choice);
+                var match = CrispAsrBackends.FirstOrDefault(p => p.Choice == crispAsrEngine.SelectedBackend.Choice);
+                if (!ReferenceEquals(SelectedCrispAsrBackend, match))
+                {
+                    SelectedCrispAsrBackend = match;
+                }
             }
             finally
             {
@@ -1640,6 +1703,66 @@ public partial class SpeechToTextViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task DownloadForcedAligner()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var engine = GetEffectiveSelectedEngine();
+        if (engine is not ICrispAsrEngine)
+        {
+            return;
+        }
+
+        var displays = new ObservableCollection<SpeechToTextModelDisplay>();
+        foreach (var aligner in ForcedAlignerOption.All())
+        {
+            if (aligner.IsBuiltIn)
+            {
+                continue;
+            }
+
+            displays.Add(new SpeechToTextModelDisplay
+            {
+                Model = aligner.ToWhisperModel(),
+                Display = aligner.Display + " (" + aligner.FileName + ")",
+                Engine = engine,
+            });
+        }
+
+        if (displays.Count == 0)
+        {
+            return;
+        }
+
+        SpeechToTextModelDisplay? preSelected = null;
+        if (SelectedForcedAligner != null && !SelectedForcedAligner.IsBuiltIn)
+        {
+            preSelected = displays.FirstOrDefault(d => d.Model.Name == SelectedForcedAligner.FileName);
+        }
+
+        preSelected ??= displays[0];
+
+        await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
+            Window, viewModel =>
+            {
+                viewModel.SetModels(displays, engine, preSelected);
+            });
+    }
+
+    private static string GetForcedAlignerPath(ICrispAsrEngine crispEngine, ForcedAlignerOption aligner)
+    {
+        if (aligner.IsBuiltIn || string.IsNullOrEmpty(aligner.FileName) || crispEngine is not CrispAsrEngineBase baseEngine)
+        {
+            return string.Empty;
+        }
+
+        return baseEngine.GetModelForCmdLine(aligner.FileName);
+    }
+
+    [RelayCommand]
     private async Task Transcribe()
     {
         if (IsBatchMode && BatchItems.Count == 0)
@@ -1875,7 +1998,8 @@ public partial class SpeechToTextViewModel : ObservableObject
             }
         }
 
-        if (engine is CrispAsrQwen3 crispQwen3Engine)
+        if (engine is CrispAsrQwen3 crispQwen3Engine
+            && (SelectedForcedAligner == null || SelectedForcedAligner.IsBuiltIn))
         {
             var modelAligner = crispQwen3Engine.ForcedAlignerModel;
             var displayModelAligner = new SpeechToTextModelDisplay
@@ -1906,6 +2030,46 @@ public partial class SpeechToTextViewModel : ObservableObject
                     Window!, viewModel =>
                     {
                         viewModel.SetModels(models, engine, displayModelAligner);
+                        viewModel.StartDownload();
+                    });
+
+                if (!vm.OkPressed)
+                {
+                    return;
+                }
+            }
+        }
+
+        if (engine is ICrispAsrEngine crispAsrEngineForAligner
+            && SelectedForcedAligner != null && !SelectedForcedAligner.IsBuiltIn)
+        {
+            var alignerPath = GetForcedAlignerPath(crispAsrEngineForAligner, SelectedForcedAligner);
+            if (string.IsNullOrEmpty(alignerPath) || !File.Exists(alignerPath))
+            {
+                var alignerWhisperModel = SelectedForcedAligner.ToWhisperModel();
+                var displayAligner = new SpeechToTextModelDisplay
+                {
+                    Model = alignerWhisperModel,
+                    Display = SelectedForcedAligner.Display + " (" + SelectedForcedAligner.FileName + ")",
+                    Engine = engine,
+                };
+                var answer = await MessageBox.Show(
+                                Window!,
+                                $"Download {SelectedForcedAligner.Display}?",
+                                $"'{SelectedForcedAligner.Display}' is selected but not installed.\nDownload and use {SelectedForcedAligner.FileName}?",
+                                MessageBoxButtons.YesNoCancel,
+                                MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+
+                var alignerModels = new ObservableCollection<SpeechToTextModelDisplay> { displayAligner };
+                var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
+                    Window!, viewModel =>
+                    {
+                        viewModel.SetModels(alignerModels, engine, displayAligner);
                         viewModel.StartDownload();
                     });
 
@@ -2235,7 +2399,16 @@ public partial class SpeechToTextViewModel : ObservableObject
                 ? $"-l {langCode} "
                 : string.Empty;
             var alignerPart = string.Empty;
-            if (crispAsrEngine is CrispAsrQwen3 crispQwen3)
+            var selectedAligner = SelectedForcedAligner ?? ForcedAlignerOption.BuiltIn();
+            if (!selectedAligner.IsBuiltIn)
+            {
+                var explicitAlignerPath = GetForcedAlignerPath(crispAsrEngine, selectedAligner);
+                if (!string.IsNullOrEmpty(explicitAlignerPath) && File.Exists(explicitAlignerPath))
+                {
+                    alignerPart = $" -am \"{explicitAlignerPath}\"";
+                }
+            }
+            else if (crispAsrEngine is CrispAsrQwen3 crispQwen3)
             {
                 var alignerPath = crispQwen3.GetModelForCmdLine(crispQwen3.ForcedAlignerModel.Name);
                 if (File.Exists(alignerPath))

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -71,6 +71,28 @@ public class SpeechToTextWindow : Window
             .WithMarginTop(10)
             .BindIsVisible(vm, nameof(vm.IsCrispAsrSelected));
 
+        var labelForcedAligner = UiUtil.MakeTextBlock("Forced aligner").WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsForcedAlignerVisible));
+        var comboForcedAligner = UiUtil.MakeComboBox(vm.ForcedAligners, vm, nameof(vm.SelectedForcedAligner))
+            .WithMinWidth(220)
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
+            .WithMarginTop(10);
+        var buttonForcedAlignerDownload = UiUtil.MakeButtonBrowse(vm.DownloadForcedAlignerCommand)
+            .WithMarginTop(10)
+            .WithMarginLeft(5)
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
+        var panelForcedAlignerControls = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                comboForcedAligner,
+                buttonForcedAlignerDownload,
+            },
+        }.BindIsVisible(vm, nameof(vm.IsForcedAlignerVisible));
+
         var labelLanguage = UiUtil.MakeTextBlock(Se.Language.Video.AudioToText.InputLanguage).WithMarginTop(10);
         var comboLanguage = UiUtil.MakeComboBox(vm.Languages, vm, nameof(vm.SelectedLanguage))
             .WithMinWidth(220)
@@ -293,6 +315,7 @@ public class SpeechToTextWindow : Window
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Engine
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Backend
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Forced aligner
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Language
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Model
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Translate to English
@@ -358,6 +381,10 @@ public class SpeechToTextWindow : Window
         grid.Add(labelBackend, row, 0);
         grid.Add(comboWhisperCppBackend, row, 1);
         grid.Add(comboCrispAsrBackend, row, 1);
+        row++;
+
+        grid.Add(labelForcedAligner, row, 0);
+        grid.Add(panelForcedAlignerControls, row, 1);
         row++;
 
         grid.Add(labelLanguage, row, 0);

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -52,6 +52,7 @@ public class SeAudioToText
     public string CommandLineParameterCrispAsrQwen3 { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrOmni { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrKyutai { get; set; } = "--max-len 50 --split-on-punct";
+    public string CrispAsrForcedAligner { get; set; } = "built-in";
 
     public string WhisperExtraSettingsHistory { get; set; } = string.Empty;
 


### PR DESCRIPTION
## Summary
- Adds a "Forced aligner" combo box and inline download button to the speech-to-text window for CrispASR engines.
- Combo contents are backend-aware: native-timestamp backends (Parakeet, Canary, Cohere) include `Built-in`; backends without native timestamps (Qwen3, Granite, FireRed, Glm, Omni, Kyutai) only list the explicit aligners.
- Selected aligner is wired to `-am <path>` on the CrispASR command line. When the chosen aligner isn't installed, the existing model-download dialog is reused to fetch `canary-ctc-aligner-q8_0.gguf` or `qwen3-forced-aligner-0.6b-q8_0.gguf`.
- Sensible defaults on engine/backend change: native backends auto-select `Built-in`; the Qwen3 backend defaults to its bundled `Qwen3 forced aligner`; other no-native backends default to `Canary CTC`.

Refs #10775

## Test plan
- [x] Open Video → Audio to text, switch to a CrispASR backend, confirm the new "Forced aligner" row shows.
- [x] Verify Parakeet/Canary/Cohere show `Built-in` as the first/default option.
- [x] Verify Qwen3/Granite/Glm/FireRed/Omni/Kyutai hide `Built-in`; Qwen3 defaults to `Qwen3 forced aligner`, others default to `Canary CTC`.
- [x] Click the `…` button → download dialog appears with both downloadable aligners.
- [ ] Pick a non-built-in aligner that is not yet downloaded and start transcription → prompt to download appears, then transcription runs with `-am "<path>"`.
- [ ] Restart the app and confirm the previously selected backend still displays in the backend combo (regression check for the Clear/Add fix).