### PR TITLE
Tail the speech-to-text console log in batch mode too

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -106,7 +106,12 @@ public partial class SpeechToTextViewModel : ObservableObject
     public Subtitle TranscribedSubtitle { get; private set; }
     public List<AudioClip> ResultAudioClips { get; private set; }
     public string? LastBatchSubtitleFileName { get; private set; }
-    public TextBox TextBoxConsoleLog { get; internal set; }
+    // Two views host the console log — the batch-mode grid layout and the single-mode
+    // standalone TextBox. Only one is visible at a time, so we track both and tail
+    // both in LogToConsole; otherwise the hidden one's reference can shadow the
+    // visible one and the user sees the log freeze at the top.
+    public TextBox TextBoxConsoleLogBatch { get; internal set; }
+    public TextBox TextBoxConsoleLogSingle { get; internal set; }
     public Button? CopyConsoleLogButton { get; internal set; }
     public DataGrid BatchGrid { get; internal set; }
 
@@ -219,7 +224,8 @@ public partial class SpeechToTextViewModel : ObservableObject
         ElapsedText = string.Empty;
         EstimatedText = string.Empty;
         TranscribedSubtitle = new Subtitle();
-        TextBoxConsoleLog = new TextBox();
+        TextBoxConsoleLogBatch = new TextBox();
+        TextBoxConsoleLogSingle = new TextBox();
         BatchGrid = new DataGrid();
         ReDownloadText = string.Empty;
         EngineDownloadHint = string.Empty;
@@ -3304,11 +3310,22 @@ public partial class SpeechToTextViewModel : ObservableObject
         // TextPresenter isn't templated yet. Drive the inner ScrollViewer
         // directly. Post at Background priority so the Render-priority layout
         // pass has updated Extent for the freshly-appended line first.
+        //
+        // Scroll BOTH the batch and single-mode TextBoxes — only one is visible
+        // at any time, and which one depends on IsBatchMode. Scrolling the hidden
+        // one is a harmless no-op; scrolling only the wrong one (the bug before
+        // this) left the visible log frozen at the top.
         Dispatcher.UIThread.Post(() =>
         {
-            var scrollViewer = TextBoxConsoleLog.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
-            scrollViewer?.ScrollToEnd();
+            ScrollTextBoxToEnd(TextBoxConsoleLogBatch);
+            ScrollTextBoxToEnd(TextBoxConsoleLogSingle);
         }, DispatcherPriority.Background);
+    }
+
+    private static void ScrollTextBoxToEnd(TextBox? textBox)
+    {
+        var scrollViewer = textBox?.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+        scrollViewer?.ScrollToEnd();
     }
 
     private static decimal GetSeconds(string timeCode)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -488,7 +488,7 @@ public class SpeechToTextWindow : Window
             Source = vm,
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
         });
-        vm.TextBoxConsoleLog = textBoxConsoleLog;
+        vm.TextBoxConsoleLogBatch = textBoxConsoleLog;
 
 
         var dataGrid = new DataGrid
@@ -619,7 +619,7 @@ public class SpeechToTextWindow : Window
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
         });
         textBoxConsoleLog.WithBindIsVisible(nameof(vm.IsBatchMode), new InverseBooleanConverter());
-        vm.TextBoxConsoleLog = textBoxConsoleLog;
+        vm.TextBoxConsoleLogSingle = textBoxConsoleLog;
 
         return textBoxConsoleLog;
     }


### PR DESCRIPTION
## Summary
- Follow-up to #10974. That PR made the inner-`ScrollViewer.ScrollToEnd()` call work for single-mode users, but batch-mode users still saw the log freeze at the top.
- Root cause: `SpeechToTextWindow` builds two console views — `MakeConsoleLogAndBatchView` (visible when `IsBatchMode`) and `MakeConsoleLogOnlyView` (visible otherwise) — each with its own `TextBox`. Both assigned `vm.TextBoxConsoleLog = textBoxConsoleLog`, so the second assignment (single-mode) won. In batch mode the *visible* TextBox was the other one and `LogToConsole` was scrolling the hidden TextBox.
- Split the VM field into `TextBoxConsoleLogBatch` / `TextBoxConsoleLogSingle`; `LogToConsole` calls `ScrollToEnd` on both. The hidden one is a harmless no-op so the visible one always tails regardless of mode.

## Test plan
- [ ] Start a transcription in **batch** mode (multiple files) and confirm the console log tails new ffmpeg / whisper lines without needing to focus the box or press PageDown.
- [ ] Start a transcription in **single** mode and confirm the existing single-mode tail behavior still works.
- [ ] Toggle batch ↔ single between runs and confirm both still tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)