### PR TITLE
Add per-engine command logging to Text-to-speech tools log

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
@@ -162,6 +162,7 @@ public class AllTalk : ITtsEngine
         }
 
         var languageCode = language != null ? language.Code : "en";
+        Se.WriteToolsLog($"AllTalk: voice={allTalkVoice.Voice}, language={languageCode}, textLen={text.Length}");
         var allTalkFileNameOutputFileName = await _ttsDownloadService.AllTalkVoiceSpeak(text, allTalkVoice, languageCode);
 
         var outputFileName = Path.Combine(GetSetAllTalkFolder(), Guid.NewGuid() + ".wav");

--- a/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
@@ -138,10 +138,13 @@ public class AzureSpeech : ITtsEngine
             throw new ArgumentException("Voice is not an AzureVoice");
         }
 
+        Se.WriteToolsLog($"AzureSpeech: voice={azureVoice.ShortName}, locale={azureVoice.Locale}, region={region}, model={model}, textLen={text.Length}");
+
         var ms = new MemoryStream();
         var ok = await _ttsDownloadService.DownloadAzureVoiceSpeak(text, azureVoice, model!, Se.Settings.Video.TextToSpeech.AzureApiKey, "en", region!, ms, null, cancellationToken);
         if (!ok)
         {
+            Se.WriteToolsLog($"AzureSpeech: request failed (voice={azureVoice.ShortName}, region={region})");
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -235,6 +235,7 @@ public class ChatterboxTtsCpp : ITtsEngine
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"Chatterbox TTS: POST {ServerBaseUrl}/v1/audio/speech (voice={chatterboxVoice}, model={ResolveModelKey(model)}, textLen={text.Length})");
         HttpResponseMessage response;
         try
         {
@@ -251,8 +252,10 @@ public class ChatterboxTtsCpp : ITtsEngine
             {
                 StopServerInternal();
             }
-            Se.LogError(ex, $"Chatterbox TTS request failed - Voice: {chatterboxVoice}, Text: {text}, "
-                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}");
+            var failMsg = $"Chatterbox TTS request failed - Voice: {chatterboxVoice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}";
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
 
             var prefix = LooksLikeUpstreamChatterboxCrash(serverLog)
                 ? "Chatterbox TTS hit a CrispASR runtime bug during synthesis (ggml tensor read out of bounds). "
@@ -273,9 +276,11 @@ public class ChatterboxTtsCpp : ITtsEngine
             {
                 var errorBody = await SafeReadErrorAsync(response, cancellationToken);
                 var serverLog = SnapshotServerLog();
-                Se.LogError($"Chatterbox TTS server error {(int)response.StatusCode} {response.StatusCode} - "
+                var errMsg = $"Chatterbox TTS server error {(int)response.StatusCode} {response.StatusCode} - "
                     + $"Voice: {chatterboxVoice}, Text: {text}, RequestJson: {body}, "
-                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}");
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}";
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
                 throw new InvalidOperationException(
                     $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}"
                     + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}"));
@@ -291,7 +296,7 @@ public class ChatterboxTtsCpp : ITtsEngine
 
     /// <summary>
     /// Renders the server launch as a shell-quotable string (file path + each arg quoted only
