### PR TITLE
Hide extend-to-line items in subtitle grid header context menu

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14353,6 +14353,8 @@ public partial class MainViewModel :
             IsSubtitleGridDataMenuVisible = false;
             IsMergeWithNextOrPreviousVisible = false;
             IsInsertLineNoSelectionVisible = false;
+            MenuItemExtendToLineBefore.IsVisible = false;
+            MenuItemExtendToLineAfter.IsVisible = false;
         }
         else if (Subtitles.Count == 0)
         {


### PR DESCRIPTION
## Summary
- In `SubtitleContextOpening`, the `MenuItemExtendToLineBefore`/`MenuItemExtendToLineAfter` visibility was set unconditionally, before the `IsSubtitleGridFlyoutHeaderVisible` branch ran. This left the two "Extend to line before/after" items visible when right-clicking the grid header, where they are out of context.
- Now hidden in the header branch alongside the other row-only menu items.

Fixes #10879

## Test plan
- [ ] Right-click the subtitle grid header — Extend to line before/after items are no longer present.
- [ ] Right-click a single subtitle row — the items are still shown (subject to the existing index/count checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)