### PR TITLE
Add Chatterbox TTS engine via CrispASR

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -32,11 +32,13 @@
     "apply": "Apply",
     "applyTo": "Apply to",
     "ascending": "Ascending",
+    "descending": "Descending",
     "attachDotDotDot": "Attach...",
     "audioFiles": "Audio files",
     "audioVisualizer": "Audio visualizer",
     "auto": "Auto",
     "autoBreak": "Auto-break text",
+    "autoBalanceLines": "Auto-balance lines",
     "autoContinue": "Auto-continue",
     "autoTranslate": "Auto-translate",
     "autodetect": "Autodetect",
@@ -671,6 +673,7 @@
       "openKeepVideo": "Open (_keep video)...",
       "openOriginal": "Open ori_ginal...",
       "closeOriginal": "_Close original",
+      "closeTranslation": "Close _translation",
       "reopen": "_Reopen...",
       "clearRecentFiles": "_Clear recent files",
       "restoreAutoBackup": "Restore auto-_backup...",
@@ -1405,7 +1408,10 @@
     },
     "sortBy": {
       "title": "Sort subtitles",
-      "sortOrder": "Sort order"
+      "sortOrder": "Sort order",
+      "sortByNumber": "Number",
+      "sortByStartTime": "Start time",
+      "sortByEndTime": "End time"
     },
     "batchConvert": {
       "title": "Batch convert",
@@ -1489,7 +1495,10 @@
       "title": "Merge short lines",
       "highlightParts": "Highlight parts (karaoke)",
       "mergedLineInfo": "Merged line {0} into {1} - {2}",
-      "linesMergedX": "Lines merged: {0}"
+      "linesMergedX": "Lines merged: {0}",
+      "maxCharacters": "Maximum characters in one paragraph",
+      "maxMillisecondsBetweenLines": "Maximum milliseconds between lines",
+      "onlyContinuationLines": "Only continuation lines"
     },
     "mergeLinesWithSameText": {
       "title": "Merge lines with same text",
@@ -2322,6 +2331,7 @@
       "commandFileNewKeepVideo": "New (keep video)",
       "fileOpenOriginal": "Open original",
       "fileCloseOriginal": "Close original",
+      "fileCloseTranslation": "Close translation",
       "restoreAutoBackup": "Restore auto-backup",
       "openContainingFolder": "Open containing folder",
       "importTimeCodes": "Import time codes",

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -220,6 +220,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<IQwen3AsrCppDownloadService, Qwen3AsrCppDownloadService>();
         collection.AddHttpClient<IQwen3TtsCppDownloadService, Qwen3TtsCppDownloadService>();
         collection.AddHttpClient<IKokoroTtsCppDownloadService, KokoroTtsCppDownloadService>();
+        collection.AddHttpClient<IChatterboxTtsCppDownloadService, ChatterboxTtsCppDownloadService>();
 
         // Window view models
         collection.AddTransient<AdvancedTtsSettingsViewModel>();

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -35,7 +35,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
     public ISpeechToTextEngine? Engine { get; internal set; }
 
     /// <summary>
-    /// Windows-only CrispASR download variant: "cpu", "vulkan", or "cuda". Defaults to "vulkan".
+    /// Windows-only CrispASR download variant: "cpu", "cpu-legacy", "vulkan", or "cuda". Defaults to "vulkan".
     /// </summary>
     public string CrispAsrWindowsVariant { get; set; } = "vulkan";
 
@@ -173,10 +173,11 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
                                 ? "crispasr-macos"
                                 : CrispAsrWindowsVariant switch
                                 {
-                                    "cuda"   => "crispasr-windows-x86_64-cuda",
-                                    "cpu"    => "crispasr-windows-x86_64-cpu-legacy",
-                                    "vulkan" => "crispasr-windows-x86_64-vulkan",
-                                    _        => Engine.UnpackSkipFolder,
+                                    "cuda"       => "crispasr-windows-x86_64-cuda",
+                                    "cpu"        => "crispasr-windows-x86_64-cpu",
+                                    "cpu-legacy" => "crispasr-windows-x86_64-cpu-legacy",
+                                    "vulkan"     => "crispasr-windows-x86_64-vulkan",
+                                    _            => Engine.UnpackSkipFolder,
                                 }
                         : Engine.UnpackSkipFolder;
 
@@ -441,9 +442,10 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
             {
                 _downloadTask = CrispAsrWindowsVariant switch
                 {
-                    "cuda" => _crispAsrDownloadService.DownloadEngineWindowsCuda(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
-                    "cpu"  => _crispAsrDownloadService.DownloadEngineWindowsCpu(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
-                    _      => _crispAsrDownloadService.DownloadEngineWindowsVulkan(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    "cuda"       => _crispAsrDownloadService.DownloadEngineWindowsCuda(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    "cpu"        => _crispAsrDownloadService.DownloadEngineWindowsCpu(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    "cpu-legacy" => _crispAsrDownloadService.DownloadEngineWindowsCpuLegacy(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    _            => _crispAsrDownloadService.DownloadEngineWindowsVulkan(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
                 };
             }
             else

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -183,6 +183,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
                     if (Engine is ICrispAsrEngine)
                     {
                         WriteCrispAsrInstalledHash(folder);
+                        RemoveStaleCrispAsrBinaries(folder);
                     }
 
                     TitleText = Se.Language.Video.AudioToText.UnpackingSpeechToTextEngine;
@@ -233,6 +234,55 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
             {
                 LinuxHelper.MakeExecutable(path);
             }
+        }
+    }
+
+    /// <summary>
+    /// Removes leftover binaries from a previous CrispASR install before extracting
+    /// the new zip. Switching variants (e.g. Vulkan → CPU-legacy) leaves orphan DLLs
+    /// in place because the CPU-legacy zip ships only EXEs — Windows then loads the
+    /// stale ggml*.dll alongside the new statically-linked EXE, which trips
+    /// `GGML_ASSERT(prev != ggml_uncaught_exception)` (a duplicate static-init).
+    ///
+    /// Only top-level executables and shared libraries are removed. Subfolders
+    /// (models/, vibevoice/), the Silero VAD .bin, downloaded GGUFs and the
+    /// .installed.sha256 sidecar are left in place.
+    /// </summary>
+    private static void RemoveStaleCrispAsrBinaries(string folder)
+    {
+        if (!Directory.Exists(folder))
+        {
+            return;
+        }
+
+        try
+        {
+            foreach (var file in Directory.GetFiles(folder, "*", SearchOption.TopDirectoryOnly))
+            {
+                var ext = Path.GetExtension(file).ToLowerInvariant();
+                var name = Path.GetFileName(file);
+                var isBinary = ext is ".exe" or ".dll" or ".so" or ".dylib"
+                    || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                        && (name == "crispasr" || name == "crispasr-quantize"));
+                if (!isBinary)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    File.Delete(file);
+                }
+                catch
+                {
+                    // best-effort — a locked file (e.g. an in-flight server) will
+                    // be overwritten by the unpack step that follows.
+                }
+            }
+        }
+        catch
+        {
+            // ignore — cleanup is best-effort
         }
     }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1604,6 +1604,16 @@ public partial class SpeechToTextViewModel : ObservableObject
                 _ => "vulkan",
             };
 
+            if (crispVariant == "cpu")
+            {
+                var cpuAnswer = await PromptCrispAsrCpuFlavorAsync();
+                if (cpuAnswer == null)
+                {
+                    return;
+                }
+                crispVariant = cpuAnswer;
+            }
+
             if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
             {
                 var vulkanAnswer = await MessageBox.Show(
@@ -1633,6 +1643,30 @@ public partial class SpeechToTextViewModel : ObservableObject
                 viewModel.CrispAsrWindowsVariant = crispVariant;
                 viewModel.StartDownload();
             });
+    }
+
+    /// <summary>
+    /// Follow-up prompt after the user picks "CPU" in the CrispASR variant selector.
+    /// Returns "cpu" (modern, recommended), "cpu-legacy" (compatibility build for CPUs without AVX2),
+    /// or null when the user cancels.
+    /// </summary>
+    private async Task<string?> PromptCrispAsrCpuFlavorAsync()
+    {
+        var cpuAnswer = await MessageBox.Show(
+            Window!,
+            "CrispASR CPU build",
+            $"{Environment.NewLine}Standard is recommended for most machines.{Environment.NewLine}{Environment.NewLine}Legacy is a fallback for older CPUs without AVX2 support.",
+            MessageBoxButtons.Cancel,
+            MessageBoxIcon.Question,
+            "Standard",
+            "Legacy");
+
+        return cpuAnswer switch
+        {
+            MessageBoxResult.Custom1 => "cpu",
+            MessageBoxResult.Custom2 => "cpu-legacy",
+            _ => null,
+        };
     }
 
     [RelayCommand]
@@ -1912,6 +1946,16 @@ public partial class SpeechToTextViewModel : ObservableObject
                     MessageBoxResult.Custom3 => "cuda",
                     _ => "vulkan",
                 };
+
+                if (crispVariant == "cpu")
+                {
+                    var cpuAnswer = await PromptCrispAsrCpuFlavorAsync();
+                    if (cpuAnswer == null)
+                    {
+                        return;
+                    }
+                    crispVariant = cpuAnswer;
+                }
 
                 if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
                 {

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -49,11 +49,13 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskQwen3TtsModels;
     private Task? _downloadTaskKokoroTtsCpp;
     private Task? _downloadTaskKokoroTtsModels;
+    private Task? _downloadTaskChatterboxModels;
     private readonly Timer _timer = new();
 
     private readonly ITtsDownloadService _ttsDownloadService;
     private readonly IQwen3TtsCppDownloadService _qwen3TtsCppDownloadService;
     private readonly IKokoroTtsCppDownloadService _kokoroTtsCppDownloadService;
+    private readonly IChatterboxTtsCppDownloadService _chatterboxTtsCppDownloadService;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly MemoryStream _downloadStream;
     private readonly MemoryStream _downloadStreamModel;
@@ -68,11 +70,13 @@ public partial class DownloadTtsViewModel : ObservableObject
 
     public DownloadTtsViewModel(ITtsDownloadService ttsDownloadService, IZipUnpacker zipUnpacker,
         IQwen3TtsCppDownloadService qwen3TtsCppDownloadService,
-        IKokoroTtsCppDownloadService kokoroTtsCppDownloadService)
+        IKokoroTtsCppDownloadService kokoroTtsCppDownloadService,
+        IChatterboxTtsCppDownloadService chatterboxTtsCppDownloadService)
     {
         _ttsDownloadService = ttsDownloadService;
         _qwen3TtsCppDownloadService = qwen3TtsCppDownloadService;
         _kokoroTtsCppDownloadService = kokoroTtsCppDownloadService;
+        _chatterboxTtsCppDownloadService = chatterboxTtsCppDownloadService;
         _zipUnpacker = zipUnpacker;
 
         _cancellationTokenSource = new CancellationTokenSource();
@@ -461,6 +465,28 @@ public partial class DownloadTtsViewModel : ObservableObject
                     Error = ex?.Message ?? "Unknown error";
                 }
             }
