### PR TITLE
Fix batch Split/Break long lines adding stray line breaks

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1703,7 +1703,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
     private Subtitle SplitBreakLongLines(Subtitle subtitle, string language)
     {
-        if (!_config.AddFormatting.IsActive)
+        if (!_config.SplitBreakLongLines.IsActive)
         {
             return subtitle;
         }

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewSplitBreakLongLines.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewSplitBreakLongLines.cs
@@ -46,7 +46,7 @@ public static class ViewSplitBreakLongLines
         var numericUpDownSingleLineMaxLength = UiUtil.MakeNumericUpDownInt(5, 1000, 10, 130, vm, nameof(vm.SplitBreakSingleLineMaxLength));
 
         var labelMaxNumberOfLines = UiUtil.MakeLabel(Se.Language.Options.Settings.MaxLines);
-        var numericUpDownMaxNumberOfLines = UiUtil.MakeNumericUpDownInt(2, 10, 2, 130, vm, nameof(vm.SplitBreakMaxNumberOfLines));
+        var numericUpDownMaxNumberOfLines = UiUtil.MakeNumericUpDownInt(1, 10, 2, 130, vm, nameof(vm.SplitBreakMaxNumberOfLines));
 
         grid.Add(labelHeader, 0, 0, 2);
 

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -245,12 +245,11 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
                 segDurationMs = Math.Max(0, Math.Min(segDurationMs, Math.Max(0, originalEndMs - accumulatedMs)));
             }
 
-            // Ensure resulting segment lines are wrapped to SingleLineMaxLength
-            var wrappedSegText = Utilities.AutoBreakLine(segText, perLineMax, Se.Settings.General.UnbreakLinesShorterThan, item.Language ?? "en");
-
+            // Keep the segment text as-is; auto-wrapping is opt-in via the
+            // RebalanceLongLines option, which runs its own AutoBreakLine pass.
             var newLine = new SubtitleLineViewModel(item, true)
             {
-                Text = wrappedSegText,
+                Text = segText,
                 StartTime = TimeSpan.FromMilliseconds(accumulatedMs),
                 EndTime = TimeSpan.FromMilliseconds(accumulatedMs + segDurationMs)
             };

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -88,7 +88,7 @@ public class SplitBreakLongLinesWindow : Window
         numericUpDownSingleLineMaxLength.ValueChanged += (s, e) => vm.SetChanged();
 
         var labelMaxNumberOfLines = UiUtil.MakeLabel(Se.Language.Options.Settings.MaxLines);
-        var numericUpDownMaxNumberOfLines = UiUtil.MakeNumericUpDownInt(2, 10, 2, 130, vm, nameof(vm.MaxNumberOfLines));
+        var numericUpDownMaxNumberOfLines = UiUtil.MakeNumericUpDownInt(1, 10, 2, 130, vm, nameof(vm.MaxNumberOfLines));
         numericUpDownMaxNumberOfLines.ValueChanged += (s, e) => vm.SetChanged();
 
         grid.Add(checkBoxSplitLongLines, 0);

--- a/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesTests.cs
+++ b/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesTests.cs
@@ -1,0 +1,65 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
+
+namespace UITests.Features.Tools.SplitBreakLongLines;
+
+public class SplitBreakLongLinesTests
+{
+    private static SubtitleLineViewModel MakeSubtitle(string text, double startSec, double endSec) =>
+        new()
+        {
+            Text = text,
+            StartTime = TimeSpan.FromSeconds(startSec),
+            EndTime = TimeSpan.FromSeconds(endSec),
+        };
+
+    [Fact]
+    public void Split_TextWithinLimit_ReturnsOriginalSubtitle()
+    {
+        var item = MakeSubtitle("This line is short enough.", 1, 3);
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 80, singleLineMaxLength: 40);
+
+        Assert.Single(result);
+        Assert.Equal("This line is short enough.", result[0].Text);
+    }
+
+    [Fact]
+    public void Split_LongText_DoesNotInsertLineBreaksIntoSegments()
+    {
+        // Regression for #10959: split-only should split into multiple subtitles
+        // without adding a line break inside each new segment. AutoBreakLine
+        // belongs to the opt-in Rebalance long lines step.
+        var longText = new string('a', 45) + " " + new string('b', 45);
+        var item = MakeSubtitle(longText, 1, 5);
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 50, singleLineMaxLength: 40);
+
+        Assert.True(result.Count > 1, "Expected the long text to be split into multiple subtitles.");
+        foreach (var line in result)
+        {
+            Assert.DoesNotContain("\n", line.Text);
+            Assert.DoesNotContain("\r", line.Text);
+        }
+    }
+
+    [Fact]
+    public void Split_MaxNumberOfLinesOne_ProducesSingleLineSegments()
+    {
+        // Regression for #10959: when MaxNumberOfLines is 1
+        // (maxCharactersPerSubtitle == singleLineMaxLength), each produced
+        // subtitle must be a single short line with no embedded line break.
+        const int singleLineMaxLength = 40;
+        var longText = string.Join(' ', Enumerable.Repeat("word", 30));
+        var item = MakeSubtitle(longText, 1, 10);
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: singleLineMaxLength, singleLineMaxLength: singleLineMaxLength);
+
+        Assert.True(result.Count > 1, "Expected the long text to be split into multiple subtitles.");
+        foreach (var line in result)
+        {
+            Assert.DoesNotContain("\n", line.Text);
+            Assert.DoesNotContain("\r", line.Text);
+        }
+    }
+}


### PR DESCRIPTION
Closes #10959

## Summary
Three issues caused the batch (and standalone tool) Split/Break long lines to add unwanted line breaks and silently drop options:

1. **Wrong guard** — `BatchConverter.SplitBreakLongLines` was gated on `_config.AddFormatting.IsActive` (copy-paste bug from the neighbouring `AddFormatting` method), so the entire step was silently skipped unless the unrelated Add Formatting step was also enabled. It now checks `_config.SplitBreakLongLines.IsActive`.
2. **Forced auto-wrap inside Split** — `SplitBreakLongLinesViewModel.Split` ran `Utilities.AutoBreakLine` on every produced segment, so users who only ticked "Split long lines" (not "Rebalance long lines") still got extra line breaks inside each new subtitle. Segments are now kept as-is; the optional Rebalance step runs its own `AutoBreakLine` pass afterwards.
3. **MaxNumberOfLines hardcoded min=2** — both the batch view (`ViewSplitBreakLongLines.cs`) and the standalone tool (`SplitBreakLongLinesWindow.cs`) used `MakeNumericUpDownInt(2, 10, …)`, so users couldn't return to 1 after raising the value. Minimum is now 1.

## Test plan
- [ ] Batch Convert → enable only "Split / break long lines" (with Split long lines checked, Rebalance unchecked). Confirm long subtitles are split into multiple paragraphs without any extra line breaks added inside the resulting subtitles.
- [ ] Same batch run with Rebalance long lines also ticked: confirm each resulting subtitle is wrapped to SingleLineMaxLength.
- [ ] Tools → Split / break long lines (standalone): repeat the two checks above.
- [ ] In both UIs, change Max number of lines to 5 and then back to 1; confirm 1 sticks and is honoured by the split.
- [ ] Regression: batch run with Split/Break long lines disabled — confirm subtitles are unchanged.
- [ ] Regression: single-subtitle split (cursor split) is unchanged and continues to split by timecode without auto-wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)