### PR TITLE
Register Alt+Space Windows system menu via Window class handler

### DIFF
--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
@@ -303,7 +303,6 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
     internal async void OnLoaded()
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
 
         if (string.IsNullOrEmpty(_videoFileName))
         {

--- a/src/ui/Features/Assa/AssaDraw/AssaDrawViewModel.cs
+++ b/src/ui/Features/Assa/AssaDraw/AssaDrawViewModel.cs
@@ -76,7 +76,6 @@ public partial class AssaDrawViewModel : ObservableObject
     public void Initialize()
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
         ZoomToFitCurrentVideoResolution();
         RefreshTreeView();
         Canvas?.InvalidateVisual();

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -1253,7 +1253,6 @@ public partial class MultipleReplaceViewModel : ObservableObject
     internal void OnLoaded()
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
     }
 
     internal void TreeViewDoubleTapped(TappedEventArgs e)

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddViewModel.cs
@@ -430,7 +430,6 @@ public partial class BinaryOcrCharacterAddViewModel : ObservableObject
     internal void Onloaded(object? sender, RoutedEventArgs e)
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
     }
 
     internal void OnClosing(object? sender, WindowClosingEventArgs e)

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterAddViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterAddViewModel.cs
@@ -661,7 +661,6 @@ public partial class NOcrCharacterAddViewModel : ObservableObject
     internal void Onloaded(object? sender, RoutedEventArgs e)
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
     }
 
     internal void OnClosing(object? sender, WindowClosingEventArgs e)

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3954,7 +3954,6 @@ public partial class OcrViewModel : ObservableObject
     internal void OnLoaded()
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
         DictionaryChanged();
         Dispatcher.UIThread.Post(() =>
         {

--- a/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
@@ -373,7 +373,6 @@ public partial class SettingsImportExportViewModel : ObservableObject
     public async void OnLoaded(object? sender, RoutedEventArgs e)
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
 
         if (!_isExport)
         {

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -2335,7 +2335,6 @@ public partial class SettingsViewModel : ObservableObject
     internal void Onloaded(object? sender, RoutedEventArgs e)
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
         _ = UpdateWaveformSpaceInfoAsync();
     }
 

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -944,7 +944,6 @@ public partial class ShortcutsViewModel : ObservableObject
     internal void Onloaded(object? sender, RoutedEventArgs e)
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
     }
 
     internal void OnClosing(object? sender, WindowClosingEventArgs e)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1777,7 +1777,6 @@ public partial class BinaryEditViewModel : ObservableObject
     public void Loaded()
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
 
         RegisterVideoShortcuts();
 

--- a/src/ui/Features/Shared/ShowImage/ShowImageViewModel.cs
+++ b/src/ui/Features/Shared/ShowImage/ShowImageViewModel.cs
@@ -105,7 +105,6 @@ public partial class ShowImageViewModel : ObservableObject
     internal void Loaded()
     {
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
     }
 
     internal void Closing(WindowClosingEventArgs e)

--- a/src/ui/Features/Shared/Undocked/AudioVisualizerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/AudioVisualizerUndockedViewModel.cs
@@ -105,6 +105,5 @@ public partial class AudioVisualizerUndockedViewModel : ObservableObject
     {
         Window!.Content = AudioVisualizer;
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
     }
 }

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -161,7 +161,6 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
         }   
 
         UiUtil.RestoreWindowPosition(Window);
-        UiUtil.SetupWindowsSystemMenu(Window);
 
         VideoPlayer = InitVideoPlayer.MakeLayoutVideoPlayer(MainViewModel, new Avalonia.Thickness(0), out var videoPlayerControl);
         Window!.Content = VideoPlayer;

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2458,17 +2458,25 @@ public static class UiUtil
         return false;
     }
 
-    internal static void SetupWindowsSystemMenu(Window? window)
+    private static bool _windowsSystemMenuClassHandlerRegistered;
+
+    /// <summary>
+    /// Registers a single class-level handler so every <see cref="Window"/> in the app
+    /// responds to Alt+Space by opening the standard Windows system menu. Call once at
+    /// application startup. No-op on non-Windows platforms or if already registered.
+    /// </summary>
+    internal static void RegisterWindowsSystemMenuClassHandler()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || window == null)
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || _windowsSystemMenuClassHandlerRegistered)
         {
             return;
         }
 
-        window.AddHandler(InputElement.KeyDownEvent, (sender, e) =>
-        {
-            TryHandleWindowSystemMenu(e, window);
-        }, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+        _windowsSystemMenuClassHandlerRegistered = true;
+
+        InputElement.KeyDownEvent.AddClassHandler<Window>(
+            (window, e) => TryHandleWindowSystemMenu(e, window),
+            RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
     }
 
     /// <summary>

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -142,6 +142,9 @@ namespace Nikse.SubtitleEdit
 
                 // Setup native menu
                 SetupNativeMenu(b.Instance, lifetime);
+
+                // Register Alt+Space handler for all windows (Windows-only)
+                UiUtil.RegisterWindowsSystemMenuClassHandler();
             }
 
             // Set custom font


### PR DESCRIPTION
## Summary
- Replace the 14 per-window `UiUtil.SetupWindowsSystemMenu(Window)` calls with a single class-level `KeyDown` handler on `Window`, registered once at app startup in `Program.ConfigureApplication`.
- Every top-level `Window` (current and future) now responds to Alt+Space on Windows automatically — no per-window opt-in required. No-op on macOS/Linux.
- Renames `SetupWindowsSystemMenu` to `RegisterWindowsSystemMenuClassHandler`; idempotent via a static guard.

## Test plan
- [ ] Build is clean (verified locally: 0 warnings, 0 errors).
- [ ] On Windows, Alt+Space opens the standard system menu (Move/Size/Min/Max/Close) on:
  - [ ] Main window
  - [ ] Settings, Shortcuts, Settings Import/Export
  - [ ] OCR, Binary OCR character add, NOCR character add
  - [ ] Multiple Replace, BinaryEdit, ShowImage
  - [ ] Undocked audio visualizer, undocked video player
  - [ ] ASSA Draw, ASSA Apply Advanced Effect
  - [ ] A window that previously did **not** opt in (e.g. Batch Convert, Fix Common Errors, Auto-Translate) — should now also respond to Alt+Space.
- [ ] On macOS/Linux, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)