### PR TITLE
Preserve PAC justification on italic lines

### DIFF
--- a/src/libse/SubtitleFormats/Pac.cs
+++ b/src/libse/SubtitleFormats/Pac.cs
@@ -1692,7 +1692,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             const int endDelimiter = 0x00;
             var alignment = buffer[feIndex + 1];
             var isSecondaryCodePage = (alignment & 0x08) != 0;
-            alignment &= 0x07;
+            alignment &= 0x03; // bits 0-1 hold alignment (0=right, 1=left, 2=center); bit 2 (0x04) is the italic flag
             var p = new Paragraph();
             var timeStartIndex = feIndex - 15;
             if (buffer[timeStartIndex] == 0x60)
@@ -1799,7 +1799,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         {
                             alignment = buffer[index + 1];
                             isSecondaryCodePage = (alignment & 0x08) != 0;
-                            alignment &= 0x07;
+                            alignment &= 0x03; // bits 0-1 hold alignment (0=right, 1=left, 2=center); bit 2 (0x04) is the italic flag
                             sb.AppendLine();
                             w16 = buffer[index + 3] == 0x1f && Encoding.ASCII.GetString(buffer, index + 4, 3) == "W16";
                             if (w16)
@@ -1842,7 +1842,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         alignment = buffer[index + 1];
                         isSecondaryCodePage = (alignment & 0x08) != 0;
-                        alignment &= 0x07;
+                        alignment &= 0x03; // bits 0-1 hold alignment (0=right, 1=left, 2=center); bit 2 (0x04) is the italic flag
                         sb.AppendLine();
                         index += 2;
                     }

--- a/tests/libse/SubtitleFormats/PacTest.cs
+++ b/tests/libse/SubtitleFormats/PacTest.cs
@@ -88,4 +88,33 @@ public class PacTest
         target.LoadSubtitle(reload, ms.ToArray());
         Assert.True(reload.Paragraphs[0].Text == "V <i>Now</i>.");
     }
+
+    [Theory]
+    [InlineData("{\\an7}<i>Italic left text</i>", "{\\an7}")]
+    [InlineData("{\\an8}<i>Italic center text</i>", "{\\an8}")]
+    [InlineData("{\\an9}<i>Italic right text</i>", "{\\an9}")]
+    public void PacItalicAlignmentIsPreserved(string input, string expectedAlignmentTag)
+    {
+        // Some external PAC writers set bit 0x04 of the alignment byte (after the 0xFE marker)
+        // as an italic flag in addition to using <...> markers in the text. The reader must mask
+        // out this italic bit so the alignment value is interpreted correctly.
+        var target = new Pac { CodePage = Pac.CodePageLatin };
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(input, 0, 999));
+        var ms = new MemoryStream();
+        target.Save("test.pac", ms, subtitle);
+        var bytes = ms.ToArray();
+
+        for (var i = 0; i < bytes.Length - 1; i++)
+        {
+            if (bytes[i] == 0xFE)
+            {
+                bytes[i + 1] |= 0x04;
+            }
+        }
+
+        var reload = new Subtitle();
+        target.LoadSubtitle(reload, bytes);
+        Assert.StartsWith(expectedAlignmentTag, reload.Paragraphs[0].Text);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes [discussion #10779](https://github.com/SubtitleEdit/subtitleedit/discussions/10779) — italic lines in PAC files lost their justification on import.

In a PAC paragraph, the alignment byte that follows the `0xFE` marker uses bits 0-1 for the alignment value (0 = right, 1 = left, 2 = center) and bit 2 (`0x04`) as an italic flag. The reader masked the byte with `0x07`, which preserved the italic bit, so italic-left (`0x05`), italic-center (`0x06`), and italic-right (`0x04`) all fell through to the default branch and were rendered as centered.

The reporter's sample (`Justtes TIV 1.pac`) — text 2 (italic left) and text 6 (italic right) lost justification, while text 17 (only the first of two lines italic) survived because the second line's `0xFE` marker had alignment `0x01` and overwrote the corrupted value.

Fix: mask alignment with `0x03` in the three places it is read from the buffer in `Pac.cs`.

## Test plan

- [x] Added `PacItalicAlignmentIsPreserved` `[Theory]` covering `{\an7}`, `{\an8}`, `{\an9}` — round-trips through Save, then sets bit `0x04` on every alignment byte (simulating an external PAC writer) and verifies the alignment tag survives the read.
- [x] All 9 tests in `PacTest` pass.
- [x] Manually open `Justtes TIV 1.pac` and confirm texts 2, 4, and 6 keep their original justification.