### PR TITLE
Bump stale workflow operations-per-run to 500

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,4 +26,4 @@ jobs:
           # Default is 30, which only covers ~24 issues per run — far less than the
           # current ~400 open issues, so old issues never get reached. Bump it so a
           # single run can drain the backlog.
-          operations-per-run: 300
+          operations-per-run: 500


### PR DESCRIPTION
## Summary
- First manual run after the 300 bump still hit the cap (processed 95 issues, exited with "No more operations left!"). Bump to 500 to chew through more of the ~410-issue backlog per run.

## Test plan
- [ ] Trigger the workflow after merge and confirm more issues are processed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)