### PR TITLE
Add change-style action to Batch convert

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1437,7 +1437,13 @@
       "rotateIn": "Rotate in",
       "tiltBounce": "Tilt bounce",
       "fontSizeBounceIn": "Font size bounce in",
-      "assaChangeResolutionOnlyAppliesToAssa": "Only applies to Advanced Sub Station Alpha (ASSA) subtitles"
+      "assaChangeResolutionOnlyAppliesToAssa": "Only applies to Advanced Sub Station Alpha (ASSA) subtitles",
+      "assaChangeStyleTitle": "Change style",
+      "assaChangeStyleFromStyle": "Change style from",
+      "assaChangeStyleToStyle": "to",
+      "assaChangeStyleImportStyle": "Import style...",
+      "assaChangeStyleImportedX": "Imported: {0}",
+      "assaChangeStyleTrimUnusedStyles": "Trim unused styles"
     },
     "changeCasing": {
       "title": "Change casing",

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -41,6 +41,7 @@ public class BatchConvertConfig
     public ApplyMinGapSettings ApplyMinGap { get; set; }
     public SplitBreakLongLinesSettings SplitBreakLongLines { get; set; }
     public AssaChangeResolutionSettings AssaChangeResolution { get; set; }
+    public AssaChangeStyleSettings AssaChangeStyle { get; set; }
     public MergeShortLinesSettings MergeShortLines { get; set; }
     public ApplyDurationLimitsSettings ApplyDurationLimits { get; set; }
     public AutoBalanceLinesSettings AutoBalanceLines { get; set; }
@@ -76,6 +77,7 @@ public class BatchConvertConfig
         ApplyMinGap = new ApplyMinGapSettings();
         SplitBreakLongLines = new SplitBreakLongLinesSettings();
         AssaChangeResolution = new AssaChangeResolutionSettings();
+        AssaChangeStyle = new AssaChangeStyleSettings();
         MergeShortLines = new MergeShortLinesSettings();
         ApplyDurationLimits = new ApplyDurationLimitsSettings();
         AutoBalanceLines = new AutoBalanceLinesSettings();
@@ -293,6 +295,22 @@ public class BatchConvertConfig
             ChangeFontSize = true;
             ChangePosition = true;
             ChangeDrawing = true;
+        }
+    }
+
+    public class AssaChangeStyleSettings
+    {
+        public bool IsActive { get; set; }
+        public string FromStyle { get; set; }
+        public string ToStyle { get; set; }
+        public string ImportedStyleHeader { get; set; }
+        public bool TrimUnusedStyles { get; set; }
+
+        public AssaChangeStyleSettings()
+        {
+            FromStyle = string.Empty;
+            ToStyle = string.Empty;
+            ImportedStyleHeader = string.Empty;
         }
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFunction.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFunction.cs
@@ -56,6 +56,7 @@ public partial class BatchConvertFunction : ObservableObject
             MakeFunction(BatchConvertFunctionType.FixRightToLeft, Se.Language.General.FixRightToLeft, ViewFixRightToLeft.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.AutoTranslate, Se.Language.General.AutoTranslate, ViewAutoTranslate.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.AssaChangeResolution, Se.Language.Assa.ResolutionResamplerTitle, ViewAssaChangeResolution.Make(vm), activeFunctions),
+            MakeFunction(BatchConvertFunctionType.AssaChangeStyle, Se.Language.Tools.BatchConvert.AssaChangeStyleTitle, ViewAssaChangeStyle.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.MergeShortLines, Se.Language.Tools.MergeShortLines.Title, ViewMergeShortLines.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.ApplyDurationLimits, Se.Language.Tools.ApplyDurationLimits.Title, ViewApplyDurationLimits.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.AutoBalanceLines, Se.Language.General.AutoBalanceLines, ViewAutoBalanceLines.Make(vm), activeFunctions),

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
@@ -22,6 +22,7 @@ public enum BatchConvertFunctionType
     SplitBreakLongLines,
     RemoveLineBreaks,
     AssaChangeResolution,
+    AssaChangeStyle,
     MergeShortLines,
     ApplyDurationLimits,
     AutoBalanceLines,

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.Translate;
+using Nikse.SubtitleEdit.Features.Assa;
 using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 using Nikse.SubtitleEdit.Features.Files.ExportCustomTextFormat;
 using Nikse.SubtitleEdit.Features.Files.ExportEbuStl;
@@ -190,6 +191,13 @@ public partial class BatchConvertViewModel : ObservableObject
     [ObservableProperty] private bool _assaChangeResolutionChangePosition;
     [ObservableProperty] private bool _assaChangeResolutionChangeDrawing;
 
+    // ASSA change style
+    [ObservableProperty] private string _assaChangeStyleFromStyle;
+    [ObservableProperty] private string _assaChangeStyleToStyle;
+    [ObservableProperty] private string _assaChangeStyleImportFileName;
+    [ObservableProperty] private string _assaChangeStyleImportedStyleHeader;
+    [ObservableProperty] private bool _assaChangeStyleTrimUnusedStyles;
+
     // Merge short lines
     [ObservableProperty] private int _mergeShortLinesMaxCharacters;
     [ObservableProperty] private int _mergeShortLinesMaxMillisecondsBetweenLines;
@@ -353,6 +361,12 @@ public partial class BatchConvertViewModel : ObservableObject
         AssaChangeResolutionChangeFontSize = true;
         AssaChangeResolutionChangePosition = true;
         AssaChangeResolutionChangeDrawing = true;
+
+        AssaChangeStyleFromStyle = string.Empty;
+        AssaChangeStyleToStyle = string.Empty;
+        AssaChangeStyleImportFileName = string.Empty;
+        AssaChangeStyleImportedStyleHeader = string.Empty;
+        AssaChangeStyleTrimUnusedStyles = false;
 
         FixCommonErrorsProfile = LoadDefaultProfile();
 
@@ -522,6 +536,11 @@ public partial class BatchConvertViewModel : ObservableObject
         Se.Settings.Tools.BatchConvert.AssaChangeResolutionChangeFontSize = AssaChangeResolutionChangeFontSize;
         Se.Settings.Tools.BatchConvert.AssaChangeResolutionChangePosition = AssaChangeResolutionChangePosition;
         Se.Settings.Tools.BatchConvert.AssaChangeResolutionChangeDrawing = AssaChangeResolutionChangeDrawing;
+
+        // ASSA change style
+        Se.Settings.Tools.BatchConvert.AssaChangeStyleFromStyle = AssaChangeStyleFromStyle ?? string.Empty;
+        Se.Settings.Tools.BatchConvert.AssaChangeStyleToStyle = AssaChangeStyleToStyle ?? string.Empty;
+        Se.Settings.Tools.BatchConvert.AssaChangeStyleTrimUnusedStyles = AssaChangeStyleTrimUnusedStyles;
 
         // Merge short lines
         Se.Settings.Tools.BatchConvert.MergeShortLinesMaxCharacters = MergeShortLinesMaxCharacters;
@@ -711,6 +730,11 @@ public partial class BatchConvertViewModel : ObservableObject
         AssaChangeResolutionChangeFontSize = Se.Settings.Tools.BatchConvert.AssaChangeResolutionChangeFontSize;
         AssaChangeResolutionChangePosition = Se.Settings.Tools.BatchConvert.AssaChangeResolutionChangePosition;
         AssaChangeResolutionChangeDrawing = Se.Settings.Tools.BatchConvert.AssaChangeResolutionChangeDrawing;
+
+        // ASSA change style
+        AssaChangeStyleFromStyle = Se.Settings.Tools.BatchConvert.AssaChangeStyleFromStyle ?? string.Empty;
+        AssaChangeStyleToStyle = Se.Settings.Tools.BatchConvert.AssaChangeStyleToStyle ?? string.Empty;
+        AssaChangeStyleTrimUnusedStyles = Se.Settings.Tools.BatchConvert.AssaChangeStyleTrimUnusedStyles;
 
         // Merge short lines
         MergeShortLinesMaxCharacters = Se.Settings.Tools.BatchConvert.MergeShortLinesMaxCharacters;
@@ -1090,6 +1114,90 @@ public partial class BatchConvertViewModel : ObservableObject
         {
             vm.Initialize(BatchItems.ToList());
         });
