### PR TITLE
Respect Apply checkbox in Fix Netflix errors

### DIFF
--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsViewModel.cs
@@ -181,7 +181,7 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
         {
             var p = _subtitle.Paragraphs[index];
             var fixedParagraph = Fixes.FirstOrDefault(ri => ri.Index == index);
-            if (fixedParagraph != null)
+            if (fixedParagraph != null && fixedParagraph.Apply)
             {
                 p.Text = fixedParagraph.After;
             }


### PR DESCRIPTION
## Summary
- `FixNetflixErrorsViewModel.Ok()` applied every queued fix unconditionally, ignoring the per-row `Apply` checkbox. Unchecking a fix had no effect.
- Added the missing `&& fixedParagraph.Apply` guard so only checked fixes are applied.

Fixes #10981

## Test plan
- [ ] Run a Netflix quality check on a subtitle that produces multiple fixable issues.
- [ ] Uncheck one or more rows in the result list and confirm those paragraphs are left untouched after pressing OK.
- [ ] Confirm checked rows are still applied as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)