### PR TITLE
Add server-managed llama.cpp auto-translate engine

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -303,6 +303,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<DownloadGoogleLensOcrViewModel>();
         collection.AddTransient<DownloadLibMpvViewModel>();
         collection.AddTransient<DownloadLibVlcViewModel>();
+        collection.AddTransient<DownloadLlamaCppViewModel>();
         collection.AddTransient<DownloadPaddleOcrViewModel>();
         collection.AddTransient<DownloadTesseractModelViewModel>();
         collection.AddTransient<DownloadTesseractViewModel>();

--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -55,11 +55,14 @@ public class MessageBox : Window
     private MessageBox(string title, string message, MessageBoxButtons buttons, MessageBoxIcon icon, string? custom1 = null, string? custom2 = null, string? custom3 = null)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Width = 400;
-        Height = 180;
         Title = title;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
         CanResize = false;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        MinWidth = 400;
+        MinHeight = 180;
+        MaxWidth = 900;
+        MaxHeight = 700;
 
         var message1 = message;
 
@@ -111,15 +114,8 @@ public class MessageBox : Window
             TextWrapping = TextWrapping.Wrap,
             Height = double.NaN,
             Width = double.NaN,
+            MaxWidth = 700, // wrap long messages instead of growing the window unbounded
         };
-
-
-        var x = TextMeasurer.MeasureString(message, textBlock.FontFamily.Name, (float)textBlock.FontSize);
-        if (x.Width > Width - 100)
-        {
-            Width += 200;
-            Height += 50;
-        }
 
         if (message.Length > 1000)
         {
@@ -127,6 +123,7 @@ public class MessageBox : Window
             {
                 Width = double.NaN,
                 Height = double.NaN,
+                MaxHeight = 400,
                 Margin = new Thickness(10),
                 Content = textBlock
             };

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -13,6 +13,7 @@ using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -68,6 +69,11 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<SpeechToTextModelDisplay> _crispAsrModels = new();
     [ObservableProperty] private SpeechToTextModelDisplay? _selectedCrispAsrModel;
     [ObservableProperty] private bool _crispAsrModelComboIsVisible;
+    [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels = new();
+    [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
+    [ObservableProperty] private bool _llamaCppModelComboIsVisible;
+    [ObservableProperty] private bool _llamaCppButtonsAreVisible;
+    [ObservableProperty] private string _llamaCppServerButtonText = "Start server";
 
     public DataGrid? RowGrid { get; set; }
 
@@ -278,11 +284,8 @@ public partial class AutoTranslateViewModel : ObservableObject
             Configuration.Settings.Tools.LmStudioModel = apiModel.Trim();
         }
 
-        if (engineType == typeof(LlamaCppTranslate))
-        {
-            Configuration.Settings.Tools.LlamaCppApiUrl = apiUrl.Trim();
-            Configuration.Settings.Tools.LlamaCppModel = apiModel.Trim();
-        }
+        // llama.cpp is server-managed: the API URL is set by LlamaCppServerManager and the
+        // model is persisted via OnSelectedLlamaCppModelChanged, so nothing to save here.
 
         if (engineType == typeof(OllamaTranslate))
         {
@@ -691,6 +694,98 @@ public partial class AutoTranslateViewModel : ObservableObject
         return ready;
     }
 
+    partial void OnSelectedLlamaCppModelChanged(LlamaCppModelDisplay? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        Se.Settings.AutoTranslate.LlamaCppModel = LlamaCppServerManager.GetModelPath(value.Model.FileName);
+        Configuration.Settings.Tools.LlamaCppModel = Se.Settings.AutoTranslate.LlamaCppModel;
+    }
+
+    private void UpdateLlamaCppServerButtonText()
+    {
+        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? "Stop server" : "Start server";
+    }
+
+    [RelayCommand]
+    private async Task DownloadLlamaCpp()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var model = SelectedLlamaCppModel?.Model;
+        var downloaded = await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model);
+        if (downloaded != null)
+        {
+            var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, selectName);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ToggleLlamaCppServer()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (LlamaCppServerManager.IsServerRunning)
+        {
+            LlamaCppServerManager.StopServer();
+            UpdateLlamaCppServerButtonText();
+            return;
+        }
+
+        await EnsureLlamaCppReady();
+        UpdateLlamaCppServerButtonText();
+    }
+
+    private async Task<bool> EnsureLlamaCppReady()
+    {
+        if (Window == null)
+        {
+            return false;
+        }
+
+        var model = SelectedLlamaCppModel?.Model;
+        if (model == null)
+        {
+            return false;
+        }
+
+        if (!await LlamaCppDownloadHelper.EnsureReadyAsync(Window, _windowService, model.FileName))
+        {
+            return false;
+        }
+
+        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, model.FileName);
+
+        try
+        {
+            await LlamaCppServerManager.EnsureServerRunningAsync(
+                LlamaCppServerManager.GetModelPath(model.FileName), _cancellationTokenSource.Token);
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                ex.Message,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return false;
+        }
+
+        UpdateLlamaCppServerButtonText();
+        return true;
+    }
+
     private async Task<bool> DoTranslate()
     {
         var translator = SelectedAutoTranslator;
@@ -752,8 +847,15 @@ public partial class AutoTranslateViewModel : ObservableObject
             return false;
         }
 
