### PR TITLE
Add Linux ARM64 (aarch64) support to release build and downloads

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -627,9 +627,23 @@ jobs:
           # Native PDBs from the SkiaSharp runtime NuGet aren't suppressed by -p:DebugType=none.
           find ./publish/linux-x64 -name "*.pdb" -delete
 
-      - name: Create Linux TAR package
+      - name: Publish Linux ARM64 app
+        run: |
+          dotnet publish src/ui/UI.csproj -c ${{ inputs.build_configuration }} -r linux-arm64 --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:DebugSymbols=false \
+            -p:DebugType=none \
+            -p:Version="$APP_VER_FULL" \
+            -p:FileVersion="$APP_VER_FULL" \
+            -p:InformationalVersion="$APP_VER_DISPLAY" \
+            -o ./publish/linux-arm64
+
+          find ./publish/linux-arm64 -name "*.pdb" -delete
+
+      - name: Create Linux TAR packages
         run: |
           cd ./publish/linux-x64 && tar -czf ../../SubtitleEdit-Linux-x64.tar.gz . && cd ../..
+          cd ./publish/linux-arm64 && tar -czf ../../SubtitleEdit-Linux-ARM64.tar.gz . && cd ../..
 
       - name: Upload Linux x64 artifact
         uses: actions/upload-artifact@v5
@@ -637,11 +651,19 @@ jobs:
           name: se-linux-x64
           path: ./publish/linux-x64/
 
-      - name: Upload Linux TAR package
+      - name: Upload Linux ARM64 artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: se-linux-arm64
+          path: ./publish/linux-arm64/
+
+      - name: Upload Linux TAR packages
         uses: actions/upload-artifact@v5
         with:
           name: linux-tar-package
-          path: ./SubtitleEdit-Linux-x64.tar.gz
+          path: |
+            ./SubtitleEdit-Linux-x64.tar.gz
+            ./SubtitleEdit-Linux-ARM64.tar.gz
 
   regenerate-flatpak-nuget-sources:
     runs-on: ubuntu-latest
@@ -800,6 +822,7 @@ jobs:
             - **macOS ARM64 (Apple Silicon - M1/M2/M3/M4 architecture):** [SubtitleEdit-macOS-ARM64.dmg](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-macOS-ARM64.dmg)
             - **macOS x64 (Intel 64-bit):** [SubtitleEdit-macOS-x64.dmg](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-macOS-x64.dmg)
             - **Linux x64 (tarball):** [SubtitleEdit-Linux-x64.tar.gz](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-Linux-x64.tar.gz)
+            - **Linux ARM64 (tarball, aarch64):** [SubtitleEdit-Linux-ARM64.tar.gz](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-Linux-ARM64.tar.gz)
             - **Linux x64 (Flatpak):** [SubtitleEdit-linux-x64.flatpak](https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/SubtitleEdit-linux-x64.flatpak)
       
             ### Installation
@@ -821,4 +844,5 @@ jobs:
             ./release-assets/SubtitleEdit-macOS-ARM64.dmg
             ./release-assets/SubtitleEdit-macOS-x64.dmg
             ./release-assets/SubtitleEdit-Linux-x64.tar.gz
+            ./release-assets/SubtitleEdit-Linux-ARM64.tar.gz
             ./release-assets/SubtitleEdit-linux-x64.flatpak

--- a/src/ui/Logic/Download/ChatLlmDownloadService.cs
+++ b/src/ui/Logic/Download/ChatLlmDownloadService.cs
@@ -56,6 +56,11 @@ public class ChatLlmDownloadService : IChatLlmDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("ChatLLM is not available for Linux ARM64.");
+            }
+
             return LinuxUrl;
         }
 

