### PR TITLE
Add CrispASR MADLAD as an auto-translate engine

### DIFF
--- a/src/libse/AudioToText/WhisperChoice.cs
+++ b/src/libse/AudioToText/WhisperChoice.cs
@@ -24,6 +24,7 @@
         public const string CrispAsrGranite = "Crisp ASR Granite";
         public const string CrispAsrOmni = "Crisp ASR Omni";
         public const string CrispAsrKyutai = "Crisp ASR Kyutai";
+        public const string CrispAsrMadlad = "Crisp ASR MADLAD";
         public const string OpenAiCompatible = "OpenAI Compatible";
     }
 }

--- a/src/libse/AutoTranslate/CrispAsrMadladTranslate.cs
+++ b/src/libse/AutoTranslate/CrispAsrMadladTranslate.cs
@@ -1,0 +1,153 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Translate;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Core.AutoTranslate
+{
+    /// <summary>
+    /// Local translation via the CrispASR command line tool using the MADLAD-400 backend.
+    /// See https://github.com/CrispStrobe/CrispASR
+    /// </summary>
+    public class CrispAsrMadladTranslate : IAutoTranslator
+    {
+        public static string StaticName { get; set; } = "CrispASR MADLAD";
+        public override string ToString() => StaticName;
+        public string Name => StaticName;
+        public string Url => "https://github.com/CrispStrobe/CrispASR";
+        public string Error { get; set; }
+        public int MaxCharacters => 1000;
+
+        private string _executablePath;
+        private string _modelPath;
+
+        public void Initialize()
+        {
+            _executablePath = Configuration.Settings.Tools.AutoTranslateCrispAsrExe;
+            _modelPath = Configuration.Settings.Tools.AutoTranslateCrispAsrModel;
+        }
+
+        public List<TranslationPair> GetSupportedSourceLanguages()
+        {
+            return ListLanguages();
+        }
+
+        public List<TranslationPair> GetSupportedTargetLanguages()
+        {
+            return ListLanguages();
+        }
+
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(_executablePath) || !File.Exists(_executablePath))
+            {
+                Error = "CrispASR executable not found - please use the 'Download' button to install it. Path: " + _executablePath;
+                throw new Exception(Error);
+            }
+
+            if (string.IsNullOrEmpty(_modelPath) || !File.Exists(_modelPath))
+            {
+                Error = "CrispASR MADLAD model not found - please use the 'Download' button to install it. Path: " + _modelPath;
+                throw new Exception(Error);
+            }
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = _executablePath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+                WorkingDirectory = Path.GetDirectoryName(_executablePath) ?? string.Empty,
+            };
+            startInfo.ArgumentList.Add("--backend");
+            startInfo.ArgumentList.Add("madlad");
+            startInfo.ArgumentList.Add("-m");
+            startInfo.ArgumentList.Add(_modelPath);
+            startInfo.ArgumentList.Add("--text");
+            startInfo.ArgumentList.Add(text.Trim());
+            startInfo.ArgumentList.Add("-sl");
+            startInfo.ArgumentList.Add(sourceLanguageCode);
+            startInfo.ArgumentList.Add("-tl");
+            startInfo.ArgumentList.Add(targetLanguageCode);
+            startInfo.ArgumentList.Add("--no-prints");
+
+            using (var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true })
+            {
+                var outputBuilder = new StringBuilder();
+                var errorBuilder = new StringBuilder();
+                var exitedSource = new TaskCompletionSource<bool>();
+
+                process.OutputDataReceived += (sender, args) =>
+                {
+                    if (args.Data != null)
+                    {
+                        outputBuilder.AppendLine(args.Data);
+                    }
+                };
+                process.ErrorDataReceived += (sender, args) =>
+                {
+                    if (args.Data != null)
+                    {
+                        errorBuilder.AppendLine(args.Data);
+                    }
+                };
+                process.Exited += (sender, args) => exitedSource.TrySetResult(true);
+
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                using (cancellationToken.Register(() =>
+                {
+                    try
+                    {
+                        if (!process.HasExited)
+                        {
+                            process.Kill();
+                        }
+                    }
+                    catch
+                    {
+                        // ignore - process may have already exited
+                    }
+
+                    exitedSource.TrySetCanceled();
+                }))
+                {
+                    await exitedSource.Task.ConfigureAwait(false);
+                }
+
+                if (process.ExitCode != 0)
+                {
+                    Error = errorBuilder.ToString().Trim();
+                    throw new Exception($"CrispASR exited with code {process.ExitCode}: {Error}");
+                }
+
+                return outputBuilder.ToString().Trim();
+            }
+        }
+
+        private static List<TranslationPair> ListLanguages()
+        {
+            var result = new List<TranslationPair>();
+            var seen = new HashSet<string>();
+            foreach (var culture in Utilities.GetSubtitleLanguageCultures(false))
+            {
+                if (!string.IsNullOrEmpty(culture.TwoLetterISOLanguageName) && seen.Add(culture.TwoLetterISOLanguageName))
+                {
+                    result.Add(new TranslationPair(culture.EnglishName, culture.TwoLetterISOLanguageName));
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/libse/Common/SeJsonParser.cs
+++ b/src/libse/Common/SeJsonParser.cs
@@ -919,6 +919,11 @@ namespace Nikse.SubtitleEdit.Core.Common
         public string GetFirstObject(string content, string name)
         {
             Errors = new List<string>();
+            if (string.IsNullOrEmpty(content))
+            {
+                return null;
+            }
+
             var i = 0;
             var max = content.Length;
             var state = new Stack<StateElement>();

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -38,6 +38,8 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string AutoTranslateLibreApiKey { get; set; }
         public string AutoTranslateMyMemoryApiKey { get; set; }
         public string AutoTranslateSeamlessM4TUrl { get; set; }
+        public string AutoTranslateCrispAsrExe { get; set; }
+        public string AutoTranslateCrispAsrModel { get; set; }
         public string AutoTranslateDeepLApiKey { get; set; }
         public string AutoTranslateDeepLUrl { get; set; }
         public string AutoTranslateDeepLFormality { get; set; }
@@ -356,6 +358,8 @@ namespace Nikse.SubtitleEdit.Core.Settings
             AutoTranslateNllbApiUrl = "http://localhost:7860/api/v4/";
             AutoTranslateLibreUrl = "http://localhost:5000/";
             AutoTranslateSeamlessM4TUrl = "http://localhost:5000/";
+            AutoTranslateCrispAsrExe = string.Empty;
+            AutoTranslateCrispAsrModel = string.Empty;
             AutoTranslateDeepLUrl = "https://api-free.deepl.com/";
             AutoTranslateDeepLXUrl = "http://localhost:1188";
             AutoTranslateMistralUrl = "https://api.mistral.ai/v1/chat/completions";

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -345,7 +345,8 @@ public partial class BatchConvertViewModel : ObservableObject
             new LmStudioTranslate(),
             new NoLanguageLeftBehindServe(),
             new NoLanguageLeftBehindApi(),
-            new DeepLTranslate()
+            new DeepLTranslate(),
+            new CrispAsrMadladTranslate(),
         ];
         SelectedAutoTranslator = AutoTranslators[0];
         OnAutoTranslatorChanged();
@@ -853,6 +854,11 @@ public partial class BatchConvertViewModel : ObservableObject
             return;
         }
 
+        if (!await EnsureCrispAsrAvailable(config))
+        {
+            return;
+        }
+
         _batchConverter.Initialize(config);
         var start = DateTime.UtcNow.Ticks;
 
@@ -1019,6 +1025,21 @@ public partial class BatchConvertViewModel : ObservableObject
         }
 
         return true;
+    }
+
+    private async Task<bool> EnsureCrispAsrAvailable(BatchConvertConfig config)
+    {
+        if (Window == null)
+        {
+            return true;
+        }
+
+        if (!config.AutoTranslate.IsActive || config.AutoTranslate.Translator is not CrispAsrMadladTranslate)
+        {
+            return true;
+        }
+
+        return await CrispAsrTranslateDownloadHelper.EnsureReadyAsync(Window, _windowService, null);
     }
 
     private static bool IsImageBasedInput(BatchConvertItem item)

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -30,6 +30,8 @@ using Nikse.SubtitleEdit.Features.Tools.BatchConvert.BatchErrorList;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.UiLogic.BatchConvert;
@@ -154,6 +156,9 @@ public partial class BatchConvertViewModel : ObservableObject
     [ObservableProperty] private bool _autoTranslateModelBrowseIsVisible;
     [ObservableProperty] private bool _autoTranslateUrlIsVisible;
     [ObservableProperty] private bool _autoTranslateApiKeyIsVisible;
