### PR TITLE
Ask whether to apply a plugin to selected or all lines

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4447,7 +4447,30 @@ public partial class MainViewModel :
             return;
         }
 
-        var request = BuildPluginRequest(plugin);
+        var selectedIndices = GetSelectedSubtitleIndices();
+        if (selectedIndices.Count > 0 && selectedIndices.Count < Subtitles.Count)
+        {
+            var choice = await MessageBox.Show(
+                Window,
+                plugin.Manifest.Name,
+                string.Format(Se.Language.Plugins.ApplyPluginToWhichLinesX, plugin.Manifest.Name),
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                custom1: string.Format(Se.Language.Plugins.ApplyToSelectedLinesX, selectedIndices.Count),
+                custom2: string.Format(Se.Language.Plugins.ApplyToAllLinesX, Subtitles.Count));
+
+            if (choice == MessageBoxResult.Cancel || choice == MessageBoxResult.None)
+            {
+                return;
+            }
+
+            if (choice == MessageBoxResult.Custom2)
+            {
+                selectedIndices.Clear();
+            }
+        }
+
+        var request = BuildPluginRequest(plugin, selectedIndices);
         var runResult = await _pluginRunner.RunAsync(plugin, request, System.Threading.CancellationToken.None);
         if (runResult.WasCancelled)
         {
@@ -4500,11 +4523,8 @@ public partial class MainViewModel :
             : response.Message!);
     }
 
-    private PluginRequest BuildPluginRequest(InstalledPlugin plugin)
+    private List<int> GetSelectedSubtitleIndices()
     {
-        var subtitle = GetUpdateSubtitle();
-        var format = SelectedSubtitleFormat;
-
         var selectedIndices = new List<int>();
         if (SubtitleGrid.SelectedItems != null)
         {
@@ -4519,6 +4539,14 @@ public partial class MainViewModel :
 
             selectedIndices.Sort();
         }
+
+        return selectedIndices;
+    }
+
+    private PluginRequest BuildPluginRequest(InstalledPlugin plugin, List<int> selectedIndices)
+    {
+        var subtitle = GetUpdateSubtitle();
+        var format = SelectedSubtitleFormat;
 
         var frameRate = _mediaInfo != null
             ? (double)_mediaInfo.FramesRateNonNormalized

--- a/src/ui/Logic/Config/Language/LanguagePlugins.cs
+++ b/src/ui/Logic/Config/Language/LanguagePlugins.cs
@@ -30,6 +30,9 @@ public class LanguagePlugins
     public string Update { get; set; }
     public string InstalledX { get; set; }
     public string UpdateAvailableXToY { get; set; }
+    public string ApplyPluginToWhichLinesX { get; set; }
+    public string ApplyToSelectedLinesX { get; set; }
+    public string ApplyToAllLinesX { get; set; }
 
     public LanguagePlugins()
     {
@@ -61,5 +64,8 @@ public class LanguagePlugins
         Update = "Update";
         InstalledX = "Installed ({0})";
         UpdateAvailableXToY = "Update available ({0} → {1})";
+        ApplyPluginToWhichLinesX = "Apply '{0}' to:";
+        ApplyToSelectedLinesX = "Selected lines ({0})";
+        ApplyToAllLinesX = "All lines ({0})";
     }
 }


### PR DESCRIPTION
## Summary
- When a user runs a plugin with a partial selection in the subtitle grid (>0 rows selected and <total), pop a small dialog asking which scope to use: **Selected lines (N)**, **All lines (M)**, or **Cancel**.
- Chosen scope drives \`PluginRequest.SelectedIndices\` — an empty list means \"all lines\" per the plugin contract (\`docs/plugin.md\`).
- No dialog when nothing is selected or every line is selected — the plugin runs against the full subtitle as today.
- Extracted the index-collection logic into a small \`GetSelectedSubtitleIndices()\` helper so \`BuildPluginRequest\` no longer recomputes selection itself.

Motivation: it was easy to accidentally run a plugin on a single selected line when you actually wanted it applied to the whole subtitle.

## Test plan
- [ ] Run a plugin with no selection — runs on all lines, no dialog.
- [ ] Run a plugin with all rows selected (Ctrl+A) — runs on all lines, no dialog.
- [ ] Select a few rows and run a plugin — dialog appears; *Selected* applies only to those rows; *All* applies to every row; *Cancel* does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)