### PR TITLE
Auto-scroll (tail) the console log in the speech-to-text dialog

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3210,8 +3210,18 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         ConsoleLog += s.Trim() + "\n";
 
-        Dispatcher.UIThread.Post(() => { TextBoxConsoleLog.CaretIndex = TextBoxConsoleLog.Text?.Length ?? 0; },
-           DispatcherPriority.Background);
+        // Tail behavior: keep the console scrolled to the latest line so the user
+        // doesn't have to camp on PageDown. Setting CaretIndex alone is unreliable
+        // here — the TextBox isn't focused, so the internal BringCaretToView is a
+        // no-op. ScrollToLine drives the inner TextPresenter directly. Post at
+        // Background priority so it runs after the layout pass that lays out the
+        // freshly-appended text.
+        Dispatcher.UIThread.Post(() =>
+        {
+            var text = TextBoxConsoleLog.Text ?? string.Empty;
+            TextBoxConsoleLog.CaretIndex = text.Length;
+            TextBoxConsoleLog.ScrollToLine(text.Count(c => c == '\n'));
+        }, DispatcherPriority.Background);
     }
 
     private static decimal GetSeconds(string timeCode)


### PR DESCRIPTION
## Summary
- The console-log TextBox in the speech-to-text dialog stayed pinned at the top while ffmpeg / whisper output streamed in, forcing users to tab into the box and camp on PageDown to actually follow what was happening.
- `LogToConsole` already set `CaretIndex` to the end after each appended line, but in Avalonia 12 that only causes a scroll when the TextBox has focus — for an unfocused read-only log, the internal `BringCaretToView` is a no-op.
- Keep the `CaretIndex` update (so a later focus lands at the bottom) and additionally call `TextBox.ScrollToLine(<last newline index>)`, which drives the inner `TextPresenter` directly. Still dispatched at `Background` priority so it runs after the layout pass for the freshly-appended line.

## Test plan
- [ ] Open Video → Speech-to-text and start a transcription with any local engine; confirm the console log keeps scrolled to the latest line as ffmpeg / whisper output streams in, without focusing the TextBox.
- [ ] Confirm the user can still manually scroll up (no fight with the auto-scroll while a transcription is running) and that focusing + scrolling back to bottom keeps tracking.
- [ ] Repeat in batch mode (smaller console-log + batch grid view) to confirm both layouts auto-scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)