### PR TITLE
Move OpenAI Compatible STT settings to STT window

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -504,6 +504,7 @@ public class SettingsPage : UserControl
             new SettingsItem(Se.Language.Options.Settings.WaveformParagraphLeftColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformParagraphLeftColor))),
             new SettingsItem(Se.Language.Options.Settings.WaveformParagraphRightColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformParagraphRightColor))),
             new SettingsItem(Se.Language.Options.Settings.WaveformFancyHighColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformFancyHighColor))),
+            MakeCheckboxSetting(Se.Language.General.OpenAiCompatibleSttAutoTranscribeOnAudioSelection, nameof(_vm.OpenAiCompatibleSttAutoTranscribeOnAudioSelection)),
             new SettingsItem(Se.Language.Options.Settings.DownloadFfmpeg, () => new StackPanel
             {
                 Children =
@@ -582,72 +583,6 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.SpeechToTextSelectedLinesPromptFirstTimeOnly, nameof(_vm.SpeechToTextSelectedLinesPromptFistTimeOnly)),
             MakeCheckboxSetting(Se.Language.Options.Settings.MultipleReplaceShowDotDotDotButtons, nameof(_vm.MultipleReplaceShowDotDotDotButtons)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
-
-            // OpenAI Compatible STT settings
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttEndpoint, () => new TextBox
-            {
-                DataContext = _vm,
-                Width = 400,
-                [!TextBox.TextProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttUrl)) { Mode = BindingMode.TwoWay }
-            }),
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttApiKey, () => new TextBox
-            {
-                DataContext = _vm,
-                Width = 400,
-                PasswordChar = '*',
-                [!TextBox.TextProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttApiKey)) { Mode = BindingMode.TwoWay }
-            }),
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttModel, () => new TextBox
-            {
-                DataContext = _vm,
-                Width = 250,
-                [!TextBox.TextProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttModel)) { Mode = BindingMode.TwoWay }
-            }),
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttLanguage, () => new TextBox
-            {
-                DataContext = _vm,
-                Width = 150,
-                [!TextBox.TextProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttLanguage)) { Mode = BindingMode.TwoWay }
-            }),
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttTimeout, () => new NumericUpDown
-            {
-                DataContext = _vm,
-                Width = 100,
-                Minimum = 10,
-                Maximum = 3600,
-                [!NumericUpDown.ValueProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttTimeoutSeconds)) { Mode = BindingMode.TwoWay }
-            }),
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttTemperature, () => new NumericUpDown
-            {
-                DataContext = _vm,
-                Width = 100,
-                Minimum = 0,
-                Maximum = 1,
-                Increment = 0.1m,
-                FormatString = "F2",
-                [!NumericUpDown.ValueProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttTemperature)) { Mode = BindingMode.TwoWay }
-            }),
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttPrompt, () => new TextBox
-            {
-                DataContext = _vm,
-                Width = 400,
-                [!TextBox.TextProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttPrompt)) { Mode = BindingMode.TwoWay }
-            }),
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttExtraHeaders, () => new TextBox
-            {
-                DataContext = _vm,
-                Width = 400,
-                Height = 80,
-                AcceptsReturn = true,
-                TextWrapping = TextWrapping.Wrap,
-                [!TextBox.TextProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttExtraHeaders)) { Mode = BindingMode.TwoWay }
-            }),
-            new SettingsItem(Se.Language.General.OpenAiCompatibleSttAutoTranscribeOnAudioSelection, () => new CheckBox
-            {
-                DataContext = _vm,
-                VerticalAlignment = VerticalAlignment.Center,
-                [!CheckBox.IsCheckedProperty] = new Binding(nameof(_vm.OpenAiCompatibleSttAutoTranscribeOnAudioSelection)) { Mode = BindingMode.TwoWay }
-            }),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.Appearance,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -124,16 +124,6 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _speechToTextSelectedLinesPromptFistTimeOnly;
     [ObservableProperty] private bool _multipleReplaceShowDotDotDotButtons;
     [ObservableProperty] private bool _gridFocusTextboxAfterInsertNew;