+    }
+
+    [RelayCommand]
+    private async Task AssaChangeStyleBrowseFromStyle()
+    {
+        var name = await PickStyleNameAsync();
+        if (!string.IsNullOrEmpty(name))
+        {
+            AssaChangeStyleFromStyle = name;
+        }
+    }
+
+    [RelayCommand]
+    private async Task AssaChangeStyleBrowseToStyle()
+    {
+        var name = await PickStyleNameAsync();
+        if (!string.IsNullOrEmpty(name))
+        {
+            AssaChangeStyleToStyle = name;
+        }
+    }
+
+    [RelayCommand]
+    private async Task AssaChangeStyleImportStyle()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var format = new AdvancedSubStationAlpha();
+        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.Assa.OpenStyleImportFile, format.Name, "*" + format.Extension);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var s = Subtitle.Parse(fileName, format);
+        if (s == null || string.IsNullOrEmpty(s.Header))
+        {
+            return;
+        }
+
+        AssaChangeStyleImportedStyleHeader = s.Header;
+        AssaChangeStyleImportFileName = Path.GetFileName(fileName);
+
+        if (string.IsNullOrEmpty(AssaChangeStyleToStyle))
+        {
+            var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(s.Header);
+            if (styles.Count > 0)
+            {
+                AssaChangeStyleToStyle = styles[0].Name;
+            }
+        }
+    }
+
+    private async Task<string> PickStyleNameAsync()
+    {
+        if (Window == null)
+        {
+            return string.Empty;
+        }
+
+        var header = !string.IsNullOrEmpty(AssaChangeStyleImportedStyleHeader)
+            ? AssaChangeStyleImportedStyleHeader
+            : AdvancedSubStationAlpha.DefaultHeader;
+
+        var ssaStyles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(header);
+        if (ssaStyles.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
+        {
+            vm.Initialize(ssaStyles.Select(p => new StyleDisplay(p)).ToList(), Se.Language.General.Ok, false);
+        });
+
+        if (!result.OkPressed || result.SelectedStyle == null)
+        {
+            return string.Empty;
+        }
+
+        return result.SelectedStyle.Name;
     }
 
 
