### PR TITLE
Open from URL: pop instantly, stop nagging, download subtitles

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -131,6 +131,7 @@ using Nikse.SubtitleEdit.Features.Video.CutVideo;
 using Nikse.SubtitleEdit.Features.Video.EmbeddedSubtitlesEdit;
 using Nikse.SubtitleEdit.Features.Video.GoToVideoPosition;
 using Nikse.SubtitleEdit.Features.Video.OpenFromUrl;
+using Nikse.SubtitleEdit.Features.Video.OpenFromUrl.PickOnlineSubtitle;
 using Nikse.SubtitleEdit.Features.Video.ReEncodeVideo;
 using Nikse.SubtitleEdit.Features.Video.ShotChanges;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
@@ -379,6 +380,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<OcrViewModel>();
         collection.AddTransient<OpenFromUrlViewModel>();
         collection.AddTransient<DownloadVideoFromUrlViewModel>();
+        collection.AddTransient<PickOnlineSubtitleViewModel>();
         collection.AddTransient<OpenSecondarySubtitleViewModel>();
         collection.AddTransient<PartsSavedViewModel>();
         collection.AddTransient<PickAlignmentViewModel>();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5387,37 +5387,21 @@ public partial class MainViewModel :
         }
 
         var isYouTubeDlInstalled = File.Exists(YtDlpDownloadService.GetFullFileName());
-        var downloadMessage = string.Empty;
+
+        // If yt-dlp is installed, run the "is it outdated" check in the background
+        // while the URL dialog is on screen — IsInstalledVersionOutdated spawns
+        // `yt-dlp --version` which can take a noticeable moment (especially on
+        // macOS where the self-extracting binary unpacks on first run). We only
+        // need the result if the user actually submits a URL.
+        Task<bool>? outdatedCheckTask = isYouTubeDlInstalled
+            ? Task.Run(() => YtDlpDownloadService.IsInstalledVersionOutdated(CancellationToken.None))
+            : null;
+
         if (!isYouTubeDlInstalled)
         {
-            downloadMessage = Se.Language.Main.YoutubeDlNotInstalledDownloadNow;
-        }
-        else if (await YtDlpDownloadService.IsInstalledVersionOutdated(CancellationToken.None))
-        {
-            downloadMessage = Se.Language.Main.YoutubeDlOutdatedDownloadNow;
-        }
-
-        if (!string.IsNullOrEmpty(downloadMessage))
-        {
-            var download = await MessageBox.Show(Window, Se.Language.General.Information,
-                downloadMessage,
-                MessageBoxButtons.YesNo, MessageBoxIcon.Information);
-            if (download == MessageBoxResult.Yes)
-            {
-                await ShowDialogAsync<DownloadYtDlpWindow, DownloadYtDlpViewModel>();
-                isYouTubeDlInstalled = File.Exists(YtDlpDownloadService.GetFullFileName());
-                var isYouTubeDlCurrent = isYouTubeDlInstalled &&
-                                         !await YtDlpDownloadService.IsInstalledVersionOutdated(CancellationToken.None, forceRefresh: true);
-                if (isYouTubeDlCurrent)
-                {
-                    ShowStatus(Se.Language.Main.YoutubeDlDownloadedSuccessfully);
-                }
-                else
-                {
-                    return;
-                }
-            }
-            else
+            // Without the binary on disk there's nothing useful the URL dialog can
+            // do — block on installing it first.
+            if (!await PromptToDownloadYtDlp(Se.Language.Main.YoutubeDlNotInstalledDownloadNow))
             {
                 return;
             }
@@ -5436,6 +5420,31 @@ public partial class MainViewModel :
             return;
         }
 
+        // Now that the user has committed to a URL, see whether the background
+        // version check came back "outdated" — and only then interrupt with the
+        // upgrade prompt. The check is almost always finished by this point, but
+        // we await it to be safe.
+        if (outdatedCheckTask is not null)
+        {
+            bool isOutdated;
+            try
+            {
+                isOutdated = await outdatedCheckTask;
+            }
+            catch
+            {
+                // Treat check failures as not-outdated; a stale binary will surface
+                // its own error on the next yt-dlp invocation.
+                isOutdated = false;
+            }
+
+            if (isOutdated &&
+                !await PromptToDownloadYtDlp(Se.Language.Main.YoutubeDlOutdatedDownloadNow))
+            {
+                return;
+            }
+        }
+
         switch (result.SelectedMode.Value)
         {
             case OpenFromUrlMode.OpenOnline:
@@ -5446,6 +5455,35 @@ public partial class MainViewModel :
                 await DownloadVideoFromUrlAndOpen(url);
                 break;
         }