-
-    // OpenAI Compatible STT settings
-    [ObservableProperty] private string? _openAiCompatibleSttUrl;
-    [ObservableProperty] private string? _openAiCompatibleSttApiKey;
-    [ObservableProperty] private string? _openAiCompatibleSttModel;
-    [ObservableProperty] private string? _openAiCompatibleSttExtraHeaders;
-    [ObservableProperty] private int _openAiCompatibleSttTimeoutSeconds;
-    [ObservableProperty] private string? _openAiCompatibleSttLanguage;
-    [ObservableProperty] private decimal _openAiCompatibleSttTemperature;
-    [ObservableProperty] private string? _openAiCompatibleSttPrompt;
     [ObservableProperty] private bool _openAiCompatibleSttAutoTranscribeOnAudioSelection;
 
     [ObservableProperty] private ObservableCollection<string> _spellCheckEngines;
@@ -631,16 +621,6 @@ public partial class SettingsViewModel : ObservableObject
         SpeechToTextSelectedLinesPromptFistTimeOnly = Se.Settings.Tools.SpeechToTextSelectedLinesPromptFirstTimeOnly;
         MultipleReplaceShowDotDotDotButtons = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
         GridFocusTextboxAfterInsertNew = Se.Settings.Tools.GridFocusTextboxAfterInsertNew;
-
-        // OpenAI Compatible STT settings
-        OpenAiCompatibleSttUrl = Se.Settings.Tools.OpenAiCompatibleSttUrl;
-        OpenAiCompatibleSttApiKey = Se.Settings.Tools.OpenAiCompatibleSttApiKey;
-        OpenAiCompatibleSttModel = Se.Settings.Tools.OpenAiCompatibleSttModel;
-        OpenAiCompatibleSttExtraHeaders = Se.Settings.Tools.OpenAiCompatibleSttExtraHeaders;
-        OpenAiCompatibleSttTimeoutSeconds = Se.Settings.Tools.OpenAiCompatibleSttTimeoutSeconds;
-        OpenAiCompatibleSttLanguage = Se.Settings.Tools.OpenAiCompatibleSttLanguage;
-        OpenAiCompatibleSttTemperature = Se.Settings.Tools.OpenAiCompatibleSttTemperature;
-        OpenAiCompatibleSttPrompt = Se.Settings.Tools.OpenAiCompatibleSttPrompt;
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 
         SelectedTheme = MapThemeToTranslation(appearance.Theme);
@@ -1236,15 +1216,6 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons = MultipleReplaceShowDotDotDotButtons;
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;
         Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
-        // OpenAI Compatible STT settings
-        Se.Settings.Tools.OpenAiCompatibleSttUrl = OpenAiCompatibleSttUrl;
-        Se.Settings.Tools.OpenAiCompatibleSttApiKey = OpenAiCompatibleSttApiKey;
-        Se.Settings.Tools.OpenAiCompatibleSttModel = OpenAiCompatibleSttModel;
-        Se.Settings.Tools.OpenAiCompatibleSttExtraHeaders = OpenAiCompatibleSttExtraHeaders;
-        Se.Settings.Tools.OpenAiCompatibleSttTimeoutSeconds = OpenAiCompatibleSttTimeoutSeconds;
-        Se.Settings.Tools.OpenAiCompatibleSttLanguage = OpenAiCompatibleSttLanguage;
-        Se.Settings.Tools.OpenAiCompatibleSttTemperature = OpenAiCompatibleSttTemperature;
-        Se.Settings.Tools.OpenAiCompatibleSttPrompt = OpenAiCompatibleSttPrompt;
         Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 
         appearance.Theme = MapThemeFromTranslation(SelectedTheme);

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -7,7 +7,6 @@ using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
-using Nikse.SubtitleEdit.Features.Options.Settings;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.GetAudioClips;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
@@ -84,6 +83,17 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private string _estimatedText;
     [ObservableProperty] private bool _isReDownloadVisible;
     [ObservableProperty] private string _reDownloadText;
