### PR TITLE
Improve OCR cancellation handling and add llama.cpp request timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -412,3 +412,6 @@ FodyWeavers.xsd
 
 # Claude AI settings (local, not project config)
 .claude/
+
+# macOS Finder metadata
+.DS_Store

--- a/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.Serialization;
@@ -184,7 +183,7 @@ public class GoogleVisionOcr
         string content;
         try
         {
-            var result = _httpClient.PostAsync(uri, new StringContent(requestBodyString)).Result;
+            var result = await _httpClient.PostAsync(uri, new StringContent(requestBodyString), cancellationToken);
             if ((int)result.StatusCode == 400)
             {
                 throw new OcrException("API key invalid (or perhaps billing/API is not enabled)?");
@@ -202,18 +201,9 @@ public class GoogleVisionOcr
 
             content = await result.Content.ReadAsStringAsync(cancellationToken);
         }
-        catch (WebException webException)
+        catch (HttpRequestException httpException)
         {
-            var message = string.Empty;
-            if (webException.Message.Contains("(400) Bad Request"))
-            {
-                message = "API key invalid (or perhaps billing is not enabled)?";
-            }
-            else if (webException.Message.Contains("(403) Forbidden."))
-            {
-                message = "Perhaps billing is not enabled (or API key is invalid)?";
-            }
-            throw new OcrException(message, webException);
+            throw new OcrException("Error calling Cloud Vision API: " + httpException.Message, httpException);
         }
 
         return string.Join(Environment.NewLine, JsonToStringList(language, content));

--- a/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
+++ b/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
@@ -16,13 +16,13 @@ public class LlamaCppOcr
 
     public string Error { get; set; }
 
-    public LlamaCppOcr()
+    public LlamaCppOcr(int timeoutMinutes = 5)
     {
         Error = string.Empty;
         _httpClient = new HttpClient();
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-        _httpClient.Timeout = TimeSpan.FromMinutes(25);
+        _httpClient.Timeout = TimeSpan.FromMinutes(Math.Max(1, timeoutMinutes));
     }
 
     public async Task<string> Ocr(SKBitmap bitmap, string url, string model, string language, string promptTemplate, CancellationToken cancellationToken)
@@ -85,6 +85,16 @@ public class LlamaCppOcr
             }
 
             return resultText.Trim();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            Error = "Request timed out";
+            SeLogger.Error(ex, "llama.cpp OCR request timed out");
+            return string.Empty;
         }
         catch (Exception ex)
         {

--- a/src/ui/Features/Ocr/Engines/MistralOcr.cs
+++ b/src/ui/Features/Ocr/Engines/MistralOcr.cs
@@ -106,6 +106,10 @@ public class MistralOcr
 
             return finalText.Trim();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             SeLogger.Error(ex, "Error calling Mistral AI OCR");

--- a/src/ui/Features/Ocr/Engines/OllamaOcr.cs
+++ b/src/ui/Features/Ocr/Engines/OllamaOcr.cs
@@ -74,6 +74,10 @@ public class OllamaOcr
 
             return resultText.Trim();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             SeLogger.Error(ex, "Error calling Ollama for OCR");

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;
@@ -17,11 +18,13 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
 
     [ObservableProperty] private string _url;
     [ObservableProperty] private string _prompt;
+    [ObservableProperty] private int _timeoutMinutes;
 
     public LlamaCppOcrSettingsViewModel()
     {
         _url = Se.Settings.Ocr.LlamaCppUrl ?? string.Empty;
         _prompt = Se.Settings.Ocr.LlamaCppOcrPrompt ?? string.Empty;
+        _timeoutMinutes = Math.Max(1, Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
     }
 
     [RelayCommand]
@@ -41,6 +44,7 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
 
         Se.Settings.Ocr.LlamaCppUrl = Url ?? string.Empty;
         Se.Settings.Ocr.LlamaCppOcrPrompt = Prompt;
+        Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes = Math.Max(1, TimeoutMinutes);
         OkPressed = true;
         Close();
     }

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
@@ -34,6 +34,9 @@ public class LlamaCppOcrSettingsWindow : Window
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
         });
 
