### PR TITLE
Add workflow_dispatch trigger to stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: "Close stale issues"
 on:
   schedule:
     - cron: '0 0 * * 2'
+  workflow_dispatch:
 
 jobs:
   stale:


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` trigger to the stale workflow so it can be kicked off on demand instead of only on the weekly Tuesday cron.

## Test plan
- [ ] After merge, run the workflow manually via `gh workflow run stale.yml` (or the Actions tab) and confirm it executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)