### PR TITLE
macOS: load libmpv from running .app bundle, not just /Applications

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -257,6 +257,9 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             [
                 MpvPath,
                 Directory.GetCurrentDirectory(),
+                // Running .app bundle's Frameworks dir, regardless of install
+                // location. AppContext.BaseDirectory is Contents/MacOS/.
+                Path.Combine(AppContext.BaseDirectory, "..", "Frameworks"),
                 "/Applications/Subtitle Edit.app/Contents/Frameworks",
                 "/opt/local/lib",
                 "/usr/local/lib",


### PR DESCRIPTION
## Summary
- The macOS libmpv search list in `LibMpvDynamicPlayer.GetLibraryPaths()` hardcoded `/Applications/Subtitle Edit.app/Contents/Frameworks` as the only bundle-aware path.
- If the user installs the .app anywhere else (`~/Applications/`, a custom folder, or runs it from the mounted DMG), that entry doesn't match. SE then falls through to `/opt/local/lib`, `/usr/local/lib`, `/opt/homebrew/lib` and either silently loads a *system* libmpv from Homebrew/MacPorts or fails to find one at all.
- Add `Path.Combine(AppContext.BaseDirectory, "..", "Frameworks")` ahead of the hardcoded path. On a self-contained .NET single-file app, `AppContext.BaseDirectory` is `Contents/MacOS/` inside the running bundle, so this resolves to the running bundle's own `Contents/Frameworks/` regardless of where the .app lives on disk.
- This is the macOS counterpart to how `DownloadFfmpegViewModel.GetFfmpegFileName()` already locates ffmpeg via `Path.Combine(AppContext.BaseDirectory, "ffmpeg")`.

## Why this matters now
`build-mac.yml` (merged in #11030) bundles libmpv + its full dep tree into `Contents/Frameworks/` so end-users without Xcode/Homebrew can run SE on macOS. Without this fix, the bundling only worked for users who installed exactly to `/Applications/Subtitle Edit.app` — everyone else silently kept depending on a brew/MacPorts install.

## Test plan
- [ ] Build a fresh macOS DMG from this branch (or wait for `build-mac.yml` to run after merge)
- [ ] Copy `Subtitle Edit.app` to a **non**-`/Applications` location (e.g. `/tmp/setest.app` or `~/Desktop/`)
- [ ] On a Mac **without** Homebrew's libmpv installed, launch SE and play a video → playback works (was previously broken in this scenario)
- [ ] On a Mac **with** Homebrew's libmpv installed: `sudo lsof -p <SE PID> | grep libmpv` shows the dylib path is inside the .app bundle, not `/opt/homebrew/lib` (was previously the brew one)
- [ ] Standard install to `/Applications/Subtitle Edit.app` still works (unchanged behavior for that path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)