### PR TITLE
Fix merge-lines in export-plain-text to merge all text

### DIFF
--- a/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
@@ -96,7 +96,7 @@ public partial class ExportPlainTextViewModel : ObservableObject
         _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
 
         FormatTextNone = false;
-        FormatTextNone = false;
+        FormatTextMerge = false;
         FormatTextUnbreak = false;
         if (Se.Settings.File.ExportPlainText.TextProcessing == "Merge")
         {
@@ -124,7 +124,7 @@ public partial class ExportPlainTextViewModel : ObservableObject
 
     private void SaveSettings()
     {
-        Se.Settings.File.ExportPlainText.TextRemoveStyling = TextRemoveStyling;
+        Se.Settings.File.ExportPlainText.TextProcessing = FormatTextMerge ? "Merge" : FormatTextUnbreak ? "Unbreak" : "None";
         Se.Settings.File.ExportPlainText.TextRemoveStyling = TextRemoveStyling;
         Se.Settings.File.ExportPlainText.ShowLineNumbers = ShowLineNumbers;
         Se.Settings.File.ExportPlainText.AddNewLineAfterLineNumber = AddNewLineAfterLineNumber;
@@ -153,6 +153,25 @@ public partial class ExportPlainTextViewModel : ObservableObject
 
     private string GetExportText()
     {
+        if (FormatTextMerge)
+        {
+            var parts = new List<string>();
+            foreach (var subtitleLine in _subtitles)
+            {
+                var text = subtitleLine.Text ?? string.Empty;
+                if (TextRemoveStyling)
+                {
+                    text = HtmlUtil.RemoveHtmlTags(text, true);
+                }
+                text = text.Replace(Environment.NewLine, " ").Trim();
+                if (!string.IsNullOrEmpty(text))
+                {
+                    parts.Add(text);
+                }
+            }
+            return string.Join(" ", parts);
+        }
+
         var sb = new StringBuilder();
 
         foreach (var subtitleLine in _subtitles)
@@ -165,12 +184,7 @@ public partial class ExportPlainTextViewModel : ObservableObject
                 text = HtmlUtil.RemoveHtmlTags(text, true);
             }
 
-            // Handle text formatting modes
-            if (FormatTextMerge)
-            {
-                text = text.Replace(Environment.NewLine, " ");
-            }
-            else if (FormatTextUnbreak)
+            if (FormatTextUnbreak)
             {
                 text = text.Replace(Environment.NewLine, " ");
                 text = Utilities.UnbreakLine(text);


### PR DESCRIPTION
## Summary
- In export-plain-text, the **Merge lines** option only stripped newlines within each subtitle but still emitted one subtitle per line. It now merges every subtitle's text into a single continuous block (joined by spaces).
- Also fixed a missing save of the `TextProcessing` radio choice in `SaveSettings` (the Merge/Unbreak/None selection was lost on reopen) and a duplicated `FormatTextNone = false` in the constructor (`FormatTextMerge = false` was missing).

Closes #10793

## Test plan
- [x] Open a subtitle, go to **File → Export → Plain text**, pick **Merge lines** — preview shows one continuous paragraph with no line breaks between subtitles.
- [x] Save the export and verify the file contains a single continuous block of text.
- [x] Toggle to **Unbreak lines** / **Do not change**, close and reopen the dialog, confirm the choice is remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)