+    }
+
+    /// <summary>
+    /// Asks the user whether to download yt-dlp, runs the download window if so, and
+    /// returns true when a usable binary is on disk afterwards. Returns false if the
+    /// user declined or the download did not produce a file (cancelled / failed).
+    /// </summary>
+    private async Task<bool> PromptToDownloadYtDlp(string message)
+    {
+        var download = await MessageBox.Show(Window!, Se.Language.General.Information,
+            message,
+            MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+        if (download != MessageBoxResult.Yes)
+        {
+            return false;
+        }
+
+        await ShowDialogAsync<DownloadYtDlpWindow, DownloadYtDlpViewModel>();
+        if (!File.Exists(YtDlpDownloadService.GetFullFileName()))
+        {
+            return false;
+        }
+
+        // We just downloaded YtDlpDownloadService.CurrentVersion, so the binary on
+        // disk is known-current; drop the cached "outdated" flag so any later
+        // periodic check reflects the new file.
+        YtDlpDownloadService.InvalidateInstalledVersionCache();
+        ShowStatus(Se.Language.Main.YoutubeDlDownloadedSuccessfully);
+        return true;
     }
 
     private async Task DownloadVideoFromUrlAndOpen(string url)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5536,8 +5536,10 @@ public partial class MainViewModel :
 
     /// <summary>
     /// Asks the user whether to download yt-dlp, runs the download window if so, and
-    /// returns true when a usable binary is on disk afterwards. Returns false if the
-    /// user declined or the download did not produce a file (cancelled / failed).
+    /// returns true when a usable current-version binary is on disk afterwards.
+    /// Returns false if the user declined, no file was produced, or — for the
+    /// outdated-upgrade path — the download didn't take and the old binary is
+    /// still on disk.
     /// </summary>
     private async Task<bool> PromptToDownloadYtDlp(string message)
     {
@@ -5555,10 +5557,18 @@ public partial class MainViewModel :
             return false;
         }
 
-        // We just downloaded YtDlpDownloadService.CurrentVersion, so the binary on
-        // disk is known-current; drop the cached "outdated" flag so any later
-        // periodic check reflects the new file.
+        // For the upgrade path File.Exists alone isn't enough — if the user
+        // cancelled the download or it errored, the old (outdated) binary is
+        // still on disk and File.Exists still returns true. Re-run the version
+        // check to confirm the binary really is current. Safe because
+        // IsVersionOutdated treats unknown/unparseable output as "not outdated"
+        // (a flaky --version on a freshly written binary won't false-positive).
         YtDlpDownloadService.InvalidateInstalledVersionCache();
+        if (await YtDlpDownloadService.IsInstalledVersionOutdated(CancellationToken.None, forceRefresh: true))
+        {
+            return false;
+        }
+
         ShowStatus(Se.Language.Main.YoutubeDlDownloadedSuccessfully);
         return true;
     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -135,6 +135,7 @@ using Nikse.SubtitleEdit.Features.Video.CutVideo;
 using Nikse.SubtitleEdit.Features.Video.EmbeddedSubtitlesEdit;
 using Nikse.SubtitleEdit.Features.Video.GoToVideoPosition;
 using Nikse.SubtitleEdit.Features.Video.OpenFromUrl;
+using Nikse.SubtitleEdit.Features.Video.OpenFromUrl.PickOnlineSubtitle;
 using Nikse.SubtitleEdit.Features.Video.ReEncodeVideo;
 using Nikse.SubtitleEdit.Features.Video.ShotChanges;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
@@ -347,6 +348,7 @@ public partial class MainViewModel :
     private readonly IPasteFromClipboardHelper _pasteFromClipboardHelper;
     private readonly IPluginCatalog _pluginCatalog;
     private readonly IPluginRunner _pluginRunner;
+    private readonly IYtDlpDownloadService _ytDlpDownloadService;
 
     private bool IsEmpty => Subtitles.Count == 0 || (Subtitles.Count == 1 && string.IsNullOrEmpty(Subtitles[0].Text));
 
@@ -415,7 +417,8 @@ public partial class MainViewModel :
         ICasingToggler casingToggler,
         IPasteFromClipboardHelper pasteFromClipboardHelper,
         IPluginCatalog pluginCatalog,
-        IPluginRunner pluginRunner)
+        IPluginRunner pluginRunner,
+        IYtDlpDownloadService ytDlpDownloadService)
     {
         _fileHelper = fileHelper;
         _folderHelper = folderHelper;
@@ -437,6 +440,7 @@ public partial class MainViewModel :
         _pasteFromClipboardHelper = pasteFromClipboardHelper;
         _pluginCatalog = pluginCatalog;
         _pluginRunner = pluginRunner;
+        _ytDlpDownloadService = ytDlpDownloadService;
 
         _loading = true;
         EditText = string.Empty;
@@ -5449,11 +5453,84 @@ public partial class MainViewModel :
         {
             case OpenFromUrlMode.OpenOnline:
                 await VideoOpenFile(url);
+                if (result.DownloadSubtitles)
+                {
+                    // No video on disk — fetch subs to a temp dir, show picker, then
+                    // clean up the temp dir once the picked subtitle is loaded.
+                    await DownloadSubtitlesOnlyAndPickAsync(url);
+                }
                 break;
 
             case OpenFromUrlMode.DownloadAndOpen:
-                await DownloadVideoFromUrlAndOpen(url);
+                // The picker is invoked inside DownloadVideoFromUrlAndOpen so it
+                // only fires when the video download actually succeeds — skipping
+                // it when the user cancels the save-as or the download itself.
+                await DownloadVideoFromUrlAndOpen(url, result.DownloadSubtitles);
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Streaming-mode helper: runs yt-dlp once to write every available subtitle
+    /// to a temp directory, shows the chooser, loads the selected file, then
+    /// cleans the temp directory. Best-effort — failures don't roll back the
+    /// already-opened video.
+    /// </summary>
+    private async Task DownloadSubtitlesOnlyAndPickAsync(string url)
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "SE-online-subs-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(tempDirectory);
+            var stem = Path.Combine(tempDirectory, "sub");
+
+            ShowStatus(Se.Language.Video.PickOnlineSubtitleFetching);
+            await _ytDlpDownloadService.DownloadAllSubtitlesAsync(url, stem, CancellationToken.None);
+
+            var downloaded = YtDlpDownloadService.EnumerateDownloadedSubtitles(tempDirectory, "sub");
+            await ShowPickerAndLoadAsync(downloaded);
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Failed to fetch subtitles for streaming URL");
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Shows the subtitle chooser populated with <paramref name="subtitles"/>; if
+    /// the user picks one, loads it into the editor. The picker itself never
+    /// downloads anything — it's just a chooser over files already on disk.
+    /// </summary>
+    private async Task ShowPickerAndLoadAsync(IReadOnlyList<DownloadedSubtitleInfo> subtitles)
+    {
+        var pickerResult = await ShowDialogAsync<PickOnlineSubtitleWindow, PickOnlineSubtitleViewModel>(
+            vm => { vm.Initialize(subtitles); });
+
+        if (!pickerResult.OkPressed || string.IsNullOrEmpty(pickerResult.SelectedSubtitlePath))
+        {
+            return;
+        }
+
+        await SubtitleOpen(pickerResult.SelectedSubtitlePath, skipLoadVideo: true);
+    }
+
+    private static void TryDeleteDirectory(string? path)
+    {
+        if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+        {
+            return;
+        }
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // best effort — leave the OS to garbage-collect /tmp
         }
     }
 
@@ -5486,7 +5563,7 @@ public partial class MainViewModel :
         return true;
     }
 