+    [ObservableProperty] private ObservableCollection<SpeechToTextModelDisplay> _crispAsrModels = new();
+    [ObservableProperty] private SpeechToTextModelDisplay? _selectedCrispAsrModel;
+    [ObservableProperty] private bool _crispAsrModelComboIsVisible;
 
     // Fix common errors
     [ObservableProperty] private FixCommonErrors.ProfileDisplayItem? _fixCommonErrorsProfile;
@@ -1039,7 +1044,15 @@ public partial class BatchConvertViewModel : ObservableObject
             return true;
         }
 
-        return await CrispAsrTranslateDownloadHelper.EnsureReadyAsync(Window, _windowService, null);
+        var ready = await CrispAsrTranslateDownloadHelper.EnsureReadyAsync(Window, _windowService, SelectedCrispAsrModel?.Model.Name);
+        if (ready)
+        {
+            SelectedCrispAsrModel = CrispAsrTranslateDownloadHelper.PopulateModels(
+                CrispAsrModels,
+                Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
+        }
+
+        return ready;
     }
 
     private static bool IsImageBasedInput(BatchConvertItem item)
@@ -2070,13 +2083,38 @@ public partial class BatchConvertViewModel : ObservableObject
         }
     }
 
+    partial void OnSelectedCrispAsrModelChanged(SpeechToTextModelDisplay? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        Se.Settings.AutoTranslate.CrispAsrModel = new CrispAsrMadlad().GetModelForCmdLine(value.Model.Name);
+        Configuration.Settings.Tools.AutoTranslateCrispAsrModel = Se.Settings.AutoTranslate.CrispAsrModel;
+    }
+
     internal void OnAutoTranslatorChanged()
     {
         var engine = SelectedAutoTranslator;
 
         AutoTranslateModelIsVisible = engine is OllamaTranslate;
+        CrispAsrModelComboIsVisible = engine is CrispAsrMadladTranslate;
 
-        if (engine is OllamaTranslate)
+        if (engine is CrispAsrMadladTranslate)
+        {
+            AutoTranslateModel = string.Empty;
+            AutoTranslateModelBrowseIsVisible = false;
+            AutoTranslateModelIsVisible = false;
+            AutoTranslateUrl = string.Empty;
+            AutoTranslateUrlIsVisible = false;
+            AutoTranslateApiKey = string.Empty;
+            AutoTranslateApiKeyIsVisible = false;
+            SelectedCrispAsrModel = CrispAsrTranslateDownloadHelper.PopulateModels(
+                CrispAsrModels,
+                Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
+        }
+        else if (engine is OllamaTranslate)
         {
             AutoTranslateModel = Se.Settings.AutoTranslate.OllamaModel;
             AutoTranslateModelBrowseIsVisible = true;

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -2190,6 +2190,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
         Configuration.Settings.Tools.AutoTranslateNllbServeUrl = Se.Settings.AutoTranslate.NnlbServeUrl;
 
+        Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
+        Configuration.Settings.Tools.AutoTranslateCrispAsrModel = Se.Settings.AutoTranslate.CrispAsrModel;
+
         var doAutoTranslate = new DoAutoTranslate();
         var translatedSubtitle = await doAutoTranslate.DoTranslate(subtitle, _config.AutoTranslate.SourceLanguage, _config.AutoTranslate.TargetLanguage,
             _config.AutoTranslate.Translator, cancellationToken);

--- a/src/ui/Features/Tools/BatchConvert/DoAutoTranslate.cs
+++ b/src/ui/Features/Tools/BatchConvert/DoAutoTranslate.cs
@@ -24,7 +24,8 @@ public class DoAutoTranslate
                                       nameof(TranslateStrategy.TranslateEachLineSeparately) ||
                                       translator.Name ==
                                       NoLanguageLeftBehindApi.StaticName || // NLLB seems to miss some text...
-                                      translator.Name == NoLanguageLeftBehindServe.StaticName;
+                                      translator.Name == NoLanguageLeftBehindServe.StaticName ||
+                                      translator.Name == CrispAsrMadladTranslate.StaticName; // one CLI process per line
 
             var index = start;
             var linesTranslated = 0;

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
@@ -33,11 +33,15 @@ public static class ViewAutoTranslate
         var labelModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.AutoTranslateModelIsVisible)).WithMarginLeft(10).WithMarginRight(3);
         var textBoxModel = UiUtil.MakeTextBox(150, vm, nameof(vm.AutoTranslateModel), nameof(vm.AutoTranslateModelIsVisible));
         var buttonModel = UiUtil.MakeButtonBrowse(vm.AutoTranslateBrowseModelCommand, nameof(vm.AutoTranslateModelBrowseIsVisible)).WithMarginLeft(3);
+        var labelCrispAsrModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.CrispAsrModelComboIsVisible)).WithMarginLeft(10).WithMarginRight(3);
+        var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
         var panelEngineControls = UiUtil.MakeHorizontalPanel(
             cbEngines,
             labelModel,
             textBoxModel,
-            buttonModel);
+            buttonModel,
+            labelCrispAsrModel,
+            crispAsrModelCombo);
 
         var labelSourceLanguage = UiUtil.MakeLabel(Se.Language.General.From);
         var sourceLangCombo = UiUtil.MakeComboBox(vm.SourceLanguages, vm, nameof(vm.SelectedSourceLanguage));

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -670,19 +670,25 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         var models = new ObservableCollection<SpeechToTextModelDisplay>();
+        SpeechToTextModelDisplay? selectedModel = null;
         foreach (var model in engine.Models)
         {
-            models.Add(new SpeechToTextModelDisplay
+            var display = new SpeechToTextModelDisplay
             {
                 Model = model,
                 Engine = engine,
-            });
+            };
+            models.Add(display);
+            if (model.Name == SelectedCrispAsrModel?.Model.Name)
+            {
+                selectedModel = display;
+            }
         }
 
         var modelsVm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
             Window, vm =>
             {
-                vm.SetModels(models, engine, null);
+                vm.SetModels(models, engine, selectedModel);
             });
 
         if (modelsVm is { OkPressed: true, SelectedModel: not null })

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -651,7 +651,8 @@ public partial class AutoTranslateViewModel : ObservableObject
             return;
         }
 
