### PR TITLE
Fix auto-translate OK button and prompt before re-downloading llama.cpp model

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -779,7 +779,25 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         var model = SelectedLlamaCppModel?.Model;
-        var downloaded = await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model);
+        var forceModelDownload = false;
+        if (model != null && LlamaCppServerManager.IsModelInstalled(model.FileName))
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                Se.Language.General.Download,
+                string.Format(Se.Language.Translate.XIsAlreadyDownloadedReDownload, model.DisplayName),
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            forceModelDownload = true;
+        }
+
+        var downloaded = await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model, forceModelDownload: forceModelDownload);
         if (downloaded != null)
         {
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
@@ -1216,11 +1234,12 @@ public partial class AutoTranslateViewModel : ObservableObject
         finally
         {
             _translationInProgress = false;
-            IsTranslateEnabled = true;
-            IsProgressEnabled = false;
 
             Dispatcher.UIThread.Invoke(() =>
             {
+                IsTranslateEnabled = true;
+                IsProgressEnabled = false;
+
                 if (_abort)
                 {
                     StatusText = Se.Language.Translate.TranslationCancelled;

--- a/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
@@ -37,6 +37,9 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
     /// <summary>Re-download the engine binary even when it is already installed (used for updates).</summary>
     public bool ForceEngineDownload { get; set; }
 
+    /// <summary>Re-download the model file even when it is already installed.</summary>
+    public bool ForceModelDownload { get; set; }
+
     private const string TemporaryFileExtension = ".$$$";
 
     private readonly ILlamaCppDownloadService _downloadService;
@@ -104,7 +107,7 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
                 MakeExecutable(LlamaCppServerManager.GetExecutable());
             }
 
-            if (Model != null && !LlamaCppServerManager.IsModelInstalled(Model.FileName))
+            if (Model != null && (ForceModelDownload || !LlamaCppServerManager.IsModelInstalled(Model.FileName)))
             {
                 TitleText = string.Format(Se.Language.General.DownloadingX, Model.DisplayName);
                 var finalPath = LlamaCppServerManager.GetModelPath(Model.FileName);

--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -122,10 +122,12 @@ public static class LlamaCppDownloadHelper
     /// Opens the llama.cpp download window (engine binary + selected model) and persists the result.
     /// When <paramref name="forceVariant"/> is given (e.g. re-downloading an update), that build is
     /// used and the Windows build picker is skipped. When <paramref name="forceEngineDownload"/> is
-    /// set, the engine binary is re-downloaded even though it is already installed.
+    /// set, the engine binary is re-downloaded even though it is already installed. When
+    /// <paramref name="forceModelDownload"/> is set, the model file is re-downloaded even though it
+    /// is already installed.
     /// </summary>
     /// <returns>The downloaded model file name, or null if nothing was downloaded.</returns>
-    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, LlamaCppTranslateModel? model, string? forceVariant = null, bool forceEngineDownload = false)
+    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, LlamaCppTranslateModel? model, string? forceVariant = null, bool forceEngineDownload = false, bool forceModelDownload = false)
     {
         var variant = forceVariant ?? Logic.Download.LlamaCppDownloadService.VariantCpu;
         if (forceVariant == null && !LlamaCppServerManager.IsEngineInstalled() && OperatingSystem.IsWindows())
@@ -160,6 +162,7 @@ public static class LlamaCppDownloadHelper
                 vm.Variant = variant;
                 vm.Model = model;
                 vm.ForceEngineDownload = forceEngineDownload;
+                vm.ForceModelDownload = forceModelDownload;
                 vm.StartDownload();
             });
 

--- a/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
+++ b/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
@@ -28,6 +28,7 @@ public class LanguageTranslate
     public string TranslationComplete { get; set; }
     public string TranslationCancelled { get; set; }
     public string SwapLanguages { get; set; }
+    public string XIsAlreadyDownloadedReDownload { get; set; }
 
     public LanguageTranslate()
     {
@@ -57,5 +58,6 @@ public class LanguageTranslate
         TranslationComplete = "Translation complete";
         TranslationCancelled = "Translation cancelled";
         SwapLanguages = "Swap source and target languages";
+        XIsAlreadyDownloadedReDownload = "{0} is already downloaded. Re-download?";
     }
 }


### PR DESCRIPTION
## Summary
- Fix the auto-translate window so the OK button enables and the progress bar hides when translation reaches 100 % (the property updates in the `finally` block were being set off the UI thread, so the bindings did not refresh).
- When the user clicks Download for a llama.cpp model that is already installed, prompt "X is already downloaded. Re-download?" instead of opening the download dialog and immediately closing it (the previous behavior looked like a blink).
- Add a new `XIsAlreadyDownloadedReDownload` entry to `LanguageTranslate` so the prompt is localizable.

## Test plan
- [ ] Run an auto-translate to completion and confirm OK enables and the progress bar disappears at 100 %.
- [ ] Cancel a translation and confirm the existing cancellation status still shows.
- [ ] With a llama.cpp model already installed, click Download and confirm the re-download prompt appears; choose No and confirm nothing happens; choose Yes and confirm the model is re-downloaded.
- [ ] With a llama.cpp model not yet installed, click Download and confirm no prompt appears and the download dialog runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)