### PR TITLE
Fix UI freeze when pressing Apply/OK in Settings

### DIFF
--- a/src/ui/Features/Options/Settings/FileTypeAssociationViewModel.cs
+++ b/src/ui/Features/Options/Settings/FileTypeAssociationViewModel.cs
@@ -5,4 +5,5 @@ public class FileTypeAssociationViewModel
     public string Extension { get; set; } = string.Empty;
     public bool IsAssociated { get; set; } = false;
     public string IconPath { get; set; } = string.Empty; // Optional: use if you have images per extension
+    public bool InitialIsAssociated { get; set; } = false;
 }

--- a/src/ui/Features/Options/Settings/FileTypeAssociationsManager.cs
+++ b/src/ui/Features/Options/Settings/FileTypeAssociationsManager.cs
@@ -24,6 +24,7 @@ public static class FileTypeAssociationsManager
         {
             GetIconPath(item);
             item.IsAssociated = FileTypeAssociationsHelper.IsDefault(item.Extension, "SubtitleEdit5");
+            item.InitialIsAssociated = item.IsAssociated;
         }
     }
 
@@ -36,23 +37,52 @@ public static class FileTypeAssociationsManager
             return;
         }
 
+        var changed = fileTypeAssociations
+            .Where(item => item.IsAssociated != item.InitialIsAssociated)
+            .ToList();
+
+        if (changed.Count == 0)
+        {
+            return;
+        }
+
         var exeFileName = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
         if (string.IsNullOrEmpty(exeFileName) || !File.Exists(exeFileName))
         {
             return;
         }
 
+        // Resolve icon paths on the UI thread (AssetLoader is an Avalonia call).
+        var work = changed
+            .Select(item => (
+                item.Extension,
+                item.IsAssociated,
+                IconPath: item.IsAssociated ? GetIconPath(item) : string.Empty))
+            .ToList();
+
         try
         {
-            var hasChanges = fileTypeAssociations.Any(item =>
-                item.IsAssociated != FileTypeAssociationsHelper.IsDefault(item.Extension, "SubtitleEdit5"));
-
-            if (!hasChanges)
+            await Task.Run(() =>
             {
-                return;
-            }
+                foreach (var item in work)
+                {
+                    if (item.IsAssociated)
+                    {
+                        FileTypeAssociationsHelper.SetFileAssociation(item.Extension, exeFileName, "SubtitleEdit5", item.IconPath);
+                    }
+                    else
+                    {
+                        FileTypeAssociationsHelper.DeleteFileAssociation(item.Extension, "SubtitleEdit5");
+                    }
+                }
 
-            await SaveFileTypeAssociationsViaRegistryAsync(fileTypeAssociations, exeFileName);
+                FileTypeAssociationsHelper.Refresh();
+            });
+
+            foreach (var item in changed)
+            {
+                item.InitialIsAssociated = item.IsAssociated;
+            }
         }
         catch (UnauthorizedAccessException ex)
         {
@@ -80,28 +110,6 @@ public static class FileTypeAssociationsManager
                 $"An unexpected error occurred: {ex.Message}",
                 openSettings: false);
         }
-    }
-
-    private static async Task SaveFileTypeAssociationsViaRegistryAsync(
-        IEnumerable<FileTypeAssociationViewModel> fileTypeAssociations,
-        string exeFileName)
-    {
-        foreach (var item in fileTypeAssociations)
-        {
-            var ext = item.Extension;
-            if (item.IsAssociated)
-            {
-                var iconFileName = GetIconPath(item);
-                FileTypeAssociationsHelper.SetFileAssociation(ext, exeFileName, "SubtitleEdit5", iconFileName);
-            }
-            else
-            {
-                FileTypeAssociationsHelper.DeleteFileAssociation(ext, "SubtitleEdit5");
-            }
-        }
-
-        FileTypeAssociationsHelper.Refresh();
-        await Task.CompletedTask;
     }
 
     private static string GetIconPath(FileTypeAssociationViewModel item)

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -2007,20 +2007,20 @@ public partial class SettingsViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void CommandOk()
+    private async Task CommandOk()
     {
         SaveSettings();
-        SaveFileTypeAssociations();
+        await FileTypeAssociationsManager.SaveFileTypeAssociationsAsync(FileTypeAssociations, Window);
 
         OkPressed = true;
         Window?.Close();
     }
 
     [RelayCommand]
-    private void Apply()
+    private async Task Apply()
     {
         SaveSettings();
-        SaveFileTypeAssociations();
+        await FileTypeAssociationsManager.SaveFileTypeAssociationsAsync(FileTypeAssociations, Window);
         _mainViewModel?.ApplySettings();
     }
 
@@ -2187,11 +2187,6 @@ public partial class SettingsViewModel : ObservableObject
     private void LoadFileTypeAssociations()
     {
         FileTypeAssociationsManager.LoadFileTypeAssociations(FileTypeAssociations);
-    }
-
-    private async void SaveFileTypeAssociations()
-    {
-        await FileTypeAssociationsManager.SaveFileTypeAssociationsAsync(FileTypeAssociations, Window);
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- Some users report a frozen UI after pressing Apply or OK in Options → Settings. Root cause: the file-type association save runs synchronously on the UI thread and calls `SHChangeNotify` with `SHCNF_FLUSH` up to 13 times per click. That flag blocks until every shell extension on the machine (OneDrive, Dropbox, antivirus, icon-overlay handlers, …) acknowledges, which can stall the UI for several seconds on machines with heavy shell-extension footprints.
- Offload the registry writes + `SHChangeNotify` to a background thread via `Task.Run`. Icon paths are still resolved on the UI thread because `AssetLoader` is an Avalonia call.
- Skip the entire save when no file-type checkbox was toggled. The previous `hasChanges` check was still doing 12 `IsDefault` registry reads on the UI thread before bailing; now an in-memory snapshot (`InitialIsAssociated`) is captured at load time and compared on save, so the common case (user opened Settings, didn't touch file types) returns instantly.
- Convert `Apply` and `CommandOk` to `async Task` so the save is properly awaited instead of fire-and-forget through an `async void` wrapper.

## Test plan
- [ ] On Windows: open Settings, change a non-file-type setting, press Apply — dialog stays responsive, settings save.
- [ ] On Windows: open Settings, toggle a file-type association, press OK — association updates, no freeze.
- [ ] On Windows: open Settings, press OK without changing anything — closes immediately.
- [ ] On Windows: open Settings, press Apply then OK rapidly — no freeze, no double-save.
- [ ] On macOS/Linux: open Settings, press Apply/OK — unchanged (the manager early-returns on non-Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)