### PR TITLE
Add llama.cpp model picker, Download, and Start/Stop server to OCR window

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -375,6 +375,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<NOcrDbNewViewModel>();
         collection.AddTransient<NOcrInspectViewModel>();
         collection.AddTransient<NOcrSettingsViewModel>();
+        collection.AddTransient<LlamaCppOcrSettingsViewModel>();
         collection.AddTransient<OcrViewModel>();
         collection.AddTransient<OpenFromUrlViewModel>();
         collection.AddTransient<OpenSecondarySubtitleViewModel>();

--- a/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
+++ b/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
@@ -37,9 +37,10 @@ public class LlamaCppOcr
             //System.IO.File.WriteAllBytes("c:\\temp\\ollama-ocr-image.png", pngBytes);
             
             var prompt = string.Format("Extract all text exactly as written. The language is {0}. Preserve line breaks.", language);
+            var modelName = string.IsNullOrEmpty(model) ? "glmocr" : model;
 
             var input =
-                "{ \"model\": \"glmocr\", \"temperature\": 0, \"messages\": [ { \"role\": \"user\", \"content\": [ " +
+                "{ \"model\": \"" + modelName + "\", \"temperature\": 0, \"messages\": [ { \"role\": \"user\", \"content\": [ " +
                 "{ \"type\": \"text\", \"text\": \"" + prompt + "\" }, " +
                 "{ \"type\": \"image_url\", \"image_url\": { \"url\": \"data:image/png;base64," + base64Image + "\" } } " +
                 "] } ] }";

--- a/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
+++ b/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
@@ -25,7 +25,7 @@ public class LlamaCppOcr
         _httpClient.Timeout = TimeSpan.FromMinutes(25);
     }
 
-    public async Task<string> Ocr(SKBitmap bitmap, string url, string model, string language, CancellationToken cancellationToken)
+    public async Task<string> Ocr(SKBitmap bitmap, string url, string model, string language, string promptTemplate, CancellationToken cancellationToken)
     {
         try
         {
@@ -35,8 +35,15 @@ public class LlamaCppOcr
 
             //var pngBytes = paddedBitmap.ToPngArray();
             //System.IO.File.WriteAllBytes("c:\\temp\\ollama-ocr-image.png", pngBytes);
-            
-            var prompt = string.Format("Extract all text exactly as written. The language is {0}. Preserve line breaks.", language);
+
+            var template = string.IsNullOrWhiteSpace(promptTemplate)
+                ? "Extract all text exactly as written. The language is {language}. Preserve line breaks."
+                : promptTemplate;
+            var prompt = template
+                .Replace("{language}", language)
+                .Replace("\"", "\\\"")
+                .Replace("\r", " ")
+                .Replace("\n", " ");
             var modelName = string.IsNullOrEmpty(model) ? "glmocr" : model;
 
             var input =

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -29,13 +29,13 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
     {
         if (string.IsNullOrWhiteSpace(Prompt))
         {
-            await ShowPromptError("The prompt cannot be empty.");
+            await ShowPromptError(Se.Language.Ocr.LlamaCppOcrPromptEmpty);
             return;
         }
 
         if (!Prompt.Contains("{language}"))
         {
-            await ShowPromptError("The prompt must contain the {language} placeholder.");
+            await ShowPromptError(Se.Language.Ocr.LlamaCppOcrPromptMissingLanguagePlaceholder);
             return;
         }
 

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -3,7 +3,10 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;
 
@@ -22,12 +25,39 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void Ok()
+    private async Task Ok()
     {
+        if (string.IsNullOrWhiteSpace(Prompt))
+        {
+            await ShowPromptError("The prompt cannot be empty.");
+            return;
+        }
+
+        if (!Prompt.Contains("{language}"))
+        {
+            await ShowPromptError("The prompt must contain the {language} placeholder.");
+            return;
+        }
+
         Se.Settings.Ocr.LlamaCppUrl = Url ?? string.Empty;
-        Se.Settings.Ocr.LlamaCppOcrPrompt = Prompt ?? string.Empty;
+        Se.Settings.Ocr.LlamaCppOcrPrompt = Prompt;
         OkPressed = true;
         Close();
+    }
+
+    private async Task ShowPromptError(string message)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await MessageBox.Show(
+            Window,
+            Se.Language.General.Error,
+            message,
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Error);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -1,0 +1,51 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Ocr;
+
+public partial class LlamaCppOcrSettingsViewModel : ObservableObject
+{
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    [ObservableProperty] private string _url;
+    [ObservableProperty] private string _prompt;
+
+    public LlamaCppOcrSettingsViewModel()
+    {
+        _url = Se.Settings.Ocr.LlamaCppUrl ?? string.Empty;
+        _prompt = Se.Settings.Ocr.LlamaCppOcrPrompt ?? string.Empty;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        Se.Settings.Ocr.LlamaCppUrl = Url ?? string.Empty;
+        Se.Settings.Ocr.LlamaCppOcrPrompt = Prompt ?? string.Empty;
+        OkPressed = true;
+        Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() => Window?.Close());
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Close();
+        }
+    }
+}

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
@@ -1,0 +1,91 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Ocr;
+
+public class LlamaCppOcrSettingsWindow : Window
+{
+    public LlamaCppOcrSettingsWindow(LlamaCppOcrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "llama.cpp OCR settings";
+        Width = 640;
+        Height = 320;
+        MinWidth = 480;
+        MinHeight = 240;
+        CanResize = true;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        vm.Window = this;
+        DataContext = vm;
+
+        var labelUrl = UiUtil.MakeTextBlock(Se.Language.General.Url);
+        var textBoxUrl = new TextBox
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            DataContext = vm,
+        };
+        textBoxUrl.Bind(TextBox.TextProperty, new Binding(nameof(vm.Url))
+        {
+            Mode = BindingMode.TwoWay,
+            UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+        });
+
+        var labelPrompt = UiUtil.MakeTextBlock(Se.Language.General.OpenAiCompatibleSttPrompt);
+        var textBoxPrompt = new TextBox
+        {
+            AcceptsReturn = true,
+            AcceptsTab = false,
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            DataContext = vm,
+        };
+        textBoxPrompt.Bind(TextBox.TextProperty, new Binding(nameof(vm.Prompt))
+        {
+            Mode = BindingMode.TwoWay,
+            UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+        });
+
+        var hintPrompt = UiUtil.MakeTextBlock("Use {language} to insert the selected OCR language.");
+        hintPrompt.Opacity = 0.7;
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonBar = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 6,
+        };
+
+        grid.Add(labelUrl, 0, 0);
+        grid.Add(textBoxUrl, 1, 0);
+        grid.Add(labelPrompt, 2, 0);
+        grid.Add(textBoxPrompt, 3, 0);
+        grid.Add(hintPrompt, 4, 0);
+        grid.Add(buttonBar, 5, 0);
+
+        Content = grid;
+
+        Activated += delegate { textBoxUrl.Focus(); };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
@@ -12,7 +12,7 @@ public class LlamaCppOcrSettingsWindow : Window
     public LlamaCppOcrSettingsWindow(LlamaCppOcrSettingsViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = "llama.cpp OCR settings";
+        Title = Se.Language.Ocr.LlamaCppOcrSettingsTitle;
         Width = 640;
         Height = 320;
         MinWidth = 480;
@@ -50,7 +50,7 @@ public class LlamaCppOcrSettingsWindow : Window
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
         });
 
