### PR TITLE
Fix right-click on video file name label on macOS

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -476,9 +476,9 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             {
                 VerticalAlignment = VerticalAlignment.Top,
                 HorizontalAlignment = HorizontalAlignment.Right,
-                FontSize = 8,
+                FontSize = 9,
                 FontWeight = FontWeight.Bold,
-                Opacity = 0.4,
+                Opacity = 0.6,
             };
             _gridProgress.Children.Add(_textBlockPlayerName);
             Grid.SetColumn(_textBlockPlayerName, 3);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16313,11 +16313,23 @@ public partial class MainViewModel :
     internal void VideoPlayerControlPointerPressed(PointerPressedEventArgs args)
     {
         var mediaInfo = _mediaInfo;
-        if (mediaInfo == null || Window == null || args.Properties.IsLeftButtonPressed)
+        if (mediaInfo == null || Window == null)
         {
             return;
         }
 
+        var props = args.GetCurrentPoint(null).Properties;
+        var isMacCtrlLeftClick = OperatingSystem.IsMacOS()
+                                 && props.IsLeftButtonPressed
+                                 && args.KeyModifiers.HasFlag(KeyModifiers.Control)
+                                 && !args.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+        if (!props.IsRightButtonPressed && !isMacCtrlLeftClick)
+        {
+            return;
+        }
+
+        args.Handled = true;
         ShowMediaInformation();
     }
 


### PR DESCRIPTION
## Summary
- The label below the video player opens the media-info dialog on right-click, but `VideoPlayerControlPointerPressed` short-circuited on `IsLeftButtonPressed`. On macOS a right-click via the trackpad is delivered as Ctrl+LeftClick, so the click was always treated as a left-click and the dialog never opened.
- Match the pattern used by `ComboBoxSubtitleFormatPointerPressed`: treat `IsRightButtonPressed` *or* a macOS Ctrl+LeftClick (without Shift) as a right-click, then mark the event handled.
- Drive-by: bump the small player-name overlay's font size from 8 → 9 and opacity from 0.4 → 0.6 to match the file-name label.

## Test plan
- [ ] On macOS, right-click (two-finger tap / Ctrl+Click) the file-name label below the video — Media info dialog opens.
- [ ] On macOS, left-click the label — nothing happens.
- [ ] On Windows/Linux, right-click the label still opens Media info; left-click does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)