### PR TITLE
Use selected audio track for waveform Extract audio and Speech-to-text

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2938,7 +2938,8 @@ public partial class MainViewModel :
                 line.StartTime.TotalSeconds,
                 line.Duration.TotalSeconds,
                 false,
-                outputFileName);
+                outputFileName,
+                _audioTrack?.FfIndex ?? -1);
 
             using var process = FfmpegGenerator.GetProcess(arguments, (_, _) => { });
             process.Start();
@@ -5005,7 +5006,7 @@ public partial class MainViewModel :
             return false;
         }
 
-        var resultGetAudioClips = await ShowDialogAsync<GetAudioClipsWindow, GetAudioClipsViewModel>(vm => { vm.Initialize(_videoFileName ?? string.Empty, selectedItems); });
+        var resultGetAudioClips = await ShowDialogAsync<GetAudioClipsWindow, GetAudioClipsViewModel>(vm => { vm.Initialize(_videoFileName ?? string.Empty, selectedItems, _audioTrack?.FfIndex ?? -1); });
 
         if (!resultGetAudioClips.OkPressed || resultGetAudioClips.AudioClips.Count == 0)
         {

--- a/src/ui/Features/Shared/GetAudioClips/GetAudioClipsViewModel.cs
+++ b/src/ui/Features/Shared/GetAudioClips/GetAudioClipsViewModel.cs
@@ -26,6 +26,7 @@ public partial class GetAudioClipsViewModel : ObservableObject
     public bool OkPressed { get; private set; }
 
     private string _videoFileName;
+    private int _audioTrackFfIndex;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private List<SubtitleLineViewModel> _lines;
 
@@ -37,13 +38,15 @@ public partial class GetAudioClipsViewModel : ObservableObject
         Error = string.Empty;
         AudioClips = new List<AudioClip>();
         _videoFileName = string.Empty;
+        _audioTrackFfIndex = -1;
         _lines = new List<SubtitleLineViewModel>();
     }
 
-    public void Initialize(string videoFileName, List<SubtitleLineViewModel> lines)
+    public void Initialize(string videoFileName, List<SubtitleLineViewModel> lines, int audioTrackFfIndex = -1)
     {
         _videoFileName = videoFileName;
         _lines = lines;
+        _audioTrackFfIndex = audioTrackFfIndex;
     }
 
     private void ExtractLines()
@@ -111,7 +114,8 @@ public partial class GetAudioClipsViewModel : ObservableObject
             line.StartTime.TotalSeconds,
             line.Duration.TotalSeconds,
             useCenterChannelOnly,
-            outputFileName);
+            outputFileName,
+            _audioTrackFfIndex);
 
         return FfmpegGenerator.GetProcess(arguments, OutputHandler);
     }

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -1126,13 +1126,22 @@ public class FfmpegGenerator
        double startSeconds,
        double durationSeconds,
        bool useCenterChannelOnly,
-       string outputFileName)
+       string outputFileName,
+       int audioTrackFfIndex = -1)
     {
         var start = $"{startSeconds:0.000}".Replace(",", ".");
         var duration = $"{durationSeconds:0.000}".Replace(",", ".");
 
         // Base parameters
-        var args = $"-y -ss {start} -t {duration} -i \"{videoFileName}\" -vn -ar 16000 -b:a 32k";
+        var args = $"-y -ss {start} -t {duration} -i \"{videoFileName}\"";
+
+        // Select the requested audio stream (e.g. for videos with multiple audio tracks).
+        if (audioTrackFfIndex >= 0)
+        {
+            args += $" -map 0:{audioTrackFfIndex}";
+        }
+
+        args += " -vn -ar 16000 -b:a 32k";
 
         // Optional center-channel only
         if (useCenterChannelOnly)


### PR DESCRIPTION
## Summary
- Multi-audio-track videos: the waveform context-menu commands "Extract audio..." and "Selected lines speech to text" (also reached from the "Speech to text new selection" flow) ignored the user's audio-track selection. They invoked `FfmpegGenerator.ExtractAudioClipFromVideoParameters` which never emitted a `-map`, so ffmpeg's default stream picker chose the audio stream — not the track the user picked in the audio-tracks menu.
- The full-file Whisper path (`SpeechToTextViewModel.GetFfmpegProcess`) already does this correctly with `-map 0:{FfIndex}`; this PR brings the per-line/extract paths in line.
- Thread the active track's `FfIndex` from `MainViewModel` through `GetAudioClipsViewModel` into `ExtractAudioClipFromVideoParameters`, which now adds `-map 0:{FfIndex}` when `>= 0`. The new parameter defaults to `-1`, so single-track files and any other callers keep their previous behavior.

## Test plan
- [ ] Open a video with multiple audio tracks; switch tracks via the audio-tracks menu.
- [ ] Waveform context menu → "Extract audio..." for a single selected line; verify the saved .wav contains audio from the *selected* track (not the default).
- [ ] Waveform context menu → "Selected lines speech to text"; verify transcription matches the selected track.
- [ ] Waveform new-selection context menu → "Speech to text new selection"; verify transcription matches the selected track.
- [ ] Sanity check: with a single-audio-track file (no track explicitly selected), all three flows still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)