### PR TITLE
Add Merge two subtitles tool

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -112,6 +112,7 @@ using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.FixNetflixErrors;
 using Nikse.SubtitleEdit.Features.Tools.JoinSubtitles;
 using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
+using Nikse.SubtitleEdit.Features.Tools.MergeTwoSubtitles;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameText;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
@@ -355,6 +356,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<MergeSameTextViewModel>();
         collection.AddTransient<MergeSameTimeCodesViewModel>();
         collection.AddTransient<MergeShortLinesViewModel>();
+        collection.AddTransient<MergeTwoSubtitlesViewModel>();
         collection.AddTransient<ModifySelectionViewModel>();
         collection.AddTransient<MultipleReplaceViewModel>();
         collection.AddTransient<NOcrCharacterAddViewModel>();

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -448,6 +448,11 @@ public static class InitMenu
             },
             new MenuItem
             {
+                Header = l.MergeTwoSubtitles,
+                Command = vm.ShowToolsMergeTwoSubtitlesCommand,
+            },
+            new MenuItem
+            {
                 Header = l.SortSubtitles,
                 Command = vm.ShowSortByCommand,
             },

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -112,6 +112,7 @@ using Nikse.SubtitleEdit.Features.Tools.ConvertActors;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.FixNetflixErrors;
 using Nikse.SubtitleEdit.Features.Tools.JoinSubtitles;
+using Nikse.SubtitleEdit.Features.Tools.MergeTwoSubtitles;
 using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameText;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
@@ -3847,6 +3848,39 @@ public partial class MainViewModel :
                           SubtitleFormats[0]);
         SelectAndScrollToRow(0);
         ShowStatus(Se.Language.Main.JoinedSubtitleLoaded);
