### PR TITLE
Fix waveform cursor lag from leaking spectrogram bitmaps

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -320,6 +320,7 @@ public class AudioVisualizer : Control
     private static readonly Cursor _cursorSizeWestEast = new Cursor(StandardCursorType.SizeWestEast);
 
     private readonly List<SubtitleLineViewModel> _displayableParagraphs = new();
+    private readonly IsSelectedHelper _isSelectedHelper = new();
     private bool _isCtrlDown;
     private bool _isMetaDown;
     private bool _isAltDown;
@@ -1500,7 +1501,7 @@ public class AudioVisualizer : Control
 
         // Convert SKBitmap to Avalonia Bitmap and draw it
         var displayHeight = height;
-        var avaloniaBitmap = skBitmapCombined.ToAvaloniaBitmap();
+        using var avaloniaBitmap = skBitmapCombined.ToAvaloniaBitmap();
 
         var destRectangle = new Rect(0, renderCtx.Height - displayHeight, renderCtx.Width, displayHeight);
         context.DrawImage(avaloniaBitmap, destRectangle);
@@ -1710,7 +1711,8 @@ public class AudioVisualizer : Control
 
     private void DrawWaveFormFancy(DrawingContext context, double waveformHeight, ref RenderContext renderCtx)
     {
-        var isSelectedHelper = new IsSelectedHelper(AllSelectedParagraphs, renderCtx.SampleRate);
+        _isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate);
+        var isSelectedHelper = _isSelectedHelper;
         var halfWaveformHeight = waveformHeight / 2;
         var div = renderCtx.SampleRate * renderCtx.ZoomFactor;
 
@@ -1826,7 +1828,8 @@ public class AudioVisualizer : Control
 
     private void DrawWaveFormClassic(DrawingContext context, double waveformHeight, ref RenderContext renderCtx)
     {
-        var isSelectedHelper = new IsSelectedHelper(AllSelectedParagraphs, renderCtx.SampleRate);
+        _isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate);
+        var isSelectedHelper = _isSelectedHelper;
         var halfWaveformHeight = waveformHeight / 2;
         var div = renderCtx.SampleRate * renderCtx.ZoomFactor;
 

--- a/src/ui/Controls/AudioVisualizerControl/IsSelectedHelper.cs
+++ b/src/ui/Controls/AudioVisualizerControl/IsSelectedHelper.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main;
 using System;
 using System.Collections.Generic;
 
@@ -6,21 +6,29 @@ namespace Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 
 public class IsSelectedHelper
 {
-    private readonly SelectionRange[] _ranges;
+    private SelectionRange[] _ranges = Array.Empty<SelectionRange>();
+    private int _rangeCount;
     private int _lastPosition = int.MaxValue;
     private SelectionRange _nextSelection;
 
-    public IsSelectedHelper(List<SubtitleLineViewModel> paragraphs, int sampleRate)
+    public void Reset(List<SubtitleLineViewModel> paragraphs, int sampleRate)
     {
-        var count = paragraphs.Count;
-        _ranges = new SelectionRange[count];
-        for (var index = 0; index < count; index++)
+        _rangeCount = paragraphs.Count;
+        if (_ranges.Length < _rangeCount)
+        {
+            Array.Resize(ref _ranges, _rangeCount);
+        }
+
+        for (var index = 0; index < _rangeCount; index++)
         {
             var p = paragraphs[index];
             var start = (int)Math.Round(p.StartTime.TotalSeconds * sampleRate);
             var end = (int)Math.Round(p.EndTime.TotalSeconds * sampleRate);
             _ranges[index] = new SelectionRange(start, end);
         }
+
+        _lastPosition = int.MaxValue;
+        _nextSelection = new SelectionRange(int.MaxValue, int.MaxValue);
     }
 
     public bool IsSelected(int position)
@@ -38,7 +46,7 @@ public class IsSelectedHelper
     private void FindNextSelection(int position)
     {
         _nextSelection = new SelectionRange(int.MaxValue, int.MaxValue);
-        for (var index = 0; index < _ranges.Length; index++)
+        for (var index = 0; index < _rangeCount; index++)
         {
             var range = _ranges[index];
             if (range.End >= position && (range.Start < _nextSelection.Start || range.Start == _nextSelection.Start && range.End > _nextSelection.End))


### PR DESCRIPTION
The spectrogram render path created a new WriteableBitmap on every render via ToAvaloniaBitmap() but never disposed it. With the 50ms position timer driving renders, unmanaged bitmap memory accumulated steadily and the waveform cursor became progressively unresponsive over long editing sessions, matching the behavior reported in #10818.

Dispose the bitmap with `using` after drawing it, and reuse a single IsSelectedHelper instance across renders instead of allocating a new one (and a fresh SelectionRange array) each time DrawWaveForm runs.

Closes #10818