### PR TITLE
Add Linux x64 download URL for OmniVoice TTS engine

### DIFF
--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -26,6 +26,7 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
     private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-win64-cpu.zip";
     private const string MacOsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-macos-universal-cpu-metal.zip";
+    private const string LinuxUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-linux-x64-cpu.zip";
 
     public OmniVoiceDownloadService(HttpClient httpClient)
     {
@@ -70,6 +71,11 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             return MacOsUrl;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return LinuxUrl;
         }
 
         throw new PlatformNotSupportedException();


### PR DESCRIPTION
## Summary
- Add Linux x64 (CPU-only, fully static) download URL to `OmniVoiceDownloadService` so OmniVoice TTS can be installed from the in-app download dialog on Linux (was previously `PlatformNotSupportedException`).

The Linux redistributable was built from `ServeurpersoCom/omnivoice.cpp` (commit `d765f4d`) inside `alpine:3.19` (musl libc) with `-static -static-libgcc -static-libstdc++`. `file` confirms `ELF 64-bit LSB executable, x86-64, statically linked`; `ldd` reports "Not a valid dynamic program" — zero dynamic dependencies. Smoke-tested by running `omnivoice-tts --help` from Ubuntu 22.04 and Debian bullseye-slim images, neither of which have musl.

Configure flags: `-DBUILD_SHARED_LIBS=OFF -DGGML_NATIVE=OFF -DGGML_BLAS=OFF -DGGML_METAL=OFF -DGGML_VULKAN=OFF -DGGML_CUDA=OFF -DGGML_OPENMP=OFF`. Portable SIMD baseline (SSE4.2 + AVX + AVX2 + FMA + F16C + BMI2). Stripped, ~3.1 MB per binary.

Zip layout (flat, drop into `<TextToSpeechFolder>/OmniVoice/`):
- `omnivoice-tts`, `omnivoice-codec` (mode 0755 in the zip)
- `LICENSE`

Hosted at `https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-linux-x64-cpu.zip` (sha256 `d7f255f536c496c69d302327e19896cd62240b42d83cd769bb15c3a6455547ae`).

Note: `DownloadTtsViewModel` already calls `LinuxHelper.MakeExecutable` on `omnivoice-tts` (and on `omnivoice-codec` after #10819), so the unzip → chmod → run flow works without further changes.

## Test plan
- [ ] On Linux x64: open Video > Text to speech, pick OmniVoice TTS, run the engine download — verify the zip downloads and unpacks into the OmniVoice folder.
- [ ] Verify `omnivoice-tts` is executable and `./omnivoice-tts --help` works from the OmniVoice folder.
- [ ] Download the OmniVoice models, generate TTS for a short subtitle, verify output WAV plays.
- [ ] Confirm the existing Windows and macOS flows are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)