### PR TITLE
Add drag-and-drop area to TTS voice import window

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
@@ -9,6 +10,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,6 +21,9 @@ public partial class VoiceSettingsViewModel : ObservableObject
 {
     [ObservableProperty] private string _voiceTestText;
     [ObservableProperty] private bool _isImportVoiceVisible;
+    [ObservableProperty] private bool _isDragOver;
+
+    private static readonly string[] SupportedAudioExtensions = { ".wav", ".mp3" };
 
     private ITtsEngine? _engine;
     private readonly IFileHelper _fileHelper;
@@ -55,6 +60,16 @@ public partial class VoiceSettingsViewModel : ObservableObject
 
         var fileName = await _fileHelper.PickOpenFile(Window!, "Open audio file (for clone)", Se.Language.General.AudioFiles, "*.wav;*.mp3");
         if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        await ImportVoiceFromFileAsync(fileName);
+    }
+
+    private async Task ImportVoiceFromFileAsync(string fileName)
+    {
+        if (Window == null || _engine == null)
         {
             return;
         }
@@ -103,6 +118,73 @@ public partial class VoiceSettingsViewModel : ObservableObject
             await MessageBox.Show(Window, Se.Language.Video.TextToSpeech.VoiceImportSuccessTitle, string.Format(Se.Language.Video.TextToSpeech.VoiceXImported, fileNameOnly));
             RefreshVoices = true;
         }
+    }
+
+    internal void OnDragOver(object? sender, DragEventArgs e)
+    {
+        if (!IsImportVoiceVisible)
+        {
+            e.DragEffects = DragDropEffects.None;
+            IsDragOver = false;
+            e.Handled = true;
+            return;
+        }
+
+        if (e.DataTransfer.Contains(DataFormat.File) && HasSupportedAudioFile(e))
+        {
+            e.DragEffects = DragDropEffects.Copy;
+            IsDragOver = true;
+        }
+        else
+        {
+            e.DragEffects = DragDropEffects.None;
+            IsDragOver = false;
+        }
+
+        e.Handled = true;
+    }
+
+    internal void OnDragLeave(object? sender, DragEventArgs e)
+    {
+        IsDragOver = false;
+    }
+
+    internal void OnDrop(object? sender, DragEventArgs e)
+    {
+        IsDragOver = false;
+
+        if (!IsImportVoiceVisible || !e.DataTransfer.Contains(DataFormat.File))
+        {
+            return;
+        }
+
+        var fileName = e.DataTransfer.TryGetFiles()?
+            .Select(f => f.Path.LocalPath)
+            .FirstOrDefault(IsSupportedAudioFile);
+
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(async () => await ImportVoiceFromFileAsync(fileName));
+    }
+
+    private static bool HasSupportedAudioFile(DragEventArgs e)
+    {
+        var files = e.DataTransfer.TryGetFiles();
+        return files != null && files.Any(f => IsSupportedAudioFile(f.Path.LocalPath));
+    }
+
+    private static bool IsSupportedAudioFile(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return false;
+        }
+
+        var ext = Path.GetExtension(fileName);
+        return SupportedAudioExtensions.Any(s => string.Equals(s, ext, StringComparison.OrdinalIgnoreCase));
     }
 
     private static string? TryReadSiblingTranscript(string audioFileName)

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsWindow.cs
@@ -1,14 +1,24 @@
+using Avalonia;
+using Avalonia.Collections;
 using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Optris.Icons.Avalonia;