-    /// when it contains whitespace). Goes into the error log so failures can be reproduced.
+    /// when it contains whitespace). Goes into the tools log so failures can be reproduced.
     /// </summary>
     private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
     {
@@ -385,10 +390,9 @@ public class ChatterboxTtsCpp : ITtsEngine
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start crispasr (chatterbox)");
 
-            // Record the exact launch command in the error log so failures later in this
-            // session can be reproduced from a shell. Logged via LogError because that's
-            // the only severity exposed by Se; this entry is informational.
-            Se.LogError("Chatterbox TTS server starting - "
+            // Record the exact launch command in the tools log so failures later in this
+            // session can be reproduced from a shell.
+            Se.WriteToolsLog("Chatterbox TTS server starting - "
                 + $"PID: {process.Id}, "
                 + $"Cmd: {FormatLaunchCommand(exe, psi.ArgumentList)}");
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
@@ -110,14 +110,51 @@ public class EdgeTts : ITtsEngine
             args += $" --volume={volume}";
         }
 
+        Se.WriteToolsLog($"EdgeTts: {_cachedExecutableFileName ?? "edge-tts"} {RedactTextArg(args)} (voice={edgeVoice.Name}, textLen={text.Length})");
+
         var (ok, stdOut, stdErr) = await RunEdgeTtsCommand(args, cancellationToken);
         if (!ok || !File.Exists(fileName))
         {
-            Se.LogError($"EdgeTts speak failed. StdOut: {stdOut} StdErr: {stdErr}");
+            var msg = $"EdgeTts speak failed. StdOut: {stdOut} StdErr: {stdErr}";
+            Se.LogError(msg);
+            Se.WriteToolsLog(msg);
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
         return new TtsResult { Text = text, FileName = fileName };
+    }
+
+    // Strip the --text "..." value from the logged command so subtitle content
+    // doesn't end up in tools-log.txt for successful runs (failures still log
+    // full args via Se.LogError).
+    private static string RedactTextArg(string args)
+    {
+        const string marker = "--text \"";
+        var start = args.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            return args;
+        }
+        var contentStart = start + marker.Length;
+        var i = contentStart;
+        while (i < args.Length)
+        {
+            if (args[i] == '\\' && i + 1 < args.Length)
+            {
+                i += 2;
+                continue;
+            }
+            if (args[i] == '"')
+            {
+                break;
+            }
+            i++;
+        }
+        if (i >= args.Length)
+        {
+            return args;
+        }
+        return args.Substring(0, contentStart) + "<text redacted>" + args.Substring(i);
     }
 
     public Task<string[]> GetRegions()

--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -286,10 +286,13 @@ public class ElevenLabs : ITtsEngine
             throw new ArgumentException("ElevenLabs model is empty");
         }
 
+        Se.WriteToolsLog($"ElevenLabs: voice={elevenLabVoice.Voice}, voiceId={elevenLabVoice.VoiceId}, model={model}, textLen={text.Length}");
+
         var ms = new MemoryStream();
         var ok = await _ttsDownloadService.DownloadElevenLabsVoiceSpeak(text, elevenLabVoice, model, Se.Settings.Video.TextToSpeech.ElevenLabsApiKey, "en", ms, null, cancellationToken);
         if (!ok)
         {
+            Se.WriteToolsLog($"ElevenLabs: request failed (voice={elevenLabVoice.Voice})");
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
@@ -148,6 +148,8 @@ public class GoogleSpeech : ITtsEngine
             throw new ArgumentException("Voice is not a GoogleVoice");
         }
 
+        Se.WriteToolsLog($"GoogleSpeech: voice={googleVoice.Name}, languageCode={googleVoice.LanguageCode}, model={model ?? "Standard"}, textLen={text.Length}");
+
         var ms = new MemoryStream();
         var ok = await _ttsDownloadService.DownloadGoogleVoiceSpeak(
             text,
@@ -159,6 +161,7 @@ public class GoogleSpeech : ITtsEngine
 
         if (!ok)
         {
+            Se.WriteToolsLog($"GoogleSpeech: request failed (voice={googleVoice.Name})");
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -200,13 +200,16 @@ public class KokoroTtsCpp : ITtsEngine
 
         var body = JsonSerializer.Serialize(new { text = inputText, voice = voiceName });
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"Kokoro TTS: POST {ServerBaseUrl}/v1/synthesize (voice={voiceName}, textLen={text.Length})");
         using var response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/synthesize", content, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await SafeReadErrorAsync(response, cancellationToken);
-            Se.LogError($"Kokoro TTS server error {(int)response.StatusCode} {response.StatusCode} - "
-                + $"Voice: {voiceName}, Text: {text}, Body: {errorBody}");
+            var errMsg = $"Kokoro TTS server error {(int)response.StatusCode} {response.StatusCode} - "
+                + $"Voice: {voiceName}, Text: {text}, Body: {errorBody}";
+            Se.LogError(errMsg);
+            Se.WriteToolsLog(errMsg);
             throw new InvalidOperationException(
                 $"Kokoro TTS synthesis failed ({(int)response.StatusCode}): {errorBody}");
         }
@@ -285,6 +288,9 @@ public class KokoroTtsCpp : ITtsEngine
 
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start kokoro-tts-server");
+
+            Se.WriteToolsLog($"Kokoro TTS server starting - PID: {process.Id}, "
+                + $"Cmd: {exe} {string.Join(' ', psi.ArgumentList)}");
 
             var stderrBuffer = new StringBuilder();
             process.ErrorDataReceived += (_, e) =>

