### PR TITLE
SE UI: select first row after OCR completes - fix #11036

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2605,6 +2605,7 @@ public partial class MainViewModel :
             _subtitleFileName = string.Empty;
             ResetSubtitle();
             Subtitles.AddRange(ocrResult.OcredSubtitle);
+            SelectAndScrollToRow(0);
         }
     }
 
@@ -11261,6 +11262,7 @@ public partial class MainViewModel :
                             _converted = true;
                             Subtitles.Clear();
                             Subtitles.AddRange(result.OcredSubtitle);
+                            SelectAndScrollToRow(0);
                         }
                     });
                     return;
@@ -12011,6 +12013,7 @@ public partial class MainViewModel :
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 Subtitles.Clear();
                 Subtitles.AddRange(result.OcredSubtitle);
+                SelectAndScrollToRow(0);
             }
         });
 
@@ -12273,6 +12276,7 @@ public partial class MainViewModel :
                     Subtitles.Clear();
                     Subtitles.AddRange(result.OcredSubtitle);
                     Renumber();
+                    SelectAndScrollToRow(0);
                 }
             });
 
@@ -12471,6 +12475,7 @@ public partial class MainViewModel :
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 Subtitles.Clear();
                 Subtitles.AddRange(result.OcredSubtitle);
+                SelectAndScrollToRow(0);
             }
         });
 
@@ -12570,6 +12575,7 @@ public partial class MainViewModel :
             _converted = true;
             Subtitles.Clear();
             Subtitles.AddRange(result.OcredSubtitle);
+            SelectAndScrollToRow(0);
             return true;
         }
 


### PR DESCRIPTION
## Summary
After an OCR pass finished, the subtitle grid had no row selected. As a result Ctrl+F did nothing and the Replace dialog's Replace / Replace-all buttons were no-ops until the user manually clicked a row (see #11036 repro). Several of the OCR-result handlers in `MainViewModel` already called `SelectAndScrollToRow(0)` after `Subtitles.AddRange(result.OcredSubtitle)`; six of them didn't. Added the call to the missing six so the post-OCR state matches the rest.

## Sites updated
- `ImportImagesForOcr` — image-file picker
- `SubtitleOpen` → BluRaySup branch — `.sup` direct open
- `ImportSubtitleFromTransportStream` — `.ts` / `.m2ts` DVB
- `LoadPgsFromMatroska` — PGS track inside `.mkv`
- `LoadVobSubFromMatroska` — VobSub track inside `.mkv`
- `ImportSubtitleFromVobSubFile` — `.idx` / `.sub` VobSub pair

The seven handlers that already called `SelectAndScrollToRow(0)` (DivX, Dost, WebVtt images, SpDvdSup, the second BluRaySup helper, the MP4 VobSub track, and the DVB-image Matroska helper) are unchanged.

## Test plan
- [ ] OCR a `.sup` file → on OK, the first row is selected; Ctrl+F focuses search; Replace's buttons act on the first line.
- [ ] OCR a VobSub `.idx`/`.sub` pair → same.
- [ ] OCR a PGS track inside an `.mkv` → same.
- [ ] OCR a VobSub track inside an `.mkv` → same.
- [ ] OCR a DVB track inside a `.ts` → same.
- [ ] OCR images selected via "Import images for OCR" → same.
- [x] `dotnet test tests/UI/UITests.csproj` — 188/188 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)