+
+    [ObservableProperty] private bool _isOpenAiCompatibleSttVisible;
+    [ObservableProperty] private bool _isAdvancedSettingsVisible = true;
+    [ObservableProperty] private string? _openAiCompatibleSttUrl;
+    [ObservableProperty] private string? _openAiCompatibleSttApiKey;
+    [ObservableProperty] private string? _openAiCompatibleSttModel;
+    [ObservableProperty] private string? _openAiCompatibleSttLanguage;
+    [ObservableProperty] private int _openAiCompatibleSttTimeoutSeconds;
+    [ObservableProperty] private decimal _openAiCompatibleSttTemperature;
+    [ObservableProperty] private string? _openAiCompatibleSttPrompt;
+    [ObservableProperty] private string? _openAiCompatibleSttExtraHeaders;
 
     public Window? Window { get; set; }
 
@@ -224,6 +234,15 @@ public partial class SpeechToTextViewModel : ObservableObject
         DoAdjustTimings = Se.Settings.Tools.AudioToText.WhisperAutoAdjustTimings;
         DoPostProcessing = Se.Settings.Tools.AudioToText.PostProcessing;
 
+        OpenAiCompatibleSttUrl = Se.Settings.Tools.OpenAiCompatibleSttUrl;
+        OpenAiCompatibleSttApiKey = Se.Settings.Tools.OpenAiCompatibleSttApiKey;
+        OpenAiCompatibleSttModel = Se.Settings.Tools.OpenAiCompatibleSttModel;
+        OpenAiCompatibleSttLanguage = Se.Settings.Tools.OpenAiCompatibleSttLanguage;
+        OpenAiCompatibleSttTimeoutSeconds = Se.Settings.Tools.OpenAiCompatibleSttTimeoutSeconds;
+        OpenAiCompatibleSttTemperature = Se.Settings.Tools.OpenAiCompatibleSttTemperature;
+        OpenAiCompatibleSttPrompt = Se.Settings.Tools.OpenAiCompatibleSttPrompt;
+        OpenAiCompatibleSttExtraHeaders = Se.Settings.Tools.OpenAiCompatibleSttExtraHeaders;
+
         var savedChoice = Se.Settings.Tools.AudioToText.WhisperChoice;
         var whisperCppEngine = Engines.OfType<WhisperCppEngine>().FirstOrDefault();
         var crispAsrEngine = Engines.OfType<CrispAsrEngine>().FirstOrDefault();
@@ -259,6 +278,15 @@ public partial class SpeechToTextViewModel : ObservableObject
         Se.Settings.Tools.AudioToText.WhisperModel = SelectedModel?.Model.Name ?? string.Empty;
         Se.Settings.Tools.AudioToText.WhisperLanguageCode = SelectedLanguage?.Code ?? string.Empty;
         Se.Settings.Tools.AudioToText.CrispAsrForcedAligner = SelectedForcedAligner?.Choice ?? ForcedAlignerOption.BuiltInChoice;
+
+        Se.Settings.Tools.OpenAiCompatibleSttUrl = OpenAiCompatibleSttUrl ?? string.Empty;
+        Se.Settings.Tools.OpenAiCompatibleSttApiKey = OpenAiCompatibleSttApiKey ?? string.Empty;
+        Se.Settings.Tools.OpenAiCompatibleSttModel = OpenAiCompatibleSttModel ?? string.Empty;
+        Se.Settings.Tools.OpenAiCompatibleSttLanguage = OpenAiCompatibleSttLanguage ?? string.Empty;
+        Se.Settings.Tools.OpenAiCompatibleSttTimeoutSeconds = OpenAiCompatibleSttTimeoutSeconds;
+        Se.Settings.Tools.OpenAiCompatibleSttTemperature = OpenAiCompatibleSttTemperature;
+        Se.Settings.Tools.OpenAiCompatibleSttPrompt = OpenAiCompatibleSttPrompt ?? string.Empty;
+        Se.Settings.Tools.OpenAiCompatibleSttExtraHeaders = OpenAiCompatibleSttExtraHeaders ?? string.Empty;
 
         Se.SaveSettings();
     }
