### PR TITLE
seconv: add --input-encoding-fallback for non-UTF-8 input

### DIFF
--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -276,6 +276,17 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 return 1;
             }
 
+            // Fail fast on a typo in --input-encoding-fallback so we don't silently substitute
+            // UTF-8 and decode the input incorrectly without the user noticing.
+            if (!string.IsNullOrWhiteSpace(settings.InputEncodingFallback) &&
+                !LibSEIntegration.TryGetEncoding(settings.InputEncodingFallback, out _))
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]Error: Unknown encoding '{settings.InputEncodingFallback.EscapeMarkup()}' for --input-encoding-fallback.[/]");
+                AnsiConsole.MarkupLine("[dim]Use 'seconv list-encodings' to see supported encodings.[/]");
+                return 1;
+            }
+
             // Load --settings:path.json overrides into libse Configuration before any conversion.
             // --profile <name> selects a named overlay from the same file.
             if (!string.IsNullOrWhiteSpace(settings.SettingsPath))

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -50,6 +50,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Encoding name")]
         public string? Encoding { get; init; }
 
+        [CommandOption("--input-encoding-fallback|--inputencodingfallback")]
+        [Description("Encoding to assume when input is not UTF-8 / has no BOM (skips ANSI auto-detection). Ignored when --encoding is set.")]
+        public string? InputEncodingFallback { get; init; }
+
         [CommandOption("--forced-only|--forcedonly")]
         [Description("Forced subtitles only")]
         public bool ForcedOnly { get; init; }
@@ -389,6 +393,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 OutputFolder = settings.OutputFolder,
                 OutputFilename = settings.OutputFilename,
                 Encoding = settings.Encoding,
+                InputEncodingFallback = settings.InputEncodingFallback,
                 Fps = settings.Fps,
                 TargetFps = settings.TargetFps,
                 Overwrite = settings.Overwrite,
@@ -447,6 +452,9 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
 
             if (!string.IsNullOrEmpty(settings.Encoding))
                 table.AddRow("Encoding", settings.Encoding);
+
+            if (string.IsNullOrEmpty(settings.Encoding) && !string.IsNullOrEmpty(settings.InputEncodingFallback))
+                table.AddRow("Input encoding fallback", settings.InputEncodingFallback);
 
             if (operations.Count > 0)
                 table.AddRow("Operations", string.Join(", ", operations));

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -51,11 +51,14 @@ internal static class LibSEIntegration
 
     /// <summary>
     /// Loads a subtitle file using LibSE. When <paramref name="encodingName"/> is null/blank,
-    /// the encoding is auto-detected from the file's content. Also returns the detected
-    /// source format so the save side can apply <c>RemoveNativeFormatting</c> if the target
-    /// is different.
+    /// the encoding is auto-detected from the file's content. When
+    /// <paramref name="fallbackEncodingName"/> is supplied (and <paramref name="encodingName"/>
+    /// is not), the fallback replaces the ANSI codepage heuristic: a BOM still wins, valid
+    /// UTF-8 still wins, but anything else uses the fallback rather than DetectAnsiEncoding.
+    /// Also returns the detected source format so the save side can apply
+    /// <c>RemoveNativeFormatting</c> if the target is different.
     /// </summary>
