### PR TITLE
Add setting to toggle tools log writing

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -727,6 +727,8 @@ public class SettingsPage : UserControl
                 () => UiUtil.MakeLink(Se.GetErrorLogFilePath(), _vm.ShowErrorLogFileCommand).WithBindEnabed(_vm, nameof(_vm.ExistsErrorLogFile))),
             new SettingsItem(Se.Language.Options.Settings.ShowToolsLogFile,
                 () => UiUtil.MakeLink(Se.GetToolsLogFilePath(), _vm.ShowToolsLogFileCommand).WithBindEnabed(_vm, nameof(_vm.ExistsToolsLogFile))),
+            new SettingsItem(Se.Language.Options.Settings.WriteToolsLog,
+                () => UiUtil.MakeCheckBox(_vm, nameof(_vm.WriteToolsLog))),
             new SettingsItem(Se.Language.Options.Settings.ShowSettingsFile,
                 () => UiUtil.MakeLink(Se.GetSettingsFilePath(), _vm.ShowSettingsFileCommand).WithBindEnabed(_vm, nameof(_vm.ExistsSettingsFile))),
         ]));

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -256,6 +256,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _existsErrorLogFile;
     [ObservableProperty] private bool _existsToolsLogFile;
     [ObservableProperty] private bool _existsSettingsFile;
+    [ObservableProperty] private bool _writeToolsLog;
 
     private int _continuationPause;
     private string _customContinuationStyleSuffix;
@@ -809,6 +810,8 @@ public partial class SettingsViewModel : ObservableObject
         ExistsErrorLogFile = File.Exists(Se.GetErrorLogFilePath());
         ExistsToolsLogFile = File.Exists(Se.GetToolsLogFilePath());
         ExistsSettingsFile = File.Exists(Se.GetSettingsFilePath());
+
+        WriteToolsLog = Se.Settings.Tools.WriteToolsLog;
     }
 
     private bool GetToolbarVisible(SeWaveformToolbarItemType type)
@@ -1209,6 +1212,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.SpeechToTextSelectedLinesPromptFirstTimeOnly = SpeechToTextSelectedLinesPromptFistTimeOnly;
         Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons = MultipleReplaceShowDotDotDotButtons;
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;
+        Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
 
         appearance.Theme = MapThemeFromTranslation(SelectedTheme);
         appearance.IconTheme = SelectedIconTheme;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -183,6 +183,7 @@ public class LanguageSettings
     public string FilesAndLogs { get; set; }
     public string ShowErrorLogFile { get; set; }
     public string ShowToolsLogFile { get; set; }
+    public string WriteToolsLog { get; set; }
     public string ShowSettingsFile { get; set; }
     public string ShowAssaLayer { get; set; }
     public string WaveformCursorColor { get; set; }
@@ -469,6 +470,7 @@ public class LanguageSettings
         FilesAndLogs = "Files and logs";
         ShowErrorLogFile = "Show error log file";
         ShowToolsLogFile = "Show tools log file";
+        WriteToolsLog = "Write tools log";
         ShowSettingsFile = "Show settings file";
         ShowAssaLayer = "Show ASSA layer box";
         WaveformCursorColor = "Waveform cursor/head color";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -454,6 +454,11 @@ public class Se
 
     public static void WriteToolsLog(string log)
     {
+        if (!Settings.Tools.WriteToolsLog)
+        {
+            return;
+        }
+
         try
         {
             var filePath = GetToolsLogFilePath();

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -106,6 +106,7 @@ public class SeTools
     public bool GridFocusTextboxAfterInsertNew { get; set; }
     public List<string> FindHistory { get; set; } = new List<string>();
     public bool AllowSingleLetterShortcutsInTextbox { get; set; }
+    public bool WriteToolsLog { get; set; } = true;
 
     public SeTools()
     {
@@ -176,7 +177,8 @@ public class SeTools
         SpeechToTextSelectedLinesPromptFirstTimeOnly = true;
         MultipleReplaceShowDotDotDotButtons = true;
         GridFocusTextboxAfterInsertNew = true;
-        AllowSingleLetterShortcutsInTextbox = false; 
+        AllowSingleLetterShortcutsInTextbox = false;
+        WriteToolsLog = true;
 
         LastColorPickerColor = Colors.Yellow.FromColorToHex();
         LastColorPickerColor1 = Colors.Red.FromColorToHex();


### PR DESCRIPTION
## Summary
- Adds a new `WriteToolsLog` boolean setting (default `true`) on `SeTools`
- `Se.WriteToolsLog` now early-returns when the setting is disabled
- New "Write tools log" checkbox in Settings > Files and logs lets the user toggle it

## Test plan
- [ ] Open Settings, navigate to Files and logs, verify the new "Write tools log" checkbox appears and defaults to on
- [ ] Run a tool that writes to the tools log (e.g. speech-to-text, burn-in) and confirm `tools-log.txt` is updated
- [ ] Uncheck the setting, Apply/OK, run the same tool, and confirm `tools-log.txt` is not appended to

🤖 Generated with [Claude Code](https://claude.com/claude-code)