### PR TITLE
Fix MP3 playback stopping before the end of the file

### DIFF
--- a/src/ui/Logic/Media/Mp3DurationReader.cs
+++ b/src/ui/Logic/Media/Mp3DurationReader.cs
@@ -1,0 +1,242 @@
+using System;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// Computes the exact duration of an MP3 file by walking every audio frame and
+/// summing per-frame durations. Used as a workaround for libmpv reporting a
+/// bitrate-based duration estimate for VBR MP3 files that lack a Xing/Info
+/// header, which makes playback stop a few seconds before the real end of the
+/// file (see issue #10953).
+/// </summary>
+public static class Mp3DurationReader
+{
+    // Bitrate tables in kbps. The first index is the encoding column derived
+    // from MPEG version + layer; the second index is the 4-bit bitrate field
+    // from the frame header. 0 = "free", 15 = "bad"; both are treated as invalid.
+    private static readonly int[,] BitrateTable = new int[5, 16]
+    {
+        // V1, L1
+        { 0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, -1 },
+        // V1, L2
+        { 0, 32, 48, 56,  64,  80,  96, 112, 128, 160, 192, 224, 256, 320, 384, -1 },
+        // V1, L3
+        { 0, 32, 40, 48,  56,  64,  80,  96, 112, 128, 160, 192, 224, 256, 320, -1 },
+        // V2/2.5, L1
+        { 0, 32, 48, 56,  64,  80,  96, 112, 128, 144, 160, 176, 192, 224, 256, -1 },
+        // V2/2.5, L2 or L3
+        { 0,  8, 16, 24,  32,  40,  48,  56,  64,  80,  96, 112, 128, 144, 160, -1 },
+    };
+
+    // Sample rate by MPEG version (V1, V2, V2.5) and the 2-bit sample-rate
+    // field; the fourth slot is reserved.
+    private static readonly int[,] SampleRateTable = new int[3, 4]
+    {
+        { 44100, 48000, 32000, -1 }, // MPEG 1
+        { 22050, 24000, 16000, -1 }, // MPEG 2
+        { 11025, 12000,  8000, -1 }, // MPEG 2.5
+    };
+
+    /// <summary>
+    /// Returns the exact duration of <paramref name="path"/> in seconds, or
+    /// null if the file is not a recognisable MP3 (or no frames could be
+    /// decoded). The file is opened read-only and never modified.
+    /// </summary>
+    public static double? TryGetDurationSeconds(string path)
+    {
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            return ReadDurationSeconds(stream);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static double? ReadDurationSeconds(Stream stream)
+    {
+        var length = stream.Length;
+        var pos = SkipId3v2(stream);
+
+        // ID3v1 lives in the last 128 bytes if present; never scan into it.
+        var end = length;
+        if (length >= 128)
+        {
+            stream.Position = length - 128;
+            Span<byte> tagProbe = stackalloc byte[3];
+            if (stream.Read(tagProbe) == 3 && tagProbe[0] == (byte)'T' && tagProbe[1] == (byte)'A' && tagProbe[2] == (byte)'G')
+            {
+                end = length - 128;
+            }
+        }
+
+        stream.Position = pos;
+        double totalSeconds = 0;
+        var frameCount = 0;
+
+        Span<byte> header = stackalloc byte[4];
+        while (pos + 4 <= end)
+        {
+            stream.Position = pos;
+            if (stream.Read(header) != 4)
+            {
+                break;
+            }
+
+            // Sync word is 11 set bits: 0xFF in byte 0, top 3 bits of byte 1 set.
+            if (header[0] != 0xFF || (header[1] & 0xE0) != 0xE0)
+            {
+                pos++;
+                continue;
+            }
+
+            if (!TryParseFrame(header, out var frameSize, out var frameDurationSeconds))
+            {
+                pos++;
+                continue;
+            }
+
+            if (frameSize <= 4 || pos + frameSize > end)
+            {
+                break;
+            }
+
+            totalSeconds += frameDurationSeconds;
+            frameCount++;
+            pos += frameSize;
+        }
+
+        return frameCount > 0 ? totalSeconds : (double?)null;
+    }
+
+    private static long SkipId3v2(Stream stream)
+    {
+        if (stream.Length < 10)
+        {
+            return 0;
+        }
+
+        stream.Position = 0;
+        Span<byte> header = stackalloc byte[10];
+        if (stream.Read(header) != 10)
+        {
+            return 0;
+        }
+
+        if (header[0] != (byte)'I' || header[1] != (byte)'D' || header[2] != (byte)'3')
+        {
+            return 0;
+        }
+
+        // Bytes 6..9 are a synchsafe 28-bit integer giving the tag size after the header.
+        var size = ((header[6] & 0x7F) << 21)
+                 | ((header[7] & 0x7F) << 14)
+                 | ((header[8] & 0x7F) << 7)
+                 |  (header[9] & 0x7F);
+
+        // Bit 4 of the flags byte (header[5]) indicates a footer (extra 10 bytes).
+        var hasFooter = (header[5] & 0x10) != 0;
+        return 10L + size + (hasFooter ? 10L : 0L);
+    }
+
+    private static bool TryParseFrame(ReadOnlySpan<byte> header, out int frameSize, out double frameDurationSeconds)
+    {
+        frameSize = 0;
+        frameDurationSeconds = 0;
+
+        var versionBits = (header[1] >> 3) & 0x03; // 00=V2.5, 01=reserved, 10=V2, 11=V1
+        var layerBits = (header[1] >> 1) & 0x03;   // 00=reserved, 01=L3, 10=L2, 11=L1
+        if (versionBits == 1 || layerBits == 0)
+        {
+            return false;
+        }
+
+        var bitrateIndex = (header[2] >> 4) & 0x0F;
+        var sampleRateIndex = (header[2] >> 2) & 0x03;
+        var padding = (header[2] >> 1) & 0x01;
+        if (bitrateIndex == 0 || bitrateIndex == 15 || sampleRateIndex == 3)
+        {
+            return false;
+        }
+
+        var isV1 = versionBits == 3;
+        var layer = 4 - layerBits; // 1, 2, or 3
+
+        int bitrateRow;
+        if (isV1)
+        {
+            bitrateRow = layer - 1; // L1=0, L2=1, L3=2
+        }
+        else
+        {
+            bitrateRow = layer == 1 ? 3 : 4; // V2/2.5 L1 has its own row; L2 and L3 share row 4
+        }
+
+        var bitrateKbps = BitrateTable[bitrateRow, bitrateIndex];
+        if (bitrateKbps <= 0)
+        {
+            return false;
+        }
+
+        int versionRow;
+        if (isV1)
+        {
+            versionRow = 0;
+        }
+        else if (versionBits == 2)
+        {
+            versionRow = 1;
+        }
+        else
+        {
+            versionRow = 2; // MPEG 2.5
+        }
+
+        var sampleRate = SampleRateTable[versionRow, sampleRateIndex];
+        if (sampleRate <= 0)
+        {
+            return false;
+        }
+
+        int samplesPerFrame;
+        if (layer == 1)
+        {
+            samplesPerFrame = 384;
+        }
+        else if (layer == 2)
+        {
+            samplesPerFrame = 1152;
+        }
+        else
+        {
+            // Layer III: 1152 for MPEG 1, 576 for MPEG 2 / 2.5.
+            samplesPerFrame = isV1 ? 1152 : 576;
+        }
+
+        var bitrateBps = bitrateKbps * 1000;
+        if (layer == 1)
+        {
+            frameSize = ((12 * bitrateBps / sampleRate) + padding) * 4;
+        }
+        else
+        {
+            frameSize = (samplesPerFrame / 8 * bitrateBps / sampleRate) + padding;
+        }
+
+        if (frameSize <= 4)
+        {
+            return false;
+        }
+
+        frameDurationSeconds = (double)samplesPerFrame / sampleRate;
+        return true;
+    }
+}

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -826,16 +826,35 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             // The lavfi-complex color source above produces frames forever, so without
             // an explicit end mpv would keep "playing" the black video past the audio's
             // end. Bound playback to the audio duration so it pauses at EOF.
-            for (var i = 0; i < 50 && !_disposed; i++)
+            //
+            // For .mp3 we read the duration by walking the frame headers ourselves
+            // because libmpv reports a bitrate-based estimate for VBR MP3s without a
+            // Xing/Info header, which is often a few seconds short and would cause
+            // playback to stop before the real end of the file (issue #10953).
+            double? bound = null;
+            if (ext.Equals(".mp3", StringComparison.OrdinalIgnoreCase))
             {
-                var d = Duration;
-                if (d > 0 && !double.IsInfinity(d) && !double.IsNaN(d))
+                bound = Media.Mp3DurationReader.TryGetDurationSeconds(path);
+            }
+
+            if (bound.HasValue && bound.Value > 0)
+            {
+                SetOptionString("end", bound.Value.ToString(CultureInfo.InvariantCulture));
+                _audioEndBound = bound.Value;
+            }
+            else
+            {
+                for (var i = 0; i < 50 && !_disposed; i++)
                 {
-                    SetOptionString("end", d.ToString(CultureInfo.InvariantCulture));
-                    _audioEndBound = d;
-                    break;
+                    var d = Duration;
+                    if (d > 0 && !double.IsInfinity(d) && !double.IsNaN(d))
+                    {
+                        SetOptionString("end", d.ToString(CultureInfo.InvariantCulture));
+                        _audioEndBound = d;
+                        break;
+                    }
+                    await Task.Delay(50);
                 }
-                await Task.Delay(50);
             }
         }
     }