-        var hintPrompt = UiUtil.MakeTextBlock("Use {language} to insert the selected OCR language.");
+        var hintPrompt = UiUtil.MakeTextBlock(Se.Language.Ocr.LlamaCppOcrPromptHint);
         hintPrompt.Opacity = 0.7;
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -33,9 +33,11 @@ using Nikse.SubtitleEdit.Features.Shared.PickFontName;
 using Nikse.SubtitleEdit.Features.Shared.ShowImage;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
+using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Dictionaries;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
@@ -78,6 +80,9 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private string _ollamaModel;
     [ObservableProperty] private string _ollamaUrl;
     [ObservableProperty] private string _llamaCppUrl;
+    [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppOcrModels;
+    [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppOcrModel;
+    [ObservableProperty] private string _llamaCppOcrServerButtonText;
     [ObservableProperty] private string _progressText;
     [ObservableProperty] private double _progressValue;
     [ObservableProperty] private Bitmap? _currentImageSource;
@@ -190,6 +195,8 @@ public partial class OcrViewModel : ObservableObject
         OllamaModel = string.Empty;
         OllamaUrl = string.Empty;
         LlamaCppUrl = string.Empty;
+        LlamaCppOcrModels = new ObservableCollection<LlamaCppModelDisplay>();
+        LlamaCppOcrServerButtonText = "Start server";
         TesseractDictionaryItems = new ObservableCollection<TesseractDictionary>();
         GoogleVisionApiKey = string.Empty;
         MistralApiKey = string.Empty;
@@ -282,6 +289,10 @@ public partial class OcrViewModel : ObservableObject
         ocr.OllamaUrl = OllamaUrl;
         ocr.OllamaLanguage = SelectedOllamaLanguage ?? "English";
         ocr.LlamaCppUrl = LlamaCppUrl;
+        if (SelectedLlamaCppOcrModel != null)
+        {
+            ocr.LlamaCppOcrModel = LlamaCppServerManager.GetModelPath(SelectedLlamaCppOcrModel.Model.FileName);
+        }
         ocr.GoogleVisionApiKey = GoogleVisionApiKey;
         ocr.MistralApiKey = MistralApiKey;
         ocr.GoogleVisionLanguage = SelectedGoogleVisionLanguage?.Code ?? "en";
@@ -934,6 +945,146 @@ public partial class OcrViewModel : ObservableObject
         {
             OllamaModel = result.SelectedModel;
         }
+    }
+
+    partial void OnSelectedLlamaCppOcrModelChanged(LlamaCppModelDisplay? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        Se.Settings.Ocr.LlamaCppOcrModel = LlamaCppServerManager.GetModelPath(value.Model.FileName);
+    }
+
+    private void UpdateLlamaCppOcrServerButtonText()
+    {
+        LlamaCppOcrServerButtonText = LlamaCppServerManager.IsServerRunning ? "Stop server" : "Start server";
+    }
+
+    [RelayCommand]
+    private async Task DownloadLlamaCppOcr()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var model = SelectedLlamaCppOcrModel?.Model;
+        var forceModelDownload = false;
+        if (model != null && LlamaCppServerManager.IsModelInstalled(model))
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                Se.Language.General.Download,
+                string.Format(Se.Language.Translate.XIsAlreadyDownloadedReDownload, model.DisplayName),
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            forceModelDownload = true;
+        }
+
+        var downloaded = await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model, forceModelDownload: forceModelDownload);
+        if (downloaded != null)
+        {
+            var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
+            SelectedLlamaCppOcrModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppOcrModels, LlamaCppServerManager.OcrModels, selectName);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ToggleLlamaCppOcrServer()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (LlamaCppServerManager.IsServerRunning)
+        {
+            LlamaCppServerManager.StopServer();
+            UpdateLlamaCppOcrServerButtonText();
+            return;
+        }
+
+        await EnsureLlamaCppOcrReady();
+        UpdateLlamaCppOcrServerButtonText();
+    }
+
+    private async Task<bool> EnsureLlamaCppOcrReady()
+    {
+        if (Window == null)
+        {
+            return false;
+        }
+
+        var model = SelectedLlamaCppOcrModel?.Model;
+        if (model == null)
+        {
+            return false;
+        }
+
+        var engineInstalled = LlamaCppServerManager.IsEngineInstalled();
+        var modelInstalled = LlamaCppServerManager.IsModelInstalled(model);
+        if (!engineInstalled || !modelInstalled)
+        {
+            string message;
+            if (!engineInstalled && !modelInstalled)
+            {
+                message = "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?";
+            }
+            else if (!engineInstalled)
+            {
+                message = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+            }
+            else
+            {
+                message = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
+            }
+
+            var answer = await MessageBox.Show(
+                Window,
+                Se.Language.General.Download,
+                message,
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model);
+            if (!LlamaCppServerManager.IsEngineInstalled() || !LlamaCppServerManager.IsModelInstalled(model))
+            {
+                return false;
+            }
+        }
+
+        SelectedLlamaCppOcrModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppOcrModels, LlamaCppServerManager.OcrModels, model.FileName);
+
+        try
+        {
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token);
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                ex.Message,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return false;
+        }
+
+        UpdateLlamaCppOcrServerButtonText();
+        return true;
     }
 
     [RelayCommand]
