### PR TITLE
Add "Extract audio..." item to waveform context menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -259,6 +259,14 @@ public class InitWaveform
             };
             flyout.Items.Add(menuItemSeekSilence);
 
+            var menuItemExtractAudio = new MenuItem
+            {
+                Header = Se.Language.Waveform.ExtractAudioDotDotDot,
+                Command = vm.WaveformExtractAudioCommand,
+            };
+            flyout.Items.Add(menuItemExtractAudio);
+            vm.MenuItemAudioVisualizerExtractAudio = menuItemExtractAudio;
+
             var menuItemSpeechToTextSelectedLines = new MenuItem
             {
                 Header = Se.Language.Waveform.SpeechToTextSelectedLinesDotDotDot,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -83,6 +83,7 @@ using Nikse.SubtitleEdit.Features.Shared.PickRuleProfile;
 using Nikse.SubtitleEdit.Features.Shared.PickSpellCheckDictionary;
 using Nikse.SubtitleEdit.Features.Shared.PickSubtitleFormat;
 using Nikse.SubtitleEdit.Features.Shared.PickTsTrack;
+using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Features.Shared.SetVideoOffset;
 using Nikse.SubtitleEdit.Features.Shared.SourceView;
@@ -363,6 +364,7 @@ public partial class MainViewModel :
     public MenuItem MenuItemAudioVisualizerMergeWithNext { get; set; }
     public MenuItem MenuItemAudioVisualizerSpeechToTextSelectedLines { get; set; }
     public MenuItem MenuItemAudioVisualizerSpeechToTextNewSelection { get; set; }
+    public MenuItem MenuItemAudioVisualizerExtractAudio { get; set; }
     public ITextBoxWrapper EditTextBoxOriginal { get; set; }
     public ITextBoxWrapper EditTextBox { get; set; }
     public TextEditorBindingHelper? EditTextBoxHelper { get; set; }
@@ -451,6 +453,7 @@ public partial class MainViewModel :
         MenuItemAudioVisualizerMergeWithNext = new MenuItem();
         MenuItemAudioVisualizerSpeechToTextSelectedLines = new MenuItem();
         MenuItemAudioVisualizerSpeechToTextNewSelection = new MenuItem();
+        MenuItemAudioVisualizerExtractAudio = new MenuItem();
         MenuItemStyles = new MenuItem();
         MenuItemActors = new MenuItem();
         AudioTraksMenuItem = new MenuItem();
@@ -2895,6 +2898,71 @@ public partial class MainViewModel :
         if (seconds >= 0)
         {
             vp.Position = seconds;
+        }
+    }
+
+    [RelayCommand]
+    private async Task WaveformExtractAudio()
+    {
+        if (Window == null || string.IsNullOrEmpty(_videoFileName))
+        {
+            return;
+        }
+
+        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        if (selectedItems.Count != 1)
+        {
+            return;
+        }
+
+        var ffmpegOk = await RequireFfmpegOk();
+        if (!ffmpegOk)
+        {
+            return;
+        }
+
+        var line = selectedItems[0];
+        var suggestedName = $"{Path.GetFileNameWithoutExtension(_videoFileName)}_{line.Number}.wav";
+        var outputFileName = await _fileHelper.PickSaveFile(Window, ".wav", suggestedName, Se.Language.Waveform.ExtractAudioDotDotDot);
+        if (string.IsNullOrEmpty(outputFileName))
+        {
+            return;
+        }
+
+        try
+        {
+            var arguments = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
+                _videoFileName,
+                line.StartTime.TotalSeconds,
+                line.Duration.TotalSeconds,
+                false,
+                outputFileName);
+
+            using var process = FfmpegGenerator.GetProcess(arguments, (_, _) => { });
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            await Task.Run(() => process.WaitForExit());
+
+            if (process.ExitCode != 0 || !File.Exists(outputFileName))
+            {
+                await MessageBox.Show(Window, Se.Language.General.Error, "Could not extract audio clip from video.", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            await ShowDialogAsync<PromptFileSavedWindow, PromptFileSavedViewModel>(vm =>
+            {
+                vm.Initialize(
+                    Se.Language.General.FileSaved,
+                    string.Format(Se.Language.General.FileSavedToX, outputFileName),
+                    outputFileName,
+                    true,
+                    true);
+            });
+        }
+        catch (Exception exception)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, exception.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
@@ -15788,6 +15856,7 @@ public partial class MainViewModel :
         MenuItemAudioVisualizerMergeWithNext.IsVisible = false;
         MenuItemAudioVisualizerSpeechToTextSelectedLines.IsVisible = false;
         MenuItemAudioVisualizerSpeechToTextNewSelection.IsVisible = false;
+        MenuItemAudioVisualizerExtractAudio.IsVisible = false;
 
         if (e.NewParagraph != null)
         {
@@ -15829,6 +15898,7 @@ public partial class MainViewModel :
             MenuItemAudioVisualizerSplit.IsVisible = true;
             MenuItemAudioVisualizerMergeWithPrevious.IsVisible = selectedIdx > 0;
             MenuItemAudioVisualizerMergeWithNext.IsVisible = !isLast;
+            MenuItemAudioVisualizerExtractAudio.IsVisible = !string.IsNullOrEmpty(_videoFileName);
             return;
         }
 

--- a/src/ui/Logic/Config/Language/Waveform/LanguageWaveform.cs
+++ b/src/ui/Logic/Config/Language/Waveform/LanguageWaveform.cs
@@ -14,6 +14,7 @@ public class LanguageWaveform
     public string MaxSilenceVolume { get; set; }
     public string GuessTimeCodesDotDotDot { get; set; }
     public string SeekSilenceDotDotDot { get; set; }
+    public string ExtractAudioDotDotDot { get; set; }
     public string ToggleShotChange { get; set; }
     public string ResetWaveformZoomAndSpeed { get; set; }
     public object ShowOnlyWaveform { get; set; }
@@ -46,6 +47,7 @@ public class LanguageWaveform
         SpeechToTextNewSelectionDotDotDot = "Speech to text for new selection...";
         SeekSilence = "Seek silence";
         SeekSilenceDotDotDot = "Seek silence...";
+        ExtractAudioDotDotDot = "Extract audio...";
         MinSilenceDurationSeconds = "Min. silence duration (seconds):";
         MaxSilenceVolume = "Max. silence volume (0.0 - 1.0):";
         ToggleShotChange = "Toggle shot change";

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -1132,7 +1132,7 @@ public class FfmpegGenerator
         var duration = $"{durationSeconds:0.000}".Replace(",", ".");
 
         // Base parameters
-        var args = $"-ss {start} -t {duration} -i \"{videoFileName}\" -vn -ar 16000 -b:a 32k";
+        var args = $"-y -ss {start} -t {duration} -i \"{videoFileName}\" -vn -ar 16000 -b:a 32k";
 
         // Optional center-channel only
         if (useCenterChannelOnly)


### PR DESCRIPTION
## Summary
- Adds an **Extract audio...** menu item right after **Seek silence** in the waveform context flyout. It is shown only when exactly one subtitle is selected and a video is loaded.
- The command extracts the audio for the selected subtitle's time range to a user-chosen `.wav` file via ffmpeg, then opens `PromptFileSavedWindow` with **show in folder** / **open file** options.
- Adds `-y` to `FfmpegGenerator.ExtractAudioClipFromVideoParameters` so ffmpeg silently overwrites the chosen output file instead of hanging on the interactive `Overwrite? [y/N]` prompt when the user picks an existing file name.

## Test plan
- [ ] Open a video and a subtitle, select exactly one subtitle line, right-click on that subtitle in the waveform → **Extract audio...** is visible after **Seek silence**.
- [ ] Right-click elsewhere or with 0/multiple selected → item is hidden.
- [ ] Right-click without a video loaded → item is hidden.
- [ ] Picking a save path produces a `.wav` for the subtitle's start/duration; `PromptFileSavedWindow` then opens with working **show in folder** / **open file** buttons.
- [ ] Picking a path that already exists overwrites without hanging.
- [ ] Cancelling the save dialog returns silently and the menu item is enabled again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)