### PR TITLE
Add "Play selected lines and focus waveform" shortcuts

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -394,6 +394,8 @@
     "playNext": "Play next",
     "playSelectedLines": "Play selected lines",
     "playSelectedLinesWithLoop": "Play selected lines with loop",
+    "playSelectedLinesAndFocusWaveform": "Play selected lines and focus waveform",
+    "playSelectedLinesWithLoopAndFocusWaveform": "Play selected lines with loop and focus waveform",
     "pleaseEnterAValidValueForX": "Please enter a valid value for \"{0}\"",
     "pleaseWait": "Please wait...",
     "position": "Position",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5294,6 +5294,24 @@ public partial class MainViewModel :
         PlayerSelectedLines(false);
     }
 
+    [RelayCommand]
+    private void PlaySelectedLinesAndFocusWaveform()
+    {
+        if (PlayerSelectedLines(false))
+        {
+            AudioVisualizer?.Focus();
+        }
+    }
+
+    [RelayCommand]
+    private void PlaySelectedLinesWithLoopAndFocusWaveform()
+    {
+        if (PlayerSelectedLines(true))
+        {
+            AudioVisualizer?.Focus();
+        }
+    }
+
     private bool PlayerSelectedLines(bool loop)
     {
         var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().OrderBy(p => p.StartTime).ToList();

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -394,6 +394,8 @@ public class LanguageGeneral
     public string PlayNext { get; set; }
     public string PlaySelectedLines { get; set; }
     public string PlaySelectedLinesWithLoop { get; set; }
+    public string PlaySelectedLinesAndFocusWaveform { get; set; }
+    public string PlaySelectedLinesWithLoopAndFocusWaveform { get; set; }
     public string PleaseEnterAValidValueForX { get; set; }
     public string PleaseWait { get; set; }
     public string Position { get; set; }
@@ -1087,6 +1089,8 @@ public class LanguageGeneral
         PlayNext = "Play next";
         PlaySelectedLines = "Play selected lines";
         PlaySelectedLinesWithLoop = "Play selected lines with loop";
+        PlaySelectedLinesAndFocusWaveform = "Play selected lines and focus waveform";
+        PlaySelectedLinesWithLoopAndFocusWaveform = "Play selected lines with loop and focus waveform";
         PleaseEnterAValidValueForX = "Please enter a valid value for \"{0}\"";
         PleaseWait = "Please wait...";
         Position = "Position";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -315,6 +315,8 @@ public static class ShortcutsMain
         { nameof(MainViewModel.SpeechToTextSelectedLinesPromptForLangaugeFirstTimeCommand), Se.Language.General.SpeechToTextSelectedLinesPromptFirstTime },
         { nameof(MainViewModel.PlaySelectedLinesWithoutLoopCommand), Se.Language.General.PlaySelectedLines },
         { nameof(MainViewModel.PlaySelectedLinesWithLoopCommand), Se.Language.General.PlaySelectedLinesWithLoop },
+        { nameof(MainViewModel.PlaySelectedLinesAndFocusWaveformCommand), Se.Language.General.PlaySelectedLinesAndFocusWaveform },
+        { nameof(MainViewModel.PlaySelectedLinesWithLoopAndFocusWaveformCommand), Se.Language.General.PlaySelectedLinesWithLoopAndFocusWaveform },
         { nameof(MainViewModel.ToggleCasingCommand), Se.Language.General.ToggleCasing },
         { nameof(MainViewModel.ImportImageSubtitleForEditCommand), Se.Language.Options.Shortcuts.ImportImageSubtitleForEdit },
         { nameof(MainViewModel.ShowMediaInformationCommand), Se.Language.Options.Shortcuts.ShowMediaInformation },
@@ -603,6 +605,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SpeechToTextSelectedLinesPromptForLangaugeFirstTimeCommand, nameof(vm.SpeechToTextSelectedLinesPromptForLangaugeFirstTimeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.PlaySelectedLinesWithoutLoopCommand, nameof(vm.PlaySelectedLinesWithoutLoopCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.PlaySelectedLinesWithLoopCommand, nameof(vm.PlaySelectedLinesWithLoopCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.PlaySelectedLinesAndFocusWaveformCommand, nameof(vm.PlaySelectedLinesAndFocusWaveformCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.PlaySelectedLinesWithLoopAndFocusWaveformCommand, nameof(vm.PlaySelectedLinesWithLoopAndFocusWaveformCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ToggleCasingCommand, nameof(vm.ToggleCasingCommand), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.ImportImageSubtitleForEditCommand, nameof(vm.ImportImageSubtitleForEditCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowMediaInformationCommand, nameof(vm.ShowMediaInformationCommand), ShortcutCategory.General);


### PR DESCRIPTION
Adds two new optional General shortcuts (unbound by default, so no existing keymap is disturbed):

| Command | Label |
|---|---|
| `PlaySelectedLinesAndFocusWaveformCommand` | Play selected lines and focus waveform |
| `PlaySelectedLinesWithLoopAndFocusWaveformCommand` | Play selected lines with loop and focus waveform |

Each delegates to the existing `PlayerSelectedLines(bool)` and calls `AudioVisualizer?.Focus()` only when playback actually started — same pattern as `ToggleFocusGridAndWaveform`.

### Motivation

Per discussion #10910, the editing flow is text → verify → playback area, so users want a single hotkey that plays the selection *and* moves focus to the waveform, instead of "play, then press the focus-waveform shortcut, then use waveform keys."

This adds explicit shortcuts rather than changing the default behavior of the existing `PlaySelectedLines*` commands, so current users are unaffected.

### Files

- `src/ui/Features/Main/MainViewModel.cs` — two new `[RelayCommand]` methods.
- `src/ui/Logic/Config/Language/LanguageGeneral.cs` — two new strings with English defaults.
- `src/ui/Logic/ShortcutsMain.cs` — name→label dictionary entries plus `AddShortcut(... ShortcutCategory.General)` registrations.
- `src/ui/Assets/Languages/English.json` — matching JSON keys.

Other locale JSONs intentionally untouched; the C# defaults are the fallback until translators pick the strings up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)