### PR TITLE
Add llama.cpp update detection via archive/executable hashes

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -16,6 +16,7 @@ using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -85,6 +86,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     private bool _onlyCurrentLine;
     private Subtitle _subtitle = new Subtitle();
     private int _translationProgressIndex;
+    private bool _llamaCppUpdatePromptShown;
     private readonly IWindowService _windowService;
 
     public AutoTranslateViewModel(IWindowService windowService)
@@ -786,6 +788,108 @@ public partial class AutoTranslateViewModel : ObservableObject
         return true;
     }
 
+    /// <summary>
+    /// When the llama.cpp engine is selected, checks whether the installed llama-server is older
+    /// than the version SE currently ships and offers to re-download it. The install version is
+    /// taken from the <c>.installed.sha256</c> sidecar, falling back to hashing llama-server itself.
+    /// </summary>
+    private async Task CheckLlamaCppForUpdateAsync()
+    {
+        if (_llamaCppUpdatePromptShown || Window == null || !LlamaCppServerManager.IsEngineInstalled())
+        {
+            return;
+        }
+
+        var folder = LlamaCppServerManager.GetAndCreateFolder();
+        var lookup = TryReadLlamaCppSidecarHash(folder) ?? TryHashInstalledLlamaCppExecutable();
+        if (lookup is not var (key, hash))
+        {
+            return;
+        }
+
+        if (DownloadHashManager.GetStatus(key, hash) != DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            return;
+        }
+
+        _llamaCppUpdatePromptShown = true;
+
+        var answer = await MessageBox.Show(
+            Window,
+            string.Format(Se.Language.Video.AudioToText.UpdateXTitle, "llama.cpp"),
+            string.Format(Se.Language.Video.AudioToText.UpdateXMessage, "llama.cpp", Environment.NewLine),
+            MessageBoxButtons.YesNoCancel,
+            MessageBoxIcon.Question);
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        // The running server holds the binary open (and a stale build would keep serving), so
+        // stop it before overwriting the install.
+        LlamaCppServerManager.StopServer();
+        UpdateLlamaCppServerButtonText();
+
+        var variant = DownloadHashManager.GetLlamaCppWindowsVariant(key)
+                      ?? (OperatingSystem.IsWindows() ? DownloadHashManager.DetectLlamaCppWindowsVariant(folder) : null);
+
+        var model = SelectedLlamaCppModel?.Model;
+        var downloaded = await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model, variant, forceEngineDownload: true);
+        if (downloaded != null)
+        {
+            var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, selectName);
+        }
+
+        UpdateLlamaCppServerButtonText();
+    }
+
+    private static (string key, string hash)? TryReadLlamaCppSidecarHash(string folder)
+    {
+        try
+        {
+            var sidecar = Path.Combine(folder, ".installed.sha256");
+            if (!File.Exists(sidecar))
+            {
+                return null;
+            }
+
+            var lines = File.ReadAllLines(sidecar);
+            if (lines.Length < 2)
+            {
+                return null;
+            }
+
+            var key = lines[0].Trim();
+            var hash = lines[1].Trim();
+            return key.Length == 0 || hash.Length == 0 ? null : (key, hash);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static (string key, string hash)? TryHashInstalledLlamaCppExecutable()
+    {
+        try
+        {
+            var key = DownloadHashManager.ResolveLlamaCppExecutableKey();
+            if (key == null)
+            {
+                return null;
+            }
+
+            var hash = DownloadHashManager.ComputeSha256(LlamaCppServerManager.GetExecutable());
+            return hash == null ? null : (key, hash);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private async Task<bool> DoTranslate()
     {
         var translator = SelectedAutoTranslator;
@@ -1288,6 +1392,11 @@ public partial class AutoTranslateViewModel : ObservableObject
             var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
             SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, savedModelName);
             UpdateLlamaCppServerButtonText();
+
+            if (!_llamaCppUpdatePromptShown)
+            {
+                Dispatcher.UIThread.Post(async () => await CheckLlamaCppForUpdateAsync());
+            }
 
             return;
         }

--- a/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
@@ -34,6 +34,9 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
     /// <summary>The model to download, or null to only install the engine.</summary>
     public LlamaCppTranslateModel? Model { get; set; }
 
+    /// <summary>Re-download the engine binary even when it is already installed (used for updates).</summary>
+    public bool ForceEngineDownload { get; set; }
+
     private const string TemporaryFileExtension = ".$$$";
 
     private readonly ILlamaCppDownloadService _downloadService;
@@ -63,7 +66,7 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
             var folder = LlamaCppServerManager.GetAndCreateFolder();
             var token = _cancellationTokenSource.Token;
 
-            if (!LlamaCppServerManager.IsEngineInstalled())
+            if (ForceEngineDownload || !LlamaCppServerManager.IsEngineInstalled())
             {
                 TitleText = string.Format(Se.Language.General.DownloadingX, "llama.cpp");
                 using (var engineStream = new MemoryStream())
@@ -78,6 +81,8 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
                     TitleText = string.Format(Se.Language.General.UnpackingX, "llama.cpp");
                     engineStream.Position = 0;
                     _zipUnpacker.UnpackZipStream(engineStream, folder, string.Empty, true, new List<string>(), null);
+
+                    WriteInstalledHash(folder, engineStream);
                 }
 
                 if (LlamaCppDownloadService.VariantNeedsCudaRuntime(Variant))
@@ -143,6 +148,32 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
             ProgressValue = percentage;
             ProgressText = string.Format(Se.Language.General.DownloadingXPercent, percentage.ToString(CultureInfo.InvariantCulture));
         });
+    }
+
+    /// <summary>
+    /// Records the downloaded engine archive's hash in a <c>.installed.sha256</c> sidecar so the
+    /// auto-translate window can later tell whether the install is outdated. Best-effort.
+    /// </summary>
+    private void WriteInstalledHash(string folder, Stream engineStream)
+    {
+        try
+        {
+            var key = DownloadHashManager.ResolveLlamaCppKey(Variant);
+            if (string.IsNullOrEmpty(key) || engineStream.Length == 0)
+            {
+                return;
+            }
+
+            engineStream.Position = 0;
+            var hash = DownloadHashManager.ComputeSha256(engineStream);
+
+            var sidecar = Path.Combine(folder, ".installed.sha256");
+            File.WriteAllText(sidecar, key + Environment.NewLine + hash);
+        }
+        catch
+        {
+            // ignore — hash side-car is best-effort
+        }
     }
 
     private static void MakeExecutable(string path)

