### PR TITLE
Add multi mode to "Add to names list" window

### DIFF
--- a/src/ui/Features/Shared/AddToNamesList/AddToNamesListViewModel.cs
+++ b/src/ui/Features/Shared/AddToNamesList/AddToNamesListViewModel.cs
@@ -150,6 +150,13 @@ public partial class AddToNamesListViewModel : ObservableObject
             return;
         }
 
+        await MessageBox.Show(
+            Window!,
+            Se.Language.General.Information,
+            string.Format(Se.Language.SpellCheck.XOfYNamesImported, addedCount, names.Count),
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information);
+
         OkPressed = true;
         Window?.Close();
     }

--- a/src/ui/Features/Shared/AddToNamesList/AddToNamesListViewModel.cs
+++ b/src/ui/Features/Shared/AddToNamesList/AddToNamesListViewModel.cs
@@ -2,11 +2,13 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Dictionaries;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Shared.AddToNamesList;
@@ -17,6 +19,15 @@ public partial class AddToNamesListViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<SpellCheckDictionaryDisplay> _dictionaries;
     [ObservableProperty] private SpellCheckDictionaryDisplay? _selectedDictionary;
     [ObservableProperty] private string _name;
+    [ObservableProperty] private string _multiNames;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsSingleMode))]
+    [NotifyPropertyChangedFor(nameof(MultiModeButtonText))]
+    private bool _isMultiMode;
+
+    public bool IsSingleMode => !IsMultiMode;
+    public string MultiModeButtonText => IsMultiMode ? Se.Language.General.SingleMode : Se.Language.General.MultiMode;
 
     public Window? Window { get; set; }
 
@@ -26,12 +37,13 @@ public partial class AddToNamesListViewModel : ObservableObject
     {
         Title = string.Empty;
         Name = string.Empty;
+        MultiNames = string.Empty;
         Dictionaries = new ObservableCollection<SpellCheckDictionaryDisplay>();
     }
 
     internal void Initialize(
-        string name, 
-        List<SpellCheckDictionaryDisplay>? dictionaries = null, 
+        string name,
+        List<SpellCheckDictionaryDisplay>? dictionaries = null,
         SpellCheckDictionaryDisplay? dictionary = null)
     {
         Name = name.Trim();
@@ -51,11 +63,6 @@ public partial class AddToNamesListViewModel : ObservableObject
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(Name))
-        {
-            return;
-        }
-
         var fiveLetterLanguageName = dictionary.GetFiveLetterLanguageName();
         if (fiveLetterLanguageName == null)
         {
@@ -65,7 +72,19 @@ public partial class AddToNamesListViewModel : ObservableObject
         }
 
         var nameList = new NameList(Se.DictionariesFolder, fiveLetterLanguageName, false, string.Empty);
