### PR TITLE
Strip <c.color> wrappers when removing color from non-WebVTT formats

### DIFF
--- a/src/ui/Logic/ColorService.cs
+++ b/src/ui/Logic/ColorService.cs
@@ -30,7 +30,7 @@ public class ColorService : IColorService
 
     private static void RemoveColorTags(SubtitleLineViewModel p, Subtitle subtitle, SubtitleFormat subtitleFormat)
     {
-        if (subtitleFormat is WebVTT)
+        if (subtitleFormat is WebVTT or WebVTTFileWithLineNumber)
         {
             var styles = WebVttHelper.GetStyles(subtitle.Header);
             foreach (var style in styles)
@@ -63,6 +63,7 @@ public class ColorService : IColorService
         }
 
         p.Text = HtmlUtil.RemoveColorTags(p.Text);
+        p.Text = WebVttHelper.RemoveDefaultColorClasses(p.Text);
     }
 
     public void SetColor(List<SubtitleLineViewModel> subtitles, Color color, Subtitle subtitle, SubtitleFormat subtitleFormat)

--- a/tests/UI/Logic/ColorServiceTests.cs
+++ b/tests/UI/Logic/ColorServiceTests.cs
@@ -144,6 +144,57 @@ public class ColorServiceTests
     }
 
     [Fact]
+    public void RemoveColorTags_WebVtt_StripsCClassWithDottedContent()
+    {
+        var service = new ColorService();
+        var subtitle = new Subtitle();
+        var format = new WebVTT();
+
+        var lines = new List<SubtitleLineViewModel>
+        {
+            Line("<c.white>france.tv access</c>"),
+        };
+
+        service.RemoveColorTags(lines, subtitle, format);
+
+        Assert.Equal("france.tv access", lines[0].Text);
+    }
+
+    [Fact]
+    public void RemoveColorTags_Srt_StripsCClassColorWrapper()
+    {
+        var service = new ColorService();
+        var subtitle = new Subtitle();
+        var format = new SubRip();
+
+        var lines = new List<SubtitleLineViewModel>
+        {
+            Line("<c.white>france.tv access</c>"),
+        };
+
+        service.RemoveColorTags(lines, subtitle, format);
+
+        Assert.Equal("france.tv access", lines[0].Text);
+    }
+
+    [Fact]
+    public void RemoveColorTags_WebVttFileWithLineNumber_StripsCClassColorWrapper()
+    {
+        var service = new ColorService();
+        var subtitle = new Subtitle();
+        var format = new WebVTTFileWithLineNumber();
+
+        var lines = new List<SubtitleLineViewModel>
+        {
+            Line("<c.white>france.tv access</c>"),
+        };
+
+        service.RemoveColorTags(lines, subtitle, format);
+
+        Assert.Equal("france.tv access", lines[0].Text);
+    }
+
+    [Fact]
     public void RemoveColorTags_Assa_StripsAssaColorTags()
     {
         var service = new ColorService();

--- a/tests/libse/Core/WebVttHelperTest.cs
+++ b/tests/libse/Core/WebVttHelperTest.cs
@@ -102,4 +102,13 @@ public class WebVttHelperTest
         var expected = "Vert" + Environment.NewLine + "Fond vert";
         Assert.Equal(expected, result);
     }
+
+    [Fact]
+    public void RemoveDefaultColorClassesContentWithDot()
+    {
+        var text = "<c.white>france.tv access</c>";
+        var result = WebVttHelper.RemoveDefaultColorClasses(text);
+
+        Assert.Equal("france.tv access", result);
+    }
 }


### PR DESCRIPTION
## Summary
- \`ColorService.RemoveColorTags\` only called \`WebVttHelper.RemoveDefaultColorClasses\` on the WebVTT branch. Subtitles in SRT (or any non-WebVTT format) that contain VTT-style \`<c.white>...</c>\` wrappers were left untouched. Added the same call on the fall-through path so \`Remove formatting > Remove color\` strips those wrappers regardless of format.
- Also treat \`WebVTTFileWithLineNumber\` the same as \`WebVTT\` for color removal — it derives directly from \`SubtitleFormat\`, not \`WebVTT\`, so it had been skipping the style-block-aware branch too.
- Added test coverage:
  - \`WebVttHelperTest.RemoveDefaultColorClassesContentWithDot\` — content containing a dot (\`france.tv access\`) doesn't confuse the matcher.
  - \`ColorServiceTests.RemoveColorTags_WebVtt_StripsCClassWithDottedContent\`
  - \`ColorServiceTests.RemoveColorTags_Srt_StripsCClassColorWrapper\`
  - \`ColorServiceTests.RemoveColorTags_WebVttFileWithLineNumber_StripsCClassColorWrapper\`

Refs #10765 (regression report in beta 25 — left open since #10765 was already closed and the maintainer may want to track this comment separately).

## Test plan
- [ ] Open an SRT containing \`<c.white>france.tv access</c>\`. Select all → Format → Remove formatting → Remove color. Text becomes \`france.tv access\`.
- [ ] Repeat with a \`.vtt\` (WebVTT) file → same result.
- [ ] Repeat with a \`.vtt\` saved in the \"WebVTT File with#\" format → same result.
- [ ] Existing \`<font color=…>\` removal still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)