### PR TITLE
Fix duplicate waveform generation when reopening a recent video

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -302,6 +302,8 @@ public partial class MainViewModel :
     private DispatcherTimer _positionTimer = new();
     private DispatcherTimer _slowTimer = new();
     private CancellationTokenSource _videoOpenTokenSource;
+    private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Lock _waveformsBeingGeneratedLock = new();
     private VideoPlayerControl? _fullScreenVideoPlayerControl;
     private static SolidColorBrush _transparentBrush = new SolidColorBrush(Colors.Transparent);
     private static SolidColorBrush _errorBrush = new SolidColorBrush(_errorColor);
@@ -1731,7 +1733,7 @@ public partial class MainViewModel :
             }
 
             VideoCloseFile();
-            await SubtitleOpen(recentFile.SubtitleFileName, recentFile.VideoFileName, recentFile.SelectedLine);
+            await SubtitleOpen(recentFile.SubtitleFileName, recentFile.VideoFileName, recentFile.SelectedLine, desiredAudioTrackId: recentFile.AudioTrack);
 
             if (!string.IsNullOrEmpty(recentFile.SubtitleFileNameOriginal) &&
                 File.Exists(recentFile.SubtitleFileNameOriginal))
@@ -10683,7 +10685,8 @@ public partial class MainViewModel :
         string? videoFileName = null,
         int? selectedSubtitleIndex = null,
         TextEncoding? textEncoding = null,