-    private async Task DownloadVideoFromUrlAndOpen(string url)
+    private async Task DownloadVideoFromUrlAndOpen(string url, bool downloadSubtitles)
     {
         if (Window == null)
         {
@@ -5502,12 +5579,31 @@ public partial class MainViewModel :
 
         var downloadResult = await ShowDialogAsync<DownloadVideoFromUrlWindow, DownloadVideoFromUrlViewModel>(vm =>
         {
-            vm.Initialize(url, outputPath);
+            vm.Initialize(url, outputPath, downloadSubtitles);
         });
 
         if (downloadResult.Success && File.Exists(downloadResult.OutputPath))
         {
             await VideoOpenFile(downloadResult.OutputPath);
+
+            if (downloadSubtitles)
+            {
+                // Subs were written into a per-download GUID temp directory so the
+                // picker can't accidentally list any pre-existing sidecar files
+                // sitting next to the user's chosen save folder. Show the picker,
+                // load the chosen file, then clean the temp dir up.
+                try
+                {
+                    if (downloadResult.DownloadedSubtitles.Count > 0)
+                    {
+                        await ShowPickerAndLoadAsync(downloadResult.DownloadedSubtitles);
+                    }
+                }
+                finally
+                {
+                    TryDeleteDirectory(downloadResult.TempSubtitleDirectory);
+                }
+            }
         }
     }
 

--- a/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
@@ -6,8 +6,10 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -26,12 +28,30 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
     public bool Success { get; private set; }
     public string OutputPath { get; private set; } = string.Empty;
 
+    /// <summary>
+    /// When the user requested subtitle download alongside the video, this lists
+    /// the subtitle files yt-dlp wrote into <see cref="TempSubtitleDirectory"/>.
+    /// Empty when subtitles weren't requested or when no subtitle tracks exist
+    /// for the video. Populated only after a successful download.
+    /// </summary>
+    public IReadOnlyList<DownloadedSubtitleInfo> DownloadedSubtitles { get; private set; } = Array.Empty<DownloadedSubtitleInfo>();
+
+    /// <summary>
+    /// Per-download GUID temp directory the subtitle sidecars live in. Scoping
+    /// downloads to a fresh directory keeps the picker from accidentally listing
+    /// unrelated <c>&lt;stem&gt;.&lt;lang&gt;.&lt;ext&gt;</c> files that may
+    /// already sit next to the user's chosen output path. Caller is responsible
+    /// for deleting it once the picked subtitle has been loaded.
+    /// </summary>
+    public string? TempSubtitleDirectory { get; private set; }
+
     private readonly IYtDlpDownloadService _ytDlpDownloadService;
     private Task? _downloadTask;
     private readonly Timer _timer;
     private bool _done;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private string _url = string.Empty;
+    private bool _downloadSubtitles;
 
     public DownloadVideoFromUrlViewModel(IYtDlpDownloadService ytDlpDownloadService)
     {
@@ -46,9 +66,10 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
         _timer.Elapsed += OnTimerElapsed;
     }
 
-    public void Initialize(string url, string outputPath)
+    public void Initialize(string url, string outputPath, bool downloadSubtitles = false)
     {
         _url = url;
+        _downloadSubtitles = downloadSubtitles;
         OutputPath = outputPath;
         FileNameDisplay = Path.GetFileName(outputPath);
     }
@@ -68,8 +89,131 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
             Directory.CreateDirectory(folder);
         }
 
-        _downloadTask = _ytDlpDownloadService.DownloadVideo(_url, OutputPath, progress, _cancellationTokenSource.Token);
+        // Always route through the temp dir wrapper, even when subs are off — yt-dlp
+        // doesn't always honor the extension in -o (some URLs land as .webm or .mp4
+        // regardless of what we ask for), so we need FindProducedVideo to locate the
+        // actual produced file and move it to the user's chosen OutputPath.
+        _downloadTask = DownloadViaTempDirectoryAsync(progress, _cancellationTokenSource.Token);
+
         _timer.Start();
