### PR TITLE
llama.cpp auto-translate: discover custom GGUFs + open-folder button

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -17,6 +17,7 @@ using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -104,10 +105,12 @@ public partial class AutoTranslateViewModel : ObservableObject
     private int _translationProgressIndex;
     private bool _llamaCppUpdatePromptShown;
     private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
 
-    public AutoTranslateViewModel(IWindowService windowService)
+    public AutoTranslateViewModel(IWindowService windowService, IFolderHelper folderHelper)
     {
         _windowService = windowService;
+        _folderHelper = folderHelper;
 
         ApiKeyText = string.Empty;
         ApiUrlText = string.Empty;
@@ -801,7 +804,25 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (downloaded != null)
         {
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, selectName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), selectName);
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenLlamaCppModelsFolder()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, LlamaCppServerManager.GetAndCreateModelsFolder());
+        }
+        catch
+        {
+            // best-effort - the path itself is shown in the model combo, so a silent failure is OK
         }
     }
 
@@ -842,7 +863,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             return false;
         }
 
-        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, model.FileName);
+        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), model.FileName);
 
         try
         {
@@ -914,7 +935,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (downloaded != null)
         {
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, selectName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), selectName);
         }
 
         UpdateLlamaCppServerButtonText();
@@ -1490,7 +1511,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             LlamaCppModelComboIsVisible = true;
             LlamaCppButtonsAreVisible = true;
             var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, savedModelName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), savedModelName);
             UpdateLlamaCppServerButtonText();
 
             if (!_llamaCppUpdatePromptShown)

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -194,6 +194,10 @@ public class AutoTranslateWindow : Window
         buttonLlamaCppServer.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppServerButtonText)));
         buttonLlamaCppServer.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
 