--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -26,6 +26,7 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
     private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.6/crispasr-windows-x86_64-cpu-legacy.zip";
     private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.6/crispasr-macos.tar.gz";
     private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.6/crispasr-linux-x86_64.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.6/crispasr-linux-arm64.tar.gz";
 
     public CrispAsrDownloadService(HttpClient httpClient)
     {
@@ -66,7 +67,7 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return LinuxUrl;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -56,6 +56,8 @@ public static class DownloadHashManager
         public const string WindowsCuda = "LlamaCpp.Windows.Cuda";
         public const string LinuxCpu = "LlamaCpp.Linux.Cpu";
         public const string LinuxVulkan = "LlamaCpp.Linux.Vulkan";
+        public const string LinuxArm64Cpu = "LlamaCpp.Linux.Arm64.Cpu";
+        public const string LinuxArm64Vulkan = "LlamaCpp.Linux.Arm64.Vulkan";
         public const string MacOsArm64 = "LlamaCpp.MacOs.Arm64";
         public const string MacOsX64 = "LlamaCpp.MacOs.X64";
 
@@ -63,9 +65,10 @@ public static class DownloadHashManager
         // version when no sidecar is present (e.g. installs from older SE builds). The Windows
         // CPU/Vulkan/CUDA builds ship an identical llama-server.exe (the backend lives in the
         // ggml-*.dll), as do the two Linux builds, so there is a single executable key per OS
-        // (plus per-arch on macOS) — enough to tell "outdated" from "up to date".
+        // (plus per-arch on macOS / Linux) — enough to tell "outdated" from "up to date".
         public const string WindowsExecutable = "LlamaCpp.Windows.Executable";
         public const string LinuxExecutable = "LlamaCpp.Linux.Executable";
+        public const string LinuxArm64Executable = "LlamaCpp.Linux.Arm64.Executable";
         public const string MacOsArm64Executable = "LlamaCpp.MacOs.Arm64.Executable";
         public const string MacOsX64Executable = "LlamaCpp.MacOs.X64.Executable";
     }
@@ -251,6 +254,14 @@ public static class DownloadHashManager
                 "d5787fa775220b3c0f896947885fa0f3dedddbb5388bd68603376a2a97252e72", // b9174 (current download URL)
                 "b4a28b06d973f662b9465b6e0e786d8991cdab4d24101f5d88b0b8f688a97aea", // b9145
             },
+            [LlamaCpp.LinuxArm64Cpu] = new[]
+            {
+                "7ad708abbb58a6dd5a148eed24d9d2ccf155f57cde8cf3c0e44f73d0d2b95c6d", // b9174 (current download URL)
+            },
+            [LlamaCpp.LinuxArm64Vulkan] = new[]
+            {
+                "84adac128b781f495804fb84d0c27d27e21cde6da03338b9ce0931ee324304f2", // b9174 (current download URL)
+            },
             [LlamaCpp.MacOsArm64] = new[]
             {
                 "39406deaac6083000446530e68194b77bb64c64ecf0533040a49d8e7cfceb363", // b9174 (current download URL)
@@ -272,6 +283,10 @@ public static class DownloadHashManager
             {
                 "fc6322995eafb9146db0454acb2b2d3f14244fa3eecb62ba742c129f8b4f5de1", // b9174 (current download URL)
                 "855bd9540073d9f020b9b77ad5866ea3ea74ca570ea3fac486da8676f0eb6933", // b9145
+            },
+            [LlamaCpp.LinuxArm64Executable] = new[]
+            {
+                "a39b9d8200591e3e16f14b933f97ba0856e464097e0ba79cd3fb101313bdde96", // b9174 (current download URL)
             },
             [LlamaCpp.MacOsArm64Executable] = new[]
             {
@@ -659,6 +674,11 @@ public static class DownloadHashManager
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                return variant == "vulkan" ? LlamaCpp.LinuxArm64Vulkan : LlamaCpp.LinuxArm64Cpu;
+            }
+
             return variant == "vulkan" ? LlamaCpp.LinuxVulkan : LlamaCpp.LinuxCpu;
         }
 