@@ -3146,9 +3297,30 @@ public partial class OcrViewModel : ObservableObject
     private void RunLlamaCppOcr(List<int> selectedIndices, CancellationToken cancellationToken)
     {
         var engine = new LlamaCppOcr();
+        var selectedModel = SelectedLlamaCppOcrModel?.Model;
 
         _ = Task.Run(async () =>
         {
+            string url;
+            string modelName;
+            if (selectedModel != null)
+            {
+                var ready = await Dispatcher.UIThread.InvokeAsync(EnsureLlamaCppOcrReady);
+                if (!ready)
+                {
+                    PauseOcr();
+                    return;
+                }
+
+                url = LlamaCppServerManager.ApiUrl;
+                modelName = Path.GetFileNameWithoutExtension(selectedModel.FileName);
+            }
+            else
+            {
+                url = LlamaCppUrl;
+                modelName = "glmocr";
+            }
+
             for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
             {
                 var i = selectedIndices[processedIndex];
@@ -3164,7 +3336,7 @@ public partial class OcrViewModel : ObservableObject
 
                 SelectAndScrollToRow(i);
 
-                var text = await engine.Ocr(bitmap, LlamaCppUrl, "", SelectedOllamaLanguage ?? "English", cancellationToken);
+                var text = await engine.Ocr(bitmap, url, modelName, SelectedOllamaLanguage ?? "English", cancellationToken);
                 item.Text = text;
 
                 OcrFixLineAndSetText(i, item);
@@ -3706,6 +3878,13 @@ public partial class OcrViewModel : ObservableObject
                 SelectedGoogleVisionLanguage = GoogleVisionLanguages.FirstOrDefault(p => p.Code == "eng") ??
                                                GoogleVisionLanguages.FirstOrDefault();
             }
+        }
+
+        if (IsLlamaCppVisible && LlamaCppOcrModels.Count == 0)
+        {
+            var savedModelName = Path.GetFileName(Se.Settings.Ocr.LlamaCppOcrModel ?? string.Empty);
+            SelectedLlamaCppOcrModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppOcrModels, LlamaCppServerManager.OcrModels, savedModelName);
+            UpdateLlamaCppOcrServerButtonText();
         }
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -957,6 +957,21 @@ public partial class OcrViewModel : ObservableObject
         Se.Settings.Ocr.LlamaCppOcrModel = LlamaCppServerManager.GetModelPath(value.Model.FileName);
     }
 