+        var buttonLlamaCppOpenFolder = UiUtil.MakeButton(vm.OpenLlamaCppModelsFolderCommand, IconNames.FolderOpen, Se.Language.General.OpenContainingFolder)
+            .WithMarginLeft(5);
+        buttonLlamaCppOpenFolder.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
+
         var settingsPanel = new WrapPanel
         {
             Orientation = Orientation.Horizontal,
@@ -224,6 +228,7 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(llamaCppModelCombo);
         settingsPanel.Children.Add(buttonDownloadLlamaCpp);
         settingsPanel.Children.Add(buttonLlamaCppServer);
+        settingsPanel.Children.Add(buttonLlamaCppOpenFolder);
 
         var settingsButton = UiUtil.MakeButton(vm.OpenSettingsCommand, IconNames.Settings, Se.Language.General.Settings);
         settingsButton.HorizontalAlignment = HorizontalAlignment.Right;

--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -26,6 +26,13 @@ public class LlamaCppModelDisplay
 
     public override string ToString()
     {
+        // Custom entries (no Url) come from a *.gguf the user dropped into the models folder -
+        // by definition already on disk, so just flag them visually instead of saying "installed".
+        if (string.IsNullOrEmpty(Model.Url))
+        {
+            return $"{Model.DisplayName} (custom, {Model.Size})";
+        }
+
         var installed = LlamaCppServerManager.IsModelInstalled(Model);
         return installed
             ? Model.DisplayName
@@ -60,7 +67,8 @@ public static class LlamaCppDownloadHelper
 
     /// <summary>
     /// Path of an installed model - the one from settings if it still exists, otherwise any
-    /// known model file found in the llama.cpp models folder.
+    /// known model file found in the llama.cpp models folder. "Known" includes both curated
+    /// entries and custom <c>*.gguf</c> files the user has dropped into the folder.
     /// </summary>
     public static string? GetInstalledModelPath()
     {
@@ -70,7 +78,7 @@ public static class LlamaCppDownloadHelper
             return configured;
         }
 
-        foreach (var model in LlamaCppServerManager.TranslateModels)
+        foreach (var model in LlamaCppServerManager.GetAllTranslateModels())
         {
             var path = LlamaCppServerManager.GetModelPath(model.FileName);
             if (File.Exists(path))
@@ -108,17 +116,18 @@ public static class LlamaCppDownloadHelper
 
     private static LlamaCppModel? ResolveModel(string? modelFileName)
     {
+        var all = LlamaCppServerManager.GetAllTranslateModels();
         if (!string.IsNullOrEmpty(modelFileName))
         {
-            var match = LlamaCppServerManager.TranslateModels.FirstOrDefault(m => m.FileName == modelFileName);
+            var match = all.FirstOrDefault(m => m.FileName == modelFileName);
             if (match != null)
             {
                 return match;
             }
         }
 
-        return LlamaCppServerManager.TranslateModels.FirstOrDefault(m => LlamaCppServerManager.IsModelInstalled(m.FileName))
-               ?? LlamaCppServerManager.TranslateModels.FirstOrDefault();
+        return all.FirstOrDefault(m => LlamaCppServerManager.IsModelInstalled(m.FileName))
+               ?? all.FirstOrDefault();
     }
 
     /// <summary>
@@ -198,6 +207,20 @@ public static class LlamaCppDownloadHelper
             }
 
             return true;
+        }
+
+        // Custom (user-supplied) model whose .gguf has vanished between discovery and now -
+        // there's no Url to download from, so prompting to download would just fail. Tell the
+        // user the file is gone and bail.
+        if (model != null && string.IsNullOrEmpty(model.Url) && !modelInstalled)
+        {
+            await MessageBox.Show(
+                owner,
+                Se.Language.General.Error,
+                $"The custom model file '{model.FileName}' was not found in the llama.cpp models folder.",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return false;
         }
 
         string message;

--- a/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
@@ -121,6 +122,80 @@ public static class LlamaCppServerManager
     {
         var path = GetModelPath(fileName);
         return File.Exists(path) && new FileInfo(path).Length > 10_000_000;
+    }
+
+    /// <summary>
+    /// Returns the curated <see cref="TranslateModels"/> plus any other <c>*.gguf</c> the user has
+    /// dropped into the llama.cpp models folder. Custom entries are emitted with an empty <c>Url</c>
+    /// (no download needed - already on disk), the file name as <c>DisplayName</c>, and a
+    /// human-readable file size. <c>mmproj-*.gguf</c> sidecars are skipped because they're not
+    /// standalone translation models.
+    /// </summary>
+    public static IReadOnlyList<LlamaCppModel> GetAllTranslateModels()
+    {
+        var folder = GetAndCreateModelsFolder();
+        if (!Directory.Exists(folder))
+        {
+            return TranslateModels;
+        }
+
+        var knownNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var m in TranslateModels.Concat(OcrModels))
+        {
+            knownNames.Add(m.FileName);
+            if (!string.IsNullOrEmpty(m.MmprojFileName))
+            {
+                knownNames.Add(m.MmprojFileName);
+            }
+        }
+
+        var custom = new List<LlamaCppModel>();
+        try
+        {
+            foreach (var path in Directory.EnumerateFiles(folder, "*.gguf", SearchOption.TopDirectoryOnly))
+            {
+                var name = Path.GetFileName(path);
+                if (knownNames.Contains(name))
+                {
+                    continue;
+                }
+                if (name.StartsWith("mmproj-", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var size = FormatFileSize(new FileInfo(path).Length);
+                custom.Add(new LlamaCppModel(name, name, size, Url: string.Empty));
+            }
+        }
+        catch
+        {
+            // ignore - if the folder can't be scanned (locked / IO error) just fall back to curated only.
+            return TranslateModels;
+        }
+
+        if (custom.Count == 0)
+        {
+            return TranslateModels;
+        }
+
+        custom.Sort((a, b) => string.Compare(a.FileName, b.FileName, StringComparison.OrdinalIgnoreCase));
+        return TranslateModels.Concat(custom).ToList();
+    }
+
+    private static string FormatFileSize(long bytes)
+    {
+        const double gb = 1024d * 1024d * 1024d;
+        const double mb = 1024d * 1024d;
+        if (bytes >= gb)
+        {
+            return (bytes / gb).ToString("0.#", CultureInfo.InvariantCulture) + " GB";
+        }
+        if (bytes >= mb)
+        {
+            return (bytes / mb).ToString("0", CultureInfo.InvariantCulture) + " MB";
+        }
+        return (bytes / 1024d).ToString("0", CultureInfo.InvariantCulture) + " KB";
     }
 
     public static bool IsModelInstalled(LlamaCppModel model)


### PR DESCRIPTION
## Summary

Two tightly-related changes to the llama.cpp auto-translate engine:

1. **Auto-discover custom GGUFs in the models folder.** Drop any `*.gguf` (e.g. Shisa v2.1 8B, a custom TranslateGemma quant, an arbitrary fine-tune) into `~/SpeechToText/LlamaCpp/models/` and it appears in the model dropdown alongside the curated catalog. No code change needed to use a model that isn't in the curated list.
2. **Open-folder button.** New folder-open icon button next to the engine's Download / Toggle-server buttons, opens the llama.cpp models folder in Explorer / Finder / xdg-open. Makes the discovery flow obvious — there's a visible button to get to the folder where dropped GGUFs are picked up from.

## Changes

| File | What |
|---|---|
| `Logic/LlamaCpp/LlamaCppServerManager.cs` | New `GetAllTranslateModels()` — curated `TranslateModels` + any non-curated `*.gguf` in the folder. Skips `mmproj-*.gguf` (vision sidecars). Custom entries: `DisplayName = FileName`, human-readable `Size` from disk, `Url = ""` (sentinel for "already on disk, no download"). Falls back to curated-only on folder-scan failure. |
| `Features/Translate/LlamaCppDownloadHelper.cs` | `LlamaCppModelDisplay.ToString()` renders custom entries as `<filename> (custom, <size>)`. `GetInstalledModelPath()` and `ResolveModel()` consult the merged list. `EnsureReadyAsync` gets a guard: if the chosen model is custom and its file has vanished, show a clear error instead of attempting a download with an empty URL. |
| `Features/Translate/AutoTranslateViewModel.cs` | Constructor now takes `IFolderHelper`. New `[RelayCommand] OpenLlamaCppModelsFolder`. Four `PopulateModels(LlamaCppModels, LlamaCppServerManager.TranslateModels, …)` call-sites swapped to `GetAllTranslateModels()`. |
| `Features/Translate/AutoTranslateWindow.cs` | New folder-open icon button (`Se.Language.General.OpenContainingFolder` tooltip) appended to the llama.cpp settings panel after the Toggle-server button. Visibility bound to the existing `LlamaCppButtonsAreVisible` flag so it shows only when llama.cpp is the selected engine. |

## Why this matters

Closes the gap reported by users wanting to try GGUFs that aren't in SE's curated list (e.g. the Shisa V2.1 Japanese-tuned models on `mradermacher/shisa-v2.1-*-GGUF`). The previous answer was "no, only TranslateGemma works"; the new answer is "drop the GGUF in the folder and pick it from the dropdown".

## Test plan

- [ ] No custom files in folder → dropdown shows only curated TranslateGemma entries (unchanged behavior).
- [ ] Drop `shisa-v2.1-qwen3-8b-Q4_K_M.gguf` (or any other GGUF) into `LlamaCpp/models/`, reopen Auto-translate, switch engine to llama.cpp → entry appears as `shisa-v2.1-qwen3-8b-Q4_K_M.gguf (custom, ~4.7 GB)`, alphabetically after the curated entries.
- [ ] Select the custom entry, run a short translation → `llama-server` starts with the custom model, translation proceeds.
- [ ] `Se.Settings.AutoTranslate.LlamaCppModel` persists the custom path across SE restarts.
- [ ] Drop an `mmproj-foo.gguf` into the folder → it does NOT appear in the dropdown (those are OCR vision sidecars).
- [ ] Drop a file with the exact same name as a curated entry (e.g. `translategemma-4b_Q4_K_M.gguf`) → only one entry shows (curated wins; size/install indicator reflects the on-disk file).
- [ ] Click the new folder-open icon → Explorer / Finder / xdg-open opens the models folder.
- [ ] Switch engine away from llama.cpp → all four engine-specific buttons (Download / Toggle server / Open folder) hide together; switch back → they reappear.
- [ ] Edge case: select a custom model, delete its `.gguf` from disk, run translation → clear "custom model file '…' was not found" error instead of a download crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)