@@ -702,7 +722,9 @@ public static class DownloadHashManager
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return LlamaCpp.LinuxExecutable;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? LlamaCpp.LinuxArm64Executable
+                : LlamaCpp.LinuxExecutable;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/ui/Logic/Download/GoogleLensOcrDownloadService.cs
+++ b/src/ui/Logic/Download/GoogleLensOcrDownloadService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -38,6 +39,11 @@ public class GoogleLensOcrDownloadService(HttpClient httpClient) : IGoogleLensOc
 
         if (OperatingSystem.IsLinux())
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("Google Lens OCR is not available for Linux ARM64.");
+            }
+
             return LinuxUrl;
         }
 

--- a/src/ui/Logic/Download/KokoroTtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/KokoroTtsCppDownloadService.cs
@@ -17,9 +17,10 @@ public class KokoroTtsCppDownloadService : IKokoroTtsCppDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsUrl = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.1/kokoro-tts-server-v0.1.1-windows-x64.zip";
-    private const string MacUrl     = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.1/kokoro-tts-server-v0.1.1-macos-arm64.zip";
-    private const string LinuxUrl   = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.1/kokoro-tts-server-v0.1.1-linux-x64.zip";
+    private const string WindowsUrl  = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.2/kokoro-tts-server-v0.1.2-windows-x64.zip";
+    private const string MacUrl      = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.2/kokoro-tts-server-v0.1.2-macos-arm64.zip";
+    private const string LinuxUrl    = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.2/kokoro-tts-server-v0.1.2-linux-x64.zip";
+    private const string LinuxArmUrl = "https://github.com/niksedk/kokoro.cpp/releases/download/v0.1.2/kokoro-tts-server-v0.1.2-linux-arm64.zip";
 
     private const string TtsModelFileName    = "kokoro-v1.1-zh.onnx";
     private const string VoicesModelFileName = "voices-v1.1-zh.bin";
@@ -68,7 +69,7 @@ public class KokoroTtsCppDownloadService : IKokoroTtsCppDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return LinuxUrl;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/ui/Logic/Download/LlamaCppDownloadService.cs
+++ b/src/ui/Logic/Download/LlamaCppDownloadService.cs
@@ -60,6 +60,18 @@ public class LlamaCppDownloadService(HttpClient httpClient) : ILlamaCppDownloadS
 
         if (OperatingSystem.IsLinux())
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                if (variant == VariantCuda)
+                {
+                    throw new PlatformNotSupportedException("llama.cpp CUDA build is not available for Linux ARM64.");
+                }
+
+                return variant == VariantVulkan
+                    ? BaseUrl + "llama-" + Version + "-bin-ubuntu-vulkan-arm64.tar.gz"
+                    : BaseUrl + "llama-" + Version + "-bin-ubuntu-arm64.tar.gz";
+            }
+
             return variant == VariantVulkan
                 ? BaseUrl + "llama-" + Version + "-bin-ubuntu-vulkan-x64.tar.gz"
                 : BaseUrl + "llama-" + Version + "-bin-ubuntu-x64.tar.gz";

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -95,6 +95,11 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("OmniVoice is not available for Linux ARM64.");
+            }
+
             return LinuxUrl;
         }
 

--- a/src/ui/Logic/Download/PaddleOcrDownloadService.cs
+++ b/src/ui/Logic/Download/PaddleOcrDownloadService.cs
@@ -39,6 +39,11 @@ public class PaddleOcrDownloadService : IPaddleOcrDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("PaddleOCR is not available for Linux ARM64.");
+            }
+
             url = DownloadLinuxEngineCpuUrl;
         }
 
@@ -51,6 +56,11 @@ public class PaddleOcrDownloadService : IPaddleOcrDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("PaddleOCR is not available for Linux ARM64.");
+            }
+
             url = DownloadLinuxEngineGpuUrl;
         }
 

--- a/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
@@ -39,6 +39,11 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("Qwen3 ASR is not available for Linux ARM64.");
+            }
+
             return LinuxUrl;
         }
 

