### PR TITLE
Show model/database picker for Ollama and nOCR in batch-convert settings

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -42,18 +42,23 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _binaryOcrDatabases;
     [ObservableProperty] private string? _selectedBinaryOcrDatabase;
 
+    [ObservableProperty] private ObservableCollection<string> _ollamaModels;
+    [ObservableProperty] private string? _selectedOllamaModel;
+
     [ObservableProperty] bool _isOcrLanguageVisible;
     [ObservableProperty] bool _isTesseractOcrVisible;
     [ObservableProperty] bool _isPaddleOCrVisible;
     [ObservableProperty] bool _isBinaryOcrVisible;
+    [ObservableProperty] bool _isOllamaVisible;
 
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
 
     private readonly IFolderHelper _folderHelper;
+    private readonly IWindowService _windowService;
 
-    public BatchConvertSettingsViewModel(IFolderHelper folderHelper)
+    public BatchConvertSettingsViewModel(IFolderHelper folderHelper, IWindowService windowService)
     {
         var encodings = EncodingHelper.GetEncodings().Select(p => p.DisplayName).ToList();
         TargetEncodings = new ObservableCollection<string>(encodings);
@@ -81,8 +86,10 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         PaddleOcrLanguages = new ObservableCollection<OcrLanguage2>(PaddleOcr.GetLanguages().OrderBy(p => p.ToString()));
         TesseractDictionaryItems = new ObservableCollection<TesseractDictionary>();
         BinaryOcrDatabases = new ObservableCollection<string>(BinaryOcrDb.GetDatabases(Se.OcrFolder));
+        OllamaModels = new ObservableCollection<string>(Se.Settings.Ocr.OllamaModels);
 
         _folderHelper = folderHelper;
+        _windowService = windowService;
 
         OutputFolder = string.Empty;
         LoadActiveTesseractDictionaries();
@@ -159,6 +166,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             Se.Settings.Tools.BatchConvert.BinaryOcrDatabase = SelectedBinaryOcrDatabase ?? "Latin";
         }
 
+        if (ocrEngine == "Ollama" && !string.IsNullOrWhiteSpace(SelectedOllamaModel))
+        {
+            Se.Settings.Ocr.OllamaModel = SelectedOllamaModel;
+        }
+
         Se.SaveSettings();
     }
 
@@ -215,10 +227,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             return;
         }
 
-        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr";
+        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr" && ocrEngine != "Ollama";
         IsTesseractOcrVisible = ocrEngine == "Tesseract";
         IsPaddleOCrVisible = ocrEngine == "PaddleOCR";
         IsBinaryOcrVisible = ocrEngine == "BinaryOcr";
+        IsOllamaVisible = ocrEngine == "Ollama";
 
         if (ocrEngine == "Tesseract")
         {
@@ -236,6 +249,34 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         {
             SelectedBinaryOcrDatabase = BinaryOcrDatabases
                 .FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.BinaryOcrDatabase) ?? BinaryOcrDatabases.FirstOrDefault();
+        }
+
+        if (ocrEngine == "Ollama")
+        {
+            var current = Se.Settings.Ocr.OllamaModel;
+            if (!string.IsNullOrWhiteSpace(current) && !OllamaModels.Contains(current))
+            {
+                OllamaModels.Add(current);
+            }
+
+            SelectedOllamaModel = OllamaModels.FirstOrDefault(p => p == current) ?? OllamaModels.FirstOrDefault();
+        }
+    }
+
+    [RelayCommand]
+    private async Task PickOllamaModel()
+    {
+        var result = await _windowService.ShowDialogAsync<PickOllamaModelWindow, PickOllamaModelViewModel>(Window!,
+            vm => { vm.Initialize(Se.Language.General.PickOllamaModel, SelectedOllamaModel, Se.Settings.Ocr.OllamaUrl); });
+
+        if (result is { OkPressed: true, SelectedModel: not null })
+        {
+            if (!OllamaModels.Contains(result.SelectedModel))
+            {
+                OllamaModels.Add(result.SelectedModel);
+            }
+
+            SelectedOllamaModel = result.SelectedModel;
         }
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -42,6 +42,9 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _binaryOcrDatabases;
     [ObservableProperty] private string? _selectedBinaryOcrDatabase;
 
+    [ObservableProperty] private ObservableCollection<string> _nOcrDatabases;
+    [ObservableProperty] private string? _selectedNOcrDatabase;
+
     [ObservableProperty] private ObservableCollection<string> _ollamaModels;
     [ObservableProperty] private string? _selectedOllamaModel;
 
@@ -49,6 +52,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] bool _isTesseractOcrVisible;
     [ObservableProperty] bool _isPaddleOCrVisible;
     [ObservableProperty] bool _isBinaryOcrVisible;
+    [ObservableProperty] bool _isNOcrVisible;
     [ObservableProperty] bool _isOllamaVisible;
 
     public Window? Window { get; set; }
@@ -86,6 +90,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         PaddleOcrLanguages = new ObservableCollection<OcrLanguage2>(PaddleOcr.GetLanguages().OrderBy(p => p.ToString()));
         TesseractDictionaryItems = new ObservableCollection<TesseractDictionary>();
         BinaryOcrDatabases = new ObservableCollection<string>(BinaryOcrDb.GetDatabases(Se.OcrFolder));
+        NOcrDatabases = new ObservableCollection<string>(NOcrDb.GetDatabases(Se.OcrFolder).OrderBy(p => p));
         OllamaModels = new ObservableCollection<string>(Se.Settings.Ocr.OllamaModels);
 
         _folderHelper = folderHelper;
