### PR TITLE
Drop right padding on undocked video player

### DIFF
--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -22,6 +22,11 @@ public static class InitVideoPlayer
 
     public static Grid MakeLayoutVideoPlayer(MainViewModel vm, out VideoPlayerControl videoPlayerControl)
     {
+        return MakeLayoutVideoPlayer(vm, new Thickness(0, 0, 8, 0), out videoPlayerControl);
+    }
+
+    public static Grid MakeLayoutVideoPlayer(MainViewModel vm, Thickness nonFullScreenMargin, out VideoPlayerControl videoPlayerControl)
+    {
         var mediaFile = string.Empty;
         double position = 0;
         if (vm.VideoPlayerControl != null)
@@ -33,7 +38,6 @@ public static class InitVideoPlayer
             vm.VideoPlayerControl = null;
         }
 
-        var nonFullScreenMargin = new Thickness(0, 0, 8, 0);
         var mainGrid = new Grid
         {
             RowDefinitions = new RowDefinitions("*"),

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -163,7 +163,7 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
         UiUtil.RestoreWindowPosition(Window);
         UiUtil.SetupWindowsSystemMenu(Window);
 
-        VideoPlayer = InitVideoPlayer.MakeLayoutVideoPlayer(MainViewModel, out var videoPlayerControl);
+        VideoPlayer = InitVideoPlayer.MakeLayoutVideoPlayer(MainViewModel, new Avalonia.Thickness(0), out var videoPlayerControl);
         Window!.Content = VideoPlayer;
         VideoPlayerControl = videoPlayerControl;
         VideoPlayerControl.FullScreenCommand = ToggleFullScreenCommand;


### PR DESCRIPTION
## Summary
- Closes #10786
- The undocked video player window was inheriting the 8px right margin that the docked layout uses to separate the player from neighbouring panels, producing a lopsided border (0px on the left, 8px on the right) in the standalone window.
- `MakeLayoutVideoPlayer` now takes the non-fullscreen margin as a parameter; docked callers keep the existing `Thickness(0, 0, 8, 0)`, the undocked viewmodel passes `Thickness(0)`.

## Test plan
- [x] Undock the video player and verify the right edge has no extra padding (matches the left).
- [x] Toggle fullscreen on the undocked window and back; non-fullscreen state still has zero margin.
- [x] Confirm the docked layout still has its normal right padding between the player and adjacent panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)