### PR TITLE
Add option to hide video controls in full-screen

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -746,6 +746,15 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         {
             _lastActivityTime = DateTime.UtcNow;
 
+            // When the user opts to hide controls in full-screen, never show them —
+            // not even briefly on entry — and don't bother arming the auto-hide timer.
+            if (Se.Settings.Video.FullscreenHideControls)
+            {
+                HideControls();
+                _autoHideTimer?.Stop();
+                return;
+            }
+
             // Show controls initially when entering full screen
             ShowControls();
 
@@ -780,6 +789,12 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             _lastActivityTime = DateTime.UtcNow;
             if (IsFullScreen)
             {
+                // If the user opted to hide controls in full-screen, don't reveal them on activity.
+                if (Se.Settings.Video.FullscreenHideControls)
+                {
+                    return;
+                }
+
                 ShowControls();
                 if (_autoHideTimer != null)
                 {

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -382,6 +382,7 @@ public class SettingsPage : UserControl
             }),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowStopButton, nameof(_vm.ShowStopButton)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowFullscreenButton, nameof(_vm.ShowFullscreenButton)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.FullscreenHideControls, nameof(_vm.FullscreenHideControls)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoOpenVideoFile, nameof(_vm.AutoOpenVideoFile)),
             new SettingsItem(!_vm.IsLibMpvDownloadVisible, Se.Language.Options.Settings.DownloadMpv, () => new StackPanel
             {

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -171,6 +171,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private VideoPlayerItem _selectedVideoPlayer;
     [ObservableProperty] private bool _showStopButton;
     [ObservableProperty] private bool _showFullscreenButton;
+    [ObservableProperty] private bool _fullscreenHideControls;
     [ObservableProperty] private bool _autoOpenVideoFile;
 
     [ObservableProperty] private bool _waveformDrawGridLines;
@@ -789,6 +790,7 @@ public partial class SettingsViewModel : ObservableObject
 
         ShowStopButton = video.ShowStopButton;
         ShowFullscreenButton = video.ShowFullscreenButton;
+        FullscreenHideControls = video.FullscreenHideControls;
         AutoOpenVideoFile = video.AutoOpen;
 
         MpvPreviewFontName = video.MpvPreviewFontName;
@@ -1367,6 +1369,7 @@ public partial class SettingsViewModel : ObservableObject
         video.VideoPlayer = SelectedVideoPlayer.Code;
         video.ShowStopButton = ShowStopButton;
         video.ShowFullscreenButton = ShowFullscreenButton;
+        video.FullscreenHideControls = FullscreenHideControls;
         video.AutoOpen = AutoOpenVideoFile;
 
         video.MpvPreviewFontName = MpvPreviewFontName;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -174,6 +174,7 @@ public class LanguageSettings
 
     public string ShowStopButton { get; set; }
     public string ShowFullscreenButton { get; set; }
+    public string FullscreenHideControls { get; set; }
     public string AutoOpenVideoFile { get; set; }
     public string DownloadMpv { get; set; }
     public string DownloadVlc { get; set; }
@@ -458,6 +459,7 @@ public class LanguageSettings
 
         ShowStopButton = "Show stop button";
         ShowFullscreenButton = "Show full-screen button";
+        FullscreenHideControls = "Hide video controls in full-screen";
         AutoOpenVideoFile = "Auto-open video file when opening subtitle";
         DownloadMpv = "Download mpv";
         DownloadVlc = "Download VLC";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -12,6 +12,7 @@ public class SeVideo
     public double Volume { get; set; }
     public bool ShowStopButton { get; set; }
     public bool ShowFullscreenButton { get; set; }
+    public bool FullscreenHideControls { get; set; }
     public bool AutoOpen { get; set; }
     public bool OpenSearchParentFolder { get; set; }
     public string CutType { get; set; }


### PR DESCRIPTION
Closes #10914.

Adds a new **Settings → Video Player** checkbox: **"Hide video controls in full-screen"**.

When enabled, the playback controls (play/pause, position slider, volume, etc.) are not shown when the video enters full-screen, and mouse/keyboard activity does not reveal them either. Keyboard shortcuts (`Space`, arrow keys, `F11`/`Esc`, the registered toggle/show-media-information shortcuts) remain the way to control playback.

Defaults to **off**, preserving the existing 3-second auto-hide behavior.

### Changes

- `SeVideo.FullscreenHideControls` setting (boolean, defaults to `false`)
- `SettingsViewModel` load/save mapping
- `LanguageSettings.FullscreenHideControls` localization string
- `SettingsPage` checkbox in the Video Player section, right after "Show full-screen button"
- `VideoPlayerControl.StartAutoHideControls` skips the initial show + timer when the option is on
- `VideoPlayerControl.OnUserActivity` skips re-showing controls on cursor/key activity in full-screen when the option is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)
