### PR TITLE
Add DeepSeek auto-translate engine and show Gemini prompt textbox

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -119,6 +119,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             new GeminiTranslate(),
             new NvidiaTranslate(),
             new MistralTranslate(),
+            new DeepSeekTranslate(),
             new PapagoTranslate(),
             new NoLanguageLeftBehindServe(),
             new NoLanguageLeftBehindApi(),
@@ -357,6 +358,13 @@ public partial class AutoTranslateViewModel : ObservableObject
             Configuration.Settings.Tools.AutoTranslateMistralApiKey = apiKey.Trim();
             Configuration.Settings.Tools.AutoTranslateMistralUrl = apiUrl.Trim();
             Configuration.Settings.Tools.AutoTranslateMistralModel = apiModel.Trim();
+        }
+
+        if (engineType == typeof(DeepSeekTranslate))
+        {
+            Configuration.Settings.Tools.DeepSeekApiKey = apiKey.Trim();
+            Configuration.Settings.Tools.DeepSeekUrl = apiUrl.Trim();
+            Configuration.Settings.Tools.DeepSeekModel = apiModel.Trim();
         }
 
         if (engineType == typeof(PapagoTranslate))
@@ -1547,6 +1555,24 @@ public partial class AutoTranslateViewModel : ObservableObject
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
             ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.AutoTranslateMistralModel) ? _apiModels[0] : Configuration.Settings.Tools.AutoTranslateMistralModel;
+
+            return;
+        }
+
+        if (engineType == typeof(DeepSeekTranslate))
+        {
+            FillUrls(new List<string>
+            {
+                Configuration.Settings.Tools.DeepSeekUrl,
+            });
+
+            ApiKeyText = Configuration.Settings.Tools.DeepSeekApiKey;
+            ApiKeyIsVisible = true;
+
+            _apiModels = DeepSeekTranslate.Models.ToList();
+            ModelIsVisible = true;
+            ButtonModelIsVisible = true;
+            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.DeepSeekModel) ? _apiModels[0] : Configuration.Settings.Tools.DeepSeekModel;
 
             return;
         }

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -58,6 +58,8 @@ public partial class TranslateSettingsViewModel : ObservableObject
             engineType == typeof(OpenRouterTranslate) ||
             engineType == typeof(NvidiaTranslate) ||
             engineType == typeof(MistralTranslate) ||
+            engineType == typeof(GeminiTranslate) ||
+            engineType == typeof(DeepSeekTranslate) ||
             engineType == typeof(LlamaCppTranslate))
         {
             if (!PromptText.Contains("{0}") || !PromptText.Contains("{1}"))
@@ -133,6 +135,14 @@ public partial class TranslateSettingsViewModel : ObservableObject
             else if (engineType == typeof(MistralTranslate))
             {
                 Se.Settings.AutoTranslate.MistralPrompt = PromptText;
+            }
+            else if (engineType == typeof(GeminiTranslate))
+            {
+                Se.Settings.AutoTranslate.GeminiPrompt = PromptText;
+            }
+            else if (engineType == typeof(DeepSeekTranslate))
+            {
+                Se.Settings.AutoTranslate.DeepSeekPrompt = PromptText;
             }
             else if (engineType == typeof(LlamaCppTranslate))
             {
@@ -234,6 +244,22 @@ public partial class TranslateSettingsViewModel : ObservableObject
             if (string.IsNullOrWhiteSpace(PromptText))
             {
                 PromptText = new SeAutoTranslate().MistralPrompt;
+            }
+        }
+        else if (engineType == typeof(GeminiTranslate))
+        {
+            PromptText = Se.Settings.AutoTranslate.GeminiPrompt;
+            if (string.IsNullOrWhiteSpace(PromptText))
+            {
+                PromptText = new SeAutoTranslate().GeminiPrompt;
+            }
+        }
+        else if (engineType == typeof(DeepSeekTranslate))
+        {
+            PromptText = Se.Settings.AutoTranslate.DeepSeekPrompt;
+            if (string.IsNullOrWhiteSpace(PromptText))
+            {
+                PromptText = new SeAutoTranslate().DeepSeekPrompt;
             }
         }
         else if (engineType == typeof(LlamaCppTranslate))


### PR DESCRIPTION
## Summary

- **Fixes #10945** — Gemini was missing from the engine list in `TranslateSettingsViewModel`, so the prompt textbox stayed hidden when opening the Settings dialog from auto-translate. Same class of bug as the Mistral one fixed in #10885.
- **Adds DeepSeek to the auto-translate engine dropdown.** DeepSeek was already wired in `LoadSettings`/`SaveSettings` but had never been added to the dropdown collection in `AutoTranslateViewModel`, so it could not be selected. Adds the dropdown entry, the per-engine save handler, the per-engine UI handler (URL + API key + model combobox, modeled on Mistral/NVIDIA), and the prompt textbox entries in `TranslateSettingsViewModel`.

## Test plan

- [ ] Open auto-translate, pick **Gemini**, click Settings — prompt textbox is visible and editable; edits persist after re-opening.
- [ ] Open auto-translate, pick **DeepSeek** from the dropdown — URL, API key, and model combobox appear and persist.
- [ ] Open Settings for DeepSeek — prompt textbox is visible and editable; edits persist.
- [ ] Regression: Mistral, ChatGPT, Anthropic, Ollama, etc. still show their prompt textboxes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)