+using System.ComponentModel;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceSettings;
 
 public class VoiceSettingsWindow : Window
 {
     private readonly VoiceSettingsViewModel _vm;
+    private Border? _dropBorder;
+    private Rectangle? _dropDashRect;
+    private Icon? _dropIcon;
 
     public VoiceSettingsWindow(VoiceSettingsViewModel vm)
     {
@@ -29,6 +39,8 @@ public class VoiceSettingsWindow : Window
 
         var textBox = UiUtil.MakeTextBox(250, vm, nameof(vm.VoiceTestText));
 
+        var dropArea = BuildDropArea(vm);
+
         var buttonImport = UiUtil.MakeButton(Se.Language.Video.TextToSpeech.ImportVoiceDotDotDot, vm.ImportVoiceCommand).WithBindIsVisible(nameof(vm.IsImportVoiceVisible));
         var buttonRefresh = UiUtil.MakeButton(Se.Language.Video.TextToSpeech.RefreshVoices, vm.RefreshVoiceListCommand);
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
@@ -39,6 +51,7 @@ public class VoiceSettingsWindow : Window
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -56,11 +69,124 @@ public class VoiceSettingsWindow : Window
 
         grid.Add(label, 0, 0);
         grid.Add(textBox, 1, 0);
-        grid.Add(panelButtons, 2, 0);
+        grid.Add(dropArea, 2, 0);
+        grid.Add(panelButtons, 3, 0);
 
         Content = grid;
 
+        vm.PropertyChanged += OnViewModelPropertyChanged;
+        Closed += (_, _) => vm.PropertyChanged -= OnViewModelPropertyChanged;
+        ApplyDropVisualState(vm.IsDragOver);
+
         Activated += delegate { textBox.Focus(); }; // hack to make OnKeyDown work
+    }
+
+    private Control BuildDropArea(VoiceSettingsViewModel vm)
+    {
+        var icon = new Icon
+        {
+            Value = IconNames.Import,
+            FontSize = 32,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Foreground = UiUtil.GetTextColor(0.55d),
+        };
+        _dropIcon = icon;
+
+        var primaryText = new TextBlock
+        {
+            Text = Se.Language.Video.TextToSpeech.DropAudioFileHereToImportVoice,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            TextAlignment = TextAlignment.Center,
+            Foreground = UiUtil.GetTextColor(0.8d),
+        };
+
+        var hintText = new TextBlock
+        {
+            Text = Se.Language.Video.TextToSpeech.DropAudioFileHereHint,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            TextAlignment = TextAlignment.Center,
+            FontSize = 11,
+            Foreground = UiUtil.GetTextColor(0.5d),
+        };
+
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 8,
+            Margin = new Thickness(24, 18),
+            Children = { icon, primaryText, hintText },
+        };
+
+        var dashRect = new Rectangle
+        {
+            Stroke = UiUtil.GetTextColor(0.35d),
+            StrokeThickness = 1.5,
+            StrokeDashArray = new AvaloniaList<double> { 4, 3 },
+            RadiusX = 8,
+            RadiusY = 8,
+            IsHitTestVisible = false,
+        };
+        _dropDashRect = dashRect;
+
+        var inner = new Grid
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Children = { dashRect, content },
+        };
+
+        var border = new Border
+        {
+            Background = Brushes.Transparent,
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(16),
+            MinHeight = 96,
+            Child = inner,
+        };
+        _dropBorder = border;
+
+        DragDrop.SetAllowDrop(border, true);
+        border.AddHandler(DragDrop.DragOverEvent, vm.OnDragOver, RoutingStrategies.Bubble);
+        border.AddHandler(DragDrop.DragLeaveEvent, vm.OnDragLeave, RoutingStrategies.Bubble);
+        border.AddHandler(DragDrop.DropEvent, vm.OnDrop, RoutingStrategies.Bubble);
+
+        border.WithBindIsVisible(nameof(vm.IsImportVoiceVisible));
+
+        return border;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(VoiceSettingsViewModel.IsDragOver))
+        {
+            ApplyDropVisualState(_vm.IsDragOver);
+        }
+    }
+
+    private void ApplyDropVisualState(bool isDragOver)
+    {
+        if (_dropBorder == null || _dropDashRect == null || _dropIcon == null)
+        {
+            return;
+        }
+
+        if (isDragOver)
+        {
+            var accent = new SolidColorBrush(Color.FromRgb(0x2E, 0x8B, 0xC0));
+            _dropDashRect.Stroke = accent;
+            _dropDashRect.StrokeThickness = 2.0;
+            _dropIcon.Foreground = accent;
+            _dropBorder.Background = new SolidColorBrush(Color.FromArgb(0x22, 0x2E, 0x8B, 0xC0));
+        }
+        else
+        {
+            _dropDashRect.Stroke = UiUtil.GetTextColor(0.35d);
+            _dropDashRect.StrokeThickness = 1.5;
+            _dropIcon.Foreground = UiUtil.GetTextColor(0.55d);
+            _dropBorder.Background = Brushes.Transparent;
+        }
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -29,6 +29,8 @@ public class LanguageTextToSpeech
     public string ImportVoiceDotDotDot { get; set; }
     public string VoiceImportSuccessTitle { get; set; }
     public string VoiceXImported { get; set; }
+    public string DropAudioFileHereToImportVoice { get; set; }
+    public string DropAudioFileHereHint { get; set; }
     public string VoiceCloneTranscriptTitle { get; set; }
     public string UseSpeechToTextDotDotDot { get; set; }
     public string AdvancedTtsSettings { get; set; }
@@ -81,6 +83,8 @@ public class LanguageTextToSpeech
         ImportVoiceDotDotDot = "Import voice...";
         VoiceImportSuccessTitle = "Voice imported";
         VoiceXImported = "Voice '{0}' imported successfully";
+        DropAudioFileHereToImportVoice = "Drop audio file here to import voice";
+        DropAudioFileHereHint = ".wav or .mp3";
         VoiceCloneTranscriptTitle = "Enter transcript of the audio (required for voice cloning)";
         UseSpeechToTextDotDotDot = "Use speech-to-text...";
         AdvancedTtsSettings = "Advanced TTS settings";


### PR DESCRIPTION
## Summary
- Adds a dashed drop zone to the TTS voice settings window so users can drag an audio file straight in instead of using the file picker.
- Only shown for engines that support voice import (Qwen3, Chatterbox, OmniVoice) and only accepts `.wav` / `.mp3`.
- The existing "Import voice..." button is kept as an explicit affordance.

## Test plan
- [ ] Open TTS voice settings for a supported engine (e.g. Qwen3) and confirm the drop area appears below the sample-text field.
- [ ] Drop a `.wav` / `.mp3` file into the area and confirm the voice is imported.
- [ ] Drag a non-audio file in and confirm the cursor shows "no drop" and nothing is imported.
- [ ] Open the window for an engine that does not support import and confirm the drop area is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)