@@ -862,16 +890,42 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
     }
 
+    private static async Task<string?> ProbeOpenAiUrlAsync(string url, CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return $"Invalid URL: '{url}'";
+        }
+
+        try
+        {
+            using var probeClient = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
+            var baseUri = new Uri(uri.GetLeftPart(UriPartial.Authority));
+            using var request = new HttpRequestMessage(HttpMethod.Head, baseUri);
+            using var response = await probeClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
     private async Task ProcessOpenAiCompatibleTranscription(string audioFileName, string? language = null, CancellationToken cancellationToken = default)
     {
+        SaveSettings();
         var openAiSettings = OpenAiSttService.GetSettingsFromConfiguration();
 
-        if (!OpenAiSttService.IsConfigured())
+        if (string.IsNullOrWhiteSpace(openAiSettings.EndpointUrl))
         {
-            await Dispatcher.UIThread.InvokeAsync(() =>
+            await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                _ = MessageBox.Show(Window!,
-                    Se.Language.General.PleaseConfigureOpenAiStt,
+                await MessageBox.Show(Window!,
+                    Se.Language.General.OpenAiCompatibleSttUrlMissing,
                     Se.Language.General.ConfigurationRequired);
                 IsTranscribeEnabled = true;
             });
@@ -879,6 +933,27 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         ProgressText = Se.Language.Video.AudioToText.Transcribing;
+        ProgressValue = 5;
+
+        var probeError = await ProbeOpenAiUrlAsync(openAiSettings.EndpointUrl, cancellationToken);
+        if (probeError != null)
+        {
+            LogToConsole($"OpenAI Compatible STT endpoint probe failed: {probeError}. Retrying...");
+            probeError = await ProbeOpenAiUrlAsync(openAiSettings.EndpointUrl, cancellationToken);
+        }
+
+        if (probeError != null)
+        {
+            await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                await MessageBox.Show(Window!,
+                    string.Format(Se.Language.General.OpenAiCompatibleSttUrlNotResponding, probeError),
+                    Se.Language.General.TranscriptionError);
+                IsTranscribeEnabled = true;
+            });
+            return;
+        }
+
         ProgressValue = 10;
 
         var subtitle = new Subtitle();
@@ -1930,12 +2005,6 @@ public partial class SpeechToTextViewModel : ObservableObject
     [RelayCommand]
     private async Task ShowAdvancedSettings()
     {
-        if (GetEffectiveSelectedEngine() is OpenAiCompatibleSttEngine)
-        {
-            await _windowService.ShowDialogAsync<SettingsWindow, SettingsViewModel>(Window!);
-            return;
-        }
-
         var vm = await _windowService.ShowDialogAsync<SpeechToTextAdvancedWindow, SpeechToTextAdvancedViewModel>(Window!,
             viewModal =>
             {
@@ -3276,6 +3345,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             SelectedLanguage = null;
         }
+
+        IsOpenAiCompatibleSttVisible = engine is OpenAiCompatibleSttEngine;
+        IsAdvancedSettingsVisible = !IsOpenAiCompatibleSttVisible;
 
         IsTranslateVisible = IsTranslateAvailable(engine);
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -153,11 +153,15 @@ public class SpeechToTextWindow : Window
             }
         };
 
-        var labelAdvancedSettings = UiUtil.MakeTextBlock(Se.Language.General.AdvancedSettings).WithMarginTop(15);
+        var openAiRows = MakeOpenAiCompatibleSttRows(vm);
+
+        var labelAdvancedSettings = UiUtil.MakeTextBlock(Se.Language.General.AdvancedSettings).WithMarginTop(15)
+            .BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible));
 
         var buttonAdvancedSettings = UiUtil.MakeButton(vm.ShowAdvancedSettingsCommand, IconNames.Settings)
                     .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
