### PR TITLE
Show full file paths in File > Reopen menu, slightly smaller menu font

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -38,13 +38,18 @@ public static class InitMenu
         menu.Items.Clear();
         menu.Opened += (s, e) => DisplayShortcuts(menu, vm);
 
-        // Drop the menu's font one notch below the theme default — a slightly
-        // denser menu reads better when there are this many entries. The style
-        // also targets nested MenuItems so submenus inherit the size.
+        // Drop the menu's font one notch below the theme default and tighten
+        // each item's vertical padding — a denser menu reads better when there
+        // are this many entries. The style targets nested MenuItems so submenu
+        // items inherit the same look.
         menu.FontSize = MenuFontSize;
         menu.Styles.Add(new Style(x => x.OfType<MenuItem>())
         {
-            Setters = { new Setter(MenuItem.FontSizeProperty, MenuFontSize) },
+            Setters =
+            {
+                new Setter(MenuItem.FontSizeProperty, MenuFontSize),
+                new Setter(MenuItem.PaddingProperty, new Thickness(10, 3)),
+            },
         });
 
         menu.Items.Add(new MenuItem

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -3,6 +3,8 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Styling;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
@@ -16,6 +18,9 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
 public static class InitMenu
 {
+    // One notch below the Fluent theme default (~14).
+    private const double MenuFontSize = 13.0;
+
     public static void Make(MainViewModel vm)
     {
         var l = Se.Language.Main.Menu;
@@ -32,6 +37,15 @@ public static class InitMenu
         menu.DataContext = vm;
         menu.Items.Clear();
         menu.Opened += (s, e) => DisplayShortcuts(menu, vm);
+
+        // Drop the menu's font one notch below the theme default — a slightly
+        // denser menu reads better when there are this many entries. The style
+        // also targets nested MenuItems so submenus inherit the size.
+        menu.FontSize = MenuFontSize;
+        menu.Styles.Add(new Style(x => x.OfType<MenuItem>())
+        {
+            Setters = { new Setter(MenuItem.FontSizeProperty, MenuFontSize) },
+        });
 
         menu.Items.Add(new MenuItem
         {
@@ -910,12 +924,20 @@ public static class InitMenu
                     }
                 }
 
+                // Wrap the path in an explicit TextBlock with TextTrimming.None so
+                // long file paths render in full instead of being clipped with an
+                // ellipsis. The MenuItem widens to fit.
                 var item = new MenuItem
                 {
-                    Header = header,
+                    Header = new TextBlock
+                    {
+                        Text = header,
+                        TextTrimming = TextTrimming.None,
+                    },
                     Command = vm.CommandFileReopenCommand,
+                    CommandParameter = file,
+                    [ToolTip.TipProperty] = header,
                 };
-                item.CommandParameter = file;
                 vm.MenuReopen.Items.Add(item);
             }
 


### PR DESCRIPTION
## Summary
Closes #11012.

- The recent-files entries in `File > Reopen` used a plain-string `MenuItem.Header`, which Avalonia renders through a default `TextBlock` that clips long paths with an ellipsis. With long working paths that's not enough to tell similarly-named files apart. Each entry now uses an explicit `TextBlock` as `Header` with `TextTrimming = TextTrimming.None`, so the menu widens to fit the longest path. The full path is also set as a `ToolTip` in case a future constraint ever clips it.
- The menu's font size drops one notch from the Fluent default (~14) to 13 — slightly denser reads better given how many entries this menu has. Applied to the `Menu` directly and via a `Style` targeting `OfType<MenuItem>` so submenu items inherit.

## Test plan
- [ ] Open a file with a long absolute path; confirm `File > Reopen` shows the full path without ellipsis.
- [ ] Hover an entry; confirm the same path appears as a tooltip.
- [ ] Confirm the menu and all submenus render at the slightly smaller font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)