### PR TITLE
Add green to WebVTT default color classes (fix #10859)

### DIFF
--- a/src/libse/Common/WebVttHelper.cs
+++ b/src/libse/Common/WebVttHelper.cs
@@ -432,8 +432,8 @@ namespace Nikse.SubtitleEdit.Core.Common
         // should strip them even when the header has no matching ::cue style.
         private static readonly string[] DefaultColorClasses =
         {
-            "white", "lime", "cyan", "red", "yellow", "magenta", "blue", "black",
-            "bg_white", "bg_lime", "bg_cyan", "bg_red", "bg_yellow", "bg_magenta", "bg_blue", "bg_black",
+            "white", "lime", "cyan", "red", "yellow", "magenta", "blue", "black", "green",
+            "bg_white", "bg_lime", "bg_cyan", "bg_red", "bg_yellow", "bg_magenta", "bg_blue", "bg_black", "bg_green",
         };
 
         public static string RemoveDefaultColorClasses(string input)

--- a/tests/libse/Core/WebVttHelperTest.cs
+++ b/tests/libse/Core/WebVttHelperTest.cs
@@ -92,4 +92,14 @@ public class WebVttHelperTest
 
         Assert.Equal("Plain text", result);
     }
+
+    [Fact]
+    public void RemoveDefaultColorClassesGreen()
+    {
+        var text = "<c.green>Vert</c>" + Environment.NewLine + "<c.bg_green>Fond vert</c>";
+        var result = WebVttHelper.RemoveDefaultColorClasses(text);
+
+        var expected = "Vert" + Environment.NewLine + "Fond vert";
+        Assert.Equal(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `green` and `bg_green` to the `DefaultColorClasses` list in `WebVttHelper` so `<c.green>` / `<c.bg_green>` are stripped along with the other color cue classes when removing color from WebVTT.
- The French accessibility standard for subtitles uses `green` (W3C's WebVTT default classes use `lime` instead), and `docs/reference/webvtt.md` already lists `green` as a predefined color class — this aligns the code with the docs and the prior fix for #10765.
- Adds a `RemoveDefaultColorClassesGreen` unit test covering both foreground and background green classes.

## Test plan
- [x] `dotnet test tests/libse/LibSETests.csproj --filter "FullyQualifiedName~WebVttHelperTest"` — 7/7 pass
- [ ] Manually verify "Remove color" on a WebVTT subtitle containing `<c.green>...</c>` strips the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)