-        var downloadedModelName = await CrispAsrTranslateDownloadHelper.DownloadAsync(Window, _windowService, SelectedCrispAsrModel?.Model.Name);
+        var downloadedModelName = await CrispAsrTranslateDownloadHelper.DownloadAsync(
+            Window, _windowService, SelectedCrispAsrModel?.Model.Name, autoStartModelDownload: true);
         if (downloadedModelName != null)
         {
             PopulateCrispAsrModels(downloadedModelName);

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -65,8 +65,8 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private string _modelText;
     [ObservableProperty] private bool _buttonModelIsVisible;
     [ObservableProperty] private bool _buttonDownloadIsVisible;
-    [ObservableProperty] private ObservableCollection<string> _crispAsrModels = new();
-    [ObservableProperty] private string? _selectedCrispAsrModel;
+    [ObservableProperty] private ObservableCollection<SpeechToTextModelDisplay> _crispAsrModels = new();
+    [ObservableProperty] private SpeechToTextModelDisplay? _selectedCrispAsrModel;
     [ObservableProperty] private bool _crispAsrModelComboIsVisible;
 
     public DataGrid? RowGrid { get; set; }
@@ -690,26 +690,37 @@ public partial class AutoTranslateViewModel : ObservableObject
             Se.Settings.AutoTranslate.CrispAsrExe = engine.GetExecutable();
             Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
 
-            var modelName = modelsVm.SelectedModel.Model.Name;
-            if (!CrispAsrModels.Contains(modelName))
-            {
-                CrispAsrModels.Add(modelName);
-            }
-
-            SelectedCrispAsrModel = modelName;
-            ModelText = engine.GetModelForCmdLine(modelName);
+            PopulateCrispAsrModels(engine, modelsVm.SelectedModel.Model.Name);
             SaveSettings();
         }
     }
 
-    partial void OnSelectedCrispAsrModelChanged(string? value)
+    private void PopulateCrispAsrModels(CrispAsrMadlad engine, string? selectModelName)
     {
-        if (string.IsNullOrEmpty(value))
+        CrispAsrModels.Clear();
+        SpeechToTextModelDisplay? toSelect = null;
+        foreach (var model in engine.Models)
+        {
+            var display = new SpeechToTextModelDisplay { Model = model, Engine = engine };
+            display.RefreshDownloadStatus();
+            CrispAsrModels.Add(display);
+            if (model.Name == selectModelName)
+            {
+                toSelect = display;
+            }
+        }
+
+        SelectedCrispAsrModel = toSelect ?? CrispAsrModels.FirstOrDefault();
+    }
+
+    partial void OnSelectedCrispAsrModelChanged(SpeechToTextModelDisplay? value)
+    {
+        if (value == null)
         {
             return;
         }
 
-        ModelText = new CrispAsrMadlad().GetModelForCmdLine(value);
+        ModelText = new CrispAsrMadlad().GetModelForCmdLine(value.Model.Name);
     }
 
     private static bool IsCrispAsrReady()
@@ -1413,17 +1424,10 @@ public partial class AutoTranslateViewModel : ObservableObject
                 Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
             }
 
-            CrispAsrModels.Clear();
-            foreach (var model in madladEngine.Models)
-            {
-                CrispAsrModels.Add(model.Name);
-            }
+            PopulateCrispAsrModels(madladEngine, Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
 
             CrispAsrModelComboIsVisible = true;
             ButtonDownloadIsVisible = true;
-
-            var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty);
-            SelectedCrispAsrModel = CrispAsrModels.Contains(savedModelName) ? savedModelName : CrispAsrModels.FirstOrDefault();
 
             return;
         }

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -11,12 +11,15 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.Translate;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -61,6 +64,10 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private bool _modelBrowseIsVisible;
     [ObservableProperty] private string _modelText;
     [ObservableProperty] private bool _buttonModelIsVisible;
+    [ObservableProperty] private bool _buttonDownloadIsVisible;
+    [ObservableProperty] private ObservableCollection<string> _crispAsrModels = new();
+    [ObservableProperty] private string? _selectedCrispAsrModel;
+    [ObservableProperty] private bool _crispAsrModelComboIsVisible;
 
     public DataGrid? RowGrid { get; set; }
 
@@ -108,6 +115,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             new NoLanguageLeftBehindServe(),
             new NoLanguageLeftBehindApi(),
             new BaiduTranslate(),
+            new CrispAsrMadladTranslate(),
         };
         SelectedAutoTranslator = AutoTranslators[0];
         AutoTranslatorLinkText = SelectedAutoTranslator.Name;
@@ -210,6 +218,9 @@ public partial class AutoTranslateViewModel : ObservableObject
         Configuration.Settings.Tools.GeminiPrompt = Se.Settings.AutoTranslate.GeminiPrompt;
 
         Configuration.Settings.Tools.AutoTranslateSeamlessM4TUrl = Se.Settings.AutoTranslate.SeamlessM4TUrl;
+
+        Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
+        Configuration.Settings.Tools.AutoTranslateCrispAsrModel = Se.Settings.AutoTranslate.CrispAsrModel;
     }
 
     public void SaveSettings()
@@ -349,6 +360,11 @@ public partial class AutoTranslateViewModel : ObservableObject
             Configuration.Settings.Tools.AutoTranslatePapagoApiKey = apiKey.Trim();
         }
 
