### PR TITLE
Fix Import Plain Text align-button label to "Speech to text"

### DIFF
--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
@@ -67,7 +67,7 @@ public class ImportPlainTextWindow : Window
 
         var labelNumberOfSubtitles = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.NumberOfSubtitles)).WithAlignmentTop();
 
-        var buttonAlignViaWhisper = UiUtil.MakeButton(Se.Language.File.Import.AlignViaTextToSpeech, vm.AlignScriptWithTimestampsFromWhisperCommand);
+        var buttonAlignViaWhisper = UiUtil.MakeButton(Se.Language.File.Import.AlignViaSpeechToText, vm.AlignScriptWithTimestampsFromWhisperCommand);
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonAlignViaWhisper, buttonOk, buttonCancel);

--- a/src/ui/Logic/Config/Language/File/LanguageImport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageImport.cs
@@ -41,7 +41,7 @@ public class LanguageImport
     public string GapMs { get; set; }
     public string UseFixedDuration { get; set; }
     public string FixedDurationMs { get; set; }
-    public string AlignViaTextToSpeech { get; set; }
+    public string AlignViaSpeechToText { get; set; }
 
     public LanguageImport()
     {
@@ -88,7 +88,7 @@ Rules:
         GapMs = "Gap (ms)";
         UseFixedDuration = "Use fixed duration";
         FixedDurationMs = "Fixed duration (ms)";
-        AlignViaTextToSpeech = "Align time codes via \"Text to speech\"...";
+        AlignViaSpeechToText = "Align time codes via \"Speech to text\"...";
         CsvXlsxCustomColumnsDotDotDot = "CSV/XLSX with custom columns...";
         TitleImportCsvXlsxCustomColumns = "Import CSV/XLSX with custom columns";
         DetectedSeparatorX = "Detected separator: {0}";


### PR DESCRIPTION
## Summary
- The "Align time codes via …" button in *Import Plain Text* runs Whisper alignment (speech-to-text), but the label said "Text to speech". Rename the language string + property to "Speech to text" so the button matches what it actually does.

Fixes #10986 (the label part — the second ask about restoring SE4 options is a separate scope and not handled here).

## Test plan
- [ ] Open Import Plain Text and confirm the align button now reads "Align time codes via \"Speech to text\"...".
- [ ] Confirm clicking it still triggers the Whisper alignment flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)