+
+            if (_downloadTaskChatterboxModels is { IsCompleted: true })
+            {
+                _timer.Stop();
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskChatterboxModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskChatterboxModels.Exception?.InnerException ?? _downloadTaskChatterboxModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
         }
     }
 
@@ -669,6 +695,27 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskKokoroTtsModels =
             _kokoroTtsCppDownloadService.DownloadModels(KokoroTtsCpp.GetSetModelsFolder(), downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadChatterboxModels()
+    {
+        TitleText = "Downloading Chatterbox TTS models (~880 MB)";
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskChatterboxModels =
+            _chatterboxTtsCppDownloadService.DownloadModels(ChatterboxTtsCpp.GetSetModelsFolder(), downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     internal void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -20,14 +20,15 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// <summary>
 /// Chatterbox TTS via the existing CrispASR install (shared with the speech-to-text feature).
 /// Spawns `crispasr --server --backend chatterbox -m auto` and POSTs to the OpenAI-compatible
-/// /v1/audio/speech endpoint. Reference WAVs imported via <see cref="ImportVoice"/> are sent
-/// per-request as the `voice` field; whether cloning actually engages depends on the running
-/// CrispASR build (the chatterbox backend is wiring up runtime WAV cloning).
+/// /v1/audio/speech endpoint. Requires CrispASR v0.6.0 or newer.
+/// Chatterbox has one baked default voice; "voices" listed beyond Default come from
+/// WAVs imported via <see cref="ImportVoice"/>. The full reference-WAV path is sent per-request
+/// as the `voice` field — runtime WAV cloning is wired upstream in CrispASR's chatterbox backend.
 /// </summary>
 public class ChatterboxTtsCpp : ITtsEngine
 {
     public string Name => "Chatterbox TTS";
-    public string Description => "voice cloning via CrispASR";
+    public string Description => "via CrispASR (one baked voice + clone via Import voice)";
     public bool HasLanguageParameter => false;
     public bool HasApiKey => false;
     public bool HasRegion => false;
@@ -231,8 +232,6 @@ public class ChatterboxTtsCpp : ITtsEngine
             psi.ArgumentList.Add("127.0.0.1");
             psi.ArgumentList.Add("--port");
             psi.ArgumentList.Add(port.ToString());
-            psi.ArgumentList.Add("--voice-dir");
-            psi.ArgumentList.Add(GetSetVoicesFolder());
 
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start crispasr (chatterbox)");
@@ -263,6 +262,12 @@ public class ChatterboxTtsCpp : ITtsEngine
                     var tail = SnapshotStderr(stderrBuffer);
                     _serverProcess = null;
                     _serverPort = 0;
+                    if (LooksLikeOutdatedCrispAsr(tail))
+                    {
+                        throw new InvalidOperationException(
+                            "Chatterbox requires CrispASR v0.6.0 or newer. Re-download CrispASR via "
+                            + "Video → Audio to text → Engine settings → Re-download, then try again.");
+                    }
                     throw new InvalidOperationException(
                         $"crispasr (chatterbox) exited during startup (code {process.ExitCode}). Output: {tail}");
                 }
@@ -282,6 +287,15 @@ public class ChatterboxTtsCpp : ITtsEngine
         {
             ServerLock.Release();
         }
+    }
+
+    private static bool LooksLikeOutdatedCrispAsr(string output)
+    {
+        // v0.5.x exits 0 and prints `error: unknown argument: ...` when it doesn't
+        // recognise --voice-dir / --backend chatterbox. v0.6.x without the chatterbox
+        // backend (e.g. ASR-only build) prints `unknown backend 'chatterbox'`.
+        return output.Contains("unknown argument", StringComparison.Ordinal)
+            || output.Contains("unknown backend", StringComparison.Ordinal);
     }
 
     private static string SnapshotStderr(StringBuilder buffer)

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -237,12 +237,13 @@ public class ChatterboxTtsCpp : ITtsEngine
                 StopServerInternal();
             }
             Se.LogError(ex, $"Chatterbox TTS request failed - Voice: {chatterboxVoice}, Text: {text}, "
-                + $"ServerExited: {died}, ServerLog: {serverLog}");
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}");
 
             var prefix = LooksLikeUpstreamChatterboxCrash(serverLog)
                 ? "Chatterbox TTS hit a CrispASR runtime bug during synthesis (ggml tensor read out of bounds). "
                   + "This is an upstream issue — please file it at https://github.com/CrispStrobe/CrispASR/issues with the server log below. "