+        if (engineType == typeof(CrispAsrMadladTranslate))
+        {
+            Configuration.Settings.Tools.AutoTranslateCrispAsrModel = apiModel.Trim();
+        }
+
         Configuration.Settings.Tools.AutoTranslateLastName = SelectedAutoTranslator.Name;
 
         Se.Settings.AutoTranslate.AutoTranslateLastName = SelectedAutoTranslator.Name;
@@ -435,6 +451,9 @@ public partial class AutoTranslateViewModel : ObservableObject
         Se.Settings.AutoTranslate.GeminiPrompt = Configuration.Settings.Tools.GeminiPrompt;
 
         Se.Settings.AutoTranslate.SeamlessM4TUrl = Configuration.Settings.Tools.AutoTranslateSeamlessM4TUrl;
+
+        Se.Settings.AutoTranslate.CrispAsrExe = Configuration.Settings.Tools.AutoTranslateCrispAsrExe;
+        Se.Settings.AutoTranslate.CrispAsrModel = Configuration.Settings.Tools.AutoTranslateCrispAsrModel;
 
         Se.SaveSettings();
     }
@@ -624,6 +643,111 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
     }
 
+    [RelayCommand]
+    private async Task DownloadCrispAsr()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var engine = new CrispAsrMadlad();
+
+        if (!engine.IsEngineInstalled())
+        {
+            var engineVm = await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
+                Window, vm =>
+                {
+                    vm.Engine = engine;
+                    vm.CrispAsrWindowsVariant = "cpu";
+                    vm.StartDownload();
+                });
+
+            if (!engineVm.OkPressed || !engine.IsEngineInstalled())
+            {
+                return;
+            }
+        }
+
+        var models = new ObservableCollection<SpeechToTextModelDisplay>();
+        foreach (var model in engine.Models)
+        {
+            models.Add(new SpeechToTextModelDisplay
+            {
+                Model = model,
+                Engine = engine,
+            });
+        }
+
+        var modelsVm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
+            Window, vm =>
+            {
+                vm.SetModels(models, engine, null);
+            });
+
+        if (modelsVm is { OkPressed: true, SelectedModel: not null })
+        {
+            Se.Settings.AutoTranslate.CrispAsrExe = engine.GetExecutable();
+            Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
+
+            var modelName = modelsVm.SelectedModel.Model.Name;
+            if (!CrispAsrModels.Contains(modelName))
+            {
+                CrispAsrModels.Add(modelName);
+            }
+
+            SelectedCrispAsrModel = modelName;
+            ModelText = engine.GetModelForCmdLine(modelName);
+            SaveSettings();
+        }
+    }
+
+    partial void OnSelectedCrispAsrModelChanged(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        ModelText = new CrispAsrMadlad().GetModelForCmdLine(value);
+    }
+
+    private static bool IsCrispAsrReady()
+    {
+        var engine = new CrispAsrMadlad();
+        var modelPath = Se.Settings.AutoTranslate.CrispAsrModel;
+        return engine.IsEngineInstalled() && !string.IsNullOrEmpty(modelPath) && File.Exists(modelPath);
+    }
+
+    private async Task<bool> EnsureCrispAsrReady()
+    {
+        if (Window == null)
+        {
+            return false;
+        }
+
+        if (IsCrispAsrReady())
+        {
+            return true;
+        }
+
+        var answer = await MessageBox.Show(
+            Window,
+            Se.Language.General.Download,
+            $"{SelectedAutoTranslator.Name} requires the CrispASR engine and a MADLAD model to be downloaded. Download now?",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            return false;
+        }
+
+        await DownloadCrispAsr();
+
+        return IsCrispAsrReady();
+    }
+
     private async Task<bool> DoTranslate()
     {
         var translator = SelectedAutoTranslator;
@@ -679,6 +803,12 @@ public partial class AutoTranslateViewModel : ObservableObject
             return false;
         }
 
+        if (engineType == typeof(CrispAsrMadladTranslate) && !await EnsureCrispAsrReady())
+        {
+            IsProgressEnabled = false;
+            return false;
+        }
+
         _translationInProgress = true;
         _cancellationTokenSource = new CancellationTokenSource();
 
@@ -728,6 +858,7 @@ public partial class AutoTranslateViewModel : ObservableObject
                                       translator.Name ==
                                       NoLanguageLeftBehindApi.StaticName || // NLLB seems to miss some text...
                                       translator.Name == NoLanguageLeftBehindServe.StaticName ||
+                                      translator.Name == CrispAsrMadladTranslate.StaticName || // one CLI process per line
                                       _onlyCurrentLine;
 
             var index = start;
@@ -928,6 +1059,10 @@ public partial class AutoTranslateViewModel : ObservableObject
         ModelIsVisible = false;
         ModelBrowseIsVisible = false;
         ButtonModelIsVisible = false;
+        ButtonDownloadIsVisible = false;
+        CrispAsrModelComboIsVisible = false;
+        CrispAsrModels.Clear();
+        SelectedCrispAsrModel = null;
         ModelText = string.Empty;
         //LabelApiUrl.Text = "API url";
         //LabelApiKey.Text = "API key";
@@ -1265,6 +1400,30 @@ public partial class AutoTranslateViewModel : ObservableObject
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
             ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.AutoTranslateMistralModel) ? _apiModels[0] : Configuration.Settings.Tools.AutoTranslateMistralModel;
+
+            return;
+        }
+
+        if (engineType == typeof(CrispAsrMadladTranslate))
+        {
+            var madladEngine = new CrispAsrMadlad();
+            if (string.IsNullOrEmpty(Se.Settings.AutoTranslate.CrispAsrExe))
+            {
+                Se.Settings.AutoTranslate.CrispAsrExe = madladEngine.GetExecutable();
+                Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
+            }
+
+            CrispAsrModels.Clear();
+            foreach (var model in madladEngine.Models)
+            {
+                CrispAsrModels.Add(model.Name);
+            }
+
+            CrispAsrModelComboIsVisible = true;
+            ButtonDownloadIsVisible = true;
+
+            var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty);
+            SelectedCrispAsrModel = CrispAsrModels.Contains(savedModelName) ? savedModelName : CrispAsrModels.FirstOrDefault();
 
             return;
         }

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -654,27 +654,14 @@ public partial class AutoTranslateViewModel : ObservableObject
         var downloadedModelName = await CrispAsrTranslateDownloadHelper.DownloadAsync(Window, _windowService, SelectedCrispAsrModel?.Model.Name);
         if (downloadedModelName != null)
         {
-            PopulateCrispAsrModels(new CrispAsrMadlad(), downloadedModelName);
+            PopulateCrispAsrModels(downloadedModelName);
             SaveSettings();
         }
     }
 