--- a/src/ui/Features/Video/TextToSpeech/Engines/MistralSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MistralSpeech.cs
@@ -136,17 +136,21 @@ public class MistralSpeech : ITtsEngine
             throw new ArgumentException("Voice is not a MistralVoice");
         }
 
+        var mistralModel = model ?? "voxtral-mini-tts-2603";
+        Se.WriteToolsLog($"MistralSpeech: voice={mistralVoice.Name}, voiceId={mistralVoice.VoiceId}, model={mistralModel}, textLen={text.Length}");
+
         var ms = new MemoryStream();
         var ok = await _ttsDownloadService.DownloadMistralSpeechSpeak(
             text,
             mistralVoice,
-            model ?? "voxtral-mini-tts-2603",
+            mistralModel,
             Se.Settings.Video.TextToSpeech.MistralApiKey,
             ms,
             null,
             cancellationToken);
         if (!ok)
         {
+            Se.WriteToolsLog($"MistralSpeech: request failed (voice={mistralVoice.Name})");
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/Murf.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Murf.cs
@@ -158,6 +158,8 @@ public class Murf : ITtsEngine
             throw new ArgumentException("Voice is not a MurfVoice");
         }
 
+        Se.WriteToolsLog($"Murf: voiceId={murfVoice.VoiceId}, locale={murfVoice.Locale}, style={Se.Settings.Video.TextToSpeech.MurfStyle}, textLen={text.Length}");
+
         var ms = new MemoryStream();
         var ok = await _ttsDownloadService
             .DownloadMurfSpeak(
@@ -169,6 +171,7 @@ public class Murf : ITtsEngine
                 cancellationToken);
         if (!ok)
         {
+            Se.WriteToolsLog($"Murf: request failed (voiceId={murfVoice.VoiceId})");
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -222,6 +222,8 @@ public class OmniVoiceTtsCpp : ITtsEngine
             psi.ArgumentList.Add(refTextPath);
         }
 
+        Se.WriteToolsLog($"OmniVoice TTS: {exe} {string.Join(' ', psi.ArgumentList)} (voice={omniVoice}, textLen={text.Length})");
+
         var process = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start omnivoice-tts");
 
@@ -239,10 +241,12 @@ public class OmniVoiceTtsCpp : ITtsEngine
 
             if (process.ExitCode != 0 || !File.Exists(outputFileName))
             {
-                Se.LogError($"OmniVoice TTS failed (exit code {process.ExitCode}) - "
+                var msg = $"OmniVoice TTS failed (exit code {process.ExitCode}) - "
                     + $"Voice: {omniVoice}, Text: {text}, "
                     + $"Args: {string.Join(' ', psi.ArgumentList)}, "
-                    + $"StdErr: {stderr.Trim()}, StdOut: {stdout.Trim()}");
+                    + $"StdErr: {stderr.Trim()}, StdOut: {stdout.Trim()}";
+                Se.LogError(msg);
+                Se.WriteToolsLog(msg);
                 throw new InvalidOperationException(
                     $"OmniVoice TTS failed (exit code {process.ExitCode}). {stderr.Trim()}");
             }

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -183,19 +183,21 @@ public class Piper : ITtsEngine
 
         var fileNameOnly = Guid.NewGuid() + ".wav";
         var process = StartPiperProcess(piperVoice, text, fileNameOnly);
+        Se.WriteToolsLog($"Piper: {process.StartInfo.FileName} {process.StartInfo.Arguments} (voice={piperVoice}, textLen={text.Length})");
         var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
         await process.WaitForExitAsync(cancellationToken);
         var stderrOutput = await stderrTask;
 
         if (process.ExitCode != 0)
         {
-            Se.LogError($"Piper process exited with code {process.ExitCode} - Parameters: "
+            var msg = $"Piper process exited with code {process.ExitCode} - Parameters: "
                 + $"Voice: {piperVoice}, "
                 + $"Text: {text}, "
                 + $"FileName: {process.StartInfo.FileName}, "
                 + $"Parameters: {process.StartInfo.Arguments}"
-                + (string.IsNullOrWhiteSpace(stderrOutput) ? string.Empty : $", StdErr: {stderrOutput.Trim()}")
-                );
+                + (string.IsNullOrWhiteSpace(stderrOutput) ? string.Empty : $", StdErr: {stderrOutput.Trim()}");
+            Se.LogError(msg);
+            Se.WriteToolsLog(msg);
         }
 
         var fileName = Path.Combine(GetSetPiperFolder(), fileNameOnly);

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -183,6 +183,9 @@ public class Qwen3TtsCpp : ITtsEngine
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
         var inputText = Utilities.UnbreakLine(text);
 
