### PR TITLE
Per-platform plugin downloads in the index

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -71,13 +71,27 @@ download. The index lives at the URL in `PluginConstants.OnlineIndexUrl`
       "url": "https://github.com/example/se-uppercase-plugin",
       "date": "2026-05-01",
       "minSeVersion": "5.0.0",
-      "downloadUrl": "https://github.com/example/se-uppercase-plugin/releases/download/v1.0.0/Uppercase.zip"
+      "downloads": {
+        "win-x64":     "https://github.com/example/se-uppercase-plugin/releases/download/v1.0.0/Uppercase-win-x64.zip",
+        "win-arm64":   "https://github.com/example/se-uppercase-plugin/releases/download/v1.0.0/Uppercase-win-arm64.zip",
+        "linux-x64":   "https://github.com/example/se-uppercase-plugin/releases/download/v1.0.0/Uppercase-linux-x64.zip",
+        "linux-arm64": "https://github.com/example/se-uppercase-plugin/releases/download/v1.0.0/Uppercase-linux-arm64.zip",
+        "osx-x64":     "https://github.com/example/se-uppercase-plugin/releases/download/v1.0.0/Uppercase-osx-x64.zip",
+        "osx-arm64":   "https://github.com/example/se-uppercase-plugin/releases/download/v1.0.0/Uppercase-osx-arm64.zip"
+      }
     }
   ]
 }
 ```
 
-- `downloadUrl` points to a `.zip` that contains the plugin's folder (with
+- `downloads` is a map of platform key → zip URL. Each key has the form
+  `{os}-{arch}` where `os` is `win`, `linux`, or `osx` and `arch` is `x64`,
+  `arm64`, `x86`, or `arm`. Keys are matched case-insensitively.
+- Subtitle Edit picks the URL whose key matches the user's OS + architecture.
+  A plugin with no key for the current platform is still shown in
+  **Get plugins online...** but its **Install** button is disabled with the
+  status *Not supported on this operating system*.
+- Each URL must point to a `.zip` containing the plugin's folder (with
   `plugin.json` inside). Subtitle Edit unpacks it into the `Plugins` directory.
 - If the zip has a single top-level folder it is used as the plugin folder name;
   otherwise the files are placed in a folder named after `name`.

--- a/src/ui/Features/Options/Plugins/GetPluginsDisplayItem.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsDisplayItem.cs
@@ -20,16 +20,28 @@ public partial class GetPluginsDisplayItem : ObservableObject
 
     public bool IsInstalled { get; private set; }
     public bool UpdateAvailable { get; private set; }
+    public bool IsSupportedOnCurrentPlatform { get; }
     public bool NotBusy => !IsBusy;
+    public bool CanInstall => NotBusy && IsSupportedOnCurrentPlatform;
 
     public GetPluginsDisplayItem(PluginIndexEntry entry, string? installedVersion)
     {
         Entry = entry;
+        IsSupportedOnCurrentPlatform = PluginPlatform.IsSupportedByEntry(entry);
         Refresh(installedVersion);
     }
 
     public void Refresh(string? installedVersion)
     {
+        if (!IsSupportedOnCurrentPlatform)
+        {
+            IsInstalled = false;
+            UpdateAvailable = false;
+            StatusText = Se.Language.Plugins.NotSupportedOnThisOs;
+            ActionText = Se.Language.Plugins.Install;
+            return;
+        }
+
         if (string.IsNullOrEmpty(installedVersion))
         {
             IsInstalled = false;
@@ -56,6 +68,7 @@ public partial class GetPluginsDisplayItem : ObservableObject
     partial void OnIsBusyChanged(bool value)
     {
         OnPropertyChanged(nameof(NotBusy));
+        OnPropertyChanged(nameof(CanInstall));
     }
 
     private static bool IsNewer(string candidate, string current)

--- a/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
@@ -63,7 +63,7 @@ public class GetPluginsWindow : Window
             };
             installButton.Bind(ContentControl.ContentProperty, new Binding(nameof(GetPluginsDisplayItem.ActionText)));
             installButton.Bind(Button.CommandParameterProperty, new Binding());
-            installButton.Bind(IsEnabledProperty, new Binding(nameof(GetPluginsDisplayItem.NotBusy)));
+            installButton.Bind(IsEnabledProperty, new Binding(nameof(GetPluginsDisplayItem.CanInstall)));
 
             var rowGrid = new Grid
             {

--- a/src/ui/Logic/Plugins/PluginDownloadService.cs
+++ b/src/ui/Logic/Plugins/PluginDownloadService.cs
@@ -33,9 +33,10 @@ public class PluginDownloadService : IPluginDownloadService
 
     public async Task InstallAsync(PluginIndexEntry entry, IProgress<float>? progress, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(entry.DownloadUrl))
+        var downloadUrl = PluginPlatform.ResolveDownloadUrl(entry);
+        if (string.IsNullOrWhiteSpace(downloadUrl))
         {
-            throw new InvalidOperationException($"Plugin '{entry.Name}' has no download URL.");
+            throw new InvalidOperationException($"Plugin '{entry.Name}' has no download for this platform ({PluginPlatform.GetCurrentKey() ?? "unknown"}).");
         }
 
         Directory.CreateDirectory(Se.PluginsFolder);
@@ -48,7 +49,7 @@ public class PluginDownloadService : IPluginDownloadService
 
             using (var zipStream = new MemoryStream())
             {
-                await DownloadHelper.DownloadFileAsync(_httpClient, entry.DownloadUrl, zipStream, progress, cancellationToken);
+                await DownloadHelper.DownloadFileAsync(_httpClient, downloadUrl, zipStream, progress, cancellationToken);
                 zipStream.Position = 0;
                 _zipUnpacker.UnpackZipStream(zipStream, tempDirectory);
             }

--- a/src/ui/Logic/Plugins/PluginIndex.cs
+++ b/src/ui/Logic/Plugins/PluginIndex.cs
@@ -18,6 +18,12 @@ public class PluginIndexEntry
     public string Date { get; set; } = string.Empty;
     public string? MinSeVersion { get; set; }
 
-    /// <summary>URL of the plugin .zip. The zip must contain the plugin's folder (with plugin.json inside).</summary>
-    public string DownloadUrl { get; set; } = string.Empty;
+    /// <summary>
+    /// Per-platform download URLs keyed by <see cref="PluginPlatform.GetCurrentKey"/>
+    /// (e.g. "win-x64", "linux-arm64", "osx-arm64"). Each URL must point to a .zip
+    /// containing the plugin's folder (with plugin.json inside). Keys are
+    /// matched case-insensitively. A plugin without a key for the current
+    /// platform is shown but cannot be installed.
+    /// </summary>
+    public Dictionary<string, string> Downloads { get; set; } = new();
 }

--- a/src/ui/Logic/Plugins/PluginJsonContext.cs
+++ b/src/ui/Logic/Plugins/PluginJsonContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -15,6 +16,7 @@ namespace Nikse.SubtitleEdit.Logic.Plugins;
 [JsonSerializable(typeof(PluginRequest))]
 [JsonSerializable(typeof(PluginResponse))]
 [JsonSerializable(typeof(PluginIndex))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
 internal partial class PluginJsonContext : JsonSerializerContext
 {
 }

--- a/src/ui/Logic/Plugins/PluginPlatform.cs
+++ b/src/ui/Logic/Plugins/PluginPlatform.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Logic.Plugins;
+
+/// <summary>
+/// Platform keys used in <see cref="PluginIndexEntry.Downloads"/> to pick the
+/// right plugin zip for the current OS + architecture (e.g. "win-x64",
+/// "linux-arm64", "osx-arm64"). Keys take the form "{os}-{arch}" where
+/// <c>os</c> is one of <c>win</c>, <c>linux</c>, <c>osx</c> and <c>arch</c>
+/// is one of <c>x64</c>, <c>arm64</c>, <c>x86</c>, <c>arm</c>.
+/// </summary>
+public static class PluginPlatform
+{
+    public static string? GetCurrentKey()
+    {
+        string os;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            os = "win";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            os = "osx";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            os = "linux";
+        }
+        else
+        {
+            return null;
+        }
+
+        var arch = RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            Architecture.X86 => "x86",
+            Architecture.Arm => "arm",
+            _ => null,
+        };
+
+        return arch == null ? null : os + "-" + arch;
+    }
+
+    /// <summary>Returns the download URL matching the current platform, or null if none.</summary>
+    public static string? ResolveDownloadUrl(PluginIndexEntry entry)
+    {
+        if (entry.Downloads == null || entry.Downloads.Count == 0)
+        {
+            return null;
+        }
+
+        var key = GetCurrentKey();
+        if (key == null)
+        {
+            return null;
+        }
+
+        var match = entry.Downloads
+            .FirstOrDefault(kv => string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase));
+        return string.IsNullOrWhiteSpace(match.Value) ? null : match.Value;
+    }
+
+    public static bool IsSupportedByEntry(PluginIndexEntry entry)
+    {
+        return !string.IsNullOrEmpty(ResolveDownloadUrl(entry));
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `PluginIndexEntry.DownloadUrl` (single URL) with a required `Downloads` map keyed by `"{os}-{arch}"` — e.g. `win-x64`, `linux-arm64`, `osx-arm64` — so a plugin can ship native binaries for each platform.
- `PluginDownloadService` resolves the URL via a new `PluginPlatform` helper that builds the current key from `RuntimeInformation.OSArchitecture` + OS detection. Install fails with a clear error when the user's platform has no entry.
- In **Get plugins online...** the Install button is disabled for entries with no download for the current platform; the row shows the existing *"Not supported on this operating system"* status (no new translation strings).
- `docs/plugin.md` updated to document the new schema and the disabled-install behavior.

This is a breaking change to the SE5 plugin index schema (`se5-plugins.json`). The only existing entry — Haxor — is being updated in the plugins repo to match.

## Test plan
- [ ] Build passes (verified locally: 0 warnings, 0 errors).
- [ ] On macOS arm64: open **Plugins → Get plugins online...** → Haxor row shows enabled Install; install + run.
- [ ] On Windows x64: same — install + run.
- [ ] On Linux x64: same — install + run.
- [ ] Manually add an entry with no key for the current platform (e.g. only `win-x64`) and verify the Install button is disabled and status reads *Not supported on this operating system*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)