### PR TITLE
Add nOCR fallback for BinaryOCR in batch convert

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -48,6 +48,9 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _nOcrFallbackBinaryOcrDatabases;
     [ObservableProperty] private string? _selectedNOcrFallbackBinaryOcrDatabase;
 
+    [ObservableProperty] private ObservableCollection<string> _binaryOcrFallbackNOcrDatabases;
+    [ObservableProperty] private string? _selectedBinaryOcrFallbackNOcrDatabase;
+
     [ObservableProperty] private ObservableCollection<string> _ollamaModels;
     [ObservableProperty] private string? _selectedOllamaModel;
 
@@ -98,6 +101,12 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         foreach (var db in BinaryOcrDb.GetDatabases(Se.OcrFolder).OrderBy(p => p))
         {
             NOcrFallbackBinaryOcrDatabases.Add(db);
+        }
+
+        BinaryOcrFallbackNOcrDatabases = new ObservableCollection<string> { Se.Language.Ocr.NOcrBinaryOcrFallbackNone };
+        foreach (var db in NOcrDb.GetDatabases(Se.OcrFolder).OrderBy(p => p))
+        {
+            BinaryOcrFallbackNOcrDatabases.Add(db);
         }
         OllamaModels = new ObservableCollection<string>(Se.Settings.Ocr.OllamaModels);
 
@@ -177,6 +186,12 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         if (ocrEngine == "BinaryOcr")
         {
             Se.Settings.Tools.BatchConvert.BinaryOcrDatabase = SelectedBinaryOcrDatabase ?? "Latin";
+
+            var fallback = SelectedBinaryOcrFallbackNOcrDatabase;
+            Se.Settings.Tools.BatchConvert.BinaryOcrNOcrFallbackDatabase =
+                string.IsNullOrEmpty(fallback) || fallback == Se.Language.Ocr.NOcrBinaryOcrFallbackNone
+                    ? string.Empty
+                    : fallback;
         }
 
         if (ocrEngine == "nOcr" && !string.IsNullOrWhiteSpace(SelectedNOcrDatabase))
@@ -219,6 +234,27 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         if (NOcrFallbackBinaryOcrDatabases != null && NOcrFallbackBinaryOcrDatabases.Contains(value))
         {
             SelectedNOcrFallbackBinaryOcrDatabase = value;
+        }
+    }
+
+    partial void OnSelectedBinaryOcrDatabaseChanged(string? value)
+    {
+        // When the user picks a different BinaryOCR DB and the nOCR fallback isn't an
+        // explicit user choice yet, re-suggest the same-name nOCR DB if one exists.
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        var saved = Se.Settings.Tools.BatchConvert.BinaryOcrNOcrFallbackDatabase;
+        if (!string.IsNullOrEmpty(saved) && BinaryOcrFallbackNOcrDatabases != null && BinaryOcrFallbackNOcrDatabases.Contains(saved))
+        {
+            return;
+        }
+
+        if (BinaryOcrFallbackNOcrDatabases != null && BinaryOcrFallbackNOcrDatabases.Contains(value))
+        {
+            SelectedBinaryOcrFallbackNOcrDatabase = value;
         }
     }
 
@@ -298,6 +334,22 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         {
             SelectedBinaryOcrDatabase = BinaryOcrDatabases
                 .FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.BinaryOcrDatabase) ?? BinaryOcrDatabases.FirstOrDefault();
+
+            // Default the nOCR fallback either to whatever the user previously picked, or
+            // (when nothing is saved) suggest the nOCR DB with the same name as the selected
+            // BinaryOCR DB. Falls back to "(none)" if no match exists.
+            var saved = Se.Settings.Tools.BatchConvert.BinaryOcrNOcrFallbackDatabase;
+            string? toSelect = null;
+            if (!string.IsNullOrEmpty(saved) && BinaryOcrFallbackNOcrDatabases.Contains(saved))
+            {
+                toSelect = saved;
+            }
+            else if (!string.IsNullOrEmpty(SelectedBinaryOcrDatabase) && BinaryOcrFallbackNOcrDatabases.Contains(SelectedBinaryOcrDatabase))
+            {
+                toSelect = SelectedBinaryOcrDatabase;
+            }
+
+            SelectedBinaryOcrFallbackNOcrDatabase = toSelect ?? BinaryOcrFallbackNOcrDatabases.First();
         }
 
         if (ocrEngine == "nOcr")

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -82,6 +82,9 @@ public class BatchConvertSettingsWindow : Window
             .WithBindVisible(nameof(vm.IsPaddleOCrVisible));
         var comboBoxBinaryOcrDatabases = UiUtil.MakeComboBox(vm.BinaryOcrDatabases, vm, nameof(vm.SelectedBinaryOcrDatabase))
             .WithBindVisible(nameof(vm.IsBinaryOcrVisible));
