### PR TITLE
Fix STT engine combo not reflecting new selection (#10925)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -693,13 +693,12 @@ public class SpeechToTextWindow : Window
         };
     }
 
-    /// <summary>
-    /// Item template for the engine combo box: each row carries a small status icon
-    /// (✓ for installed, ⬇ for download-required, blank for cloud/online engines) and
-    /// — when relevant — the approximate download size. Status is read fresh from the
-    /// engine each time the template runs, so the dropdown reflects the current state
-    /// after a download completes (the VM nudges SelectedEngine to force a re-render).
-    /// </summary>
+    // Engine combo item template: each row gets a small status icon (✓ installed,
+    // ⬇ download-required, blank for cloud-only) plus the approximate download size
+    // when relevant. The template hard-codes engine.Name/icon/size at build time
+    // instead of binding, so recycling MUST stay off — otherwise the ComboBox would
+    // reuse one visual across engines and the closed-state display would freeze on
+    // whichever engine first populated the recycled visual.
     private static FuncDataTemplate<ISpeechToTextEngine> MakeEngineItemTemplate()
     {
         return new FuncDataTemplate<ISpeechToTextEngine>((engine, _) =>
@@ -755,6 +754,6 @@ public class SpeechToTextWindow : Window
             }
 
             return panel;
-        }, supportsRecycling: true);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Disable visual recycling on the speech-to-text engine `FuncDataTemplate`. The lambda hard-codes `engine.Name`, the install/download icon, and `engine.DownloadSizeText` into freshly-built `TextBlock`/`StackPanel` instances with no `Binding` to `DataContext`. With `supportsRecycling: true`, Avalonia reuses one visual across engines — only the `DataContext` swaps — so the closed-state SelectionBox display freezes on whichever engine first populated the recycled visual.
- Cost of dropping recycling is negligible (engine list is small). Updated the comment above the template to record the constraint so this isn't reintroduced.

Fixes #10925.

## Test plan
- [ ] Open Video → Speech-to-text and pick several different engines in the combo; confirm the displayed engine name, status icon, and size update immediately on each change.
- [ ] Confirm model / language / advanced-parameters panes underneath still switch correctly (driven by the existing `SelectionChanged → EngineChanged()` hook).
- [ ] Confirm initial selection on window open matches the persisted `WhisperChoice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)