+    [RelayCommand]
+    private async Task ShowLlamaCppOcrSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<LlamaCppOcrSettingsWindow, LlamaCppOcrSettingsViewModel>(Window);
+        if (result.OkPressed)
+        {
+            LlamaCppUrl = Se.Settings.Ocr.LlamaCppUrl;
+        }
+    }
+
     private void UpdateLlamaCppOcrServerButtonText()
     {
         LlamaCppOcrServerButtonText = LlamaCppServerManager.IsServerRunning ? "Stop server" : "Start server";
@@ -3298,6 +3313,7 @@ public partial class OcrViewModel : ObservableObject
     {
         var engine = new LlamaCppOcr();
         var selectedModel = SelectedLlamaCppOcrModel?.Model;
+        var prompt = Se.Settings.Ocr.LlamaCppOcrPrompt;
 
         _ = Task.Run(async () =>
         {
@@ -3336,7 +3352,7 @@ public partial class OcrViewModel : ObservableObject
 
                 SelectAndScrollToRow(i);
 
-                var text = await engine.Ocr(bitmap, url, modelName, SelectedOllamaLanguage ?? "English", cancellationToken);
+                var text = await engine.Ocr(bitmap, url, modelName, SelectedOllamaLanguage ?? "English", prompt, cancellationToken);
                 item.Text = text;
 
                 OcrFixLineAndSetText(i, item);

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -290,6 +290,7 @@ public class OcrWindow : Window
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Model, vm => vm.IsLlamaCppVisible),
                 UiUtil.MakeComboBox(vm.LlamaCppOcrModels, vm, nameof(vm.SelectedLlamaCppOcrModel),
                         nameof(vm.IsLlamaCppVisible))
+                    .WithWidth(220)
                     .WithMarginRight(5)
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
                 UiUtil.MakeButton(vm.DownloadLlamaCppOcrCommand, IconNames.Download, Se.Language.General.Download)
@@ -297,11 +298,11 @@ public class OcrWindow : Window
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
                 MakeLlamaCppOcrToggleServerButton(vm)
-                    .WithMarginRight(10)
+                    .WithMarginRight(5)
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
-                UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Url, vm => vm.IsLlamaCppVisible),
-                UiUtil.MakeTextBox(220, vm, nameof(vm.LlamaCppUrl))
+                UiUtil.MakeButton(vm.ShowLlamaCppOcrSettingsCommand, IconNames.Settings, Se.Language.General.Settings)
+                    .WithMarginRight(10)
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
 

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -292,7 +292,7 @@ public class OcrWindow : Window
                         nameof(vm.IsLlamaCppVisible))
                     .WithMarginRight(5)
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
-                UiUtil.MakeButton(Se.Language.General.Download, vm.DownloadLlamaCppOcrCommand)
+                UiUtil.MakeButton(vm.DownloadLlamaCppOcrCommand, IconNames.Download, Se.Language.General.Download)
                     .WithMarginRight(5)
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -280,20 +280,26 @@ public class OcrWindow : Window
                     .BindIsVisible(vm, nameof(vm.IsOllamaVisible))
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
 
-                 // Ollama settings
+                // llama.cpp settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsLlamaCppVisible),
                 UiUtil.MakeComboBox(vm.OllamaLanguages, vm, nameof(vm.SelectedOllamaLanguage),
                         nameof(vm.IsLlamaCppVisible))
                     .WithWidth(100)
                     .WithMarginRight(10)
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
-                //UiUtil.MakeLabel(Se.Language.General.Model, nameof(vm.IsLlamaCppVisible)),
-                //UiUtil.MakeTextBox(160, vm, nameof(vm.OllamaModel))
-                //    .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
-                //    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
-                //UiUtil.MakeBrowseButton(vm.PickOllamaModelCommand)
-                //    .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
-                //    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Model, vm => vm.IsLlamaCppVisible),
+                UiUtil.MakeComboBox(vm.LlamaCppOcrModels, vm, nameof(vm.SelectedLlamaCppOcrModel),
+                        nameof(vm.IsLlamaCppVisible))
+                    .WithMarginRight(5)
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                UiUtil.MakeButton(Se.Language.General.Download, vm.DownloadLlamaCppOcrCommand)
+                    .WithMarginRight(5)
+                    .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                MakeLlamaCppOcrToggleServerButton(vm)
+                    .WithMarginRight(10)
+                    .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Url, vm => vm.IsLlamaCppVisible),
                 UiUtil.MakeTextBox(220, vm, nameof(vm.LlamaCppUrl))
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
@@ -971,5 +977,12 @@ public class OcrWindow : Window
         grid.Add(buttonCancel, 0, 7);
 
         return grid;
+    }
+
+    private static Button MakeLlamaCppOcrToggleServerButton(OcrViewModel vm)
+    {
+        var button = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppOcrServerCommand);
+        button.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppOcrServerButtonText)));
+        return button;
     }
 }

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -801,7 +801,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (downloaded != null)
         {
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, selectName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, selectName);
         }
     }
 
@@ -842,12 +842,11 @@ public partial class AutoTranslateViewModel : ObservableObject
             return false;
         }
 
-        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, model.FileName);
+        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, model.FileName);
 
         try
         {
-            await LlamaCppServerManager.EnsureServerRunningAsync(
-                LlamaCppServerManager.GetModelPath(model.FileName), _cancellationTokenSource.Token);
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token);
         }
         catch (Exception ex)
         {
@@ -915,7 +914,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (downloaded != null)
         {
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, selectName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, selectName);
         }
 
         UpdateLlamaCppServerButtonText();
@@ -1491,7 +1490,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             LlamaCppModelComboIsVisible = true;
             LlamaCppButtonsAreVisible = true;
             var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, savedModelName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, savedModelName);
             UpdateLlamaCppServerButtonText();
 
             if (!_llamaCppUpdatePromptShown)

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -187,7 +187,7 @@ public class AutoTranslateWindow : Window
 
         var llamaCppModelCombo = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel), nameof(vm.LlamaCppModelComboIsVisible));
 
-        var buttonDownloadLlamaCpp = UiUtil.MakeButton(Se.Language.General.Download, vm.DownloadLlamaCppCommand).WithMarginLeft(5);
+        var buttonDownloadLlamaCpp = UiUtil.MakeButton(vm.DownloadLlamaCppCommand, IconNames.Download, Se.Language.General.Download).WithMarginLeft(5);
         buttonDownloadLlamaCpp.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
 
         var buttonLlamaCppServer = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppServerCommand).WithMarginLeft(5);

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -185,7 +185,7 @@ public class AutoTranslateWindow : Window
 
         var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
 
-        var llamaCppModelCombo = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel), nameof(vm.LlamaCppModelComboIsVisible));
+        var llamaCppModelCombo = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel), nameof(vm.LlamaCppModelComboIsVisible)).WithWidth(220);
 
         var buttonDownloadLlamaCpp = UiUtil.MakeButton(vm.DownloadLlamaCppCommand, IconNames.Download, Se.Language.General.Download).WithMarginLeft(5);
         buttonDownloadLlamaCpp.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));

--- a/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
@@ -32,7 +32,7 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
     public string Variant { get; set; } = LlamaCppDownloadService.VariantCpu;
 
     /// <summary>The model to download, or null to only install the engine.</summary>
-    public LlamaCppTranslateModel? Model { get; set; }
+    public LlamaCppModel? Model { get; set; }
 
     /// <summary>Re-download the engine binary even when it is already installed (used for updates).</summary>
     public bool ForceEngineDownload { get; set; }
@@ -113,6 +113,28 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
                 var finalPath = LlamaCppServerManager.GetModelPath(Model.FileName);
                 var tempPath = finalPath + TemporaryFileExtension;
                 await _downloadService.DownloadModel(Model.Url, tempPath, MakeProgress(), token);
