### PR TITLE
Add VobSub/DVD custom-color picker to OCR window

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -42,6 +42,7 @@ using Nikse.SubtitleEdit.Features.Ocr.BinaryOcr;
 using Nikse.SubtitleEdit.Features.Ocr.Download;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 using Nikse.SubtitleEdit.Features.Ocr.NOcr;
+using Nikse.SubtitleEdit.Features.Ocr.VobSubColorChooser;
 using Nikse.SubtitleEdit.Features.Options.Language;
 using Nikse.SubtitleEdit.Features.Options.Plugins;
 using Nikse.SubtitleEdit.Features.Options.Settings;
@@ -394,6 +395,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<PointSyncViaOtherViewModel>();
         collection.AddTransient<PointSyncViewModel>();
         collection.AddTransient<PreProcessingViewModel>();
+        collection.AddTransient<VobSubColorChooserViewModel>();
         collection.AddTransient<ProfilesExportViewModel>();
         collection.AddTransient<ProfilesViewModel>();
         collection.AddTransient<PromptFileSavedViewModel>();

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleVobSub.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleVobSub.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.VobSub;
 using SkiaSharp;
 using System;
@@ -9,6 +9,12 @@ namespace Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
 public class OcrSubtitleVobSub : IOcrSubtitle
 {
     public int Count { get; private set; }
+
+    public bool UseCustomColors { get; set; }
+    public SKColor Background { get; set; } = SKColors.Transparent;
+    public SKColor Pattern { get; set; } = SKColors.Black;
+    public SKColor Emphasis1 { get; set; } = SKColors.White;
+    public SKColor Emphasis2 { get; set; } = SKColors.Black;
 
     private readonly List<VobSubMergedPack> _vobSubMergedPack;
     private List<SKColor>? _palette;
@@ -25,6 +31,11 @@ public class OcrSubtitleVobSub : IOcrSubtitle
         if (_palette != null)
         {
             _vobSubMergedPack[index].Palette = _palette;
+        }
+
+        if (UseCustomColors)
+        {
+            return _vobSubMergedPack[index].SubPicture.GetBitmap(_palette, Background, Pattern, Emphasis1, Emphasis2, true, true);
         }
 
         return _vobSubMergedPack[index].GetBitmap();
@@ -51,6 +62,21 @@ public class OcrSubtitleVobSub : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public SubPicture? GetSubPicture(int index)
+    {
+        if (index < 0 || index >= _vobSubMergedPack.Count)
+        {
+            return null;
+        }
+
+        return _vobSubMergedPack[index].SubPicture;
+    }
+
+    public List<SKColor>? GetPalette()
+    {
+        return _palette;
+    }
+
     public SKPointI GetPosition(int index)
     {
         var item = _vobSubMergedPack[index];
@@ -70,13 +96,13 @@ public class OcrSubtitleVobSub : IOcrSubtitle
 
         return new SKPointI(left, top);
 
-        //var position = _vobSubMergedPack[index].GetPosition();  
+        //var position = _vobSubMergedPack[index].GetPosition();
         //return new SKPointI(position.Left, position.Top);
     }
 
     public SKSizeI GetScreenSize(int index)
     {
-        var screenSize = _vobSubMergedPack[index].GetScreenSize();  
+        var screenSize = _vobSubMergedPack[index].GetScreenSize();
         return new SKSizeI((int)screenSize.Width, (int)screenSize.Height);
     }
 }

--- a/src/ui/Features/Ocr/OcrSubtitleItem.cs
+++ b/src/ui/Features/Ocr/OcrSubtitleItem.cs
@@ -39,6 +39,11 @@ public partial class OcrSubtitleItem : ObservableObject
         }
     }
 
