### PR TITLE
SE UI batch convert: add "Try to use source encoding" option - fix #11019

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -71,6 +71,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     public BatchConvertSettingsViewModel(IFolderHelper folderHelper, IWindowService windowService)
     {
         var encodings = EncodingHelper.GetEncodings().Select(p => p.DisplayName).ToList();
+        encodings.Insert(0, EncodingHelper.TryToUseSourceEncoding);
         TargetEncodings = new ObservableCollection<string>(encodings);
 
         OcrEngines = new ObservableCollection<string> { "nOcr", "BinaryOcr", "Tesseract", "Ollama" };
@@ -159,8 +160,10 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         UseOutputFolder = !UseSourceFolder;
         OutputFolder = Se.Settings.Tools.BatchConvert.OutputFolder;
         Overwrite = Se.Settings.Tools.BatchConvert.Overwrite;
-        SelectedTargetEncoding = Se.Settings.Tools.BatchConvert.TargetEncoding;
-        SelectedOcrEngine = OcrEngines.FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.OcrEngine) ?? OcrEngines.First();    
+        SelectedTargetEncoding = TargetEncodings.FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.TargetEncoding)
+            ?? TargetEncodings.FirstOrDefault(p => p == TextEncoding.Utf8WithBom)
+            ?? TargetEncodings.First();
+        SelectedOcrEngine = OcrEngines.FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.OcrEngine) ?? OcrEngines.First();
     }
 
     private void SaveSettings()
@@ -168,7 +171,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         Se.Settings.Tools.BatchConvert.SaveInSourceFolder = !UseOutputFolder;
         Se.Settings.Tools.BatchConvert.OutputFolder = OutputFolder;
         Se.Settings.Tools.BatchConvert.Overwrite = Overwrite;
-        Se.Settings.Tools.BatchConvert.TargetEncoding = SelectedTargetEncoding ?? TargetEncodings.First();
+        Se.Settings.Tools.BatchConvert.TargetEncoding = SelectedTargetEncoding ?? TextEncoding.Utf8WithBom;
         Se.Settings.Tools.BatchConvert.LanguagePostFix = SelectedLanguagePostFix ?? Se.Language.General.TwoLetterLanguageCode;
         Se.Settings.Tools.BatchConvert.OcrEngine = SelectedOcrEngine ?? "nOcr";
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -339,6 +339,7 @@ public partial class BatchConvertViewModel : ObservableObject
         _cancellationToken = _cancellationTokenSource.Token;
 
         _encodings = EncodingHelper.GetEncodings().Select(p => p.DisplayName).ToList();
+        _encodings.Insert(0, EncodingHelper.TryToUseSourceEncoding);
 
         AutoTranslateModel = string.Empty;
         AutoTranslateUrl = string.Empty;
@@ -773,7 +774,8 @@ public partial class BatchConvertViewModel : ObservableObject
             _encodings.FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.TargetEncoding);
         if (targetEncoding == null)
         {
-            targetEncoding = _encodings.First();
+            targetEncoding = _encodings.FirstOrDefault(p => p == TextEncoding.Utf8WithBom)
+                ?? _encodings.First();
             Se.Settings.Tools.BatchConvert.TargetEncoding = targetEncoding;
         }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1406,9 +1406,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 }
             }
 
-            var converted = targetFormat.ToText(s, _config.TargetEncoding);
+            var converted = targetFormat.ToText(s, Path.GetFileNameWithoutExtension(item.FileName));
             var path = MakeOutputFileName(item, targetFormat.Extension);
-            await File.WriteAllTextAsync(path, converted, cancellationToken);
+            var encoding = EncodingHelper.ResolveEncoding(_config.TargetEncoding, item.FileName);
+            await File.WriteAllTextAsync(path, converted, encoding, cancellationToken);
             item.Status = Se.Language.General.Converted;
         }
         catch (Exception exception)