-    public static (Subtitle Subtitle, SubtitleFormat Format) LoadSubtitleWithFormat(string filePath, string? encodingName = null)
+    public static (Subtitle Subtitle, SubtitleFormat Format) LoadSubtitleWithFormat(string filePath, string? encodingName = null, string? fallbackEncodingName = null)
     {
         if (!File.Exists(filePath))
         {
@@ -63,9 +66,19 @@ internal static class LibSEIntegration
         }
 
         var subtitle = new Subtitle();
-        var encoding = string.IsNullOrWhiteSpace(encodingName)
-            ? LanguageAutoDetect.GetEncodingFromFile(filePath)
-            : GetEncoding(encodingName);
+        Encoding encoding;
+        if (!string.IsNullOrWhiteSpace(encodingName))
+        {
+            encoding = GetEncoding(encodingName);
+        }
+        else if (!string.IsNullOrWhiteSpace(fallbackEncodingName))
+        {
+            encoding = DetectEncodingWithFallback(filePath, fallbackEncodingName);
+        }
+        else
+        {
+            encoding = LanguageAutoDetect.GetEncodingFromFile(filePath);
+        }
 
         var lines = new List<string>(File.ReadAllLines(filePath, encoding));
 
@@ -145,6 +158,113 @@ internal static class LibSEIntegration
     /// </summary>
     public static Subtitle LoadSubtitle(string filePath, string? encodingName = null)
         => LoadSubtitleWithFormat(filePath, encodingName).Subtitle;
+
+    /// <summary>
+    /// Resolves the input encoding for a file when the user supplied
+    /// <c>--input-encoding-fallback</c> but no explicit <c>--encoding</c>.
+    /// Mirrors the early decisions in <see cref="LanguageAutoDetect.GetEncodingFromFile"/>
+    /// (BOM, then UTF-8 byte-pattern check) and replaces the final ANSI heuristic with the
+    /// user-supplied fallback. The fallback only fires when no BOM is present and the bytes
+    /// do not validate as UTF-8, which is exactly where the heuristic was misfiring on
+    /// Central European content getting tagged as Western European.
+    /// </summary>
+    internal static Encoding DetectEncodingWithFallback(string filePath, string fallbackEncodingName)
+    {
+        try
+        {
+            using var file = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            var bom = new byte[4];
+            var bomRead = file.Read(bom, 0, bom.Length);
+
+            if (bomRead >= 3 && bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf)
+            {
+                return Encoding.UTF8;
+            }
+            if (bomRead >= 4 && bom[0] == 0xff && bom[1] == 0xfe && bom[2] == 0 && bom[3] == 0)
+            {
+                return Encoding.GetEncoding(12000);
+            }
+            if (bomRead >= 2 && bom[0] == 0xff && bom[1] == 0xfe)
+            {
+                return Encoding.Unicode;
+            }
+            if (bomRead >= 2 && bom[0] == 0xfe && bom[1] == 0xff)
+            {
+                return Encoding.BigEndianUnicode;
+            }
+            if (bomRead >= 4 && bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff)
+            {
+                return Encoding.GetEncoding(12001);
+            }
+
+            // No BOM — sniff for valid UTF-8 byte patterns over up to the first 500KB.
+            file.Position = 0;
+            var length = file.Length > 500_000 ? 500_000 : file.Length;
+            var buffer = new byte[length];
+            var totalRead = 0;
+            while (totalRead < buffer.Length)
+            {
+                var n = file.Read(buffer, totalRead, buffer.Length - totalRead);
+                if (n <= 0) break;
+                totalRead += n;
+            }
+
+            if (LooksLikeUtf8(buffer, totalRead))
+            {
+                return Encoding.UTF8;
+            }
+        }
+        catch
+        {
+            // Fall through to the user-supplied fallback on any read/IO trouble.
+        }
+
+        return GetEncoding(fallbackEncodingName);
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="buffer"/> contains at least one valid multi-byte
+    /// UTF-8 sequence and no invalid ones. Mirrors the private
+    /// <c>LanguageAutoDetect.IsUtf8</c> so we can decide UTF-8 vs. fallback without
+    /// touching libse's API surface.
+    /// </summary>
+    private static bool LooksLikeUtf8(byte[] buffer, int length)
+    {
+        var utf8Count = 0;
+        var i = 0;
+        while (i < length - 3)
+        {
+            var b = buffer[i];
+            if (b > 127)
+            {
+                if (b >= 194 && b <= 223 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191)
+                {
+                    utf8Count++;
+                    i++;
+                }
+                else if (b >= 224 && b <= 239 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
+                                                 buffer[i + 2] >= 128 && buffer[i + 2] <= 191)
+                {
+                    utf8Count++;
+                    i += 2;
+                }
+                else if (b >= 240 && b <= 244 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
+                                                 buffer[i + 2] >= 128 && buffer[i + 2] <= 191 &&
+                                                 buffer[i + 3] >= 128 && buffer[i + 3] <= 191)
+                {
+                    utf8Count++;
+                    i += 3;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            i++;
+        }
+
+        return utf8Count > 0;
+    }
 
     /// <summary>
     /// Saves a subtitle to a file using LibSE. Dispatches to format-specific Save methods

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -226,31 +226,35 @@ internal static class LibSEIntegration
     /// Returns true when <paramref name="buffer"/> contains at least one valid multi-byte
     /// UTF-8 sequence and no invalid ones. Mirrors the private
     /// <c>LanguageAutoDetect.IsUtf8</c> so we can decide UTF-8 vs. fallback without
-    /// touching libse's API surface.
+    /// touching libse's API surface — but scans the full buffer (libse stops 3 bytes
+    /// early, which misses a UTF-8 file whose only non-ASCII char is at the tail).
     /// </summary>
     private static bool LooksLikeUtf8(byte[] buffer, int length)
     {
         var utf8Count = 0;
         var i = 0;
-        while (i < length - 3)
+        while (i < length)
         {
             var b = buffer[i];
             if (b > 127)
             {
-                if (b >= 194 && b <= 223 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191)
+                if (b >= 194 && b <= 223 && i + 1 < length &&
+                    buffer[i + 1] >= 128 && buffer[i + 1] <= 191)
                 {
                     utf8Count++;
                     i++;
                 }
-                else if (b >= 224 && b <= 239 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
-                                                 buffer[i + 2] >= 128 && buffer[i + 2] <= 191)
+                else if (b >= 224 && b <= 239 && i + 2 < length &&
+                         buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
+                         buffer[i + 2] >= 128 && buffer[i + 2] <= 191)
                 {
                     utf8Count++;
                     i += 2;
                 }
-                else if (b >= 240 && b <= 244 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
-                                                 buffer[i + 2] >= 128 && buffer[i + 2] <= 191 &&
-                                                 buffer[i + 3] >= 128 && buffer[i + 3] <= 191)
+                else if (b >= 240 && b <= 244 && i + 3 < length &&
+                         buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
+                         buffer[i + 2] >= 128 && buffer[i + 2] <= 191 &&
+                         buffer[i + 3] >= 128 && buffer[i + 3] <= 191)
                 {
                     utf8Count++;
                     i += 3;
@@ -837,6 +841,47 @@ internal static class LibSEIntegration
         {
             // Fall back to UTF-8 with BOM if encoding not found
             return new UTF8Encoding(true);
+        }
+    }
+
+    /// <summary>
+    /// Non-throwing variant of <see cref="GetEncoding"/> used to validate user input. Returns
+    /// false (and a null out) for an unrecognized name or code page so the CLI can report
+    /// a typo instead of silently substituting UTF-8 and producing mojibake.
+    /// </summary>
+    internal static bool TryGetEncoding(string? encodingName, out Encoding? encoding)
+    {
+        if (string.IsNullOrWhiteSpace(encodingName))
+        {
+            encoding = null;
+            return false;
+        }
+
+        var name = encodingName.Trim().ToLowerInvariant();
+
+        if (name is "utf8" or "utf-8" or "utf-8-bom")
+        {
+            encoding = new UTF8Encoding(true);
+            return true;
+        }
+
+        if (name is "utf-8-no-bom" or "utf-8-nobom" or "utf8-nobom")
+        {
+            encoding = new UTF8Encoding(false);
+            return true;
+        }
+
+        try
+        {
+            encoding = int.TryParse(encodingName, out var codePage)
+                ? Encoding.GetEncoding(codePage)
+                : Encoding.GetEncoding(encodingName);
+            return true;
+        }
+        catch
+        {
+            encoding = null;
+            return false;
         }
     }
 

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -155,7 +155,7 @@ internal class SubtitleConverter
             {
                 // Load subtitle file using LibSE — keep the detected format so the
                 // save side can apply RemoveNativeFormatting when the target differs.
-                var (subtitle, sourceFormat) = LibSEIntegration.LoadSubtitleWithFormat(inputFile, options.Encoding);
+                var (subtitle, sourceFormat) = LibSEIntegration.LoadSubtitleWithFormat(inputFile, options.Encoding, options.InputEncodingFallback);
 
                 if (subtitle == null || subtitle.Paragraphs.Count == 0)
                 {
@@ -348,6 +348,13 @@ internal class ConversionOptions
     public string? OutputFolder { get; init; }
     public string? OutputFilename { get; init; }
     public string? Encoding { get; init; }
+
+    /// <summary>
+    /// Encoding to assume when input has no BOM and is not detected as UTF-8.
+    /// Replaces the ANSI codepage heuristic only — BOM and valid UTF-8 still win.
+    /// Ignored when <see cref="Encoding"/> is set (which already forces input encoding).
+    /// </summary>
+    public string? InputEncodingFallback { get; init; }
     public double? Fps { get; init; }
     public double? TargetFps { get; init; }
     public bool Overwrite { get; init; }

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -23,6 +23,7 @@ internal static class HelpDisplay
         ShowParameter("--change-speed:<percent>", "Change speed by percent (e.g. 125 = 1.25x faster)");
         ShowParameter("--ebu-header-file:<file name>", "EBU header file");
         ShowParameter("--encoding:<encoding name>", "Character encoding (e.g., utf-8, windows-1252)");
+        ShowParameter("--input-encoding-fallback:<name>", "Assumed input encoding when no BOM and not UTF-8 (skips ANSI guess)");
         ShowParameter("--forced-only", "Process forced subtitles only");
         ShowParameter("--fps:<frame rate>", "Frame rate for conversion");
         ShowParameter("--input-folder:<folder name>", "Input folder path");
@@ -97,6 +98,9 @@ internal static class HelpDisplay
         ShowExample(
             "seconv sub1.srt subrip --encoding:windows-1252",
             "Convert with specific encoding");
+        ShowExample(
+            "seconv *.srt subrip --input-encoding-fallback:windows-1250",
+            "Bulk convert to UTF-8; assume CP1250 only when input isn't UTF-8");
         ShowExample(
             "seconv *.sub subrip --fps:25 --output-folder:C:\\Temp",
             "Convert frame-based to time-based with FPS");

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -153,6 +153,7 @@ internal class Program
         "--custom-format", "--customformat",
         "--ebu-header-file", "--ebuheaderfile",
         "--encoding",
+        "--input-encoding-fallback", "--inputencodingfallback",
         "--fps",
         "--input-folder", "--inputfolder",
         "--multiple-replace", "--multiplereplace",

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -35,6 +35,7 @@ seconv <pattern> --format <name> [options]   # alternative syntax
 ```bash
 seconv *.srt sami                                              # SRT → SAMI
 seconv movie.srt subrip --encoding:windows-1252                # encoding override
+seconv *.srt subrip --input-encoding-fallback:windows-1250     # UTF-8 wins; CP1250 only if not UTF-8
 seconv *.sub subrip --fps:25 --output-folder ./out             # frame-based → time-based
 
 seconv movie.mkv subrip --track-number:3                       # extract MKV text track #3
@@ -85,6 +86,7 @@ seconv lint *.srt --json                    # CI-friendly: exit 1 on any issue
 | `--output-filename:<name>` | Output file name (single input only) |
 | `--overwrite` | Overwrite existing files (default: rotate to `name_2.ext`, `_3.ext`, ...) |
 | `--encoding:<name>` | Encoding name or codepage (defaults: auto-detect on input, UTF-8 BOM on output) |
+| `--input-encoding-fallback:<name>` | Encoding to assume when input has no BOM and is not detected as UTF-8 (replaces the ANSI codepage heuristic). Ignored when `--encoding` is set. |
 
 ### Time / Frame
 | Option | Description |

--- a/tests/seconv/Core/InputEncodingFallbackTest.cs
+++ b/tests/seconv/Core/InputEncodingFallbackTest.cs
@@ -1,0 +1,117 @@
+using System.Text;
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+public class InputEncodingFallbackTest : IDisposable
+{
+    private readonly string _tempRoot;
+
+    private const string SrtContentAscii = """
+        1
+        00:00:01,000 --> 00:00:03,000
+        Hello.
+
+        """;
+
+    // Polish 'ą' is the unambiguous case: CP1250 encodes it as the single byte 0xB9, which
+    // is > 127 yet not a valid UTF-8 lead byte, so LooksLikeUtf8 must return false and
+    // the fallback must take over.
+    private const string SrtContentCentralEuropean = """
+        1
+        00:00:01,000 --> 00:00:03,000
+        Cześć ąęłóż.
+
+        """;
+
+    public InputEncodingFallbackTest()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "InputEncFallbackTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    [Fact]
+    public void DetectEncodingWithFallback_Utf8Bom_ReturnsUtf8()
+    {
+        var path = Path.Combine(_tempRoot, "bom.srt");
+        File.WriteAllText(path, SrtContentCentralEuropean, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        var result = LibSEIntegration.DetectEncodingWithFallback(path, "windows-1250");
+
+        Assert.Equal(Encoding.UTF8.WebName, result.WebName);
+    }
+
+    [Fact]
+    public void DetectEncodingWithFallback_Utf8NoBomValidMultibyte_ReturnsUtf8()
+    {
+        var path = Path.Combine(_tempRoot, "utf8.srt");
+        File.WriteAllText(path, SrtContentCentralEuropean, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var result = LibSEIntegration.DetectEncodingWithFallback(path, "windows-1250");
+
+        Assert.Equal(Encoding.UTF8.WebName, result.WebName);
+    }
+
+    [Fact]
+    public void DetectEncodingWithFallback_CentralEuropeanBytesNoBom_ReturnsFallback()
+    {
+        var path = Path.Combine(_tempRoot, "cp1250.srt");
+        // Encoding.GetEncoding(1250) requires the code pages provider, which seconv's
+        // module initializer wires up; tests get it via the LibSE bootstrap as well.
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var cp1250 = Encoding.GetEncoding(1250);
+        File.WriteAllBytes(path, cp1250.GetBytes(SrtContentCentralEuropean));
+
+        var result = LibSEIntegration.DetectEncodingWithFallback(path, "windows-1250");
+
+        Assert.Equal(1250, result.CodePage);
+    }
+
+    [Fact]
+    public void DetectEncodingWithFallback_AsciiOnly_ReturnsFallback()
+    {
+        // Pure ASCII has no UTF-8 multi-byte sequences, so LooksLikeUtf8 returns false
+        // and the fallback takes over. (Decoded text is identical either way for ASCII.)
+        var path = Path.Combine(_tempRoot, "ascii.srt");
+        File.WriteAllBytes(path, Encoding.ASCII.GetBytes(SrtContentAscii));
+
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var result = LibSEIntegration.DetectEncodingWithFallback(path, "windows-1250");
+
+        Assert.Equal(1250, result.CodePage);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_CentralEuropeanInputWithFallback_OutputsCorrectUtf8()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var cp1250 = Encoding.GetEncoding(1250);
+
+        var input = Path.Combine(_tempRoot, "in.srt");
+        await File.WriteAllBytesAsync(input, cp1250.GetBytes(SrtContentCentralEuropean), TestContext.Current.CancellationToken);
+        var outDir = Path.Combine(_tempRoot, "out");
+        Directory.CreateDirectory(outDir);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "SubRip",
+            OutputFolder = outDir,
+            Overwrite = true,
+            InputEncodingFallback = "windows-1250",
+        });
+
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+
+        var outText = await File.ReadAllTextAsync(Path.Combine(outDir, "in.srt"), Encoding.UTF8, TestContext.Current.CancellationToken);
+        Assert.Contains("Cześć ąęłóż.", outText);
+    }
+}

--- a/tests/seconv/Core/InputEncodingFallbackTest.cs
+++ b/tests/seconv/Core/InputEncodingFallbackTest.cs
@@ -89,6 +89,48 @@ public class InputEncodingFallbackTest : IDisposable
     }
 
     [Fact]
+    public void DetectEncodingWithFallback_Utf8MultibyteAtVeryEndOfFile_ReturnsUtf8()
+    {
+        // Regression: the libse IsUtf8 scan stops 3 bytes early; the LooksLikeUtf8 fix
+        // scans the full buffer so a UTF-8 file whose only non-ASCII char sits at the
+        // tail is still recognized as UTF-8 (and not decoded with the fallback).
+        var path = Path.Combine(_tempRoot, "tail.srt");
+        var bytes = new List<byte>(Encoding.ASCII.GetBytes("ABCDEFGHIJK"));
+        bytes.AddRange(new byte[] { 0xC4, 0x85 }); // 'ą' in UTF-8 at the very end
+        File.WriteAllBytes(path, bytes.ToArray());
+
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var result = LibSEIntegration.DetectEncodingWithFallback(path, "windows-1250");
+
+        Assert.Equal(Encoding.UTF8.WebName, result.WebName);
+    }
+
+    [Fact]
+    public void TryGetEncoding_KnownName_ReturnsTrue()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+        Assert.True(LibSEIntegration.TryGetEncoding("windows-1250", out var enc));
+        Assert.NotNull(enc);
+        Assert.Equal(1250, enc!.CodePage);
+    }
+
+    [Fact]
+    public void TryGetEncoding_UnknownName_ReturnsFalse()
+    {
+        Assert.False(LibSEIntegration.TryGetEncoding("windowz-1250", out var enc));
+        Assert.Null(enc);
+    }
+
+    [Fact]
+    public void TryGetEncoding_NullOrEmpty_ReturnsFalse()
+    {
+        Assert.False(LibSEIntegration.TryGetEncoding(null, out _));
+        Assert.False(LibSEIntegration.TryGetEncoding(string.Empty, out _));
+        Assert.False(LibSEIntegration.TryGetEncoding("   ", out _));
+    }
+
+    [Fact]
     public async Task ConvertAsync_CentralEuropeanInputWithFallback_OutputsCorrectUtf8()
     {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);


### PR DESCRIPTION
## Summary
- Adds `--input-encoding-fallback <name>` to seconv. The ANSI codepage heuristic in `LanguageAutoDetect.GetEncodingFromFile` occasionally misdetects Central European content as Western European; the new flag lets the user name an encoding to use **only** when BOM detection and UTF-8 byte-pattern detection both come up empty.
- BOM still wins (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE) and valid UTF-8 without BOM still wins. The fallback only replaces the heuristic step, so bulk conversion of mixed UTF-8 / region-specific files lands consistently on UTF-8.
- Ignored when `--encoding` is set (that already forces input encoding too).

Closes #11002.

## Example
```
seconv *.srt subrip --input-encoding-fallback:windows-1250
```

## Test plan
- [x] Unit tests added in `tests/seconv/Core/InputEncodingFallbackTest.cs` covering: UTF-8 BOM wins over fallback; UTF-8 no-BOM with valid multi-byte wins over fallback; CP1250 bytes (no BOM, not valid UTF-8) → fallback; pure ASCII → fallback (decoded text identical either way); end-to-end `ConvertAsync` round-trip from CP1250 input to UTF-8 output with correct `Cześć ąęłóż.`.
- [x] Full seconv test suite: 134/135 pass. The one failure (`ContainerLoaderTest.ConvertAsync_MkvWithImageTracks_SkipsAndReportsZeroSuccess`) is pre-existing on `main`, unrelated to this change.
- [x] CLI smoke test: a CP1250-encoded `.srt` converts to UTF-8 BOM with all Polish diacritics correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)