+    }
+
+    [RelayCommand]
+    private async Task ShowToolsMergeTwoSubtitles()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        var lines = Subtitles.ToList();
+        var hasOriginal = ShowColumnOriginalText && lines.Any(p => !string.IsNullOrEmpty(p.OriginalText));
+        var result = await ShowDialogAsync<MergeTwoSubtitlesWindow, MergeTwoSubtitlesViewModel>(vm =>
+        {
+            vm.Initialize(lines, hasOriginal);
+        });
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        ResetSubtitle();
+        SetSubtitles(result.ResultSubtitle);
+        SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == result.ResultFormat.Name) ??
+                          SubtitleFormats[0]);
+        SelectAndScrollToRow(0);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesDisplayItem.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesDisplayItem.cs
@@ -1,0 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Tools.MergeTwoSubtitles;
+
+public partial class MergeTwoSubtitlesDisplayItem : ObservableObject
+{
+    [ObservableProperty] private int _number;
+    [ObservableProperty] private TimeSpan _startTime;
+    [ObservableProperty] private TimeSpan _endTime;
+    [ObservableProperty] private string _text = string.Empty;
+}

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesViewModel.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesViewModel.cs
@@ -1,0 +1,684 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Tools.MergeTwoSubtitles;
+
+public partial class MergeTwoSubtitlesViewModel : ObservableObject
+{
+    public const string OutputFormatSubRip = "SubRip";
+    public const string OutputFormatAssa = "Assa";
+
+    [ObservableProperty] private ObservableCollection<MergeTwoSubtitlesDisplayItem> _items1;
+    [ObservableProperty] private ObservableCollection<MergeTwoSubtitlesDisplayItem> _items2;
+    [ObservableProperty] private MergeTwoSubtitlesDisplayItem? _selectedItem1;
+    [ObservableProperty] private MergeTwoSubtitlesDisplayItem? _selectedItem2;
+    [ObservableProperty] private string _file1Display;
+    [ObservableProperty] private string _file2Display;
+
+    [ObservableProperty] private ObservableCollection<OutputFormatItem> _outputFormats;
+    [ObservableProperty] private OutputFormatItem _selectedOutputFormat;
+    [ObservableProperty] private bool _isAssaSelected;
+
+    [ObservableProperty] private ObservableCollection<string> _fontNames;
+
+    // Style 1
+    [ObservableProperty] private string _fontName1;
+    [ObservableProperty] private int _fontSize1;
+    [ObservableProperty] private bool _bold1;
+    [ObservableProperty] private bool _italic1;
+    [ObservableProperty] private Color _primaryColor1;
+    [ObservableProperty] private Color _outlineColor1;
+    [ObservableProperty] private decimal _outlineWidth1;
+    [ObservableProperty] private decimal _shadowWidth1;
+    [ObservableProperty] private bool _alignTop1;
+
+    // Style 2
+    [ObservableProperty] private string _fontName2;
+    [ObservableProperty] private int _fontSize2;
+    [ObservableProperty] private bool _bold2;
+    [ObservableProperty] private bool _italic2;
+    [ObservableProperty] private Color _primaryColor2;
+    [ObservableProperty] private Color _outlineColor2;
+    [ObservableProperty] private decimal _outlineWidth2;
+    [ObservableProperty] private decimal _shadowWidth2;
+    [ObservableProperty] private bool _alignTop2;
+
+    [ObservableProperty] private Bitmap? _imagePreview;
+    [ObservableProperty] private bool _isMergeEnabled;
+
+    public Window? Window { get; set; }
+
+    public bool OkPressed { get; private set; }
+    public Subtitle ResultSubtitle { get; private set; }
+    public SubtitleFormat ResultFormat { get; private set; }
+
+    private readonly IFileHelper _fileHelper;
+    private Subtitle _subtitle1;
+    private Subtitle _subtitle2;
+    private bool _loaded;
+
+    public MergeTwoSubtitlesViewModel(IFileHelper fileHelper)
+    {
+        _fileHelper = fileHelper;
+
+        Items1 = new ObservableCollection<MergeTwoSubtitlesDisplayItem>();
+        Items2 = new ObservableCollection<MergeTwoSubtitlesDisplayItem>();
+        File1Display = string.Empty;
+        File2Display = string.Empty;
+
+        _subtitle1 = new Subtitle();
+        _subtitle2 = new Subtitle();
+        ResultSubtitle = new Subtitle();
+        ResultFormat = new SubRip();
+
+        OutputFormats = new ObservableCollection<OutputFormatItem>
+        {
+            new(OutputFormatSubRip, Se.Language.Tools.MergeTwoSubtitles.OutputFormatSubRip),
+            new(OutputFormatAssa, Se.Language.Tools.MergeTwoSubtitles.OutputFormatAssa),
+        };
+
+        FontNames = new ObservableCollection<string>(FontHelper.GetSystemFonts());
+
+        var s = Se.Settings.Tools;
+        var format = OutputFormats.FirstOrDefault(p => p.Id == s.MergeTwoSubtitlesOutputFormat) ?? OutputFormats[1];
+        SelectedOutputFormat = format;
+        IsAssaSelected = format.Id == OutputFormatAssa;
+
+        FontName1 = ResolveFontName(s.MergeTwoSubtitlesFontName1);
+        FontSize1 = s.MergeTwoSubtitlesFontSize1;
+        Bold1 = s.MergeTwoSubtitlesBold1;
+        Italic1 = s.MergeTwoSubtitlesItalic1;
+        PrimaryColor1 = s.MergeTwoSubtitlesPrimaryColor1.FromHexToColor();
+        OutlineColor1 = s.MergeTwoSubtitlesOutlineColor1.FromHexToColor();
+        OutlineWidth1 = s.MergeTwoSubtitlesOutlineWidth1;
+        ShadowWidth1 = s.MergeTwoSubtitlesShadowWidth1;
+        AlignTop1 = s.MergeTwoSubtitlesAlignTop1;
+
+        FontName2 = ResolveFontName(s.MergeTwoSubtitlesFontName2);
+        FontSize2 = s.MergeTwoSubtitlesFontSize2;
+        Bold2 = s.MergeTwoSubtitlesBold2;
+        Italic2 = s.MergeTwoSubtitlesItalic2;
+        PrimaryColor2 = s.MergeTwoSubtitlesPrimaryColor2.FromHexToColor();
+        OutlineColor2 = s.MergeTwoSubtitlesOutlineColor2.FromHexToColor();
+        OutlineWidth2 = s.MergeTwoSubtitlesOutlineWidth2;
+        ShadowWidth2 = s.MergeTwoSubtitlesShadowWidth2;
+        AlignTop2 = s.MergeTwoSubtitlesAlignTop2;
+
+        _loaded = true;
+    }
+
+    private string ResolveFontName(string? name)
+    {
+        if (!string.IsNullOrEmpty(name) && FontNames.Contains(name))
+        {
+            return name;
+        }
+
+        return FontNames.FirstOrDefault() ?? "Arial";
+    }
+
+    public void Initialize(IList<SubtitleLineViewModel> currentLines, bool hasOriginal)
+    {
+        var sub1 = new Subtitle();
+        foreach (var line in currentLines)
+        {
+            if (string.IsNullOrWhiteSpace(line.Text))
+            {
+                continue;
+            }
+
+            sub1.Paragraphs.Add(new Paragraph(line.Text, line.StartTime.TotalMilliseconds, line.EndTime.TotalMilliseconds));
+        }
+
+        var sub2 = new Subtitle();
+        if (hasOriginal)
+        {
+            foreach (var line in currentLines)
+            {
+                if (string.IsNullOrWhiteSpace(line.OriginalText))
+                {
+                    continue;
+                }
+
+                sub2.Paragraphs.Add(new Paragraph(line.OriginalText, line.StartTime.TotalMilliseconds, line.EndTime.TotalMilliseconds));
+            }
+        }
+
+        SetSubtitle1(sub1, Se.Language.Tools.MergeTwoSubtitles.LoadFromCurrentText);
+        SetSubtitle2(sub2, hasOriginal
+            ? Se.Language.Tools.MergeTwoSubtitles.LoadFromCurrentTranslation
+            : string.Empty);
+
+        UpdateMergeEnabled();
+        UpdatePreview();
+    }
+
+    private void SetSubtitle1(Subtitle subtitle, string display)
+    {
+        _subtitle1 = subtitle;
+        File1Display = display;
+        Items1.Clear();
+        var index = 1;
+        foreach (var p in subtitle.Paragraphs)
+        {
+            Items1.Add(new MergeTwoSubtitlesDisplayItem
+            {
+                Number = index++,
+                StartTime = p.StartTime.TimeSpan,
+                EndTime = p.EndTime.TimeSpan,
+                Text = p.Text,
+            });
+        }
+    }
+
+    private void SetSubtitle2(Subtitle subtitle, string display)
+    {
+        _subtitle2 = subtitle;
+        File2Display = display;
+        Items2.Clear();
+        var index = 1;
+        foreach (var p in subtitle.Paragraphs)
+        {
+            Items2.Add(new MergeTwoSubtitlesDisplayItem
+            {
+                Number = index++,
+                StartTime = p.StartTime.TimeSpan,
+                EndTime = p.EndTime.TimeSpan,
+                Text = p.Text,
+            });
+        }
+    }
+
+    [RelayCommand]
+    private async Task LoadFile1()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenSubtitleFile(Window, Se.Language.General.OpenSubtitleFileTitle, false);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var subtitle = LoadSubtitleFile(fileName);
+        if (subtitle == null)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, "Unable to read subtitle: " + fileName);
+            return;
+        }
+
+        SetSubtitle1(subtitle, Path.GetFileName(fileName));
+        UpdateMergeEnabled();
+    }
+
+    [RelayCommand]
+    private async Task LoadFile2()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenSubtitleFile(Window, Se.Language.General.OpenSubtitleFileTitle, false);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var subtitle = LoadSubtitleFile(fileName);
+        if (subtitle == null)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, "Unable to read subtitle: " + fileName);
+            return;
+        }
+
+        SetSubtitle2(subtitle, Path.GetFileName(fileName));
+        UpdateMergeEnabled();
+    }
+
+    private static Subtitle? LoadSubtitleFile(string fileName)
+    {
+        var sub = Subtitle.Parse(fileName);
+        if (sub == null || sub.Paragraphs.Count == 0)
+        {
+            return null;
+        }
+
+        return sub;
+    }
+
+    private void UpdateMergeEnabled()
+    {
+        IsMergeEnabled = _subtitle1.Paragraphs.Count > 0 && _subtitle2.Paragraphs.Count > 0;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        if (_subtitle1.Paragraphs.Count == 0 || _subtitle2.Paragraphs.Count == 0)
+        {
+            return;
+        }
+
+        SaveSettings();
+        BuildResult();
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    private void SaveSettings()
+    {
+        var s = Se.Settings.Tools;
+        s.MergeTwoSubtitlesOutputFormat = SelectedOutputFormat.Id;
+        s.MergeTwoSubtitlesFontName1 = FontName1;
+        s.MergeTwoSubtitlesFontSize1 = FontSize1;
+        s.MergeTwoSubtitlesBold1 = Bold1;
+        s.MergeTwoSubtitlesItalic1 = Italic1;
+        s.MergeTwoSubtitlesPrimaryColor1 = PrimaryColor1.FromColorToHex();
+        s.MergeTwoSubtitlesOutlineColor1 = OutlineColor1.FromColorToHex();
+        s.MergeTwoSubtitlesOutlineWidth1 = OutlineWidth1;
+        s.MergeTwoSubtitlesShadowWidth1 = ShadowWidth1;
+        s.MergeTwoSubtitlesAlignTop1 = AlignTop1;
+        s.MergeTwoSubtitlesFontName2 = FontName2;
+        s.MergeTwoSubtitlesFontSize2 = FontSize2;
+        s.MergeTwoSubtitlesBold2 = Bold2;
+        s.MergeTwoSubtitlesItalic2 = Italic2;
+        s.MergeTwoSubtitlesPrimaryColor2 = PrimaryColor2.FromColorToHex();
+        s.MergeTwoSubtitlesOutlineColor2 = OutlineColor2.FromColorToHex();
+        s.MergeTwoSubtitlesOutlineWidth2 = OutlineWidth2;
+        s.MergeTwoSubtitlesShadowWidth2 = ShadowWidth2;
+        s.MergeTwoSubtitlesAlignTop2 = AlignTop2;
+        Se.SaveSettings();
+    }
+
+    private void BuildResult()
+    {
+        if (SelectedOutputFormat.Id == OutputFormatSubRip)
+        {
+            ResultSubtitle = BuildSubRipMerge(_subtitle1, _subtitle2);
+            ResultFormat = new SubRip();
+        }
+        else
+        {
+            ResultSubtitle = BuildAssaMerge(_subtitle1, _subtitle2);
+            ResultFormat = new AdvancedSubStationAlpha();
+        }
+
+        ResultSubtitle.Renumber();
+    }
+
+    private static Subtitle BuildSubRipMerge(Subtitle sub1, Subtitle sub2)
+    {
+        var result = new Subtitle();
+        var used2 = new HashSet<int>();
+
+        for (var i1 = 0; i1 < sub1.Paragraphs.Count; i1++)
+        {
+            var p1 = sub1.Paragraphs[i1];
+            var matchIndex = FindOverlapping(p1, sub2, used2);
+            if (matchIndex >= 0)
+            {
+                used2.Add(matchIndex);
+                var p2 = sub2.Paragraphs[matchIndex];
+                var combined = new Paragraph(
+                    p1.Text + Environment.NewLine + p2.Text,
+                    p1.StartTime.TotalMilliseconds,
+                    p1.EndTime.TotalMilliseconds);
+                result.Paragraphs.Add(combined);
+            }
+            else
+            {
+                result.Paragraphs.Add(new Paragraph(p1));
+            }
+        }
+
+        for (var i2 = 0; i2 < sub2.Paragraphs.Count; i2++)
+        {
+            if (used2.Contains(i2))
+            {
+                continue;
+            }
+
+            result.Paragraphs.Add(new Paragraph(sub2.Paragraphs[i2]));
+        }
+
+        result.Paragraphs.Sort((a, b) => a.StartTime.TotalMilliseconds.CompareTo(b.StartTime.TotalMilliseconds));
+        return result;
+    }
+
+    private static int FindOverlapping(Paragraph p, Subtitle other, HashSet<int> used)
+    {
+        for (var i = 0; i < other.Paragraphs.Count; i++)
+        {
+            if (used.Contains(i))
+            {
+                continue;
+            }
+
+            var q = other.Paragraphs[i];
+            if (p.StartTime.TotalMilliseconds < q.EndTime.TotalMilliseconds &&
+                q.StartTime.TotalMilliseconds < p.EndTime.TotalMilliseconds)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private Subtitle BuildAssaMerge(Subtitle sub1, Subtitle sub2)
+    {
+        var style1 = BuildSsaStyle("Style1", FontName1, FontSize1, Bold1, Italic1,
+            PrimaryColor1, OutlineColor1, OutlineWidth1, ShadowWidth1, AlignTop1);
+        var style2 = BuildSsaStyle("Style2", FontName2, FontSize2, Bold2, Italic2,
+            PrimaryColor2, OutlineColor2, OutlineWidth2, ShadowWidth2, AlignTop2);
+
+        var header = AdvancedSubStationAlpha.DefaultHeader;
+        header = AdvancedSubStationAlpha.UpdateOrAddStyle(header, style1);
+        header = AdvancedSubStationAlpha.UpdateOrAddStyle(header, style2);
+        // Remove the leftover "Default" style
+        header = RemoveDefaultStyleFromHeader(header);
+
+        var result = new Subtitle { Header = header };
+        foreach (var p in sub1.Paragraphs)
+        {
+            var copy = new Paragraph(p) { Extra = "Style1" };
+            result.Paragraphs.Add(copy);
+        }
+
+        foreach (var p in sub2.Paragraphs)
+        {
+            var copy = new Paragraph(p) { Extra = "Style2" };
+            result.Paragraphs.Add(copy);
+        }
+
+        result.Paragraphs.Sort((a, b) => a.StartTime.TotalMilliseconds.CompareTo(b.StartTime.TotalMilliseconds));
+        return result;
+    }
+
+    private static string RemoveDefaultStyleFromHeader(string header)
+    {
+        var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(header);
+        var keep = styles.Where(p => !string.Equals(p.Name, "Default", StringComparison.OrdinalIgnoreCase)).ToList();
+        if (keep.Count == styles.Count || keep.Count == 0)
+        {
+            return header;
+        }
+
+        return AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(header, keep);
+    }
+
+    private static SsaStyle BuildSsaStyle(string name, string fontName, int fontSize, bool bold, bool italic,
+        Color primary, Color outline, decimal outlineWidth, decimal shadowWidth, bool alignTop)
+    {
+        return new SsaStyle
+        {
+            Name = name,
+            FontName = fontName,
+            FontSize = fontSize,
+            Bold = bold,
+            Italic = italic,
+            Primary = ToSkColor(primary),
+            Secondary = SKColors.Yellow,
+            Outline = ToSkColor(outline),
+            Background = SKColors.Black,
+            OutlineWidth = outlineWidth,
+            ShadowWidth = shadowWidth,
+            Alignment = alignTop ? "8" : "2",
+            BorderStyle = "1",
+            MarginLeft = 10,
+            MarginRight = 10,
+            MarginVertical = 10,
+            ScaleX = 100,
+            ScaleY = 100,
+            Spacing = 0,
+            Angle = 0,
+        };
+    }
+
+    private static SKColor ToSkColor(Color c) => new(c.R, c.G, c.B, c.A);
+
+    internal void OnPropertyChangedFromUi()
+    {
+        if (!_loaded)
+        {
+            return;
+        }
+
+        IsAssaSelected = SelectedOutputFormat?.Id == OutputFormatAssa;
+        UpdatePreview();
+    }
+
+    partial void OnSelectedOutputFormatChanged(OutputFormatItem value) => OnPropertyChangedFromUi();
+    partial void OnSelectedItem1Changed(MergeTwoSubtitlesDisplayItem? value) => UpdatePreview();
+    partial void OnSelectedItem2Changed(MergeTwoSubtitlesDisplayItem? value) => UpdatePreview();
+    partial void OnFontName1Changed(string value) => UpdatePreview();
+    partial void OnFontSize1Changed(int value) => UpdatePreview();
+    partial void OnBold1Changed(bool value) => UpdatePreview();
+    partial void OnItalic1Changed(bool value) => UpdatePreview();
+    partial void OnPrimaryColor1Changed(Color value) => UpdatePreview();
+    partial void OnOutlineColor1Changed(Color value) => UpdatePreview();
+    partial void OnOutlineWidth1Changed(decimal value) => UpdatePreview();
+    partial void OnShadowWidth1Changed(decimal value) => UpdatePreview();
+    partial void OnAlignTop1Changed(bool value) => UpdatePreview();
+    partial void OnFontName2Changed(string value) => UpdatePreview();
+    partial void OnFontSize2Changed(int value) => UpdatePreview();
+    partial void OnBold2Changed(bool value) => UpdatePreview();
+    partial void OnItalic2Changed(bool value) => UpdatePreview();
+    partial void OnPrimaryColor2Changed(Color value) => UpdatePreview();
+    partial void OnOutlineColor2Changed(Color value) => UpdatePreview();
+    partial void OnOutlineWidth2Changed(decimal value) => UpdatePreview();
+    partial void OnShadowWidth2Changed(decimal value) => UpdatePreview();
+    partial void OnAlignTop2Changed(bool value) => UpdatePreview();
+
+    private void UpdatePreview()
+    {
+        if (!_loaded)
+        {
+            return;
+        }
+
+        const int width = 480;
+        const int height = 200;
+
+        var bitmap = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            DrawCheckerboard(canvas, width, height);
+
+            var sample1 = SelectedItem1?.Text;
+            if (string.IsNullOrEmpty(sample1))
+            {
+                sample1 = Items1.FirstOrDefault()?.Text ?? "Subtitle 1 example";
+            }
+
+            var sample2 = SelectedItem2?.Text;
+            if (string.IsNullOrEmpty(sample2))
+            {
+                sample2 = Items2.FirstOrDefault()?.Text ?? "Subtitle 2 example";
+            }
+
+            DrawText(canvas, width, height, sample1!, FontName1, FontSize1, Bold1, Italic1,
+                PrimaryColor1, OutlineColor1, OutlineWidth1, ShadowWidth1, AlignTop1);
+            DrawText(canvas, width, height, sample2!, FontName2, FontSize2, Bold2, Italic2,
+                PrimaryColor2, OutlineColor2, OutlineWidth2, ShadowWidth2, AlignTop2);
+        }
+
+        ImagePreview = bitmap.ToAvaloniaBitmap();
+    }
+
+    private static void DrawCheckerboard(SKCanvas canvas, int width, int height)
+    {
+        const int rectangleSize = 9;
+        using var lightBrush = new SKPaint { Color = new SKColor(245, 245, 245), Style = SKPaintStyle.Fill };
+        using var darkBrush = new SKPaint { Color = new SKColor(211, 211, 211), Style = SKPaintStyle.Fill };
+        for (var y = 0; y < height; y += rectangleSize)
+        {
+            for (var x = 0; x < width; x += rectangleSize)
+            {
+                var darker = (y / rectangleSize + x / rectangleSize) % 2 == 0;
+                canvas.DrawRect(new SKRect(x, y, x + rectangleSize, y + rectangleSize), darker ? darkBrush : lightBrush);
+            }
+        }
+    }
+
+    private static void DrawText(SKCanvas canvas, int width, int height, string text, string fontName, int fontSize,
+        bool bold, bool italic, Color primary, Color outline, decimal outlineWidth, decimal shadowWidth,
+        bool alignTop)
+    {
+        var lines = SplitPreviewLines(text);
+        if (lines.Length == 0)
+        {
+            return;
+        }
+
+        var weight = bold ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal;
+        var slant = italic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright;
+        using var typeface = SKTypeface.FromFamilyName(fontName, weight, SKFontStyleWidth.Normal, slant)
+                             ?? SKTypeface.Default;
+        using var font = new SKFont(typeface, fontSize);
+
+        using var fillPaint = new SKPaint
+        {
+            Color = ToSkColor(primary),
+            IsAntialias = true,
+            Style = SKPaintStyle.Fill,
+        };
+
+        var metrics = font.Metrics;
+        var lineHeight = metrics.Descent - metrics.Ascent;
+
+        float blockTop;
+        if (alignTop)
+        {
+            blockTop = -metrics.Ascent + 10;
+        }
+        else
+        {
+            blockTop = height - 10 - lineHeight * lines.Length - metrics.Ascent;
+        }
+
+        SKPaint? shadowPaint = null;
+        SKPaint? outlinePaint = null;
+        try
+        {
+            if (shadowWidth > 0)
+            {
+                shadowPaint = new SKPaint
+                {
+                    Color = new SKColor(0, 0, 0, 200),
+                    IsAntialias = true,
+                    Style = SKPaintStyle.Fill,
+                };
+            }
+
+            if (outlineWidth > 0)
+            {
+                outlinePaint = new SKPaint
+                {
+                    Color = ToSkColor(outline),
+                    IsAntialias = true,
+                    Style = SKPaintStyle.Stroke,
+                    StrokeWidth = (float)outlineWidth * 2f,
+                    StrokeJoin = SKStrokeJoin.Round,
+                };
+            }
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                var textWidth = font.MeasureText(line);
+                var x = (width - textWidth) / 2f;
+                var y = blockTop + i * lineHeight;
+
+                if (shadowPaint != null)
+                {
+                    for (var s = 1; s <= (int)shadowWidth; s++)
+                    {
+                        canvas.DrawText(line, x + s, y + s, font, shadowPaint);
+                    }
+                }
+
+                if (outlinePaint != null)
+                {
+                    canvas.DrawText(line, x, y, font, outlinePaint);
+                }
+
+                canvas.DrawText(line, x, y, font, fillPaint);
+            }
+        }
+        finally
+        {
+            shadowPaint?.Dispose();
+            outlinePaint?.Dispose();
+        }
+    }
+
+    private static string[] SplitPreviewLines(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return Array.Empty<string>();
+        }
+
+        var clean = HtmlUtil.RemoveHtmlTags(text, true)
+            .Replace("\\N", "\n", StringComparison.Ordinal)
+            .Replace("\\n", "\n", StringComparison.Ordinal);
+
+        return clean.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n');
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}
+
+public class OutputFormatItem
+{
+    public string Id { get; }
+    public string Display { get; }
+
+    public OutputFormatItem(string id, string display)
+    {
+        Id = id;
+        Display = display;
+    }
+
+    public override string ToString() => Display;
+}

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
@@ -1,0 +1,391 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+
+namespace Nikse.SubtitleEdit.Features.Tools.MergeTwoSubtitles;
+
+public class MergeTwoSubtitlesWindow : Window
+{
+    public MergeTwoSubtitlesWindow(MergeTwoSubtitlesViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Tools.MergeTwoSubtitles.Title;
+        CanResize = true;
+        Width = 1200;
+        Height = 800;
+        MinWidth = 950;
+        MinHeight = 600;
+        vm.Window = this;
+        DataContext = vm;
+
+        var listsView = MakeListsView(vm);
+        var formatRow = MakeFormatRow(vm);
+        var stylesView = MakeStylesView(vm);
+        var previewView = MakePreviewView(vm);
+
+        var buttonOk = UiUtil.MakeButton(Se.Language.Tools.MergeTwoSubtitles.Merge, vm.OkCommand)
+            .WithBindEnabled(nameof(vm.IsMergeEnabled));
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var bottomGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 10,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        bottomGrid.Add(stylesView, 0, 0);
+        bottomGrid.Add(previewView, 0, 1);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // lists
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // format combo
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // styles + preview
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(listsView, 0, 0);
+        grid.Add(formatRow, 1, 0);
+        grid.Add(bottomGrid, 2, 0);
+        grid.Add(buttonPanel, 3, 0);
+
+        Content = grid;
+
+        Activated += delegate { buttonOk.Focus(); };
+        KeyDown += vm.KeyDown;
+    }
+
+    private static Border MakeListsView(MergeTwoSubtitlesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 10,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+
+        grid.Add(MakeOneListView(vm,
+            Se.Language.Tools.MergeTwoSubtitles.Subtitle1,
+            nameof(vm.Items1),
+            nameof(vm.SelectedItem1),
+            nameof(vm.File1Display),
+            vm.LoadFile1Command), 0, 0);
+
+        grid.Add(MakeOneListView(vm,
+            Se.Language.Tools.MergeTwoSubtitles.Subtitle2,
+            nameof(vm.Items2),
+            nameof(vm.SelectedItem2),
+            nameof(vm.File2Display),
+            vm.LoadFile2Command), 0, 1);
+
+        return UiUtil.MakeBorderForControlNoPadding(grid);
+    }
+
+    private static Border MakeOneListView(MergeTwoSubtitlesViewModel vm,
+        string title,
+        string itemsPath,
+        string selectedItemPath,
+        string fileNamePath,
+        CommunityToolkit.Mvvm.Input.IRelayCommand loadCommand)
+    {
+        var labelTitle = UiUtil.MakeLabel(title);
+        var labelFile = UiUtil.MakeLabel(string.Empty).WithBindText(vm, fileNamePath);
+        var buttonLoad = UiUtil.MakeButton(Se.Language.Tools.MergeTwoSubtitles.LoadFromFile, loadCommand);
+
+        var fullTimeConverter = new TimeSpanToDisplayFullConverter();
+
+        var dataGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            CanUserResizeColumns = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = null,
+            Columns =
+            {
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.NumberSymbol,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.Number)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(60, DataGridLengthUnitType.Pixel),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.StartTime,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.StartTime)) { Converter = fullTimeConverter },
+                    IsReadOnly = true,
+                    Width = new DataGridLength(120, DataGridLengthUnitType.Pixel),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.EndTime,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.EndTime)) { Converter = fullTimeConverter },
+                    IsReadOnly = true,
+                    Width = new DataGridLength(120, DataGridLengthUnitType.Pixel),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Text,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.Text)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+            },
+        };
+        dataGrid.Bind(DataGrid.ItemsSourceProperty, new Binding(itemsPath) { Source = vm });
+        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(selectedItemPath) { Source = vm });
+
+        var headerPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children =
+            {
+                labelTitle,
+                labelFile,
+            },
+        };
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowSpacing = 5,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+        grid.Add(headerPanel, 0, 0);
+        grid.Add(dataGrid, 1, 0);
+        grid.Add(buttonLoad, 2, 0);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+
+    private static StackPanel MakeFormatRow(MergeTwoSubtitlesViewModel vm)
+    {
+        var label = UiUtil.MakeLabel(Se.Language.Tools.MergeTwoSubtitles.OutputFormat);
+        var combo = UiUtil.MakeComboBox(vm.OutputFormats, vm, nameof(vm.SelectedOutputFormat))
+            .WithMinWidth(260);
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                label,
+                combo,
+            },
+        };
+    }
+
+    private static Border MakeStylesView(MergeTwoSubtitlesViewModel vm)
+    {
+        var l = Se.Language.Tools.MergeTwoSubtitles;
+
+        var col1 = MakeStyleColumn(vm, l.Style1,
+            nameof(vm.FontName1), nameof(vm.FontSize1),
+            nameof(vm.Bold1), nameof(vm.Italic1),
+            nameof(vm.PrimaryColor1), nameof(vm.OutlineColor1),
+            nameof(vm.OutlineWidth1), nameof(vm.ShadowWidth1),
+            nameof(vm.AlignTop1), "AlignGroup1");
+
+        var col2 = MakeStyleColumn(vm, l.Style2,
+            nameof(vm.FontName2), nameof(vm.FontSize2),
+            nameof(vm.Bold2), nameof(vm.Italic2),
+            nameof(vm.PrimaryColor2), nameof(vm.OutlineColor2),
+            nameof(vm.OutlineWidth2), nameof(vm.ShadowWidth2),
+            nameof(vm.AlignTop2), "AlignGroup2");
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 10,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        grid.Add(col1, 0, 0);
+        grid.Add(col2, 0, 1);
+
+        var border = UiUtil.MakeBorderForControl(grid);
+        border.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsAssaSelected)) { Source = vm });
+        return border;
+    }
+
+    private static Grid MakeStyleColumn(MergeTwoSubtitlesViewModel vm,
+        string title,
+        string fontNamePath, string fontSizePath,
+        string boldPath, string italicPath,
+        string primaryColorPath, string outlineColorPath,
+        string outlineWidthPath, string shadowWidthPath,
+        string alignTopPath, string alignGroupName)
+    {
+        var l = Se.Language.Tools.MergeTwoSubtitles;
+
+        var labelTitle = UiUtil.MakeLabel(title);
+        labelTitle.FontWeight = FontWeight.Bold;
+
+        var labelFontName = UiUtil.MakeLabel(Se.Language.General.FontName);
+        var comboFontName = UiUtil.MakeComboBox(vm.FontNames, vm, fontNamePath).WithMinWidth(180);
+
+        var labelFontSize = UiUtil.MakeLabel(Se.Language.General.FontSize);
+        var numFontSize = UiUtil.MakeNumericUpDownInt(6, 200, 20, 140, vm, fontSizePath);
+
+        var checkBold = UiUtil.MakeCheckBox(Se.Language.General.Bold, vm, boldPath);
+        var checkItalic = UiUtil.MakeCheckBox(Se.Language.General.Italic, vm, italicPath);
+        var stylePanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { checkBold, checkItalic },
+        };
+
+        var labelPrimary = UiUtil.MakeLabel(Se.Language.General.TextColor);
+        var primaryPicker = UiUtil.MakeColorPickerButton(vm, primaryColorPath, false);
+
+        var labelOutline = UiUtil.MakeLabel(Se.Language.General.OutlineColor);
+        var outlinePicker = UiUtil.MakeColorPickerButton(vm, outlineColorPath, false);
+
+        var labelOutlineWidth = UiUtil.MakeLabel(l.OutlineWidth);
+        var numOutlineWidth = UiUtil.MakeNumericUpDownOneDecimal(0, 20, 140, vm, outlineWidthPath);
+
+        var labelShadowWidth = UiUtil.MakeLabel(l.ShadowWidth);
+        var numShadowWidth = UiUtil.MakeNumericUpDownOneDecimal(0, 20, 140, vm, shadowWidthPath);
+
+        var radioTop = UiUtil.MakeRadioButton(l.AlignTop, vm, alignTopPath, alignGroupName);
+        var radioBottom = new RadioButton
+        {
+            Content = l.AlignBottom,
+            GroupName = alignGroupName,
+            DataContext = vm,
+        };
+        radioBottom.Bind(RadioButton.IsCheckedProperty, new Binding(alignTopPath)
+        {
+            Source = vm,
+            Mode = BindingMode.TwoWay,
+            Converter = new InverseBooleanConverter(),
+        });
+        var alignPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { radioTop, radioBottom },
+        };
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 10,
+            RowSpacing = 6,
+        };
+
+        grid.Add(labelTitle, 0, 0, 1, 2);
+        grid.Add(labelFontName, 1, 0); grid.Add(comboFontName, 1, 1);
+        grid.Add(labelFontSize, 2, 0); grid.Add(numFontSize, 2, 1);
+        grid.Add(stylePanel, 3, 1);
+        grid.Add(labelPrimary, 4, 0); grid.Add(primaryPicker, 4, 1);
+        grid.Add(labelOutline, 5, 0); grid.Add(outlinePicker, 5, 1);
+        grid.Add(labelOutlineWidth, 6, 0); grid.Add(numOutlineWidth, 6, 1);
+        grid.Add(labelShadowWidth, 7, 0); grid.Add(numShadowWidth, 7, 1);
+        grid.Add(alignPanel, 8, 1);
+
+        return grid;
+    }
+
+    private static Border MakePreviewView(MergeTwoSubtitlesViewModel vm)
+    {
+        var labelPreview = UiUtil.MakeLabel(Se.Language.General.Preview);
+
+        var image = new Image
+        {
+            [!Image.SourceProperty] = new Binding(nameof(vm.ImagePreview)),
+            DataContext = vm,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Stretch = Stretch.None,
+        };
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            RowSpacing = 5,
+        };
+        grid.Add(labelPreview, 0, 0);
+        grid.Add(image, 1, 0);
+
+        var border = UiUtil.MakeBorderForControl(grid);
+        border.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsAssaSelected)) { Source = vm });
+        return border;
+    }
+}

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -58,6 +58,7 @@ public class LanguageMainMenu
     public string ConvertActors { get; set; }
     public string JoinSubtitles { get; set; }
     public string SplitSubtitle { get; set; }
