### PR TITLE
Set +x on plugin binary before launch on Unix

### DIFF
--- a/src/ui/Logic/Plugins/PluginRunner.cs
+++ b/src/ui/Logic/Plugins/PluginRunner.cs
@@ -2,6 +2,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,6 +48,7 @@ public class PluginRunner : IPluginRunner
             }
             else
             {
+                EnsureExecutable(plugin.LaunchPath);
                 startInfo.FileName = plugin.LaunchPath;
             }
 
@@ -112,6 +114,31 @@ public class PluginRunner : IPluginRunner
         finally
         {
             TryDeleteDirectory(tempDirectory);
+        }
+    }
+
+    // System.IO.Compression.ZipFile.ExtractToDirectory does not preserve Unix file
+    // modes, so a self-contained plugin binary unpacked from a zip on macOS/Linux
+    // arrives without its +x bit. Set it here before launching.
+    private static void EnsureExecutable(string path)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+            var needed = UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+            if ((mode & needed) != needed)
+            {
+                File.SetUnixFileMode(path, mode | needed);
+            }
+        }
+        catch
+        {
+            // ignore - if we can't chmod, Process.Start will fail with a clear permission error
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix \"Permission denied\" when launching a self-contained native plugin on macOS / Linux (reproduced with Haxor on macOS: \`Could not start plugin 'Haxor': ... Permission denied\`).
- Root cause: \`System.IO.Compression.ZipFile.ExtractToDirectory\` (used by \`PluginDownloadService\`) does not preserve Unix file modes, so the plugin binary loses its \`+x\` bit during install.
- Fix: in \`PluginRunner\`, right before \`Process.Start\` for non-dotnet plugins, call \`File.SetUnixFileMode\` to set user/group/other execute bits. Idempotent — skips if already executable. No-op on Windows.

This also fixes plugins that are already installed on disk without \`+x\` (no reinstall needed).

## Test plan
- [ ] macOS arm64: install Haxor via **Get plugins online...**, run it from the Plugins menu — completes without \"Permission denied\".
- [ ] Linux x64: same.
- [ ] Windows x64: still launches normally (no-op path).
- [ ] dotnet-runtime plugins (no native exe) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)