-                  + "Switching to the Vulkan or CUDA CrispASR build (re-download via Audio to text) may avoid the CPU-only code path that triggers it."
+                  + "The crash reproduces on the CPU and Vulkan builds (chatterbox's T3 step runs on CPU regardless of the build); "
+                  + "the CUDA build may avoid it but is unverified."
                 : "Chatterbox TTS request failed — "
                   + (died ? "the crispasr server crashed during synthesis." : "the connection to the crispasr server was dropped.");
 
@@ -258,7 +259,8 @@ public class ChatterboxTtsCpp : ITtsEngine
                 var errorBody = await SafeReadErrorAsync(response, cancellationToken);
                 var serverLog = SnapshotServerLog();
                 Se.LogError($"Chatterbox TTS server error {(int)response.StatusCode} {response.StatusCode} - "
-                    + $"Voice: {chatterboxVoice}, Text: {text}, Body: {errorBody}, ServerLog: {serverLog}");
+                    + $"Voice: {chatterboxVoice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}");
                 throw new InvalidOperationException(
                     $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}"
                     + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}"));
@@ -270,6 +272,25 @@ public class ChatterboxTtsCpp : ITtsEngine
         }
 
         return new TtsResult(outputFileName, text);
+    }
+
+    /// <summary>
+    /// Renders the server launch as a shell-quotable string (file path + each arg quoted only
+    /// when it contains whitespace). Goes into the error log so failures can be reproduced.
+    /// </summary>
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
     }
 
     private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
@@ -335,9 +356,25 @@ public class ChatterboxTtsCpp : ITtsEngine
             psi.ArgumentList.Add("127.0.0.1");
             psi.ArgumentList.Add("--port");
             psi.ArgumentList.Add(port.ToString());
+            // The crispasr server gates /v1/audio/speech requests with a `voice` field
+            // behind --voice-dir being set ("warning: --voice-dir not set; … will reject
+            // requests with a 'voice' field"). Imported reference-WAV cloning sends an
+            // absolute path as `voice`, which the chatterbox backend resolves directly,
+            // but the server-level gate still applies. Pointing --voice-dir at our
+            // voices folder satisfies the gate and also makes /v1/voices reflect the
+            // imported WAVs.
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
 
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start crispasr (chatterbox)");
+
+            // Record the exact launch command in the error log so failures later in this
+            // session can be reproduced from a shell. Logged via LogError because that's
+            // the only severity exposed by Se; this entry is informational.
+            Se.LogError("Chatterbox TTS server starting - "
+                + $"PID: {process.Id}, "
+                + $"Cmd: {FormatLaunchCommand(exe, psi.ArgumentList)}");
 
             lock (_serverLog) _serverLog.Clear();
             process.ErrorDataReceived += (_, e) =>

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -307,6 +307,14 @@ public class ChatterboxTtsCpp : ITtsEngine
                             "Chatterbox requires CrispASR v0.6.0 or newer. Re-download CrispASR via "
                             + "Video → Audio to text → Engine settings → Re-download, then try again.");
                     }
+                    if (LooksLikeStaleModelCache(tail))
+                    {
+                        throw new InvalidOperationException(
+                            "Chatterbox failed to load its model — the cached GGUF files in "
+                            + GetCrispAsrCacheDir() + " are likely stale or partially downloaded. "
+                            + "Delete chatterbox-*.gguf in that folder and try again. Original output: "
+                            + tail);
+                    }
                     throw new InvalidOperationException(
                         $"crispasr (chatterbox) exited during startup (code {process.ExitCode}). Output: {tail}");
                 }
@@ -335,6 +343,26 @@ public class ChatterboxTtsCpp : ITtsEngine
         // backend (e.g. ASR-only build) prints `unknown backend 'chatterbox'`.
         return output.Contains("unknown argument", StringComparison.Ordinal)
             || output.Contains("unknown backend", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeStaleModelCache(string output)
+    {
+        // Stale or partially-downloaded GGUFs in ~/.cache/crispasr/ surface as either
+        // a clean "tensor not found" / "failed to bind" message or — when the format
+        // mismatch trips a C++ exception during ggml init — the `GGML_ASSERT(prev !=
+        // ggml_uncaught_exception)` abort with a Windows STATUS_STACK_BUFFER_OVERRUN
+        // exit code (-1073740791 / 0xC0000409).
+        return output.Contains("required tensor", StringComparison.Ordinal)
+            || output.Contains("failed to bind", StringComparison.Ordinal)
+            || output.Contains("ggml_uncaught_exception", StringComparison.Ordinal);
+    }
+
+    private static string GetCrispAsrCacheDir()
+    {
+        // Mirrors crispasr's platform-default cache location: ~/.cache/crispasr on
+        // POSIX, %USERPROFILE%\.cache\crispasr on Windows.
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".cache", "crispasr");
     }
 
     private static string SnapshotStderr(StringBuilder buffer)

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -21,8 +21,11 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
 /// <summary>
 /// Chatterbox TTS via the existing CrispASR install (shared with the speech-to-text feature).
-/// Spawns `crispasr --server --backend chatterbox -m auto` and POSTs to the OpenAI-compatible
-/// /v1/audio/speech endpoint. Requires CrispASR v0.6.0 or newer.
+/// Spawns `crispasr --server --backend chatterbox -m &lt;t3&gt; --codec-model &lt;s3gen&gt;` and POSTs
+/// to the OpenAI-compatible /v1/audio/speech endpoint. Requires CrispASR v0.6.0 or newer.
+/// The T3 + S3Gen GGUFs are downloaded explicitly into TextToSpeech/Chatterbox/models/ —
+/// `-m auto` is avoided because its codec auto-discovery only finds *-s3gen-f16.gguf
+/// while it actually downloads the q8_0 variants.
 /// Chatterbox has one baked default voice; "voices" listed beyond Default come from
 /// WAVs imported via <see cref="ImportVoice"/>. The full reference-WAV path is sent per-request
 /// as the `voice` field — runtime WAV cloning is wired upstream in CrispASR's chatterbox backend.
@@ -133,6 +136,26 @@ public class ChatterboxTtsCpp : ITtsEngine
 
         return voicesFolder;
     }
