### PR TITLE
Open media info window faster and make shortcut work in fullscreen

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8594,12 +8594,30 @@ public partial class MainViewModel :
         _fullScreenVideoPlayerControl.IsFullScreen = true;
         var toggleKeys = Se.Settings.Shortcuts
             .FirstOrDefault(s => s.ActionName == nameof(VideoFullScreenCommand))?.Keys;
+        var showMediaInfoKeys = Se.Settings.Shortcuts
+            .FirstOrDefault(s => s.ActionName == nameof(ShowMediaInformationCommand))?.Keys;
+        Action<Window> showMediaInformationOwnedBy = ownerWindow =>
+        {
+            var mediaInfo = _mediaInfo;
+            var fileName = _videoFileName ?? string.Empty;
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return;
+            }
+
+            Dispatcher.UIThread.Post(async void () =>
+            {
+                await _windowService.ShowDialogAsync<MediaInfoViewWindow, MediaInfoViewViewModel>(
+                    ownerWindow,
+                    vm => vm.Initialize(fileName, mediaInfo));
+            });
+        };
         var fullScreenWindow = new FullScreenVideoWindow(_fullScreenVideoPlayerControl, _videoFileName, _subtitleFileName ?? string.Empty, position, volume, () =>
         {
             control!.Position = _fullScreenVideoPlayerControl.Position;
             control!.Volume = _fullScreenVideoPlayerControl.Volume;
             _fullScreenVideoPlayerControl = null;
-        }, toggleKeys);
+        }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy);
         fullScreenWindow.Show(Window!);
         _shortcutManager.ClearKeys();
 
@@ -16760,12 +16778,12 @@ public partial class MainViewModel :
     [RelayCommand]
     private void ShowMediaInformation()
     {
-        var mediaInfo = _mediaInfo;
-        if (mediaInfo == null || Window == null)
+        if (Window == null || string.IsNullOrEmpty(_videoFileName))
         {
             return;
         }
 
+        var mediaInfo = _mediaInfo;
         Dispatcher.UIThread.Post(async void () =>
         {
             var result = await ShowDialogAsync<MediaInfoViewWindow, MediaInfoViewViewModel>(vm => { vm.Initialize(_videoFileName ?? string.Empty, mediaInfo); });

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -24,7 +24,9 @@ public class FullScreenVideoWindow : Window
         double position,
         double volume,
         Action onClose,
-        List<string>? toggleShortcutKeys = null)
+        List<string>? toggleShortcutKeys = null,
+        List<string>? showMediaInformationKeys = null,
+        Action<Window>? showMediaInformation = null)
     {
         WindowState = WindowState.FullScreen;
         WindowDecorations = WindowDecorations.None;
@@ -48,6 +50,18 @@ public class FullScreenVideoWindow : Window
                 toggleShortcutKeys,
                 ShortcutCategory.General,
                 new RelayCommand(Close)));
+        }
+
+        // Handle the Show-Media-Information shortcut locally so the dialog can be
+        // opened with the fullscreen window as owner (otherwise it would appear
+        // behind the fullscreen window which has the main window as its owner).
+        if (showMediaInformationKeys != null && showMediaInformationKeys.Count > 0 && showMediaInformation != null)
+        {
+            shortcutManager.RegisterShortcut(new ShortCut(
+                nameof(FullScreenVideoWindow) + "_ShowMediaInformation",
+                showMediaInformationKeys,
+                ShortcutCategory.General,
+                new RelayCommand(() => showMediaInformation(this))));
         }
 
         // Poll for actual cursor position using platform APIs

--- a/src/ui/Features/Shared/MediaInfoView/MediaInfoViewViewModel.cs
+++ b/src/ui/Features/Shared/MediaInfoView/MediaInfoViewViewModel.cs
@@ -41,13 +41,63 @@ public partial class MediaInfoViewViewModel : ObservableObject
         TextBoxContainer = new Border();
     }
 
