### PR TITLE
Stop mp3 position jumping back to last seek at EOF

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -995,6 +995,16 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     {
         get
         {
+            // Audio-EOF pin must take priority over the paused-value cache. mpv auto-pauses
+            // at EOF (keep-open=always), so IsPaused flips true; if the user did any seek
+            // earlier in the session, _pausedValue still holds that stale seek target and
+            // the cache below would return it, causing the position to "jump back" to the
+            // last seek when playback completes. See #10835 / #10877.
+            if (_audioEndBound.HasValue && IsEofReached())
+            {
+                return _audioEndBound.Value;
+            }
+
             if (_pausedValue.HasValue && IsPaused && !Se.Settings.General.UseFrameMode)
             {
                 return _pausedValue.Value;
@@ -1015,16 +1025,6 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 if (err < 0)
                 {
                     return 0;
-                }
-
-                // When playback reaches the bound set for audio-only files, mpv's time-pos
-                // can lag the actual end by several seconds (the lavfi-complex virtual video
-                // produces frames forever, so its demuxer keeps buffering past audio EOF and
-                // the rendered playback time falls behind). Pin to the bound at EOF so the
-                // waveform doesn't appear to jump back when audio playback completes.
-                if (_audioEndBound.HasValue && IsEofReached())
-                {
-                    return _audioEndBound.Value;
                 }
 
                 return position;
@@ -1204,6 +1204,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     public void Play()
     {
+        _pausedValue = null;
         EnsureNotDisposed();
         if (_mpv == IntPtr.Zero)
         {


### PR DESCRIPTION
## Summary
The previous fix for #10835 pinned position to the cached audio end bound when \`eof-reached\` flips true, but the check ran *after* the \`_pausedValue\` seek cache:

\`\`\`csharp
if (_pausedValue.HasValue && IsPaused && !UseFrameMode) return _pausedValue.Value;
// ... read time-pos ...
if (_audioEndBound.HasValue && IsEofReached()) return _audioEndBound.Value;
\`\`\`

mpv auto-pauses at EOF (because \`keep-open=always\`), so \`IsPaused\` flips true. If the user had clicked the waveform anywhere earlier in the session, \`_pausedValue\` still held that prior seek target, and the early return shipped it back to the UI — explaining the user's report that the playhead jumps to *\"a different point every time it happens\"*.

Two-part fix:
- **Move the audio-EOF pin to the top of the \`Position\` getter** so it takes priority over the seek cache.
- **Clear \`_pausedValue\` in \`Play()\`** so that explicitly resuming playback invalidates the stale seek-while-paused cache. The other resume paths (\`PlayOrPause\`, \`Stop\`, step-frame) already do this; only \`Play()\` had been forgotten.

Refs #10835, refs #10877.

## Test plan
- [x] Open \`G5_2_1A.M1U1.mp3\` (or any MP3) with the libmpv engine.
- [x] Let it play to the natural end without clicking. Playhead pins at EOF, timer shows \`duration / duration\`.
- [x] Replay: click the waveform around the middle, then press play, let it run to EOF. Playhead should pin at EOF (not jump back to where you clicked).
- [x] Existing video files still pause at EOF normally (no \`_audioEndBound\`, fall-through unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)