### PR TITLE
Fix main window freeze after closing Settings with OK (#10815)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6328,8 +6328,16 @@ public partial class MainViewModel :
         if (oldSettngsSerialized != newSettingsSerialized)
         {
             var firstSelectedIndex = SubtitleGrid.SelectedIndex;
-            ApplySettings();
-            SelectAndScrollToRow(firstSelectedIndex);
+
+            // Defer to a fresh dispatcher cycle: ApplySettings rebuilds the layout, which
+            // destroys and recreates the video player control (a native Win32 HWND on Windows
+            // with mpv-wid/VLC). Doing that inside the ShowDialog continuation races the modal
+            // dialog's teardown and can leave the main window disabled - a full UI freeze (#10815).
+            Dispatcher.UIThread.Post(() =>
+            {
+                ApplySettings();
+                SelectAndScrollToRow(firstSelectedIndex);
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
Addresses #10815 (does not auto-close it — needs reporter verification on Windows). Changing certain options (e.g. Video player → "Show stop button"), then clicking **OK**, freezes the whole main window: the subtitle grid, menus and even the X button stop responding. Using **Apply + Cancel** instead never triggered it.

### Root cause
`CommandShowSettings` ran `ApplySettings()` directly in the `await ShowDialogAsync` continuation — the same call stack as the modal `SettingsWindow` tearing down. `ApplySettings()` rebuilds the layout, which destroys and recreates the video player control; on Windows with the mpv-wid / VLC players that control is a **native Win32 `NativeControlHost` HWND**. Recreating a native child HWND *during the modal dialog's teardown* races the Win32 `EnableWindow` modal bookkeeping and can leave the main window stuck disabled — a complete UI freeze.

This explains every clue in the issue:
- **Apply + Cancel works** — `ApplySettings()` then runs while the dialog is still legitimately open, so there's no teardown race.
- **Not reproducible on the maintainer's machines** — it depends on the video-player type (native HWND vs the Avalonia-rendered OpenGL control) and the exact teardown timing, so it's highly machine-dependent.
- **"Show stop button" specifically** — that's a `Se.Settings.Video.*` value only read when the video player control is *created*, so changing it guarantees the layout-rebuild path runs.

### Fix
Defer `ApplySettings()` (and the follow-up `SelectAndScrollToRow`) to a fresh dispatcher cycle via `Dispatcher.UIThread.Post`, so the modal teardown fully completes — owner window re-enabled, dialog HWND destroyed — before the layout rebuild starts.

## Test plan
- [ ] Windows + mpv-wid/VLC player: Options → Settings → Video player → toggle "Show stop button" → **OK**. Main window stays responsive; grid/menus/X all work.
- [ ] Same with **Apply** then **OK**.
- [ ] **Apply** then **Cancel** still works (regression check).
- [ ] Settings that change the layout (theme, layout number, waveform) still apply correctly after OK.
- [ ] Closing Settings with **Cancel** / no changes does nothing unexpected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)