-        _translationInProgress = true;
         _cancellationTokenSource = new CancellationTokenSource();
+
+        if (engineType == typeof(LlamaCppTranslate) && !await EnsureLlamaCppReady())
+        {
+            IsProgressEnabled = false;
+            return false;
+        }
+
+        _translationInProgress = true;
 
 
         SaveSettings();
@@ -1006,6 +1108,10 @@ public partial class AutoTranslateViewModel : ObservableObject
         CrispAsrModelComboIsVisible = false;
         CrispAsrModels.Clear();
         SelectedCrispAsrModel = null;
+        LlamaCppModelComboIsVisible = false;
+        LlamaCppButtonsAreVisible = false;
+        LlamaCppModels.Clear();
+        SelectedLlamaCppModel = null;
         ModelText = string.Empty;
         //LabelApiUrl.Text = "API url";
         //LabelApiKey.Text = "API key";
@@ -1177,22 +1283,11 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         if (engineType == typeof(LlamaCppTranslate))
         {
-            ModelBrowseIsVisible = false;
-
-            if (string.IsNullOrEmpty(Se.Settings.AutoTranslate.LlamaCppApiUrl))
-            {
-                Se.Settings.AutoTranslate.LlamaCppApiUrl = "http://localhost:8080/v1/chat/completions";
-            }
-
-            FillUrls(new List<string>
-            {
-                Se.Settings.AutoTranslate.LlamaCppApiUrl.TrimEnd('/'),
-            });
-
-            _apiModels = Configuration.Settings.Tools.OllamaModels.Split(',').ToList(); //TODO: fix this to get LlamaCpp models
-            ModelIsVisible = false;
-            ButtonModelIsVisible = false;
-            ModelText = Se.Settings.AutoTranslate.LlamaCppModel;
+            LlamaCppModelComboIsVisible = true;
+            LlamaCppButtonsAreVisible = true;
+            var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, savedModelName);
+            UpdateLlamaCppServerButtonText();
 
             return;
         }

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -144,6 +144,15 @@ public class AutoTranslateWindow : Window
 
         var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
 
+        var llamaCppModelCombo = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel), nameof(vm.LlamaCppModelComboIsVisible));
+
+        var buttonDownloadLlamaCpp = UiUtil.MakeButton(Se.Language.General.Download, vm.DownloadLlamaCppCommand).WithMarginLeft(5);
+        buttonDownloadLlamaCpp.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
+
+        var buttonLlamaCppServer = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppServerCommand).WithMarginLeft(5);
+        buttonLlamaCppServer.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppServerButtonText)));
+        buttonLlamaCppServer.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
+
         StackPanel settingsBar = UiUtil.MakeControlBarLeft(
 
             UiUtil.MakeTextBlock(Se.Language.General.Id, vm, null, nameof(vm.ApiIdIsVisible)).WithMarginRight(5),
@@ -164,7 +173,12 @@ public class AutoTranslateWindow : Window
 
             UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.CrispAsrModelComboIsVisible)).WithMarginRight(5),
             crispAsrModelCombo,
-            buttonDownloadCrispAsr
+            buttonDownloadCrispAsr,
+
+            UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.LlamaCppModelComboIsVisible)).WithMarginRight(5),
+            llamaCppModelCombo,
+            buttonDownloadLlamaCpp,
+            buttonLlamaCppServer
         );
 
         var settingsLink = UiUtil.MakeLink(Se.Language.General.Settings, vm.OpenSettingsCommand).WithMarginRight(10);

