### PR TITLE
llama.cpp auto-translate: add Qwen 3 4B Instruct + Qwen 3 8B

### DIFF
--- a/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
@@ -53,6 +53,19 @@ public static class LlamaCppServerManager
         new LlamaCppModel("TranslateGemma 12B (Q4_K_M)", "translategemma-12b-it-q4_k_m.gguf", "7.3 GB",
             "https://huggingface.co/NikolayKozloff/translategemma-12b-it-Q4_K_M-GGUF/resolve/main/translategemma-12b-it-q4_k_m.gguf",
             ChatTemplate: "gemma", NoJinja: true),
+
+        // Alternative model family. Qwen 3 is the strongest open model for CJK
+        // (Chinese/Japanese/Korean) and competitive elsewhere — useful fallback
+        // when Gemma's quirks bite (occasional refusals, formatting drift, etc).
+        // --no-jinja + chatml bypasses the embedded Jinja template's
+        // enable_thinking logic on the hybrid Qwen3-8B so output is clean
+        // translation, not <think>...</think> reasoning blocks.
+        new LlamaCppModel("Qwen 3 4B Instruct (Q4_K_M)", "Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf", "2.5 GB",
+            "https://huggingface.co/bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF/resolve/main/Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+            ChatTemplate: "chatml", NoJinja: true),
+        new LlamaCppModel("Qwen 3 8B (Q4_K_M)", "Qwen_Qwen3-8B-Q4_K_M.gguf", "4.7 GB",
+            "https://huggingface.co/bartowski/Qwen_Qwen3-8B-GGUF/resolve/main/Qwen_Qwen3-8B-Q4_K_M.gguf",
+            ChatTemplate: "chatml", NoJinja: true),
     };
 
     public static readonly IReadOnlyList<LlamaCppModel> OcrModels = new[]


### PR DESCRIPTION
## Summary
Adds Qwen 3 as an alternative model family in the curated llama.cpp auto-translate model list. Until now the list was four quantizations of the same model (TranslateGemma); users hitting Gemma's quirks (occasional refusals on adult-themed dialogue, formatting drift, weaker CJK quality) had no real fallback. Qwen 3 is the strongest open model for Japanese/Chinese/Korean translation in 2026 and is competitive on European pairs.

Two new entries in `LlamaCppServerManager.TranslateModels`:

| Model | Size | Source |
|---|---|---|
| Qwen 3 4B Instruct (Q4_K_M) | 2.5 GB | `bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF` |
| Qwen 3 8B (Q4_K_M) | 4.7 GB | `bartowski/Qwen_Qwen3-8B-GGUF` |

## Why bartowski as the GGUF source
The two most reliable GGUF authors are ggml-org (official llama.cpp org) and bartowski. ggml-org's `Qwen3-4B-Instruct-2507-Q8_0-GGUF` only ships the 8 GB Q8_0 quant, and they don't ship Qwen3-8B-Instruct as separate GGUFs at all. bartowski ships every standard quant for both, is the highest-trafficked GGUF maintainer on HF, and tracks upstream releases promptly.

## Why Qwen3-8B (hybrid) and not Qwen3-8B-Instruct-2507
Qwen never released a separate `Qwen3-8B-Instruct-2507` — only the 4B and 30B-A3B sizes got the Instruct/Thinking split. For the 8B size the original hybrid `Qwen3-8B` is what's available.

The existing wiring already handles this correctly: setting `ChatTemplate: "chatml", NoJinja: true` translates to `--no-jinja --chat-template chatml` on the llama-server command line. That bypasses the embedded Jinja template's `enable_thinking` logic and feeds the model a plain chatml prompt, so output is clean translation rather than `<think>...</think>` reasoning blocks.

## What stays the same
- TranslateGemma 4B Q4_K_M remains the default first-pick (no change to existing users)
- Custom GGUF discovery in the models folder is unaffected (PR #11028's work intact)
- No changes to download logic, server lifecycle, or chat-template wiring — just new entries in the curated list

## Test plan
- [ ] Build SE locally and open Auto-Translate window — dropdown shows the two new entries below the TranslateGemma group
- [ ] Click download on "Qwen 3 4B Instruct (Q4_K_M)" — file downloads to the llama.cpp models folder
- [ ] Translate a small subtitle file — verify output is clean translation, no `<think>` blocks, no system-token leakage
- [ ] Repeat with "Qwen 3 8B (Q4_K_M)" — same checks, especially that the hybrid model doesn't fall into thinking mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)