### PR TITLE
Speech-to-text: settings window for downloadable engines (closes #11022 partially)

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -139,6 +139,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceSettings;
@@ -262,6 +263,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<SsaStylesViewModel>();
         collection.AddTransient<AssaTagHistoryViewModel>();
         collection.AddTransient<SpeechToTextViewModel>();
+        collection.AddTransient<SpeechToTextEngineSettingsViewModel>();
         collection.AddTransient<AudioVisualizerUndockedViewModel>();
         collection.AddTransient<AutoTranslateViewModel>();
         collection.AddTransient<BatchConvertAssaViewModel>();

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -1,0 +1,280 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
+
+public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
+{
+    private readonly IFolderHelper _folderHelper;
+
+    private ISpeechToTextEngine? _engine;
+    private Func<Task>? _redownloadAsync;
+
+    [ObservableProperty] private string _titleText = string.Empty;
+    [ObservableProperty] private string _subtitleText = string.Empty;
+    [ObservableProperty] private string _backendLabel = string.Empty;
+    [ObservableProperty] private string _statusLabel = string.Empty;
+    [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
+    [ObservableProperty] private string _installFolder = string.Empty;
+    [ObservableProperty] private bool _isInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public SpeechToTextEngineSettingsViewModel(IFolderHelper folderHelper)
+    {
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize(ISpeechToTextEngine engine, Func<Task> redownloadAsync)
+    {
+        _engine = engine;
+        _redownloadAsync = redownloadAsync;
+
+        TitleText = engine.Name;
+        SubtitleText = "Speech-to-text engine";
+
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        if (_engine == null)
+        {
+            return;
+        }
+
+        InstallFolder = _engine.GetAndCreateWhisperFolder();
+        IsInstalled = _engine.IsEngineInstalled();
+        BackendLabel = IsInstalled ? DetectBackend(_engine, InstallFolder) : "Not installed";
+        ApplyStatus(IsInstalled ? ComputeStatus(_engine, InstallFolder) : DownloadHashManager.UpdateStatus.Unknown, IsInstalled);
+    }
+
+    private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)
+    {
+        if (!installed)
+        {
+            StatusLabel = "Not installed";
+            StatusBrush = new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));   // red
+            return;
+        }
+
+        switch (status)
+        {
+            case DownloadHashManager.UpdateStatus.UpToDate:
+                StatusLabel = "Up to date";
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
+                break;
+            case DownloadHashManager.UpdateStatus.UpdateAvailable:
+                StatusLabel = "Update available";
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
+                break;
+            default:
+                StatusLabel = "Unknown (no install record)";
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
+                break;
+        }
+    }
+
+    // Whisper.cpp variants live in their own folder per backend, so the choice is the backend.
+    // CrispASR shares a single folder across variants — DownloadHashManager.Detect* reads the
+    // sidecar / installed DLLs to figure out which backend is active.
+    private static string DetectBackend(ISpeechToTextEngine engine, string folder)
+    {
+        if (engine is WhisperEngineCpp)
+        {
+            return Configuration.IsRunningOnLinux ? "Vulkan (Linux)"
+                : Configuration.IsRunningOnMac ? "macOS native"
+                : "BLAS (Windows CPU)";
+        }
+        if (engine is WhisperEngineCppCuBlas)
+        {
+            return "cuBLAS (CUDA)";
+        }
+        if (engine is WhisperEngineCppVulkan)
+        {
+            return "Vulkan";
+        }
+
+        if (engine is ICrispAsrEngine)
+        {
+            if (Configuration.IsRunningOnMac)
+            {
+                return "macOS universal";
+            }
+
+            if (Configuration.IsRunningOnLinux)
+            {
+                if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                {
+                    return "Linux ARM64 (CPU)";
+                }
+                var linuxVariant = DownloadHashManager.DetectCrispAsrLinuxVariant(folder);
+                return linuxVariant == "cuda" ? "Linux x64 (CUDA)" : "Linux x64 (CPU)";
+            }
+
+            var winVariant = DownloadHashManager.DetectCrispAsrWindowsVariant(folder);
+            return winVariant switch
+            {
+                "cuda" => "Windows x64 (CUDA)",
+                "vulkan" => "Windows x64 (Vulkan)",
+                "cpu-legacy" => "Windows x64 (CPU, legacy)",
+                "cpu" => "Windows x64 (CPU)",
+                _ => "Windows x64",
+            };
+        }
+
+        // Single-backend engines (CTranslate2 / ConstMe / Purfview): no variant to disambiguate -
+        // just show the OS/arch the install is for so the row says something useful.
+        if (Configuration.IsRunningOnMac)
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "macOS ARM64"
+                : "macOS x64";
+        }
+        if (Configuration.IsRunningOnLinux)
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "Linux ARM64"
+                : "Linux x64";
+        }
+        return "Windows x64";
+    }
+
+    private static DownloadHashManager.UpdateStatus ComputeStatus(ISpeechToTextEngine engine, string folder)
+    {
+        var lookup = TryReadSidecarHash(folder)
+                     ?? (engine is ICrispAsrEngine
+                         ? TryHashCrispAsrExecutable(engine, folder)
+                         : TryHashWhisperCppExecutable(engine));
+
+        return lookup is var (key, hash)
+            ? DownloadHashManager.GetStatus(key, hash)
+            : DownloadHashManager.UpdateStatus.Unknown;
+    }
+
+    private static (string key, string hash)? TryReadSidecarHash(string folder)
+    {
+        var sidecar = Path.Combine(folder, ".installed.sha256");
+        if (!File.Exists(sidecar))
+        {
+            return null;
+        }
+        try
+        {
+            var lines = File.ReadAllLines(sidecar);
+            if (lines.Length < 2)
+            {
+                return null;
+            }
+            var key = lines[0].Trim();
+            var hash = lines[1].Trim();
+            return (key.Length == 0 || hash.Length == 0) ? null : (key, hash);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static (string key, string hash)? TryHashWhisperCppExecutable(ISpeechToTextEngine engine)
+    {
+        try
+        {
+            var key = DownloadHashManager.ResolveWhisperCppExecutableKey(engine.Choice);
+            if (key == null)
+            {
+                return null;
+            }
+            var hash = DownloadHashManager.ComputeSha256(engine.GetExecutable());
+            return hash == null ? null : (key, hash);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static (string key, string hash)? TryHashCrispAsrExecutable(ISpeechToTextEngine engine, string folder)
+    {
+        try
+        {
+            string? variant = null;
+            if (Configuration.IsRunningOnWindows)
+            {
+                variant = DownloadHashManager.DetectCrispAsrWindowsVariant(folder);
+            }
+            else if (Configuration.IsRunningOnLinux && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                variant = DownloadHashManager.DetectCrispAsrLinuxVariant(folder);
+            }
+            var key = DownloadHashManager.ResolveCrispAsrExecutableKey(variant);
+            if (key == null)
+            {
+                return null;
+            }
+            var hash = DownloadHashManager.ComputeSha256(engine.GetExecutable());
+            return hash == null ? null : (key, hash);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [RelayCommand]
+    private async Task Redownload()
+    {
+        if (_redownloadAsync == null)
+        {
+            return;
+        }
+        await _redownloadAsync();
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(InstallFolder))
+        {
+            return;
+        }
+        try
+        {
+            await _folderHelper.OpenFolder(Window, InstallFolder);
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsWindow.cs
@@ -1,0 +1,213 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
+
+public class SpeechToTextEngineSettingsWindow : Window
+{
+    private const int LabelWidth = 110;
+    private const int ValueWidth = 360;
+
+    private readonly SpeechToTextEngineSettingsViewModel _vm;
+
+    public SpeechToTextEngineSettingsWindow(SpeechToTextEngineSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "Speech-to-text engine settings";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 540;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(SpeechToTextEngineSettingsViewModel vm)
+    {
+        var header = BuildHeader(vm);
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader(SpeechToTextEngineSettingsViewModel vm)
+    {
+        var title = new TextBlock
+        {
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.TitleText)),
+        };
+
+        var subtitle = new TextBlock
+        {
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.SubtitleText)),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(SpeechToTextEngineSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        // Backend
+        grid.Add(MakeLabel("Backend"), 0, 0);
+        grid.Add(MakeValue(nameof(vm.BackendLabel)), 0, 1);
+
+        // Status (coloured dot + text)
+        grid.Add(MakeLabel("Status"), 1, 0);
+        var statusDot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(nameof(vm.StatusBrush)),
+        };
+        var statusText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusLabel)),
+        };
+        var statusPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { statusDot, statusText },
+        };
+        grid.Add(statusPanel, 1, 1);
+
+        // Install folder
+        grid.Add(MakeLabel("Install folder"), 2, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.InstallFolder)),
+        };
+        grid.Add(folderText, 2, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static Grid BuildActions(SpeechToTextEngineSettingsViewModel vm)
+    {
+        var redownload = UiUtil.MakeButton("Re-download...", vm.RedownloadCommand).WithIconLeft(IconNames.Download);
+        var openFolder = UiUtil.MakeButton("Open folder", vm.OpenFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { redownload, openFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    private static TextBlock MakeValue(string bindingPath) => new()
+    {
+        FontWeight = FontWeight.SemiBold,
+        VerticalAlignment = VerticalAlignment.Center,
+        [!TextBlock.TextProperty] = new Binding(bindingPath),
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.GetAudioClips;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -87,6 +88,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private string _reDownloadText;
 
     [ObservableProperty] private bool _isEngineDownloadButtonVisible;
+    [ObservableProperty] private bool _isEngineSettingsButtonVisible;
     [ObservableProperty] private string _engineDownloadHint;
 
     [ObservableProperty] private bool _isOpenAiCompatibleSttVisible;
@@ -3516,6 +3518,11 @@ public partial class SpeechToTextViewModel : ObservableObject
         var canDownload = engine.CanBeDownloaded();
         var isInstalled = engine.IsEngineInstalled();
 
+        // Settings gear is for downloadable engines that already have a binary on disk.
+        // It opens a dialog with the installed backend, status and Re-download — which is
+        // also the answer to issue #11022 (switch backend after the initial install).
+        IsEngineSettingsButtonVisible = canDownload && isInstalled && IsSettingsCapable(engine);
+
         if (!canDownload || isInstalled)
         {
             EngineDownloadHint = string.Empty;
@@ -3530,6 +3537,19 @@ public partial class SpeechToTextViewModel : ObservableObject
         IsEngineDownloadButtonVisible = true;
     }
 
+    // Show the gear for any engine that is locally downloadable (i.e. produces a binary on disk
+    // we can describe, re-download or open the folder for). Whisper.cpp variants and CrispASR
+    // additionally have hash tracking so their Status row is meaningful; CTranslate2 / ConstMe /
+    // Purfview have no DownloadHashManager entry yet and will show "Unknown" until hashes land.
+    private static bool IsSettingsCapable(ISpeechToTextEngine engine)
+        => engine is WhisperEngineCpp
+                   or WhisperEngineCppCuBlas
+                   or WhisperEngineCppVulkan
+                   or WhisperEngineCTranslate2
+                   or WhisperEngineConstMe
+                   or WhisperEnginePurfviewFasterWhisperXxl
+                   or ICrispAsrEngine;
+
     [RelayCommand]
     private async Task DownloadSelectedEngine()
     {
@@ -3540,6 +3560,27 @@ public partial class SpeechToTextViewModel : ObservableObject
         // opened — that's acceptable since the typical path is download → transcribe and
         // the user doesn't revisit the dropdown mid-session.
         await ReDownloadWhisperEngine();
+        UpdateEngineStatusUi(GetEffectiveSelectedEngine());
+    }
+
+    [RelayCommand]
+    private async Task ShowEngineSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var engine = GetEffectiveSelectedEngine();
+        if (!IsSettingsCapable(engine) || !engine.IsEngineInstalled())
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<SpeechToTextEngineSettingsWindow, SpeechToTextEngineSettingsViewModel>(
+            Window,
+            vm => vm.Initialize(engine, async () => await ReDownloadWhisperEngine()));
+
         UpdateEngineStatusUi(GetEffectiveSelectedEngine());
     }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -68,6 +68,13 @@ public class SpeechToTextWindow : Window
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
         });
 
+        var buttonEngineSettings = UiUtil.MakeButton(vm.ShowEngineSettingsCommand, IconNames.Settings)
+            .WithMarginLeft(5)
+            .WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsEngineSettingsButtonVisible))
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
+        ToolTip.SetTip(buttonEngineSettings, "Backend and update status");
+
         var panelEngineControls = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -78,6 +85,7 @@ public class SpeechToTextWindow : Window
                 comboEngine,
                 buttonEngineWebsite,
                 buttonEngineDownload,
+                buttonEngineSettings,
             }
         };
 