+    public void InvalidateBitmap()
+    {
+        _bitmap = null;
+    }
+
     public SKBitmap GetSkBitmapClean()
     {
         var bitmap = _ocrSubtitle.GetBitmap(_index);

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -93,6 +93,8 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private bool _isGoogleVisionVisible;
     [ObservableProperty] private bool _isGoogleLensVisible;
     [ObservableProperty] private bool _isMistralOcrVisible;
+    [ObservableProperty] private bool _isVobSubVisible;
+    [ObservableProperty] private bool _hasCustomVobSubColors;
     [ObservableProperty] private bool _nOcrDrawUnknownText;
     [ObservableProperty] private bool _isInspectLineVisible;
     [ObservableProperty] private bool _isInspectAdditionsVisible;
@@ -1301,6 +1303,114 @@ public partial class OcrViewModel : ObservableObject
                 _preProcessingSettings.Binarize ||
                 _preProcessingSettings.RemoveBorders;
         });
+    }
+
+    [RelayCommand]
+    private async Task PickVobSubColors()
+    {
+        if (Window == null || _ocrSubtitle is not OcrSubtitleVobSub vobSub)
+        {
+            return;
+        }
+
+        var previewSubPicture = vobSub.GetSubPicture(SelectedOcrSubtitleItem != null
+            ? Math.Max(0, OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem))
+            : 0);
+
+        var result = await _windowService.ShowDialogAsync<VobSubColorChooser.VobSubColorChooserWindow, VobSubColorChooser.VobSubColorChooserViewModel>(
+            Window,
+            vm => vm.Initialize(previewSubPicture, vobSub.GetPalette(), vobSub.Background, vobSub.Pattern, vobSub.Emphasis1, vobSub.Emphasis2));
+
+        _isCtrlDown = false;
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        vobSub.Background = result.Background;
+        vobSub.Pattern = result.Pattern;
+        vobSub.Emphasis1 = result.Emphasis1;
+        vobSub.Emphasis2 = result.Emphasis2;
+        vobSub.UseCustomColors = !AreDefaultVobSubColors(vobSub);
+
+        HasCustomVobSubColors = vobSub.UseCustomColors;
+        SaveVobSubColors();
+        RefreshOcrSubtitleItemBitmaps();
+    }
+
+    private static bool AreDefaultVobSubColors(OcrSubtitleVobSub vobSub)
+    {
+        return vobSub.Background == SkiaSharp.SKColors.Transparent
+               && vobSub.Pattern == SkiaSharp.SKColors.Black
+               && vobSub.Emphasis1 == SkiaSharp.SKColors.White
+               && vobSub.Emphasis2 == SkiaSharp.SKColors.Black;
+    }
+
+    private void RefreshOcrSubtitleItemBitmaps()
+    {
+        var selectedIndex = SelectedOcrSubtitleItem != null
+            ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem)
+            : -1;
+
+        foreach (var item in OcrSubtitleItems)
+        {
+            item.InvalidateBitmap();
+        }
+
+        var temp = OcrSubtitleItems.ToList();
+        OcrSubtitleItems.Clear();
+        OcrSubtitleItems.AddRange(temp);
+
+        if (selectedIndex >= 0)
+        {
+            SelectAndScrollToRow(selectedIndex);
+        }
+    }
+
+    private void ApplyStoredVobSubColors()
+    {
+        if (_ocrSubtitle is not OcrSubtitleVobSub vobSub)
+        {
+            return;
+        }
+
+        var ocr = Se.Settings.Ocr;
+        if (!ocr.VobSubUseCustomColors)
+        {
+            HasCustomVobSubColors = false;
+            return;
+        }
+
+        try
+        {
+            vobSub.Background = ocr.VobSubColorBackground.FromHex();
+            vobSub.Pattern = ocr.VobSubColorPattern.FromHex();
+            vobSub.Emphasis1 = ocr.VobSubColorEmphasis1.FromHex();
+            vobSub.Emphasis2 = ocr.VobSubColorEmphasis2.FromHex();
+            vobSub.UseCustomColors = !AreDefaultVobSubColors(vobSub);
+            HasCustomVobSubColors = vobSub.UseCustomColors;
+        }
+        catch
+        {
+            HasCustomVobSubColors = false;
+        }
+    }
+
+    private void SaveVobSubColors()
+    {
+        if (_ocrSubtitle is not OcrSubtitleVobSub vobSub)
+        {
+            return;
+        }
+
+        var ocr = Se.Settings.Ocr;
+        ocr.VobSubUseCustomColors = vobSub.UseCustomColors;
+        ocr.VobSubColorBackground = vobSub.Background.ToHex();
+        ocr.VobSubColorPattern = vobSub.Pattern.ToHex();
+        ocr.VobSubColorEmphasis1 = vobSub.Emphasis1.ToHex();
+        ocr.VobSubColorEmphasis2 = vobSub.Emphasis2.ToHex();
+        Se.SaveSettings();
     }
 
     [RelayCommand]
