### PR TITLE
Add VobSub language picker dialog for multi-language .sub imports

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -82,6 +82,7 @@ using Nikse.SubtitleEdit.Features.Shared.PickRuleProfile;
 using Nikse.SubtitleEdit.Features.Shared.PickSpellCheckDictionary;
 using Nikse.SubtitleEdit.Features.Shared.PickSubtitleFormat;
 using Nikse.SubtitleEdit.Features.Shared.PickTsTrack;
+using Nikse.SubtitleEdit.Features.Shared.PickVobSubLanguage;
 using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Features.Shared.ShowImage;
@@ -390,6 +391,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<PickSpellCheckDictionaryViewModel>();
         collection.AddTransient<PickSubtitleFormatViewModel>();
         collection.AddTransient<PickTsTrackViewModel>();
+        collection.AddTransient<PickVobSubLanguageViewModel>();
         collection.AddTransient<PluginManagerViewModel>();
         collection.AddTransient<GetPluginsViewModel>();
         collection.AddTransient<PointSyncViaOtherViewModel>();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -87,6 +87,7 @@ using Nikse.SubtitleEdit.Features.Shared.PickRuleProfile;
 using Nikse.SubtitleEdit.Features.Shared.PickSpellCheckDictionary;
 using Nikse.SubtitleEdit.Features.Shared.PickSubtitleFormat;
 using Nikse.SubtitleEdit.Features.Shared.PickTsTrack;
+using Nikse.SubtitleEdit.Features.Shared.PickVobSubLanguage;
 using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Features.Shared.SetVideoOffset;
@@ -12281,42 +12282,23 @@ public partial class MainViewModel :
             return false;
         }
 
+        int streamId;
         if (languageStreamIds.Count > 1)
         {
-            //using (var chooseLanguage = new DvdSubRipChooseLanguage())
-            //{
-            //    if (ShowInTaskbar)
-            //    {
-            //        chooseLanguage.Icon = (Icon)Icon.Clone();
-            //        chooseLanguage.ShowInTaskbar = true;
-            //        chooseLanguage.ShowIcon = true;
-            //    }
+            var pickResult = await ShowDialogAsync<PickVobSubLanguageWindow, PickVobSubLanguageViewModel>(
+                vm => vm.Initialize(streamIdDictionary, palette, vobSubParser.IdxLanguages, vobSubFileName));
+            if (!pickResult.OkPressed)
+            {
+                return false;
+            }
 
-            //    chooseLanguage.Initialize(_vobSubMergedPackList, _palette, vobSubParser.IdxLanguages, string.Empty);
-            //    var form = _main ?? (Form)this;
-            //    if (batchMode)
-            //    {
-            //        chooseLanguage.SelectActive();
-            //        vobSubMergedPackList = chooseLanguage.SelectedVobSubMergedPacks;
-            //        SetTesseractLanguageFromLanguageString(chooseLanguage.SelectedLanguageString);
-            //        _importLanguageString = chooseLanguage.SelectedLanguageString;
-            //        return true;
-            //    }
-
-            //    chooseLanguage.Activate();
-            //    if (chooseLanguage.ShowDialog(form) == DialogResult.OK)
-            //    {
-            //        _vobSubMergedPackList = chooseLanguage.SelectedVobSubMergedPacks;
-            //        SetTesseractLanguageFromLanguageString(chooseLanguage.SelectedLanguageString);
-            //        _importLanguageString = chooseLanguage.SelectedLanguageString;
-            //        return true;
-            //    }
-
-            //    return false;
-            //}
+            streamId = pickResult.SelectedStreamId;
+        }
+        else
+        {
+            streamId = languageStreamIds.First();
         }
 
-        var streamId = languageStreamIds.First();
         var result = await ShowDialogAsync<OcrWindow, OcrViewModel>(vm => { vm.Initialize(streamIdDictionary[streamId], palette, vobSubFileName); });
 
         if (result.OkPressed)