+    }
+
+    /// <summary>
+    /// Routes yt-dlp's output through a fresh GUID temp directory. Two reasons:
+    /// (1) subtitle sidecars yt-dlp writes can't collide with any pre-existing
+    /// <c>&lt;stem&gt;.&lt;lang&gt;.&lt;ext&gt;</c> files in the user's chosen save
+    /// folder; (2) yt-dlp doesn't always produce a file with the extension we
+    /// asked for in <c>-o</c>, so we need to look in a known-empty directory to
+    /// reliably find what it actually wrote and rename it to the user's target.
+    /// The subtitle sidecars stay in the temp dir for the picker to enumerate
+    /// and are cleaned up by the caller once a track has been loaded.
+    /// </summary>
+    private async Task DownloadViaTempDirectoryAsync(IProgress<float> progress, CancellationToken cancellationToken)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "SE-dl-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        if (_downloadSubtitles)
+        {
+            TempSubtitleDirectory = tempDir;
+        }
+
+        // Pass yt-dlp the literal "%(ext)s" placeholder so it picks the actual
+        // container extension. If we use the user's chosen extension verbatim
+        // (e.g. "download.mkv"), yt-dlp treats the whole thing as the template
+        // stem and writes "download.mkv.webm" after the merge — leaving us
+        // unable to find the produced file by predicted name.
+        var templatePath = Path.Combine(tempDir, "download.%(ext)s");
+
+        try
+        {
+            await _ytDlpDownloadService.DownloadVideo(_url, templatePath, _downloadSubtitles, progress, cancellationToken);
+
+            var actualVideoPath = FindProducedVideo(tempDir);
+            if (actualVideoPath is null)
+            {
+                throw new FileNotFoundException(
+                    "yt-dlp finished but no video file was produced." + Environment.NewLine +
+                    $"Temp directory: {tempDir}" + Environment.NewLine +
+                    "Contents: " + (Directory.Exists(tempDir)
+                        ? string.Join(", ", Directory.EnumerateFiles(tempDir).Select(Path.GetFileName))
+                        : "<missing>"));
+            }
+
+            if (File.Exists(OutputPath))
+            {
+                File.Delete(OutputPath);
+            }
+            File.Move(actualVideoPath, OutputPath);
+
+            if (_downloadSubtitles)
+            {
+                DownloadedSubtitles = YtDlpDownloadService.EnumerateDownloadedSubtitles(tempDir, "download");
+            }
+            else
+            {
+                // No subs to keep — clean the temp dir right away so we don't
+                // leak it. (When subs are on, the caller owns cleanup.)
+                TryDeleteDirectory(tempDir);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup on any failure — caller never sees the temp dir
+            // in that case, so it would otherwise leak.
+            TryDeleteDirectory(tempDir);
+            TempSubtitleDirectory = null;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Scans <paramref name="tempDir"/> for the video yt-dlp wrote. Video files
+    /// have the shape <c>download.&lt;ext&gt;</c> (single-segment extension);
+    /// subtitle sidecars (<c>download.&lt;lang&gt;.&lt;ext&gt;</c>) and incomplete
+    /// <c>.part</c> files are filtered out.
+    /// </summary>
+    private static string? FindProducedVideo(string tempDir)
+    {
+        foreach (var file in Directory.EnumerateFiles(tempDir, "download.*"))
+        {
+            var name = Path.GetFileName(file);
+            if (!name.StartsWith("download.", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var rest = name.Substring("download.".Length);
+            if (rest.Contains('.'))
+            {
+                // "download.<lang>.<subext>" — a subtitle sidecar, not the video.
+                continue;
+            }
+
+            if (string.Equals(rest, "part", StringComparison.OrdinalIgnoreCase))
+            {
+                // Incomplete intermediate from a failed prior download attempt.
+                continue;
+            }
+
+            return file;
+        }
+
+        return null;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort
+        }
     }
 
     private readonly Lock _lockObj = new();
@@ -92,6 +236,8 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
                 {
                     Error = $"Download finished but output file was not found:{Environment.NewLine}{OutputPath}";
                 }
+                // DownloadedSubtitles / TempSubtitleDirectory are populated inside
+                // DownloadViaTempDirectoryAsync before this branch is reached.
 
                 Close();
             }
@@ -143,6 +289,16 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
     [RelayCommand]
     private void CommandCancel()
     {
+        // After a download error the window is intentionally kept open so the
+        // user can read the error (see Close()). In that state the download task
+        // is already done, so cancelling the token does nothing — Cancel here
+        // becomes "dismiss the error and close the window".
+        if (_done)
+        {
+            Window?.Close();
+            return;
+        }
+
         _cancellationTokenSource.Cancel();
         // Let the timer pick up the cancellation and close cleanly.
     }

--- a/src/ui/Features/Video/OpenFromUrl/OpenFromUrlViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/OpenFromUrlViewModel.cs
@@ -14,6 +14,7 @@ public enum OpenFromUrlMode
 public partial class OpenFromUrlViewModel : ObservableObject
 {
     [ObservableProperty] private string _url;
+    [ObservableProperty] private bool _downloadSubtitles;
 
     public Window? Window { get; set; }
 
@@ -24,6 +25,7 @@ public partial class OpenFromUrlViewModel : ObservableObject
     public OpenFromUrlViewModel()
     {
         Url = string.Empty;
+        DownloadSubtitles = false;
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/OpenFromUrl/OpenFromUrlWindow.cs
+++ b/src/ui/Features/Video/OpenFromUrl/OpenFromUrlWindow.cs
@@ -55,6 +55,14 @@ public class OpenFromUrlWindow : Window
             [!TextBox.TextProperty] = new Binding(nameof(vm.Url)) { Mode = BindingMode.TwoWay },
         };
 
+        var downloadSubtitlesCheckBox = new CheckBox
+        {
+            Content = Se.Language.Video.OpenFromUrlDownloadSubtitles,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Margin = new Thickness(0, 4, 0, 4),
+            [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.DownloadSubtitles)) { Mode = BindingMode.TwoWay },
+        };
+
         var openOnlineCard = BuildCard(
             "▶", // ▶
             Se.Language.Video.OpenFromUrlOpenOnline,
@@ -85,13 +93,22 @@ public class OpenFromUrlWindow : Window
                 new Border { Height = 4 }, // spacer
                 openOnlineCard,
                 downloadCard,
+                downloadSubtitlesCheckBox,
                 cancelBar,
             },
         };
 
         Content = content;
 
-        Activated += delegate { _urlTextBox.Focus(); };
+        // Activated fires before the visual tree is fully ready; deferring the
+        // Focus call to Loaded + Input priority makes it actually stick when the
+        // window first opens.
+        Loaded += (_, _) =>
+        {
+            Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                () => _urlTextBox.Focus(),
+                Avalonia.Threading.DispatcherPriority.Input);
+        };
     }
 
     private Button BuildCard(string iconGlyph, string title, string description, string note, IRelayCommand command, bool isRecommended)

