### PR TITLE
Don't invert waveform zoom direction with "Invert mouse wheel"

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -584,7 +584,7 @@ public class AudioVisualizer : Control
 
         if (_isAltDown)
         {
-            var deltaAlt = InvertMouseWheel ? -e.Delta.Y : e.Delta.Y;
+            var deltaAlt = e.Delta.Y;
             var newZoomFactor = ZoomFactor + deltaAlt / 10.0;
 
             if (newZoomFactor < MinZoomFactor)


### PR DESCRIPTION
The "Invert mouse wheel" waveform setting also flipped the alt+wheel horizontal zoom direction, which is inconsistent with shift+wheel vertical zoom (which never inverted). Users reasonably expect the setting to affect scrolling only.

Closes #10813