+                if (token.IsCancellationRequested)
+                {
+                    TryDelete(tempPath);
+                    Close();
+                    return;
+                }
+
+                if (File.Exists(finalPath))
+                {
+                    File.Delete(finalPath);
+                }
+
+                File.Move(tempPath, finalPath);
+            }
+
+            if (Model?.MmprojFileName != null && Model.MmprojUrl != null &&
+                (ForceModelDownload || !LlamaCppServerManager.IsModelInstalled(Model.MmprojFileName)))
+            {
+                TitleText = string.Format(Se.Language.General.DownloadingX, Model.MmprojFileName);
+                var finalPath = LlamaCppServerManager.GetModelPath(Model.MmprojFileName);
+                var tempPath = finalPath + TemporaryFileExtension;
+                await _downloadService.DownloadModel(Model.MmprojUrl, tempPath, MakeProgress(), token);
                 if (token.IsCancellationRequested)
                 {
                     TryDelete(tempPath);

--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -17,16 +17,16 @@ namespace Nikse.SubtitleEdit.Features.Translate;
 /// </summary>
 public class LlamaCppModelDisplay
 {
-    public LlamaCppTranslateModel Model { get; }
+    public LlamaCppModel Model { get; }
 
-    public LlamaCppModelDisplay(LlamaCppTranslateModel model)
+    public LlamaCppModelDisplay(LlamaCppModel model)
     {
         Model = model;
     }
 
     public override string ToString()
     {
-        var installed = LlamaCppServerManager.IsModelInstalled(Model.FileName);
+        var installed = LlamaCppServerManager.IsModelInstalled(Model);
         return installed
             ? $"{Model.DisplayName} ({Model.Size})"
             : $"{Model.DisplayName} ({Model.Size}, not installed)";
@@ -70,7 +70,7 @@ public static class LlamaCppDownloadHelper
             return configured;
         }
 
-        foreach (var model in LlamaCppServerManager.Models)
+        foreach (var model in LlamaCppServerManager.TranslateModels)
         {
             var path = LlamaCppServerManager.GetModelPath(model.FileName);
             if (File.Exists(path))
@@ -83,14 +83,17 @@ public static class LlamaCppDownloadHelper
     }
 
     /// <summary>
-    /// Fills <paramref name="target"/> with the curated models and returns the one matching
+    /// Fills <paramref name="target"/> with the given curated models and returns the one matching
     /// <paramref name="selectFileName"/>, or the first model otherwise.
     /// </summary>
-    public static LlamaCppModelDisplay? PopulateModels(ObservableCollection<LlamaCppModelDisplay> target, string? selectFileName)
+    public static LlamaCppModelDisplay? PopulateModels(
+        ObservableCollection<LlamaCppModelDisplay> target,
+        System.Collections.Generic.IReadOnlyList<LlamaCppModel> models,
+        string? selectFileName)
     {
         target.Clear();
         LlamaCppModelDisplay? toSelect = null;
-        foreach (var model in LlamaCppServerManager.Models)
+        foreach (var model in models)
         {
             var display = new LlamaCppModelDisplay(model);
             target.Add(display);
@@ -103,19 +106,19 @@ public static class LlamaCppDownloadHelper
         return toSelect ?? target.FirstOrDefault();
     }
 
-    private static LlamaCppTranslateModel? ResolveModel(string? modelFileName)
+    private static LlamaCppModel? ResolveModel(string? modelFileName)
     {
         if (!string.IsNullOrEmpty(modelFileName))
         {
-            var match = LlamaCppServerManager.Models.FirstOrDefault(m => m.FileName == modelFileName);
+            var match = LlamaCppServerManager.TranslateModels.FirstOrDefault(m => m.FileName == modelFileName);
             if (match != null)
             {
                 return match;
             }
         }
 
-        return LlamaCppServerManager.Models.FirstOrDefault(m => LlamaCppServerManager.IsModelInstalled(m.FileName))
-               ?? LlamaCppServerManager.Models.FirstOrDefault();
+        return LlamaCppServerManager.TranslateModels.FirstOrDefault(m => LlamaCppServerManager.IsModelInstalled(m.FileName))
+               ?? LlamaCppServerManager.TranslateModels.FirstOrDefault();
     }
 
     /// <summary>
@@ -127,7 +130,7 @@ public static class LlamaCppDownloadHelper
     /// is already installed.
     /// </summary>
     /// <returns>The downloaded model file name, or null if nothing was downloaded.</returns>
-    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, LlamaCppTranslateModel? model, string? forceVariant = null, bool forceEngineDownload = false, bool forceModelDownload = false)
+    public static async Task<string?> DownloadAsync(Window owner, IWindowService windowService, LlamaCppModel? model, string? forceVariant = null, bool forceEngineDownload = false, bool forceModelDownload = false)
     {
         var variant = forceVariant ?? Logic.Download.LlamaCppDownloadService.VariantCpu;
         if (forceVariant == null && !LlamaCppServerManager.IsEngineInstalled() && OperatingSystem.IsWindows())
@@ -171,15 +174,7 @@ public static class LlamaCppDownloadHelper
             return null;
         }
 
-        if (model != null)
-        {
-            Se.Settings.AutoTranslate.LlamaCppModel = LlamaCppServerManager.GetModelPath(model.FileName);
-            Configuration.Settings.Tools.LlamaCppModel = Se.Settings.AutoTranslate.LlamaCppModel;
-            Se.SaveSettings();
-            return model.FileName;
-        }
-
-        return string.Empty;
+        return model?.FileName ?? string.Empty;
     }
 
     /// <summary>
@@ -190,7 +185,7 @@ public static class LlamaCppDownloadHelper
     {
         var engineInstalled = LlamaCppServerManager.IsEngineInstalled();
         var model = ResolveModel(modelFileName);
-        var modelInstalled = model != null && LlamaCppServerManager.IsModelInstalled(model.FileName);
+        var modelInstalled = model != null && LlamaCppServerManager.IsModelInstalled(model);
 
         if (engineInstalled && modelInstalled)
         {
@@ -235,6 +230,6 @@ public static class LlamaCppDownloadHelper
 
         return LlamaCppServerManager.IsEngineInstalled()
                && model != null
-               && LlamaCppServerManager.IsModelInstalled(model.FileName);
+               && LlamaCppServerManager.IsModelInstalled(model);
     }
 }

--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -28,8 +28,8 @@ public class LlamaCppModelDisplay
     {
         var installed = LlamaCppServerManager.IsModelInstalled(Model);
         return installed
-            ? $"{Model.DisplayName} ({Model.Size})"
-            : $"{Model.DisplayName} ({Model.Size}, not installed)";
+            ? Model.DisplayName
+            : $"{Model.DisplayName} - not installed";
     }
 }
 

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -91,6 +91,10 @@ public class LanguageOcr
     public string VobSubColorEmphasis1 { get; set; }
     public string VobSubColorEmphasis2 { get; set; }
     public string VobSubColorsInvert { get; set; }
+    public string LlamaCppOcrSettingsTitle { get; set; }
+    public string LlamaCppOcrPromptHint { get; set; }
+    public string LlamaCppOcrPromptEmpty { get; set; }
+    public string LlamaCppOcrPromptMissingLanguagePlaceholder { get; set; }
 
     public LanguageOcr()
     {
@@ -181,5 +185,10 @@ public class LanguageOcr
         VobSubColorEmphasis1 = "Emphasis 1";
         VobSubColorEmphasis2 = "Emphasis 2";
         VobSubColorsInvert = "Invert background / emphasis 1";
+
+        LlamaCppOcrSettingsTitle = "llama.cpp OCR settings";
+        LlamaCppOcrPromptHint = "Use {language} to insert the selected OCR language.";
+        LlamaCppOcrPromptEmpty = "The prompt cannot be empty.";
+        LlamaCppOcrPromptMissingLanguagePlaceholder = "The prompt must contain the {language} placeholder.";
     }
 }

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -18,6 +18,7 @@ public class SeOcr
     public string OllamaLanguage { get; set; }
     public string LlamaCppUrl { get; set; }
     public string LlamaCppOcrModel { get; set; }