--- a/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/OnlineSubtitleCueDisplay.cs
+++ b/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/OnlineSubtitleCueDisplay.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Video.OpenFromUrl.PickOnlineSubtitle;
+
+/// <summary>
+/// DataGrid row for the preview pane in the picker — one entry per parsed cue.
+/// </summary>
+public class OnlineSubtitleCueDisplay
+{
+    public int Number { get; set; }
+    public TimeSpan Show { get; set; }
+    public TimeSpan Duration { get; set; }
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/OnlineSubtitleTrackDisplay.cs
+++ b/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/OnlineSubtitleTrackDisplay.cs
@@ -1,0 +1,13 @@
+namespace Nikse.SubtitleEdit.Features.Video.OpenFromUrl.PickOnlineSubtitle;
+
+/// <summary>
+/// DataGrid row for a pre-downloaded subtitle file in the picker.
+/// </summary>
+public class OnlineSubtitleTrackDisplay
+{
+    public string Language { get; set; } = string.Empty;
+    public string LanguageCode { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Format { get; set; } = string.Empty;
+    public string FilePath { get; set; } = string.Empty;
+}

--- a/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleViewModel.cs
@@ -1,0 +1,187 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.OpenFromUrl.PickOnlineSubtitle;
+
+public partial class PickOnlineSubtitleViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<OnlineSubtitleTrackDisplay> _tracks;
+    [ObservableProperty] private OnlineSubtitleTrackDisplay? _selectedTrack;
+    [ObservableProperty] private ObservableCollection<OnlineSubtitleCueDisplay> _previewRows;
+    [ObservableProperty] private string _statusText;
+    [ObservableProperty] private bool _isOkEnabled;
+
+    public Window? Window { get; set; }
+    public DataGrid TracksGrid { get; set; }
+    public bool OkPressed { get; private set; }
+    public string? SelectedSubtitlePath { get; private set; }
+
+    public PickOnlineSubtitleViewModel()
+    {
+        Tracks = new ObservableCollection<OnlineSubtitleTrackDisplay>();
+        PreviewRows = new ObservableCollection<OnlineSubtitleCueDisplay>();
+        StatusText = string.Empty;
+        TracksGrid = new DataGrid();
+    }
+
+    /// <summary>
+    /// Initializes the picker with pre-downloaded subtitle files. The picker
+    /// itself never spawns yt-dlp — it's purely a chooser over what's on disk.
+    /// </summary>
+    public void Initialize(IReadOnlyList<DownloadedSubtitleInfo> subtitles)
+    {
+        Tracks.Clear();
+        PreviewRows.Clear();
+
+        if (subtitles.Count == 0)
+        {
+            StatusText = Se.Language.Video.PickOnlineSubtitleNoneFound;
+            IsOkEnabled = false;
+            return;
+        }
+
+        foreach (var sub in subtitles)
+        {
+            Tracks.Add(new OnlineSubtitleTrackDisplay
+            {
+                Language = FormatLanguage(sub.LanguageCode),
+                LanguageCode = sub.LanguageCode,
+                Name = string.Empty,
+                Format = sub.Format,
+                FilePath = sub.FilePath,
+            });
+        }
+
+        StatusText = string.Empty;
+        var initial = Tracks.First();
+        SelectedTrack = initial;
+        TracksGrid.SelectedItem = initial;
+        TracksGrid.ScrollIntoView(initial, null);
+    }
+
+    partial void OnSelectedTrackChanged(OnlineSubtitleTrackDisplay? value)
+    {
+        IsOkEnabled = value != null;
+        LoadPreview(value);
+    }
+
+    private void LoadPreview(OnlineSubtitleTrackDisplay? track)
+    {
+        PreviewRows.Clear();
+        if (track is null || string.IsNullOrEmpty(track.FilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var subtitle = Subtitle.Parse(track.FilePath);
+            if (subtitle == null || subtitle.Paragraphs.Count == 0)
+            {
+                StatusText = Se.Language.Video.PickOnlineSubtitleNoneFound;
+                return;
+            }
+
+            // Skip empty cues — VTT tracks often use text-less paragraphs as
+            // timing markers. Cap at the first 200 non-empty cues so the preview
+            // stays snappy for very long subtitles.
+            const int maxPreview = 200;
+            var displayed = 0;
+            foreach (var p in subtitle.Paragraphs)
+            {
+                if (string.IsNullOrWhiteSpace(p.Text))
+                {
+                    continue;
+                }
+
+                displayed++;
+                PreviewRows.Add(new OnlineSubtitleCueDisplay
+                {
+                    Number = displayed,
+                    Show = p.StartTime.TimeSpan,
+                    Duration = TimeSpan.FromMilliseconds(Math.Max(0, p.EndTime.TotalMilliseconds - p.StartTime.TotalMilliseconds)),
+                    Text = p.Text,
+                });
+
+                if (displayed >= maxPreview)
+                {
+                    break;
+                }
+            }
+
+            StatusText = displayed == 0 ? Se.Language.Video.PickOnlineSubtitleNoneFound : string.Empty;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Failed to parse subtitle for preview: {track.FilePath}");
+            StatusText = ex.Message;
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        var selected = SelectedTrack;
+        if (selected is null || string.IsNullOrEmpty(selected.FilePath) || Window is null)
+        {
+            return;
+        }
+
+        SelectedSubtitlePath = selected.FilePath;
+        OkPressed = true;
+        Window.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDownHandler(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Cancel();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter && IsOkEnabled)
+        {
+            Ok();
+            e.Handled = true;
+        }
+    }
+
+    /// <summary>
+    /// Turns a BCP-47 / ISO language code into a friendly display like
+    /// "English (en)". Falls back to just the raw code for tags yt-dlp invents
+    /// such as <c>en-orig</c> or <c>live_chat</c>.
+    /// </summary>
+    private static string FormatLanguage(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var ci = CultureInfo.GetCultureInfo(code.Replace('_', '-'));
+            return $"{ci.DisplayName} ({code})";
+        }
+        catch (CultureNotFoundException)
+        {
+            return code;
+        }
+    }
+}

--- a/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleWindow.cs
+++ b/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleWindow.cs
@@ -101,7 +101,7 @@ public class PickOnlineSubtitleWindow : Window
                 },
                 new DataGridTextColumn
                 {
-                    Header = "Format",
+                    Header = Se.Language.General.Format,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     Binding = new Binding(nameof(OnlineSubtitleTrackDisplay.Format)),
                     IsReadOnly = true,

--- a/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleWindow.cs
+++ b/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleWindow.cs
@@ -1,0 +1,195 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+
+namespace Nikse.SubtitleEdit.Features.Video.OpenFromUrl.PickOnlineSubtitle;
+
+public class PickOnlineSubtitleWindow : Window
+{
+    public PickOnlineSubtitleWindow(PickOnlineSubtitleViewModel vm)
+    {
+        vm.Window = this;
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Video.PickOnlineSubtitleTitle;
+        Width = 1024;
+        Height = 600;
+        MinWidth = 800;
+        MinHeight = 500;
+        CanResize = true;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        DataContext = vm;
+
+        var tracksView = MakeTracksView(vm);
+        var previewView = MakePreviewView(vm);
+
+        var statusBar = MakeStatusBar(vm);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        buttonOk.Bind(IsEnabledProperty, new Binding(nameof(vm.IsOkEnabled)));
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var splitGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 10,
+        };
+        splitGrid.Add(tracksView, 0, 0);
+        splitGrid.Add(previewView, 0, 1);
+
+        var outer = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 8,
+        };
+        outer.Add(splitGrid, 0);
+        outer.Add(statusBar, 1);
+        outer.Add(panelButtons, 2);
+
+        Content = outer;
+
+        AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
+    }
+
+    private static Border MakeTracksView(PickOnlineSubtitleViewModel vm)
+    {
+        var dataGridTracks = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = vm.Tracks,
+            Columns =
+            {
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Language,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(OnlineSubtitleTrackDisplay.Language)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1.6, DataGridLengthUnitType.Star),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Name,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(OnlineSubtitleTrackDisplay.Name)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+                new DataGridTextColumn
+                {
+                    Header = "Format",
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(OnlineSubtitleTrackDisplay.Format)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(0.6, DataGridLengthUnitType.Star),
+                },
+            },
+        };
+        dataGridTracks.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedTrack)) { Mode = BindingMode.TwoWay });
+        dataGridTracks.DoubleTapped += (_, _) =>
+        {
+            if (vm.IsOkEnabled)
+            {
+                vm.OkCommand.Execute(null);
+            }
+        };
+        vm.TracksGrid = dataGridTracks;
+
+        return UiUtil.MakeBorderForControlNoPadding(dataGridTracks);
+    }
+
+    private static Border MakePreviewView(PickOnlineSubtitleViewModel vm)
+    {
+        var fullTimeConverter = new TimeSpanToDisplayFullConverter();
+        var shortTimeConverter = new TimeSpanToDisplayShortConverter();
+        var dataGridPreview = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = vm.PreviewRows,
+            Columns =
+            {
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.NumberSymbol,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(OnlineSubtitleCueDisplay.Number)),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Show,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(OnlineSubtitleCueDisplay.Show)) { Converter = fullTimeConverter },
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Duration,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(OnlineSubtitleCueDisplay.Duration)) { Converter = shortTimeConverter },
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Text,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(OnlineSubtitleCueDisplay.Text)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+            },
+        };
+
+        return UiUtil.MakeBorderForControlNoPadding(dataGridPreview);
+    }
+
+    private static Border MakeStatusBar(PickOnlineSubtitleViewModel vm)
+    {
+        var statusText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            TextWrapping = TextWrapping.NoWrap,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            Opacity = 0.85,
+        };
+        statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusText)));
+
+        return new Border
+        {
+            Child = statusText,
+            Padding = new Thickness(4, 2),
+        };
+    }
+}

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -48,6 +48,10 @@ public class LanguageVideo
     public string OpenFromUrlMissing { get; set; }
     public string OpenFromUrlDownloadingTitle { get; set; }
     public string OpenFromUrlSaveAs { get; set; }
