### PR TITLE
Numpad keys: capture distinctly from main keyboard (#10934)

### DIFF
--- a/src/ui/Features/Options/Shortcuts/GetKeyViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/GetKeyViewModel.cs
@@ -59,33 +59,39 @@ public partial class GetKeyViewModel : ObservableObject
             Window?.Close();
             return;
         }
-        
+
         if (e.Key is Key.LWin or Key.RWin)
         {
             e.Handled = true;
             _isWinDown = true;
             return;
         }
-        
-        if (e.Key is Key.LeftShift or Key.RightShift or 
-                     Key.LeftAlt or Key.RightAlt or 
-                     Key.LeftCtrl or Key.RightCtrl)
+
+        if (e.Key is Key.LeftShift or Key.RightShift or
+                     Key.LeftAlt or Key.RightAlt or
+                     Key.LeftCtrl or Key.RightCtrl or
+                     Key.NumLock)
         {
+            // NumLock is a state toggle, not a chord key — swallow it instead of
+            // capturing "NumLock" as the bound shortcut.
             e.Handled = true;
             return;
         }
 
         var infoText = string.Empty;
-        
+
         var isMac = OperatingSystem.IsMacOS() ;
         var ctrlLabel = isMac ? Se.Language.Options.Shortcuts.ControlMac : Se.Language.Options.Shortcuts.Control;
         var altLabel = isMac ? Se.Language.Options.Shortcuts.AltMac : Se.Language.Options.Shortcuts.Alt;
         var shiftLabel = isMac ? Se.Language.Options.Shortcuts.ShiftMac : Se.Language.Options.Shortcuts.Shift;
         var winLabel = isMac ? Se.Language.Options.Shortcuts.WinMac : Se.Language.Options.Shortcuts.Win;
 
-        var key = ShortcutManager.GetShortcutKey(e);
+        // Use the physical-key-aware name so numpad-Delete (NumLock off) records
+        // as "NumPadDelete" rather than the misleading "Decimal", and so it stays
+        // bindable distinct from main Delete and from numpad-Decimal (NumLock on).
+        var keyName = ShortcutManager.GetShortcutKeyName(e);
 
-        PressedKey = key.ToString();
+        PressedKey = keyName;
         PressedKeyOnly = PressedKey;
         IsControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
         IsAltPressed = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
@@ -122,8 +128,8 @@ public partial class GetKeyViewModel : ObservableObject
             infoText += winLabel + " + ";       
         }
         
-        PressedKey += key;
-        infoText += key;
+        PressedKey += keyName;
+        infoText += keyName;
 
         InfoText = string.Format(Se.Language.Options.Shortcuts.PressedKeyX, infoText);
     }

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -11,6 +11,12 @@ namespace Nikse.SubtitleEdit.Logic;
 public class ShortcutManager : IShortcutManager
 {
     private readonly HashSet<Key> _activeKeys = [];
+    // Parallel to _activeKeys but uses the physical-key-aware string token (see
+    // GetShortcutKeyName). Numpad keys collapse to NumLock-on names in Avalonia's
+    // Key enum, so HashSet<Key> can't tell main-Delete from numpad-Delete (NumLock
+    // off) from numpad-Decimal (NumLock on). This set is what we hash for lookup
+    // so users can bind each of those independently.
+    private readonly HashSet<string> _activeKeyNames = [];
     private readonly List<ShortCut> _shortcuts = [];
     private FrozenDictionary<string, ShortCut>? _lookupTable;
     private bool _isDirty = true;
@@ -22,14 +28,29 @@ public class ShortcutManager : IShortcutManager
         bool isMac = OperatingSystem.IsMacOS();
         var shortcuts = Se.Language.Options.Shortcuts;
 
-        return key switch
+        switch (key)
         {
-            "Ctrl" or "Control" => isMac ? shortcuts.ControlMac : shortcuts.Control,
-            "Alt" => isMac ? shortcuts.AltMac : shortcuts.Alt,
-            "Shift" => isMac ? shortcuts.ShiftMac : shortcuts.Shift,
-            "Win" or "Cmd" => isMac ? shortcuts.WinMac : shortcuts.Win,
-            _ => key
-        };
+            case "Ctrl":
+            case "Control":
+                return isMac ? shortcuts.ControlMac : shortcuts.Control;
+            case "Alt":
+                return isMac ? shortcuts.AltMac : shortcuts.Alt;
+            case "Shift":
+                return isMac ? shortcuts.ShiftMac : shortcuts.Shift;
+            case "Win":
+            case "Cmd":
+                return isMac ? shortcuts.WinMac : shortcuts.Win;
+        }
+
+        // Render "NumPadDelete" / "NumPad0" as "Numpad Delete" / "Numpad 0" so
+        // the lists and shortcut hints read naturally. Storage stays in the
+        // PascalCase form for matching.
+        if (key.Length > "NumPad".Length && key.StartsWith("NumPad", StringComparison.Ordinal))
+        {
+            return "Numpad " + key.Substring("NumPad".Length);
+        }
+
+        return key;
     }
 
     public static Key GetShortcutKey(KeyEventArgs e)
