### PR TITLE
Update batch-convert model textbox after picking Ollama model

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1561,6 +1561,7 @@ public partial class BatchConvertViewModel : ObservableObject
 
         if (result is { OkPressed: true, SelectedModel: not null })
         {
+            AutoTranslateModel = result.SelectedModel;
             Se.Settings.AutoTranslate.OllamaModel = result.SelectedModel;
             SaveSettings();
         }


### PR DESCRIPTION
## Summary
In batch-convert > auto-translate with the Ollama engine, picking a model via the "..." button left the model textbox showing its previous value (typically empty on first use of Ollama in the session). `AutoTranslateBrowseModel` wrote the picked model to `Se.Settings.AutoTranslate.OllamaModel` but never updated the `AutoTranslateModel` property the textbox is bound to. Now updated alongside the settings write.

## Test plan
- [ ] Open Batch Convert, enable Auto-translate, select Ollama engine, click "..." next to Model, pick a model, click OK — textbox should show the picked model name.
- [ ] Re-open the picker — previously picked model should be pre-selected.
- [ ] Run the batch convert with that model to confirm it's still used downstream.

Generated with [Claude Code](https://claude.com/claude-code)