### PR TITLE
Show llama.cpp model size for not-yet-installed entries

### DIFF
--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -29,7 +29,7 @@ public class LlamaCppModelDisplay
         var installed = LlamaCppServerManager.IsModelInstalled(Model);
         return installed
             ? Model.DisplayName
-            : $"{Model.DisplayName} - not installed";
+            : $"{Model.DisplayName} ({Model.Size}, not installed)";
     }
 }
 


### PR DESCRIPTION
## Summary
- Re-add the `(size, not installed)` suffix in `LlamaCppModelDisplay.ToString` for entries that still need to be downloaded, so users see the download size up-front (e.g. `GLM-OCR 0.9B (Q8_0) (1.4 GB, not installed)`).
- Installed models keep the short display (just `DisplayName`).

## Test plan
- [ ] OCR window with llama.cpp engine selected: open the Model combo on a fresh install; confirm uninstalled entries show "(<size>, not installed)" and installed entries show only the display name.
- [ ] Same check in the auto-translate window's llama.cpp model picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)