### PR TITLE
Extract symlinks from tar.gz archives (fixes llama.cpp on macOS/Linux)

### DIFF
--- a/src/ui/Logic/Compression/ZipUnpacker.cs
+++ b/src/ui/Logic/Compression/ZipUnpacker.cs
@@ -95,7 +95,8 @@ public class ZipUnpacker : IZipUnpacker
         TarEntry? entry;
         while ((entry = tarReader.GetNextEntry()) != null)
         {
-            if (entry.EntryType != TarEntryType.RegularFile)
+            var isSymbolicLink = entry.EntryType is TarEntryType.SymbolicLink or TarEntryType.HardLink;
+            if (entry.EntryType != TarEntryType.RegularFile && !isSymbolicLink)
             {
                 continue;
             }
@@ -119,20 +120,65 @@ public class ZipUnpacker : IZipUnpacker
                 Directory.CreateDirectory(directoryPath);
             }
 
-            if (!string.IsNullOrEmpty(Path.GetFileName(entryFullName)))
+            if (string.IsNullOrEmpty(Path.GetFileName(entryFullName)))
             {
-                if (allowedExtensions.Count > 0)
+                continue;
+            }
+
+            if (allowedExtensions.Count > 0)
+            {
+                var extension = Path.GetExtension(entryFullName).ToLowerInvariant();
+                if (!allowedExtensions.Contains(extension))
                 {
-                    var extension = Path.GetExtension(entryFullName).ToLowerInvariant();
-                    if (!allowedExtensions.Contains(extension))
+                    continue;
+                }
+            }
+
+            if (isSymbolicLink)
+            {
+                // Versioned native libraries (e.g. macOS/Linux llama.cpp builds) ship as symlink
+                // chains; recreate them so loader @rpath references keep resolving.
+                var linkTarget = entry.LinkName;
+                if (allToOutputPath)
+                {
+                    linkTarget = Path.GetFileName(linkTarget);
+                }
+
+                if (string.IsNullOrEmpty(linkTarget))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (File.Exists(filePath) || Directory.Exists(filePath))
+                    {
+                        File.Delete(filePath);
+                    }
+
+                    File.CreateSymbolicLink(filePath, linkTarget);
+                }
+                catch
+                {
+                    // Symlinks may be unsupported (e.g. Windows without privileges) - fall back to
+                    // copying the already-extracted target file when it is available.
+                    var resolvedTarget = Path.Combine(directoryPath ?? outputPath, linkTarget);
+                    if (File.Exists(resolvedTarget) && !File.Exists(filePath))
+                    {
+                        File.Copy(resolvedTarget, filePath);
+                    }
+                    else
                     {
                         continue;
                     }
                 }
-
-                entry.ExtractToFile(filePath, overwrite: true);
-                outputFileNames?.Add(filePath);
             }
+            else
+            {
+                entry.ExtractToFile(filePath, overwrite: true);
+            }
+
+            outputFileNames?.Add(filePath);
         }
     }
 


### PR DESCRIPTION
## Summary
Starting the new server-managed llama.cpp engine (#10901) failed on macOS:

```
llama-server exited during startup (code 134). Output: dyld: Library not loaded:
@rpath/libllama-common.0.dylib
```

The macOS/Linux llama.cpp release tarballs ship their native libraries as **symlink chains**:

```
libllama-common.dylib        -> libllama-common.0.dylib
libllama-common.0.dylib      -> libllama-common.0.0.9145.dylib   (symlink)
libllama-common.0.0.9145.dylib                                   (real file)
```

`llama-server` is linked against `@rpath/libllama-common.0.dylib` — the *symlink*. But `ZipUnpacker.UnpackTarGzStream` did `if (entry.EntryType != TarEntryType.RegularFile) continue;`, dropping every symlink. Only the real `…0.0.9145.dylib` reached disk, so the loader could not resolve the versioned name.

- Recreate `SymbolicLink` / `HardLink` tar entries with `File.CreateSymbolicLink`, flattening the link target alongside the entry name when `allToOutputPath` is set (the targets in these tarballs are already plain basenames, so the relative links resolve inside the output folder).
- Fall back to copying an already-extracted target file if symlink creation is not permitted (e.g. Windows without Developer Mode / admin).
- Windows llama.cpp builds are `.zip` and unaffected; this only touches the tar.gz path.

## Test plan
- [x] Unpacked the real `llama-b9145-bin-macos-arm64.tar.gz` through `ZipUnpacker` — `libllama-common.0.dylib` and `libllama-common.dylib` are now recreated as symlinks, real files intact.
- [x] `./llama-server --version` starts and loads all libraries (exit 0) — previously failed with code 134.
- [ ] Linux: download + start the llama.cpp engine.
- [ ] Windows (`.zip` path) still unpacks the engine unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)