-        var ok = nameList.Add(Name);
+
+        if (IsMultiMode)
+        {
+            await OkMultiMode(nameList);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Name))
+        {
+            return;
+        }
+
+        var ok = nameList.Add(Name.Trim());
         if (!ok)
         {
             var message = $"Could not add name \"{Name}\" to \"Name list\" - perhaps it already exists";
@@ -75,6 +94,111 @@ public partial class AddToNamesListViewModel : ObservableObject
 
         OkPressed = true;
         Window?.Close();
+    }
+
+    private async Task OkMultiMode(NameList nameList)
+    {
+        var names = MultiNames.SplitToLines()
+            .Select(p => p.Trim())
+            .Where(p => p.Length > 0)
+            .Distinct()
+            .ToList();
+
+        if (names.Count == 0)
+        {
+            return;
+        }
+
+        var hasCasingIssue = names.Any(n => !StartsWithUpper(n) || IsAllUpper(n));
+        if (hasCasingIssue)
+        {
+            var warnResult = await MessageBox.Show(
+                Window!,
+                Se.Language.General.Warning,
+                Se.Language.SpellCheck.SomeNamesAreNotProperCase,
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+            if (warnResult != MessageBoxResult.Yes)
+            {
+                return;
+            }
+        }
+
+        var confirm = await MessageBox.Show(
+            Window!,
+            Se.Language.General.Question,
+            string.Format(Se.Language.SpellCheck.ImportXNames, names.Count),
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+        if (confirm != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        var addedCount = 0;
+        foreach (var n in names)
+        {
+            if (nameList.Add(n))
+            {
+                addedCount++;
+            }
+        }
+
+        if (addedCount == 0)
+        {
+            await MessageBox.Show(Window!, Se.Language.General.Error, Se.Language.SpellCheck.NoNamesAdded, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    private static bool StartsWithUpper(string s)
+    {
+        foreach (var c in s)
+        {
+            if (char.IsLetter(c))
+            {
+                return char.IsUpper(c);
+            }
+        }
+        return false;
+    }
+
+    private static bool IsAllUpper(string s)
+    {
+        var hasLetter = false;
+        foreach (var c in s)
+        {
+            if (char.IsLetter(c))
+            {
+                hasLetter = true;
+                if (char.IsLower(c))
+                {
+                    return false;
+                }
+            }
+        }
+        return hasLetter;
+    }
+
+    [RelayCommand]
+    private void ToggleMultiMode()
+    {
+        IsMultiMode = !IsMultiMode;
+        if (IsMultiMode)
+        {
+            Title = Se.Language.SpellCheck.AddNamesToNamesList;
+            if (string.IsNullOrEmpty(MultiNames) && !string.IsNullOrWhiteSpace(Name))
+            {
+                MultiNames = Name;
+            }
+        }
+        else
+        {
+            Title = Se.Language.SpellCheck.AddNameToNamesList;
+        }
     }
 
     [RelayCommand]
@@ -90,7 +214,7 @@ public partial class AddToNamesListViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
-        else if (e.Key == Key.Enter)
+        else if (e.Key == Key.Enter && !IsMultiMode)
         {
             e.Handled = true;
             using var _ = Ok();

--- a/src/ui/Features/Shared/AddToNamesList/AddToNamesListWindow.cs
+++ b/src/ui/Features/Shared/AddToNamesList/AddToNamesListWindow.cs
@@ -19,7 +19,23 @@ public class AddToNamesListWindow : Window
         DataContext = vm;
 
         var labelWord = UiUtil.MakeLabel(Se.Language.Ocr.NameToAdd);
-        var textBoxWord = UiUtil.MakeTextBox(200, vm, nameof(vm.Name));
+        labelWord.Bind(Label.IsVisibleProperty, new Binding(nameof(vm.IsSingleMode)));
+
+        var textBoxWord = UiUtil.MakeTextBox(200, vm, nameof(vm.Name), nameof(vm.IsSingleMode));
+
+        var labelMultiNames = UiUtil.MakeLabel(Se.Language.SpellCheck.EnterOneNamePerLine);
+        labelMultiNames.Bind(Label.IsVisibleProperty, new Binding(nameof(vm.IsMultiMode)));
+
+        var textBoxMultiNames = new TextBox
+        {
+            Width = 400,
+            Height = 250,
+            AcceptsReturn = true,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.MultiNames)) { Mode = BindingMode.TwoWay },
+            [!TextBox.IsVisibleProperty] = new Binding(nameof(vm.IsMultiMode)),
+        };
 
         var labelDictionary = UiUtil.MakeLabel(Se.Language.General.Dictionary).WithMarginTop(20);
         var comboBoxDictionaries = new ComboBox
@@ -30,13 +46,17 @@ public class AddToNamesListWindow : Window
         };
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonMultiMode = UiUtil.MakeButton(Se.Language.General.MultiMode, vm.ToggleMultiModeCommand);
+        buttonMultiMode.Bind(Button.ContentProperty, new Binding(nameof(vm.MultiModeButtonText)));
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonMultiMode, buttonCancel);
 
         var grid = new Grid
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -56,9 +76,11 @@ public class AddToNamesListWindow : Window
 
         grid.Add(labelWord, 0);
         grid.Add(textBoxWord, 1);
-        grid.Add(labelDictionary, 2);
-        grid.Add(comboBoxDictionaries, 3);
-        grid.Add(buttonPanel, 4);
+        grid.Add(labelMultiNames, 2);
+        grid.Add(textBoxMultiNames, 3);
+        grid.Add(labelDictionary, 4);
+        grid.Add(comboBoxDictionaries, 5);
+        grid.Add(buttonPanel, 6);
 
         Content = grid;
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -307,6 +307,7 @@ public class LanguageGeneral
     public string MoreInfo { get; set; }
     public string MoveAllShotChangeOneFrameBack { get; set; }
     public string MoveAllShotChangeOneFrameForward { get; set; }
+    public string MultiMode { get; set; }
     public string MoveDown { get; set; }
     public string MoveUp { get; set; }
     public string MultipleReplace { get; set; }
@@ -974,6 +975,7 @@ public class LanguageGeneral
         MoreInfo = "More info";
         MoveAllShotChangeOneFrameBack = "Move all shot changes one frame back";
         MoveAllShotChangeOneFrameForward = "Move all shot changes one frame forward";
+        MultiMode = "Multi mode";
         MoveDown = "Move down";
         MoveUp = "Move up";
         MultipleReplace = "Multiple replace";

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -14,6 +14,7 @@ public class LanguageSpellCheck
     public string SomeNamesAreNotProperCase { get; set; }
     public string EnterOneNamePerLine { get; set; }
     public string NoNamesAdded { get; set; }
+    public string XOfYNamesImported { get; set; }
     public string NoDictionariesFound { get; set; }
     public string WordNotFound { get; set; }
     public string LineXofY { get; set; }
@@ -43,6 +44,7 @@ public class LanguageSpellCheck
         SomeNamesAreNotProperCase = "Some names do not start with an uppercase letter or are all uppercase. Import anyway?";
         EnterOneNamePerLine = "Enter one name per line";
         NoNamesAdded = "No names were added (perhaps they already exist).";
+        XOfYNamesImported = "{0} of {1} names imported (the rest may already exist).";
         NoDictionariesFound = "No dictionaries found";
         WordNotFound = "Word not found";
         LineXofY = "Spell checker - line {0} of {1}";

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -9,6 +9,11 @@ public class LanguageSpellCheck
     public string GetDictionaryInstructions { get; set; }
     public string AddNameToUserDictionary { get; set; }
     public string AddNameToNamesList { get; set; }
+    public string AddNamesToNamesList { get; set; }
+    public string ImportXNames { get; set; }
+    public string SomeNamesAreNotProperCase { get; set; }
+    public string EnterOneNamePerLine { get; set; }
+    public string NoNamesAdded { get; set; }
     public string NoDictionariesFound { get; set; }
     public string WordNotFound { get; set; }
     public string LineXofY { get; set; }
@@ -33,6 +38,11 @@ public class LanguageSpellCheck
         GetDictionaryInstructions = "Choose your language and click download";
         AddNameToUserDictionary = "Add name to user dictionary";
         AddNameToNamesList = "Add name to names list";
+        AddNamesToNamesList = "Add names to names list";
+        ImportXNames = "Import {0} names?";
+        SomeNamesAreNotProperCase = "Some names do not start with an uppercase letter or are all uppercase. Import anyway?";
+        EnterOneNamePerLine = "Enter one name per line";
+        NoNamesAdded = "No names were added (perhaps they already exist).";
         NoDictionariesFound = "No dictionaries found";
         WordNotFound = "Word not found";
         LineXofY = "Spell checker - line {0} of {1}";


### PR DESCRIPTION
## Summary
- Add a "Multi mode" toggle button to the AddToNamesList dialog that swaps the single-name input for a multi-line text box.
- On import: blank lines are skipped, names are trimmed and deduped, casing problems (no leading uppercase or all-uppercase) trigger a warning, and the user confirms via an "Import N names?" prompt before bulk add.
- All new user-facing strings go through the language files (`LanguageGeneral.MultiMode` and new entries in `LanguageSpellCheck`).

## Test plan
- [ ] Open the "Add to names list" dialog (e.g. via spell check) — verify it still works in single mode.
- [ ] Click "Multi mode" — verify the single name field is replaced with a multi-line text box and the button label flips to "Single mode".
- [ ] Paste several names (one per line, with blank lines and surrounding whitespace) and click OK — verify the "Import N names?" prompt shows the deduped/non-blank count.
- [ ] Include a name with no leading uppercase or an all-uppercase name — verify the warning prompt appears before the import confirmation.
- [ ] Confirm the names appear in the user names list and the Enter key still submits in single mode (and inserts a newline in multi mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)