### PR TITLE
Show download progress inside plugin Install button

### DIFF
--- a/src/ui/Features/Options/Plugins/GetPluginsDisplayItem.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsDisplayItem.cs
@@ -9,6 +9,7 @@ public partial class GetPluginsDisplayItem : ObservableObject
     [ObservableProperty] private bool _isBusy;
     [ObservableProperty] private string _statusText = string.Empty;
     [ObservableProperty] private string _actionText = string.Empty;
+    [ObservableProperty] private double _downloadProgress;
 
     public PluginIndexEntry Entry { get; }
 

--- a/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
@@ -91,9 +91,13 @@ public partial class GetPluginsViewModel : ObservableObject
         }
 
         item.IsBusy = true;
+        item.DownloadProgress = 0;
         var previousStatus = item.StatusText;
         var progress = new Progress<float>(p =>
-            item.StatusText = string.Format(Se.Language.Plugins.DownloadingXPercent, (int)Math.Round(p * 100)));
+        {
+            item.DownloadProgress = p * 100;
+            item.StatusText = string.Format(Se.Language.Plugins.DownloadingXPercent, (int)Math.Round(p * 100));
+        });
 
         try
         {

--- a/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
@@ -55,13 +55,36 @@ public class GetPluginsWindow : Window
                 Children = { titleRow, description, status },
             };
 
+            var actionLabel = new TextBlock
+            {
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            actionLabel.Bind(TextBlock.TextProperty, new Binding(nameof(GetPluginsDisplayItem.ActionText)));
+            actionLabel.Bind(IsVisibleProperty, new Binding(nameof(GetPluginsDisplayItem.NotBusy)));
+
+            var downloadProgress = new ProgressBar
+            {
+                Minimum = 0,
+                Maximum = 100,
+                Height = 14,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            downloadProgress.Bind(ProgressBar.ValueProperty, new Binding(nameof(GetPluginsDisplayItem.DownloadProgress)));
+            downloadProgress.Bind(IsVisibleProperty, new Binding(nameof(GetPluginsDisplayItem.IsBusy)));
+
+            var buttonContent = new Grid { MinWidth = 80 };
+            buttonContent.Children.Add(actionLabel);
+            buttonContent.Children.Add(downloadProgress);
+
             var installButton = new Button
             {
                 VerticalAlignment = VerticalAlignment.Center,
                 MinWidth = 100,
                 Command = vm.InstallCommand,
+                Content = buttonContent,
             };
-            installButton.Bind(ContentControl.ContentProperty, new Binding(nameof(GetPluginsDisplayItem.ActionText)));
             installButton.Bind(Button.CommandParameterProperty, new Binding());
             installButton.Bind(IsEnabledProperty, new Binding(nameof(GetPluginsDisplayItem.CanInstall)));
 


### PR DESCRIPTION
## Summary
- While a plugin is being downloaded, the **Install** / **Update** / **Reinstall** label in the Get plugins online... dialog is swapped for a thin determinate ProgressBar.
- Driven by the existing \`Progress<float>\` reporter \`PluginDownloadService\` already feeds — no new plumbing, just a new \`DownloadProgress\` property on \`GetPluginsDisplayItem\` plus a visibility-swap in \`GetPluginsWindow\`.
- The textual \"Downloading X%...\" status under the description is unchanged.

## Test plan
- [ ] Install a plugin — verify the button label is replaced by a filling progress bar that disappears when install completes.
- [ ] When install fails, button label returns and CanInstall re-enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)