@@ -37,6 +58,11 @@ public class ShortcutManager : IShortcutManager
         return GetShortcutKey(e.Key, e.PhysicalKey);
     }
 
+    // Legacy accessor: collapses any numpad physical key to its NumLock-on Key
+    // value. Kept for callers that still operate on the Avalonia Key enum (e.g.
+    // single-key allowance checks). New code should prefer GetShortcutKeyName so
+    // numpad keys can be distinguished across NumLock states and from their
+    // main-keyboard counterparts.
     public static Key GetShortcutKey(Key key, PhysicalKey physicalKey)
     {
         return physicalKey switch
@@ -60,6 +86,40 @@ public class ShortcutManager : IShortcutManager
         };
     }
 
+    // Returns a stable token for the pressed key that distinguishes numpad keys
+    // from their main-keyboard counterparts and from each other across NumLock
+    // states. Numpad physical keys get the "NumPad" prefix unless the Avalonia
+    // Key name already carries it (NumPad0..NumPad9). For non-numpad physical
+    // keys this is just Key.ToString(), preserving every existing binding string.
+    public static string GetShortcutKeyName(KeyEventArgs e)
+    {
+        return GetShortcutKeyName(e.Key, e.PhysicalKey);
+    }
+
+    public static string GetShortcutKeyName(Key key, PhysicalKey physicalKey)
+    {
+        if (!IsNumPadPhysicalKey(physicalKey))
+        {
+            return key.ToString();
+        }
+
+        var keyName = key.ToString();
+        return keyName.StartsWith("NumPad", StringComparison.Ordinal)
+            ? keyName
+            : "NumPad" + keyName;
+    }
+
+    private static bool IsNumPadPhysicalKey(PhysicalKey physicalKey)
+    {
+        return physicalKey is
+            PhysicalKey.NumPad0 or PhysicalKey.NumPad1 or PhysicalKey.NumPad2 or
+            PhysicalKey.NumPad3 or PhysicalKey.NumPad4 or PhysicalKey.NumPad5 or
+            PhysicalKey.NumPad6 or PhysicalKey.NumPad7 or PhysicalKey.NumPad8 or
+            PhysicalKey.NumPad9 or PhysicalKey.NumPadAdd or PhysicalKey.NumPadDecimal or
+            PhysicalKey.NumPadDivide or PhysicalKey.NumPadMultiply or
+            PhysicalKey.NumPadSubtract or PhysicalKey.NumPadEnter;
+    }
+
     public void OnKeyPressed(object? sender, KeyEventArgs e)
     {
         // When IME is processing input, clear all active keys to prevent stale keys
@@ -68,19 +128,22 @@ public class ShortcutManager : IShortcutManager
             Key.ImeAccept or Key.ImeModeChange or Key.DeadCharProcessed or Key.None)
         {
             _activeKeys.Clear();
+            _activeKeyNames.Clear();
             return;
         }
 
         var key = GetShortcutKey(e);
 
-        // Avoid adding modifier keys to the active keys set to prevent redundancy
-        // with KeyEventArgs.KeyModifiers
+        // Skip standalone modifier-like keys: Ctrl/Shift/Alt/Win redundantly
+        // duplicate KeyEventArgs.KeyModifiers, and NumLock is a state toggle —
+        // we never want it captured as a shortcut chord on its own.
         if (key is not (Key.LeftCtrl or Key.RightCtrl or
             Key.LeftShift or Key.RightShift or
             Key.LeftAlt or Key.RightAlt or
-            Key.LWin or Key.RWin))
+            Key.LWin or Key.RWin or Key.NumLock))
         {
             _activeKeys.Add(key);
+            _activeKeyNames.Add(GetShortcutKeyName(e));
         }
 
         _isControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