+
+    public static string GetSetModelsFolder()
+    {
+        var modelsFolder = Path.Combine(GetSetFolder(), "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetT3ModelPath() =>
+        Path.Combine(GetSetModelsFolder(), ChatterboxTtsCppDownloadService.T3ModelFileName);
+
+    public static string GetS3GenModelPath() =>
+        Path.Combine(GetSetModelsFolder(), ChatterboxTtsCppDownloadService.S3GenModelFileName);
+
+    public static bool AreModelsInstalled() =>
+        File.Exists(GetT3ModelPath()) && File.Exists(GetS3GenModelPath());
 
     public Task<Voice[]> GetVoices(string language)
     {
@@ -272,7 +295,12 @@ public class ChatterboxTtsCpp : ITtsEngine
             psi.ArgumentList.Add("--backend");
             psi.ArgumentList.Add(BackendName);
             psi.ArgumentList.Add("-m");
-            psi.ArgumentList.Add("auto");
+            psi.ArgumentList.Add(GetT3ModelPath());
+            // Pass S3Gen explicitly. The chatterbox backend's auto-discovery only finds
+            // *-s3gen-f16.gguf, so without this flag the q8_0 codec we ship is ignored
+            // and synth returns empty audio.
+            psi.ArgumentList.Add("--codec-model");
+            psi.ArgumentList.Add(GetS3GenModelPath());
             psi.ArgumentList.Add("--host");
             psi.ArgumentList.Add("127.0.0.1");
             psi.ArgumentList.Add("--port");
@@ -316,10 +344,9 @@ public class ChatterboxTtsCpp : ITtsEngine
                     if (LooksLikeStaleModelCache(tail))
                     {
                         throw new InvalidOperationException(
-                            "Chatterbox failed to load its model — the cached GGUF files in "
-                            + GetCrispAsrCacheDir() + " are likely stale or partially downloaded. "
-                            + "Delete chatterbox-*.gguf in that folder and try again. Original output: "
-                            + tail);
+                            "Chatterbox failed to load its model — the GGUFs in "
+                            + GetSetModelsFolder() + " are likely stale or partially downloaded. "
+                            + "Delete them and try again so they re-download. Original output: " + tail);
                     }
                     throw new InvalidOperationException(
                         $"crispasr (chatterbox) exited during startup (code {process.ExitCode}). Output: {tail}");
@@ -353,22 +380,14 @@ public class ChatterboxTtsCpp : ITtsEngine
 
     private static bool LooksLikeStaleModelCache(string output)
     {
-        // Stale or partially-downloaded GGUFs in ~/.cache/crispasr/ surface as either
-        // a clean "tensor not found" / "failed to bind" message or — when the format
-        // mismatch trips a C++ exception during ggml init — the `GGML_ASSERT(prev !=
-        // ggml_uncaught_exception)` abort with a Windows STATUS_STACK_BUFFER_OVERRUN
-        // exit code (-1073740791 / 0xC0000409).
+        // A truncated/format-mismatched GGUF surfaces as either a clean "tensor not
+        // found" / "failed to bind" message or — when the format mismatch trips a C++
+        // exception during ggml init — the `GGML_ASSERT(prev != ggml_uncaught_exception)`
+        // abort with a Windows STATUS_STACK_BUFFER_OVERRUN exit code
+        // (-1073740791 / 0xC0000409).
         return output.Contains("required tensor", StringComparison.Ordinal)
             || output.Contains("failed to bind", StringComparison.Ordinal)
             || output.Contains("ggml_uncaught_exception", StringComparison.Ordinal);
-    }
-
-    private static string GetCrispAsrCacheDir()
-    {
-        // Mirrors crispasr's platform-default cache location: ~/.cache/crispasr on
-        // POSIX, %USERPROFILE%\.cache\crispasr on Windows.
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        return Path.Combine(home, ".cache", "crispasr");
     }
 
     private static string SnapshotServerLog()

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -47,6 +47,10 @@ public class ChatterboxTtsCpp : ITtsEngine
     private static Process? _serverProcess;
     private static int _serverPort;
     private static bool _processExitHooked;
+    // Rolling buffer of the server's stdout+stderr — used to attach context to
+    // /v1/audio/speech failures (the response body alone says "synthesis failed"
+    // without the actual reason; the backend prints the reason to stderr).
+    private static readonly StringBuilder _serverLog = new();
 
     private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
 
@@ -198,10 +202,12 @@ public class ChatterboxTtsCpp : ITtsEngine
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+            var serverLog = SnapshotServerLog();
             Se.LogError($"Chatterbox TTS server error {(int)response.StatusCode} {response.StatusCode} - "
-                + $"Voice: {chatterboxVoice}, Text: {text}, Body: {errorBody}");
+                + $"Voice: {chatterboxVoice}, Text: {text}, Body: {errorBody}, ServerLog: {serverLog}");
             throw new InvalidOperationException(
-                $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}");
+                $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}"));
         }
 
         await using (var fileStream = File.Create(outputFileName))
@@ -275,14 +281,14 @@ public class ChatterboxTtsCpp : ITtsEngine
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start crispasr (chatterbox)");
 
-            var stderrBuffer = new StringBuilder();
+            lock (_serverLog) _serverLog.Clear();
             process.ErrorDataReceived += (_, e) =>
             {
-                if (e.Data != null) lock (stderrBuffer) stderrBuffer.AppendLine(e.Data);
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
             };
             process.OutputDataReceived += (_, e) =>
             {
-                if (e.Data != null) lock (stderrBuffer) stderrBuffer.AppendLine(e.Data);
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
             };
             process.BeginErrorReadLine();
             process.BeginOutputReadLine();
@@ -298,7 +304,7 @@ public class ChatterboxTtsCpp : ITtsEngine
                 ct.ThrowIfCancellationRequested();
                 if (process.HasExited)
                 {
-                    var tail = SnapshotStderr(stderrBuffer);
+                    var tail = SnapshotServerLog();
                     _serverProcess = null;
                     _serverPort = 0;
                     if (LooksLikeOutdatedCrispAsr(tail))
@@ -325,7 +331,7 @@ public class ChatterboxTtsCpp : ITtsEngine
                 await Task.Delay(TimeSpan.FromSeconds(1), ct);
             }
 
-            var lastOutput = SnapshotStderr(stderrBuffer);
+            var lastOutput = SnapshotServerLog();
             StopServerInternal();
             throw new TimeoutException(
                 $"crispasr (chatterbox) did not report healthy within 15 minutes. Last output: {lastOutput}");
@@ -365,11 +371,11 @@ public class ChatterboxTtsCpp : ITtsEngine
         return Path.Combine(home, ".cache", "crispasr");
     }
 
-    private static string SnapshotStderr(StringBuilder buffer)
+    private static string SnapshotServerLog()
     {
-        lock (buffer)
+        lock (_serverLog)
         {
-            var s = buffer.ToString().TrimEnd();
+            var s = _serverLog.ToString().TrimEnd();
             return s.Length > 2000 ? s[^2000..] : s;
         }
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -2,6 +2,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
@@ -10,6 +11,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -62,6 +64,43 @@ public class ChatterboxTtsCpp : ITtsEngine
     public static string GetCrispAsrExecutable()
     {
         return new CrispAsrCohere().GetExecutable();
+    }
+
+    /// <summary>
+    /// Returns true when the installed crispasr executable matches a known
+    /// chatterbox-capable release (currently v0.6.0+ — earlier builds neither
+    /// recognise --backend chatterbox nor expose the /v1/audio/speech endpoint).
+    /// Returns true when the hash is unknown so we don't false-positive on
+    /// custom local builds.
+    /// </summary>
+    public static bool IsCrispAsrChatterboxCapable()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return false;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        var variant = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && folder != null
+            ? DownloadHashManager.DetectCrispAsrWindowsVariant(folder)
+            : null;
+        var key = DownloadHashManager.ResolveCrispAsrExecutableKey(variant);
+        if (key == null)
+        {
+            return true;
+        }
+
+        var hash = DownloadHashManager.ComputeSha256(exe);
+        if (hash == null)
+        {
+            return true;
+        }
+
+        // UpdateAvailable means the installed hash is a known *older* release —
+        // demote those to "not chatterbox-capable" so the user is prompted to
+        // re-download. UpToDate and Unknown both pass through.
+        return DownloadHashManager.GetStatus(key, hash) != DownloadHashManager.UpdateStatus.UpdateAvailable;
     }
 
     public static string GetSetFolder()

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -220,22 +220,46 @@ public class ChatterboxTtsCpp : ITtsEngine
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        using var response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
+        HttpResponseMessage response;
+        try
         {
-            var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            // Connection dropped before a response — typically the server crashed
+            // during synth (ggml fault, OOM, etc.). Attach what the server printed
+            // so the user/we can see the underlying reason.
             var serverLog = SnapshotServerLog();
-            Se.LogError($"Chatterbox TTS server error {(int)response.StatusCode} {response.StatusCode} - "
-                + $"Voice: {chatterboxVoice}, Text: {text}, Body: {errorBody}, ServerLog: {serverLog}");
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+            Se.LogError(ex, $"Chatterbox TTS request failed - Voice: {chatterboxVoice}, Text: {text}, "
+                + $"ServerExited: {died}, ServerLog: {serverLog}");
             throw new InvalidOperationException(
-                $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}"
-                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}"));
+                "Chatterbox TTS request failed — "
+                + (died ? "the crispasr server crashed during synthesis." : "the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}"),
+                ex);
         }
 
