### PR TITLE
Add BinaryOCR fallback for nOCR in batch convert

### DIFF
--- a/src/libuilogic/Ocr/NOcrDb.cs
+++ b/src/libuilogic/Ocr/NOcrDb.cs
@@ -283,7 +283,7 @@ public class NOcrDb
         return new OcrPoint(maximumX - minimumX, maximumY - minimumY);
     }
 
-    public NOcrChar? GetMatch(NikseBitmap2 parentBitmap, List<ImageSplitterItem2> list, ImageSplitterItem2 item, int topMargin, bool deepSeek, int maxWrongPixels)
+    public NOcrChar? GetMatch(NikseBitmap2 parentBitmap, List<ImageSplitterItem2> list, ImageSplitterItem2 item, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch = false)
     {
         if (item.NikseBitmap == null)
         {
@@ -304,7 +304,7 @@ public class NOcrDb
             return expandedResult;
         }
 
-        return GetMatchSingle(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels);
+        return GetMatchSingle(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels, lastDitch);
     }
 
     private NOcrChar? GetExactMatchSingle(NikseBitmap2 bitmap, int topMargin)
@@ -323,7 +323,7 @@ public class NOcrDb
         return null;
     }
 
-    public NOcrChar? GetMatchSingle(NikseBitmap2 bitmap, int topMargin, bool deepSeek, int maxWrongPixels)
+    public NOcrChar? GetMatchSingle(NikseBitmap2 bitmap, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch = false)
     {
         var exact = GetExactMatchSingle(bitmap, topMargin);
         if (exact != null)
@@ -336,6 +336,11 @@ public class NOcrDb
         foreach (var pass in MatchPasses)
         {
             if (pass.RequireDeepSeek && !deepSeek)
+            {
+                continue;
+            }
+
+            if (pass.RequireLastDitch && !lastDitch)
             {
                 continue;
             }
@@ -412,6 +417,7 @@ public class NOcrDb
     {
         public int MinAllowance { get; init; }       // run only if maxWrongPixels >= this (0 = always)
         public bool RequireDeepSeek { get; init; }
+        public bool RequireLastDitch { get; init; }  // run only when the caller opted in (batch convert)
         public int AspectMaxDelta { get; init; }     // int.MaxValue = no aspect-ratio check
         public int SizeMaxDelta { get; init; }       // int.MaxValue = no width/height check; otherwise applied to both
         public int MarginTopMaxDelta { get; init; }
@@ -426,6 +432,7 @@ public class NOcrDb
     private static readonly Func<int, int> ErrorsCappedAtThree = max => Math.Min(3, max);
     private static readonly Func<int, int> ErrorsCappedAtTwenty = max => Math.Min(20, max);
     private static readonly Func<int, int> ErrorsAsRequested = max => max;
+    private static readonly Func<int, int> ErrorsAsRequestedDoubled = max => max * 2;
 
     private static readonly MatchPass[] MatchPasses =
     {
@@ -479,6 +486,18 @@ public class NOcrDb
             AspectMaxDelta = 60, SizeMaxDelta = int.MaxValue, MarginTopMaxDelta = 17,
             MinLineCount = 51,
             ErrorsAllowed = ErrorsAsRequested,
+        },
+        // last-ditch: opt-in from batch contexts where the user can't fix asterisks inline.
+        // Drop the MinLineCount gate that blocks sparsely-trained DB characters and double the
+        // error budget so we return a best-guess character instead of "*". Wrong guesses can
+        // still be cleaned up by the "fix common OCR errors" and replace-list passes; an
+        // asterisk blocks them entirely. (#10766)
+        new MatchPass
+        {
+            RequireLastDitch = true,
+            AspectMaxDelta = 80, SizeMaxDelta = int.MaxValue, MarginTopMaxDelta = 25,
+            MinLineCount = 15,
+            ErrorsAllowed = ErrorsAsRequestedDoubled,
         },
     };
 

--- a/src/seconv/Core/NOcrOcrEngine.cs
+++ b/src/seconv/Core/NOcrOcrEngine.cs
@@ -58,7 +58,7 @@ internal sealed class NOcrOcrEngine : IOcrEngine
             }
             else
             {
-                var match = _db.GetMatch(parent, letters, item, item.Top, true, MaxWrongPixels);
+                var match = _db.GetMatch(parent, letters, item, item.Top, true, MaxWrongPixels, lastDitch: true);
                 if (match is { ExpandCount: > 0 })
                 {
                     i += match.ExpandCount - 1;

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -45,6 +45,9 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _nOcrDatabases;
     [ObservableProperty] private string? _selectedNOcrDatabase;
 
+    [ObservableProperty] private ObservableCollection<string> _nOcrFallbackBinaryOcrDatabases;
+    [ObservableProperty] private string? _selectedNOcrFallbackBinaryOcrDatabase;
+
     [ObservableProperty] private ObservableCollection<string> _ollamaModels;
     [ObservableProperty] private string? _selectedOllamaModel;
 
@@ -91,6 +94,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         TesseractDictionaryItems = new ObservableCollection<TesseractDictionary>();
         BinaryOcrDatabases = new ObservableCollection<string>(BinaryOcrDb.GetDatabases(Se.OcrFolder));
         NOcrDatabases = new ObservableCollection<string>(NOcrDb.GetDatabases(Se.OcrFolder).OrderBy(p => p));
+        NOcrFallbackBinaryOcrDatabases = new ObservableCollection<string> { Se.Language.Ocr.NOcrBinaryOcrFallbackNone };
+        foreach (var db in BinaryOcrDb.GetDatabases(Se.OcrFolder).OrderBy(p => p))
+        {
+            NOcrFallbackBinaryOcrDatabases.Add(db);
+        }
         OllamaModels = new ObservableCollection<string>(Se.Settings.Ocr.OllamaModels);
 
         _folderHelper = folderHelper;
@@ -176,12 +184,42 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             Se.Settings.Ocr.NOcrDatabase = SelectedNOcrDatabase;
         }
 
+        if (ocrEngine == "nOcr")
+        {
+            var fallback = SelectedNOcrFallbackBinaryOcrDatabase;
+            Se.Settings.Tools.BatchConvert.NOcrBinaryOcrFallbackDatabase =
+                string.IsNullOrEmpty(fallback) || fallback == Se.Language.Ocr.NOcrBinaryOcrFallbackNone
+                    ? string.Empty
+                    : fallback;
+        }
+
         if (ocrEngine == "Ollama" && !string.IsNullOrWhiteSpace(SelectedOllamaModel))
         {
             Se.Settings.Ocr.OllamaModel = SelectedOllamaModel;
         }
 
         Se.SaveSettings();
+    }
+
+    partial void OnSelectedNOcrDatabaseChanged(string? value)
+    {
+        // When the user picks a different nOCR DB and the fallback isn't an explicit user
+        // choice yet, re-suggest the same-name BinaryOCR DB if one exists.
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        var saved = Se.Settings.Tools.BatchConvert.NOcrBinaryOcrFallbackDatabase;
+        if (!string.IsNullOrEmpty(saved) && NOcrFallbackBinaryOcrDatabases != null && NOcrFallbackBinaryOcrDatabases.Contains(saved))
+        {
+            return;
+        }
+
+        if (NOcrFallbackBinaryOcrDatabases != null && NOcrFallbackBinaryOcrDatabases.Contains(value))
+        {
+            SelectedNOcrFallbackBinaryOcrDatabase = value;
+        }
     }
 
     [RelayCommand]
@@ -266,6 +304,22 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         {
             SelectedNOcrDatabase = NOcrDatabases
                 .FirstOrDefault(p => p == Se.Settings.Ocr.NOcrDatabase) ?? NOcrDatabases.FirstOrDefault();
+
+            // Default the BinaryOCR fallback either to whatever the user previously picked,
+            // or (when nothing is saved) suggest the BinaryOCR DB with the same name as the
+            // selected nOCR DB. Falls back to "(none)" if no match exists.
+            var saved = Se.Settings.Tools.BatchConvert.NOcrBinaryOcrFallbackDatabase;
+            string? toSelect = null;
+            if (!string.IsNullOrEmpty(saved) && NOcrFallbackBinaryOcrDatabases.Contains(saved))
+            {
+                toSelect = saved;
+            }
+            else if (!string.IsNullOrEmpty(SelectedNOcrDatabase) && NOcrFallbackBinaryOcrDatabases.Contains(SelectedNOcrDatabase))
+            {
+                toSelect = SelectedNOcrDatabase;
+            }
+
+            SelectedNOcrFallbackBinaryOcrDatabase = toSelect ?? NOcrFallbackBinaryOcrDatabases.First();
         }
 
         if (ocrEngine == "Ollama")

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -85,6 +85,9 @@ public class BatchConvertSettingsWindow : Window
         var labelNOcrDatabase = UiUtil.MakeLabel(Se.Language.Ocr.Database).WithBindVisible(vm, nameof(vm.IsNOcrVisible)).WithMarginLeft(10);
         var comboBoxNOcrDatabases = UiUtil.MakeComboBox(vm.NOcrDatabases, vm, nameof(vm.SelectedNOcrDatabase))
             .WithBindVisible(nameof(vm.IsNOcrVisible));
+        var labelNOcrFallback = UiUtil.MakeLabel(Se.Language.Ocr.NOcrBinaryOcrFallbackDatabase).WithBindVisible(vm, nameof(vm.IsNOcrVisible)).WithMarginLeft(10);
+        var comboBoxNOcrFallback = UiUtil.MakeComboBox(vm.NOcrFallbackBinaryOcrDatabases, vm, nameof(vm.SelectedNOcrFallbackBinaryOcrDatabase))
+            .WithBindVisible(nameof(vm.IsNOcrVisible));
         var labelOllamaModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.IsOllamaVisible)).WithMarginLeft(10);
         var comboBoxOllamaModels = UiUtil.MakeComboBox(vm.OllamaModels, vm, nameof(vm.SelectedOllamaModel))
             .WithBindVisible(nameof(vm.IsOllamaVisible));