@@ -1711,6 +1819,15 @@ public partial class BatchConvertViewModel : ObservableObject
                 ChangeFontSize = AssaChangeResolutionChangeFontSize,
                 ChangePosition = AssaChangeResolutionChangePosition,
                 ChangeDrawing = AssaChangeResolutionChangeDrawing,
+            },
+
+            AssaChangeStyle = new BatchConvertConfig.AssaChangeStyleSettings
+            {
+                IsActive = activeFunctions.Contains(BatchConvertFunctionType.AssaChangeStyle),
+                FromStyle = AssaChangeStyleFromStyle ?? string.Empty,
+                ToStyle = AssaChangeStyleToStyle ?? string.Empty,
+                ImportedStyleHeader = AssaChangeStyleImportedStyleHeader ?? string.Empty,
+                TrimUnusedStyles = AssaChangeStyleTrimUnusedStyles,
             },
 
             MergeShortLines = new BatchConvertConfig.MergeShortLinesSettings

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1438,6 +1438,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             s = RemoveTextForHearingImpaired(s, Language);
             s = FixRightToLeft(s);
             s = AssaChangeResolution(s);
+            s = AssaChangeStyle(s);
             s = SortBy(s);
         }
 
@@ -1967,6 +1968,67 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             c.ChangeFontSize,
             c.ChangeDrawing,
             c.ChangePosition);
