### PR TITLE
Show prompt text box for Mistral in translate settings

### DIFF
--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -57,6 +57,7 @@ public partial class TranslateSettingsViewModel : ObservableObject
             engineType == typeof(GroqTranslate) ||
             engineType == typeof(OpenRouterTranslate) ||
             engineType == typeof(NvidiaTranslate) ||
+            engineType == typeof(MistralTranslate) ||
             engineType == typeof(LlamaCppTranslate))
         {
             if (!PromptText.Contains("{0}") || !PromptText.Contains("{1}"))
@@ -128,6 +129,10 @@ public partial class TranslateSettingsViewModel : ObservableObject
             else if (engineType == typeof(NvidiaTranslate))
             {
                 Se.Settings.Tools.NvidiaPrompt = PromptText;
+            }
+            else if (engineType == typeof(MistralTranslate))
+            {
+                Se.Settings.AutoTranslate.MistralPrompt = PromptText;
             }
             else if (engineType == typeof(LlamaCppTranslate))
             {
@@ -221,6 +226,14 @@ public partial class TranslateSettingsViewModel : ObservableObject
             if (string.IsNullOrWhiteSpace(PromptText))
             {
                 PromptText = new SeAutoTranslate().NvidiaPrompt;
+            }
+        }
+        else if (engineType == typeof(MistralTranslate))
+        {
+            PromptText = Se.Settings.AutoTranslate.MistralPrompt;
+            if (string.IsNullOrWhiteSpace(PromptText))
+            {
+                PromptText = new SeAutoTranslate().MistralPrompt;
             }
         }
         else if (engineType == typeof(LlamaCppTranslate))


### PR DESCRIPTION
## Summary
- `TranslateSettingsViewModel` was missing `MistralTranslate` in the engine-type checks, so the prompt text box was hidden and the prompt could not be edited/saved when configuring Mistral.
- Added Mistral to the prompt validation block in `Ok()`, to `LoadValues()` (using `Se.Settings.AutoTranslate.MistralPrompt` with the `SeAutoTranslate` default as fallback), and to `SaveValues()`.

Fixes #10885

## Test plan
- [x] Open Auto-translate, pick Mistral, open the engine settings dialog — the prompt text box is visible and prefilled with the current/default prompt.
- [x] Edit the prompt and click OK — value persists across reopening the dialog.
- [x] Confirm `{0}`/`{1}` validation triggers if the prompt is missing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)