-        await using (var fileStream = File.Create(outputFileName))
-        await using (var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken))
+        using (response)
         {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                Se.LogError($"Chatterbox TTS server error {(int)response.StatusCode} {response.StatusCode} - "
+                    + $"Voice: {chatterboxVoice}, Text: {text}, Body: {errorBody}, ServerLog: {serverLog}");
+                throw new InvalidOperationException(
+                    $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}"));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
             await contentStream.CopyToAsync(fileStream, cancellationToken);
         }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -238,10 +238,16 @@ public class ChatterboxTtsCpp : ITtsEngine
             }
             Se.LogError(ex, $"Chatterbox TTS request failed - Voice: {chatterboxVoice}, Text: {text}, "
                 + $"ServerExited: {died}, ServerLog: {serverLog}");
+
+            var prefix = LooksLikeUpstreamChatterboxCrash(serverLog)
+                ? "Chatterbox TTS hit a CrispASR runtime bug during synthesis (ggml tensor read out of bounds). "
+                  + "This is an upstream issue — please file it at https://github.com/CrispStrobe/CrispASR/issues with the server log below. "
+                  + "Switching to the Vulkan or CUDA CrispASR build (re-download via Audio to text) may avoid the CPU-only code path that triggers it."
+                : "Chatterbox TTS request failed — "
+                  + (died ? "the crispasr server crashed during synthesis." : "the connection to the crispasr server was dropped.");
+
             throw new InvalidOperationException(
-                "Chatterbox TTS request failed — "
-                + (died ? "the crispasr server crashed during synthesis." : "the connection to the crispasr server was dropped.")
-                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}"),
+                prefix + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}"),
                 ex);
         }
 