@@ -3424,6 +3534,8 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, vobSubFileName);
         _ocrSubtitle = new OcrSubtitleVobSub(vobSubMergedPackList, palette);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        IsVobSubVisible = true;
+        ApplyStoredVobSubColors();
     }
 
     public void Initialize(Trak mp4SubtitleTrack, List<Paragraph> paragraphs, string fileName)
@@ -3438,6 +3550,8 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleVobSub(mergedVobSubPacks, palette);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        IsVobSubVisible = true;
+        ApplyStoredVobSubColors();
     }
 
     public void Initialize(MatroskaTrackInfo matroskaSubtitleInfo, Subtitle subtitle, List<DvbSubPes> subtitleImages, string fileName)

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -170,6 +170,17 @@ public class OcrWindow : Window
         toggleButtonPreProcessing.Bind(ToggleButton.IsCheckedProperty, new Binding(nameof(vm.HasPreProcessingSettings)));
         Attached.SetIcon(toggleButtonPreProcessing, IconNames.Image);
         ToolTip.SetTip(toggleButtonPreProcessing, Se.Language.Ocr.ImagePreProcessing);
+
+        var toggleButtonVobSubColors = new ToggleButton
+        {
+            Command = vm.PickVobSubColorsCommand,
+            Margin = new Thickness(2, 0, 0, 0),
+        };
+        toggleButtonVobSubColors.Bind(ToggleButton.IsCheckedProperty, new Binding(nameof(vm.HasCustomVobSubColors)));
+        toggleButtonVobSubColors.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsVobSubVisible)));
+        Attached.SetIcon(toggleButtonVobSubColors, IconNames.Palette);
+        ToolTip.SetTip(toggleButtonVobSubColors, Se.Language.Ocr.VobSubColors);
+
         var panelRight = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -178,6 +189,7 @@ public class OcrWindow : Window
             {
                 toggleButtonCaptureAlignment,
                 toggleButtonPreProcessing,
+                toggleButtonVobSubColors,
             }
         };
 