@@ -93,10 +156,12 @@ public class ShortcutManager : IShortcutManager
             Key.ImeAccept or Key.ImeModeChange or Key.DeadCharProcessed or Key.None)
         {
             _activeKeys.Clear();
+            _activeKeyNames.Clear();
         }
         else
         {
             _activeKeys.Remove(GetShortcutKey(e));
+            _activeKeyNames.Remove(GetShortcutKeyName(e));
         }
 
         _isControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
@@ -106,6 +171,7 @@ public class ShortcutManager : IShortcutManager
     public void ClearKeys()
     {
         _activeKeys.Clear();
+        _activeKeyNames.Clear();
         _isControlPressed = false;
         _isShiftPressed = false;
     }
@@ -154,12 +220,14 @@ public class ShortcutManager : IShortcutManager
             RebuildLookupTable();
         }
 
-        // Build the current state key list with initial capacity
-        var currentInputKeys = new List<string>(_activeKeys.Count + 2);
+        // Build the current state key list with initial capacity. Read from the
+        // physical-key-aware name set so numpad keys hash distinctly from their
+        // main-keyboard counterparts.
+        var currentInputKeys = new List<string>(_activeKeyNames.Count + 2);
 
-        foreach (var key in _activeKeys)
+        foreach (var keyName in _activeKeyNames)
         {
-            currentInputKeys.Add(key.ToString());
+            currentInputKeys.Add(keyName);
         }
 
         // Add normalized modifiers based on the event state

--- a/tests/UI/Logic/ShortcutManagerTests.cs
+++ b/tests/UI/Logic/ShortcutManagerTests.cs
@@ -17,4 +17,52 @@ public class ShortcutManagerTests
 
         Assert.Equal(expected, result);
     }
+
+    // GetShortcutKeyName must produce *distinct* tokens for the same physical
+    // numpad key across NumLock states, and for numpad keys vs. their
+    // main-keyboard counterparts. This is what lets users bind numpad-Delete
+    // (NumLock off) independently from main Delete and from numpad-Decimal
+    // (NumLock on) — the bug behind #10934.
+    [Theory]
+    // NumLock-off keys on the numpad
+    [InlineData(Key.Delete, PhysicalKey.NumPadDecimal, "NumPadDelete")]
+    [InlineData(Key.Insert, PhysicalKey.NumPad0, "NumPadInsert")]
+    [InlineData(Key.End, PhysicalKey.NumPad1, "NumPadEnd")]
+    [InlineData(Key.Down, PhysicalKey.NumPad2, "NumPadDown")]
+    [InlineData(Key.PageDown, PhysicalKey.NumPad3, "NumPadPageDown")]
+    [InlineData(Key.Left, PhysicalKey.NumPad4, "NumPadLeft")]
+    [InlineData(Key.Right, PhysicalKey.NumPad6, "NumPadRight")]
+    [InlineData(Key.Home, PhysicalKey.NumPad7, "NumPadHome")]
+    [InlineData(Key.Up, PhysicalKey.NumPad8, "NumPadUp")]
+    [InlineData(Key.PageUp, PhysicalKey.NumPad9, "NumPadPageUp")]
+    // NumLock-on numpad keys (Key.ToString() already starts with "NumPad")
+    [InlineData(Key.NumPad0, PhysicalKey.NumPad0, "NumPad0")]
+    [InlineData(Key.NumPad9, PhysicalKey.NumPad9, "NumPad9")]
+    [InlineData(Key.Decimal, PhysicalKey.NumPadDecimal, "NumPadDecimal")]
+    [InlineData(Key.Add, PhysicalKey.NumPadAdd, "NumPadAdd")]
+    [InlineData(Key.Subtract, PhysicalKey.NumPadSubtract, "NumPadSubtract")]
+    [InlineData(Key.Divide, PhysicalKey.NumPadDivide, "NumPadDivide")]
+    [InlineData(Key.Multiply, PhysicalKey.NumPadMultiply, "NumPadMultiply")]
+    // Main-keyboard keys keep their plain names
+    [InlineData(Key.Delete, PhysicalKey.Delete, "Delete")]
+    [InlineData(Key.Home, PhysicalKey.Home, "Home")]
+    [InlineData(Key.A, PhysicalKey.A, "A")]
+    [InlineData(Key.F1, PhysicalKey.F1, "F1")]
+    public void GetShortcutKeyNameDifferentiatesNumpad(Key key, PhysicalKey physicalKey, string expected)
+    {
+        var result = ShortcutManager.GetShortcutKeyName(key, physicalKey);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetShortcutKeyNameNumPadDeleteIsNotMainDelete()
+    {
+        // Same Avalonia Key value (Delete) but different physical keys must
+        // produce different tokens so they can be bound independently.
+        var numpad = ShortcutManager.GetShortcutKeyName(Key.Delete, PhysicalKey.NumPadDecimal);
+        var main = ShortcutManager.GetShortcutKeyName(Key.Delete, PhysicalKey.Delete);
+
+        Assert.NotEqual(numpad, main);
+    }
 }