+    public string OpenFromUrlDownloadSubtitles { get; set; }
+    public string PickOnlineSubtitleTitle { get; set; }
+    public string PickOnlineSubtitleFetching { get; set; }
+    public string PickOnlineSubtitleNoneFound { get; set; }
     public string ToggleCurrentSubtitleWhilePlaying { get; set; }
     public string OnlyMkvCanSupportEmbeddedSubtitleEditing { get; set; }
     public string ReEncodeInfo { get; set; }
@@ -101,6 +105,10 @@ public class LanguageVideo
         OpenFromUrlMissing = "Please enter a video URL first.";
         OpenFromUrlDownloadingTitle = "Downloading video";
         OpenFromUrlSaveAs = "Save video as";
+        OpenFromUrlDownloadSubtitles = "Also download subtitles";
+        PickOnlineSubtitleTitle = "Pick subtitle to download";
+        PickOnlineSubtitleFetching = "Downloading subtitles...";
+        PickOnlineSubtitleNoneFound = "No subtitles found for this URL.";
         ToggleCurrentSubtitleWhilePlaying = "Toggle current subtitle while playing";
         OnlyMkvCanSupportEmbeddedSubtitleEditing = "Only Matroska (.mkv, .webm) files are supported for editing embedded subtitles.";
         ReEncodeInfo = "Re-encoding can make subtitling smoother:" + Environment.NewLine +

--- a/src/ui/Logic/Download/YtDlpDownloadService.cs
+++ b/src/ui/Logic/Download/YtDlpDownloadService.cs
@@ -21,7 +21,10 @@ public class YtDlpDownloadService : IYtDlpDownloadService
 {
     private readonly HttpClient _httpClient;
     internal const string CurrentVersion = "2026.03.17";
-    private static readonly TimeSpan VersionCheckTimeout = TimeSpan.FromSeconds(5);
+    // First-run extraction of the self-extracting yt-dlp bundle (especially
+    // yt-dlp_macos) routinely needs more than 5s on slower disks; bumped to 15s
+    // so the timeout doesn't masquerade as "version unknown / outdated".
+    private static readonly TimeSpan VersionCheckTimeout = TimeSpan.FromSeconds(15);
     private const string WindowsUrl = "https://github.com/yt-dlp/yt-dlp/releases/download/" + CurrentVersion + "/yt-dlp.exe";
     private const string LinuxUrl = "https://github.com/yt-dlp/yt-dlp/releases/download/" + CurrentVersion + "/yt-dlp_linux";
     private const string LinuxArmUrl = "https://github.com/yt-dlp/yt-dlp/releases/download/" + CurrentVersion + "/yt-dlp_linux_aarch64";
@@ -243,13 +246,42 @@ public class YtDlpDownloadService : IYtDlpDownloadService
         }
     }
 