+        var labelTimeout = UiUtil.MakeTextBlock(Se.Language.Ocr.LlamaCppOcrTimeoutMinutes);
+        var numericTimeout = UiUtil.MakeNumericUpDownInt(1, 120, 5, 100, vm, nameof(vm.TimeoutMinutes));
+
         var labelPrompt = UiUtil.MakeTextBlock(Se.Language.General.OpenAiCompatibleSttPrompt);
         var textBoxPrompt = new TextBox
         {
@@ -64,6 +67,8 @@ public class LlamaCppOcrSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -78,10 +83,12 @@ public class LlamaCppOcrSettingsWindow : Window
 
         grid.Add(labelUrl, 0, 0);
         grid.Add(textBoxUrl, 1, 0);
-        grid.Add(labelPrompt, 2, 0);
-        grid.Add(textBoxPrompt, 3, 0);
-        grid.Add(hintPrompt, 4, 0);
-        grid.Add(buttonBar, 5, 0);
+        grid.Add(labelTimeout, 2, 0);
+        grid.Add(numericTimeout, 3, 0);
+        grid.Add(labelPrompt, 4, 0);
+        grid.Add(textBoxPrompt, 5, 0);
+        grid.Add(hintPrompt, 6, 0);
+        grid.Add(buttonBar, 7, 0);
 
         Content = grid;
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3284,34 +3284,42 @@ public partial class OcrViewModel : ObservableObject
 
         _ = Task.Run(async () =>
         {
-            for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
+            try
             {
-                var i = selectedIndices[processedIndex];
-                if (cancellationToken.IsCancellationRequested)
+                for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
                 {
-                    return;
+                    var i = selectedIndices[processedIndex];
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
+
+                    var item = OcrSubtitleItems[i];
+                    var bitmap = item.GetSkBitmap();
+
+                    SelectAndScrollToRow(i);
+
+                    var text = await ollamaOcr.Ocr(bitmap, OllamaUrl, OllamaModel, SelectedOllamaLanguage ?? "English", cancellationToken);
+                    item.Text = text;
+
+                    OcrFixLineAndSetText(i, item);
                 }
-
-                UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
-
-                var item = OcrSubtitleItems[i];
-                var bitmap = item.GetSkBitmap();
-
-                SelectAndScrollToRow(i);
-
-                var text = await ollamaOcr.Ocr(bitmap, OllamaUrl, OllamaModel, SelectedOllamaLanguage ?? "English", cancellationToken);
-                item.Text = text;
-
-                OcrFixLineAndSetText(i, item);
             }
-
-            PauseOcr();
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                PauseOcr();
+            }
         });
     }
 
     private void RunLlamaCppOcr(List<int> selectedIndices, CancellationToken cancellationToken)
     {
-        var engine = new LlamaCppOcr();
+        var engine = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
         var selectedModel = SelectedLlamaCppOcrModel?.Model;
         var prompt = Se.Settings.Ocr.LlamaCppOcrPrompt;
 
@@ -3337,28 +3345,36 @@ public partial class OcrViewModel : ObservableObject
                 modelName = "glmocr";
             }
 
-            for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
+            try
             {
-                var i = selectedIndices[processedIndex];
-                if (cancellationToken.IsCancellationRequested)
+                for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
                 {
-                    return;
+                    var i = selectedIndices[processedIndex];
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
+
+                    var item = OcrSubtitleItems[i];
+                    var bitmap = item.GetSkBitmap();
+
+                    SelectAndScrollToRow(i);
+
+                    var text = await engine.Ocr(bitmap, url, modelName, SelectedOllamaLanguage ?? "English", prompt, cancellationToken);
+                    item.Text = text;
+
+                    OcrFixLineAndSetText(i, item);
                 }
-
-                UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
-
-                var item = OcrSubtitleItems[i];
-                var bitmap = item.GetSkBitmap();
-
-                SelectAndScrollToRow(i);
-
-                var text = await engine.Ocr(bitmap, url, modelName, SelectedOllamaLanguage ?? "English", prompt, cancellationToken);
-                item.Text = text;
-
-                OcrFixLineAndSetText(i, item);
             }
-
-            PauseOcr();
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                PauseOcr();
+            }
         });
     }
 
@@ -3368,28 +3384,36 @@ public partial class OcrViewModel : ObservableObject
 
         _ = Task.Run(async () =>
         {
-            for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
+            try
             {
-                var i = selectedIndices[processedIndex];
-                if (cancellationToken.IsCancellationRequested)
+                for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
                 {
-                    return;
+                    var i = selectedIndices[processedIndex];
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
+
+                    var item = OcrSubtitleItems[i];
+                    var bitmap = item.GetSkBitmap();
+
+                    SelectAndScrollToRow(i);
+
+                    var text = await mistralOcr.Ocr(bitmap, SelectedOllamaLanguage ?? "English", cancellationToken);
+                    item.Text = text;
+
+                    OcrFixLineAndSetText(i, item);
                 }
-
-                UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
-
-                var item = OcrSubtitleItems[i];
-                var bitmap = item.GetSkBitmap();
-
-                SelectAndScrollToRow(i);
-
-                var text = await mistralOcr.Ocr(bitmap, SelectedOllamaLanguage ?? "English", cancellationToken);
-                item.Text = text;
-
-                OcrFixLineAndSetText(i, item);
             }
-
-            PauseOcr();
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                PauseOcr();
+            }
         });
     }
 