### PR DESCRIPTION
## Summary

Adds a gear icon next to the engine combo on the Speech-to-text window, visible once a downloadable engine has a binary on disk. Clicking it opens a new settings dialog (same visual style as the OmniVoice TTS one) that shows which backend is installed, whether it is up to date, where the install folder lives, and offers **Re-download...** and **Open folder**.

**Re-download...** delegates to the existing `ReDownloadWhisperEngine` flow, so the CrispASR CPU/Vulkan/CUDA picker, Standard/Legacy CPU follow-up, Vulkan-runtime warning and Linux variant prompt all stay in one place — which doubles as the answer to issue #11022 (switch backend *after* the initial install).

## Engines that get the gear

- **Whisper.cpp** (BLAS / cuBLAS / Vulkan) — full backend label and green/amber status (hashes already in `DownloadHashManager`).
- **CrispASR** (all variants) — backend detected from `.installed.sha256` sidecar with a `ggml-*.dll` fallback for pre-sidecar installs.
- **Whisper CTranslate2**, **Const-me Whisper**, **Purfview Faster-Whisper-XXL** — backend row shows OS/arch; Status reads *"Unknown (no install record)"* until hashes for them land. The plumbing already reads sidecars generically, so the only follow-up is hash entries in `DownloadHashManager` + a `WriteSingleBackendInstalledHash` branch in `DownloadSpeechToTextEngineViewModel`.

