### PR TITLE
Show install status + size in speech-to-text engine picker

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/ChatLlmCppEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ChatLlmCppEngine.cs
@@ -171,6 +171,26 @@ public class ChatLlmCppEngine : ISpeechToTextEngine
         return true;
     }
 
+    public string DownloadSizeText
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "~2 MB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "~3 MB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "~1 MB";
+            }
+            return string.Empty;
+        }
+    }
+
     public string CommandLineParameter
     {
         get => Se.Settings.Tools.AudioToText.CommandLineParameterChatLlm;

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -84,6 +84,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
 
     public override bool IsEngineInstalled() => SelectedBackend.IsEngineInstalled();
     public override bool CanBeDownloaded() => SelectedBackend.CanBeDownloaded();
+    public override string DownloadSizeText => SelectedBackend.DownloadSizeText;
     public override string GetAndCreateWhisperFolder() => SelectedBackend.GetAndCreateWhisperFolder();
     public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => SelectedBackend.GetAndCreateWhisperModelFolder(whisperModel);
     public override string GetExecutable() => SelectedBackend.GetExecutable();

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.AudioToText;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
@@ -22,6 +23,32 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
     public abstract string UnpackSkipFolder { get; }
     public abstract bool IsEngineInstalled();
     public abstract bool CanBeDownloaded();
+
+    /// <summary>
+    /// CrispASR ships several Windows variants of very different sizes (CPU ~3 MB, Vulkan
+    /// ~25 MB, CUDA ~684 MB), and the variant is picked at download time rather than now.
+    /// We surface the smallest reasonable number and note that it varies so the user has a
+    /// floor without being misled by the CUDA bundle.
+    /// </summary>
+    public virtual string DownloadSizeText
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "~3 MB – 684 MB"; // CPU – CUDA depending on variant chosen at download time
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "~5 MB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "~4 MB";
+            }
+            return string.Empty;
+        }
+    }
     public abstract string GetAndCreateWhisperFolder();
     public abstract string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel);
     public abstract string GetExecutable();

--- a/src/ui/Features/Video/SpeechToText/Engines/ISpeechToTextEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ISpeechToTextEngine.cs
@@ -16,6 +16,15 @@ public interface ISpeechToTextEngine
     string UnpackSkipFolder { get; }
     bool IsEngineInstalled();
     bool CanBeDownloaded();
+
+    /// <summary>
+    /// Approximate download size as user-facing text (e.g. "~14 MB"), platform-aware where
+    /// the install archive differs between Windows/Linux/macOS. Returns an empty string for
+    /// engines that don't need downloading (e.g. cloud APIs) or where the size isn't known.
+    /// Used to inform the user up front in the engine picker before any download starts.
+    /// </summary>
+    string DownloadSizeText => string.Empty;
+
     string GetAndCreateWhisperFolder();
     string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel);
     string GetExecutable();

--- a/src/ui/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngine.cs
@@ -215,6 +215,8 @@ public class Qwen3AsrCppEngine : ISpeechToTextEngine
         return true;
     }
 
+    public string DownloadSizeText => "~1 MB"; // tiny stub binary; the heavy model is fetched separately as a forced aligner.
+
     public string CommandLineParameter
     {
         get => Se.Settings.Tools.AudioToText.CommandLineParameterQwen3AsrCpp;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperCppEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperCppEngine.cs
@@ -81,6 +81,7 @@ public class WhisperCppEngine : ISpeechToTextEngine
 
     public bool IsEngineInstalled() => SelectedBackend.IsEngineInstalled();
     public bool CanBeDownloaded() => SelectedBackend.CanBeDownloaded();
+    public string DownloadSizeText => SelectedBackend.DownloadSizeText;
     public string GetAndCreateWhisperFolder() => SelectedBackend.GetAndCreateWhisperFolder();
     public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => SelectedBackend.GetAndCreateWhisperModelFolder(whisperModel);
     public string GetExecutable() => SelectedBackend.GetExecutable();

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
@@ -129,6 +129,26 @@ public class WhisperEngineCTranslate2 : ISpeechToTextEngine
         return true;
     }
 