+
+        return subtitle;
+    }
+
+    private Subtitle AssaChangeStyle(Subtitle subtitle)
+    {
+        if (!_config.AssaChangeStyle.IsActive)
+        {
+            return subtitle;
+        }
+
+        if (subtitle.OriginalFormat == null || subtitle.OriginalFormat.Name != AdvancedSubStationAlpha.NameOfFormat)
+        {
+            return subtitle;
+        }
+
+        var c = _config.AssaChangeStyle;
+
+        if (string.IsNullOrEmpty(subtitle.Header))
+        {
+            subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
+        }
+
+        if (!string.IsNullOrEmpty(c.ImportedStyleHeader))
+        {
+            var importedStyles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(c.ImportedStyleHeader);
+            foreach (var style in importedStyles)
+            {
+                subtitle.Header = AdvancedSubStationAlpha.UpdateOrAddStyle(subtitle.Header, style);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(c.FromStyle) && !string.IsNullOrEmpty(c.ToStyle))
+        {
+            foreach (var p in subtitle.Paragraphs)
+            {
+                if (string.Equals(p.Extra?.TrimStart('*'), c.FromStyle, StringComparison.OrdinalIgnoreCase))
+                {
+                    p.Extra = c.ToStyle;
+                }
+            }
+        }
+
+        if (c.TrimUnusedStyles)
+        {
+            var usedStyleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var p in subtitle.Paragraphs)
+            {
+                if (!string.IsNullOrEmpty(p.Extra))
+                {
+                    usedStyleNames.Add(p.Extra.TrimStart('*'));
+                }
+            }
+
+            var allStyles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header);
+            var keptStyles = allStyles.Where(s => usedStyleNames.Contains(s.Name)).ToList();
+            if (keptStyles.Count > 0 && keptStyles.Count != allStyles.Count)
+            {
+                subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(subtitle.Header, keptStyles);
+            }
+        }
 
         return subtitle;
     }

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAssaChangeStyle.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAssaChangeStyle.cs
@@ -1,0 +1,86 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert.FunctionViews;
+
+public static class ViewAssaChangeStyle
+{
+    public static Control Make(BatchConvertViewModel vm)
+    {
+        var labelHeader = new Label
+        {
+            Content = Se.Language.Tools.BatchConvert.AssaChangeStyleTitle,
+            FontWeight = Avalonia.Media.FontWeight.Bold,
+            Margin = new Avalonia.Thickness(0, 0, 0, 10),
+        };
+
+        var labelOnlyAssa = new Label
+        {
+            Content = Se.Language.Tools.BatchConvert.AssaChangeResolutionOnlyAppliesToAssa,
+            FontStyle = Avalonia.Media.FontStyle.Italic,
+            Margin = new Avalonia.Thickness(0, 0, 0, 10),
+        };
+
+        var labelFrom = UiUtil.MakeLabel(Se.Language.Tools.BatchConvert.AssaChangeStyleFromStyle);
+        var textBoxFrom = UiUtil.MakeTextBox(130, vm, nameof(vm.AssaChangeStyleFromStyle));
+        var buttonBrowseFrom = UiUtil.MakeButtonBrowse(vm.AssaChangeStyleBrowseFromStyleCommand);
+
+        var labelTo = UiUtil.MakeLabel(Se.Language.Tools.BatchConvert.AssaChangeStyleToStyle);
+        var textBoxTo = UiUtil.MakeTextBox(130, vm, nameof(vm.AssaChangeStyleToStyle));
+        var buttonBrowseTo = UiUtil.MakeButtonBrowse(vm.AssaChangeStyleBrowseToStyleCommand);
+
+        var panelFromTo = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            Children =
+            {
+                labelFrom,
+                textBoxFrom,
+                buttonBrowseFrom,
+                labelTo,
+                textBoxTo,
+                buttonBrowseTo,
+            },
+            Margin = new Avalonia.Thickness(0, 0, 0, 10),
+        };
+
+        var buttonImport = UiUtil.MakeButton(Se.Language.Tools.BatchConvert.AssaChangeStyleImportStyle, vm.AssaChangeStyleImportStyleCommand);
+        var labelImported = UiUtil.MakeLabel(string.Empty);
+        labelImported.Bind(Label.ContentProperty, new Binding
+        {
+            Path = nameof(vm.AssaChangeStyleImportFileName),
+            Mode = BindingMode.OneWay,
+            Source = vm,
+        });
+
+        var panelImport = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            Children = { buttonImport, labelImported },
+            Margin = new Avalonia.Thickness(0, 0, 0, 10),
+        };
+
+        var checkBoxTrim = UiUtil.MakeCheckBox(Se.Language.Tools.BatchConvert.AssaChangeStyleTrimUnusedStyles, vm, nameof(vm.AssaChangeStyleTrimUnusedStyles));
+
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Children =
+            {
+                labelHeader,
+                labelOnlyAssa,
+                panelImport,
+                panelFromTo,
+                checkBoxTrim,
+            },
+            Margin = new Avalonia.Thickness(10),
+        };
+
+        return panel;
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
@@ -35,6 +35,12 @@ public class LanguageBatchConvert
     public string TiltBounce { get; set; }
     public string FontSizeBounceIn { get; set; }
     public string AssaChangeResolutionOnlyAppliesToAssa { get; set; }