--- a/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
@@ -22,10 +22,11 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
     public const string WindowsVariantVulkan = "vulkan";
     public const string WindowsVariantCpu = "cpu";
 
-    private const string WindowsVulkanUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.2/qwen3-tts-server-v0.4.2-windows-vulkan-x64.zip";
-    private const string WindowsCpuUrl    = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.2/qwen3-tts-server-v0.4.2-windows-cpu-x64.zip";
-    private const string MacUrl           = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.2/qwen3-tts-server-v0.4.2-macos-metal-arm64.zip";
-    private const string LinuxUrl         = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.2/qwen3-tts-server-v0.4.2-linux-vulkan-x64.zip";
+    private const string WindowsVulkanUrl = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.3/qwen3-tts-server-v0.4.3-windows-vulkan-x64.zip";
+    private const string WindowsCpuUrl    = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.3/qwen3-tts-server-v0.4.3-windows-cpu-x64.zip";
+    private const string MacUrl           = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.3/qwen3-tts-server-v0.4.3-macos-metal-arm64.zip";
+    private const string LinuxUrl         = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.3/qwen3-tts-server-v0.4.3-linux-vulkan-x64.zip";
+    private const string LinuxArmUrl      = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/v0.4.3/qwen3-tts-server-v0.4.3-linux-arm64.zip";
 
     private const string TokenizerModelFileName = "qwen3-tts-tokenizer-q8_0.gguf";
     private const string TokenizerModelUrl = "https://huggingface.co/koboldcpp/tts/resolve/main/qwen3-tts-tokenizer-q8_0.gguf";
@@ -92,7 +93,7 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return LinuxUrl;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -80,6 +81,7 @@ public class TtsDownloadService : ITtsDownloadService
     private const string WindowsPiperUrl = "https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_windows_amd64.zip";
     private const string MacPiperUrl = "https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_macos_x64.tar.gz";
     private const string LinuxPiperUrl = "https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_x86_64.tar.gz";
+    private const string LinuxPiperArmUrl = "https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_aarch64.tar.gz";
 
     public TtsDownloadService(HttpClient httpClient)
     {
@@ -97,11 +99,11 @@ public class TtsDownloadService : ITtsDownloadService
         var url = WindowsPiperUrl;
         if (OperatingSystem.IsLinux())
         {
-            url = LinuxPiperUrl;
+            url = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxPiperArmUrl : LinuxPiperUrl;
         }
         else if (OperatingSystem.IsMacOS())
         {
-            url = MacPiperUrl; 
+            url = MacPiperUrl;
         }
 
         await DownloadHelper.DownloadFileAsync(_httpClient, url, stream, progress, cancellationToken);

--- a/src/ui/Logic/Download/WhisperDownloadService.cs
+++ b/src/ui/Logic/Download/WhisperDownloadService.cs
@@ -76,6 +76,11 @@ public class WhisperDownloadService : IWhisperDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("Faster-Whisper-XXL is not available for Linux ARM64.");
+            }
+
             url = DownloadUrlPurfviewFasterWhisperXxlLinux;
         }
 
@@ -141,6 +146,11 @@ public class WhisperDownloadService : IWhisperDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("whisper.cpp Vulkan build is not available for Linux ARM64.");
+            }
+
             return LinuxUrl;
         }
 
@@ -169,6 +179,11 @@ public class WhisperDownloadService : IWhisperDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException("whisper.cpp CUDA build is not available for Linux ARM64.");
+            }
+
             return LinuxUrlCuBlass;
         }
 

--- a/src/ui/Logic/Download/YtDlpDownloadService.cs
+++ b/src/ui/Logic/Download/YtDlpDownloadService.cs
@@ -18,6 +18,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
     private readonly HttpClient _httpClient;
     private const string WindowsUrl = "https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp.exe";
     private const string LinuxUrl = "https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux";