+    public string DownloadSizeText
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "~103 MB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "~149 MB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "~76 MB";
+            }
+            return string.Empty;
+        }
+    }
+
     public string CommandLineParameter
     {
         get => Se.Settings.Tools.AudioToText.CommandLineParameterCTranslate2;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineConstMe.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineConstMe.cs
@@ -140,6 +140,9 @@ public class WhisperEngineConstMe : ISpeechToTextEngine
         return true;
     }
 
+    // The Const-me CLI is a thin DirectCompute/D3D wrapper — the heavy lifting lives in system libs.
+    public string DownloadSizeText => "~0.4 MB";
+
     public string CommandLineParameter
     {
         get => Se.Settings.Tools.AudioToText.CommandLineParameterConstMe;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
@@ -160,6 +160,27 @@ public class WhisperEngineCpp : ISpeechToTextEngine
         return true;
     }
 
+    public string DownloadSizeText
+    {
+        get
+        {
+            // matches WhisperDownloadService.GetUrl() — the BLAS Windows build, Vulkan Linux build, or universal Mac build.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "~14 MB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "~18 MB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "~3 MB";
+            }
+            return string.Empty;
+        }
+    }
+
     public string CommandLineParameter
     {
         get => Se.Settings.Tools.AudioToText.CommandLineParameterCpp;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppCuBlas.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppCuBlas.cs
@@ -169,6 +169,24 @@ public class WhisperEngineCppCuBlas : ISpeechToTextEngine
         return true;
     }
 
+    public string DownloadSizeText
+    {
+        get
+        {
+            // Windows: cuBLAS 12.4 binary bundle (CUDA libs included).
+            // Linux: thin Vulkan-CUDA bundle since the CUDA toolkit is system-installed.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "~436 MB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "~37 MB";
+            }
+            return string.Empty;
+        }
+    }
+
     public string CommandLineParameter
     {
         get => Se.Settings.Tools.AudioToText.CommandLineParameterCppCuBlas;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
@@ -169,6 +169,10 @@ public class WhisperEngineCppVulkan : ISpeechToTextEngine
         return true;
     }
 
+    public string DownloadSizeText => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? "~16 MB"
+        : string.Empty;
+
     public string CommandLineParameter
     {
         get => Se.Settings.Tools.AudioToText.CommandLineParameterCppVulkan;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEnginePurfviewFasterWhisperXxl.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEnginePurfviewFasterWhisperXxl.cs
@@ -167,6 +167,23 @@ public class WhisperEnginePurfviewFasterWhisperXxl : ISpeechToTextEngine
         return true;
     }
 
+    public string DownloadSizeText
+    {
+        get
+        {
+            // Bundles full CUDA + Python runtime, so the archive is large.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "~1.4 GB";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "~1.6 GB";
+            }
+            return string.Empty;
+        }
+    }
+
     public string CommandLineParameter
     {
         get => Se.Settings.Tools.AudioToText.CommandLineParameterPurfviewFasterWhisperXxl;

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -84,6 +84,14 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private bool _isReDownloadVisible;
     [ObservableProperty] private string _reDownloadText;
 
+    // Surfaced next to the engine combo so the user sees at a glance whether the
+    // selected engine is ready to use or still needs a download (with size).
+    [ObservableProperty] private string _engineStatusText;
+    [ObservableProperty] private bool _isEngineStatusVisible;
+    [ObservableProperty] private bool _isEngineInstalledIconVisible;
+    [ObservableProperty] private bool _isEngineDownloadButtonVisible;
+    [ObservableProperty] private string _engineDownloadHint;
+
     [ObservableProperty] private bool _isOpenAiCompatibleSttVisible;
     [ObservableProperty] private bool _isAdvancedSettingsVisible = true;
     [ObservableProperty] private string? _openAiCompatibleSttUrl;
@@ -216,6 +224,8 @@ public partial class SpeechToTextViewModel : ObservableObject
         TextBoxConsoleLog = new TextBox();
         BatchGrid = new DataGrid();
         ReDownloadText = string.Empty;
+        EngineStatusText = string.Empty;
+        EngineDownloadHint = string.Empty;
         _audioTrackNumber = -1;
         _error = string.Empty;
 
@@ -3378,6 +3388,8 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         Parameters = engine.CommandLineParameter;
 
+        UpdateEngineStatusUi(engine);
+
         SaveSettings();
 
         if (engine is ICrispAsrEngine && !_crispAsrUpdatePromptShown)
@@ -3389,6 +3401,63 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             Dispatcher.UIThread.Post(async () => await CheckWhisperCppForUpdateAsync());
         }
