### PR TITLE
Narrow plugin Install button progress bar and show percent

### DIFF
--- a/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
@@ -67,14 +67,17 @@ public class GetPluginsWindow : Window
             {
                 Minimum = 0,
                 Maximum = 100,
-                Height = 14,
-                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Width = 70,
+                Height = 16,
+                ShowProgressText = true,
+                ProgressTextFormat = "{0:0}%",
+                HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
             };
             downloadProgress.Bind(ProgressBar.ValueProperty, new Binding(nameof(GetPluginsDisplayItem.DownloadProgress)));
             downloadProgress.Bind(IsVisibleProperty, new Binding(nameof(GetPluginsDisplayItem.IsBusy)));
 
-            var buttonContent = new Grid { MinWidth = 80 };
+            var buttonContent = new Grid();
             buttonContent.Children.Add(actionLabel);
             buttonContent.Children.Add(downloadProgress);
 


### PR DESCRIPTION
## Summary
- The progress bar inside the Install/Update/Reinstall button (added in #11000) stretched to the full button width and showed no number.
- Constrain it to 70×16, centered, and turn on \`ShowProgressText\` with \`\"{0:0}%\"\` so the percent shows inside the bar while downloading.

## Test plan
- [ ] Install a plugin — verify the bar is a centered pill (not full-width) and reads e.g. \`47%\` inside.
- [ ] Bar disappears and the action label returns when install completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)