### PR TITLE
Improve VideoPlayerControl accessibility for screen readers

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
@@ -266,6 +267,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             _buttonPlay = new Button
             {
                 Margin = new Thickness(0, 0, 3, 0),
+                [AutomationProperties.NameProperty] = Se.Language.General.Play,
             };
             Attached.SetIcon(_buttonPlay, "fa-solid fa-play");
             _buttonPlay.Click += (_, _) =>
@@ -278,6 +280,10 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Path = nameof(PlayCommand),
                 Source = this
             });
+            if (Se.Settings.Appearance.ShowHints)
+            {
+                ToolTip.SetTip(_buttonPlay, Se.Language.General.Play);
+            }
 
             stackPanel.Children.Add(_buttonPlay);
 
@@ -285,6 +291,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             var buttonStop = new Button
             {
                 Margin = new Thickness(0, 0, 3, 0),
+                [AutomationProperties.NameProperty] = Se.Language.General.Stop,
             };
             buttonStop.Bind(Button.IsVisibleProperty, new Binding
             {
@@ -297,6 +304,10 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 _videoPlayerInstance.Stop();
                 StopRequested?.Invoke();
             };
+            if (Se.Settings.Appearance.ShowHints)
+            {
+                ToolTip.SetTip(buttonStop, Se.Language.General.Stop);
+            }
             stackPanel.Children.Add(buttonStop);
             buttonStop.Bind(Button.CommandProperty, new Binding
             {
@@ -308,6 +319,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             _buttonFullScreen = new Button
             {
                 Margin = new Thickness(0, 0, 3, 0),
+                [AutomationProperties.NameProperty] = Se.Language.General.FullScreen,
             };
             _buttonFullScreen.Bind(IsVisibleProperty, new Binding
             {
@@ -316,6 +328,10 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             });
             Attached.SetIcon(_buttonFullScreen, "fa-solid fa-expand");
             _buttonFullScreen.Click += (_, _) => FullscreenRequested?.Invoke();
+            if (Se.Settings.Appearance.ShowHints)
+            {
+                ToolTip.SetTip(_buttonFullScreen, Se.Language.General.FullScreen);
+            }
             stackPanel.Children.Add(_buttonFullScreen);
             _buttonFullScreen.Bind(Button.CommandProperty, new Binding
             {
@@ -328,9 +344,14 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             {
                 Margin = new Thickness(0, 0, 3, 0),
                 IsVisible = false,
+                [AutomationProperties.NameProperty] = Se.Language.General.ExitFullScreen,
             };
             Attached.SetIcon(_buttonFullScreenCollapse, "fa-solid fa-compress");
             _buttonFullScreenCollapse.Click += (_, _) => FullscreenCollapseRequested?.Invoke();
+            if (Se.Settings.Appearance.ShowHints)
+            {
+                ToolTip.SetTip(_buttonFullScreenCollapse, Se.Language.General.ExitFullScreen);
+            }
             stackPanel.Children.Add(_buttonFullScreenCollapse);
 
             _gridProgress.Children.Add(stackPanel);
@@ -340,7 +361,12 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             {
                 Minimum = 0,
                 Margin = new Thickness(2, 0, 0, 0),
+                [AutomationProperties.NameProperty] = Se.Language.General.VideoPosition,
             };
+            if (Se.Settings.Appearance.ShowHints)
+            {
+                ToolTip.SetTip(sliderPosition, Se.Language.General.VideoPosition);
+            }
             sliderPosition.TemplateApplied += (s, e) =>
             {
                 if (e.NameScope.Find<Thumb>("thumb") is Thumb thumb)
@@ -376,8 +402,14 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Minimum = 0,
                 Maximum = videoPlayerInstance.VolumeMaximum,
                 Width = 80,
-                VerticalAlignment = VerticalAlignment.Center
+                VerticalAlignment = VerticalAlignment.Center,
+                Focusable = true,
+                [AutomationProperties.NameProperty] = Se.Language.General.Volume,
             };
+            if (Se.Settings.Appearance.ShowHints)
+            {
+                ToolTip.SetTip(sliderVolume, Se.Language.General.Volume);
+            }
             sliderVolume.TemplateApplied += (s, e) =>
             {
                 if (e.NameScope.Find<Thumb>("thumb") is Thumb thumb)
@@ -540,10 +572,20 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             if (isPlaying)
             {
                 Attached.SetIcon(_buttonPlay, "fa-solid fa-pause");
+                AutomationProperties.SetName(_buttonPlay, Se.Language.General.Pause);
+                if (Se.Settings.Appearance.ShowHints)
+                {
+                    ToolTip.SetTip(_buttonPlay, Se.Language.General.Pause);
+                }
             }
             else
             {
                 Attached.SetIcon(_buttonPlay, "fa-solid fa-play");
+                AutomationProperties.SetName(_buttonPlay, Se.Language.General.Play);
+                if (Se.Settings.Appearance.ShowHints)
+                {
+                    ToolTip.SetTip(_buttonPlay, Se.Language.General.Play);
+                }
             }
         }
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -166,6 +166,7 @@ public class LanguageGeneral
     public string ExtendSelectedToNext { get; set; }
     public string ExtendSelectedToPrevious { get; set; }
     public string ExtractingAudioClips { get; set; }
+    public string ExitFullScreen { get; set; }
     public string Fade { get; set; }
     public string FetchFirstWordFromNextSubtitle { get; set; }
     public string FileAlreadyExists { get; set; }
@@ -211,6 +212,7 @@ public class LanguageGeneral
     public string Frames { get; set; }
     public string From { get; set; }
     public string FromCurrentVideoPosition { get; set; }
+    public string FullScreen { get; set; }
     public string Gap { get; set; }
     public string General { get; set; }
     public string GeneralText { get; set; }
@@ -308,6 +310,7 @@ public class LanguageGeneral
     public string MoveDown { get; set; }
     public string MoveUp { get; set; }
     public string MultipleReplace { get; set; }
+    public string Mute { get; set; }
     public string Name { get; set; }
     public string Negative { get; set; }
     public string New { get; set; }
@@ -629,6 +632,7 @@ public class LanguageGeneral
     public string ViewX { get; set; }
     public string Visible { get; set; }
     public string Voice { get; set; }
+    public string Volume { get; set; }
     public string Warning { get; set; }
     public string WaveformCenterOnVideoPosition { get; set; }
     public string WaveformPasteFromClipboard { get; set; }
@@ -828,6 +832,7 @@ public class LanguageGeneral
         ExtendSelectedToNext = "Extend selected to next";
         ExtendSelectedToPrevious = "Extend selected to previous";
         ExtractingAudioClips = "Extracting audio clips...";
+        ExitFullScreen = "Exit full screen";
         Fade = "Fade";
         FetchFirstWordFromNextSubtitle = "Fetch first word from next subtitle";
         FileAlreadyExists = "File already exists";
@@ -873,6 +878,7 @@ public class LanguageGeneral
         Frames = "Frames";
         From = "From";
         FromCurrentVideoPosition = "from current video position";
+        FullScreen = "Full screen";
         Gap = "Gap";
         General = "General";
         GeneralText = "General";
@@ -970,6 +976,7 @@ public class LanguageGeneral
         MoveDown = "Move down";
         MoveUp = "Move up";
         MultipleReplace = "Multiple replace";
+        Mute = "Mute";
         Name = "Name";
         Negative = "Negative";
         New = "New";
@@ -1291,6 +1298,7 @@ public class LanguageGeneral
         ViewX = "View {0}";
         Visible = "Visible";
         Voice = "Voice";
+        Volume = "Volume";
         Warning = "Warning";
         WaveformCenterOnVideoPosition = "Waveform center on video position";
         WaveformPasteFromClipboard = "Paste from clipboard";


### PR DESCRIPTION
## Summary
- Add `AutomationProperties.Name` and tooltips on Play/Pause, Stop, FullScreen and ExitFullScreen buttons plus the position and volume sliders so screen readers announce them by name instead of just "button"
- Toggle the Play button's accessible name (and tooltip) between Play/Pause to match the icon state
- Make the volume slider focusable so it can be reached and adjusted from the keyboard
- Tooltips honor the existing `Se.Settings.Appearance.ShowHints` setting

Fix #10753

## Test plan
- [ ] Play, pause, stop, fullscreen, exit-fullscreen buttons all announce a meaningful name in a screen reader
- [ ] Play button's announced name flips when toggling play/pause
- [ ] Position and volume sliders announce their name and current value
- [ ] Volume slider is reachable via Tab and adjustable with Left/Right arrows
- [ ] Tooltips appear when `Show hints` is enabled in Appearance settings, and do not appear when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)