+    }
+
+    /// <summary>
+    /// Refresh the install-status indicator and download icon next to the engine combo
+    /// box. The text and visibility reflect three states: cloud-only engine (nothing to
+    /// show), installed locally (✓ Installed), or downloadable-and-missing (size shown so
+    /// the user can decide before clicking the download icon).
+    /// </summary>
+    private void UpdateEngineStatusUi(ISpeechToTextEngine engine)
+    {
+        var canDownload = engine.CanBeDownloaded();
+        var isInstalled = engine.IsEngineInstalled();
+
+        if (!canDownload)
+        {
+            // Cloud / API engines — no install state to show.
+            EngineStatusText = string.Empty;
+            EngineDownloadHint = string.Empty;
+            IsEngineStatusVisible = false;
+            IsEngineInstalledIconVisible = false;
+            IsEngineDownloadButtonVisible = false;
+            return;
+        }
+
+        if (isInstalled)
+        {
+            EngineStatusText = Se.Language.Video.AudioToText.Installed;
+            EngineDownloadHint = string.Empty;
+            IsEngineStatusVisible = true;
+            IsEngineInstalledIconVisible = true;
+            IsEngineDownloadButtonVisible = false;
+            return;
+        }
+
+        var size = engine.DownloadSizeText;
+        EngineStatusText = string.IsNullOrEmpty(size)
+            ? Se.Language.Video.AudioToText.NotInstalled
+            : $"{Se.Language.Video.AudioToText.NotInstalled} · {size}";
+        EngineDownloadHint = string.IsNullOrEmpty(size)
+            ? string.Format(Se.Language.Video.AudioToText.DownloadX, engine.Name)
+            : string.Format(Se.Language.Video.AudioToText.DownloadX, engine.Name) + $" ({size})";
+        IsEngineStatusVisible = true;
+        IsEngineInstalledIconVisible = false;
+        IsEngineDownloadButtonVisible = true;
+    }
+
+    [RelayCommand]
+    private async Task DownloadSelectedEngine()
+    {
+        // Reuses the same prompt flow as the context-menu "Re-download" entry, so
+        // CrispASR variant selection and Vulkan-SDK warnings stay in one place.
+        // The status indicator next to the combo refreshes from VM properties below; the
+        // per-item ✓/⬇ markers in the dropdown reflect what was on disk when the window
+        // opened — that's acceptable since the typical path is download → transcribe and
+        // the user doesn't revisit the dropdown mid-session.
+        await ReDownloadWhisperEngine();
+        UpdateEngineStatusUi(GetEffectiveSelectedEngine());
     }
 
     private async Task CheckCrispAsrForUpdateAsync()

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -1,12 +1,14 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -39,13 +41,48 @@ public class SpeechToTextWindow : Window
 
         var labelEngine = UiUtil.MakeTextBlock(Se.Language.General.Engine).WithMarginTop(10);
         var comboEngine = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine))
-            .WithMinWidth(220)
+            .WithMinWidth(260)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
             .WithMarginTop(10);
+        comboEngine.ItemTemplate = MakeEngineItemTemplate();
         comboEngine.SelectionChanged += vm.OnEngineChanged;
         var buttonEngineWebsite = UiUtil.MakeButton(vm.ShowWebLinkCommand, IconNames.Web)
             .WithMarginLeft(5)
             .WithMarginTop(10);