+    private static readonly Regex VersionLineRegex = new(@"^\s*v?(\d+\.\d+(?:\.\d+){0,2})\s*$",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    /// <summary>
+    /// Extracts a YYYY.MM[.DD[.N]] version string from <c>yt-dlp --version</c>
+    /// output. Scans all lines instead of taking the first because the macOS
+    /// self-extracting bundle can print bootstrap/extraction noise on first run
+    /// before the actual version line. Returns null if no line in the output
+    /// matches a version shape.
+    /// </summary>
+    internal static string? ExtractVersion(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return null;
+        }
+
+        var match = VersionLineRegex.Match(output);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    /// <summary>
+    /// Returns true only when we can confirm the installed version is older than
+    /// <see cref="CurrentVersion"/>. Anything we can't parse — null, empty, weird
+    /// pre-release suffix, extraction-noise output — returns false. Nagging the
+    /// user to redownload every session because <c>--version</c> printed something
+    /// we didn't expect is worse than trusting the binary and letting the next
+    /// real yt-dlp call surface a concrete error.
+    /// </summary>
     internal static bool IsVersionOutdated(string? installedVersion)
     {
         if (string.IsNullOrWhiteSpace(installedVersion) ||
             !Version.TryParse(installedVersion.Trim(), out var parsedInstalledVersion) ||
             !Version.TryParse(CurrentVersion, out var parsedCurrentVersion))
         {
-            return true;
+            return false;
         }
 
         return parsedInstalledVersion < parsedCurrentVersion;
@@ -300,8 +332,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
             }
 
             var output = await stdoutTask;
-            var lines = output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            return lines.Length == 0 ? null : lines[0];
+            return ExtractVersion(output);
         }
         finally
         {

--- a/src/ui/Logic/Download/YtDlpDownloadService.cs
+++ b/src/ui/Logic/Download/YtDlpDownloadService.cs
@@ -1,8 +1,10 @@
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -14,8 +16,28 @@ namespace Nikse.SubtitleEdit.Logic.Download;
 public interface IYtDlpDownloadService
 {
     Task DownloadYtDlp(IProgress<float>? progress, CancellationToken cancellationToken);
-    Task DownloadVideo(string url, string outputPath, IProgress<float>? progress, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Downloads <paramref name="url"/> to <paramref name="outputPath"/>. When
+    /// <paramref name="downloadAllSubtitles"/> is true, also writes every
+    /// human-uploaded subtitle track as a sibling file
+    /// (<c>{stem}.{lang}.{ext}</c>) using the same single yt-dlp invocation.
+    /// </summary>
+    Task DownloadVideo(string url, string outputPath, bool downloadAllSubtitles, IProgress<float>? progress, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Subtitle-only download (no video). Writes every human-uploaded subtitle
+    /// track to <paramref name="outputStem"/>.<c>{lang}.{ext}</c> via a single
+    /// yt-dlp invocation. Caller is responsible for cleaning up the directory.
+    /// </summary>
+    Task DownloadAllSubtitlesAsync(string url, string outputStem, CancellationToken cancellationToken);
 }
+
+/// <summary>
+/// A subtitle file that yt-dlp wrote to disk. Constructed from the resulting
+/// filename — yt-dlp uses <c>{stem}.{lang}.{ext}</c>.
+/// </summary>
+public sealed record DownloadedSubtitleInfo(string FilePath, string LanguageCode, string Format);
 
 public class YtDlpDownloadService : IYtDlpDownloadService
 {
@@ -83,7 +105,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
 
     private static readonly Regex PercentageRegex = new(@"(?<pct>\d+(?:\.\d+)?)\s*%", RegexOptions.Compiled);
 
-    public async Task DownloadVideo(string url, string outputPath, IProgress<float>? progress, CancellationToken cancellationToken)
+    public async Task DownloadVideo(string url, string outputPath, bool downloadAllSubtitles, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -92,19 +114,33 @@ public class YtDlpDownloadService : IYtDlpDownloadService
             throw new InvalidOperationException("yt-dlp is not installed");
         }
 
+        var args = new List<string>
+        {
+            "--newline",       // emit one progress line per update, never carriage-return rewriting
+            "--no-mtime",      // don't carry remote mtime to the local file
+            "--no-playlist",   // single video only — playlist URLs would download many files
+            "-o", outputPath,
+        };
+
+        if (downloadAllSubtitles)
+        {
+            // Ride along with the video download: yt-dlp writes every available
+            // human-uploaded subtitle track as a sibling file using the same
+            // <stem>.<lang>.<ext> naming so the caller can find them by globbing.
+            args.Add("--write-subs");
+            args.Add("--sub-langs");
+            args.Add("all");
+            args.Add("--sub-format");
+            args.Add("vtt/best");
+        }
+
+        args.Add(url);
+
         using var process = new Process
         {
             StartInfo = new ProcessStartInfo
             {
                 FileName = GetFullFileName(),
-                ArgumentList =
-                {
-                    "--newline",       // emit one progress line per update, never carriage-return rewriting
-                    "--no-mtime",      // don't carry remote mtime to the local file
-                    "--no-playlist",   // single video only — playlist URLs would download many files
-                    "-o", outputPath,
-                    url,
-                },
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -112,6 +148,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
             },
             EnableRaisingEvents = true,
         };
+        foreach (var a in args) process.StartInfo.ArgumentList.Add(a);
 
         var stderrBuffer = new System.Text.StringBuilder();
 
@@ -164,6 +201,124 @@ public class YtDlpDownloadService : IYtDlpDownloadService
 
         progress?.Report(1f);
     }
+
+    public async Task DownloadAllSubtitlesAsync(string url, string outputStem, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!File.Exists(GetFullFileName()))
+        {
+            throw new InvalidOperationException("yt-dlp is not installed");
+        }
+
+        var directory = Path.GetDirectoryName(outputStem);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var args = new List<string>
+        {
+            "--skip-download",
+            "--no-warnings",
+            "--no-playlist",
+            "--write-subs",
+            "--sub-langs", "all",
+            "--sub-format", "vtt/best",
+            "-o", outputStem,
+            url,
+        };
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = GetFullFileName(),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+        foreach (var a in args) process.StartInfo.ArgumentList.Add(a);
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start yt-dlp");
+        }
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKillProcess(process);
+            throw;
+        }
+
+        await stdoutTask;
+        if (process.ExitCode != 0)
+        {
+            var details = (await stderrTask).Trim();
+            throw new InvalidOperationException(
+                $"yt-dlp subtitle download exited with code {process.ExitCode}." +
+                (string.IsNullOrEmpty(details) ? string.Empty : Environment.NewLine + details));
+        }
+    }
+
+    /// <summary>
+    /// Scans <paramref name="directory"/> for files yt-dlp produced via its
+    /// <c>{stem}.{lang}.{ext}</c> sidecar naming. Filters to subtitle extensions
+    /// so the video file (and any unrelated stem.* files) are excluded.
+    /// </summary>
+    public static IReadOnlyList<DownloadedSubtitleInfo> EnumerateDownloadedSubtitles(string directory, string stem)
+    {
+        var results = new List<DownloadedSubtitleInfo>();
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory) || string.IsNullOrEmpty(stem))
+        {
+            return results;
+        }
+
+        var prefix = stem + ".";
+        foreach (var path in Directory.EnumerateFiles(directory, stem + ".*"))
+        {
+            var fileName = Path.GetFileName(path);
+            if (!fileName.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var rest = fileName.Substring(prefix.Length);
+            var dotIdx = rest.LastIndexOf('.');
+            if (dotIdx <= 0)
+            {
+                // No language segment — that's the video file (or other) itself.
+                continue;
+            }
+
+            var lang = rest.Substring(0, dotIdx);
+            var ext = rest.Substring(dotIdx + 1);
+            if (!IsSubtitleExtension(ext))
+            {
+                continue;
+            }
+
+            results.Add(new DownloadedSubtitleInfo(path, lang, ext));
+        }
+
+        results.Sort(static (a, b) => string.Compare(a.LanguageCode, b.LanguageCode, StringComparison.OrdinalIgnoreCase));
+        return results;
+    }
+
+    private static bool IsSubtitleExtension(string ext) => ext switch
+    {
+        "vtt" or "srt" or "ttml" or "ass" or "ssa" or "sbv" or "lrc"
+            or "srv1" or "srv2" or "srv3" or "json3" or "ytt" => true,
+        _ => false,
+    };
 
     private static void ReportProgressFromLine(string line, IProgress<float>? progress)
     {

--- a/tests/UI/Logic/Download/YtDlpDownloadServiceTests.cs
+++ b/tests/UI/Logic/Download/YtDlpDownloadServiceTests.cs
@@ -52,4 +52,40 @@ public class YtDlpDownloadServiceTests
 
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void EnumerateDownloadedSubtitles_FindsSidecarFiles_FiltersByExtensionAndSorts()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "EnumerateSubsTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "video.mkv"), ""); // not a sub — filtered out by ext
+            File.WriteAllText(Path.Combine(tempDir, "video.es.vtt"), "");
+            File.WriteAllText(Path.Combine(tempDir, "video.en.vtt"), "");
+            File.WriteAllText(Path.Combine(tempDir, "video.fr.srt"), "");
+            File.WriteAllText(Path.Combine(tempDir, "video.txt"), ""); // no language segment
+            File.WriteAllText(Path.Combine(tempDir, "other.en.vtt"), ""); // different stem
+
+            var result = YtDlpDownloadService.EnumerateDownloadedSubtitles(tempDir, "video");
+
+            Assert.Equal(3, result.Count);
+            Assert.Equal("en", result[0].LanguageCode);
+            Assert.Equal("vtt", result[0].Format);
+            Assert.Equal("es", result[1].LanguageCode);
+            Assert.Equal("fr", result[2].LanguageCode);
+            Assert.Equal("srt", result[2].Format);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EnumerateDownloadedSubtitles_MissingDirOrEmptyStem_ReturnsEmpty()
+    {
+        Assert.Empty(YtDlpDownloadService.EnumerateDownloadedSubtitles("/nonexistent/path", "video"));
+        Assert.Empty(YtDlpDownloadService.EnumerateDownloadedSubtitles(Path.GetTempPath(), ""));
+    }
 }