+    public string LlamaCppOcrPrompt { get; set; }
     public string GoogleVisionApiKey { get; set; }
     public string GoogleVisionLanguage { get; set; }
     public string MistralApiKey { get; set; }
@@ -71,6 +72,7 @@ public class SeOcr
 
         LlamaCppUrl = "http://127.0.0.1:8080/v1/chat/completions";
         LlamaCppOcrModel = string.Empty;
+        LlamaCppOcrPrompt = "Extract all text exactly as written. The language is {language}. Preserve line breaks.";
 
         GoogleVisionApiKey = string.Empty;
         GoogleVisionLanguage = "en";

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -17,6 +17,7 @@ public class SeOcr
     public string OllamaUrl { get; set; }
     public string OllamaLanguage { get; set; }
     public string LlamaCppUrl { get; set; }
+    public string LlamaCppOcrModel { get; set; }
     public string GoogleVisionApiKey { get; set; }
     public string GoogleVisionLanguage { get; set; }
     public string MistralApiKey { get; set; }
@@ -69,6 +70,7 @@ public class SeOcr
         OllamaUrl = "http://localhost:11434/api/chat/";
 
         LlamaCppUrl = "http://127.0.0.1:8080/v1/chat/completions";
+        LlamaCppOcrModel = string.Empty;
 
         GoogleVisionApiKey = string.Empty;
         GoogleVisionLanguage = "en";

--- a/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
@@ -15,27 +15,55 @@ using System.Threading.Tasks;
 namespace Nikse.SubtitleEdit.Logic.LlamaCpp;
 
 /// <summary>
-/// A curated TranslateGemma model that can be downloaded and served via llama.cpp.
+/// A curated llama.cpp model that can be downloaded and served. Optional <paramref name="MmprojFileName"/>
+/// / <paramref name="MmprojUrl"/> are set for multimodal (vision) models that need a separate vision
+/// projector. <paramref name="ChatTemplate"/> and <paramref name="NoJinja"/> override the llama-server
+/// launch flags when the bundled chat template needs replacing (TranslateGemma ships a non-standard
+/// Jinja template).
 /// </summary>
-public sealed record LlamaCppTranslateModel(string DisplayName, string FileName, string Size, string Url);
+public sealed record LlamaCppModel(
+    string DisplayName,
+    string FileName,
+    string Size,
+    string Url,
+    string? MmprojFileName = null,
+    string? MmprojUrl = null,
+    string? ChatTemplate = null,
+    bool NoJinja = false);
 
 /// <summary>