--- a/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
@@ -1,0 +1,192 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Compression;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Translate;
+
+public partial class DownloadLlamaCppViewModel : ObservableObject
+{
+    [ObservableProperty] private string _titleText;
+    [ObservableProperty] private double _progressValue;
+    [ObservableProperty] private string _progressText;
+    [ObservableProperty] private string _error;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    /// <summary>"cpu", "vulkan" or "cuda" - which llama.cpp build to download (Windows only).</summary>
+    public string Variant { get; set; } = LlamaCppDownloadService.VariantCpu;
+
+    /// <summary>The model to download, or null to only install the engine.</summary>
+    public LlamaCppTranslateModel? Model { get; set; }
+
+    private const string TemporaryFileExtension = ".$$$";
+
+    private readonly ILlamaCppDownloadService _downloadService;
+    private readonly IZipUnpacker _zipUnpacker;
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    public DownloadLlamaCppViewModel(ILlamaCppDownloadService downloadService, IZipUnpacker zipUnpacker)
+    {
+        _downloadService = downloadService;
+        _zipUnpacker = zipUnpacker;
+        TitleText = string.Format(Se.Language.General.DownloadingX, "llama.cpp");
+        ProgressText = Se.Language.General.StartingDotDotDot;
+        Error = string.Empty;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        _cancellationTokenSource.Cancel();
+        Close();
+    }
+
+    public async void StartDownload()
+    {
+        try
+        {
+            var folder = LlamaCppServerManager.GetAndCreateFolder();
+            var token = _cancellationTokenSource.Token;
+
+            if (!LlamaCppServerManager.IsEngineInstalled())
+            {
+                TitleText = string.Format(Se.Language.General.DownloadingX, "llama.cpp");
+                using (var engineStream = new MemoryStream())
+                {
+                    await _downloadService.DownloadEngine(engineStream, Variant, MakeProgress(), token);
+                    if (token.IsCancellationRequested)
+                    {
+                        Close();
+                        return;
+                    }
+
+                    TitleText = string.Format(Se.Language.General.UnpackingX, "llama.cpp");
+                    engineStream.Position = 0;
+                    _zipUnpacker.UnpackZipStream(engineStream, folder, string.Empty, true, new List<string>(), null);
+                }
+
+                if (LlamaCppDownloadService.VariantNeedsCudaRuntime(Variant))
+                {
+                    TitleText = string.Format(Se.Language.General.DownloadingX, "CUDA runtime");
+                    using var cudartStream = new MemoryStream();
+                    await _downloadService.DownloadCudaRuntime(cudartStream, MakeProgress(), token);
+                    if (token.IsCancellationRequested)
+                    {
+                        Close();
+                        return;
+                    }
+
+                    TitleText = string.Format(Se.Language.General.UnpackingX, "CUDA runtime");
+                    cudartStream.Position = 0;
+                    _zipUnpacker.UnpackZipStream(cudartStream, folder, string.Empty, true, new List<string>(), null);
+                }
+
+                MakeExecutable(LlamaCppServerManager.GetExecutable());
+            }
+
+            if (Model != null && !LlamaCppServerManager.IsModelInstalled(Model.FileName))
+            {
+                TitleText = string.Format(Se.Language.General.DownloadingX, Model.DisplayName);
+                var finalPath = LlamaCppServerManager.GetModelPath(Model.FileName);
+                var tempPath = finalPath + TemporaryFileExtension;
+                await _downloadService.DownloadModel(Model.Url, tempPath, MakeProgress(), token);
+                if (token.IsCancellationRequested)
+                {
+                    TryDelete(tempPath);
+                    Close();
+                    return;
+                }
+
+                if (File.Exists(finalPath))
+                {
+                    File.Delete(finalPath);
+                }
+
+                File.Move(tempPath, finalPath);
+            }
+
+            OkPressed = true;
+            Close();
+        }
+        catch (OperationCanceledException)
+        {
+            Close();
+        }
+        catch (Exception ex)
+        {
+            ProgressText = "Download failed";
+            Error = ex.Message;
+            Se.LogError(ex, "Error downloading llama.cpp");
+        }
+    }
+
+    private IProgress<float> MakeProgress()
+    {
+        return new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, percentage.ToString(CultureInfo.InvariantCulture));
+        });
+    }
+
+    private static void MakeExecutable(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            MacHelper.MakeExecutable(path);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            LinuxHelper.MakeExecutable(path);
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() => Window?.Close());
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Cancel();
+        }
+    }
+}