--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -120,12 +120,15 @@ public static class LlamaCppDownloadHelper
 
     /// <summary>
     /// Opens the llama.cpp download window (engine binary + selected model) and persists the result.
+    /// When <paramref name="forceVariant"/> is given (e.g. re-downloading an update), that build is
+    /// used and the Windows build picker is skipped. When <paramref name="forceEngineDownload"/> is
+    /// set, the engine binary is re-downloaded even though it is already installed.
     /// </summary>
     /// <returns>The downloaded model file name, or null if nothing was downloaded.</returns>
-    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, LlamaCppTranslateModel? model)
+    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, LlamaCppTranslateModel? model, string? forceVariant = null, bool forceEngineDownload = false)
     {
-        var variant = Logic.Download.LlamaCppDownloadService.VariantCpu;
-        if (!LlamaCppServerManager.IsEngineInstalled() && OperatingSystem.IsWindows())
+        var variant = forceVariant ?? Logic.Download.LlamaCppDownloadService.VariantCpu;
+        if (forceVariant == null && !LlamaCppServerManager.IsEngineInstalled() && OperatingSystem.IsWindows())
         {
             var buildAnswer = await MessageBox.Show(
                 owner,
@@ -156,6 +159,7 @@ public static class LlamaCppDownloadHelper
             {
                 vm.Variant = variant;
                 vm.Model = model;
+                vm.ForceEngineDownload = forceEngineDownload;
                 vm.StartDownload();
             });
 

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -48,6 +48,28 @@ public static class DownloadHashManager
         public const string LinuxExecutable = "CrispAsr.Linux.Executable";
     }
 
+    public static class LlamaCpp
+    {
+        // Hashes of the release archive (.zip / .tar.gz) — used when a sidecar hash exists alongside the install.
+        public const string WindowsCpu = "LlamaCpp.Windows.Cpu";
+        public const string WindowsVulkan = "LlamaCpp.Windows.Vulkan";
+        public const string WindowsCuda = "LlamaCpp.Windows.Cuda";
+        public const string LinuxCpu = "LlamaCpp.Linux.Cpu";
+        public const string LinuxVulkan = "LlamaCpp.Linux.Vulkan";
+        public const string MacOsArm64 = "LlamaCpp.MacOs.Arm64";
+        public const string MacOsX64 = "LlamaCpp.MacOs.X64";
+
+        // Hashes of the unpacked llama-server / llama-server.exe — used to detect the installed
+        // version when no sidecar is present (e.g. installs from older SE builds). The Windows
+        // CPU/Vulkan/CUDA builds ship an identical llama-server.exe (the backend lives in the
+        // ggml-*.dll), as do the two Linux builds, so there is a single executable key per OS
+        // (plus per-arch on macOS) — enough to tell "outdated" from "up to date".
+        public const string WindowsExecutable = "LlamaCpp.Windows.Executable";
+        public const string LinuxExecutable = "LlamaCpp.Linux.Executable";
+        public const string MacOsArm64Executable = "LlamaCpp.MacOs.Arm64.Executable";
+        public const string MacOsX64Executable = "LlamaCpp.MacOs.X64.Executable";
+    }
+
     public static class WhisperCpp
     {
         // Hashes of the release archive (.zip) — used when a sidecar hash exists alongside the install.
@@ -199,6 +221,56 @@ public static class DownloadHashManager
                 "7ea6e45b16f396c5cfee8447b0245e872399e504b6dc3d8bb81c3a3c262acbb5", // v0.5.4
                 "a92723269e7e16b93184aadadef3868396e75994665066b817218a0d208c1d2e", // v0.5.3
                 "b99c7d6f51652f7bcddfb6b5bd73f11c541f9947256f040758a20bd1c7ad6591", // v0.5.2
+            },
+
+            // llama.cpp — https://github.com/ggml-org/llama.cpp/releases
+            // Index 0 must match whatever version LlamaCppDownloadService.cs is pinned to,
+            // otherwise users will be prompted to "update" to the same version they just got.
+            [LlamaCpp.WindowsCpu] = new[]
+            {
+                "8e2266646ede106a112023340adc25a2c2150243826e9dfe4bd9f7ed30f8e042", // b9145 (current download URL)
+            },
+            [LlamaCpp.WindowsVulkan] = new[]
+            {
+                "5b54c452458bf6ad06d030a18458c484848b9def4d56b7b94171ff464e670d66", // b9145 (current download URL)
+            },
+            [LlamaCpp.WindowsCuda] = new[]
+            {
+                "a323ccfa87aaa31c47d62be75181799f16f2fe4636786c09bd8beeb6ac722266", // b9145 (current download URL)
+            },
+            [LlamaCpp.LinuxCpu] = new[]
+            {
+                "4cb45bdbf358bc15c77acb84e83e311a3f2c9247b9980f4f1886ebe3bd7e46d0", // b9145 (current download URL)
+            },
+            [LlamaCpp.LinuxVulkan] = new[]
+            {
+                "b4a28b06d973f662b9465b6e0e786d8991cdab4d24101f5d88b0b8f688a97aea", // b9145 (current download URL)
+            },
+            [LlamaCpp.MacOsArm64] = new[]
+            {
+                "3c0cef9bcf8898c3bd169e94fa2acec249b8ebc94d8fade2c165b6d6a01e2693", // b9145 (current download URL)
+            },
+            [LlamaCpp.MacOsX64] = new[]
+            {
+                "0391b2dfe4a4f384916ebf98c33bfe1205443cde8bffec7563b73671d3060149", // b9145 (current download URL)
+            },
+
+            // SHA-256 of llama-server / llama-server.exe extracted from each archive above.
+            [LlamaCpp.WindowsExecutable] = new[]
+            {
+                "528ff8471ff7072ac75494a80467a0fced073ec11dcbf96a0e1c3ec0334b9dd0", // b9145 (current download URL)
+            },
+            [LlamaCpp.LinuxExecutable] = new[]
+            {
+                "855bd9540073d9f020b9b77ad5866ea3ea74ca570ea3fac486da8676f0eb6933", // b9145 (current download URL)
+            },
+            [LlamaCpp.MacOsArm64Executable] = new[]
+            {
+                "61b18501af97dce62cb7e1c019981734d7b0e1003122079ac212edaeb86a36e4", // b9145 (current download URL)
+            },
+            [LlamaCpp.MacOsX64Executable] = new[]
+            {
+                "c33c8f47da7d7751cd07c9ab32e77c84b3f5ac56b56299016f62b2d184fe3dfb", // b9145 (current download URL)
             },
 
             // whisper.cpp — https://github.com/ggml-org/whisper.cpp/releases (and SE-repackaged builds
@@ -555,5 +627,109 @@ public static class DownloadHashManager
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Resolves the llama.cpp archive hash key for the current OS, architecture and (Windows/Linux)
+    /// variant ("cpu" / "vulkan" / "cuda"). Returns null when the combination is unknown.
+    /// </summary>
+    public static string? ResolveLlamaCppKey(string? variant)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return variant switch
+            {
+                "cuda" => LlamaCpp.WindowsCuda,
+                "vulkan" => LlamaCpp.WindowsVulkan,
+                "cpu" => LlamaCpp.WindowsCpu,
+                _ => null,
+            };
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return variant == "vulkan" ? LlamaCpp.LinuxVulkan : LlamaCpp.LinuxCpu;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? LlamaCpp.MacOsArm64
+                : LlamaCpp.MacOsX64;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reverse of <see cref="ResolveLlamaCppKey"/> for Windows variants only:
+    /// returns "cuda" / "vulkan" / "cpu" matching the given archive key, or null otherwise.
+    /// </summary>
+    public static string? GetLlamaCppWindowsVariant(string key)
+    {
+        return key switch
+        {
+            LlamaCpp.WindowsCuda => "cuda",
+            LlamaCpp.WindowsVulkan => "vulkan",
+            LlamaCpp.WindowsCpu => "cpu",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Resolves the llama.cpp executable-hash key for the current OS and architecture.
+    /// Used as a fallback when no sidecar hash exists alongside the install. The Windows
+    /// CPU/Vulkan/CUDA builds (and the two Linux builds) share an identical llama-server
+    /// binary, so there is a single key per OS, plus per-arch on macOS.
+    /// </summary>
+    public static string? ResolveLlamaCppExecutableKey()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return LlamaCpp.WindowsExecutable;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return LlamaCpp.LinuxExecutable;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? LlamaCpp.MacOsArm64Executable
+                : LlamaCpp.MacOsX64Executable;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Detects which Windows llama.cpp variant is installed from its backend DLLs.
+    /// Returns "cuda" / "vulkan" / "cpu", or null if the folder doesn't look like a llama.cpp install.
+    /// </summary>
+    public static string? DetectLlamaCppWindowsVariant(string installFolder)
+    {
+        if (string.IsNullOrEmpty(installFolder) || !Directory.Exists(installFolder))
+        {
+            return null;
+        }
+
+        if (!File.Exists(Path.Combine(installFolder, "llama-server.exe")))
+        {
+            return null;
+        }
+
+        if (File.Exists(Path.Combine(installFolder, "ggml-cuda.dll")))
+        {
+            return "cuda";
+        }
+
+        if (File.Exists(Path.Combine(installFolder, "ggml-vulkan.dll")))
+        {
+            return "vulkan";
+        }
+
+        return "cpu";
     }
 }


### PR DESCRIPTION
## Summary
The server-managed llama.cpp auto-translate engine (#10901) had no way to tell an outdated install from a current one, so it could never prompt for updates the way CrispASR and whisper.cpp already do. This wires llama.cpp into the existing `DownloadHashManager` infrastructure.

- **`DownloadHashManager`** — new `LlamaCpp` key set: archive hashes for all seven `b9145` builds (Win CPU/Vulkan/CUDA, Linux CPU/Vulkan, macOS arm64/x64) plus one executable hash per OS, per-arch on macOS. The Windows CPU/Vulkan/CUDA builds ship a **byte-identical `llama-server.exe`** (the backend lives in the `ggml-*.dll`), as do the two Linux builds — same situation the code already notes for whisper.cpp — so a single executable key per OS is enough to tell "outdated" from "up to date". Adds `ResolveLlamaCppKey` / `ResolveLlamaCppExecutableKey` / `GetLlamaCppWindowsVariant` / `DetectLlamaCppWindowsVariant`.
- **`DownloadLlamaCppViewModel`** — writes a `.installed.sha256` sidecar (archive key + hash) after unpacking the engine, mirroring `DownloadSpeechToTextEngineViewModel`. New `ForceEngineDownload` flag so an update re-downloads the binary even though one is already installed.
- **`LlamaCppDownloadHelper.DownloadAsync`** — optional `forceVariant` / `forceEngineDownload` params for the update path (skips the Windows build picker, forces the engine re-download).
- **`AutoTranslateViewModel`** — when llama.cpp is selected, reads the sidecar (or hashes the installed `llama-server`); if `DownloadHashManager` reports `UpdateAvailable`, prompts the user and re-downloads — stopping the running server first and reusing the previously installed variant (from the sidecar key, or detected from the backend DLLs on Windows).

`b9145` is the first hashed version, so no one is prompted yet — the next llama.cpp bump just adds the new hashes at index 0 and existing `b9145` installs start getting the prompt.

## Test plan
- [ ] Select "llama.cpp" in Auto-translate with an up-to-date (`b9145`) install → no update prompt.
- [ ] Temporarily move `b9145` hashes to index 1 (simulate a newer release) → selecting llama.cpp prompts to update; accepting re-downloads the engine + writes a fresh sidecar.
- [ ] Update flow stops a running `llama-server` before re-downloading.
- [ ] Windows: update reuses the installed variant (CPU/Vulkan/CUDA) instead of silently downgrading to CPU.
- [ ] Install with no sidecar (older SE build) → executable-hash fallback still resolves the install version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)