### PR TITLE
Write Settings.json indented for human readability (#10936)

### DIFF
--- a/src/ui/Logic/Config/SeJsonContext.cs
+++ b/src/ui/Logic/Config/SeJsonContext.cs
@@ -3,11 +3,15 @@ using System.Text.Json.Serialization;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
+// WriteIndented makes Settings.json human-readable so users can diff older
+// versions or hand-edit in a text editor (issue #10936). The file grows by
+// ~2x, but it lives outside hot paths and the cost is negligible.
 [JsonSourceGenerationOptions(
     PropertyNameCaseInsensitive = true,
     ReadCommentHandling = JsonCommentHandling.Skip,
     AllowTrailingCommas = true,
-    UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip)]
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+    WriteIndented = true)]
 [JsonSerializable(typeof(Se))]
 internal partial class SeJsonContext : JsonSerializerContext
 {


### PR DESCRIPTION
## Summary
- `Settings.json` was written as a single line, so users couldn't diff between versions or hand-edit in a text editor — the complaint in #10936.
- Adds `WriteIndented = true` to the `JsonSourceGenerationOptions` on `SeJsonContext` so the serializer pretty-prints. Affects both reads and writes via the source-generated context, but only the write side has visible effect — deserialization already tolerated whitespace.
- File size roughly 2x, but the settings file is small and written off the hot path, so the cost is negligible.
- Files written by older builds load unchanged; files written by this build still load fine in older builds (whitespace is just ignored).

Fixes #10936.

## Test plan
- [ ] Build, run, change any setting, exit. Open `Settings.json` in a text editor and confirm it is multi-line with two-space indentation.
- [ ] Open a `Settings.json` from a previous build (single-line) — confirm it still loads and a subsequent save rewrites it indented.
- [ ] Confirm no behavioral change in the app itself (settings round-trip correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)