-                    .WithMarginTop(15);
+                    .WithMarginTop(15)
+                    .BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible));
 
         var textBoxAdvancedSettings = new TextBox()
         {
@@ -169,7 +173,7 @@ public class SpeechToTextWindow : Window
             Opacity = 0.6,
             BorderThickness = new Thickness(0),
             MaxWidth = 320,
-        };
+        }.BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible));
         textBoxAdvancedSettings.Bind(TextBox.TextProperty, new Binding
         {
             Path = nameof(vm.Parameters),
@@ -324,6 +328,14 @@ public class SpeechToTextWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Forced aligner
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Language
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Model
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // OpenAI STT - Endpoint URL
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // OpenAI STT - API Key
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // OpenAI STT - Model
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // OpenAI STT - Language
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // OpenAI STT - Timeout
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // OpenAI STT - Temperature
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // OpenAI STT - Prompt
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // OpenAI STT - Extra Headers
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Translate to English
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Post processing
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Advanced settings
@@ -375,8 +387,8 @@ public class SpeechToTextWindow : Window
         grid.Add(labelConsoleLog, row, 2);
         row++;
 
-        grid.Add(consoleLogAndBatchView, row, 2, 9);
-        grid.Add(consoleLogOnlyView, row, 2, 9);
+        grid.Add(consoleLogAndBatchView, row, 2, 17);
+        grid.Add(consoleLogOnlyView, row, 2, 17);
         row++;
 
         grid.Add(labelEngine, row, 0);
@@ -399,6 +411,13 @@ public class SpeechToTextWindow : Window
         grid.Add(labelModel, row, 0);
         grid.Add(panelModelControls, row, 1);
         row++;
+
+        foreach (var (label, control) in openAiRows)
+        {
+            grid.Add(label, row, 0);
+            grid.Add(control, row, 1);
+            row++;
+        }
 
         grid.Add(labelTranslateToEnglish, row, 0);
         grid.Add(checkTranslateToEnglish, row, 1);
@@ -580,5 +599,81 @@ public class SpeechToTextWindow : Window
         vm.TextBoxConsoleLog = textBoxConsoleLog;
 
         return textBoxConsoleLog;
+    }
+
+    private static (Control Label, Control Control)[] MakeOpenAiCompatibleSttRows(SpeechToTextViewModel vm)
+    {
+        Control MakeLabel(string text) => UiUtil.MakeTextBlock(text).WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsOpenAiCompatibleSttVisible));
+
+        TextBox MakeText(string property, double width, bool isPassword = false)
+        {
+            var tb = new TextBox
+            {
+                DataContext = vm,
+                Width = width,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 10, 0, 0),
+                [!TextBox.TextProperty] = new Binding(property) { Mode = BindingMode.TwoWay }
+            };
+            if (isPassword)
+            {
+                tb.PasswordChar = '*';
+            }
+            return tb.BindIsVisible(vm, nameof(vm.IsOpenAiCompatibleSttVisible));
+        }
+
+        var numericTimeout = new NumericUpDown
+        {
+            DataContext = vm,
+            Width = 120,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            Minimum = 10,
+            Maximum = 3600,
+            FormatString = "F0",
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.OpenAiCompatibleSttTimeoutSeconds)) { Mode = BindingMode.TwoWay }
+        }.BindIsVisible(vm, nameof(vm.IsOpenAiCompatibleSttVisible));
+
+        var numericTemperature = new NumericUpDown
+        {
+            DataContext = vm,
+            Width = 120,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            Minimum = 0,
+            Maximum = 1,
+            Increment = 0.1m,
+            FormatString = "F2",
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.OpenAiCompatibleSttTemperature)) { Mode = BindingMode.TwoWay }
+        }.BindIsVisible(vm, nameof(vm.IsOpenAiCompatibleSttVisible));
+
+        var textExtraHeaders = new TextBox
+        {
+            DataContext = vm,
+            Width = 400,
+            Height = 60,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.OpenAiCompatibleSttExtraHeaders)) { Mode = BindingMode.TwoWay }
+        }.BindIsVisible(vm, nameof(vm.IsOpenAiCompatibleSttVisible));
+
+        return new (Control, Control)[]
+        {
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttEndpoint), MakeText(nameof(vm.OpenAiCompatibleSttUrl), 400)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttApiKey), MakeText(nameof(vm.OpenAiCompatibleSttApiKey), 400, isPassword: true)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttModel), MakeText(nameof(vm.OpenAiCompatibleSttModel), 250)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttLanguage), MakeText(nameof(vm.OpenAiCompatibleSttLanguage), 150)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttTimeout), numericTimeout),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttTemperature), numericTemperature),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttPrompt), MakeText(nameof(vm.OpenAiCompatibleSttPrompt), 400)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttExtraHeaders), textExtraHeaders),
+        };
     }
 }

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -692,6 +692,8 @@ public class LanguageGeneral
     public string NoSelection { get; set; }
     public string PleaseSelectSubtitleLinesAndVideo { get; set; }
     public string OpenAiCompatibleSttNotConfigured { get; set; }