@@ -400,6 +406,17 @@ public class ChatterboxTtsCpp : ITtsEngine
         // backend (e.g. ASR-only build) prints `unknown backend 'chatterbox'`.
         return output.Contains("unknown argument", StringComparison.Ordinal)
             || output.Contains("unknown backend", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeUpstreamChatterboxCrash(string output)
+    {
+        // Known CrispASR v0.6.0 chatterbox synth crash on the CPU build:
+        //   ggml-backend.cpp:349: GGML_ASSERT(offset + size <= ggml_nbytes(tensor)
+        //                         && "tensor read out of bounds") failed
+        // Hits during the first AR step after KV-cache allocation. Upstream fix
+        // pending. Distinct from the static-init duplicate ggml assert at
+        // ggml.cpp:22 (caught by LooksLikeStaleModelCache via a different match).
+        return output.Contains("tensor read out of bounds", StringComparison.Ordinal);
     }
 
     private static bool LooksLikeStaleModelCache(string output)

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -1,0 +1,418 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Chatterbox TTS via the existing CrispASR install (shared with the speech-to-text feature).
+/// Spawns `crispasr --server --backend chatterbox -m auto` and POSTs to the OpenAI-compatible
+/// /v1/audio/speech endpoint. Reference WAVs imported via <see cref="ImportVoice"/> are sent
+/// per-request as the `voice` field; whether cloning actually engages depends on the running
+/// CrispASR build (the chatterbox backend is wiring up runtime WAV cloning).
+/// </summary>
+public class ChatterboxTtsCpp : ITtsEngine
+{
+    public string Name => "Chatterbox TTS";
+    public string Description => "voice cloning via CrispASR";
+    public bool HasLanguageParameter => false;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => false;
+    public bool HasKeyFile => false;
+
+    private const string BackendName = "chatterbox";
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(5),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static bool _processExitHooked;
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Path to the crispasr executable installed by the speech-to-text feature.
+    /// Chatterbox piggy-backs on the same install so users don't download two copies.
+    /// </summary>
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "Chatterbox");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        return voicesFolder;
+    }
+
+    public Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>
+        {
+            new Voice(new ChatterboxVoice("Default", string.Empty)),
+        };
+
+        var voicesFolder = GetSetVoicesFolder();
+        foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+        {
+            var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+            result.Add(new Voice(new ChatterboxVoice(name, file)));
+        }
+
+        return Task.FromResult(result.ToArray());
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(Array.Empty<string>());
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken)
+    {
+        return GetVoices(language);
+    }
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not ChatterboxVoice chatterboxVoice)
+        {
+            throw new ArgumentException("Voice is not a ChatterboxVoice");
+        }
+
+        await EnsureServerRunningAsync(cancellationToken);
+
+        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var inputText = Utilities.UnbreakLine(text);
+
+        // Per /v1/audio/speech: send full reference WAV path as the `voice` field.
+        // Empty string falls back to the model's baked default voice.
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = inputText,
+            ["response_format"] = "wav",
+        };
+        if (!string.IsNullOrEmpty(chatterboxVoice.FilePath))
+        {
+            payload["voice"] = chatterboxVoice.FilePath;
+        }
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+            Se.LogError($"Chatterbox TTS server error {(int)response.StatusCode} {response.StatusCode} - "
+                + $"Voice: {chatterboxVoice}, Text: {text}, Body: {errorBody}");
+            throw new InvalidOperationException(
+                $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}");
+        }
+
+        await using (var fileStream = File.Create(outputFileName))
+        await using (var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken))
+        {
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(CancellationToken ct)
+    {
+        if (_serverProcess is { HasExited: false } && _serverPort != 0)
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0)
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(BackendName);
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add("auto");
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString());
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (chatterbox)");
+
+            var stderrBuffer = new StringBuilder();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (stderrBuffer) stderrBuffer.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (stderrBuffer) stderrBuffer.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            HookProcessExitOnce();
+
+            // First-run model auto-download (~880 MB) needs a generous timeout.
+            var deadline = DateTime.UtcNow.AddMinutes(15);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotStderr(stderrBuffer);
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    throw new InvalidOperationException(
+                        $"crispasr (chatterbox) exited during startup (code {process.ExitCode}). Output: {tail}");
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotStderr(stderrBuffer);
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (chatterbox) did not report healthy within 15 minutes. Last output: {lastOutput}");
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotStderr(StringBuilder buffer)
+    {
+        lock (buffer)
+        {
+            var s = buffer.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked) return;
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    public static void StopServer()
+    {
+        ServerLock.Wait();
+        try
+        {
+            StopServerInternal();
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        if (p == null) return;
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        if (Path.GetExtension(fileName).Equals(".wav", StringComparison.OrdinalIgnoreCase))
+        {
+            File.Copy(fileName, destinationFileName, overwrite: false);
+            return true;
+        }
+
+        var process = FfmpegGenerator.ConvertFormat(fileName, destinationFileName);
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        {
+            _ = process.Start();
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Process.Start() is not supported on this platform.");
+        }
+
+        process.WaitForExit();
+
+        return File.Exists(destinationFileName);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -776,6 +776,17 @@ public partial class TextToSpeechViewModel : ObservableObject
                 return false;
             }
 
+            if (!ChatterboxTtsCpp.IsCrispAsrChatterboxCapable())
+            {
+                await MessageBox.Show(
+                    Window,
+                    "CrispASR update required",
+                    $"{Environment.NewLine}\"Chatterbox TTS\" needs CrispASR v0.6.0 or newer.{Environment.NewLine}{Environment.NewLine}Re-download CrispASR via \"Video → Audio to text → Engine settings → Re-download\", then return here.",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                return false;
+            }
+
             return true;
         }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -10,6 +10,8 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
@@ -765,29 +767,7 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         if (engine is ChatterboxTtsCpp)
         {
-            if (!await engine.IsInstalled(SelectedRegion))
-            {
-                await MessageBox.Show(
-                    Window,
-                    "CrispASR required",
-                    $"{Environment.NewLine}\"Chatterbox TTS\" runs through the CrispASR runtime, which is not installed.{Environment.NewLine}{Environment.NewLine}Install CrispASR via \"Video → Audio to text\" first, then return here.",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Information);
-                return false;
-            }
-
-            if (!ChatterboxTtsCpp.IsCrispAsrChatterboxCapable())
-            {
-                await MessageBox.Show(
-                    Window,
-                    "CrispASR update required",
-                    $"{Environment.NewLine}\"Chatterbox TTS\" needs CrispASR v0.6.0 or newer.{Environment.NewLine}{Environment.NewLine}Re-download CrispASR via \"Video → Audio to text → Engine settings → Re-download\", then return here.",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Information);
-                return false;
-            }
-
-            return true;
+            return await EnsureCrispAsrForChatterbox(engine);
         }
 
         if (await engine.IsInstalled(SelectedRegion) || Window == null)
@@ -885,6 +865,122 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         return false;
+    }
+
+    private async Task<bool> EnsureCrispAsrForChatterbox(ITtsEngine engine)
+    {
+        if (Window == null)
+        {
+            return false;
+        }
+
+        var isInstalled = await engine.IsInstalled(SelectedRegion);
+        var isCapable = isInstalled && ChatterboxTtsCpp.IsCrispAsrChatterboxCapable();
+        if (isInstalled && isCapable)
+        {
+            return true;
+        }
+
+        var crispAsrEngine = (ISpeechToTextEngine)new CrispAsrCohere();
+        string crispVariant;
+
+        if (isInstalled)
+        {
+            // Already installed but the hash matches a known older release —
+            // re-download with the same variant the user picked originally.
+            var folder = crispAsrEngine.GetAndCreateWhisperFolder();
+            crispVariant = (Configuration.IsRunningOnWindows
+                ? DownloadHashManager.DetectCrispAsrWindowsVariant(folder)
+                : null) ?? "vulkan";
+
+            var answer = await MessageBox.Show(
+                Window,
+                "CrispASR update required",
+                $"{Environment.NewLine}\"Chatterbox TTS\" needs CrispASR v0.6.0 or newer. Re-download now?",
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+        }
+        else if (Configuration.IsRunningOnWindows)
+        {
+            var variantAnswer = await MessageBox.Show(
+                Window,
+                "Download CrispASR?",
+                $"{Environment.NewLine}\"Chatterbox TTS\" runs through the CrispASR runtime. Select a build to download:",
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                "CPU",
+                "Vulkan",
+                "CUDA");
+
+            if (variantAnswer == MessageBoxResult.None || variantAnswer == MessageBoxResult.Cancel)
+            {
+                return false;
+            }
+
+            crispVariant = variantAnswer switch
+            {
+                MessageBoxResult.Custom1 => "cpu",
+                MessageBoxResult.Custom3 => "cuda",
+                _ => "vulkan",
+            };
+
+            if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
+            {
+                var vulkanAnswer = await MessageBox.Show(
+                    Window,
+                    "Vulkan SDK may be required",
+                    $"The Vulkan version requires the Vulkan SDK to be installed.{Environment.NewLine}{Environment.NewLine}You can download it from:{Environment.NewLine}https://vulkan.lunarg.com/sdk/home{Environment.NewLine}{Environment.NewLine}Continue with Vulkan download?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (vulkanAnswer == MessageBoxResult.No)
+                {
+                    UiUtil.OpenUrl("https://vulkan.lunarg.com/sdk/home");
+                    return false;
+                }
+
+                if (vulkanAnswer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+            }
+        }
+        else
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                "Download CrispASR?",
+                $"{Environment.NewLine}\"Chatterbox TTS\" runs through the CrispASR runtime. Download and install now?",
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            crispVariant = "vulkan"; // ignored on non-Windows
+        }
+
+        var dlVm = await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
+            Window!, viewModel =>
+            {
+                viewModel.Engine = crispAsrEngine;
+                viewModel.CrispAsrWindowsVariant = crispVariant;
+                viewModel.StartDownload();
+            });
+
+        if (!dlVm.OkPressed)
+        {
+            return false;
+        }
+
+        return await engine.IsInstalled(SelectedRegion) && ChatterboxTtsCpp.IsCrispAsrChatterboxCapable();
     }
 
     private async Task MergeAndAddToVideo(TtsStepResult[] fixSpeedResult)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -128,6 +128,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             new GoogleSpeech(ttsDownloadService),
             new Qwen3TtsCpp(),
             new KokoroTtsCpp(),
+            new ChatterboxTtsCpp(),
         ];
 
         if (!OperatingSystem.IsMacOS())
@@ -757,6 +758,22 @@ public partial class TextToSpeechViewModel : ObservableObject
 
                 var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadKokoroTtsModels());
                 return dlResult.OkPressed && KokoroTtsCpp.AreModelsInstalled();
+            }
+
+            return true;
+        }
+
+        if (engine is ChatterboxTtsCpp)
+        {
+            if (!await engine.IsInstalled(SelectedRegion))
+            {
+                await MessageBox.Show(
+                    Window,
+                    "CrispASR required",
+                    $"{Environment.NewLine}\"Chatterbox TTS\" runs through the CrispASR runtime, which is not installed.{Environment.NewLine}{Environment.NewLine}Install CrispASR via \"Video → Audio to text\" first, then return here.",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                return false;
             }
 
             return true;

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -767,7 +767,30 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         if (engine is ChatterboxTtsCpp)
         {
-            return await EnsureCrispAsrForChatterbox(engine);
+            if (!await EnsureCrispAsrForChatterbox(engine))
+            {
+                return false;
+            }
+
+            if (!ChatterboxTtsCpp.AreModelsInstalled())
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download Chatterbox TTS models?",
+                    $"{Environment.NewLine}\"Chatterbox TTS\" requires models (~880 MB).{Environment.NewLine}{Environment.NewLine}Download models?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadChatterboxModels());
+                return dlResult.OkPressed && ChatterboxTtsCpp.AreModelsInstalled();
+            }
+
+            return true;
         }
 
         if (await engine.IsInstalled(SelectedRegion) || Window == null)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -952,6 +952,16 @@ public partial class TextToSpeechViewModel : ObservableObject
                 _ => "vulkan",
             };
 