Cloud / non-downloadable engines (OpenAI, OpenAI-compatible, ChatLLM, Qwen3-ASR, Parakeet) intentionally don't get the gear — nothing useful to show.

## Files

- `Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs` (new) — backend detection, status check, re-download callback, Open folder.
- `Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsWindow.cs` (new) — header + bordered details panel + status dot + action row, identical layout to `OmniVoiceSettingsWindow`.
- `Features/Video/SpeechToText/SpeechToTextViewModel.cs` — `IsEngineSettingsButtonVisible`, `ShowEngineSettingsCommand`, `IsSettingsCapable` filter.
- `Features/Video/SpeechToText/SpeechToTextWindow.cs` — gear button added to `panelEngineControls` after the existing Download button.
- `DependencyInjectionExtensions.cs` — registers `SpeechToTextEngineSettingsViewModel`.

## Test plan

- [ ] Whisper.cpp BLAS (Windows): install → gear appears → opens window → Backend: *BLAS (Windows CPU)*, Status: *Up to date*, Folder shown → Re-download… kicks the existing prompt.
- [ ] Whisper.cpp cuBLAS / Vulkan: same flow, Backend reads accordingly.
- [ ] CrispASR (Windows CUDA / Vulkan / CPU / CPU-legacy): gear → Backend detected from sidecar or `ggml-*.dll`. Re-download… prompts CPU/Vulkan/CUDA → install a different one → close → reopen gear → Backend label updates.
- [ ] CrispASR Linux x64 (CPU / CUDA): Backend reads accordingly.
- [ ] CrispASR Linux ARM64: Backend reads *Linux ARM64 (CPU)*.
- [ ] CrispASR macOS: Backend reads *macOS universal*.
- [ ] CTranslate2 / ConstMe / Purfview: gear appears once installed; Status: *Unknown (no install record)*; Re-download… and Open folder work; Switching engine away hides the gear again.
- [ ] Non-downloadable engines (cloud / OpenAI-compatible): gear stays hidden.
- [ ] Issue #11022: install CrispASR CPU first, open gear, Re-download → pick Vulkan → folder now contains Vulkan binaries.

## Follow-up (not in this PR)

Adding SHA-256 entries for CTranslate2 (3 zips), ConstMe (1 zip) and Purfview (2 zips) to `DownloadHashManager`, plus a `WriteSingleBackendInstalledHash` branch in `DownloadSpeechToTextEngineViewModel`, will flip the Status row from *Unknown* to green/amber for those three engines. Mechanical; left out of this PR to keep scope focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)