--- a/tests/UI/Logic/Download/YtDlpDownloadServiceTests.cs
+++ b/tests/UI/Logic/Download/YtDlpDownloadServiceTests.cs
@@ -5,11 +5,11 @@ namespace UITests.Logic.Download;
 public class YtDlpDownloadServiceTests
 {
     [Theory]
-    [InlineData("2025.07.21", true)]
-    [InlineData(YtDlpDownloadService.CurrentVersion, false)]
-    [InlineData("", true)]
-    [InlineData("not-a-version", true)]
-    public void IsVersionOutdated_DetectsStaleOrInvalidVersions(string installedVersion, bool expected)
+    [InlineData("2025.07.21", true)]   // definitively older → nag
+    [InlineData(YtDlpDownloadService.CurrentVersion, false)] // current → don't nag
+    [InlineData("", false)]            // unknown → don't nag (subprocess returned nothing)
+    [InlineData("not-a-version", false)] // unknown → don't nag (unparseable output)
+    public void IsVersionOutdated_OnlyFlagsConfirmedOlderVersions(string installedVersion, bool expected)
     {
         var actual = YtDlpDownloadService.IsVersionOutdated(installedVersion);
 
@@ -35,5 +35,21 @@ public class YtDlpDownloadServiceTests
 
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
             YtDlpDownloadService.IsInstalledVersionOutdated(cancellationTokenSource.Token));
+    }
+
+    [Theory]
+    [InlineData("2026.03.17\n", "2026.03.17")]
+    [InlineData("v2026.03.17\n", "2026.03.17")]
+    [InlineData("  2026.03.17  \n", "2026.03.17")]
+    [InlineData("2026.03.17.1\n", "2026.03.17.1")]
+    [InlineData("[debug] Bootstrapping...\nExtracting bundle\n2026.03.17\n", "2026.03.17")]
+    [InlineData("", null)]
+    [InlineData("   \n  \n", null)]
+    [InlineData("not a version at all", null)]
+    public void ExtractVersion_PullsVersionFromAnyLineInOutput(string output, string? expected)
+    {
+        var actual = YtDlpDownloadService.ExtractVersion(output);
+
+        Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
## Summary
Three related improvements to the Open from URL flow, plus a subtitle-download feature.

### 1. URL dialog pops instantly
`ShowVideoOpenFromUrl` used to block on `IsInstalledVersionOutdated` (a `yt-dlp --version` subprocess) before showing the dialog. Now the version check runs in parallel via `Task.Run` while the URL dialog is on screen — only awaited after the user submits a URL.

### 2. Stop reporting "outdated" when the version is unknown
`IsVersionOutdated` previously returned `true` for null / empty / unparseable input. On macOS the self-extracting yt-dlp bundle can take longer than 5s to unpack on first run, so `--version` timed out and the result was cached as "outdated" — nagging the user every session. Now: returns `false` for unknown / unparseable, and only flags confirmed-older versions. Bumped the timeout 5s → 15s. `GetInstalledVersion` now scans all output lines for a `YYYY.MM[.DD[.N]]` pattern instead of taking `lines[0]` (yt-dlp_macos prints extraction noise on first run).

### 3. Download subtitles + Matroska-style picker
New "Also download subtitles" checkbox on the URL dialog. When checked, yt-dlp downloads every available human-uploaded subtitle alongside the video in the same invocation (`--write-subs --sub-langs all`). A Matroska-style picker shows the tracks with a preview pane and loads the chosen one into the editor.

Notable implementation choices:
- Subtitles land in a per-download GUID temp dir so the picker can't accidentally enumerate any pre-existing `<stem>.<lang>.<ext>` files sitting next to the user's chosen save folder. The video is moved out to the user's chosen path; subs stay in temp until the picker loads the chosen one, then the dir is cleaned up.
- The video download is always routed through the temp dir (regardless of subs flag) because yt-dlp doesn't always honor the `-o` extension — for VP9+Opus YouTube videos `-o "download.mkv"` produces `download.mkv.webm`. Fix: pass `download.%(ext)s` and locate the produced file by globbing.
- The picker is purely a chooser — it doesn't spawn yt-dlp. For the streaming ("Open online") path, MainViewModel pre-downloads subs into its own GUID temp dir and feeds the list in.
- Auto-generated YouTube captions are excluded (noisy word-level cues, not what users expect).

### 4. Polish
- Cancel button in the video download window now closes the window when clicked after an error (previously it cancelled an already-completed token and did nothing).
- URL textbox is now focused via `Loaded + Dispatcher.UIThread.InvokeAsync(... Input)` instead of `Activated` (which fires before the visual tree is ready).

## Test plan
- [x] Unit tests (18 pass): `IsVersionOutdated`, `ExtractVersion` multi-line/v-prefix/whitespace, `EnumerateDownloadedSubtitles` extension filtering + sorting.
- [x] Verified yt-dlp behavior locally against the URL that originally failed (`youtube.com/watch?v=BV4ab2l0Re4`) — confirmed `-o "download.mkv"` produces `download.mkv.webm` and `-o "download.%(ext)s"` produces `download.webm`.
- [ ] Open from URL → URL dialog pops instantly.
- [ ] Open online + subs → video plays, picker appears, chosen subtitle loads.
- [ ] Download and open + subs → video saves to chosen path, picker appears, chosen subtitle loads, temp dir is cleaned up.
- [ ] Cancel during a faulted download → window closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)