+    private const string LinuxArmUrl = "https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux_aarch64";
     private const string MacUrl = "https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_macos";
 
     public YtDlpDownloadService(HttpClient httpClient)
@@ -34,7 +35,9 @@ public class YtDlpDownloadService : IYtDlpDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return Path.Combine(Se.DataFolder, "yt-dlp_linux");
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? Path.Combine(Se.DataFolder, "yt-dlp_linux_aarch64")
+                : Path.Combine(Se.DataFolder, "yt-dlp_linux");
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -53,7 +56,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return LinuxUrl;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))


### PR DESCRIPTION
## Summary
- **build-ui.yml**: cross-publishes a self-contained `linux-arm64` single-file binary from the existing `ubuntu-latest` runner, packages it as `SubtitleEdit-Linux-ARM64.tar.gz`, and adds it to the release assets + release body alongside the `linux-x64` tarball. No new runner needed.
- **Download services with upstream ARM64 builds** now pick the aarch64 URL on `Architecture.Arm64` instead of silently fetching the x86_64 archive:
  - YtDlp → `yt-dlp_linux_aarch64`
  - CrispASR → `crispasr-linux-arm64.tar.gz`
  - Piper TTS → `piper_linux_aarch64.tar.gz`
  - llama.cpp → `llama-b9174-bin-ubuntu-arm64.tar.gz` (CPU) / `…-vulkan-arm64.tar.gz` (Vulkan). CUDA throws — upstream has no arm64 CUDA build.
  - Kokoro TTS → bumped to v0.1.2 to pick up the new `kokoro-tts-server-v0.1.2-linux-arm64.zip`
  - Qwen3 TTS → bumped to v0.4.3 to pick up the new `qwen3-tts-server-v0.4.3-linux-arm64.zip`
- **Download services with no upstream ARM64 build** now throw `PlatformNotSupportedException` with a feature-specific message on Linux ARM64 instead of downloading an x86_64 archive that won't execute: PaddleOCR, Google Lens OCR, Faster-Whisper-XXL, whisper.cpp Vulkan and CUDA, Qwen3 ASR, ChatLLM, OmniVoice.
- **DownloadHashManager**: registers new `LinuxArm64Cpu` / `LinuxArm64Vulkan` / `LinuxArm64Executable` keys with SHA-256 hashes for the llama.cpp b9174 ARM64 archives. Without this the install-hash sidecar wrote ARM64 hashes under the x64 keys, so the auto-translate view always reported `Unknown` and ARM64 users would never get update prompts.

Refs #10977 (request for Linux ARM64 builds). Leaves the issue open since this is the first step — several engines (PaddleOCR, Faster-Whisper-XXL, whisper.cpp, Qwen3 ASR, ChatLLM, OmniVoice) are still gated off on ARM64 pending upstream builds.

## Test plan
- [ ] Trigger the **Build and release UI** workflow → verify `SubtitleEdit-Linux-ARM64.tar.gz` appears in the artifacts and release assets
- [ ] On a Linux ARM64 machine, extract the new tarball and confirm the app launches
- [ ] On Linux ARM64, open **Video → Auto-translate → llama.cpp** → download the CPU engine → confirm the right archive (`…-ubuntu-arm64.tar.gz`) is fetched, the install succeeds, and the `.installed.sha256` sidecar holds the `LlamaCpp.Linux.Arm64.Cpu` key
- [ ] Repeat with the Vulkan llama.cpp engine variant; confirm CUDA variant shows a clean "not available for Linux ARM64" error rather than a broken download
- [ ] On Linux ARM64, install Piper TTS, yt-dlp, CrispASR, Kokoro TTS, Qwen3 TTS → confirm each downloads the aarch64 archive and runs
- [ ] On Linux ARM64, try to install one of the gated engines (e.g. PaddleOCR) → confirm clean `PlatformNotSupportedException` surfaces in the UI rather than a silent x86_64 download
- [ ] On Linux x64, smoke-test the same engines to confirm no regression on the existing platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)