+    public string MergeTwoSubtitles { get; set; }
 
     public string AssaTools { get; set; }
     public string AssaProgressBar { get; set; }
@@ -184,6 +185,7 @@ public class LanguageMainMenu
         BatchConvert = "_Batch convert...";
         JoinSubtitles = "_Join subtitles...";
         SplitSubtitle = "_Split subtitle...";
+        MergeTwoSubtitles = "Merge two subtitles...";
 
         AssaTools = "_ASSA tools";
         AssaChangeResolution = "Change _resolution...";

--- a/src/ui/Logic/Config/Language/Tools/LanguageMergeTwoSubtitles.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageMergeTwoSubtitles.cs
@@ -1,0 +1,43 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language;
+
+public class LanguageMergeTwoSubtitles
+{
+    public string Title { get; set; }
+    public string Subtitle1 { get; set; }
+    public string Subtitle2 { get; set; }
+    public string LoadFromCurrentText { get; set; }
+    public string LoadFromCurrentTranslation { get; set; }
+    public string LoadFromFile { get; set; }
+    public string OutputFormat { get; set; }
+    public string OutputFormatSubRip { get; set; }
+    public string OutputFormatAssa { get; set; }
+    public string Style1 { get; set; }
+    public string Style2 { get; set; }
+    public string OutlineWidth { get; set; }
+    public string ShadowWidth { get; set; }
+    public string AlignTop { get; set; }
+    public string AlignBottom { get; set; }
+    public string Merge { get; set; }
+    public string PleaseLoadTwoSubtitles { get; set; }
+
+    public LanguageMergeTwoSubtitles()
+    {
+        Title = "Merge two subtitles";
+        Subtitle1 = "Subtitle 1";
+        Subtitle2 = "Subtitle 2";
+        LoadFromCurrentText = "Load from current (text)";
+        LoadFromCurrentTranslation = "Load from current (translation)";
+        LoadFromFile = "Load from file...";
+        OutputFormat = "Output format";
+        OutputFormatSubRip = "SubRip (.srt)";
+        OutputFormatAssa = "Advanced Sub Station Alpha (.ass)";
+        Style1 = "Style 1";
+        Style2 = "Style 2";
+        OutlineWidth = "Outline width";
+        ShadowWidth = "Shadow width";
+        AlignTop = "Top";
+        AlignBottom = "Bottom";
+        Merge = "_Merge";
+        PleaseLoadTwoSubtitles = "Please load two subtitles";
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
@@ -15,6 +15,7 @@ public class LanguageTools
     public LanguageChangeFormatting ChangeFormatting { get; set; } = new();
     public LanguageConvertActors ConvertActors { get; set; } = new();
     public LanguageJoinSubtitles JoinSubtitles { get; set; } = new();
+    public LanguageMergeTwoSubtitles MergeTwoSubtitles { get; set; } = new();
     public LanguageSplitSubtitle SplitSubtitle { get; set; } = new();
     public LanguageSplitBreakLongLines SplitBreakLongLines { get; set; } = new();
     public LanguageMergeShortLines MergeShortLines { get; set; } = new();

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -30,6 +30,26 @@ public class SeTools
     public string NvidiaPrompt { get; set; }
     public bool JoinKeepTimeCodes { get; set; }
     public int JoinAppendMilliseconds { get; set; }
+
+    public string MergeTwoSubtitlesOutputFormat { get; set; }
+    public string MergeTwoSubtitlesFontName1 { get; set; }
+    public int MergeTwoSubtitlesFontSize1 { get; set; }
+    public bool MergeTwoSubtitlesBold1 { get; set; }
+    public bool MergeTwoSubtitlesItalic1 { get; set; }
+    public string MergeTwoSubtitlesPrimaryColor1 { get; set; }
+    public string MergeTwoSubtitlesOutlineColor1 { get; set; }
+    public decimal MergeTwoSubtitlesOutlineWidth1 { get; set; }
+    public decimal MergeTwoSubtitlesShadowWidth1 { get; set; }
+    public bool MergeTwoSubtitlesAlignTop1 { get; set; }
+    public string MergeTwoSubtitlesFontName2 { get; set; }
+    public int MergeTwoSubtitlesFontSize2 { get; set; }
+    public bool MergeTwoSubtitlesBold2 { get; set; }
+    public bool MergeTwoSubtitlesItalic2 { get; set; }
+    public string MergeTwoSubtitlesPrimaryColor2 { get; set; }
+    public string MergeTwoSubtitlesOutlineColor2 { get; set; }
+    public decimal MergeTwoSubtitlesOutlineWidth2 { get; set; }
+    public decimal MergeTwoSubtitlesShadowWidth2 { get; set; }
+    public bool MergeTwoSubtitlesAlignTop2 { get; set; }
     public int SplitNumberOfEqualParts { get; set; }
     public string SplitOutputFolder { get; set; }
     public bool SplitByLines { get; set; }
@@ -98,6 +118,22 @@ public class SeTools
         OpenRouterPrompt = string.Empty;
         NvidiaPrompt = string.Empty;
         JoinKeepTimeCodes = true;
+
+        MergeTwoSubtitlesOutputFormat = AdvancedSubStationAlpha.NameOfFormat;
+        MergeTwoSubtitlesFontName1 = "Arial";
+        MergeTwoSubtitlesFontSize1 = 20;
+        MergeTwoSubtitlesPrimaryColor1 = Colors.White.FromColorToHex();
+        MergeTwoSubtitlesOutlineColor1 = Colors.Black.FromColorToHex();
+        MergeTwoSubtitlesOutlineWidth1 = 2;
+        MergeTwoSubtitlesShadowWidth1 = 1;
+        MergeTwoSubtitlesAlignTop1 = true;
+        MergeTwoSubtitlesFontName2 = "Arial";
+        MergeTwoSubtitlesFontSize2 = 20;
+        MergeTwoSubtitlesPrimaryColor2 = Colors.White.FromColorToHex();
+        MergeTwoSubtitlesOutlineColor2 = Colors.Black.FromColorToHex();
+        MergeTwoSubtitlesOutlineWidth2 = 2;
+        MergeTwoSubtitlesShadowWidth2 = 1;
+        MergeTwoSubtitlesAlignTop2 = false;
         SplitNumberOfEqualParts = 2;
         SplitByLines = true;
         SplitOutputFolder = string.Empty;


### PR DESCRIPTION
## Summary
- Adds a new **Tools → Merge two subtitles…** entry that combines two subtitles into one
- Inputs: the currently loaded subtitle's `Text` + `OriginalText` (translation) columns by default; either side can be replaced via "Load from file…"
- Output: **SubRip** (overlapping pairs collapse into one entry stacked line1/line2) or **Advanced SubStation Alpha** with two configurable styles (font, size, bold/italic, primary/outline color, outline/shadow width, top/bottom alignment) and a live preview
- Inspired by the SE4 `MergeTwoSrtToAss` plugin (https://github.com/SubtitleEdit/plugins)

## Test plan
- [ ] Open a subtitle that has a translation column → Tools → Merge two subtitles… → both grids prefilled (Text on left, Translation on right)
- [ ] Switch output format between SubRip and ASSA — style/preview panes appear only for ASSA
- [ ] Adjust font / size / bold / italic / colors / outline / shadow / top|bottom for each style — preview updates live
- [ ] Click a row in either grid — preview shows that line's text in the corresponding style
- [ ] Multi-line texts render correctly in the preview (no tofu boxes between lines)
- [ ] "Load from file…" replaces either side; merge stays disabled until both sides have paragraphs
- [ ] Merge → main subtitle is replaced with the merged result in the chosen format
- [ ] Settings (per-style font/colors/widths/alignment + chosen output format) persist across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)