### PR TITLE
Fix PaddleOCR CUDA extraction on Linux

### DIFF
--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -150,7 +150,7 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject
                 else if (_downloadType == PaddleOcrDownloadType.EngineGpuLinux)
                 {
                     StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
-                    Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-GPU-v1.4.0-Linux", _cancellationTokenSource, text => ProgressText = text);
+                    Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-GPU-v1.4.0-CUDA-12.9-Linux", _cancellationTokenSource, text => ProgressText = text);
                     var binFile = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
                     if (File.Exists(binFile))
                     {


### PR DESCRIPTION
Extraction would hang because of incorrect base path within the 7z file.