### PR TITLE
Add macOS download URL for OmniVoice TTS engine

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -522,11 +522,16 @@ public partial class DownloadTtsViewModel : ObservableObject
                 }
 
                 var exePath = OmniVoiceTtsCpp.GetExecutableFileName();
+                var codecExePath = OmniVoiceTtsCpp.GetCodecExecutableFileName();
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     if (File.Exists(exePath))
                     {
                         LinuxHelper.MakeExecutable(exePath);
+                    }
+                    if (File.Exists(codecExePath))
+                    {
+                        LinuxHelper.MakeExecutable(codecExePath);
                     }
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -534,6 +539,10 @@ public partial class DownloadTtsViewModel : ObservableObject
                     if (File.Exists(exePath))
                     {
                         MacHelper.MakeExecutable(exePath);
+                    }
+                    if (File.Exists(codecExePath))
+                    {
+                        MacHelper.MakeExecutable(codecExePath);
                     }
                 }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -84,6 +84,11 @@ public class OmniVoiceTtsCpp : ITtsEngine
         return Path.Combine(GetSetFolder(), OperatingSystem.IsWindows() ? "omnivoice-tts.exe" : "omnivoice-tts");
     }
 
+    public static string GetCodecExecutableFileName()
+    {
+        return Path.Combine(GetSetFolder(), OperatingSystem.IsWindows() ? "omnivoice-codec.exe" : "omnivoice-codec");
+    }
+
     public static string GetModelBasePath() =>
         Path.Combine(GetSetModelsFolder(), OmniVoiceDownloadService.ModelBaseFileName);
 

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -25,6 +25,7 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
     private const string ModelTokenizerUrl = "https://huggingface.co/Serveurperso/OmniVoice-GGUF/resolve/main/omnivoice-tokenizer-F32.gguf";
 
     private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-win64-cpu.zip";
+    private const string MacOsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-macos-universal-cpu-metal.zip";
 
     public OmniVoiceDownloadService(HttpClient httpClient)
     {
@@ -64,6 +65,11 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return WindowsUrl;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return MacOsUrl;
         }
 
         throw new PlatformNotSupportedException();


### PR DESCRIPTION
## Summary
- Add macOS universal (arm64+x86_64, CPU+Metal) download URL to `OmniVoiceDownloadService` so OmniVoice TTS can be installed from the in-app download dialog on Mac (was previously `PlatformNotSupportedException`).
- Add `OmniVoiceTtsCpp.GetCodecExecutableFileName()` and `chmod +x` it after unzip on Mac/Linux next to the existing `omnivoice-tts` chmod, so users can run `omnivoice-codec` manually if they want. Subtitle Edit itself still only invokes `omnivoice-tts`.

The redistributable was built from `ServeurpersoCom/omnivoice.cpp` (commit `d765f4d`) with `-DGGML_METAL=ON -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=Apple`. arm64 and x86_64 slices were built separately and `lipo`'d. Executables ad-hoc signed; rpath set to `@loader_path` so the bundled ggml dylibs resolve from the same folder.

Zip layout (flat, drop into `<TextToSpeechFolder>/OmniVoice/`):
- `omnivoice-tts`, `omnivoice-codec`
- `libggml{,-base,-cpu,-blas,-metal}.0.dylib` (no symlinks — `System.IO.Compression.ZipArchive` doesn't preserve them)
- `LICENSE`

Hosted at `https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-macos-universal-cpu-metal.zip` (sha256 `e151ecd792ed80b093fa0f09a610e21e3c0469904e08b92f07709124caf4457d`).

## Test plan
- [ ] On macOS: open Video > Text to speech, pick OmniVoice TTS, run the engine download — verify the zip downloads and unpacks into the OmniVoice folder.
- [ ] Verify `omnivoice-tts` and `omnivoice-codec` are executable (`ls -l`) and that running `./omnivoice-tts --help` from the OmniVoice folder works.
- [ ] Download the OmniVoice models, generate TTS for a short subtitle, verify output WAV plays.
- [ ] Repeat on Apple Silicon and Intel Mac (or at least confirm `lipo -archs` shows both slices).
- [ ] Smoke test on Windows to confirm the existing flow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)