### PR TITLE
Fix fullscreen video controls not auto-hiding after re-show

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -143,6 +143,11 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             get => _isFullScreen;
             set
             {
+                if (_isFullScreen == value)
+                {
+                    return;
+                }
+
                 _buttonFullScreenCollapse.IsVisible = value;
                 _buttonFullScreen.IsVisible = !value;
                 _isFullScreen = value;
@@ -662,22 +667,30 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             // Show controls initially when entering full screen
             ShowControls();
 
-            // Timer to hide controls after 3 seconds of inactivity
-            _autoHideTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
-            _autoHideTimer.Tick += (s, e) =>
+            // Single one-shot timer reset on each user activity. Stops itself on tick so
+            // Stop()+Start() reliably reschedules a fresh 3-second wait from "now" — a
+            // free-running periodic timer can drift out of phase with _lastActivityTime
+            // and fail to hide after the user re-shows controls during playback.
+            if (_autoHideTimer == null)
             {
-                if (IsFullScreen && (DateTime.UtcNow - _lastActivityTime).TotalSeconds >= 3)
+                _autoHideTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+                _autoHideTimer.Tick += (s, e) =>
                 {
-                    HideControls();
-                }
-            };
+                    _autoHideTimer?.Stop();
+                    if (IsFullScreen)
+                    {
+                        HideControls();
+                    }
+                };
+            }
+
+            _autoHideTimer.Stop();
             _autoHideTimer.Start();
         }
 
         private void StopAutoHideControls()
         {
             _autoHideTimer?.Stop();
-            _autoHideTimer = null;
         }
 
         private void OnUserActivity()
@@ -686,7 +699,11 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             if (IsFullScreen)
             {
                 ShowControls();
-                _autoHideTimer?.Start();
+                if (_autoHideTimer != null)
+                {
+                    _autoHideTimer.Stop();
+                    _autoHideTimer.Start();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #10747. After the initial fix in 96012ddb8, controls auto-hide on first launch — but if the user does something during playback that re-shows them (key press, click on the video surface, slider drag), they stay shown until the user waves the mouse over them once.

Root cause: the auto-hide was a free-running periodic `DispatcherTimer`. Activity coming through `OnUserActivity` only called `Start()` — a no-op while the timer is already running — so the tick schedule could drift out of phase with `_lastActivityTime` and miss the hide condition. Mouse-waving "fixed" it because `PointerMoved` re-ran the `IsFullScreen` setter, which leaked the old timer and created a fresh one (also leaking timers on every move).

Fix:
- `IsFullScreen` setter is now idempotent (no-op when value didn't change).
- Single one-shot timer instance, reused.
- `OnUserActivity` does `Stop()` + `Start()` so the hide fires deterministically 3 seconds after the last activity.

## Test plan

- [x] Open SE with the undocked video player set to fullscreen — controls show, then hide after a few seconds.
- [x] During playback, press a key / click the video surface so controls re-show — verify they auto-hide again ~3 s later without needing to wave the mouse.
- [x] Toggle fullscreen off then on — controls show, then hide on inactivity.
- [x] Mouse movement still keeps the controls visible while moving and hides them shortly after stopping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)