@@ -166,6 +171,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             Se.Settings.Tools.BatchConvert.BinaryOcrDatabase = SelectedBinaryOcrDatabase ?? "Latin";
         }
 
+        if (ocrEngine == "nOcr" && !string.IsNullOrWhiteSpace(SelectedNOcrDatabase))
+        {
+            Se.Settings.Ocr.NOcrDatabase = SelectedNOcrDatabase;
+        }
+
         if (ocrEngine == "Ollama" && !string.IsNullOrWhiteSpace(SelectedOllamaModel))
         {
             Se.Settings.Ocr.OllamaModel = SelectedOllamaModel;
@@ -231,6 +241,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         IsTesseractOcrVisible = ocrEngine == "Tesseract";
         IsPaddleOCrVisible = ocrEngine == "PaddleOCR";
         IsBinaryOcrVisible = ocrEngine == "BinaryOcr";
+        IsNOcrVisible = ocrEngine == "nOcr";
         IsOllamaVisible = ocrEngine == "Ollama";
 
         if (ocrEngine == "Tesseract")
@@ -249,6 +260,12 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         {
             SelectedBinaryOcrDatabase = BinaryOcrDatabases
                 .FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.BinaryOcrDatabase) ?? BinaryOcrDatabases.FirstOrDefault();
+        }
+
+        if (ocrEngine == "nOcr")
+        {
+            SelectedNOcrDatabase = NOcrDatabases
+                .FirstOrDefault(p => p == Se.Settings.Ocr.NOcrDatabase) ?? NOcrDatabases.FirstOrDefault();
         }
 
         if (ocrEngine == "Ollama")

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -82,6 +82,9 @@ public class BatchConvertSettingsWindow : Window
             .WithBindVisible(nameof(vm.IsPaddleOCrVisible));
         var comboBoxBinaryOcrDatabases = UiUtil.MakeComboBox(vm.BinaryOcrDatabases, vm, nameof(vm.SelectedBinaryOcrDatabase))
             .WithBindVisible(nameof(vm.IsBinaryOcrVisible));
+        var labelNOcrDatabase = UiUtil.MakeLabel(Se.Language.Ocr.Database).WithBindVisible(vm, nameof(vm.IsNOcrVisible)).WithMarginLeft(10);
+        var comboBoxNOcrDatabases = UiUtil.MakeComboBox(vm.NOcrDatabases, vm, nameof(vm.SelectedNOcrDatabase))
+            .WithBindVisible(nameof(vm.IsNOcrVisible));
         var labelOllamaModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.IsOllamaVisible)).WithMarginLeft(10);
         var comboBoxOllamaModels = UiUtil.MakeComboBox(vm.OllamaModels, vm, nameof(vm.SelectedOllamaModel))
             .WithBindVisible(nameof(vm.IsOllamaVisible));
@@ -90,7 +93,7 @@ public class BatchConvertSettingsWindow : Window
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(0, 30, 0, 0),
-            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse }
+            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelNOcrDatabase, comboBoxNOcrDatabases, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse }
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -82,11 +82,15 @@ public class BatchConvertSettingsWindow : Window
             .WithBindVisible(nameof(vm.IsPaddleOCrVisible));
         var comboBoxBinaryOcrDatabases = UiUtil.MakeComboBox(vm.BinaryOcrDatabases, vm, nameof(vm.SelectedBinaryOcrDatabase))
             .WithBindVisible(nameof(vm.IsBinaryOcrVisible));
+        var labelOllamaModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.IsOllamaVisible)).WithMarginLeft(10);
+        var comboBoxOllamaModels = UiUtil.MakeComboBox(vm.OllamaModels, vm, nameof(vm.SelectedOllamaModel))
+            .WithBindVisible(nameof(vm.IsOllamaVisible));
+        var buttonOllamaModelBrowse = UiUtil.MakeButtonBrowse(vm.PickOllamaModelCommand, nameof(vm.IsOllamaVisible)).WithMarginLeft(3);
         var panelOcrEngine = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(0, 30, 0, 0),
-            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases }
+            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse }
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 


### PR DESCRIPTION
## Summary
Two small additions to Batch Convert > Settings:

- **Ollama**: selecting Ollama as the OCR engine now reveals a model combo (seeded from `Se.Settings.Ocr.OllamaModels`, currently saved model appended if missing) and a "..." button that opens the existing `PickOllamaModelWindow` to query the local Ollama server. Selection persists to `Se.Settings.Ocr.OllamaModel` (same field as the main OCR window).
- **nOCR**: selecting nOCR as the OCR engine now reveals a database combo, seeded from `NOcrDb.GetDatabases(Se.OcrFolder)`. Selection persists to `Se.Settings.Ocr.NOcrDatabase` — the same field the batch converter already reads when running nOCR (`BatchConverter.cs:676`).

## Test plan
- [ ] Tools > Batch Convert > Settings. Pick **Ollama** in the OCR Engine combo — language combo hides, a Model combo + "..." button appear.
- [ ] Type/pick a model from the Ollama combo, OK, reopen settings — selection retained.
- [ ] Click "...", pick a model from the local Ollama server, OK — model becomes selected (and is added to the combo if it wasn't already).
- [ ] Pick **nOCR** in the OCR Engine combo — language combo hides, a Database combo appears with the local `.nocr` files.
- [ ] Pick a database, OK, reopen settings — selection retained; running batch convert against image-based subs uses that database.
- [ ] Switch back to Tesseract/PaddleOCR/BinaryOcr — Ollama/nOCR UI hides; other engines behave as before.