### PR TITLE
SE UI drop video: find and offer matching subtitle - fix #11020

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17054,7 +17054,9 @@ public partial class MainViewModel :
             return;
         }
 
-        if (!IsEmpty)
+        // Prompt + run the save-if-unsaved flow whenever either column has content,
+        // so the original-text column's unsaved edits aren't silently discarded.
+        if (!IsEmpty || !IsEmptyOriginal)
         {
             var answer = await MessageBox.Show(
                 Window!,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17033,10 +17033,48 @@ public partial class MainViewModel :
                         }
 
                         await VideoOpenFile(path);
+                        await TryLoadAssociatedSubtitle(path);
                     }
                 }
             });
         }
+    }
+
+    private async Task TryLoadAssociatedSubtitle(string videoFileName)
+    {
+        if (!FindSubtitleFileName.TryFindSubtitleFileName(videoFileName, out var foundSubtitleFileName))
+        {
+            return;
+        }
+
+        // Already loaded in the editor - nothing to do.
+        if (!string.IsNullOrEmpty(_subtitleFileName) &&
+            string.Equals(Path.GetFullPath(_subtitleFileName), Path.GetFullPath(foundSubtitleFileName), StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (!IsEmpty)
+        {
+            var answer = await MessageBox.Show(
+                Window!,
+                Se.Language.Title,
+                string.Format(Se.Language.Main.OpenSubtitleFileX, Path.GetFileName(foundSubtitleFileName)),
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            var doContinue = await HasChangesContinue();
+            if (!doContinue)
+            {
+                return;
+            }
+        }
+
+        await SubtitleOpen(foundSubtitleFileName, skipLoadVideo: true);
     }
 
     internal void AudioVisualizerOnDeletePressed(object sender, ParagraphEventArgs e)

--- a/src/ui/Logic/Media/FindSubtitleFileName.cs
+++ b/src/ui/Logic/Media/FindSubtitleFileName.cs
@@ -1,4 +1,6 @@
-﻿using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -10,30 +12,76 @@ public static class FindSubtitleFileName
     {
         subtitleFileName = string.Empty;
 
-        if (string.IsNullOrEmpty(videoFileName))
+        if (string.IsNullOrWhiteSpace(videoFileName))
         {
             return false;
         }
 
-        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(videoFileName);
-        foreach (var extension in SubtitleFormat.AllSubtitleFormats.Select(p => p.Extension).Distinct())
-        {
-            var fileName = fileNameWithoutExtension + extension;
-            if (File.Exists(fileName))
-            {
-                subtitleFileName = fileName;
-                return true;
-            }
-        }
+        var directory = Path.GetDirectoryName(videoFileName) ?? string.Empty;
+        var nameWithoutExtension = Path.GetFileNameWithoutExtension(videoFileName);
+        var extensions = SubtitleFormat.AllSubtitleFormats
+            .Select(p => p.Extension)
+            .Where(e => !string.IsNullOrEmpty(e))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
-        var index = fileNameWithoutExtension.LastIndexOf('.');
-        if (index > 0 && TryFindSubtitleFileName(fileNameWithoutExtension.Remove(index), out subtitleFileName))
+        if (TryFindExactOrTrimmed(directory, nameWithoutExtension, extensions, out subtitleFileName))
         {
             return true;
         }
 
-        index = fileNameWithoutExtension.LastIndexOf('_');
-        if (index > 0 && TryFindSubtitleFileName(fileNameWithoutExtension.Remove(index), out subtitleFileName))
+        // Fall back: scan the directory for files like "{name}.{lang}.{subExt}" (e.g. "movie.en.srt")
+        if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+        {
+            try
+            {
+                foreach (var candidate in Directory.EnumerateFiles(directory, nameWithoutExtension + ".*"))
+                {
+                    var ext = Path.GetExtension(candidate);
+                    if (!string.IsNullOrEmpty(ext) &&
+                        extensions.Contains(ext, StringComparer.OrdinalIgnoreCase))
+                    {
+                        subtitleFileName = candidate;
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                // ignore - directory not accessible
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryFindExactOrTrimmed(string directory, string nameWithoutExtension, IList<string> extensions, out string subtitleFileName)
+    {
+        subtitleFileName = string.Empty;
+
+        if (string.IsNullOrEmpty(nameWithoutExtension))
+        {
+            return false;
+        }
+
+        foreach (var extension in extensions)
+        {
+            var candidate = Path.Combine(directory, nameWithoutExtension + extension);
+            if (File.Exists(candidate))
+            {
+                subtitleFileName = candidate;
+                return true;
+            }
+        }
+
+        var dotIndex = nameWithoutExtension.LastIndexOf('.');
+        if (dotIndex > 0 && TryFindExactOrTrimmed(directory, nameWithoutExtension.Substring(0, dotIndex), extensions, out subtitleFileName))
+        {
+            return true;
+        }
+
+        var underscoreIndex = nameWithoutExtension.LastIndexOf('_');
+        if (underscoreIndex > 0 && TryFindExactOrTrimmed(directory, nameWithoutExtension.Substring(0, underscoreIndex), extensions, out subtitleFileName))
         {
             return true;
         }

--- a/src/ui/Logic/Media/FindSubtitleFileName.cs
+++ b/src/ui/Logic/Media/FindSubtitleFileName.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 
 namespace Nikse.SubtitleEdit.Logic.Media;
 
@@ -17,7 +18,10 @@ public static class FindSubtitleFileName
             return false;
         }
 
-        var directory = Path.GetDirectoryName(videoFileName) ?? string.Empty;
+        var rawDirectory = Path.GetDirectoryName(videoFileName);
+        // Drop targets always carry an absolute path, but treat a missing directory
+        // as "current directory" so relative-path callers still get the fallback scan.
+        var directory = string.IsNullOrEmpty(rawDirectory) ? "." : rawDirectory;
         var nameWithoutExtension = Path.GetFileNameWithoutExtension(videoFileName);
         var extensions = SubtitleFormat.AllSubtitleFormats
             .Select(p => p.Extension)
@@ -31,7 +35,7 @@ public static class FindSubtitleFileName
         }
 
         // Fall back: scan the directory for files like "{name}.{lang}.{subExt}" (e.g. "movie.en.srt")
-        if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+        if (Directory.Exists(directory))
         {
             try
             {
@@ -46,9 +50,13 @@ public static class FindSubtitleFileName
                     }
                 }
             }
-            catch
+            catch (Exception ex) when (
+                ex is IOException ||
+                ex is UnauthorizedAccessException ||
+                ex is SecurityException ||
+                ex is ArgumentException)
             {
-                // ignore - directory not accessible
+                // ignore - directory not accessible or path invalid
             }
         }
 


### PR DESCRIPTION
## Summary
- Fixes the drag/drop asymmetry from #11020: dropping a subtitle already opens its matching video, but dropping a video onto the video player did not load the matching subtitle.
- After a dropped video opens, we now look for an associated subtitle file. If the editor is empty, we load it directly; otherwise we prompt (and the existing save-if-unsaved flow runs on confirmation).
- Repairs `FindSubtitleFileName`, which was effectively broken: it called `File.Exists` with no directory, so it would only ever match files in the current working directory. It now searches the video's own folder, recurses into trimmed name variants (`movie.en` → `movie`, `movie_en` → `movie`), and finally scans for `movie.<lang>.srt` style names.

## Test plan
- [ ] Drop a video onto the video player with a matching subtitle (`movie.mp4` + `movie.srt`) when the editor is empty — subtitle loads automatically.
- [ ] Drop a video onto the video player with a matching subtitle when a subtitle is already loaded — user is prompted; on Yes, save-if-unsaved kicks in, then the subtitle loads.
- [ ] Drop a video with a language-suffixed subtitle (`movie.mp4` + `movie.en.srt`) — found and loaded.
- [ ] Drop a video with no matching subtitle — no prompt, video opens normally.
- [ ] Drop a subtitle on the window — still works as before (matching video is auto-loaded).
- [x] `dotnet test tests/UI/UITests.csproj` — 188/188 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)