### PR TITLE
OmniVoice: SHA-256 verification, settings window, new release URLs

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -138,6 +138,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceSettings;
@@ -378,6 +379,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<NOcrSettingsViewModel>();
         collection.AddTransient<LlamaCppOcrSettingsViewModel>();
         collection.AddTransient<OcrViewModel>();
+        collection.AddTransient<OmniVoiceSettingsViewModel>();
         collection.AddTransient<OpenFromUrlViewModel>();
         collection.AddTransient<DownloadVideoFromUrlViewModel>();
         collection.AddTransient<PickOnlineSubtitleViewModel>();

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -54,6 +54,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskOmniVoice;
     private Task? _downloadTaskOmniVoiceVoices;
     private Task? _downloadTaskOmniVoiceModels;
+    private string _omniVoiceVariant = OmniVoiceDownloadService.WindowsVariantVulkan;
     private readonly Timer _timer = new();
 
     private readonly ITtsDownloadService _ttsDownloadService;
@@ -520,6 +521,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                     // the OmniVoice folder where GetExecutableFileName() looks for them.
                     var flatten = !Configuration.IsRunningOnWindows;
                     _zipUnpacker.UnpackZipStream(_downloadStreamOmniVoice, folder, string.Empty, flatten, new List<string>(), null);
+                    WriteOmniVoiceInstalledHash(folder, _downloadStreamOmniVoice, DownloadHashManager.ResolveOmniVoiceKey(_omniVoiceVariant));
                     _downloadStreamOmniVoice.Dispose();
                 }
                 catch (Exception ex)
@@ -609,6 +611,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                     {
                         _downloadStreamOmniVoiceVoices.Position = 0;
                         _zipUnpacker.UnpackZipStream(_downloadStreamOmniVoiceVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        WriteOmniVoiceInstalledHash(voicesFolder, _downloadStreamOmniVoiceVoices, DownloadHashManager.OmniVoice.Voices);
                     }
                     catch (Exception ex)
                     {
@@ -741,6 +744,30 @@ public partial class DownloadTtsViewModel : ObservableObject
     private static string QuoteForBash(string value)
     {
         return "'" + value.Replace("'", "'\"'\"'") + "'";
+    }
+
+    // Records the downloaded archive's hash in a .installed.sha256 sidecar so SE can later tell
+    // whether the install is outdated (see DownloadHashManager.GetStatus). Best-effort - failure
+    // is swallowed because the engine itself is already on disk and usable without the sidecar.
+    private static void WriteOmniVoiceInstalledHash(string folder, Stream archiveStream, string? key)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(key) || archiveStream.Length == 0)
+            {
+                return;
+            }
+
+            archiveStream.Position = 0;
+            var hash = DownloadHashManager.ComputeSha256(archiveStream);
+
+            var sidecar = Path.Combine(folder, ".installed.sha256");
+            File.WriteAllText(sidecar, key + Environment.NewLine + hash);
+        }
+        catch
+        {
+            // ignore - hash sidecar is best-effort
+        }
     }
 
     private void Close()
