### PR TITLE
Preserve original subtitle format on save after auto-translate

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1808,7 +1808,7 @@ public partial class MainViewModel :
         var saved = await SaveSubtitle();
         var savedOriginal = false;
 
-        if (ShowColumnOriginalText)
+        if (ShowColumnOriginalText && _changeSubtitleHashOriginal != GetFastHashOriginal())
         {
             savedOriginal = await SaveSubtitleOriginal();
         }
@@ -4063,6 +4063,8 @@ public partial class MainViewModel :
         }
 
         _subtitleFileNameOriginal = _subtitleFileName;
+        _subtitleOriginal ??= new Subtitle();
+        _subtitleOriginal.OriginalFormat = _subtitle.OriginalFormat ?? SelectedSubtitleFormat;
         _subtitleFileName = null;
         _converted = true;
         _shortcutManager.ClearKeys();
@@ -6181,6 +6183,8 @@ public partial class MainViewModel :
 
         var targetLanguageCode = result.SelectedTargetLanguage?.TwoLetterIsoLanguageName;
         _subtitleFileNameOriginal = _subtitleFileName;
+        _subtitleOriginal ??= new Subtitle();
+        _subtitleOriginal.OriginalFormat = _subtitle.OriginalFormat ?? SelectedSubtitleFormat;
         if (!string.IsNullOrEmpty(_subtitleFileName) && !string.IsNullOrEmpty(targetLanguageCode))
         {
             var directory = Path.GetDirectoryName(_subtitleFileName) ?? string.Empty;
@@ -6310,6 +6314,8 @@ public partial class MainViewModel :
         }
 
         _subtitleFileNameOriginal = _subtitleFileName;
+        _subtitleOriginal ??= new Subtitle();
+        _subtitleOriginal.OriginalFormat = _subtitle.OriginalFormat ?? SelectedSubtitleFormat;
         _subtitleFileName = string.Empty;
         ShowColumnOriginalText = true;
         AutoFitColumns();
@@ -12540,17 +12546,13 @@ public partial class MainViewModel :
             return false;
         }
 
-        if (string.IsNullOrEmpty(_subtitleFileNameOriginal) || _converted)
+        if (string.IsNullOrEmpty(_subtitleFileNameOriginal))
         {
             return await SaveSubtitleOriginalAs();
         }
 
-        if (_lastOpenSaveFormat == null || _lastOpenSaveFormat.Name != SelectedSubtitleFormat.Name)
-        {
-            return await SaveSubtitleOriginalAs();
-        }
-
-        var text = GetUpdateSubtitleOriginal(true).ToText(SelectedSubtitleFormat);
+        var originalFormat = _subtitleOriginal?.OriginalFormat ?? SelectedSubtitleFormat;
+        var text = GetUpdateSubtitleOriginal(true).ToText(originalFormat);
 
         try
         {
@@ -12576,7 +12578,6 @@ public partial class MainViewModel :
         }
 
         _changeSubtitleHashOriginal = GetFastHashOriginal();
-        _lastOpenSaveFormat = SelectedSubtitleFormat;
         return true;
     }
 
@@ -12596,11 +12597,12 @@ public partial class MainViewModel :
     {
         _subtitleOriginal ??= new Subtitle();
         _subtitleOriginal.OriginalFormat ??= SelectedSubtitleFormat;
+        var originalFormat = _subtitleOriginal.OriginalFormat ?? SelectedSubtitleFormat;
 
         _subtitleOriginal.Paragraphs.Clear();
         foreach (var line in Subtitles)
         {
-            var p = line.ToParagraphOriginal(SelectedSubtitleFormat);
+            var p = line.ToParagraphOriginal(originalFormat);
             _subtitleOriginal.Paragraphs.Add(p);
         }
 


### PR DESCRIPTION
## Summary
- Fixes the remaining bug in #10893 where, after auto-translating `something.fr.vtt` to English and saving the translation in a new format (e.g. "WebVTT with numbers"), the original `something.fr.vtt` (or `.fr.srt`) was silently overwritten on disk in that same format — even though the title bar showed it as unchanged.
- Captures the original subtitle's format (`_subtitleOriginal.OriginalFormat`) at the point where the main subtitle becomes the "original" (auto-translate, copy/paste translate, "make empty translation"), and uses that format when writing the original back to disk instead of `SelectedSubtitleFormat`.
- Adds a dirty check in `CommandFileSave` so an untouched original file is no longer rewritten on disk.

## Root cause
`SaveSubtitleOriginal` / `GetUpdateSubtitleOriginal` serialized the original using `SelectedSubtitleFormat`. After the user picked a new format in Save As for the translation, `SetSubtitleFormat` had already mutated `SelectedSubtitleFormat` to the new format, so the original was written in the wrong format. The guard `_lastOpenSaveFormat.Name != SelectedSubtitleFormat.Name` was also broken because both names had just been set to the new format.

## Test plan
- [ ] Open `something.fr.vtt`, auto-translate to English, Save as `something.en.vtt` in "WebVTT with numbers" — confirm `something.fr.vtt` is **not** modified on disk (timestamp unchanged, content intact in plain WebVTT format).
- [ ] Same flow with `something.fr.srt` — confirm `.srt` content/timestamps remain SubRip and the file is not touched.
- [ ] Auto-translate, then edit a cell in the Original Text column, then Save — confirm the original file IS saved, in its original format (WebVTT stays WebVTT, SRT stays SRT).
- [ ] File → Open, File → Open original (SRT), edit original, Save — confirm original saves in SRT.
- [ ] Regular save of a non-translation subtitle still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)