+        var endpoint = string.IsNullOrEmpty(qwen3Voice.FilePath) ? "/v1/synthesize" : "/v1/synthesize_with_voice";
+        Se.WriteToolsLog($"Qwen3 TTS: POST {ServerBaseUrl}{endpoint} (voice={qwen3Voice}, model={modelFileName}, textLen={text.Length})");
+
         using HttpResponseMessage response = string.IsNullOrEmpty(qwen3Voice.FilePath)
             ? await SynthesizeAsync(inputText, cancellationToken)
             : await SynthesizeWithVoiceAsync(inputText, qwen3Voice.FilePath, cancellationToken);
@@ -190,8 +193,10 @@ public class Qwen3TtsCpp : ITtsEngine
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await SafeReadErrorAsync(response, cancellationToken);
-            Se.LogError($"Qwen3 TTS server error {(int)response.StatusCode} {response.StatusCode} - "
-                + $"Voice: {qwen3Voice}, Text: {text}, Body: {errorBody}");
+            var errMsg = $"Qwen3 TTS server error {(int)response.StatusCode} {response.StatusCode} - "
+                + $"Voice: {qwen3Voice}, Text: {text}, Body: {errorBody}";
+            Se.LogError(errMsg);
+            Se.WriteToolsLog(errMsg);
             throw new InvalidOperationException(
                 $"Qwen3 TTS synthesis failed ({(int)response.StatusCode}): {errorBody}");
         }
@@ -297,6 +302,9 @@ public class Qwen3TtsCpp : ITtsEngine
 
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start qwen3-tts-server");
+
+            Se.WriteToolsLog($"Qwen3 TTS server starting - PID: {process.Id}, "
+                + $"Cmd: {exe} {string.Join(' ', psi.ArgumentList)}");
 
             var stderrBuffer = new StringBuilder();
             process.ErrorDataReceived += (_, e) =>


### PR DESCRIPTION
## Summary
- Text-to-speech engines now write per-call command / API summaries to `tools-log.txt`, matching the existing speech-to-text coverage. Previously TTS only logged a single startup line, so debugging engine-level failures (Piper command-line, Chatterbox server crash, etc.) required guessing.
- Local process engines log `exe + args` per `Speak`: Piper, EdgeTts (with `--text` value redacted from the logged args), OmniVoice.
- Local server engines log the server launch command on (re)start, plus a one-liner per `POST /v1/...` request: Chatterbox, Kokoro, Qwen3. Chatterbox's existing server-start entry moves from `error-log.txt` (where it was tagged as `LogError` only because no info-level sink existed) to `tools-log.txt`.
- Cloud API engines log one summary line per call with voice / model / language / region: Azure, Google, Mistral, Murf, ElevenLabs, AllTalk.
- Errors previously sent only to `Se.LogError` are now also mirrored to `Se.WriteToolsLog`, so the tools log is self-contained.
- Subtitle text is not written to the tools log on success (only `textLen=N`). On failure the existing detailed error message (which contains the text) is still logged through both sinks, unchanged from before.
- All logging is gated by the existing `Tools → Write tools log` setting.

## Test plan
- [ ] Toggle `Tools → Write tools log` off, run a TTS job, verify `tools-log.txt` is untouched.
- [ ] Toggle it on, generate speech with Piper and confirm each segment's exe+args appears.
- [ ] Generate speech with EdgeTts and confirm the logged command shows `--text "<text redacted>"`.
- [ ] Start Chatterbox / Kokoro / Qwen3 and confirm a single server-launch entry plus one request line per segment.
- [ ] Trigger a failure path (e.g. wrong API key on Azure) and confirm the error lands in both `error-log.txt` and `tools-log.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)