### PR TITLE
Allow editing subtitle text in Fix common errors step 2

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -32,9 +32,6 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [ObservableProperty] private FixDisplayItem? _selectedFix;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _paragraphs;
     [ObservableProperty] private SubtitleLineViewModel? _selectedParagraph;
-    [ObservableProperty] private string _editText;
-    [ObservableProperty] private TimeSpan _editShow;
-    [ObservableProperty] private TimeSpan _editDuration;
     [ObservableProperty] private ObservableCollection<ProfileDisplayItem> _profiles;
     [ObservableProperty] private ProfileDisplayItem? _selectedProfile;
     [ObservableProperty] private bool _step1IsVisible;
@@ -76,7 +73,6 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         Language = new string(' ', 0);
         Fixes = new ObservableCollection<FixDisplayItem>();
         Paragraphs = new ObservableCollection<SubtitleLineViewModel>();
-        EditText = string.Empty;
         _language = Se.Language.Tools.FixCommonErrors;
         Step1IsVisible = true;
         _oldSelectedLanguage = new LanguageDisplayItem(new CultureInfo("en"), "English");
@@ -281,6 +277,29 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         ApplyFixes();
 
         RefreshFixes();
+    }
+
+    partial void OnSelectedParagraphChanged(SubtitleLineViewModel? oldValue, SubtitleLineViewModel? newValue)
+    {
+        if (oldValue != null)
+        {
+            oldValue.PropertyChanged -= SelectedParagraph_PropertyChanged;
+        }
+
+        if (newValue != null)
+        {
+            newValue.PropertyChanged += SelectedParagraph_PropertyChanged;
+        }
+    }
+
+    private void SelectedParagraph_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SubtitleLineViewModel.Text) &&
+            sender is SubtitleLineViewModel vm &&
+            vm.Paragraph != null)
+        {
+            vm.Paragraph.Text = vm.Text;
+        }
     }
 
     private void RefreshFixes()

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -417,23 +417,7 @@ public class FixCommonErrorsWindow : Window
         dataGridSubtitles.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedParagraph)));
         _vm.GridSubtitles = dataGridSubtitles;
 
-        var gridCurrentSubtbtitle = new Grid
-        {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-            },
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-            },
-            ColumnSpacing = 0,
-            RowSpacing = 0,
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-        };
+        var gridCurrentSubtbtitle = MakeStep2EditPanel();
 
         gridSubtitles.Children.Add(dataGridSubtitles);
         Grid.SetRow(dataGridSubtitles, 0);
@@ -468,6 +452,53 @@ public class FixCommonErrorsWindow : Window
         grid.Children.Add(borderSubtitles);
         Grid.SetRow(borderSubtitles, 1);
         Grid.SetColumn(borderSubtitles, 0);
+
+        return grid;
+    }
+
+    private Grid MakeStep2EditPanel()
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowSpacing = 2,
+            Margin = new Thickness(4),
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var labelText = UiUtil.MakeTextBlock(Se.Language.General.Text);
+
+        var textBox = new TextBox
+        {
+            DataContext = _vm,
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            MinHeight = 60,
+            [!TextBox.TextProperty] = new Binding($"{nameof(_vm.SelectedParagraph)}.{nameof(SubtitleLineViewModel.Text)}")
+            {
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+            },
+        };
+
+        grid.Children.Add(labelText);
+        Grid.SetRow(labelText, 0);
+        Grid.SetColumn(labelText, 0);
+
+        grid.Children.Add(textBox);
+        Grid.SetRow(textBox, 1);
+        Grid.SetColumn(textBox, 0);
 
         return grid;
     }


### PR DESCRIPTION
## Summary
- Adds a multiline text edit box below the subtitles grid in step 2 of the Fix common errors window
- Edits propagate live to the underlying paragraph in `FixedSubtitle` via `SubtitleLineViewModel.PropertyChanged` so the next *Refresh fixes* picks them up
- Requested by Sinisa

## Test plan
- [ ] Open Fix common errors, advance to step 2
- [ ] Select a line in the bottom grid → text appears in the new edit box
- [ ] Edit the text → grid row updates live
- [ ] Click *Refresh fixes* → fix list re-evaluates against the edited text
- [ ] Click *Apply fixes and close* → edits are kept in the saved subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)