### PR TITLE
Show friendly voice names in Kokoro TTS

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1493,7 +1493,8 @@ public partial class TextToSpeechViewModel : ObservableObject
                 var savedVoice = Se.Settings.Video.TextToSpeech.KokoroVoice;
                 if (!string.IsNullOrEmpty(savedVoice))
                 {
-                    var match = Voices.FirstOrDefault(v => v.Name == savedVoice);
+                    var match = Voices.FirstOrDefault(v =>
+                        v.EngineVoice is Voices.KokoroTtsVoice kv && kv.Voice == savedVoice);
                     if (match != null)
                     {
                         SelectedVoice = match;

--- a/src/ui/Features/Video/TextToSpeech/Voices/KokoroTtsVoice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/KokoroTtsVoice.cs
@@ -9,7 +9,7 @@ public class KokoroTtsVoice
 
     public override string ToString()
     {
-        return Voice;
+        return GetDisplayName(Voice);
     }
 
     public KokoroTtsVoice()
@@ -20,5 +20,50 @@ public class KokoroTtsVoice
     public KokoroTtsVoice(string voice)
     {
         Voice = voice;
+    }
+
+    // Convert a Kokoro voice id like "af_maple" or "zm_009" into a UI-friendly
+    // label such as "English (US) Female - Maple". Falls back to the raw id if
+    // the format is unrecognized.
+    public static string GetDisplayName(string id)
+    {
+        if (string.IsNullOrEmpty(id) || id.Length < 4 || id[2] != '_')
+        {
+            return id ?? string.Empty;
+        }
+
+        var language = id[0] switch
+        {
+            'a' => "English (US)",
+            'b' => "English (UK)",
+            'e' => "Spanish",
+            'f' => "French",
+            'h' => "Hindi",
+            'i' => "Italian",
+            'j' => "Japanese",
+            'p' => "Portuguese (BR)",
+            'z' => "Chinese",
+            _ => null,
+        };
+
+        var gender = id[1] switch
+        {
+            'f' => "Female",
+            'm' => "Male",
+            _ => null,
+        };
+
+        if (language == null || gender == null)
+        {
+            return id;
+        }
+
+        var name = id.Substring(3);
+        if (name.Length > 0 && char.IsLetter(name[0]))
+        {
+            name = char.ToUpperInvariant(name[0]) + name.Substring(1);
+        }
+
+        return $"{language} {gender} - {name}";
     }
 }


### PR DESCRIPTION
Decode the Kokoro voice id convention (e.g. af_maple, zm_009) into labels like "English (US) Female - Maple" or "Chinese Male - 009" in the voice dropdown. The underlying id is still what gets persisted and sent to the synthesis server.