### PR TITLE
Remember selected rules in Fix Netflix errors

### DIFF
--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsViewModel.cs
@@ -109,10 +109,12 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
     private void LoadChecks()
     {
         Checks.Clear();
+        var saved = Se.Settings.Tools.FixNetflixErrors.SelectedRules;
+        var hasSaved = saved.Count > 0;
         foreach (var checker in NetflixQualityController.GetAllCheckers())
         {
-            var name = checker.Name;
-            Checks.Add(new NetflixCheckDisplayItem(checker, name, true));
+            var isSelected = !hasSaved || saved.Contains(checker.GetType().Name);
+            Checks.Add(new NetflixCheckDisplayItem(checker, checker.Name, isSelected));
         }
     }
 
@@ -122,6 +124,10 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
 
     private void SaveSettings()
     {
+        Se.Settings.Tools.FixNetflixErrors.SelectedRules = Checks
+            .Where(c => c.IsSelected)
+            .Select(c => c.Checker.GetType().Name)
+            .ToList();
         Se.SaveSettings();
     }
 

--- a/src/ui/Logic/Config/SeFixNetflixErrors.cs
+++ b/src/ui/Logic/Config/SeFixNetflixErrors.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Logic.Config;
+
+public class SeFixNetflixErrors
+{
+    public List<string> SelectedRules { get; set; } = new();
+}

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -9,6 +9,7 @@ public class SeTools
     public SeAudioToText AudioToText { get; set; } = new();
     public SeConvertActors ConvertActors { get; set; } = new();
     public SeFixCommonErrors FixCommonErrors { get; set; } = new();
+    public SeFixNetflixErrors FixNetflixErrors { get; set; } = new();
     public SeAdjustDisplayDurations AdjustDurations { get; set; } = new();
     public SeApplyDurationLimits ApplyDurationLimits { get; set; } = new();
     public SeBridgeGaps BridgeGaps { get; set; } = new();


### PR DESCRIPTION
## Summary
- Persist the rule checkboxes in the Fix Netflix errors window via a new `SeFixNetflixErrors` settings section so the user's selection survives across runs.
- Selections are keyed by checker class type name (the `Name` property is localized and not stable).
- First-run / empty saved list still defaults to all rules selected.

## Test plan
- [x] Open Fix Netflix errors, uncheck some rules, click OK, reopen — same rules remain unchecked.
- [x] Fresh install / no saved selection: all rules are selected by default.
- [x] Cancel after toggling does not change persisted selection (only OK saves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)