### PR TITLE
Add opt-in last-ditch nOCR pass for batch convert (fewer asterisks)

### DIFF
--- a/src/libuilogic/Ocr/NOcrDb.cs
+++ b/src/libuilogic/Ocr/NOcrDb.cs
@@ -283,7 +283,7 @@ public class NOcrDb
         return new OcrPoint(maximumX - minimumX, maximumY - minimumY);
     }
 
-    public NOcrChar? GetMatch(NikseBitmap2 parentBitmap, List<ImageSplitterItem2> list, ImageSplitterItem2 item, int topMargin, bool deepSeek, int maxWrongPixels)
+    public NOcrChar? GetMatch(NikseBitmap2 parentBitmap, List<ImageSplitterItem2> list, ImageSplitterItem2 item, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch = false)
     {
         if (item.NikseBitmap == null)
         {
@@ -304,7 +304,7 @@ public class NOcrDb
             return expandedResult;
         }
 
-        return GetMatchSingle(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels);
+        return GetMatchSingle(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels, lastDitch);
     }
 
     private NOcrChar? GetExactMatchSingle(NikseBitmap2 bitmap, int topMargin)
@@ -323,7 +323,7 @@ public class NOcrDb
         return null;
     }
 
-    public NOcrChar? GetMatchSingle(NikseBitmap2 bitmap, int topMargin, bool deepSeek, int maxWrongPixels)
+    public NOcrChar? GetMatchSingle(NikseBitmap2 bitmap, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch = false)
     {
         var exact = GetExactMatchSingle(bitmap, topMargin);
         if (exact != null)
@@ -336,6 +336,11 @@ public class NOcrDb
         foreach (var pass in MatchPasses)
         {
             if (pass.RequireDeepSeek && !deepSeek)
+            {
+                continue;
+            }
+
+            if (pass.RequireLastDitch && !lastDitch)
             {
                 continue;
             }
@@ -412,6 +417,7 @@ public class NOcrDb
     {
         public int MinAllowance { get; init; }       // run only if maxWrongPixels >= this (0 = always)
         public bool RequireDeepSeek { get; init; }
+        public bool RequireLastDitch { get; init; }  // run only when the caller opted in (batch convert)
         public int AspectMaxDelta { get; init; }     // int.MaxValue = no aspect-ratio check
         public int SizeMaxDelta { get; init; }       // int.MaxValue = no width/height check; otherwise applied to both
         public int MarginTopMaxDelta { get; init; }
@@ -426,6 +432,7 @@ public class NOcrDb
     private static readonly Func<int, int> ErrorsCappedAtThree = max => Math.Min(3, max);
     private static readonly Func<int, int> ErrorsCappedAtTwenty = max => Math.Min(20, max);
     private static readonly Func<int, int> ErrorsAsRequested = max => max;
+    private static readonly Func<int, int> ErrorsAsRequestedDoubled = max => max * 2;
 
     private static readonly MatchPass[] MatchPasses =
     {
@@ -479,6 +486,18 @@ public class NOcrDb
             AspectMaxDelta = 60, SizeMaxDelta = int.MaxValue, MarginTopMaxDelta = 17,
             MinLineCount = 51,
             ErrorsAllowed = ErrorsAsRequested,
+        },
+        // last-ditch: opt-in from batch contexts where the user can't fix asterisks inline.
+        // Drop the MinLineCount gate that blocks sparsely-trained DB characters and double the
+        // error budget so we return a best-guess character instead of "*". Wrong guesses can
+        // still be cleaned up by the "fix common OCR errors" and replace-list passes; an
+        // asterisk blocks them entirely. (#10766)
+        new MatchPass
+        {
+            RequireLastDitch = true,
+            AspectMaxDelta = 80, SizeMaxDelta = int.MaxValue, MarginTopMaxDelta = 25,
+            MinLineCount = 15,
+            ErrorsAllowed = ErrorsAsRequestedDoubled,
         },
     };
 

--- a/src/seconv/Core/NOcrOcrEngine.cs
+++ b/src/seconv/Core/NOcrOcrEngine.cs
@@ -58,7 +58,7 @@ internal sealed class NOcrOcrEngine : IOcrEngine
             }
             else
             {
-                var match = _db.GetMatch(parent, letters, item, item.Top, true, MaxWrongPixels);
+                var match = _db.GetMatch(parent, letters, item, item.Top, true, MaxWrongPixels, lastDitch: true);
                 if (match is { ExpandCount: > 0 })
                 {
                     i += match.ExpandCount - 1;

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -768,7 +768,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
             else
             {
-                var match = nOcrDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, maxWrongPixels);
+                var match = nOcrDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, maxWrongPixels, lastDitch: true);
                 if (match is { ExpandCount: > 0 })
                 {
                     index += match.ExpandCount - 1;


### PR DESCRIPTION
Refs https://github.com/SubtitleEdit/subtitleedit/discussions/10766#discussioncomment-16933663

## Summary
A discussion comment reports that nOCR via Batch Convert in SE 5 produces lots of `*` characters for unrecognized glyphs, and the asterisks then defeat the downstream "fix common OCR errors" and replace-list passes.

The nOCR match cascade in `NOcrDb.GetMatchSingle` already has 7 passes, the most permissive of which (`deepSeek`) still requires the matched database character to have at least 51 training "lines". Sparsely trained DB characters get filtered out, the loop returns null, and the caller writes `*`.

Add a final, opt-in match pass that runs only when the caller passes `lastDitch: true`:

- drops `MinLineCount` from 51 → 15 so sparsely trained DB characters can still match
- widens `AspectMaxDelta` from 60 → 80 and `MarginTopMaxDelta` from 17 → 25
- doubles the error budget (`maxWrongPixels * 2`)

Wire `BatchConverter.OcrSingleNOcrImage` and `seconv` to opt in. Interactive OCR (`OcrViewModel` runs, nOCR inspect, etc.) keeps the existing stricter behavior — there the asterisk is useful since the user can add the missing character to the database.

## Tradeoff
The last-ditch pass returns best-guess characters that may be wrong. In batch / CLI contexts where the user can't inline-fix output, a wrong character is more recoverable than an asterisk because the OCR fix-up tools can still chew on it (and asterisks are an italic-text marker downstream too). Interactive OCR is unchanged, so the trade only applies to batch.

## Test plan
- [x] `dotnet build` — clean.
- [ ] Batch Convert a Blu-ray .sup or VobSub with the nOCR engine using a sparse nOCR database; confirm noticeably fewer `*` in the output and that obvious wrong matches are then cleaned up by the OCR fix-up steps.
- [ ] Open the same file via the OCR window (interactive) and confirm asterisks are still produced for unknown characters (so the user can add them to the database).
- [ ] `seconv` regression: run the CLI on a sample image subtitle and confirm output looks reasonable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)