--- a/tests/UI/Logic/Media/Mp3DurationReaderTests.cs
+++ b/tests/UI/Logic/Media/Mp3DurationReaderTests.cs
@@ -1,0 +1,109 @@
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic.Media;
+
+public class Mp3DurationReaderTests
+{
+    // MPEG-1 Layer III, 128 kbps, 44.1 kHz, no padding, stereo.
+    // 1152 samples per frame at 44100 Hz = 1152 / 44100 s per frame.
+    // Frame size = (1152 / 8 * 128000 / 44100) = 417 bytes.
+    private const double FrameDurationSeconds = 1152.0 / 44100.0;
+    private const int FrameSize = 417;
+
+    private static byte[] BuildMp3WithFrames(int frameCount)
+    {
+        var data = new byte[frameCount * FrameSize];
+        for (var f = 0; f < frameCount; f++)
+        {
+            var offset = f * FrameSize;
+            data[offset + 0] = 0xFF; // sync
+            data[offset + 1] = 0xFB; // sync + MPEG 1 + Layer III + protection bit
+            data[offset + 2] = 0x90; // bitrate index 9 (128 kbps), sample rate index 0 (44.1 kHz), no padding
+            data[offset + 3] = 0x00; // stereo + no copyright + no original + no emphasis
+        }
+
+        return data;
+    }
+
+    [Fact]
+    public void TryGetDurationSeconds_RawFrames_MatchesExpectedDuration()
+    {
+        var temp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(temp, BuildMp3WithFrames(100));
+
+            var result = Mp3DurationReader.TryGetDurationSeconds(temp);
+
+            Assert.NotNull(result);
+            Assert.Equal(100 * FrameDurationSeconds, result!.Value, precision: 5);
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void TryGetDurationSeconds_WithId3v2Header_SkipsTagAndStillCounts()
+    {
+        var temp = Path.GetTempFileName();
+        try
+        {
+            // 10-byte ID3v2 header declaring a 50-byte tag (synchsafe: 50 = 0x32),
+            // followed by 50 zero bytes, followed by 50 MP3 frames.
+            var id3 = new byte[10 + 50];
+            id3[0] = (byte)'I';
+            id3[1] = (byte)'D';
+            id3[2] = (byte)'3';
+            id3[3] = 0x04; // major version
+            id3[4] = 0x00; // revision
+            id3[5] = 0x00; // flags (no footer)
+            id3[6] = 0x00;
+            id3[7] = 0x00;
+            id3[8] = 0x00;
+            id3[9] = 0x32;
+
+            var frames = BuildMp3WithFrames(50);
+            var combined = new byte[id3.Length + frames.Length];
+            Buffer.BlockCopy(id3, 0, combined, 0, id3.Length);
+            Buffer.BlockCopy(frames, 0, combined, id3.Length, frames.Length);
+            File.WriteAllBytes(temp, combined);
+
+            var result = Mp3DurationReader.TryGetDurationSeconds(temp);
+
+            Assert.NotNull(result);
+            Assert.Equal(50 * FrameDurationSeconds, result!.Value, precision: 5);
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void TryGetDurationSeconds_NonMp3File_ReturnsNull()
+    {
+        var temp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(temp, new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 });
+
+            var result = Mp3DurationReader.TryGetDurationSeconds(temp);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void TryGetDurationSeconds_MissingFile_ReturnsNull()
+    {
+        var result = Mp3DurationReader.TryGetDurationSeconds(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".mp3"));
+
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
Refs #10953

## Root cause
For audio-only files, `LibMpvDynamicPlayer.LoadFile` injects a `lavfi` virtual black-video stream (so subtitles have something to render onto), then sets mpv's `end` option to mpv's reported `duration` so playback pauses when the audio finishes (without that, the lavfi source would keep "playing" forever).

The problem: for VBR MP3 files that lack a Xing/Info header, libmpv reports a *bitrate × file-size* duration estimate that is typically a few seconds short of the real audio length. Setting `end` to that short value made mpv pause before the real end of the file — exactly the symptom in #10953. Prior PRs (#10850, #10892) addressed *where the playhead ends up* once mpv pauses; they did not fix the cause of the premature pause.

## Fix
Add `Mp3DurationReader` (pure C#, no external dependencies — no ffmpeg, no ffprobe, no native libs): it skips any leading ID3v2 tag, walks every MP3 frame's 4-byte sync header to derive bitrate / sample rate / samples-per-frame / frame size, and sums per-frame durations. Returns the exact duration of the file in a few milliseconds.

`LibMpvDynamicPlayer.LoadFile` now calls this reader for `.mp3` files only, and uses the result for mpv's `end` option and the `_audioEndBound` UI pin. Other audio formats (`.m4a`, `.flac`, `.ogg`, `.aac`, …) keep the previous mpv-duration polling — their container metadata is normally reliable so the bug doesn't apply.

If the parser can't read the file (corrupt, exotic, or zero-frame), it returns null and the player falls back to the old polling behaviour — never worse than today.

## Test plan
- [x] Unit tests in `tests/UI/Logic/Media/Mp3DurationReaderTests.cs` cover: raw MP3 frame stream, ID3v2-prefixed stream, non-MP3 file, missing file. All pass locally.
- [x] Load `G5_2_1A.M1U1.mp3` (the file from #10835 with the broken VBR header) in SE with the libmpv engine. Confirm playback runs all the way to the end of the waveform and pauses there.
- [ ] Regression: open a well-formed VBR MP3 with a Xing header. Confirm duration is the same as before and playback ends correctly.
- [ ] Regression: open a CBR MP3. Same.
- [ ] Regression: open `.m4a`, `.flac`, `.ogg` audio files. Confirm playback ends correctly (these still use mpv's reported duration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)