@@ -897,6 +924,8 @@ public partial class DownloadTtsViewModel : ObservableObject
 
     public void StartDownloadOmniVoice(string windowsVariant = OmniVoiceDownloadService.WindowsVariantVulkan)
     {
+        _omniVoiceVariant = windowsVariant;
+
         string variantLabel;
         if (Configuration.IsRunningOnWindows)
         {
@@ -905,6 +934,10 @@ public partial class DownloadTtsViewModel : ObservableObject
         else if (Configuration.IsRunningOnMac)
         {
             variantLabel = "macOS universal CPU+Metal";
+        }
+        else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        {
+            variantLabel = "Linux ARM64 CPU";
         }
         else
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -39,6 +39,43 @@ public class OmniVoiceTtsCpp : ITtsEngine
         return File.Exists(GetModelBasePath()) && File.Exists(GetModelTokenizerPath());
     }
 
+    /// <summary>
+    /// Returns the update status of the installed OmniVoice engine relative to the release
+    /// pinned in <see cref="OmniVoiceDownloadService"/>. Reads the key from the
+    /// <c>.installed.sha256</c> sidecar written at install time. Returns
+    /// <see cref="DownloadHashManager.UpdateStatus.Unknown"/> when nothing is installed yet
+    /// or the sidecar is missing (older installs predating hash tracking), so callers do
+    /// not false-positive an update prompt.
+    /// </summary>
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var folder = GetSetFolder();
+        if (!File.Exists(GetExecutableFileName()))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var sidecar = Path.Combine(folder, ".installed.sha256");
+        if (!File.Exists(sidecar))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        try
+        {
+            var lines = File.ReadAllLines(sidecar);
+            if (lines.Length < 2)
+            {
+                return DownloadHashManager.UpdateStatus.Unknown;
+            }
+            return DownloadHashManager.GetStatus(lines[0].Trim(), lines[1].Trim());
+        }
+        catch
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+    }
+
     public override string ToString() => Name;
 
     public static string GetSetFolder()

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
@@ -1,0 +1,232 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
+
+public partial class OmniVoiceSettingsViewModel : ObservableObject
+{
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _backendLabel = string.Empty;
+    [ObservableProperty] private string _statusLabel = string.Empty;
+    [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
+    [ObservableProperty] private string _releaseTag = OmniVoiceDownloadService.ReleaseTag;
+    [ObservableProperty] private string _installFolder = string.Empty;
+    [ObservableProperty] private bool _isInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public OmniVoiceSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        InstallFolder = OmniVoiceTtsCpp.GetSetFolder();
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        IsInstalled = File.Exists(OmniVoiceTtsCpp.GetExecutableFileName());
+        BackendLabel = IsInstalled ? DetectInstalledBackend() : "Not installed";
+        ApplyStatus(IsInstalled ? OmniVoiceTtsCpp.GetEngineUpdateStatus() : DownloadHashManager.UpdateStatus.Unknown, IsInstalled);
+    }
+
+    private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)
+    {
+        if (!installed)
+        {
+            StatusLabel = "Not installed";
+            StatusBrush = new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));   // red
+            return;
+        }
+
+        switch (status)
+        {
+            case DownloadHashManager.UpdateStatus.UpToDate:
+                StatusLabel = "Up to date";
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
+                break;
+            case DownloadHashManager.UpdateStatus.UpdateAvailable:
+                StatusLabel = "Update available";
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
+                break;
+            default:
+                StatusLabel = "Unknown (no install record)";
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
+                break;
+        }
+    }
+
+    // Reads the .installed.sha256 sidecar (written by DownloadTtsViewModel after unpack) to learn
+    // which Windows variant is installed. Falls back to ggml-*.dll detection on Windows, and to
+    // OS+arch on macOS and Linux where the variant is unambiguous.
+    private static string DetectInstalledBackend()
+    {
+        if (Configuration.IsRunningOnMac)
+        {
+            return "macOS universal (CPU + Metal)";
+        }
+
+        if (Configuration.IsRunningOnLinux)
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "Linux ARM64 (CPU)"
+                : "Linux x64 (CPU)";
+        }
+
+        var folder = OmniVoiceTtsCpp.GetSetFolder();
+        var sidecar = Path.Combine(folder, ".installed.sha256");
+        if (File.Exists(sidecar))
+        {
+            try
+            {
+                var key = File.ReadLines(sidecar).FirstOrDefault()?.Trim();
+                if (!string.IsNullOrEmpty(key))
+                {
+                    return key switch
+                    {
+                        DownloadHashManager.OmniVoice.WindowsCuda => "Windows x64 (CUDA)",
+                        DownloadHashManager.OmniVoice.WindowsVulkan => "Windows x64 (Vulkan)",
+                        DownloadHashManager.OmniVoice.WindowsCpu => "Windows x64 (CPU)",
+                        _ => "Windows x64",
+                    };
+                }
+            }
+            catch
+            {
+                // fall through to DLL detection
+            }
+        }
+
+        if (File.Exists(Path.Combine(folder, "ggml-cuda.dll"))) return "Windows x64 (CUDA)";
+        if (File.Exists(Path.Combine(folder, "ggml-vulkan.dll"))) return "Windows x64 (Vulkan)";
+        return "Windows x64 (CPU)";
+    }
+
+    [RelayCommand]
+    private async Task Redownload()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var variant = OmniVoiceDownloadService.WindowsVariantVulkan;
+        if (Configuration.IsRunningOnWindows)
+        {
+            var variantAnswer = await MessageBox.Show(
+                Window,
+                "Re-download OmniVoice TTS",
+                $"{Environment.NewLine}Select the build to download:",
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                "CPU",
+                "Vulkan",
+                "CUDA");
+
+            if (variantAnswer == MessageBoxResult.None || variantAnswer == MessageBoxResult.Cancel)
+            {
+                return;
+            }
+
+            variant = variantAnswer switch
+            {
+                MessageBoxResult.Custom1 => OmniVoiceDownloadService.WindowsVariantCpu,
+                MessageBoxResult.Custom3 => OmniVoiceDownloadService.WindowsVariantCuda,
+                _ => OmniVoiceDownloadService.WindowsVariantVulkan,
+            };
+
+            if (variant == OmniVoiceDownloadService.WindowsVariantVulkan && !VulkanHelper.IsInstalled())
+            {
+                var vulkanAnswer = await MessageBox.Show(
+                    Window,
+                    "Vulkan runtime may be required",
+                    $"The Vulkan build needs the Vulkan runtime (vulkan-1.dll). It usually ships with current GPU drivers but was not detected.{Environment.NewLine}{Environment.NewLine}Install it from:{Environment.NewLine}https://vulkan.lunarg.com/sdk/home{Environment.NewLine}{Environment.NewLine}Continue with Vulkan anyway?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (vulkanAnswer == MessageBoxResult.No)
+                {
+                    UiUtil.OpenUrl("https://vulkan.lunarg.com/sdk/home");
+                    return;
+                }
+                if (vulkanAnswer != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+            }
+        }
+        else
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                "Re-download OmniVoice TTS",
+                $"{Environment.NewLine}Download the latest OmniVoice TTS now?",
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+        }
+
+        await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window, vm => vm.StartDownloadOmniVoice(variant));
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(InstallFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, InstallFolder);
+        }
+        catch
+        {
+            // ignore - best-effort UX, the path label is still shown
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsWindow.cs
@@ -1,0 +1,226 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
+
+public class OmniVoiceSettingsWindow : Window
+{
+    private const int LabelWidth = 110;
+    private const int ValueWidth = 360;
+
+    private readonly OmniVoiceSettingsViewModel _vm;
+
+    public OmniVoiceSettingsWindow(OmniVoiceSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "OmniVoice TTS settings";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 540;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); }; // ensure OnKeyDown fires
+    }
+
+    private Border BuildContent(OmniVoiceSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "OmniVoice TTS",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new OmniVoiceTtsCpp().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(OmniVoiceSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        // Backend
+        grid.Add(MakeLabel("Backend"), 0, 0);
+        grid.Add(MakeValue(nameof(vm.BackendLabel)), 0, 1);
+
+        // Status (colored dot + text)
+        grid.Add(MakeLabel("Status"), 1, 0);
+        var statusDot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(nameof(vm.StatusBrush)),
+        };
+        var statusText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusLabel)),
+        };
+        var statusPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { statusDot, statusText },
+        };
+        grid.Add(statusPanel, 1, 1);
+
+        // Release
+        grid.Add(MakeLabel("Release"), 2, 0);
+        var releaseText = new TextBlock
+        {
+            FontFamily = new FontFamily("Cascadia Mono,Consolas,Menlo,Monaco,monospace"),
+            FontSize = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.ReleaseTag)),
+        };
+        grid.Add(releaseText, 2, 1);
+
+        // Install folder
+        grid.Add(MakeLabel("Install folder"), 3, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.InstallFolder)),
+        };
+        grid.Add(folderText, 3, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static Grid BuildActions(OmniVoiceSettingsViewModel vm)
+    {
+        var redownload = UiUtil.MakeButton("Re-download...", vm.RedownloadCommand).WithIconLeft(IconNames.Download);
+        var openFolder = UiUtil.MakeButton("Open folder", vm.OpenFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { redownload, openFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    private static TextBlock MakeValue(string bindingPath) => new()
+    {
+        FontWeight = FontWeight.SemiBold,
+        VerticalAlignment = VerticalAlignment.Center,
+        [!TextBlock.TextProperty] = new Binding(bindingPath),
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -13,6 +13,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceSettings;
@@ -381,6 +382,12 @@ public partial class TextToSpeechViewModel : ObservableObject
     [RelayCommand]
     private async Task ShowEngineSettings()
     {
+        if (SelectedEngine is OmniVoiceTtsCpp)
+        {
+            await _windowService.ShowDialogAsync<OmniVoiceSettingsWindow, OmniVoiceSettingsViewModel>(Window!, vm => vm.Initialize());
+            return;
+        }
+
         await _windowService.ShowDialogAsync<ElevenLabsSettingsWindow, ElevenLabsSettingsViewModel>(Window!, vm => { });
     }
 
@@ -1834,6 +1841,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                 {
                     SelectedModel = Models.FirstOrDefault();
                 }
+            }
+            else if (SelectedEngine is OmniVoiceTtsCpp)
+            {
+                IsEngineSettingsVisible = true;
             }
             else if (SelectedEngine is KokoroTtsCpp)
             {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -75,6 +75,21 @@ public static class DownloadHashManager
         public const string MacOsX64Executable = "LlamaCpp.MacOs.X64.Executable";
     }
 
+    public static class OmniVoice
+    {
+        // Hashes of the release archive (.zip) - used at download time to fail fast on a corrupt
+        // or tampered file, and later to recognise the installed version from the .installed.sha256
+        // sidecar. There is no executable-hash fallback because OmniVoice has only ever shipped via
+        // SE with a sidecar (no legacy installs to migrate).
+        public const string WindowsCpu = "OmniVoice.Windows.Cpu";
+        public const string WindowsVulkan = "OmniVoice.Windows.Vulkan";
+        public const string WindowsCuda = "OmniVoice.Windows.Cuda";
+        public const string MacOs = "OmniVoice.MacOs";
+        public const string LinuxX64 = "OmniVoice.Linux.X64";
+        public const string LinuxArm64 = "OmniVoice.Linux.Arm64";
+        public const string Voices = "OmniVoice.Voices";
+    }
+
     public static class WhisperCpp
     {
         // Hashes of the release archive (.zip) — used when a sidecar hash exists alongside the install.
@@ -318,6 +333,38 @@ public static class DownloadHashManager
             {
                 "a63265bf5136200b2a8c2f86404151975090a58dae24df934a6054b52348aa1c", // b9174 (current download URL)
                 "c33c8f47da7d7751cd07c9ab32e77c84b3f5ac56b56299016f62b2d184fe3dfb", // b9145
+            },
+
+            // OmniVoice — https://github.com/niksedk/omnivoice.cpp/releases
+            // Index 0 must match whatever release OmniVoiceDownloadService.cs is pinned to,
+            // otherwise users will be prompted to "update" to the same version they just got.
+            [OmniVoice.WindowsCpu] = new[]
+            {
+                "ea1f0c6032f5a0333103ccffa7d7478c5ee00a35867776c277d717512587766c", // omnivoice-2026-05-17 (current download URL)
+            },
+            [OmniVoice.WindowsVulkan] = new[]
+            {
+                "b461b8535892b3e6979aec79eff4d6a0109a31184008b778b6848d7d36ea9901", // omnivoice-2026-05-17 (current download URL)
+            },
+            [OmniVoice.WindowsCuda] = new[]
+            {
+                "79308e79bb47df9f2bd2d31c6a60fe5672b74f43c3caf9b0a09566408894789e", // omnivoice-2026-05-17 (current download URL)
+            },
+            [OmniVoice.MacOs] = new[]
+            {
+                "bbe354cdf8995641074c46d02d7f8b9353fa4803452cb45a762de10e899aca8e", // omnivoice-2026-05-17 (current download URL)
+            },
+            [OmniVoice.LinuxX64] = new[]
+            {
+                "198046721ebcbe49ded959fd832ec4a091d899be49e2a26b549723e32b82daba", // omnivoice-2026-05-17 (current download URL)
+            },
+            [OmniVoice.LinuxArm64] = new[]
+            {
+                "3802d4136a6ffdc37cce72b286ab7c17422d55964fec13d4e3eb36f26e6ae1fe", // omnivoice-2026-05-17 (current download URL)
+            },
+            [OmniVoice.Voices] = new[]
+            {
+                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-05-17 (current download URL — identical to the support-files/omnivoice-26-06 copy)
             },
 
             // whisper.cpp — https://github.com/ggml-org/whisper.cpp/releases (and SE-repackaged builds
@@ -827,6 +874,39 @@ public static class DownloadHashManager
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? LlamaCpp.MacOsArm64Executable
                 : LlamaCpp.MacOsX64Executable;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the OmniVoice archive hash key for the current OS, architecture and
+    /// (Windows-only) variant ("cpu" / "vulkan" / "cuda"). Returns null when the
+    /// combination is unknown.
+    /// </summary>
+    public static string? ResolveOmniVoiceKey(string? windowsVariant)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return windowsVariant switch
+            {
+                "cuda" => OmniVoice.WindowsCuda,
+                "vulkan" => OmniVoice.WindowsVulkan,
+                "cpu" => OmniVoice.WindowsCpu,
+                _ => OmniVoice.WindowsVulkan, // Vulkan is the recommended default on Windows.
+            };
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return OmniVoice.MacOs;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? OmniVoice.LinuxArm64
+                : OmniVoice.LinuxX64;
         }
 
         return null;

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -30,13 +30,19 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
     private const string ModelBaseUrl = "https://huggingface.co/Serveurperso/OmniVoice-GGUF/resolve/main/omnivoice-base-Q8_0.gguf";
     private const string ModelTokenizerUrl = "https://huggingface.co/Serveurperso/OmniVoice-GGUF/resolve/main/omnivoice-tokenizer-F32.gguf";
 
-    private const string WindowsCpuUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-win64-cpu.zip";
-    private const string WindowsVulkanUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-win64-vulkan.zip";
-    private const string WindowsCudaUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-win64-cuda.zip";
-    private const string MacOsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-macos-universal-cpu-metal.zip";
-    private const string LinuxUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/omnivoice-linux-x64-cpu.zip";
+    // omnivoice.cpp release pin. Bump in lockstep with the hashes in DownloadHashManager.OmniVoice
+    // (each new release: prepend the new SHA-256 at index 0, keep the previous one for "update available").
+    private const string ReleaseTag = "omnivoice-2026-05-17";
+    private const string ReleaseUrlBase = "https://github.com/niksedk/omnivoice.cpp/releases/download/" + ReleaseTag + "/";
 
-    private const string VoicesUrl = "https://github.com/SubtitleEdit/support-files/releases/download/omnivoice-26-06/OmniVoices.zip";
+    private const string WindowsCpuUrl = ReleaseUrlBase + "omnivoice-win64-cpu.zip";
+    private const string WindowsVulkanUrl = ReleaseUrlBase + "omnivoice-win64-vulkan.zip";
+    private const string WindowsCudaUrl = ReleaseUrlBase + "omnivoice-win64-cuda.zip";
+    private const string MacOsUrl = ReleaseUrlBase + "omnivoice-macos-universal-cpu-metal.zip";
+    private const string LinuxX64Url = ReleaseUrlBase + "omnivoice-linux-x64-cpu.zip";
+    private const string LinuxArm64Url = ReleaseUrlBase + "omnivoice-linux-arm64-cpu.zip";
+
+    private const string VoicesUrl = ReleaseUrlBase + "OmniVoices.zip";
 
     public OmniVoiceDownloadService(HttpClient httpClient)
     {
@@ -69,11 +75,41 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
     public async Task DownloadEngine(Stream stream, string windowsVariant, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(windowsVariant), stream, progress, cancellationToken);
+        VerifyArchive(stream, DownloadHashManager.ResolveOmniVoiceKey(windowsVariant), "engine");
     }
 
     public async Task DownloadVoices(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         await DownloadHelper.DownloadFileAsync(_httpClient, VoicesUrl, stream, progress, cancellationToken);
+        VerifyArchive(stream, DownloadHashManager.OmniVoice.Voices, "voices");
+    }
+
+    // Compares the downloaded bytes against the known SHA-256 for this key and throws on mismatch
+    // so the caller's IsFaulted branch surfaces "Download failed" instead of silently unpacking a
+    // truncated or tampered file. A null/unknown key (e.g. unrecognised Windows variant) skips the
+    // check rather than failing closed - same policy as the rest of DownloadHashManager.
+    private static void VerifyArchive(Stream stream, string? key, string label)
+    {
+        if (string.IsNullOrEmpty(key) || stream.Length == 0)
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        stream.Position = 0;
+        var actual = DownloadHashManager.ComputeSha256(stream);
+        stream.Position = 0;
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"OmniVoice {label} download failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
     }
 
     private static string GetUrl(string windowsVariant)
@@ -95,12 +131,9 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-            {
-                throw new PlatformNotSupportedException("OmniVoice is not available for Linux ARM64.");
-            }
-
-            return LinuxUrl;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? LinuxArm64Url
+                : LinuxX64Url;
         }
 
         throw new PlatformNotSupportedException();

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -32,7 +32,7 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
     // omnivoice.cpp release pin. Bump in lockstep with the hashes in DownloadHashManager.OmniVoice
     // (each new release: prepend the new SHA-256 at index 0, keep the previous one for "update available").
-    private const string ReleaseTag = "omnivoice-2026-05-17";
+    public const string ReleaseTag = "omnivoice-2026-05-17";
     private const string ReleaseUrlBase = "https://github.com/niksedk/omnivoice.cpp/releases/download/" + ReleaseTag + "/";
 
     private const string WindowsCpuUrl = ReleaseUrlBase + "omnivoice-win64-cpu.zip";


### PR DESCRIPTION
Two related commits.

## 1. SHA-256 verification + new release URLs (3c5d6d5)

- Switches OmniVoice engine + voices downloads to `niksedk/omnivoice.cpp@omnivoice-2026-05-17`. URL composition uses a single `ReleaseTag` const at the top of `OmniVoiceDownloadService` — bumping a future release is a one-liner.
- Adds end-to-end SHA-256 integrity: new `DownloadHashManager.OmniVoice` key set (7 entries), download-time `VerifyArchive` that throws `IOException` on mismatch, and a `.installed.sha256` sidecar written after unpack — same convention LlamaCpp / CrispASR already use.
- Enables Linux ARM64: drops the existing `PlatformNotSupportedException` in `OmniVoiceDownloadService.GetUrl`, wires the arm64 zip URL, updates the download-window title label.
- Adds `OmniVoiceTtsCpp.GetEngineUpdateStatus()` for *UpToDate* / *UpdateAvailable* / *Unknown* detection without re-downloading. Old installs without a sidecar return *Unknown* (no false-positive update prompts).

HuggingFace GGUF model downloads are intentionally still hashless — Serveurperso re-quantizes occasionally and pinning would false-positive on a legitimate file.

## 2. Settings window for OmniVoice (58bace1)

- The gear icon next to the engine combobox (already in the layout but only ever flipped on for ElevenLabs) is now visible for OmniVoice too.
- New `OmniVoiceSettingsWindow` shows:
  - **Backend** — derived from the `.installed.sha256` sidecar on Windows (CPU / Vulkan / CUDA), with a ggml-*.dll fallback for pre-sidecar installs. macOS / Linux are derived from OS + arch.
  - **Status** — coloured dot + label using `GetEngineUpdateStatus()`. Green = up to date, amber = update available, grey = unknown, red = not installed.
  - **Release** — current `OmniVoiceDownloadService.ReleaseTag`.
  - **Install folder** — selectable / copyable read-only text.
- **Re-download…** reuses the existing first-install flow: variant chooser on Windows (CPU/Vulkan/CUDA + Vulkan-runtime warning), confirm on macOS/Linux, then opens `DownloadTtsWindow` with `StartDownloadOmniVoice(variant)`. Refreshes the display after the download closes.
- **Open folder** uses the existing `IFolderHelper`.

## Test plan

- [ ] Fresh install on Windows: pick CPU, then Vulkan, then CUDA — each downloads, passes the new SHA-256 check, writes `.installed.sha256`.
- [ ] Fresh install on macOS (universal): same — sidecar present, settings window shows "macOS universal (CPU + Metal)".
- [ ] Fresh install on Linux x64 *and* Linux ARM64: ARM64 no longer throws and produces a working binary; settings shows the right backend label.
- [ ] Voices step: `OmniVoices.zip` downloads, passes verification, writes a sidecar in the voices folder.
- [ ] Tamper test: temporarily change one byte of the expected hash in `DownloadHashManager` → the download ends with "Download failed: …expected SHA-256 X, got Y".
- [ ] Old install without sidecar: status shows "Unknown (no install record)"; ggml-*.dll fallback still labels the Windows backend correctly.
- [ ] Settings window: pick OmniVoice → gear appears → click → see installed backend, status, release, folder. **Re-download…** prompts for variant on Windows; on success the status flips back to "Up to date". **Open folder** opens the OmniVoice folder in Explorer/Finder/xdg-open.
- [ ] Switch away from OmniVoice → gear hides again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)