+            if (crispVariant == "cpu")
+            {
+                var cpuAnswer = await PromptCrispAsrCpuFlavorAsync();
+                if (cpuAnswer == null)
+                {
+                    return false;
+                }
+                crispVariant = cpuAnswer;
+            }
+
             if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
             {
                 var vulkanAnswer = await MessageBox.Show(
@@ -1004,6 +1014,30 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         return await engine.IsInstalled(SelectedRegion) && ChatterboxTtsCpp.IsCrispAsrChatterboxCapable();
+    }
+
+    /// <summary>
+    /// Follow-up prompt after the user picks "CPU" in the CrispASR variant selector.
+    /// Returns "cpu" (modern, recommended), "cpu-legacy" (compatibility build for CPUs without AVX2),
+    /// or null when the user cancels.
+    /// </summary>
+    private async Task<string?> PromptCrispAsrCpuFlavorAsync()
+    {
+        var cpuAnswer = await MessageBox.Show(
+            Window!,
+            "CrispASR CPU build",
+            $"{Environment.NewLine}Standard is recommended for most machines.{Environment.NewLine}{Environment.NewLine}Legacy is a fallback for older CPUs without AVX2 support.",
+            MessageBoxButtons.Cancel,
+            MessageBoxIcon.Question,
+            "Standard",
+            "Legacy");
+
+        return cpuAnswer switch
+        {
+            MessageBoxResult.Custom1 => "cpu",
+            MessageBoxResult.Custom2 => "cpu-legacy",
+            _ => null,
+        };
     }
 
     private async Task MergeAndAddToVideo(TtsStepResult[] fixSpeedResult)

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -89,6 +89,6 @@ public partial class VoiceSettingsViewModel : ObservableObject
     internal void Initialize(ITtsEngine engine)
     {
         _engine = engine;
-        IsImportVoiceVisible = engine.GetType() == typeof(Qwen3TtsCpp);
+        IsImportVoiceVisible = engine.GetType() == typeof(Qwen3TtsCpp) || engine.GetType() == typeof(ChatterboxTtsCpp);
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Voices/ChatterboxVoice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/ChatterboxVoice.cs
@@ -1,0 +1,24 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+public class ChatterboxVoice
+{
+    public string Voice { get; set; }
+    public string FilePath { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public ChatterboxVoice()
+    {
+        Voice = string.Empty;
+        FilePath = string.Empty;
+    }
+
+    public ChatterboxVoice(string voice, string filePath)
+    {
+        Voice = voice;
+        FilePath = filePath;
+    }
+}

--- a/src/ui/Logic/Download/ChatterboxTtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/ChatterboxTtsCppDownloadService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IChatterboxTtsCppDownloadService
+{
+    Task DownloadModels(string modelsFolder, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+public class ChatterboxTtsCppDownloadService : IChatterboxTtsCppDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    // Chatterbox is a two-GGUF runtime: T3 AR talker + S3Gen flow-matching codec.
+    // We download the q8_0 variants directly so we can hand explicit paths to crispasr
+    // (its `-m auto` codec auto-discovery only finds *-s3gen-f16.gguf, not q8_0).
+    public const string T3ModelFileName = "chatterbox-t3-q8_0.gguf";
+    public const string S3GenModelFileName = "chatterbox-s3gen-q8_0.gguf";
+
+    private const string T3ModelUrl = "https://huggingface.co/cstr/chatterbox-GGUF/resolve/main/chatterbox-t3-q8_0.gguf";
+    private const string S3GenModelUrl = "https://huggingface.co/cstr/chatterbox-GGUF/resolve/main/chatterbox-s3gen-q8_0.gguf";
+
+    public ChatterboxTtsCppDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var t3Path = Path.Combine(modelsFolder, T3ModelFileName);
+        var s3genPath = Path.Combine(modelsFolder, S3GenModelFileName);
+        var needT3 = !File.Exists(t3Path);
+        var needS3Gen = !File.Exists(s3genPath);
+        var total = (needT3 ? 1 : 0) + (needS3Gen ? 1 : 0);
+        var step = 0;
+
+        if (needT3)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Chatterbox TTS models ({step}/{total}): {T3ModelFileName}");
+            await DownloadHelper.DownloadFileAsync(_httpClient, T3ModelUrl, t3Path, progress, cancellationToken);
+        }
+        if (needS3Gen)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Chatterbox TTS models ({step}/{total}): {S3GenModelFileName}");
+            await DownloadHelper.DownloadFileAsync(_httpClient, S3GenModelUrl, s3genPath, progress, cancellationToken);
+        }
+    }
+}

--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -13,6 +13,7 @@ public interface ICrispAsrDownloadService
     Task DownloadEngineWindowsCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadEngineWindowsVulkan(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadEngineWindowsCpu(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngineWindowsCpuLegacy(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
 }
 
 public class CrispAsrDownloadService : ICrispAsrDownloadService
@@ -21,7 +22,8 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
 
     private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.0/crispasr-windows-x86_64-cuda.zip";
     private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.0/crispasr-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.0/crispasr-windows-x86_64-cpu-legacy.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.0/crispasr-windows-x86_64-cpu.zip";
+    private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.0/crispasr-windows-x86_64-cpu-legacy.zip";
     private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.0/crispasr-macos.tar.gz";
     private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.0/crispasr-linux-x86_64.tar.gz";
 
@@ -48,6 +50,11 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
     public async Task DownloadEngineWindowsCpu(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         await DownloadHelper.DownloadFileAsync(_httpClient, WindowsCpuUrl, stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadEngineWindowsCpuLegacy(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, WindowsCpuLegacyUrl, stream, progress, cancellationToken);
     }
 
     private static string GetUrl()

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
@@ -31,6 +32,7 @@ public static class DownloadHashManager
         // Hashes of the release archive (.zip / .tar.gz) — used when a sidecar hash exists alongside the install.
         public const string WindowsCuda = "CrispAsr.Windows.Cuda";
         public const string WindowsVulkan = "CrispAsr.Windows.Vulkan";
+        public const string WindowsCpu = "CrispAsr.Windows.Cpu";
         public const string WindowsCpuLegacy = "CrispAsr.Windows.CpuLegacy";
         public const string MacOs = "CrispAsr.MacOs";
         public const string Linux = "CrispAsr.Linux";
@@ -39,6 +41,7 @@ public static class DownloadHashManager
         // installed version when no sidecar is present (e.g. installs from older SE builds).
         public const string WindowsCudaExecutable = "CrispAsr.Windows.Cuda.Executable";
         public const string WindowsVulkanExecutable = "CrispAsr.Windows.Vulkan.Executable";
+        public const string WindowsCpuExecutable = "CrispAsr.Windows.Cpu.Executable";
         public const string WindowsCpuLegacyExecutable = "CrispAsr.Windows.CpuLegacy.Executable";
         public const string MacOsExecutable = "CrispAsr.MacOs.Executable";
         public const string LinuxExecutable = "CrispAsr.Linux.Executable";
@@ -71,6 +74,10 @@ public static class DownloadHashManager
                 "1f0793e6279bc5e82a17eaacc6a2227842d4a839f9ed3b2e244b8515746a66bd", // v0.5.4
                 "aadb324d33dea7c28ff703a64403169a0814dc71449f7d635f270e8bc1e0b7c3", // v0.5.3
                 "b7c58fba959f8a7a013e458764cf526a4cf6595d8c6247b8893c37cb8c9dd000", // v0.5.2
+            },
+            [CrispAsr.WindowsCpu] = new[]
+            {
+                "46fe3bc88966c973eef66b7c2271f95bb40b2b4bf338643e71834186cba0ae3d", // v0.6.0 (current download URL — first non-legacy CPU build SE has shipped)
             },
             [CrispAsr.WindowsCpuLegacy] = new[]
             {
@@ -114,6 +121,10 @@ public static class DownloadHashManager
                 "50a4934aa3adb7bd9e78ddea407f9125f605ebf85f0f1fb286718a0216b5140d", // v0.5.4
                 "6217ae5ff00fac3997225e930576aa9ff58b8708d8a66a86163c2c555bb88ec5", // v0.5.3
                 "112862f031cfc65656e282a61b0b156f8f3037a3d2f606df826fb7ed824d3d92", // v0.5.2
+            },
+            [CrispAsr.WindowsCpuExecutable] = new[]
+            {
+                "28da4dcf6e72738b408400ebdef00203f8e70dccf392446ecee90a15c971e186", // v0.6.0 (current download URL — first non-legacy CPU build SE has shipped)
             },
             [CrispAsr.WindowsCpuLegacyExecutable] = new[]
             {
@@ -250,7 +261,8 @@ public static class DownloadHashManager
             return windowsVariant switch
             {
                 "cuda" => CrispAsr.WindowsCuda,
-                "cpu" => CrispAsr.WindowsCpuLegacy,
+                "cpu" => CrispAsr.WindowsCpu,
+                "cpu-legacy" => CrispAsr.WindowsCpuLegacy,
                 "vulkan" => CrispAsr.WindowsVulkan,
                 _ => null,
             };
@@ -261,7 +273,7 @@ public static class DownloadHashManager
 
     /// <summary>
     /// Reverse of <see cref="ResolveCrispAsrKey"/> for Windows variants only:
-    /// returns "cuda" / "vulkan" / "cpu" matching the given key, or null otherwise.
+    /// returns "cuda" / "vulkan" / "cpu" / "cpu-legacy" matching the given key, or null otherwise.
     /// </summary>
     public static string? GetCrispAsrWindowsVariant(string key)
     {
@@ -269,7 +281,8 @@ public static class DownloadHashManager
         {
             CrispAsr.WindowsCuda or CrispAsr.WindowsCudaExecutable => "cuda",
             CrispAsr.WindowsVulkan or CrispAsr.WindowsVulkanExecutable => "vulkan",
-            CrispAsr.WindowsCpuLegacy or CrispAsr.WindowsCpuLegacyExecutable => "cpu",
+            CrispAsr.WindowsCpu or CrispAsr.WindowsCpuExecutable => "cpu",
+            CrispAsr.WindowsCpuLegacy or CrispAsr.WindowsCpuLegacyExecutable => "cpu-legacy",
             _ => null,
         };
     }
@@ -295,7 +308,8 @@ public static class DownloadHashManager
             return windowsVariant switch
             {
                 "cuda" => CrispAsr.WindowsCudaExecutable,
-                "cpu" => CrispAsr.WindowsCpuLegacyExecutable,
+                "cpu" => CrispAsr.WindowsCpuExecutable,
+                "cpu-legacy" => CrispAsr.WindowsCpuLegacyExecutable,
                 "vulkan" => CrispAsr.WindowsVulkanExecutable,
                 _ => null,
             };
@@ -305,8 +319,12 @@ public static class DownloadHashManager
     }
 
     /// <summary>
-    /// Detects which Windows CrispASR variant is installed by looking for variant-specific DLLs.
-    /// Returns "cuda" / "vulkan" / "cpu", or null if the folder doesn't look like a CrispASR install.
+    /// Detects which Windows CrispASR variant is installed.
+    /// Returns "cuda" / "vulkan" / "cpu" / "cpu-legacy", or null if the folder doesn't look like a CrispASR install.
+    /// CUDA and Vulkan are identified by their backend DLLs. CPU vs CPU-legacy share an identical layout
+    /// (only crispasr.exe at the top level), so we disambiguate from the .installed.sha256 sidecar
+    /// recorded at install time, falling back to hashing crispasr.exe against the known CPU-legacy set.
+    /// Unknown CPU EXE hashes default to "cpu" (the modern build).
     /// </summary>
     public static string? DetectCrispAsrWindowsVariant(string installFolder)
     {
@@ -325,11 +343,54 @@ public static class DownloadHashManager
             return "vulkan";
         }
 
-        if (File.Exists(Path.Combine(installFolder, "crispasr.exe")))
+        var exe = Path.Combine(installFolder, "crispasr.exe");
+        if (!File.Exists(exe))
+        {
+            return null;
+        }
+
+        var sidecarKey = TryReadInstalledKey(installFolder);
+        if (sidecarKey == CrispAsr.WindowsCpuLegacy)
+        {
+            return "cpu-legacy";
+        }
+        if (sidecarKey == CrispAsr.WindowsCpu)
         {
             return "cpu";
         }
 
-        return null;
+        // No usable sidecar — match the EXE against known CPU-legacy hashes so older
+        // installs (made before the sidecar existed) are still recognised as legacy.
+        var exeHash = ComputeSha256(exe);
+        if (exeHash != null)
+        {
+            foreach (var legacy in GetKnownHashes(CrispAsr.WindowsCpuLegacyExecutable))
+            {
+                if (legacy.Equals(exeHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    return "cpu-legacy";
+                }
+            }
+        }
+
+        return "cpu";
+    }
+
+    private static string? TryReadInstalledKey(string installFolder)
+    {
+        try
+        {
+            var sidecar = Path.Combine(installFolder, ".installed.sha256");
+            if (!File.Exists(sidecar))
+            {
+                return null;
+            }
+            var firstLine = File.ReadLines(sidecar).FirstOrDefault();
+            return string.IsNullOrWhiteSpace(firstLine) ? null : firstLine.Trim();
+        }
+        catch
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds **Chatterbox TTS** as a Text-to-speech engine. It piggy-backs on the existing CrispASR install (shared with the Audio-to-text feature, no second download), spawning `crispasr --server --backend chatterbox -m auto` and POSTing to the OpenAI-compatible `/v1/audio/speech` endpoint. The first run auto-downloads the chatterbox T3 + S3Gen GGUFs (~880 MB) into `~/.cache/crispasr/`.

Voice cloning is plumbed end-to-end on the SE side: the **Import voice…** button under Voice settings (previously Qwen3-only) now also accepts WAV/MP3 for Chatterbox; imports are stored under `TextToSpeech/Chatterbox/voices/` and the full reference-WAV path is passed per-request as the request's `voice` field.

> Note: actual runtime WAV cloning depends on CrispASR's chatterbox backend wiring `params.tts_voice` through to `chatterbox_set_voice_from_wav`, which is currently a stub at v0.6.0. The SE side is forward-compatible — once that lands upstream, no SE changes needed.

If `crispasr` isn't installed when the user picks Chatterbox, SE prompts them to install it via Audio-to-text first.

## Test plan

- [ ] With CrispASR installed: pick Chatterbox TTS, generate a short clip with the Default voice → server starts, audio plays back.
- [ ] Without CrispASR: pick Chatterbox TTS → "Install CrispASR via Audio to text first" prompt appears.
- [ ] Import voice (WAV) and (MP3) → file appears in voices folder, refreshed in voice list.
- [ ] Stop generation mid-synth → server process is torn down on app exit.

References:
- CrispASR Chatterbox backend: https://github.com/CrispStrobe/CrispASR/blob/main/docs/tts.md#chatterbox--flow-matching-tts-voice-cloning--multilingual
- OpenAI-compatible TTS endpoint: https://github.com/CrispStrobe/CrispASR/blob/main/docs/server.md#text-to-speech-endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)