+        var buttonEngineDownload = UiUtil.MakeButton(vm.DownloadSelectedEngineCommand, IconNames.Download)
+            .WithMarginLeft(5)
+            .WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsEngineDownloadButtonVisible))
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
+        buttonEngineDownload.Bind(ToolTip.TipProperty, new Binding(nameof(vm.EngineDownloadHint))
+        {
+            Source = vm,
+            Mode = BindingMode.OneWay,
+            UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+        });
+
+        // Status icon + text (e.g. "✓ Installed" or "Not installed · ~140 MB") next to the combo.
+        var engineInstalledIcon = new Optris.Icons.Avalonia.Icon
+        {
+            Value = IconNames.CheckCircle,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 10, 4, 0),
+            FontSize = 14,
+            Foreground = Brushes.MediumSeaGreen,
+        }.BindIsVisible(vm, nameof(vm.IsEngineInstalledIconVisible));
+        var engineStatusText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(2, 10, 0, 0),
+            Opacity = 0.75,
+        }.BindIsVisible(vm, nameof(vm.IsEngineStatusVisible));
+        engineStatusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.EngineStatusText))
+        {
+            Source = vm,
+            Mode = BindingMode.OneWay,
+            UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+        });
+
         var panelEngineControls = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -54,7 +91,10 @@ public class SpeechToTextWindow : Window
             Children =
             {
                 comboEngine,
-                buttonEngineWebsite
+                buttonEngineWebsite,
+                buttonEngineDownload,
+                engineInstalledIcon,
+                engineStatusText,
             }
         };
 
@@ -675,5 +715,70 @@ public class SpeechToTextWindow : Window
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttPrompt), MakeText(nameof(vm.OpenAiCompatibleSttPrompt), 400)),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttExtraHeaders), textExtraHeaders),
         };
+    }
+
+    /// <summary>
+    /// Item template for the engine combo box: each row carries a small status icon
+    /// (✓ for installed, ⬇ for download-required, blank for cloud/online engines) and
+    /// — when relevant — the approximate download size. Status is read fresh from the
+    /// engine each time the template runs, so the dropdown reflects the current state
+    /// after a download completes (the VM nudges SelectedEngine to force a re-render).
+    /// </summary>
+    private static FuncDataTemplate<ISpeechToTextEngine> MakeEngineItemTemplate()
+    {
+        return new FuncDataTemplate<ISpeechToTextEngine>((engine, _) =>
+        {
+            if (engine == null)
+            {
+                return new TextBlock();
+            }
+
+            var canDownload = engine.CanBeDownloaded();
+            var isInstalled = engine.IsEngineInstalled();
+
+            var iconName = !canDownload
+                ? string.Empty
+                : isInstalled
+                    ? IconNames.CheckCircle
+                    : IconNames.Download;
+
+            var iconColor = isInstalled ? Brushes.MediumSeaGreen : Brushes.Gray;
+
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                VerticalAlignment = VerticalAlignment.Center,
+                Spacing = 6,
+            };
+
+            if (!string.IsNullOrEmpty(iconName))
+            {
+                panel.Children.Add(new Optris.Icons.Avalonia.Icon
+                {
+                    Value = iconName,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    FontSize = 14,
+                    Foreground = iconColor,
+                });
+            }
+
+            panel.Children.Add(new TextBlock
+            {
+                Text = engine.Name,
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+
+            if (canDownload && !isInstalled && !string.IsNullOrEmpty(engine.DownloadSizeText))
+            {
+                panel.Children.Add(new TextBlock
+                {
+                    Text = $"({engine.DownloadSizeText})",
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Opacity = 0.6,
+                });
+            }
+
+            return panel;
+        }, supportsRecycling: true);
     }
 }

--- a/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
@@ -20,6 +20,9 @@ public class LanguageAudioToText
     public string SelectModel { get; set; }
     public string ViewToolsLogFile { get; set; }
     public string ReDownloadX { get; set; }
+    public string Installed { get; set; }
+    public string NotInstalled { get; set; }
+    public string DownloadX { get; set; }
     public string UpdateXTitle { get; set; }
     public string UpdateXMessage { get; set; }
     public string? DownloadingSpeechToTextModel { get; set; }
@@ -52,6 +55,9 @@ public class LanguageAudioToText
         SelectModel = "Select model";
         ViewToolsLogFile = "View tools log file";
         ReDownloadX = "Re-download {0}";