--- a/src/ui/Features/Shared/PickVobSubLanguage/PickVobSubLanguageViewModel.cs
+++ b/src/ui/Features/Shared/PickVobSubLanguage/PickVobSubLanguageViewModel.cs
@@ -1,0 +1,159 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.VobSub;
+using Nikse.SubtitleEdit.Logic;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Shared.PickVobSubLanguage;
+
+public partial class PickVobSubLanguageViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<VobSubLanguageDisplay> _languages;
+    [ObservableProperty] private VobSubLanguageDisplay? _selectedLanguage;
+    [ObservableProperty] private ObservableCollection<VobSubLanguageCueDisplay> _rows;
+
+    public Window? Window { get; set; }
+    public DataGrid LanguagesGrid { get; set; }
+    public bool OkPressed { get; private set; }
+    public string WindowTitle { get; private set; }
+
+    public int SelectedStreamId { get; private set; }
+    public string SelectedLanguageString { get; private set; }
+
+    private const int PreviewCount = 20;
+
+    private Dictionary<int, List<VobSubMergedPack>> _streamIdDictionary;
+    private List<SKColor>? _palette;
+
+    public PickVobSubLanguageViewModel()
+    {
+        Languages = new ObservableCollection<VobSubLanguageDisplay>();
+        Rows = new ObservableCollection<VobSubLanguageCueDisplay>();
+        LanguagesGrid = new DataGrid();
+        WindowTitle = string.Empty;
+        SelectedLanguageString = string.Empty;
+        _streamIdDictionary = new Dictionary<int, List<VobSubMergedPack>>();
+    }
+
+    public void Initialize(Dictionary<int, List<VobSubMergedPack>> streamIdDictionary, List<SKColor> palette, List<string> idxLanguages, string fileName)
+    {
+        _streamIdDictionary = streamIdDictionary;
+        _palette = palette;
+        WindowTitle = "Pick VobSub language - " + Path.GetFileName(fileName);
+
+        foreach (var streamId in streamIdDictionary.Keys.OrderBy(k => k))
+        {
+            Languages.Add(new VobSubLanguageDisplay
+            {
+                StreamId = streamId,
+                StreamIdHex = $"0x{streamId:X2}",
+                Language = LookupLanguage(streamId, idxLanguages),
+                Count = streamIdDictionary[streamId].Count,
+            });
+        }
+    }
+
+    private static string LookupLanguage(int streamId, List<string> idxLanguages)
+    {
+        // Idx.cs formats entries as "{LanguageName} ‎(0x{streamId:x})"
+        var marker = $"(0x{streamId:x})";
+        var match = idxLanguages.FirstOrDefault(l => l.Contains(marker, StringComparison.OrdinalIgnoreCase));
+        return match ?? string.Empty;
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() => { Window?.Close(); });
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        if (SelectedLanguage == null)
+        {
+            return;
+        }
+
+        SelectedStreamId = SelectedLanguage.StreamId;
+        SelectedLanguageString = SelectedLanguage.Language;
+        OkPressed = true;
+        Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    internal void OnKeyDownHandler(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Cancel();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter && LanguagesGrid.IsFocused)
+        {
+            Ok();
+            e.Handled = true;
+        }
+    }
+
+    internal void DataGridLanguagesSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        LanguageChanged();
+    }
+
+    private void LanguageChanged()
+    {
+        Rows.Clear();
+
+        var selected = SelectedLanguage;
+        if (selected == null || !_streamIdDictionary.TryGetValue(selected.StreamId, out var packs))
+        {
+            return;
+        }
+
+        for (var i = 0; i < PreviewCount && i < packs.Count; i++)
+        {
+            var pack = packs[i];
+            if (_palette != null)
+            {
+                pack.Palette = _palette;
+            }
+
+            var bitmap = pack.GetBitmap();
+            Rows.Add(new VobSubLanguageCueDisplay
+            {
+                Number = i + 1,
+                Show = pack.StartTime,
+                Duration = pack.EndTime - pack.StartTime,
+                Image = new Image { Source = bitmap.ToAvaloniaBitmap() },
+            });
+        }
+    }
+
+    internal void SelectAndScrollToRow(int index)
+    {
+        if (index < 0 || index >= Languages.Count)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            LanguagesGrid.SelectedIndex = index;
+            LanguagesGrid.ScrollIntoView(LanguagesGrid.SelectedItem, null);
+            LanguageChanged();
+        }, DispatcherPriority.Background);
+    }
+}