-    private void PopulateCrispAsrModels(CrispAsrMadlad engine, string? selectModelName)
+    private void PopulateCrispAsrModels(string? selectModelName)
     {
-        CrispAsrModels.Clear();
-        SpeechToTextModelDisplay? toSelect = null;
-        foreach (var model in engine.Models)
-        {
-            var display = new SpeechToTextModelDisplay { Model = model, Engine = engine };
-            display.RefreshDownloadStatus();
-            CrispAsrModels.Add(display);
-            if (model.Name == selectModelName)
-            {
-                toSelect = display;
-            }
-        }
-
-        SelectedCrispAsrModel = toSelect ?? CrispAsrModels.FirstOrDefault();
+        SelectedCrispAsrModel = CrispAsrTranslateDownloadHelper.PopulateModels(CrispAsrModels, selectModelName);
     }
 
     partial void OnSelectedCrispAsrModelChanged(SpeechToTextModelDisplay? value)
@@ -697,7 +684,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         var ready = await CrispAsrTranslateDownloadHelper.EnsureReadyAsync(Window, _windowService, SelectedCrispAsrModel?.Model.Name);
         if (ready)
         {
-            PopulateCrispAsrModels(new CrispAsrMadlad(), Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
+            PopulateCrispAsrModels(Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
         }
 
         return ready;
@@ -1361,14 +1348,13 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         if (engineType == typeof(CrispAsrMadladTranslate))
         {
-            var madladEngine = new CrispAsrMadlad();
             if (string.IsNullOrEmpty(Se.Settings.AutoTranslate.CrispAsrExe))
             {
-                Se.Settings.AutoTranslate.CrispAsrExe = madladEngine.GetExecutable();
+                Se.Settings.AutoTranslate.CrispAsrExe = new CrispAsrMadlad().GetExecutable();
                 Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
             }
 
-            PopulateCrispAsrModels(madladEngine, Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
+            PopulateCrispAsrModels(Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
 
             CrispAsrModelComboIsVisible = true;
             ButtonDownloadIsVisible = true;

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -651,52 +651,10 @@ public partial class AutoTranslateViewModel : ObservableObject
             return;
         }
 
-        var engine = new CrispAsrMadlad();
-
-        if (!engine.IsEngineInstalled())
+        var downloadedModelName = await CrispAsrTranslateDownloadHelper.DownloadAsync(Window, _windowService, SelectedCrispAsrModel?.Model.Name);
+        if (downloadedModelName != null)
         {
-            var engineVm = await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
-                Window, vm =>
-                {
-                    vm.Engine = engine;
-                    vm.CrispAsrWindowsVariant = "cpu";
-                    vm.StartDownload();
-                });
-
-            if (!engineVm.OkPressed || !engine.IsEngineInstalled())
-            {
-                return;
-            }
-        }
-
-        var models = new ObservableCollection<SpeechToTextModelDisplay>();
-        SpeechToTextModelDisplay? selectedModel = null;
-        foreach (var model in engine.Models)
-        {
-            var display = new SpeechToTextModelDisplay
-            {
-                Model = model,
-                Engine = engine,
-            };
-            models.Add(display);
-            if (model.Name == SelectedCrispAsrModel?.Model.Name)
-            {
-                selectedModel = display;
-            }
-        }
-
-        var modelsVm = await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
-            Window, vm =>
-            {
-                vm.SetModels(models, engine, selectedModel);
-            });
-
-        if (modelsVm is { OkPressed: true, SelectedModel: not null })
-        {
-            Se.Settings.AutoTranslate.CrispAsrExe = engine.GetExecutable();
-            Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
-
-            PopulateCrispAsrModels(engine, modelsVm.SelectedModel.Model.Name);
+            PopulateCrispAsrModels(new CrispAsrMadlad(), downloadedModelName);
             SaveSettings();
         }
     }
@@ -729,13 +687,6 @@ public partial class AutoTranslateViewModel : ObservableObject
         ModelText = new CrispAsrMadlad().GetModelForCmdLine(value.Model.Name);
     }
 
-    private static bool IsCrispAsrReady()
-    {
-        var engine = new CrispAsrMadlad();
-        var modelPath = Se.Settings.AutoTranslate.CrispAsrModel;
-        return engine.IsEngineInstalled() && !string.IsNullOrEmpty(modelPath) && File.Exists(modelPath);
-    }
-
     private async Task<bool> EnsureCrispAsrReady()
     {
         if (Window == null)
@@ -743,26 +694,13 @@ public partial class AutoTranslateViewModel : ObservableObject
             return false;
         }
 
-        if (IsCrispAsrReady())
+        var ready = await CrispAsrTranslateDownloadHelper.EnsureReadyAsync(Window, _windowService, SelectedCrispAsrModel?.Model.Name);
+        if (ready)
         {
-            return true;
+            PopulateCrispAsrModels(new CrispAsrMadlad(), Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
         }
 
-        var answer = await MessageBox.Show(
-            Window,
-            Se.Language.General.Download,
-            $"{SelectedAutoTranslator.Name} requires the CrispASR engine and a MADLAD model to be downloaded. Download now?",
-            MessageBoxButtons.YesNo,
-            MessageBoxIcon.Question);
-
-        if (answer != MessageBoxResult.Yes)
-        {
-            return false;
-        }
-
-        await DownloadCrispAsr();
-
-        return IsCrispAsrReady();
+        return ready;
     }
 
     private async Task<bool> DoTranslate()

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -139,6 +139,11 @@ public class AutoTranslateWindow : Window
 
         var dataGridBorder = UiUtil.MakeBorderForControlNoPadding(dataGrid);
 
+        var buttonDownloadCrispAsr = UiUtil.MakeButton(Se.Language.General.Download, vm.DownloadCrispAsrCommand).WithMarginLeft(5);
+        buttonDownloadCrispAsr.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.ButtonDownloadIsVisible)));
+
+        var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
+
         StackPanel settingsBar = UiUtil.MakeControlBarLeft(
 
             UiUtil.MakeTextBlock(Se.Language.General.Id, vm, null, nameof(vm.ApiIdIsVisible)).WithMarginRight(5),
@@ -155,7 +160,11 @@ public class AutoTranslateWindow : Window
 
             UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.ModelIsVisible)).WithMarginRight(5),
             UiUtil.MakeTextBox(150, vm, nameof(vm.ModelText), nameof(vm.ModelIsVisible)),
-            UiUtil.MakeButtonBrowse(vm.BrowseModelCommand, nameof(vm.ModelBrowseIsVisible)).WithMarginLeft(5)
+            UiUtil.MakeButtonBrowse(vm.BrowseModelCommand, nameof(vm.ModelBrowseIsVisible)).WithMarginLeft(5),
+
+            UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.CrispAsrModelComboIsVisible)).WithMarginRight(5),
+            crispAsrModelCombo,
+            buttonDownloadCrispAsr
         );
 
         var settingsLink = UiUtil.MakeLink(Se.Language.General.Settings, vm.OpenSettingsCommand).WithMarginRight(10);