--- a/src/ui/Features/Ocr/VobSubColorChooser/VobSubColorChooserViewModel.cs
+++ b/src/ui/Features/Ocr/VobSubColorChooser/VobSubColorChooserViewModel.cs
@@ -1,0 +1,216 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.VobSub;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
+using Nikse.SubtitleEdit.Logic;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.VobSubColorChooser;
+
+public partial class VobSubColorChooserViewModel : ObservableObject
+{
+    [ObservableProperty] private Color _backgroundColor = Colors.Transparent;
+    [ObservableProperty] private Color _patternColor = Colors.Black;
+    [ObservableProperty] private Color _emphasis1Color = Colors.White;
+    [ObservableProperty] private Color _emphasis2Color = Colors.Black;
+
+    [ObservableProperty] private string _backgroundHex = "#00000000";
+    [ObservableProperty] private string _patternHex = "#FF000000";
+    [ObservableProperty] private string _emphasis1Hex = "#FFFFFFFF";
+    [ObservableProperty] private string _emphasis2Hex = "#FF000000";
+
+    [ObservableProperty] private Bitmap? _previewImage;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public SKColor Background { get; private set; } = SKColors.Transparent;
+    public SKColor Pattern { get; private set; } = SKColors.Black;
+    public SKColor Emphasis1 { get; private set; } = SKColors.White;
+    public SKColor Emphasis2 { get; private set; } = SKColors.Black;
+
+    private readonly IWindowService _windowService;
+    private SubPicture? _previewSubPicture;
+    private List<SKColor>? _palette;
+
+    public VobSubColorChooserViewModel(IWindowService windowService)
+    {
+        _windowService = windowService;
+    }
+
+    public void Initialize(SubPicture? previewSubPicture, List<SKColor>? palette, SKColor background, SKColor pattern, SKColor emphasis1, SKColor emphasis2)
+    {
+        _previewSubPicture = previewSubPicture;
+        _palette = palette;
+
+        Background = background;
+        Pattern = pattern;
+        Emphasis1 = emphasis1;
+        Emphasis2 = emphasis2;
+
+        BackgroundColor = background.ToAvaloniaColor();
+        PatternColor = pattern.ToAvaloniaColor();
+        Emphasis1Color = emphasis1.ToAvaloniaColor();
+        Emphasis2Color = emphasis2.ToAvaloniaColor();
+
+        UpdateHex();
+        UpdatePreview();
+    }
+
+    partial void OnBackgroundColorChanged(Color value)
+    {
+        Background = value.ToSkColor();
+        BackgroundHex = value.FromColorToHex();
+        UpdatePreview();
+    }
+
+    partial void OnPatternColorChanged(Color value)
+    {
+        Pattern = value.ToSkColor();
+        PatternHex = value.FromColorToHex();
+        UpdatePreview();
+    }
+
+    partial void OnEmphasis1ColorChanged(Color value)
+    {
+        Emphasis1 = value.ToSkColor();
+        Emphasis1Hex = value.FromColorToHex();
+        UpdatePreview();
+    }
+
+    partial void OnEmphasis2ColorChanged(Color value)
+    {
+        Emphasis2 = value.ToSkColor();
+        Emphasis2Hex = value.FromColorToHex();
+        UpdatePreview();
+    }
+
+    private void UpdateHex()
+    {
+        BackgroundHex = BackgroundColor.FromColorToHex();
+        PatternHex = PatternColor.FromColorToHex();
+        Emphasis1Hex = Emphasis1Color.FromColorToHex();
+        Emphasis2Hex = Emphasis2Color.FromColorToHex();
+    }
+
+    private void UpdatePreview()
+    {
+        if (_previewSubPicture == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var bmp = _previewSubPicture.GetBitmap(_palette, Background, Pattern, Emphasis1, Emphasis2, true, true);
+            if (bmp != null)
+            {
+                PreviewImage = bmp.ToAvaloniaBitmap();
+            }
+        }
+        catch
+        {
+            // ignore preview render failures
+        }
+    }
+
+    [RelayCommand]
+    private async Task PickBackground()
+    {
+        var color = await PickColor(BackgroundColor);
+        if (color.HasValue)
+        {
+            BackgroundColor = color.Value;
+        }
+    }
+
+    [RelayCommand]
+    private async Task PickPattern()
+    {
+        var color = await PickColor(PatternColor);
+        if (color.HasValue)
+        {
+            PatternColor = color.Value;
+        }
+    }
+
+    [RelayCommand]
+    private async Task PickEmphasis1()
+    {
+        var color = await PickColor(Emphasis1Color);
+        if (color.HasValue)
+        {
+            Emphasis1Color = color.Value;
+        }
+    }
+
+    [RelayCommand]
+    private async Task PickEmphasis2()
+    {
+        var color = await PickColor(Emphasis2Color);
+        if (color.HasValue)
+        {
+            Emphasis2Color = color.Value;
+        }
+    }
+
+    private async Task<Color?> PickColor(Color current)
+    {
+        if (Window == null)
+        {
+            return null;
+        }
+
+        var vm = await _windowService.ShowDialogAsync<ColorPickerWindow, ColorPickerViewModel>(
+            Window, viewModel => viewModel.Initialize(current));
+
+        return vm.OkPressed ? vm.SelectedColor : (Color?)null;
+    }
+
+    [RelayCommand]
+    private void ResetToDefaults()
+    {
+        BackgroundColor = Colors.Transparent;
+        PatternColor = Colors.Black;
+        Emphasis1Color = Colors.White;
+        Emphasis2Color = Colors.Black;
+    }
+
+    [RelayCommand]
+    private void InvertBackgroundForeground()
+    {
+        var bg = BackgroundColor;
+        BackgroundColor = Emphasis1Color;
+        Emphasis1Color = bg;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Ocr/VobSubColorChooser/VobSubColorChooserWindow.cs
+++ b/src/ui/Features/Ocr/VobSubColorChooser/VobSubColorChooserWindow.cs
@@ -1,0 +1,243 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.VobSubColorChooser;
+
+public class VobSubColorChooserWindow : Window
+{
+    private const double SwatchSize = 56;
+
+    public VobSubColorChooserWindow(VobSubColorChooserViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Ocr.VobSubColorsTitle;
+        CanResize = false;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        vm.Window = this;
+        DataContext = vm;
+
+        var headerText = new TextBlock
+        {
+            Text = Se.Language.Ocr.VobSubColorsHeader,
+            FontSize = 14,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(0, 0, 0, 4),
+        };
+
+        var descriptionText = new TextBlock
+        {
+            Text = Se.Language.Ocr.VobSubColorsDescription,
+            TextWrapping = TextWrapping.Wrap,
+            MaxWidth = 560,
+            Opacity = 0.8,
+            Margin = new Thickness(0, 0, 0, 12),
+        };
+
+        var swatchesPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 14,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 0, 0, 12),
+            Children =
+            {
+                MakeSwatchTile(Se.Language.Ocr.VobSubColorBackground,
+                    nameof(vm.BackgroundColor), nameof(vm.BackgroundHex), vm.PickBackgroundCommand),
+                MakeSwatchTile(Se.Language.Ocr.VobSubColorPattern,
+                    nameof(vm.PatternColor), nameof(vm.PatternHex), vm.PickPatternCommand),
+                MakeSwatchTile(Se.Language.Ocr.VobSubColorEmphasis1,
+                    nameof(vm.Emphasis1Color), nameof(vm.Emphasis1Hex), vm.PickEmphasis1Command),
+                MakeSwatchTile(Se.Language.Ocr.VobSubColorEmphasis2,
+                    nameof(vm.Emphasis2Color), nameof(vm.Emphasis2Hex), vm.PickEmphasis2Command),
+            }
+        };
+
+        var previewPanel = MakePreviewPanel(vm);
+
+        var buttonReset = UiUtil.MakeButton(Se.Language.General.Reset, vm.ResetToDefaultsCommand);
+        var buttonInvert = UiUtil.MakeButton(Se.Language.Ocr.VobSubColorsInvert, vm.InvertBackgroundForegroundCommand);
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+
+        var leftButtonsPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Children = { buttonReset, buttonInvert }
+        };
+
+        var rightButtonsPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Children = { buttonOk, buttonCancel }
+        };
+
+        var buttonRow = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = new Thickness(0, 12, 0, 0),
+        };
+        buttonRow.Add(leftButtonsPanel, 0, 0);
+        buttonRow.Add(rightButtonsPanel, 0, 1);
+
+        var rootPanel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = UiUtil.MakeWindowMargin(),
+            Spacing = 0,
+            Width = 600,
+            Children =
+            {
+                headerText,
+                descriptionText,
+                swatchesPanel,
+                previewPanel,
+                buttonRow,
+            }
+        };
+
+        Content = rootPanel;
+
+        Activated += delegate { buttonOk.Focus(); };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    private static Border MakeSwatchTile(string label, string colorProperty, string hexProperty, IRelayCommand command)
+    {
+        var swatch = new Border
+        {
+            Width = SwatchSize,
+            Height = SwatchSize,
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(180, 160, 160, 160)),
+            Cursor = new Cursor(StandardCursorType.Hand),
+            HorizontalAlignment = HorizontalAlignment.Center,
+            // Show a checker pattern through transparency by layering on a neutral background
+            Background = MakeCheckerboardBrush(),
+        };
+
+        var swatchFill = new Border
+        {
+            Width = SwatchSize,
+            Height = SwatchSize,
+            CornerRadius = new CornerRadius(6),
+        };
+        swatchFill.Bind(Border.BackgroundProperty, new Binding(colorProperty)
+        {
+            Converter = new ColorToBrushConverter(),
+        });
+        swatch.Child = swatchFill;
+
+        ToolTip.SetTip(swatch, Se.Language.General.ChooseColorDotDotDot);
+        swatch.PointerPressed += (s, e) =>
+        {
+            if (e.GetCurrentPoint(swatch).Properties.IsLeftButtonPressed && command.CanExecute(null))
+            {
+                command.Execute(null);
+            }
+        };
+
+        var labelBlock = new TextBlock
+        {
+            Text = label,
+            FontWeight = FontWeight.SemiBold,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 6, 0, 0),
+        };
+
+        var hexBlock = new TextBlock
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Opacity = 0.7,
+            FontSize = 11,
+        };
+        hexBlock.Bind(TextBlock.TextProperty, new Binding(hexProperty));
+
+        var tilePanel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Children = { swatch, labelBlock, hexBlock },
+        };
+
+        return new Border
+        {
+            Padding = new Thickness(8),
+            CornerRadius = new CornerRadius(8),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(60, 128, 128, 128)),
+            Child = tilePanel,
+        };
+    }
+
+    private static Border MakePreviewPanel(VobSubColorChooserViewModel vm)
+    {
+        var previewImage = new Image
+        {
+            Stretch = Stretch.Uniform,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            MaxHeight = 180,
+        };
+        previewImage.Bind(Image.SourceProperty, new Binding(nameof(vm.PreviewImage)));
+
+        var previewHost = new Border
+        {
+            MinHeight = 140,
+            Padding = new Thickness(8),
+            CornerRadius = new CornerRadius(8),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(60, 128, 128, 128)),
+            Background = MakeCheckerboardBrush(),
+            Child = previewImage,
+        };
+
+        var label = new TextBlock
+        {
+            Text = Se.Language.General.Preview,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(0, 0, 0, 6),
+        };
+
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Children = { label, previewHost },
+        };
+
+        return new Border { Child = panel };
+    }
+
+    private static IBrush MakeCheckerboardBrush()
+    {
+        // Simple subtle checker effect via a DrawingBrush would require resources;
+        // use a soft neutral gradient so transparent areas show consistently across themes.
+        return new LinearGradientBrush
+        {
+            StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
+            EndPoint = new RelativePoint(1, 1, RelativeUnit.Relative),
+            GradientStops =
+            {
+                new GradientStop(Color.FromArgb(40, 128, 128, 128), 0.0),
+                new GradientStop(Color.FromArgb(20, 128, 128, 128), 1.0),
+            }
+        };
+    }
+}

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -82,6 +82,15 @@ public class LanguageOcr
     public string ImportTextFromSubtitleXLinesImported { get; set; }
     public string ExportTextAsSubtitleDotDotDot { get; set; }
     public string ExportTextAsSubtitleNoText { get; set; }