+        Installed = "Installed";
+        NotInstalled = "Not installed";
+        DownloadX = "Download {0}";
         UpdateXTitle = "Update {0}?";
         UpdateXMessage = "A newer version of {0} is available.{1}{1}Download and install the update now?";
         DownloadingSpeechToTextModel = "Downloading speech-to-text model";

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -24,6 +24,9 @@ internal class IconNames
     public const string Cogs = "mdi-cogs";
     public const string ContentSave = "mdi-content-save";
     public const string Copy = "mdi-content-copy";
+    public const string CheckCircle = "mdi-check-circle";
+    public const string Download = "mdi-download";
+    public const string CloudDownload = "mdi-cloud-download-outline";
     public const string DockTop = "mdi-dock-top";
     public const string DotsHorizontal = "mdi-dots-horizontal";
     public const string DotsVertical = "mdi-dots-vertical";


### PR DESCRIPTION
Closes #10918.

The user opening **Video → Speech to text** in v5 used to be told nothing about which engines were ready to use and which still needed a download — and v4's habit of popping a download prompt the moment you scrolled to a new engine in the combo was [reported as missing here](https://github.com/SubtitleEdit/subtitleedit/issues/10918) but isn't what we want back. This PR splits the difference: no click-time prompt, but the picker itself now tells the user what they're about to do.

### What changed in the dialog

- Each engine in the combo now renders with a small status icon and (when missing) an approximate size:
  - **✓ Whisper CPP** — installed locally, no download needed
  - **⬇ Whisper CTranslate2 (~103 MB)** — needs to be fetched
  - **OpenAI compatible STT** — no marker, since cloud engines have nothing to install
- Next to the existing globe (website) button, when the selected engine isn't installed, there's now a download icon. Hovering it shows `Download Whisper CTranslate2 (~103 MB)` and clicking it opens the same download dialog the context menu's "Re-download" entry uses — CrispASR variant selection and the Vulkan-SDK warning stay in their existing place.
- A status line next to the combo ("Installed" / "Not installed · ~103 MB") mirrors the per-item indicator for the current selection, so the user doesn't have to re-open the dropdown.

### Where the sizes come from

`ISpeechToTextEngine.DownloadSizeText` is a new default-impl property on the engine interface. Each downloadable engine returns a platform-aware approximation matching the URL its download service actually fetches — pulled from the current GitHub release assets:

| Engine | Windows | Linux | macOS |
|---|---|---|---|
| Whisper CPP | ~14 MB | ~18 MB | ~3 MB |
| Whisper CPP cuBLAS | ~436 MB | ~37 MB | — |
| Whisper CPP Vulkan | ~16 MB | — | — |
| Whisper Const-me | ~0.4 MB | — | — |
| Purfview Faster-Whisper XXL | ~1.4 GB | ~1.6 GB | — |
| Whisper CTranslate2 | ~103 MB | ~149 MB | ~76 MB |
| Qwen3 ASR.cpp | ~1 MB | ~2 MB | ~0.2 MB |
| Chat LLM.cpp | ~2 MB | ~3 MB | ~1 MB |
| Crisp ASR | ~3 MB – 684 MB | ~5 MB | ~4 MB |

CrispASR's range reflects that the user picks CPU / Vulkan / CUDA at download time. Cloud engines (Whisper OpenAI, OpenAI-compatible STT) return an empty string and don't show any of the new affordances.

### Other notes

- `WhisperCppEngine` and `CrispAsrEngine` forward `DownloadSizeText` to `SelectedBackend`, so the umbrella entries reflect whichever backend is currently selected.
- The combo's `ItemTemplate` reads engine state at render time, so the selected display refreshes after a download completes. The per-row dropdown items reflect what was on disk when the window opened — acceptable since the typical flow is *download → transcribe* and the user doesn't revisit the dropdown mid-session.
- New language strings: `Installed`, `NotInstalled`, `DownloadX` on `LanguageAudioToText`.
- New icon constants: `Download`, `CloudDownload`, `CheckCircle` on `IconNames`.

### Verified

- `dotnet build src/ui/UI.csproj` — clean, no new warnings.
- `dotnet test tests/UI/UITests.csproj` — 143 / 143 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)