--- a/src/ui/Logic/EncodingHelper.cs
+++ b/src/ui/Logic/EncodingHelper.cs
@@ -1,11 +1,17 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Nikse.SubtitleEdit.Logic;
 
 public static class EncodingHelper
 {
+    // Stable sentinel for the batch-convert "use the source file's encoding" option.
+    // Stored verbatim in settings, so kept English (matches "UTF-8 with BOM" et al.).
+    public const string TryToUseSourceEncoding = "Try to use source encoding";
+
     public static List<TextEncoding> GetEncodings()
     {
         var encodingList = new List<TextEncoding>();
@@ -37,5 +43,37 @@ public static class EncodingHelper
         }
 
         return encodingList;
+    }
+
+    /// <summary>
+    /// Resolves a target-encoding <see cref="TextEncoding.DisplayName"/> (as stored in
+    /// settings) to a concrete <see cref="Encoding"/>. Honors the <see cref="TryToUseSourceEncoding"/>
+    /// sentinel by detecting the source file's encoding. Falls back to UTF-8 with BOM
+    /// when the name is empty, unknown, or detection fails.
+    /// </summary>
+    public static Encoding ResolveEncoding(string? displayName, string? sourceFile)
+    {
+        if (string.Equals(displayName, TryToUseSourceEncoding, System.StringComparison.Ordinal))
+        {
+            if (!string.IsNullOrEmpty(sourceFile) && File.Exists(sourceFile))
+            {
+                return LanguageAutoDetect.GetEncodingFromFile(sourceFile);
+            }
+            return new UTF8Encoding(true);
+        }
+
+        if (string.IsNullOrEmpty(displayName) ||
+            string.Equals(displayName, TextEncoding.Utf8WithBom, System.StringComparison.Ordinal))
+        {
+            return new UTF8Encoding(true);
+        }
+
+        if (string.Equals(displayName, TextEncoding.Utf8WithoutBom, System.StringComparison.Ordinal))
+        {
+            return new UTF8Encoding(false);
+        }
+
+        var match = GetEncodings().FirstOrDefault(e => e.DisplayName == displayName);
+        return match?.Encoding ?? new UTF8Encoding(true);
     }
 }


### PR DESCRIPTION
## Summary
- Restores the WinForms-era **Try to use source encoding** entry to the target-encoding dropdown in batch convert — both the settings dialog and the main view (sidenote in #11019).
- Fixes a latent bug where the selected encoding never reached disk: `SaveSubtitleFormat` was passing `_config.TargetEncoding` as the `title` arg to `ToText()` and writing via `File.WriteAllTextAsync` without an encoding, so output always landed as UTF-8 without BOM regardless of the user's choice. Encoding is now resolved through `EncodingHelper.ResolveEncoding` and passed to the write.
- For the new option, the encoding is detected per-file via `LanguageAutoDetect.GetEncodingFromFile(item.FileName)`.
- Defaults are pinned to **UTF-8 with BOM** (rather than "first item in the list") so existing installs without a saved choice don't migrate onto the new option.

> Note: this PR doesn't touch the dropdown's center-alignment / variable-width complaint that's the primary topic of #11019 — that's a separate styling change.

## Test plan
- [ ] Open Batch convert > Settings — **Try to use source encoding** appears at the top of the **Target encoding** dropdown, and the main batch-convert view shows the same option.
- [ ] Convert a UTF-8-with-BOM SRT with target encoding **Try to use source encoding** → output retains UTF-8 with BOM.
- [ ] Convert a Windows-1252 SRT with **Try to use source encoding** → output is Windows-1252.
- [ ] Convert with target encoding explicitly **UTF-8 without BOM** → output has no BOM (regression check of the write-path fix).
- [ ] Convert with target encoding **1252: Western European (Windows)** → output bytes match cp1252.
- [ ] Fresh install / wiped `Se.Settings.Tools.BatchConvert.TargetEncoding` → default is UTF-8 with BOM, not the new option.
- [x] `dotnet test tests/UI/UITests.csproj` — 188/188 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)