+        var labelBinaryOcrFallback = UiUtil.MakeLabel(Se.Language.Ocr.BinaryOcrNOcrFallbackDatabase).WithBindVisible(vm, nameof(vm.IsBinaryOcrVisible)).WithMarginLeft(10);
+        var comboBoxBinaryOcrFallback = UiUtil.MakeComboBox(vm.BinaryOcrFallbackNOcrDatabases, vm, nameof(vm.SelectedBinaryOcrFallbackNOcrDatabase))
+            .WithBindVisible(nameof(vm.IsBinaryOcrVisible));
         var labelNOcrDatabase = UiUtil.MakeLabel(Se.Language.Ocr.Database).WithBindVisible(vm, nameof(vm.IsNOcrVisible)).WithMarginLeft(10);
         var comboBoxNOcrDatabases = UiUtil.MakeComboBox(vm.NOcrDatabases, vm, nameof(vm.SelectedNOcrDatabase))
             .WithBindVisible(nameof(vm.IsNOcrVisible));
@@ -96,7 +99,7 @@ public class BatchConvertSettingsWindow : Window
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(0, 30, 0, 0),
-            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse }
+            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelBinaryOcrFallback, comboBoxBinaryOcrFallback, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse }
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -908,6 +908,23 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             return;
         }
 
+        // Optional nOCR fallback for characters BinaryOCR can't recognise. Falling back to
+        // a wrong-but-recognised character beats an asterisk because the OCR fix-up tools
+        // can still chew on it. The user picks the fallback DB in batch-convert settings;
+        // empty / missing = no fallback. The DB is shared across worker threads (read-only
+        // after construction).
+        NOcrDb? nOcrFallbackDb = null;
+        var nOcrMaxWrongPixels = Se.Settings.Ocr.NOcrMaxWrongPixels > 0 ? Se.Settings.Ocr.NOcrMaxWrongPixels : 25;
+        var nOcrFallbackName = Se.Settings.Tools.BatchConvert.BinaryOcrNOcrFallbackDatabase;
+        if (!string.IsNullOrEmpty(nOcrFallbackName))
+        {
+            var nOcrFallbackPath = Path.Combine(Se.OcrFolder, nOcrFallbackName + ".nocr");
+            if (File.Exists(nOcrFallbackPath))
+            {
+                nOcrFallbackDb = new NOcrDb(nOcrFallbackPath);
+            }
+        }
+
         item.Subtitle = new Subtitle();
         var sharedBinaryOcrDb = new BinaryOcrDb(fileName, true);
         var results = RunBinaryOcrParallel(
@@ -920,7 +937,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 var pct = processedCount * 100 / totalCount;
                 item.Status = string.Format(Se.Language.General.OcrPercentX, pct);
             },
-            cancellationToken);
+            cancellationToken,
+            nOcrFallbackDb,
+            nOcrMaxWrongPixels);
 
         if (cancellationToken.IsCancellationRequested)
         {
@@ -956,7 +975,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         int pixelsAreSpace,
         double maxErrorPercent,
         Action<int>? onProgress,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        NOcrDb? nOcrFallbackDb = null,
+        int nOcrMaxWrongPixels = 25)
     {
         var totalCount = imageSubtitles.Count;
         var results = new Paragraph[totalCount];
@@ -974,7 +995,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             () => new BinaryOcrDb(sharedBinaryOcrDb),
             (i, _, threadDb) =>
             {
-                results[i] = OcrSingleBinaryImage(imageSubtitles, i, threadDb, pixelsAreSpace, maxErrorPercent);
+                results[i] = OcrSingleBinaryImage(imageSubtitles, i, threadDb, pixelsAreSpace, maxErrorPercent, nOcrFallbackDb, nOcrMaxWrongPixels);
 
                 lock (lockObj)
                 {
@@ -989,7 +1010,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         return results;
     }
 
-    private Paragraph OcrSingleBinaryImage(IOcrSubtitle imageSubtitles, int i, BinaryOcrDb binaryOcrDb, int pixelsAreSpace, double maxErrorPercent)
+    private Paragraph OcrSingleBinaryImage(IOcrSubtitle imageSubtitles, int i, BinaryOcrDb binaryOcrDb, int pixelsAreSpace, double maxErrorPercent, NOcrDb? nOcrFallbackDb, int nOcrMaxWrongPixels)
     {
         var bitmap = imageSubtitles.GetBitmap(i);
         var parentBitmap = new NikseBitmap2(bitmap);
@@ -1016,6 +1037,23 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                     index += match.ExpandCount - 1;
                 }
 
+                if (match == null && nOcrFallbackDb != null)
+                {
+                    var nMatch = nOcrFallbackDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, nOcrMaxWrongPixels, lastDitch: true);
+                    if (nMatch != null)
+                    {
+                        if (nMatch.ExpandCount > 0)
+                        {
+                            index += nMatch.ExpandCount - 1;
+                        }
+
+                        var text = _nOcrCaseFixer.FixUppercaseLowercaseIssues(splitterItem, nMatch);
+                        matches.Add(new BinaryOcrMatcher.CompareMatch(text, nMatch.Italic, nMatch.ExpandCount, nMatch.Text ?? string.Empty));
+                        index++;
+                        continue;
+                    }
+                }
+
                 if (match == null)
                 {
                     matches.Add(new BinaryOcrMatcher.CompareMatch("*", false, 0, null));
@@ -1029,8 +1067,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             index++;
         }
 
-        var text = ItalicTextMerger.MergeWithItalicTags(matches).Trim();
-        return new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
+        var text2 = ItalicTextMerger.MergeWithItalicTags(matches).Trim();
+        return new Paragraph(text2, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
     }
 
     private static int? DetectPixelsIsSpace(IOcrSubtitle imageSubtitles, int sampleSize, CancellationToken cancellationToken)

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -97,6 +97,7 @@ public class LanguageOcr
     public string LlamaCppOcrPromptMissingLanguagePlaceholder { get; set; }
     public string NOcrBinaryOcrFallbackDatabase { get; set; }
     public string NOcrBinaryOcrFallbackNone { get; set; }
+    public string BinaryOcrNOcrFallbackDatabase { get; set; }
 
     public LanguageOcr()
     {
@@ -195,5 +196,6 @@ public class LanguageOcr
 
         NOcrBinaryOcrFallbackDatabase = "BinaryOCR fallback database";
         NOcrBinaryOcrFallbackNone = "(none)";
+        BinaryOcrNOcrFallbackDatabase = "nOCR fallback database";
     }
 }

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -14,6 +14,7 @@ public class SeBatchConvert
     public string PaddleLanguage { get; set; }
     public string BinaryOcrDatabase { get; set; }
     public string NOcrBinaryOcrFallbackDatabase { get; set; }
