### PR TITLE
Fix mp3 playback position jumping back 15s at EOF (#10845)

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -25,6 +25,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private IntPtr _renderContext = IntPtr.Zero;
     private volatile bool _disposed;
     private string _fileName = string.Empty;
+    private double? _audioEndBound;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct MpvOpenGlInitParams
@@ -748,6 +749,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
         // Reset any end-of-playback bound from a previous file (see audio-only handling below).
         SetOptionString("end", "none");
+        _audioEndBound = null;
 
         var err = await Task.Run(() => DoMpvCommand("loadfile", path));
         if (_disposed)
@@ -830,6 +832,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 if (d > 0 && !double.IsInfinity(d) && !double.IsNaN(d))
                 {
                     SetOptionString("end", d.ToString(CultureInfo.InvariantCulture));
+                    _audioEndBound = d;
                     break;
                 }
                 await Task.Delay(50);
@@ -881,6 +884,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     {
         _fileName = string.Empty;
         _pausedValue = null;
+        _audioEndBound = null;
 
         EnsureNotDisposed();
         if (_mpv == IntPtr.Zero)
@@ -962,6 +966,31 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     private double? _pausedValue;
 
+    private bool IsEofReached()
+    {
+        if (_mpv == IntPtr.Zero || _mpvGetPropertyDouble == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            double eofValue = 0;
+            var nameBytes = GetUtf8Bytes("eof-reached");
+            var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_FLAG, ref eofValue);
+            if (err < 0)
+            {
+                return false;
+            }
+
+            return eofValue != 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public double Position
     {
         get
@@ -986,6 +1015,16 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 if (err < 0)
                 {
                     return 0;
+                }
+
+                // When playback reaches the bound set for audio-only files, mpv's time-pos
+                // can lag the actual end by several seconds (the lavfi-complex virtual video
+                // produces frames forever, so its demuxer keeps buffering past audio EOF and
+                // the rendered playback time falls behind). Pin to the bound at EOF so the
+                // waveform doesn't appear to jump back when audio playback completes.
+                if (_audioEndBound.HasValue && IsEofReached())
+                {
+                    return _audioEndBound.Value;
                 }
 
                 return position;


### PR DESCRIPTION
## Summary
- When an audio-only file finishes playing, the waveform/position jumped back from the end (a consistent ~15s on the reporter's files). The underlying audio playback was actually at EOF — pressing Play immediately caught up to the end — so the bug was cosmetic but disruptive.
- Root cause: for audio files we inject a virtual lavfi-complex `color` video so subtitles can render, and the existing fix bounds playback with `--end=<audio_duration>`. The lavfi source keeps producing frames past audio EOF, so mpv's `time-pos` (the rendered playback time) lags behind the audio duration once playback ends.
- Cache the `--end` value we set and, when `eof-reached` becomes true, return that bound from `Position` so the UI shows the actual end instead of the lagging `time-pos`. The bound is reset on `LoadFile`/`CloseFile`.

Fix #10845

## Test plan
- [ ] Open an MP3, let it play to the end — waveform stops at the end of the file (no 15s jump-back).
- [ ] After EOF, click Play — playback behaves as before (no regression).
- [ ] Seek to a position before the end — `Position` reports the real time-pos again (eof-reached clears on seek).
- [ ] Open a normal video file — no behavior change (no `--end` bound is set, so the new branch is skipped).
- [ ] Ctrl+N then load another MP3 — second file still starts at 0 (regression check against #10835).

🤖 Generated with [Claude Code](https://claude.com/claude-code)