@@ -93,7 +96,7 @@ public class BatchConvertSettingsWindow : Window
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(0, 30, 0, 0),
-            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelNOcrDatabase, comboBoxNOcrDatabases, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse }
+            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse }
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -678,6 +678,23 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         var totalCount = imageSubtitles.Count;
         var maxWrongPixels = Se.Settings.Ocr.NOcrMaxWrongPixels > 0 ? Se.Settings.Ocr.NOcrMaxWrongPixels : 25;
 
+        // Optional BinaryOCR fallback for characters nOCR can't recognise. Falling back to
+        // a wrong-but-recognised character beats an asterisk because the OCR fix-up tools
+        // can still chew on it. The user picks the fallback DB in batch-convert settings;
+        // empty / missing = no fallback.
+        BinaryOcrDb? binaryOcrFallbackDb = null;
+        BinaryOcrMatcher? binaryOcrFallbackMatcher = null;
+        var fallbackName = Se.Settings.Tools.BatchConvert.NOcrBinaryOcrFallbackDatabase;
+        if (!string.IsNullOrEmpty(fallbackName))
+        {
+            var fallbackPath = Path.Combine(Se.OcrFolder, fallbackName + BinaryOcrDb.Extension);
+            if (File.Exists(fallbackPath))
+            {
+                binaryOcrFallbackDb = new BinaryOcrDb(fallbackPath, true);
+                binaryOcrFallbackMatcher = new BinaryOcrMatcher();
+            }
+        }
+
         // Pre-flight: detect pixels-is-space from a sample of images.
         var sampleSize = Math.Min(OcrPreflightSampleSize, totalCount);
         var pixelsAreSpace = Se.Settings.Ocr.NOcrPixelsAreSpace > 0 ? Se.Settings.Ocr.NOcrPixelsAreSpace : 12;