+    public string OpenAiCompatibleSttUrlMissing { get; set; }
+    public string OpenAiCompatibleSttUrlNotResponding { get; set; }
     public string TranscriptionFailed { get; set; }
 
     public LanguageGeneral()
@@ -1371,7 +1373,7 @@ public class LanguageGeneral
         OpenAiCompatibleSttLanguage = "Language Hint";
         OpenAiCompatibleSttTemperature = "Temperature";
         OpenAiCompatibleSttPrompt = "Prompt";
-        OpenAiCompatibleSttAutoTranscribeOnAudioSelection = "Auto transcribe on audio selection";
+        OpenAiCompatibleSttAutoTranscribeOnAudioSelection = "Auto-transcribe new waveform selection via speech-to-text";
         ConfigurationRequired = "Configuration Required";
         PleaseConfigureOpenAiStt = "Please configure OpenAI Compatible STT settings first.";
         TranscriptionError = "Transcription Error";
@@ -1384,6 +1386,8 @@ public class LanguageGeneral
         NoSelection = "No Selection";
         PleaseSelectSubtitleLinesAndVideo = "Please select subtitle lines and ensure a video file is loaded.";
         OpenAiCompatibleSttNotConfigured = "OpenAI Compatible STT is not configured.\n\nWould you like to configure it now?";
+        OpenAiCompatibleSttUrlMissing = "OpenAI Compatible STT endpoint URL is required. Please enter a URL and try again.";
+        OpenAiCompatibleSttUrlNotResponding = "The OpenAI Compatible STT endpoint did not respond:\n{0}\n\nPlease verify the URL and that the server is running.";
         TranscriptionFailed = "Transcription failed";
     }
 }


### PR DESCRIPTION
- Show STT endpoint, API key, model, language hint, timeout, temperature, prompt, and extra-header fields inline when the OpenAI Compatible engine is selected; settings panel no longer carries the per-engine config.
- Hide Advanced Settings row when the OpenAI Compatible engine is selected.
- Keep "Auto-transcribe waveform selection via OpenAI Compatible STT" in Options under Waveform & Spectrogram.
- Probe the configured URL before transcribing (with one retry); on failure show a clear error pointing at the URL.
- Reject empty URLs with a dedicated message.