--- a/src/ui/Features/Shared/PickVobSubLanguage/PickVobSubLanguageWindow.cs
+++ b/src/ui/Features/Shared/PickVobSubLanguage/PickVobSubLanguageWindow.cs
@@ -1,0 +1,183 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+
+namespace Nikse.SubtitleEdit.Features.Shared.PickVobSubLanguage;
+
+public class PickVobSubLanguageWindow : Window
+{
+    public PickVobSubLanguageWindow(PickVobSubLanguageViewModel vm)
+    {
+        vm.Window = this;
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = vm.WindowTitle;
+        Width = 1024;
+        Height = 600;
+        MinWidth = 800;
+        MinHeight = 500;
+        CanResize = true;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        DataContext = vm;
+
+        var languagesView = MakeLanguagesView(vm);
+        var previewView = MakePreviewView(vm);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(languagesView, 0);
+        grid.Add(previewView, 0, 1);
+        grid.Add(panelButtons, 1, 0, 1, 2);
+
+        Content = grid;
+
+        AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
+
+        Loaded += (_, _) =>
+        {
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                vm.SelectAndScrollToRow(0);
+                vm.LanguagesGrid.Focus();
+            }, DispatcherPriority.Input);
+        };
+    }
+
+    private static Border MakeLanguagesView(PickVobSubLanguageViewModel vm)
+    {
+        var dataGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = vm.Languages,
+            Columns =
+            {
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.NumberSymbol,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(VobSubLanguageDisplay.StreamIdHex)),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Language,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(VobSubLanguageDisplay.Language)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Count,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(VobSubLanguageDisplay.Count)),
+                    IsReadOnly = true,
+                },
+            },
+        };
+        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedLanguage)));
+        dataGrid.SelectionChanged += vm.DataGridLanguagesSelectionChanged;
+        dataGrid.DoubleTapped += (_, _) => vm.OkCommand.Execute(null);
+        vm.LanguagesGrid = dataGrid;
+
+        return UiUtil.MakeBorderForControlNoPadding(dataGrid);
+    }
+
+    private static Border MakePreviewView(PickVobSubLanguageViewModel vm)
+    {
+        var fullTimeConverter = new TimeSpanToDisplayFullConverter();
+        var shortTimeConverter = new TimeSpanToDisplayShortConverter();
+        var dataGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = false,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = vm.Rows,
+            Columns =
+            {
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.NumberSymbol,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(VobSubLanguageCueDisplay.Number)),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Show,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(VobSubLanguageCueDisplay.Show)) { Converter = fullTimeConverter },
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Duration,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(VobSubLanguageCueDisplay.Duration)) { Converter = shortTimeConverter },
+                    IsReadOnly = true,
+                },
+                new DataGridTemplateColumn
+                {
+                    Header = Se.Language.General.Image,
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                    CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<VobSubLanguageCueDisplay>((item, _) =>
+                    {
+                        if (item.Image == null)
+                        {
+                            return new TextBlock();
+                        }
+
+                        return new Image
+                        {
+                            Source = item.Image.Source,
+                            MaxHeight = 100,
+                            MaxWidth = 300,
+                            Stretch = Avalonia.Media.Stretch.Uniform,
+                        };
+                    }),
+                },
+            },
+        };
+
+        return UiUtil.MakeBorderForControlNoPadding(dataGrid);
+    }
+}

--- a/src/ui/Features/Shared/PickVobSubLanguage/VobSubLanguageCueDisplay.cs
+++ b/src/ui/Features/Shared/PickVobSubLanguage/VobSubLanguageCueDisplay.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Shared.PickVobSubLanguage;
+
+public class VobSubLanguageCueDisplay
+{
+    public int Number { get; set; }
+    public TimeSpan Show { get; set; }
+    public TimeSpan Duration { get; set; }
+    public Image? Image { get; set; }
+}

--- a/src/ui/Features/Shared/PickVobSubLanguage/VobSubLanguageDisplay.cs
+++ b/src/ui/Features/Shared/PickVobSubLanguage/VobSubLanguageDisplay.cs
@@ -1,0 +1,15 @@
+namespace Nikse.SubtitleEdit.Features.Shared.PickVobSubLanguage;
+
+public class VobSubLanguageDisplay
+{
+    public int StreamId { get; set; }
+    public string StreamIdHex { get; set; }
+    public string Language { get; set; }
+    public int Count { get; set; }
+
+    public VobSubLanguageDisplay()
+    {
+        StreamIdHex = string.Empty;
+        Language = string.Empty;
+    }
+}


### PR DESCRIPTION
When importing a VobSub `.sub` file containing more than one language stream, Subtitle Edit currently picks the first stream silently. This PR adds a new `PickVobSubLanguage` dialog so the user can choose.

## What it does
- Implements the previously-empty `languageStreamIds.Count > 1` branch in `MainViewModel.ImportSubtitleFromVobSubFile` (`src/ui/Features/Main/MainViewModel.cs`).
- New dialog under `src/ui/Features/Shared/PickVobSubLanguage/`, mirroring the `PickMatroskaTrack` layout: language list on the left, preview of the first 20 rendered subtitle images on the right, updating as the selection changes.
- Language names are resolved from `VobSubParser.IdxLanguages` by matching the `(0xXX)` stream-id suffix written by `Idx.cs`; unknown stream IDs simply show `0xXX` with a count.
- VM registered in `DependencyInjectionExtensions.cs`.

## Notes
- Esc/Enter, double-tap to confirm, and OK/Cancel buttons match the other pick dialogs.
- The legacy WinForms behavior of feeding `SelectedLanguageString` into `SetTesseractLanguageFromLanguageString` is left as a TODO — the helper isn't ported yet, but the VM exposes `SelectedLanguageString` so it's a one-line addition once available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)