@@ -708,7 +725,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             MaxDegreeOfParallelism = Environment.ProcessorCount
         }, i =>
         {
-            results[i] = OcrSingleNOcrImage(imageSubtitles, i, nOcrDb, pixelsAreSpace, maxWrongPixels);
+            results[i] = OcrSingleNOcrImage(imageSubtitles, i, nOcrDb, pixelsAreSpace, maxWrongPixels, binaryOcrFallbackDb, binaryOcrFallbackMatcher);
 
             lock (lockObj)
             {
@@ -746,7 +763,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         }
     }
 
-    private Paragraph OcrSingleNOcrImage(IOcrSubtitle imageSubtitles, int i, NOcrDb nOcrDb, int pixelsAreSpace, int maxWrongPixels)
+    private Paragraph OcrSingleNOcrImage(IOcrSubtitle imageSubtitles, int i, NOcrDb nOcrDb, int pixelsAreSpace, int maxWrongPixels, BinaryOcrDb? binaryOcrFallbackDb, BinaryOcrMatcher? binaryOcrFallbackMatcher)
     {
         var bitmap = imageSubtitles.GetBitmap(i);
         var parentBitmap = new NikseBitmap2(bitmap);
@@ -756,6 +773,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             false, true, 20, true);
         var index = 0;
         var matches = new List<NOcrChar>();