+    public string VobSubColors { get; set; }
+    public string VobSubColorsTitle { get; set; }
+    public string VobSubColorsHeader { get; set; }
+    public string VobSubColorsDescription { get; set; }
+    public string VobSubColorBackground { get; set; }
+    public string VobSubColorPattern { get; set; }
+    public string VobSubColorEmphasis1 { get; set; }
+    public string VobSubColorEmphasis2 { get; set; }
+    public string VobSubColorsInvert { get; set; }
 
     public LanguageOcr()
     {
@@ -163,5 +172,14 @@ public class LanguageOcr
         ImportTextFromSubtitleXLinesImported = "Imported text for {0} line(s).";
         ExportTextAsSubtitleDotDotDot = "Export text as subtitle...";
         ExportTextAsSubtitleNoText = "No OCR text to export. Run OCR first or import text.";
+        VobSubColors = "VobSub/DVD colors...";
+        VobSubColorsTitle = "VobSub/DVD colors";
+        VobSubColorsHeader = "Customize the four VobSub colors";
+        VobSubColorsDescription = "VobSub/DVD subtitles use four indexed colors: background, pattern, emphasis 1 and emphasis 2. Pick each color below to override the embedded palette - useful when the original colors give poor OCR contrast.";
+        VobSubColorBackground = "Background";
+        VobSubColorPattern = "Pattern";
+        VobSubColorEmphasis1 = "Emphasis 1";
+        VobSubColorEmphasis2 = "Emphasis 2";
+        VobSubColorsInvert = "Invert background / emphasis 1";
     }
 }

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -40,6 +40,11 @@ public class SeOcr
     public bool TextBoxFontBold { get; set; }
     public string TextBoxFontName { get; set; }
     public bool UseWordSplitList { get; set; }
