### PR TITLE
Prompt for variant when re-downloading Crisp ASR

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1579,10 +1579,58 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         var engine = GetEffectiveSelectedEngine();
-        var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
+        var crispVariant = "vulkan";
+        if (engine is ICrispAsrEngine && Configuration.IsRunningOnWindows)
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                $"Download {CrispAsrEngine.StaticName}?",
+                $"{Environment.NewLine}\"{CrispAsrEngine.StaticName}\" requires downloading the CrispASR engine.{Environment.NewLine}{Environment.NewLine}Select a version to download:",
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                "CPU",
+                "Vulkan",
+                "CUDA");
+
+            if (answer == MessageBoxResult.None || answer == MessageBoxResult.Cancel)
+            {
+                return;
+            }
+
+            crispVariant = answer switch
+            {
+                MessageBoxResult.Custom1 => "cpu",
+                MessageBoxResult.Custom3 => "cuda",
+                _ => "vulkan",
+            };
+
+            if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
+            {
+                var vulkanAnswer = await MessageBox.Show(
+                    Window,
+                    "Vulkan SDK may be required",
+                    $"The Vulkan version requires the Vulkan SDK to be installed.{Environment.NewLine}{Environment.NewLine}You can download it from:{Environment.NewLine}https://vulkan.lunarg.com/sdk/home{Environment.NewLine}{Environment.NewLine}Continue with Vulkan download?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (vulkanAnswer == MessageBoxResult.No)
+                {
+                    UiUtil.OpenUrl("https://vulkan.lunarg.com/sdk/home");
+                    return;
+                }
+
+                if (vulkanAnswer != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+            }
+        }
+
+        await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
             Window, viewModel =>
             {
                 viewModel.Engine = engine;
+                viewModel.CrispAsrWindowsVariant = crispVariant;
                 viewModel.StartDownload();
             });
     }
@@ -3166,13 +3214,14 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         IsReDownloadVisible = true;
+        var displayName = engine is ICrispAsrEngine ? CrispAsrEngine.StaticName : engine.Name;
         if (engine.IsEngineInstalled())
         {
-            ReDownloadText = string.Format(Se.Language.General.ReDownloadX, engine.Name);
+            ReDownloadText = string.Format(Se.Language.General.ReDownloadX, displayName);
         }
         else
         {
-            ReDownloadText = string.Format(Se.Language.General.DownloadX, engine.Name);
+            ReDownloadText = string.Format(Se.Language.General.DownloadX, displayName);
         }
     }
 


### PR DESCRIPTION
## Summary
- Speech-to-text context menu shows "Re-download Crisp ASR" instead of "Re-download Crisp ASR Parakeet" (the engine binary is shared across all CrispASR backends, so the per-backend label was misleading).
- On Windows, the re-download command now opens the CPU / Vulkan / CUDA picker that the first-install path uses — including the Vulkan SDK warning — and forwards the chosen variant to `DownloadSpeechToTextEngineViewModel.CrispAsrWindowsVariant`.

## Test plan
- [ ] Open Video → Audio to text, pick a CrispASR backend (e.g. Parakeet), right-click → menu shows "Re-download Crisp ASR".
- [ ] Click "Re-download Crisp ASR" on Windows → CPU / Vulkan / CUDA picker appears.
- [ ] Pick CUDA → CUDA build downloads. Pick CPU → CPU build downloads. Pick Vulkan without the SDK → Vulkan-SDK warning appears.
- [ ] Repeat with the engine NOT installed → menu reads "Download Crisp ASR" and the picker still appears.
- [ ] On macOS / Linux → re-download runs without a picker (single platform binary).