+        var maxErrorPercent = Se.Settings.Ocr.BinaryOcrMaxErrorPercent > 0 ? Se.Settings.Ocr.BinaryOcrMaxErrorPercent : 7.5;
         while (index < letters.Count)
         {
             var splitterItem = letters[index];
@@ -772,6 +790,28 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 if (match is { ExpandCount: > 0 })
                 {
                     index += match.ExpandCount - 1;
+                }
+
+                if (match == null && binaryOcrFallbackDb != null && binaryOcrFallbackMatcher != null)
+                {
+                    var compare = binaryOcrFallbackMatcher.GetCompareMatch(splitterItem, out _, letters, index, binaryOcrFallbackDb, maxErrorPercent);
+                    if (compare != null && !string.IsNullOrEmpty(compare.Text))
+                    {
+                        if (compare.ExpandCount > 0)
+                        {
+                            index += compare.ExpandCount - 1;
+                        }
+
+                        matches.Add(new NOcrChar
+                        {
+                            Text = compare.Text,
+                            Italic = compare.Italic,
+                            ExpandCount = compare.ExpandCount,
+                            ImageSplitterItem = splitterItem,
+                        });
+                        index++;
+                        continue;
+                    }
                 }
 
                 if (match == null)

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -768,7 +768,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
             else
             {
-                var match = nOcrDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, maxWrongPixels);
+                var match = nOcrDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, maxWrongPixels, lastDitch: true);
                 if (match is { ExpandCount: > 0 })
                 {
                     index += match.ExpandCount - 1;

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -95,6 +95,8 @@ public class LanguageOcr
     public string LlamaCppOcrPromptHint { get; set; }
     public string LlamaCppOcrPromptEmpty { get; set; }
     public string LlamaCppOcrPromptMissingLanguagePlaceholder { get; set; }
+    public string NOcrBinaryOcrFallbackDatabase { get; set; }
+    public string NOcrBinaryOcrFallbackNone { get; set; }
 
     public LanguageOcr()
     {
@@ -190,5 +192,8 @@ public class LanguageOcr
         LlamaCppOcrPromptHint = "Use {language} to insert the selected OCR language.";
         LlamaCppOcrPromptEmpty = "The prompt cannot be empty.";
         LlamaCppOcrPromptMissingLanguagePlaceholder = "The prompt must contain the {language} placeholder.";
+
+        NOcrBinaryOcrFallbackDatabase = "BinaryOCR fallback database";
+        NOcrBinaryOcrFallbackNone = "(none)";
     }
 }

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -13,6 +13,7 @@ public class SeBatchConvert
     public string TesseractLanguage { get; set; }
     public string PaddleLanguage { get; set; }
     public string BinaryOcrDatabase { get; set; }
+    public string NOcrBinaryOcrFallbackDatabase { get; set; }
 
     public bool FormattingRemoveAll { get; set; }
     public bool FormattingRemoveItalic { get; set; }
@@ -102,6 +103,7 @@ public class SeBatchConvert
         TesseractLanguage = "eng";
         PaddleLanguage = "en";
         BinaryOcrDatabase = "Latin";
+        NOcrBinaryOcrFallbackDatabase = string.Empty;
         OffsetTimeCodesForward = true;
         AdjustVia = "Seconds";
         AdjustDurationSeconds = 0.1;


### PR DESCRIPTION
Refs https://github.com/SubtitleEdit/subtitleedit/discussions/10766#discussioncomment-16933663

## Summary
Mirror the SE4 behaviour where nOCR falls back to BinaryOCR for characters it can't recognise, so batch conversion produces fewer asterisks. A wrong-but-recognised character is friendlier than \`*\` because the downstream OCR fix-up + replace-list passes can still chew on it.

- **New persisted setting** \`SeBatchConvert.NOcrBinaryOcrFallbackDatabase\` (empty string = no fallback).
- **Batch-convert settings dialog**: explicit BinaryOCR fallback DB picker, shown when nOCR is the selected engine, with a "(none)" option. Default suggestion = the BinaryOCR DB with the same name as the selected nOCR DB if one exists; otherwise "(none)". The first time the user changes the nOCR DB (and the fallback isn't already an explicit choice), the suggestion re-applies.
- **\`BatchConverter.RunNOcr\`** loads the fallback DB (if any) and a single \`BinaryOcrMatcher\`. \`OcrSingleNOcrImage\` uses them as a fallback after nOCR's own cascade (including the last-ditch pass from the previous PR) returns null, before emitting \`*\`. Uses \`Se.Settings.Ocr.BinaryOcrMaxErrorPercent\` for the match threshold.
- **Localized** via \`LanguageOcr.NOcrBinaryOcrFallbackDatabase\` and \`LanguageOcr.NOcrBinaryOcrFallbackNone\`.

Order is now nOCR cascade → nOCR last-ditch → BinaryOCR fallback → \`*\`.

Interactive OCR, nOCR inspect, and the seconv CLI are unchanged.

## Test plan
- [x] \`dotnet build\` clean.
- [ ] Open Batch Convert → Settings; pick the nOCR engine. Confirm the new "BinaryOCR fallback database" combo appears and defaults to the same-name BinaryOCR DB if one exists, else "(none)".
- [ ] Change the nOCR DB to a different name where a matching BinaryOCR DB exists; confirm the fallback suggestion re-applies.
- [ ] Change the fallback explicitly, save, reopen settings — confirm the choice is restored.
- [ ] Run Batch Convert with nOCR + a non-trivial BinaryOCR fallback DB on a file that previously produced asterisks. Confirm noticeably fewer asterisks and that the wrong guesses get cleaned up by the OCR fix-up steps.
- [ ] Set fallback to "(none)"; confirm behaviour matches the previous PR (last-ditch pass only).
- [ ] Switch the OCR engine away and back to nOCR; confirm the picker reappears with the previously saved fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)