@@ -3399,28 +3423,36 @@ public partial class OcrViewModel : ObservableObject
 
         _ = Task.Run(async () =>
         {
-            for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
+            try
             {
-                var i = selectedIndices[processedIndex];
-                if (cancellationToken.IsCancellationRequested)
+                for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
                 {
-                    return;
+                    var i = selectedIndices[processedIndex];
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
+
+                    var item = OcrSubtitleItems[i];
+                    var bitmap = item.GetSkBitmap();
+
+                    SelectAndScrollToRow(i);
+
+                    var text = await engine.Ocr(bitmap, GoogleVisionApiKey, SelectedGoogleVisionLanguage?.Code ?? "en", cancellationToken);
+                    item.Text = text;
+
+                    OcrFixLineAndSetText(i, item);
                 }
-
-                UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
-
-                var item = OcrSubtitleItems[i];
-                var bitmap = item.GetSkBitmap();
-
-                SelectAndScrollToRow(i);
-
-                var text = await engine.Ocr(bitmap, GoogleVisionApiKey, SelectedGoogleVisionLanguage?.Code ?? "en", cancellationToken);
-                item.Text = text;
-
-                OcrFixLineAndSetText(i, item);
             }
-
-            PauseOcr();
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                PauseOcr();
+            }
         });
     }
 

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -95,6 +95,7 @@ public class LanguageOcr
     public string LlamaCppOcrPromptHint { get; set; }
     public string LlamaCppOcrPromptEmpty { get; set; }
     public string LlamaCppOcrPromptMissingLanguagePlaceholder { get; set; }
+    public string LlamaCppOcrTimeoutMinutes { get; set; }
     public string NOcrBinaryOcrFallbackDatabase { get; set; }
     public string NOcrBinaryOcrFallbackNone { get; set; }
     public string BinaryOcrNOcrFallbackDatabase { get; set; }
@@ -195,6 +196,7 @@ public class LanguageOcr
         LlamaCppOcrPromptHint = "Use {language} to insert the selected OCR language.";
         LlamaCppOcrPromptEmpty = "The prompt cannot be empty.";
         LlamaCppOcrPromptMissingLanguagePlaceholder = "The prompt must contain the {language} placeholder.";
+        LlamaCppOcrTimeoutMinutes = "Request timeout (minutes)";
 
         NOcrBinaryOcrFallbackDatabase = "BinaryOCR fallback database";
         NOcrBinaryOcrFallbackNone = "(none)";

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -19,6 +19,7 @@ public class SeOcr
     public string LlamaCppUrl { get; set; }
     public string LlamaCppOcrModel { get; set; }
     public string LlamaCppOcrPrompt { get; set; }
+    public int LlamaCppOcrTimeoutMinutes { get; set; }
     public string GoogleVisionApiKey { get; set; }
     public string GoogleVisionLanguage { get; set; }
     public string MistralApiKey { get; set; }
@@ -73,6 +74,7 @@ public class SeOcr
         LlamaCppUrl = "http://127.0.0.1:8080/v1/chat/completions";
         LlamaCppOcrModel = string.Empty;
         LlamaCppOcrPrompt = "Extract all text exactly as written. The language is {language}. Preserve line breaks.";
+        LlamaCppOcrTimeoutMinutes = 5;
 
         GoogleVisionApiKey = string.Empty;
         GoogleVisionLanguage = "en";


### PR DESCRIPTION
## Summary
- Cancelling an in-flight OCR request no longer logs a spurious error or overwrites the current row's text with an empty string. Applies to the llama.cpp, Ollama, Mistral, and Google Vision engines.
- `LlamaCppOcr` distinguishes a user cancellation from a request timeout, logging the latter so a stuck remote server leaves a real diagnostic instead of silently aborting the batch.
- `GoogleVisionOcr` is now properly async (`await` replaces `.Result`) with the cancellation token bound to `PostAsync`; the unreachable `WebException` catch is replaced with `HttpRequestException`.
- New configurable `LlamaCppOcrTimeoutMinutes` setting (default 5, exposed in the llama.cpp OCR settings window, range 1–120) replaces the hardcoded 25-minute timeout that made remote-server stalls look like freezes (refs #10951).
- Adds `.DS_Store` to `.gitignore`.

## Test plan
- [ ] Start an OCR run with the llama.cpp engine, hit Cancel mid-request — the current row keeps its original text (no blank overwrite), and no "Error calling llama.cpp for OCR" appears in the log
- [ ] Repeat the cancel test with Ollama, Mistral, and Google Vision engines
- [ ] Open the llama.cpp OCR settings window — the new "Request timeout (minutes)" field shows, defaults to 5, persists across OK/Cancel
- [ ] Set timeout to 1 minute and point llama.cpp OCR at an unresponsive endpoint — the request fails fast and the log shows "llama.cpp OCR request timed out" instead of hanging for 25 min
- [ ] Run a normal Google Vision OCR happy-path — confirm async refactor didn't regress it
- [ ] On macOS, confirm `.DS_Store` no longer appears in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)