+    public string BinaryOcrNOcrFallbackDatabase { get; set; }
 
     public bool FormattingRemoveAll { get; set; }
     public bool FormattingRemoveItalic { get; set; }
@@ -104,6 +105,7 @@ public class SeBatchConvert
         PaddleLanguage = "en";
         BinaryOcrDatabase = "Latin";
         NOcrBinaryOcrFallbackDatabase = string.Empty;
+        BinaryOcrNOcrFallbackDatabase = string.Empty;
         OffsetTimeCodesForward = true;
         AdjustVia = "Seconds";
         AdjustDurationSeconds = 0.1;


### PR DESCRIPTION
Refs https://github.com/SubtitleEdit/subtitleedit/discussions/10766#discussioncomment-16933663

## Summary
Symmetric to #10968 (nOCR → BinaryOCR fallback). When BinaryOCR is the selected batch-convert engine, characters it can't recognise can now be retried against an optional nOCR database before being written as \`*\`. A wrong-but-recognised character beats an asterisk because the OCR fix-up + replace-list passes can still chew on it.

- **New persisted setting** \`SeBatchConvert.BinaryOcrNOcrFallbackDatabase\` (empty string = no fallback).
- **Batch-convert settings dialog**: explicit nOCR fallback DB picker, shown when BinaryOCR is the selected engine, with a "(none)" option. Default suggestion = the nOCR DB with the same name as the selected BinaryOCR DB if one exists. When the user changes the BinaryOCR DB and the fallback isn't a pinned choice yet, the suggestion follows.
- **\`BatchConverter.RunBinaryOcr\`** loads the optional nOCR fallback DB and threads it through \`RunBinaryOcrParallel\` into \`OcrSingleBinaryImage\`. After the BinaryOCR matcher returns null and before emitting \`*\`, it calls \`nOcrFallbackDb.GetMatch(..., lastDitch: true)\`. The nOCR result is run through \`INOcrCaseFixer\` and wrapped back into a \`BinaryOcrMatcher.CompareMatch\` so the existing italic merger continues to work.
- The two new \`RunBinaryOcrParallel\` parameters are **optional**, so the existing \`BatchConverterRunBinaryOcrTests\` keep passing untouched.
- Localized via \`LanguageOcr.BinaryOcrNOcrFallbackDatabase\`; reuses the existing \`NOcrBinaryOcrFallbackNone\` "(none)" string.

Order is now BinaryOCR matcher → nOCR fallback (with last-ditch) → \`*\`.

Interactive OCR, nOCR inspect, and the seconv CLI are unchanged.

## Test plan
- [x] \`dotnet build\` clean, existing \`BatchConverterRunBinaryOcrTests\` (2) still pass.
- [ ] Open Batch Convert → Settings; pick the BinaryOCR engine. Confirm the new "nOCR fallback database" combo appears and defaults to the same-name nOCR DB if one exists, else "(none)".
- [ ] Change the BinaryOCR DB to a name where a matching nOCR DB exists; confirm the fallback suggestion re-applies.
- [ ] Pin a specific fallback, save, reopen settings — confirm the choice is restored.
- [ ] Run Batch Convert with BinaryOCR + a non-trivial nOCR fallback DB on a file that previously produced asterisks. Confirm noticeably fewer asterisks.
- [ ] Set fallback to "(none)"; confirm behaviour matches the previous PR (BinaryOCR-only).
- [ ] Switch the OCR engine away and back to BinaryOCR; confirm the picker reappears with the previously saved fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)