### PR DESCRIPTION
## Summary
The shortcut-capture path collapsed every numpad physical key to its NumLock-on Avalonia `Key` value, so:
- numpad-Delete (NumLock off) was recorded as the misleading `"Decimal"`,
- there was no way to bind a numpad key independently of its main-keyboard counterpart or of the opposite NumLock state,
- pressing `NumLock` alone was captured as the shortcut, even though it's a state toggle.

This PR introduces `ShortcutManager.GetShortcutKeyName(KeyEventArgs)` which emits a physical-key-aware token: numpad physical keys get the `"NumPad"` prefix unless `Key.ToString()` already carries it (`NumPad0..NumPad9`). The same physical key now produces different tokens across NumLock states (`NumPadDelete` vs `NumPadDecimal`), and numpad keys are distinct from main-keyboard ones.

`ShortcutManager` keeps a parallel `_activeKeyNames` `HashSet<string>` alongside the existing `_activeKeys` `HashSet<Key>`. Runtime lookup (`CheckShortcuts`) hashes against the name set, so what the editor captured is what the runtime matches. The legacy `HashSet<Key>` is unchanged for callers that still operate on `Avalonia.Input.Key` (single-key-allowance checks, etc.), so this is not a breaking change for those code paths.

Also:
- `NumLock` is added to the modifier-filter list in both `OnKeyPressed` and the editor's `OnKeyDown`, so it can't be captured as a chord key on its own.
- `GetKeyDisplayName` renders `"NumPadDelete"` as `"Numpad Delete"` in the list and tooltips; storage stays in PascalCase for matching.
- xUnit tests cover the NumLock-off, NumLock-on, and arithmetic numpad keys plus the numpad-vs-main distinction.

⚠️ Note: users who previously bound shortcuts to the legacy tokens (`"Decimal"`, `"Add"`, `"Subtract"`, `"Multiply"`, `"Divide"`) will need to rebind, since those collapsed names are no longer produced by the capture path. None of the shipped defaults use these tokens.

Fixes #10934.

## Test plan
- [ ] Open Options → Shortcuts, find an action, click the `...` editor.
  - [ ] Press main `Delete` → shows `Delete`. Press numpad `Delete` with NumLock **off** → shows `Numpad Delete`. Press numpad `.` with NumLock **on** → shows `Numpad Decimal`. All three are distinct.
  - [ ] Press numpad `7` with NumLock **off** → shows `Numpad Home`. With NumLock **on** → shows `Numpad 7`.
  - [ ] Press `NumLock` alone → no shortcut captured (editor stays on the previous capture or empty).
  - [ ] Press `Ctrl + Numpad 0` (NumLock on) → shows `Ctrl + Numpad 0`.
- [ ] Bind delete-selected-lines to numpad-`Delete` (NumLock off) only; confirm pressing main `Delete` does not fire it and numpad `Delete` does. Bind a different action to numpad-Decimal (NumLock on) and confirm both can coexist.
- [ ] Existing non-numpad shortcuts (`Ctrl+S`, `F3`, `Delete` to delete lines, etc.) continue to fire.
- [ ] `dotnet test tests/UI/UITests.csproj` — all 165 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)