+    public bool VobSubUseCustomColors { get; set; }
+    public string VobSubColorBackground { get; set; }
+    public string VobSubColorPattern { get; set; }
+    public string VobSubColorEmphasis1 { get; set; }
+    public string VobSubColorEmphasis2 { get; set; }
 
     public SeOcr()
     {
@@ -86,5 +91,11 @@ public class SeOcr
         CaptureAssaPosition = false;
 
         PromptForBlankOcrText = true;
+
+        VobSubUseCustomColors = false;
+        VobSubColorBackground = "#00000000";
+        VobSubColorPattern = "#FF000000";
+        VobSubColorEmphasis1 = "#FFFFFFFF";
+        VobSubColorEmphasis2 = "#FF000000";
     }
 }


### PR DESCRIPTION
Adds a palette icon button in the top-right of the OCR window, visible only for VobSub sources, that opens a new dialog for customizing the four colors VobSub/DVD subpictures use: **background**, **pattern**, **emphasis 1**, **emphasis 2**. Useful when a DVD's embedded palette gives poor OCR contrast.

## UI

- New `Palette` toggle button appears alongside the existing capture-alignment and pre-processing buttons.
- Button is only visible for VobSub sources (`.sub`/`.idx`, MKV VobSub tracks).
- Button is **only** toggled on when the colors actually differ from the standard defaults (Transparent / Black / White / Black) — opening the dialog and clicking OK without changing anything leaves it off.

## Dialog

- Header + short description of what the four DVD colors mean.
- Four large rounded swatch tiles laid out horizontally, each labeled and showing its current ARGB hex.
- Click any swatch to open the existing `ColorPickerWindow` for that channel.
- Live preview pane re-renders the currently selected subtitle as colors change.
- **Reset to defaults**, **Invert background / emphasis 1**, **OK**, **Cancel** buttons.

## Persistence & refresh

- Custom colors are stored in `Se.Settings.Ocr` (`VobSubUseCustomColors` + four ARGB hex values) and restored when the same VobSub file is opened again.
- On accept, all cached row bitmaps are invalidated so the OCR grid refreshes immediately.

## Implementation notes

- `OcrSubtitleVobSub` gained `UseCustomColors` + four `SKColor` properties; when active, `GetBitmap` delegates to `SubPicture.GetBitmap(..., useCustomColors: true)`, which short-circuits the DVD palette's dynamic `SetColor` commands and keeps the supplied colors throughout.
- `OcrSubtitleItem.InvalidateBitmap()` was added so `OcrViewModel` can force a fresh render after a color change without rebuilding the item list semantics.
- Toggle state (`HasCustomVobSubColors`) is computed from a defaults check, not from "did the user click OK" — keeps the UI honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)