-        bool skipLoadVideo = false)
+        bool skipLoadVideo = false,
+        int desiredAudioTrackId = -1)
     {
         if (string.IsNullOrEmpty(fileName))
         {
@@ -11107,11 +11110,11 @@ public partial class MainViewModel :
             {
                 if (!string.IsNullOrEmpty(videoFileName) && File.Exists(videoFileName))
                 {
-                    await VideoOpenFile(videoFileName);
+                    await VideoOpenFile(videoFileName, desiredAudioTrackId);
                 }
                 else if (FindVideoFileName.TryFindVideoFileName(fileName, out videoFileName))
                 {
-                    await VideoOpenFile(videoFileName);
+                    await VideoOpenFile(videoFileName, desiredAudioTrackId);
                 }
             }
 
@@ -12803,7 +12806,7 @@ public partial class MainViewModel :
                             InitLayout.RestoreLayoutPositions(Se.Settings.Appearance.CurrentLayoutPositions, ContentGrid.Children.FirstOrDefault() as Grid);
                         }
 
-                        await SubtitleOpen(first.SubtitleFileName, first.VideoFileName, first.SelectedLine, null, skipLoadVideo);
+                        await SubtitleOpen(first.SubtitleFileName, first.VideoFileName, first.SelectedLine, null, skipLoadVideo, first.AudioTrack);
                         var vp = GetVideoPlayerControl();
                         if (!string.IsNullOrEmpty(_videoFileName) && SelectedSubtitle != null && vp != null)
                         {
@@ -12950,7 +12953,7 @@ public partial class MainViewModel :
                && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
     }
 
-    private async Task VideoOpenFile(string videoFileName) // OpenVideoFile
+    private async Task VideoOpenFile(string videoFileName, int desiredAudioTrackId = -1) // OpenVideoFile
     {
         var vp = GetVideoPlayerControl();
         if (vp == null)
@@ -12974,6 +12977,26 @@ public partial class MainViewModel :
 
         IsVideoLoaded = true;
 
+        // Resolve _audioTrack before LoadWaveformAndSpectrogram so it sees the right FfIndex (and we don't race LoadAudioTrackMenuItems).
+        if (vp.VideoPlayer is LibMpvDynamicPlayer mpv)
+        {
+            var tracks = mpv.GetAudioTracks();
+            if (tracks.Count > 0)
+            {
+                var chosen = desiredAudioTrackId >= 0
+                    ? tracks.FirstOrDefault(t => t.Id == desiredAudioTrackId)
+                    : null;
+                chosen ??= tracks.FirstOrDefault(t => t.IsSelected) ?? tracks[0];
+
+                if (desiredAudioTrackId >= 0 && chosen.Id != -1)
+                {
+                    mpv.SetAudioTrack(chosen.Id);
+                }
+
+                _audioTrack = chosen;
+            }
+        }
+
         var _ = Task.Run(() =>
         {
             Dispatcher.UIThread.Post(() => LoadWaveformAndSpectrogram(videoFileName));
@@ -12991,6 +13014,14 @@ public partial class MainViewModel :
         {
             if (FfmpegHelper.IsFfmpegInstalled())
             {
+                lock (_waveformsBeingGeneratedLock)
+                {
+                    if (!_waveformsBeingGenerated.Add(peakWaveFileName))
+                    {
+                        return; // already generating for this peak-wave file
+                    }
+                }
+
                 var tempWaveFileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.wav");
                 var process = WaveFileExtractor.GetCommandLineProcess(videoFileName, trackNumber, tempWaveFileName,
                     Configuration.Settings.General.VlcWaveTranscodeSettings, out _);
@@ -13308,6 +13339,10 @@ public partial class MainViewModel :
             IsWaveformGenerating = false;
             WaveformGeneratingText = string.Empty;
             DeleteTempFile(tempWaveFileName);
+            lock (_waveformsBeingGeneratedLock)
+            {
+                _waveformsBeingGenerated.Remove(peakWaveFileName);
+            }
         }
     }
 

--- a/src/ui/Logic/Media/WaveToVisualizer2.cs
+++ b/src/ui/Logic/Media/WaveToVisualizer2.cs
@@ -481,12 +481,21 @@ public class WavePeakGenerator2 : IDisposable
 
         var hash = MovieHasher.GenerateHash(videoFileName);
 
-        var files = Directory.GetFiles(dir, $"{hash}_*.wav")
-            .OrderBy(p => p)
-            .ToList();
-        if (files.Count > 0 && trackNumber < 0)
+        if (trackNumber < 0)
         {
-            return files[0];
+            var bare = Path.Combine(dir, $"{hash}.wav");
+            if (File.Exists(bare))
+            {
+                return bare;
+            }
+
+            var files = Directory.GetFiles(dir, $"{hash}-*.wav")
+                .OrderBy(p => p)
+                .ToList();
+            if (files.Count > 0)
+            {
+                return files[0];
+            }
         }
 
         var wavePeakName = trackNumber >= 0 ? $"{hash}-{trackNumber}.wav" : $"{hash}.wav";


### PR DESCRIPTION
## Summary
- Reopening a recent file with a non-default audio track triggered two concurrent ffmpeg waveform-extraction passes — once for the default track (because `_audioTrack` was still null) and again for the actual track after `SetRecentFileProperties` ran `PickAudioTrack`. `VideoOpenFile` / `SubtitleOpen` now accept an optional `desiredAudioTrackId` and resolve `_audioTrack` synchronously before `LoadWaveformAndSpectrogram` is posted, so reopen sites pass `recentFile.AudioTrack` through and get a single correct generation.
- Added a small in-flight guard (a `HashSet<string>` keyed by the peak-wave file name, released in `ExtractWaveformAndSpectrogramAndShotChanges`'s `finally`) so duplicate concurrent calls for the same file become no-ops, removing the residual `LoadAudioTrackMenuItems` race.
- `WavePeakGenerator2.GetPeakWaveFileName` cache fallback searched `{hash}_*.wav` (underscore) but files are saved as `{hash}-N.wav` (dash), so track-specific cached peaks were invisible when no track was specified and got regenerated. Now checks `{hash}.wav` first and falls back to the correct `{hash}-*.wav` glob.

## Test plan
- [ ] Open a multi-audio-track video, pick a non-default track, close, reopen via *Recent files* — confirm only one waveform-generation pass runs (status bar / ffmpeg).
- [ ] Open the same video again (cached) — confirm the existing peak-wave file is found and no regeneration happens.
- [ ] Open a recent video at startup (`RememberPositionAndSize` on) and verify the saved audio track is selected and a single waveform pass runs.
- [ ] Switch audio tracks manually via the waveform context menu and confirm waveform regenerates exactly once for the new track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)