### PR TITLE
Remember active functions in Batch convert

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -466,6 +466,11 @@ public partial class BatchConvertViewModel : ObservableObject
     {
         Se.Settings.Tools.BatchConvert.TargetFormat = SelectedTargetFormat ?? TargetFormats.First();
 
+        Se.Settings.Tools.BatchConvert.ActiveFunctions = BatchFunctions
+            .Where(p => p.IsSelected)
+            .Select(p => p.Type.ToString())
+            .ToArray();
+
         Se.Settings.Tools.BatchConvert.LastFilterItem = SelectedFilterItem ?? string.Empty;
 
         Se.Settings.Tools.BatchConvert.AdjustVia = SelectedAdjustType.Name;


### PR DESCRIPTION
## Summary
- Persist the checked actions in the Batch convert window so they're restored next time the window opens.
- Closes #10797.

The `ActiveFunctions` setting and the load-side wiring (`BatchConvertFunction.List` reads it at construction) already existed — only the save was missing in `BatchConvertViewModel.SaveSettings()`.

## Test plan
- [x] Open Batch convert, check a few actions, click Done.
- [x] Reopen Batch convert and verify the same actions are still checked.
- [x] Same flow but click Convert instead of Done — settings should also persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)