-/// Manages the local <c>llama-server</c> process used by the llama.cpp auto-translate engine:
-/// folder/executable paths, the curated model list, and the server lifecycle (start, health
-/// probe, stop, kill on app exit). Modeled on the CrispASR/Chatterbox server handling.
+/// Manages the local <c>llama-server</c> process used by the llama.cpp auto-translate and OCR
+/// engines: folder/executable paths, the curated model lists, and the server lifecycle (start,
+/// health probe, stop, kill on app exit). Modeled on the CrispASR/Chatterbox server handling.
 /// </summary>
 public static class LlamaCppServerManager
 {
-    public static readonly IReadOnlyList<LlamaCppTranslateModel> Models = new[]
+    public static readonly IReadOnlyList<LlamaCppModel> TranslateModels = new[]
     {
-        new LlamaCppTranslateModel("TranslateGemma 4B (Q4_K_M)", "translategemma-4b_Q4_K_M.gguf", "2.5 GB",
-            "https://huggingface.co/SandLogicTechnologies/translategemma-4b-it-GGUF/resolve/main/translategemma-4b_Q4_K_M.gguf"),
-        new LlamaCppTranslateModel("TranslateGemma 4B (Q5_K_M)", "translategemma-4b_Q5_K_M.gguf", "2.8 GB",
-            "https://huggingface.co/SandLogicTechnologies/translategemma-4b-it-GGUF/resolve/main/translategemma-4b_Q5_K_M.gguf"),
-        new LlamaCppTranslateModel("TranslateGemma 4B (Q8_0)", "translategemma-4b-it-q8_0.gguf", "4.1 GB",
-            "https://huggingface.co/NikolayKozloff/translategemma-4b-it-Q8_0-GGUF/resolve/main/translategemma-4b-it-q8_0.gguf"),
-        new LlamaCppTranslateModel("TranslateGemma 12B (Q4_K_M)", "translategemma-12b-it-q4_k_m.gguf", "7.3 GB",
-            "https://huggingface.co/NikolayKozloff/translategemma-12b-it-Q4_K_M-GGUF/resolve/main/translategemma-12b-it-q4_k_m.gguf"),
+        new LlamaCppModel("TranslateGemma 4B (Q4_K_M)", "translategemma-4b_Q4_K_M.gguf", "2.5 GB",
+            "https://huggingface.co/SandLogicTechnologies/translategemma-4b-it-GGUF/resolve/main/translategemma-4b_Q4_K_M.gguf",
+            ChatTemplate: "gemma", NoJinja: true),
+        new LlamaCppModel("TranslateGemma 4B (Q5_K_M)", "translategemma-4b_Q5_K_M.gguf", "2.8 GB",
+            "https://huggingface.co/SandLogicTechnologies/translategemma-4b-it-GGUF/resolve/main/translategemma-4b_Q5_K_M.gguf",
+            ChatTemplate: "gemma", NoJinja: true),
+        new LlamaCppModel("TranslateGemma 4B (Q8_0)", "translategemma-4b-it-q8_0.gguf", "4.1 GB",
+            "https://huggingface.co/NikolayKozloff/translategemma-4b-it-Q8_0-GGUF/resolve/main/translategemma-4b-it-q8_0.gguf",
+            ChatTemplate: "gemma", NoJinja: true),
+        new LlamaCppModel("TranslateGemma 12B (Q4_K_M)", "translategemma-12b-it-q4_k_m.gguf", "7.3 GB",
+            "https://huggingface.co/NikolayKozloff/translategemma-12b-it-Q4_K_M-GGUF/resolve/main/translategemma-12b-it-q4_k_m.gguf",
+            ChatTemplate: "gemma", NoJinja: true),
+    };
+
+    public static readonly IReadOnlyList<LlamaCppModel> OcrModels = new[]
+    {
+        new LlamaCppModel("GLM-OCR 0.9B (Q8_0)", "GLM-OCR-Q8_0.gguf", "1.4 GB",
+            "https://huggingface.co/ggml-org/GLM-OCR-GGUF/resolve/main/GLM-OCR-Q8_0.gguf",
+            MmprojFileName: "mmproj-GLM-OCR-Q8_0.gguf",
+            MmprojUrl: "https://huggingface.co/ggml-org/GLM-OCR-GGUF/resolve/main/mmproj-GLM-OCR-Q8_0.gguf"),
+        new LlamaCppModel("LightOnOCR 1B (Q8_0)", "LightOnOCR-1B-1025-Q8_0.gguf", "1.2 GB",
+            "https://huggingface.co/ggml-org/LightOnOCR-1B-1025-GGUF/resolve/main/LightOnOCR-1B-1025-Q8_0.gguf",
+            MmprojFileName: "mmproj-LightOnOCR-1B-1025-Q8_0.gguf",
+            MmprojUrl: "https://huggingface.co/ggml-org/LightOnOCR-1B-1025-GGUF/resolve/main/mmproj-LightOnOCR-1B-1025-Q8_0.gguf"),
     };
 
     private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromMinutes(5) };
@@ -95,12 +123,28 @@ public static class LlamaCppServerManager
         return File.Exists(path) && new FileInfo(path).Length > 10_000_000;
     }
 
+    public static bool IsModelInstalled(LlamaCppModel model)
+    {
+        if (!IsModelInstalled(model.FileName))
+        {
+            return false;
+        }
+
+        if (model.MmprojFileName == null)
+        {
+            return true;
+        }
+
+        return IsModelInstalled(model.MmprojFileName);
+    }
+
     /// <summary>
     /// Starts (or reuses) a llama-server for the given model and points
     /// <see cref="Core.Settings.ToolsSettings.LlamaCppApiUrl"/> at it. Throws on failure.
     /// </summary>
