### PR TITLE
Fix auto-translate prompt persistence and translated filename

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6184,8 +6184,19 @@ public partial class MainViewModel :
         if (!string.IsNullOrEmpty(_subtitleFileName) && !string.IsNullOrEmpty(targetLanguageCode))
         {
             var directory = Path.GetDirectoryName(_subtitleFileName) ?? string.Empty;
-            var nameWithoutExt = Path.GetFileNameWithoutExtension(_subtitleFileName);
-            var extension = Path.GetExtension(_subtitleFileName);
+            var fileName = Path.GetFileName(_subtitleFileName);
+
+            var nameWithoutExt = fileName;
+            var extension = string.Empty;
+            foreach (var ext in SubtitleFormats.Select(f => f.Extension))
+            {
+                if (fileName.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+                {
+                    nameWithoutExt = fileName.Substring(0, fileName.Length - ext.Length);
+                    extension = ext;
+                    break;
+                }
+            }
 
             var lastDot = nameWithoutExt.LastIndexOf('.');
             if (lastDot > 0)

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Interactivity;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.AutoTranslate;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -103,6 +104,7 @@ public partial class TranslateSettingsViewModel : ObservableObject
             if (engineType == typeof(ChatGptTranslate))
             {
                 Se.Settings.AutoTranslate.ChatGptPrompt = PromptText;
+                Configuration.Settings.Tools.ChatGptPrompt = PromptText;
             }
             else if (engineType == typeof(OllamaTranslate))
             {
@@ -135,14 +137,17 @@ public partial class TranslateSettingsViewModel : ObservableObject
             else if (engineType == typeof(MistralTranslate))
             {
                 Se.Settings.AutoTranslate.MistralPrompt = PromptText;
+                Configuration.Settings.Tools.AutoTranslateMistralPrompt = PromptText;
             }
             else if (engineType == typeof(GeminiTranslate))
             {
                 Se.Settings.AutoTranslate.GeminiPrompt = PromptText;
+                Configuration.Settings.Tools.GeminiPrompt = PromptText;
             }
             else if (engineType == typeof(DeepSeekTranslate))
             {
                 Se.Settings.AutoTranslate.DeepSeekPrompt = PromptText;
+                Configuration.Settings.Tools.DeepSeekPrompt = PromptText;
             }
             else if (engineType == typeof(LlamaCppTranslate))
             {


### PR DESCRIPTION
## Summary
- ChatGPT (and Mistral/Gemini/DeepSeek) prompt edits are now persisted between sessions. The save path in `TranslateSettingsViewModel` only wrote to `Se.Settings.AutoTranslate.*Prompt`, which `AutoTranslateViewModel.SaveSettings` then overwrote from `Configuration.Settings.Tools.*Prompt` on close — wiping the user's change. Anthropic was unaffected because it persists to `Se.Settings.Tools.AnthropicPrompt`, which isn't touched by that sync. Writing the prompt to both fields lets the sync preserve the new value.
- The post-translate filename builder no longer mangles names like `Knock Out S01E06 WeTV 1080p WEB-DL AAC H.264-darrensstarkid.srt` into `...H.de.264-darrensstarkid.srt`. The bug was using `Path.GetExtension` / `Path.GetFileNameWithoutExtension` on `_subtitleFileName`; in flows where that variable lacks a real subtitle extension, those APIs split on the last `.` in the name and put the language code at the wrong spot. We now detect the real extension against the known `SubtitleFormats` list, matching the existing local `GetFileNameWithoutExtension` helper.

Fixes #10950

## Test plan
- [ ] Open the auto-translate window, switch engine to ChatGPT, edit the prompt, click OK, close the window, reopen — prompt should still be the edited value.
- [ ] Same check for Mistral, Gemini, DeepSeek (same bug pattern).
- [ ] Anthropic prompt still persists (regression check).
- [ ] Open `Knock Out S01E06 WeTV 1080p WEB-DL AAC H.264-darrensstarkid.srt`, auto-translate to German, Save As — suggested filename should be `...darrensstarkid.de.srt`, not `...H.de.264-darrensstarkid.srt`.
- [ ] Same check with `.ass` extension.
- [ ] Re-translate an already `.de.srt` file to e.g. `fr` — the existing `.de` should be stripped, output should be `....fr.srt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)