-    internal void Initialize(string videoFileName, FfmpegMediaInfo2 mediaInfo)
+    internal void Initialize(string videoFileName, FfmpegMediaInfo2? mediaInfo)
     {
         _videoFileName = videoFileName;
 
+        // Show basic file info immediately so the window can open without waiting
+        // for container/ffmpeg parsing on large files.
+        Text = BuildBasicInfoText(videoFileName, includeLoadingHint: true);
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            Task.Delay(50).Wait(); // Slight delay to ensure control is ready
+
+            SourceViewTextBox = CreateAdvancedTextBoxWrapper(Text);
+
+            TextBoxContainer.Child = SourceViewTextBox.ContentControl;
+
+            Task.Delay(50).Wait(); // Slight delay to ensure control is ready
+            SourceViewTextBox.Focus();
+            SourceViewTextBox.CaretIndex = 0;
+        }, DispatcherPriority.Input);
+
+        // Build the full report in the background — MatroskaFile/MP4Parser and
+        // FfmpegMediaInfo2.Parse can be slow on large files.
+        Task.Run(() =>
+        {
+            var info = mediaInfo ?? FfmpegMediaInfo2.Parse(videoFileName);
+            var fullText = BuildFullInfoText(videoFileName, info);
+            Dispatcher.UIThread.Post(() => Text = fullText);
+        });
+    }
+
+    private static string BuildBasicInfoText(string videoFileName, bool includeLoadingHint)
+    {
         var sb = new StringBuilder();
         sb.AppendLine($"File name: {videoFileName}");
-        sb.AppendLine($"File size: {Utilities.FormatBytesToDisplayFileSize(new FileInfo(videoFileName).Length)}");
+        try
+        {
+            sb.AppendLine($"File size: {Utilities.FormatBytesToDisplayFileSize(new FileInfo(videoFileName).Length)}");
+        }
+        catch
+        {
+            // ignored — file may be inaccessible
+        }
+
+        if (includeLoadingHint)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Loading media information...");
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    private static string BuildFullInfoText(string videoFileName, FfmpegMediaInfo2 mediaInfo)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(BuildBasicInfoText(videoFileName, includeLoadingHint: false));
 
         if (mediaInfo.Duration != null)
         {
@@ -64,12 +114,12 @@ public partial class MediaInfoViewViewModel : ObservableObject
             sb.AppendLine($"Framerate: {mediaInfo.FramesRate:0.###}");
         }
 
-        if (FileUtil.IsWav(_videoFileName))
+        if (FileUtil.IsWav(videoFileName))
         {
             sb.AppendLine($"Codec: WAVE");
         }
 
-        if (FileUtil.IsMp3(_videoFileName))
+        if (FileUtil.IsMp3(videoFileName))
         {
             sb.AppendLine($"Codec: MP3");
         }
@@ -104,20 +154,7 @@ public partial class MediaInfoViewViewModel : ObservableObject
             trackNo++;
         }
 
-        Text = sb.ToString().Trim();
-
-        Dispatcher.UIThread.Post(() =>
-        {
-            Task.Delay(50).Wait(); // Slight delay to ensure control is ready  
-
-            SourceViewTextBox = CreateAdvancedTextBoxWrapper(Text);
-
-            TextBoxContainer.Child = SourceViewTextBox.ContentControl;
-
-            Task.Delay(50).Wait(); // Slight delay to ensure control is ready  
-            SourceViewTextBox.Focus();
-            SourceViewTextBox.CaretIndex = 0;
-        }, DispatcherPriority.Input);
+        return sb.ToString().Trim();
     }
 
     private TextEditorWrapper CreateAdvancedTextBoxWrapper(string text)


### PR DESCRIPTION
## Summary
- **Faster open**: `MediaInfoViewViewModel.Initialize` now shows file name + size immediately with a *Loading media information...* hint, and runs the container parsing (Matroska / MP4) and ffmpeg parse in a background task. The full report replaces the placeholder once parsing finishes.
- **No early-return**: `MainViewModel.ShowMediaInformation` no longer bails when `_mediaInfo` is still null (i.e. the user invoked the shortcut before ffmpeg parsing finished). The dialog opens and the background task runs the parse itself.
- **Fullscreen support**: `FullScreenVideoWindow` accepts the Show-Media-Information shortcut keys plus an `Action<Window>` delegate. The local `ShortcutManager` registers it so the shortcut now fires while fullscreen has focus, and the dialog opens with the fullscreen window as owner — otherwise it would appear behind the fullscreen window (which has the main window as owner).

The fullscreen window keeps its existing self-contained shortcut model — only the Show-Media-Information shortcut is wired in. Other main-window shortcuts remain inactive in fullscreen.

Fixes #10881

## Test plan
- [ ] Open a video. Right-click the video → Show media information. Window opens quickly even on large MKV/MP4 files; full info populates a moment later.
- [ ] Bind a shortcut (e.g. Ctrl+Alt+I) to *Show media information*. Verify it works in normal mode, undocked mode, **and fullscreen** (F11). In fullscreen the dialog should appear on top of the fullscreen window.
- [ ] Invoke the shortcut very early after opening a video (before ffmpeg parsing finishes). The dialog should still open and populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)