--- a/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
+++ b/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Translate;
@@ -46,6 +47,29 @@ public static class CrispAsrTranslateDownloadHelper
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Fills <paramref name="target"/> with the available MADLAD models (with download status) and
+    /// returns the one matching <paramref name="selectModelName"/>, or the first model otherwise.
+    /// </summary>
+    public static SpeechToTextModelDisplay? PopulateModels(ObservableCollection<SpeechToTextModelDisplay> target, string? selectModelName)
+    {
+        target.Clear();
+        var engine = new CrispAsrMadlad();
+        SpeechToTextModelDisplay? toSelect = null;
+        foreach (var model in engine.Models)
+        {
+            var display = new SpeechToTextModelDisplay { Model = model, Engine = engine };
+            display.RefreshDownloadStatus();
+            target.Add(display);
+            if (model.Name == selectModelName)
+            {
+                toSelect = display;
+            }
+        }
+
+        return toSelect ?? target.FirstOrDefault();
     }
 
     /// <summary>

--- a/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
+++ b/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
@@ -20,9 +20,32 @@ public static class CrispAsrTranslateDownloadHelper
 {
     public static bool IsReady()
     {
+        return new CrispAsrMadlad().IsEngineInstalled() && GetInstalledModelPath() != null;
+    }
+
+    /// <summary>
+    /// Returns the path of an installed MADLAD model - the one from settings if it still exists,
+    /// otherwise any known model file found in the CrispASR models folder.
+    /// </summary>
+    public static string? GetInstalledModelPath()
+    {
+        var configured = Se.Settings.AutoTranslate.CrispAsrModel;
+        if (!string.IsNullOrEmpty(configured) && File.Exists(configured))
+        {
+            return configured;
+        }
+
         var engine = new CrispAsrMadlad();
-        var modelPath = Se.Settings.AutoTranslate.CrispAsrModel;
-        return engine.IsEngineInstalled() && !string.IsNullOrEmpty(modelPath) && File.Exists(modelPath);
+        foreach (var model in engine.Models)
+        {
+            var path = engine.GetModelForCmdLine(model.Name);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -90,15 +113,36 @@ public static class CrispAsrTranslateDownloadHelper
     /// <returns>True if the engine is ready to use.</returns>
     public static async Task<bool> EnsureReadyAsync(Window owner, IWindowService windowService, string? preselectModelName)
     {
-        if (IsReady())
+        var engine = new CrispAsrMadlad();
+        var engineInstalled = engine.IsEngineInstalled();
+        if (engineInstalled)
         {
-            return true;
+            var installedModel = GetInstalledModelPath();
+            if (installedModel != null)
+            {
+                // self-heal: point settings at the binary/model that are actually on disk
+                if (Se.Settings.AutoTranslate.CrispAsrExe != engine.GetExecutable() ||
+                    Se.Settings.AutoTranslate.CrispAsrModel != installedModel)
+                {
+                    Se.Settings.AutoTranslate.CrispAsrExe = engine.GetExecutable();
+                    Se.Settings.AutoTranslate.CrispAsrModel = installedModel;
+                    Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
+                    Configuration.Settings.Tools.AutoTranslateCrispAsrModel = installedModel;
+                    Se.SaveSettings();
+                }
+
+                return true;
+            }
         }
+
+        var message = engineInstalled
+            ? $"{CrispAsrMadladTranslate.StaticName} requires a MADLAD model to be downloaded. Download now?"
+            : $"{CrispAsrMadladTranslate.StaticName} requires the CrispASR engine and a MADLAD model to be downloaded. Download now?";
 
         var answer = await MessageBox.Show(
             owner,
             Se.Language.General.Download,
-            $"{CrispAsrMadladTranslate.StaticName} requires the CrispASR engine and a MADLAD model to be downloaded. Download now?",
+            message,
             MessageBoxButtons.YesNo,
             MessageBoxIcon.Question);
 

--- a/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
+++ b/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
@@ -19,9 +19,25 @@ namespace Nikse.SubtitleEdit.Features.Translate;
 /// </summary>
 public static class CrispAsrTranslateDownloadHelper
 {
-    public static bool IsReady()
+    /// <summary>
+    /// True when the CrispASR engine is installed and a MADLAD model is available. When
+    /// <paramref name="modelName"/> is given, that specific model must be installed; otherwise
+    /// any installed model counts.
+    /// </summary>
+    public static bool IsReady(string? modelName = null)
     {
-        return new CrispAsrMadlad().IsEngineInstalled() && GetInstalledModelPath() != null;
+        var engine = new CrispAsrMadlad();
+        if (!engine.IsEngineInstalled())
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(modelName))
+        {
+            return File.Exists(engine.GetModelForCmdLine(modelName));
+        }
+
+        return GetInstalledModelPath() != null;
     }
 
     /// <summary>
@@ -76,7 +92,7 @@ public static class CrispAsrTranslateDownloadHelper
     /// Opens the download window(s) for the CrispASR engine binary and a MADLAD model and persists the result.
     /// </summary>
     /// <returns>The name of the downloaded model, or null if nothing was downloaded.</returns>
-    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, string? preselectModelName)
+    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, string? preselectModelName, bool autoStartModelDownload = false)
     {
         var engine = new CrispAsrMadlad();
 
@@ -116,6 +132,10 @@ public static class CrispAsrTranslateDownloadHelper
             owner, vm =>
             {
                 vm.SetModels(models, engine, selectedModel);
+                if (autoStartModelDownload && selectedModel != null)
+                {
+                    vm.StartDownload();
+                }
             });
 
         if (modelsVm is { OkPressed: true, SelectedModel: not null })
@@ -139,29 +159,42 @@ public static class CrispAsrTranslateDownloadHelper
     {
         var engine = new CrispAsrMadlad();
         var engineInstalled = engine.IsEngineInstalled();
-        if (engineInstalled)
-        {
-            var installedModel = GetInstalledModelPath();
-            if (installedModel != null)
-            {
-                // self-heal: point settings at the binary/model that are actually on disk
-                if (Se.Settings.AutoTranslate.CrispAsrExe != engine.GetExecutable() ||
-                    Se.Settings.AutoTranslate.CrispAsrModel != installedModel)
-                {
-                    Se.Settings.AutoTranslate.CrispAsrExe = engine.GetExecutable();
-                    Se.Settings.AutoTranslate.CrispAsrModel = installedModel;
-                    Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
-                    Configuration.Settings.Tools.AutoTranslateCrispAsrModel = installedModel;
-                    Se.SaveSettings();
-                }
 
-                return true;
+        // The model we need on disk: the specific one the caller picked, or any installed one as a fallback.
+        var wantedModelPath = !string.IsNullOrEmpty(preselectModelName)
+            ? engine.GetModelForCmdLine(preselectModelName)
+            : GetInstalledModelPath();
+        var modelInstalled = wantedModelPath != null && File.Exists(wantedModelPath);
+
+        if (engineInstalled && modelInstalled)
+        {
+            // self-heal: point settings at the binary/model that are actually on disk
+            if (Se.Settings.AutoTranslate.CrispAsrExe != engine.GetExecutable() ||
+                Se.Settings.AutoTranslate.CrispAsrModel != wantedModelPath)
+            {
+                Se.Settings.AutoTranslate.CrispAsrExe = engine.GetExecutable();
+                Se.Settings.AutoTranslate.CrispAsrModel = wantedModelPath!;
+                Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
+                Configuration.Settings.Tools.AutoTranslateCrispAsrModel = wantedModelPath!;
+                Se.SaveSettings();
             }
+
+            return true;
         }
 
-        var message = engineInstalled
-            ? $"{CrispAsrMadladTranslate.StaticName} requires a MADLAD model to be downloaded. Download now?"
-            : $"{CrispAsrMadladTranslate.StaticName} requires the CrispASR engine and a MADLAD model to be downloaded. Download now?";
+        string message;
+        if (!engineInstalled && !modelInstalled)
+        {
+            message = $"{CrispAsrMadladTranslate.StaticName} requires the CrispASR engine and a MADLAD model to be downloaded. Download now?";
+        }
+        else if (!engineInstalled)
+        {
+            message = $"{CrispAsrMadladTranslate.StaticName} requires the CrispASR engine to be downloaded. Download now?";
+        }
+        else
+        {
+            message = $"{CrispAsrMadladTranslate.StaticName} requires the selected MADLAD model to be downloaded. Download now?";
+        }
 
         var answer = await MessageBox.Show(
             owner,
@@ -175,8 +208,8 @@ public static class CrispAsrTranslateDownloadHelper
             return false;
         }
 
-        await DownloadAsync(owner, windowService, preselectModelName);
+        await DownloadAsync(owner, windowService, preselectModelName, autoStartModelDownload: !string.IsNullOrEmpty(preselectModelName));
 
-        return IsReady();
+        return IsReady(preselectModelName);
     }
 }

--- a/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
+++ b/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
@@ -1,0 +1,114 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Core.AutoTranslate;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Translate;
+
+/// <summary>
+/// Shared download/availability logic for the <see cref="CrispAsrMadladTranslate"/> auto-translate engine,
+/// used by both the auto-translate window and batch convert.
+/// </summary>
+public static class CrispAsrTranslateDownloadHelper
+{
+    public static bool IsReady()
+    {
+        var engine = new CrispAsrMadlad();
+        var modelPath = Se.Settings.AutoTranslate.CrispAsrModel;
+        return engine.IsEngineInstalled() && !string.IsNullOrEmpty(modelPath) && File.Exists(modelPath);
+    }
+
+    /// <summary>
+    /// Opens the download window(s) for the CrispASR engine binary and a MADLAD model and persists the result.
+    /// </summary>
+    /// <returns>The name of the downloaded model, or null if nothing was downloaded.</returns>
+    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, string? preselectModelName)
+    {
+        var engine = new CrispAsrMadlad();
+
+        if (!engine.IsEngineInstalled())
+        {
+            var engineVm = await windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
+                owner, vm =>
+                {
+                    vm.Engine = engine;
+                    vm.CrispAsrWindowsVariant = "cpu";
+                    vm.StartDownload();
+                });
+
+            if (!engineVm.OkPressed || !engine.IsEngineInstalled())
+            {
+                return null;
+            }
+        }
+
+        var models = new ObservableCollection<SpeechToTextModelDisplay>();
+        SpeechToTextModelDisplay? selectedModel = null;
+        foreach (var model in engine.Models)
+        {
+            var display = new SpeechToTextModelDisplay
+            {
+                Model = model,
+                Engine = engine,
+            };
+            models.Add(display);
+            if (model.Name == preselectModelName)
+            {
+                selectedModel = display;
+            }
+        }
+
+        var modelsVm = await windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
+            owner, vm =>
+            {
+                vm.SetModels(models, engine, selectedModel);
+            });
+
+        if (modelsVm is { OkPressed: true, SelectedModel: not null })
+        {
+            Se.Settings.AutoTranslate.CrispAsrExe = engine.GetExecutable();
+            Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
+            Se.Settings.AutoTranslate.CrispAsrModel = engine.GetModelForCmdLine(modelsVm.SelectedModel.Model.Name);
+            Configuration.Settings.Tools.AutoTranslateCrispAsrModel = Se.Settings.AutoTranslate.CrispAsrModel;
+            Se.SaveSettings();
+            return modelsVm.SelectedModel.Model.Name;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Ensures the CrispASR engine and a MADLAD model are installed, prompting the user to download them if not.
+    /// </summary>
+    /// <returns>True if the engine is ready to use.</returns>
+    public static async Task<bool> EnsureReadyAsync(Window owner, IWindowService windowService, string? preselectModelName)
+    {
+        if (IsReady())
+        {
+            return true;
+        }
+
+        var answer = await MessageBox.Show(
+            owner,
+            Se.Language.General.Download,
+            $"{CrispAsrMadladTranslate.StaticName} requires the CrispASR engine and a MADLAD model to be downloaded. Download now?",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            return false;
+        }
+
+        await DownloadAsync(owner, windowService, preselectModelName);
+
+        return IsReady();
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCanary.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCanary.cs
@@ -104,13 +104,7 @@ public class CrispAsrCanary : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
@@ -114,13 +114,7 @@ public class CrispAsrCohere : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFireRed.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFireRed.cs
@@ -124,13 +124,7 @@ public class CrispAsrFireRed : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGlm.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGlm.cs
@@ -88,13 +88,7 @@ public class CrispAsrGlm : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGranite.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGranite.cs
@@ -84,13 +84,7 @@ public class CrispAsrGranite : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrKyutai.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrKyutai.cs
@@ -71,13 +71,7 @@ public class CrispAsrKyutai : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMadlad.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMadlad.cs
@@ -1,0 +1,146 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// CrispASR MADLAD-400 text translation backend. This is not a speech-to-text engine - it is
+/// only used to drive the shared CrispASR binary/model download windows for the auto-translate
+/// feature, so it is intentionally not registered in <see cref="CrispAsrEngine"/>.
+/// </summary>
+public class CrispAsrMadlad : CrispAsrEngineBase
+{
+    public static string StaticName => "Crisp ASR MADLAD";
+    public override string Name => StaticName;
+    public override string Choice => WhisperChoice.CrispAsrMadlad;
+    public override string Url => "https://github.com/CrispStrobe/CrispASR";
+    public override string BackendName => "madlad";
+    public override string DefaultLanguage => "en";
+    public override bool IncludeLanguage => false;
+    public override bool HasNativeTimestamps => false;
+
+    public override List<WhisperLanguage> Languages => new();
+
+    public override List<WhisperModel> Models =>
+       new()
+       {
+            new WhisperModel
+            {
+                Name = "madlad400-3b-mt-q4_k.gguf",
+                Size = "1.8 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/madlad400-3b-mt-GGUF/resolve/main/madlad400-3b-mt-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "madlad400-3b-mt-q8_0.gguf",
+                Size = "3.1 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/madlad400-3b-mt-GGUF/resolve/main/madlad400-3b-mt-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "madlad400-3b-mt-f16.gguf",
+                Size = "5.7 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/madlad400-3b-mt-GGUF/resolve/main/madlad400-3b-mt-f16.gguf",
+                ],
+            },
+       };
+
+    public override string Extension => string.Empty;
+    public override string UnpackSkipFolder => string.Empty;
+
+    public override bool IsEngineInstalled()
+    {
+        var executableFile = GetExecutable();
+        return File.Exists(executableFile);
+    }
+
+    public override string ToString()
+    {
+        return StaticName;
+    }
+
+    public override string GetAndCreateWhisperFolder()
+    {
+        var baseFolder = Se.SpeechToTextFolder;
+        if (!Directory.Exists(baseFolder))
+        {
+            Directory.CreateDirectory(baseFolder);
+        }
+
+        var folder = Path.Combine(baseFolder, "CrispASR");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = GetAndCreateWhisperFolder();
+        var modelsFolder = Path.Combine(folder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public override string GetExecutable()
+    {
+        return Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+    }
+
+    public override bool IsModelInstalled(WhisperModel model)
+    {
+        var modelFile = GetModelForCmdLine(model.Name);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string GetModelForCmdLine(string modelName)
+    {
+        return Path.Combine(GetAndCreateWhisperModelFolder(null), modelName);
+    }
+
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        var folder = GetAndCreateWhisperModelFolder(whisperModel);
+        var fileNameOnly = Path.GetFileName(url);
+        return Path.Combine(folder, fileNameOnly);
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "crispasr.exe";
+        }
+
+        return "crispasr";
+    }
+
+    public override bool CanBeDownloaded()
+    {
+        return true;
+    }
+
+    public override string CommandLineParameter { get; set; } = string.Empty;
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMadlad.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMadlad.cs
@@ -72,13 +72,7 @@ public class CrispAsrMadlad : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrOmni.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrOmni.cs
@@ -245,13 +245,7 @@ public class CrispAsrOmni : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -102,13 +102,7 @@ public class CrispAsrParakeet : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
@@ -110,13 +110,7 @@ public class CrispAsrQwen3 : CrispAsrEngineBase
 
     public override string GetAndCreateWhisperFolder()
     {
-        var baseFolder = Se.SpeechToTextFolder;
-        if (!Directory.Exists(baseFolder))
-        {
-            Directory.CreateDirectory(baseFolder);
-        }
-
-        var folder = Path.Combine(baseFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
@@ -144,7 +144,7 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
 
     private string? GetVadCrispAsrFile()
     {
-        var folder = Path.Combine(Se.SpeechToTextFolder, "CrispASR");
+        var folder = Se.CrispAsrFolder;
         if (!Directory.Exists(folder))
         {
             return null;

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -96,6 +96,7 @@ public class Se
     public static string FfmpegFolder => Path.Combine(DataFolder, "ffmpeg");
     public static string TextToSpeechFolder => Path.Combine(DataFolder, "TextToSpeech");
     public static string SpeechToTextFolder => Path.Combine(DataFolder, "SpeechToText");
+    public static string CrispAsrFolder => Path.Combine(DataFolder, "CrispASR");
     public static string WaveformsFolder => Path.Combine(DataFolder, "Waveforms");
     public static string SpectrogramsFolder => Path.Combine(DataFolder, "Spectrograms");
     public static string ShotChangesFolder => Path.Combine(DataFolder, "ShotChanges");

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -92,6 +92,8 @@ public class SeAutoTranslate
     public string GeminiModel { get; set; }
     public string GeminiPrompt { get; set; }
     public string SeamlessM4TUrl { get; set; }
+    public string CrispAsrExe { get; set; }
+    public string CrispAsrModel { get; set; }
 
     public SeAutoTranslate()
     {
@@ -176,6 +178,8 @@ public class SeAutoTranslate
         PapagoApiKeyId = string.Empty;
         RequestMaxBytes = 1000;
         SeamlessM4TUrl = "http://localhost:5000/";
+        CrispAsrExe = string.Empty;
+        CrispAsrModel = string.Empty;
         LaraApiId = string.Empty;
         LaraApiSecret = string.Empty;
     }


### PR DESCRIPTION
## Summary

Adds **CrispASR MADLAD** as a new auto-translate engine. It runs the local [CrispASR](https://github.com/CrispStrobe/CrispASR) command line tool with the MADLAD-400 backend (`crispasr --backend madlad -m <model> --text <t> -sl <s> -tl <t> --no-prints`) and returns the translated text from stdout.

- New `CrispAsrMadladTranslate` engine in `libse` — spawns the `crispasr` binary per line, netstandard2.1-compatible async process wait that kills the process on cancellation.
- **Auto-download** of the CrispASR binary and the MADLAD GGUF model, reusing the existing speech-to-text download windows. The binary lives in the shared `CrispASR` folder, so it is skipped if already installed for speech-to-text.
- **Model combobox** in the auto-translate UI (q4_k 1.8 GB / q8_0 3.1 GB / f16 5.7 GB) plus a **Download** button.
- Clicking **Translate** when the engine/model is not yet installed prompts to download.
- `SeJsonParser.GetFirstObject` now returns null for null/empty input instead of throwing `NullReferenceException`.

CrispASR's HTTP server has no text-translation endpoint (only ASR/TTS), so the CLI is the only way to drive MADLAD; the flags and clean `--no-prints` stdout are confirmed by CrispASR's own `tests/test-translators.sh`.

## Test plan

- [ ] Select "CrispASR MADLAD" in Auto-translate; the model combobox + Download button appear
- [ ] Download flow installs the `crispasr` binary (if missing) then the selected MADLAD model
- [ ] Translating without binary/model prompts to download
- [ ] Translation produces expected output for a few language pairs
- [ ] Cancelling a translation terminates the `crispasr` process

🤖 Generated with [Claude Code](https://claude.com/claude-code)