+    public string AssaChangeStyleTitle { get; set; }
+    public string AssaChangeStyleFromStyle { get; set; }
+    public string AssaChangeStyleToStyle { get; set; }
+    public string AssaChangeStyleImportStyle { get; set; }
+    public string AssaChangeStyleImportedX { get; set; }
+    public string AssaChangeStyleTrimUnusedStyles { get; set; }
 
     public LanguageBatchConvert()
     {
@@ -68,5 +74,11 @@ public class LanguageBatchConvert
         TiltBounce = "Tilt bounce";
         FontSizeBounceIn = "Font size bounce in";
         AssaChangeResolutionOnlyAppliesToAssa = "Only applies to Advanced Sub Station Alpha (ASSA) subtitles";
+        AssaChangeStyleTitle = "Change style";
+        AssaChangeStyleFromStyle = "Change style from";
+        AssaChangeStyleToStyle = "to";
+        AssaChangeStyleImportStyle = "Import style...";
+        AssaChangeStyleImportedX = "Imported: {0}";
+        AssaChangeStyleTrimUnusedStyles = "Trim unused styles";
     }
 }

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -59,6 +59,10 @@ public class SeBatchConvert
     public bool AssaChangeResolutionChangePosition { get; set; }
     public bool AssaChangeResolutionChangeDrawing { get; set; }
 
+    public string AssaChangeStyleFromStyle { get; set; }
+    public string AssaChangeStyleToStyle { get; set; }
+    public bool AssaChangeStyleTrimUnusedStyles { get; set; }
+
     public bool SaveInSourceFolder { get; set; }
 
     public string AutoTranslateEngine { get; set; }
@@ -116,6 +120,9 @@ public class SeBatchConvert
         AssaChangeResolutionChangeFontSize = true;
         AssaChangeResolutionChangePosition = true;
         AssaChangeResolutionChangeDrawing = true;
+        AssaChangeStyleFromStyle = string.Empty;
+        AssaChangeStyleToStyle = string.Empty;
+        AssaChangeStyleTrimUnusedStyles = false;
         AutoTranslateEngine = new OllamaTranslate().Name;
         AutoTranslateSourceLanguage = "auto";
         AutoTranslateTargetLanguage = "en";


### PR DESCRIPTION
## Summary
- New ASSA-only action **Change style** under Batch convert (placed right after **Change resolution**).
- Lets the user import a style from another `.ass` file, rename a style across all dialogue lines (`from x` → `to y`), and optionally trim styles that no paragraph references.
- Browse buttons next to the *from* / *to* boxes pick names from the imported style file (or the default ASSA header if nothing has been imported yet).

## Behavior
For each ASSA file the run sees:
1. If a style file was imported, every style from its header is merged into the output's `[V4+ Styles]` (existing names overwritten).
2. Paragraphs whose style equals **from** are re-tagged with **to**.
3. If **Trim unused styles** is checked, styles in the header that no paragraph references are removed.

`from`, `to`, and the trim flag are persisted; the imported header is in-memory only.

Closes #10741

## Test plan
- [ ] Open Batch convert, select an `.ass` file, enable **Change style**.
- [ ] Click **Import style...** and pick another `.ass` — confirm the file name shows next to the button and the *to* style auto-fills.
- [ ] Use the browse buttons to verify they list styles from the imported file.
- [ ] Set *from* to a style used in the source (e.g. `Default`) and *to* to an imported style (e.g. `opening english`); run the conversion and verify dialogue lines now reference the new style and the new style is present in the output header.
- [ ] Re-run with **Trim unused styles** checked and confirm only referenced styles remain in the header.
- [ ] Confirm non-ASSA files in the same batch are untouched by this action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)