-    public static async Task EnsureServerRunningAsync(string modelPath, CancellationToken cancellationToken)
+    public static async Task EnsureServerRunningAsync(LlamaCppModel model, CancellationToken cancellationToken)
     {
+        var modelPath = GetModelPath(model.FileName);
         if (IsServerRunning && _serverModelPath == modelPath)
         {
             Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
@@ -133,6 +177,16 @@ public static class LlamaCppServerManager
                 throw new FileNotFoundException("llama.cpp model not found - please download a model first.", modelPath);
             }
 
+            string? mmprojPath = null;
+            if (model.MmprojFileName != null)
+            {
+                mmprojPath = GetModelPath(model.MmprojFileName);
+                if (!File.Exists(mmprojPath))
+                {
+                    throw new FileNotFoundException("llama.cpp vision projector not found - please download the model first.", mmprojPath);
+                }
+            }
+
             var port = FindFreeLoopbackPort();
             var psi = new ProcessStartInfo
             {
@@ -145,6 +199,11 @@ public static class LlamaCppServerManager
             };
             psi.ArgumentList.Add("-m");
             psi.ArgumentList.Add(modelPath);
+            if (mmprojPath != null)
+            {
+                psi.ArgumentList.Add("--mmproj");
+                psi.ArgumentList.Add(mmprojPath);
+            }
             psi.ArgumentList.Add("--host");
             psi.ArgumentList.Add("127.0.0.1");
             psi.ArgumentList.Add("--port");
@@ -154,14 +213,15 @@ public static class LlamaCppServerManager
             psi.ArgumentList.Add("99");
             psi.ArgumentList.Add("-c");
             psi.ArgumentList.Add("8192");
-            // TranslateGemma ships a non-standard Jinja chat template (it expects structured
-            // content with source/target language codes) that llama-server rejects at startup.
-            // The curated models are all Gemma-3 based, so fall back to the plain Gemma chat
-            // template - this keeps the OpenAI /v1/chat/completions endpoint working with the
-            // normal text messages the translate engine sends.
-            psi.ArgumentList.Add("--no-jinja");
-            psi.ArgumentList.Add("--chat-template");
-            psi.ArgumentList.Add("gemma");
+            if (model.NoJinja)
+            {
+                psi.ArgumentList.Add("--no-jinja");
+            }
+            if (model.ChatTemplate != null)
+            {
+                psi.ArgumentList.Add("--chat-template");
+                psi.ArgumentList.Add(model.ChatTemplate);
+            }
 
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start llama-server");


### PR DESCRIPTION
Closes #10954

## Summary
- Mirror the auto-translate llama.cpp UX in the OCR window: curated GGUF model combo, a Download button, and a Start/Stop server button. A new Settings (gear) icon button opens an advanced dialog with the manual URL and an editable OCR prompt.
- Curated OCR models (from the `ggml-org` collection on Hugging Face):
  - **GLM-OCR 0.9B (Q8_0)** — 950 MB model + 484 MB mmproj
  - **LightOnOCR 1B (Q8_0)** — 805 MB model + 437 MB mmproj
- Generalize the llama.cpp plumbing for both features:
  - Rename `LlamaCppTranslateModel` → `LlamaCppModel` with optional `MmprojFileName` / `MmprojUrl` / `ChatTemplate` / `NoJinja` fields.
  - Split `LlamaCppServerManager.Models` into `TranslateModels` and `OcrModels`. The previously hardcoded `--no-jinja --chat-template gemma` flags are now driven by per-model fields, so OCR models launch with the right defaults.
  - `EnsureServerRunningAsync` takes a `LlamaCppModel` and passes `--mmproj <path>` when set, so vision projectors are loaded for multimodal OCR models.
  - New `IsModelInstalled(LlamaCppModel)` overload checks both the main GGUF and the mmproj file.
  - `DownloadLlamaCppViewModel` downloads the mmproj alongside the main model.
  - `LlamaCppDownloadHelper.PopulateModels` now takes the model list as a parameter (each feature passes its own curated list).
- OCR side:
  - New `LlamaCppOcrModel` and `LlamaCppOcrPrompt` persisted settings in `SeOcr`.
  - `OcrViewModel` adds `DownloadLlamaCppOcr` / `ToggleLlamaCppOcrServer` / `ShowLlamaCppOcrSettings` commands and an `EnsureLlamaCppOcrReady` flow that prompts to download missing engine / model and then starts the local server.
  - `RunLlamaCppOcr` uses `LlamaCppServerManager.ApiUrl` (after starting the server) when a curated model is selected; falls back to the manual `LlamaCppUrl` textbox otherwise.
  - New `LlamaCppOcrSettingsWindow` exposes the URL and a custom prompt; the prompt is validated (non-empty + must contain `{language}`) before being saved. All strings are localizable via `LanguageOcr`.
  - `LlamaCppOcr.Ocr` accepts the prompt template, replaces `{language}` with the selected OCR language, and uses the supplied model name instead of the hardcoded `"glmocr"`.
- UI polish: the Download buttons in both the auto-translate and OCR windows are now icon buttons (tooltip "Download"); the model combos use a fixed width of 220 and the display drops the size suffix to keep entries compact.

## Test plan
- [ ] OCR window: select **llama.cpp** engine; confirm the new Model combo, Download (icon), Start/Stop server, and Settings (gear) buttons appear.
- [ ] Click Download with **GLM-OCR** selected; confirm both the model GGUF and the mmproj file are downloaded.
- [ ] Click Download again with the model already installed; confirm the re-download prompt appears (same flow as auto-translate).
- [ ] Click Start server; confirm llama-server launches with `--mmproj` and the button toggles to Stop server.
- [ ] Run OCR on a few subtitle frames; confirm text comes back via the local server.
- [ ] Open the Settings dialog; confirm the URL and Prompt are populated from settings.
- [ ] Try to OK with an empty Prompt or one missing `{language}` — confirm the validation error appears and the dialog stays open.
- [ ] Edit the prompt and confirm subsequent OCR uses the new prompt.
- [ ] Re-open the OCR window; confirm the previously selected model is restored.
- [ ] Switch the OCR engine away and back to llama.cpp; confirm the picker still works.
- [ ] Auto-translate regression: open the auto-translate window with the llama.cpp engine; confirm model picker, Download, Start/Stop, and translation all still work (the Models→TranslateModels rename + EnsureServerRunningAsync signature change should be transparent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)