### PR TITLE
Fix saving interjections for non-English languages

### DIFF
--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/InterjectionsViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/InterjectionsViewModel.cs
@@ -27,18 +27,27 @@ public partial class InterjectionsViewModel : ObservableObject
         _languageCode = string.Empty;
     }
     
-    [RelayCommand]                   
-    private void Ok() 
+    [RelayCommand]
+    private void Ok()
     {
-        var interjectionLanguage = 
-            Se.Settings.Tools.RemoveTextForHi.Interjections
-            .FirstOrDefault(p => p.LanguageCode == _languageCode);
-        
-        if (interjectionLanguage == null)
+        if (string.IsNullOrEmpty(_languageCode))
         {
             return;
         }
-        
+
+        var interjectionLanguage =
+            Se.Settings.Tools.RemoveTextForHi.Interjections
+            .FirstOrDefault(p => p.LanguageCode == _languageCode);
+
+        if (interjectionLanguage == null)
+        {
+            interjectionLanguage = new SeRemoveTextForHi.InterjectionLanguage
+            {
+                LanguageCode = _languageCode,
+            };
+            Se.Settings.Tools.RemoveTextForHi.Interjections.Add(interjectionLanguage);
+        }
+
         interjectionLanguage.Interjections = InterjectionsText.SplitToLines()
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Select(p => p.Trim())


### PR DESCRIPTION
## Summary
- The Interjections dialog (`InterjectionsViewModel.Ok()`) returned early whenever the selected language didn't already exist in `Se.Settings.Tools.RemoveTextForHi.Interjections`.
- Only `"en"` is seeded by `SeRemoveTextForHi`'s constructor, so every other language hit the early return — the OK button did nothing and the dialog wouldn't close.
- Now a new `InterjectionLanguage` entry is created on save when one is missing for the current language code, so non-English interjections persist correctly.

Fixes #10808

## Test plan
- [x] Build succeeds (`dotnet build` in `src/ui`)
- [x] Open *Remove text for hearing impaired* → switch language to a non-English one (e.g. Danish, French) → click *Edit interjections* → add some interjections → click *OK* → dialog closes and entries are persisted in `Settings.json`
- [x] Re-open the dialog for the same language and confirm the interjections are still there
- [x] English language continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)