--- a/src/ui/Features/Translate/DownloadLlamaCppWindow.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppWindow.cs
@@ -1,0 +1,88 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Translate;
+
+public class DownloadLlamaCppWindow : Window
+{
+    public DownloadLlamaCppWindow(DownloadLlamaCppViewModel vm)
+    {
+        vm.Window = this;
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = string.Format(Se.Language.General.DownloadingX, "llama.cpp");
+        Width = 500;
+        Height = 190;
+        CanResize = false;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        DataContext = vm;
+
+        var titleText = new TextBlock
+        {
+            FontSize = 20,
+            FontWeight = FontWeight.Bold,
+        };
+        titleText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.TitleText)));
+
+        var progressSlider = new Slider
+        {
+            Minimum = 0,
+            Maximum = 100,
+            IsHitTestVisible = false,
+            Focusable = false,
+            Styles =
+            {
+                new Style(x => x.OfType<Thumb>())
+                {
+                    Setters =
+                    {
+                        new Setter(Thumb.IsVisibleProperty, false)
+                    }
+                },
+                new Style(x => x.OfType<Track>())
+                {
+                    Setters =
+                    {
+                        new Setter(Track.HeightProperty, 6.0)
+                    }
+                },
+            }
+        };
+        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+
+        var statusText = new TextBlock();
+        statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
+
+        var errorText = new TextBlock
+        {
+            Foreground = Brushes.IndianRed,
+            TextWrapping = TextWrapping.Wrap,
+        };
+        errorText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Error)));
+
+        var buttonCancel = UiUtil.MakeButton(Se.Language.General.Cancel, vm.CancelCommand);
+        var buttonBar = UiUtil.MakeButtonBar(buttonCancel);
+
+        Content = new StackPanel
+        {
+            Spacing = 8,
+            Margin = new Thickness(20),
+            Children =
+            {
+                titleText,
+                progressSlider,
+                statusText,
+                errorText,
+                buttonBar,
+            }
+        };
+
+        Activated += delegate { buttonCancel.Focus(); };
+        KeyDown += (s, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -1,0 +1,233 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Translate;
+
+/// <summary>
+/// A curated llama.cpp translate model wrapped for display in a combobox (name + size + install status).
+/// </summary>
+public class LlamaCppModelDisplay
+{
+    public LlamaCppTranslateModel Model { get; }
+
+    public LlamaCppModelDisplay(LlamaCppTranslateModel model)
+    {
+        Model = model;
+    }
+
+    public override string ToString()
+    {
+        var installed = LlamaCppServerManager.IsModelInstalled(Model.FileName);
+        return installed
+            ? $"{Model.DisplayName} ({Model.Size})"
+            : $"{Model.DisplayName} ({Model.Size}, not installed)";
+    }
+}
+
+/// <summary>
+/// Shared download/availability logic for the llama.cpp auto-translate engine - mirrors
+/// <see cref="CrispAsrTranslateDownloadHelper"/>.
+/// </summary>
+public static class LlamaCppDownloadHelper
+{
+    /// <summary>
+    /// True when the llama-server binary is installed and a model is available. When
+    /// <paramref name="modelFileName"/> is given, that specific model must be installed.
+    /// </summary>
+    public static bool IsReady(string? modelFileName = null)
+    {
+        if (!LlamaCppServerManager.IsEngineInstalled())
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(modelFileName))
+        {
+            return LlamaCppServerManager.IsModelInstalled(modelFileName);
+        }
+
+        return GetInstalledModelPath() != null;
+    }
+
+    /// <summary>
+    /// Path of an installed model - the one from settings if it still exists, otherwise any
+    /// known model file found in the llama.cpp models folder.
+    /// </summary>
+    public static string? GetInstalledModelPath()
+    {
+        var configured = Se.Settings.AutoTranslate.LlamaCppModel;
+        if (!string.IsNullOrEmpty(configured) && File.Exists(configured))
+        {
+            return configured;
+        }
+
+        foreach (var model in LlamaCppServerManager.Models)
+        {
+            var path = LlamaCppServerManager.GetModelPath(model.FileName);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Fills <paramref name="target"/> with the curated models and returns the one matching
+    /// <paramref name="selectFileName"/>, or the first model otherwise.
+    /// </summary>
+    public static LlamaCppModelDisplay? PopulateModels(ObservableCollection<LlamaCppModelDisplay> target, string? selectFileName)
+    {
+        target.Clear();
+        LlamaCppModelDisplay? toSelect = null;
+        foreach (var model in LlamaCppServerManager.Models)
+        {
+            var display = new LlamaCppModelDisplay(model);
+            target.Add(display);
+            if (model.FileName == selectFileName)
+            {
+                toSelect = display;
+            }
+        }
+
+        return toSelect ?? target.FirstOrDefault();
+    }
+
+    private static LlamaCppTranslateModel? ResolveModel(string? modelFileName)
+    {
+        if (!string.IsNullOrEmpty(modelFileName))
+        {
+            var match = LlamaCppServerManager.Models.FirstOrDefault(m => m.FileName == modelFileName);
+            if (match != null)
+            {
+                return match;
+            }
+        }
+
+        return LlamaCppServerManager.Models.FirstOrDefault(m => LlamaCppServerManager.IsModelInstalled(m.FileName))
+               ?? LlamaCppServerManager.Models.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Opens the llama.cpp download window (engine binary + selected model) and persists the result.
+    /// </summary>
+    /// <returns>The downloaded model file name, or null if nothing was downloaded.</returns>
+    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, LlamaCppTranslateModel? model)
+    {
+        var variant = Logic.Download.LlamaCppDownloadService.VariantCpu;
+        if (!LlamaCppServerManager.IsEngineInstalled() && OperatingSystem.IsWindows())
+        {
+            var buildAnswer = await MessageBox.Show(
+                owner,
+                "Download llama.cpp?",
+                "Select which llama.cpp build to download:",
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                "CPU",
+                "Vulkan (GPU)",
+                "CUDA (NVIDIA GPU)");
+
+            variant = buildAnswer switch
+            {
+                MessageBoxResult.Custom1 => Logic.Download.LlamaCppDownloadService.VariantCpu,
+                MessageBoxResult.Custom2 => Logic.Download.LlamaCppDownloadService.VariantVulkan,
+                MessageBoxResult.Custom3 => Logic.Download.LlamaCppDownloadService.VariantCuda,
+                _ => null,
+            } ?? string.Empty;
+
+            if (string.IsNullOrEmpty(variant))
+            {
+                return null;
+            }
+        }
+
+        var dlVm = await windowService.ShowDialogAsync<DownloadLlamaCppWindow, DownloadLlamaCppViewModel>(
+            owner, vm =>
+            {
+                vm.Variant = variant;
+                vm.Model = model;
+                vm.StartDownload();
+            });
+
+        if (!dlVm.OkPressed)
+        {
+            return null;
+        }
+
+        if (model != null)
+        {
+            Se.Settings.AutoTranslate.LlamaCppModel = LlamaCppServerManager.GetModelPath(model.FileName);
+            Configuration.Settings.Tools.LlamaCppModel = Se.Settings.AutoTranslate.LlamaCppModel;
+            Se.SaveSettings();
+            return model.FileName;
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Ensures the llama-server binary and the requested model are installed, prompting the user
+    /// to download them if not.
+    /// </summary>
+    public static async Task<bool> EnsureReadyAsync(Window owner, IWindowService windowService, string? modelFileName)
+    {
+        var engineInstalled = LlamaCppServerManager.IsEngineInstalled();
+        var model = ResolveModel(modelFileName);
+        var modelInstalled = model != null && LlamaCppServerManager.IsModelInstalled(model.FileName);
+
+        if (engineInstalled && modelInstalled)
+        {
+            var modelPath = LlamaCppServerManager.GetModelPath(model!.FileName);
+            if (Se.Settings.AutoTranslate.LlamaCppModel != modelPath)
+            {
+                Se.Settings.AutoTranslate.LlamaCppModel = modelPath;
+                Configuration.Settings.Tools.LlamaCppModel = modelPath;
+                Se.SaveSettings();
+            }
+
+            return true;
+        }
+
+        string message;
+        if (!engineInstalled && !modelInstalled)
+        {
+            message = "llama.cpp requires the llama-server engine and a translation model to be downloaded. Download now?";
+        }
+        else if (!engineInstalled)
+        {
+            message = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+        }
+        else
+        {
+            message = "llama.cpp requires the selected translation model to be downloaded. Download now?";
+        }
+
+        var answer = await MessageBox.Show(
+            owner,
+            Se.Language.General.Download,
+            message,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            return false;
+        }
+
+        await DownloadAsync(owner, windowService, model);
+
+        return LlamaCppServerManager.IsEngineInstalled()
+               && model != null
+               && LlamaCppServerManager.IsModelInstalled(model.FileName);
+    }
+}

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -97,6 +97,7 @@ public class Se
     public static string TextToSpeechFolder => Path.Combine(DataFolder, "TextToSpeech");
     public static string SpeechToTextFolder => Path.Combine(DataFolder, "SpeechToText");
     public static string CrispAsrFolder => Path.Combine(DataFolder, "CrispASR");
+    public static string LlamaCppFolder => Path.Combine(DataFolder, "llama.cpp");
     public static string WaveformsFolder => Path.Combine(DataFolder, "Waveforms");
     public static string SpectrogramsFolder => Path.Combine(DataFolder, "Spectrograms");
     public static string ShotChangesFolder => Path.Combine(DataFolder, "ShotChanges");

--- a/src/ui/Logic/Download/LlamaCppDownloadService.cs
+++ b/src/ui/Logic/Download/LlamaCppDownloadService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -9,51 +9,69 @@ namespace Nikse.SubtitleEdit.Logic.Download;
 
 public interface ILlamaCppDownloadService
 {
-    Task DownloadllamaCpp(string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken);
-
-    Task DownloadllamaCpp(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngine(Stream stream, string variant, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadCudaRuntime(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadModel(string url, string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken);
 }
 
 public class LlamaCppDownloadService(HttpClient httpClient) : ILlamaCppDownloadService
 {
-    private const string WindowsUrl = "https://github.com/ggml-org/llama.cpp/releases/download/b7489/llama-b7489-bin-win-cpu-x64.zip";
-    private const string MacArmUrl = "https://github.com/ggml-org/llama.cpp/releases/download/b7489/llama-b7489-bin-macos-arm64.tar.gz";
-    private const string MacX64Url = "https://github.com/ggml-org/llama.cpp/releases/download/b7489/llama-b7489-bin-macos-x64.tar.gz";
-    private const string LinuxUrl = "https://github.com/ggml-org/llama.cpp/releases/download/b7489/llama-b7489-bin-ubuntu-x64.tar.gz";
+    private const string Version = "b9145";
+    private const string BaseUrl = "https://github.com/ggml-org/llama.cpp/releases/download/" + Version + "/";
 
-    public async Task DownloadllamaCpp(string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    public const string VariantCpu = "cpu";
+    public const string VariantVulkan = "vulkan";
+    public const string VariantCuda = "cuda";
+
+    public async Task DownloadEngine(Stream stream, string variant, IProgress<float>? progress, CancellationToken cancellationToken)
     {
-        await DownloadHelper.DownloadFileAsync(httpClient, GetUrl(), destinationFileName, progress, cancellationToken);
+        await DownloadHelper.DownloadFileAsync(httpClient, GetEngineUrl(variant), stream, progress, cancellationToken);
     }
 
-    public async Task DownloadllamaCpp(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    public async Task DownloadCudaRuntime(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
     {
-        await DownloadHelper.DownloadFileAsync(httpClient, GetUrl(), stream, progress, cancellationToken);
+        await DownloadHelper.DownloadFileAsync(httpClient, BaseUrl + "cudart-llama-bin-win-cuda-12.4-x64.zip", stream, progress, cancellationToken);
     }
 
-    private string GetUrl()
+    public async Task DownloadModel(string url, string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(httpClient, url, destinationFileName, progress, cancellationToken);
+    }
+
+    /// <summary>
+    /// True when the given variant ships its GPU runtime DLLs in a separate archive (Windows CUDA build).
+    /// </summary>
+    public static bool VariantNeedsCudaRuntime(string variant)
+    {
+        return OperatingSystem.IsWindows() && variant == VariantCuda;
+    }
+
+    private static string GetEngineUrl(string variant)
     {
         if (OperatingSystem.IsWindows())
         {
-            return WindowsUrl;
+            return variant switch
+            {
+                VariantCuda => BaseUrl + "llama-" + Version + "-bin-win-cuda-12.4-x64.zip",
+                VariantVulkan => BaseUrl + "llama-" + Version + "-bin-win-vulkan-x64.zip",
+                _ => BaseUrl + "llama-" + Version + "-bin-win-cpu-x64.zip",
+            };
         }
 
         if (OperatingSystem.IsLinux())
         {
-            return LinuxUrl;
+            return variant == VariantVulkan
+                ? BaseUrl + "llama-" + Version + "-bin-ubuntu-vulkan-x64.tar.gz"
+                : BaseUrl + "llama-" + Version + "-bin-ubuntu-x64.tar.gz";
         }
 
         if (OperatingSystem.IsMacOS())
         {
-            switch (RuntimeInformation.ProcessArchitecture)
-            {
-                case Architecture.Arm64:
-                    return MacArmUrl; // e.g., for M1, M2, M3, M4, M5 chips
-                case Architecture.X64:
-                    return MacX64Url;
-            }
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? BaseUrl + "llama-" + Version + "-bin-macos-arm64.tar.gz"
+                : BaseUrl + "llama-" + Version + "-bin-macos-x64.tar.gz";
         }
 
-        throw new PlatformNotSupportedException("Llama.cpp download is not support on this platform.");
+        throw new PlatformNotSupportedException("llama.cpp download is not supported on this platform.");
     }
 }

--- a/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
@@ -1,0 +1,330 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.LlamaCpp;
+
+/// <summary>
+/// A curated TranslateGemma model that can be downloaded and served via llama.cpp.
+/// </summary>
+public sealed record LlamaCppTranslateModel(string DisplayName, string FileName, string Size, string Url);
+
+/// <summary>
+/// Manages the local <c>llama-server</c> process used by the llama.cpp auto-translate engine:
+/// folder/executable paths, the curated model list, and the server lifecycle (start, health
+/// probe, stop, kill on app exit). Modeled on the CrispASR/Chatterbox server handling.
+/// </summary>
+public static class LlamaCppServerManager
+{
+    public static readonly IReadOnlyList<LlamaCppTranslateModel> Models = new[]
+    {
+        new LlamaCppTranslateModel("TranslateGemma 4B (Q4_K_M)", "translategemma-4b_Q4_K_M.gguf", "2.5 GB",
+            "https://huggingface.co/SandLogicTechnologies/translategemma-4b-it-GGUF/resolve/main/translategemma-4b_Q4_K_M.gguf"),
+        new LlamaCppTranslateModel("TranslateGemma 4B (Q5_K_M)", "translategemma-4b_Q5_K_M.gguf", "2.8 GB",
+            "https://huggingface.co/SandLogicTechnologies/translategemma-4b-it-GGUF/resolve/main/translategemma-4b_Q5_K_M.gguf"),
+        new LlamaCppTranslateModel("TranslateGemma 4B (Q8_0)", "translategemma-4b-it-q8_0.gguf", "4.1 GB",
+            "https://huggingface.co/NikolayKozloff/translategemma-4b-it-Q8_0-GGUF/resolve/main/translategemma-4b-it-q8_0.gguf"),
+        new LlamaCppTranslateModel("TranslateGemma 12B (Q4_K_M)", "translategemma-12b-it-q4_k_m.gguf", "7.3 GB",
+            "https://huggingface.co/NikolayKozloff/translategemma-12b-it-Q4_K_M-GGUF/resolve/main/translategemma-12b-it-q4_k_m.gguf"),
+    };
+
+    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromMinutes(5) };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverModelPath;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    public static bool IsServerRunning => _serverProcess is { HasExited: false } && _serverPort != 0;
+
+    public static string? RunningModelPath => IsServerRunning ? _serverModelPath : null;
+
+    public static string ApiUrl => $"http://127.0.0.1:{_serverPort}/v1/chat/completions";
+
+    public static string GetAndCreateFolder()
+    {
+        var folder = Se.LlamaCppFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetAndCreateModelsFolder()
+    {
+        var folder = Path.Combine(GetAndCreateFolder(), "models");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetExecutable()
+    {
+        return Path.Combine(GetAndCreateFolder(), OperatingSystem.IsWindows() ? "llama-server.exe" : "llama-server");
+    }
+
+    public static bool IsEngineInstalled()
+    {
+        return File.Exists(GetExecutable());
+    }
+
+    public static string GetModelPath(string fileName)
+    {
+        return Path.Combine(GetAndCreateModelsFolder(), fileName);
+    }
+
+    public static bool IsModelInstalled(string fileName)
+    {
+        var path = GetModelPath(fileName);
+        return File.Exists(path) && new FileInfo(path).Length > 10_000_000;
+    }
+
+    /// <summary>
+    /// Starts (or reuses) a llama-server for the given model and points
+    /// <see cref="Core.Settings.ToolsSettings.LlamaCppApiUrl"/> at it. Throws on failure.
+    /// </summary>
+    public static async Task EnsureServerRunningAsync(string modelPath, CancellationToken cancellationToken)
+    {
+        if (IsServerRunning && _serverModelPath == modelPath)
+        {
+            Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
+            return;
+        }
+
+        await ServerLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (IsServerRunning && _serverModelPath == modelPath)
+            {
+                Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
+                return;
+            }
+
+            // Server not running, or running with a different model - (re)start.
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException("llama-server executable not found - please download llama.cpp first.", exe);
+            }
+
+            if (!File.Exists(modelPath))
+            {
+                throw new FileNotFoundException("llama.cpp model not found - please download a model first.", modelPath);
+            }
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetAndCreateFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(modelPath);
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString(CultureInfo.InvariantCulture));
+            // Offload all layers to the GPU when a GPU build is in use; ignored by the CPU build.
+            psi.ArgumentList.Add("-ngl");
+            psi.ArgumentList.Add("99");
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add("8192");
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start llama-server");
+
+            Se.WriteToolsLog($"llama-server starting - PID: {process.Id}, Cmd: {FormatLaunchCommand(exe, psi.ArgumentList)}");
+
+            lock (_serverLog)
+            {
+                _serverLog.Clear();
+            }
+
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null)
+                {
+                    lock (_serverLog) _serverLog.AppendLine(e.Data);
+                }
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null)
+                {
+                    lock (_serverLog) _serverLog.AppendLine(e.Data);
+                }
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelPath = modelPath;
+            HookProcessExitOnce();
+
+            var deadline = DateTime.UtcNow.AddMinutes(5);
+            while (DateTime.UtcNow < deadline)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverModelPath = null;
+                    throw new InvalidOperationException(
+                        $"llama-server exited during startup (code {process.ExitCode}). Output: {tail}");
+                }
+
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), cancellationToken))
+                {
+                    Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            StopServerInternal();
+            throw new TimeoutException(
+                $"llama-server did not report healthy within 5 minutes. Last output: {lastOutput}");
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    public static void StopServer()
+    {
+        ServerLock.Wait();
+        try
+        {
+            StopServerInternal();
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverModelPath = null;
+        if (p == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    public static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked)
+        {
+            return;
+        }
+
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
@@ -154,6 +154,14 @@ public static class LlamaCppServerManager
             psi.ArgumentList.Add("99");
             psi.ArgumentList.Add("-c");
             psi.ArgumentList.Add("8192");
+            // TranslateGemma ships a non-standard Jinja chat template (it expects structured
+            // content with source/target language codes) that llama-server rejects at startup.
+            // The curated models are all Gemma-3 based, so fall back to the plain Gemma chat
+            // template - this keeps the OpenAI /v1/chat/completions endpoint working with the
+            // normal text messages the translate engine sends.
+            psi.ArgumentList.Add("--no-jinja");
+            psi.ArgumentList.Add("--chat-template");
+            psi.ArgumentList.Add("gemma");
 
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start llama-server");


### PR DESCRIPTION
## Summary

Turns the dormant `LlamaCppDownloadService` into a fully server-managed auto-translate engine. SubtitleEdit now downloads llama.cpp, manages a local `llama-server` process, and offers a curated model picker — no manual server setup required.

- **`Se.LlamaCppFolder`** → `<data>/llama.cpp` (binary in the root, GGUFs in `models/`)
- **`LlamaCppDownloadService`** — updated **b7489 → b9145**, now variant-aware (CPU / Vulkan / CUDA, the CUDA build also pulls the `cudart` runtime), plus a model-file download method
- **`LlamaCppServerManager`** — spawns `llama-server -m <model> --host 127.0.0.1 --port <free> -ngl 99`, polls `/health`, points `LlamaCppApiUrl` at itself, and kills the process tree on app exit (modeled on the proven `ChatterboxTtsCpp` server code)
- **`DownloadLlamaCppWindow` + VM** — downloads/unpacks the binary (+ cudart for CUDA) and the selected GGUF with a progress UI
- **`LlamaCppDownloadHelper`** — `IsReady` / `EnsureReadyAsync` / `PopulateModels`, mirroring `CrispAsrTranslateDownloadHelper`
- **Auto-translate UI** — when `llama.cpp` is selected: a **model combobox** (curated TranslateGemma 4B Q4_K_M / Q5_K_M / Q8_0 and 12B Q4_K_M, with size + install status), a **Download** button, and a **Start/Stop server** button. The server also auto-starts on Translate, prompting to download the binary/model if missing. On first-time engine download the user picks the build (CPU/Vulkan/CUDA) via a dialog.

The libse `LlamaCppTranslate` engine is unchanged — it stays a thin HTTP client and just reads the `LlamaCppApiUrl` the server manager sets.

## Test plan

- [ ] Select "llama.cpp" in Auto-translate → model combobox + Download + Start server buttons appear
- [ ] Download flow: pick CPU/Vulkan/CUDA build, binary + cudart (CUDA) + model download and unpack into `<data>/llama.cpp`
- [ ] Start server button launches `llama-server`, button flips to "Stop server"
- [ ] Translate auto-starts the server if not running and produces translations
- [ ] Stop server / app exit terminates the `llama-server` process
- [ ] Translating without binary/model prompts to download

🤖 Generated with [Claude Code](https://claude.com/claude-code)