### PR TITLE
seconv: reject unknown --encoding values, add --encoding:source

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -44,6 +44,7 @@ Options accept either `--option:value`, `--option=value`, or `--option value`. T
 ```bash
 seconv *.srt sami                                                  # SRT → SAMI
 seconv movie.srt subrip --encoding:windows-1252                    # encoding override
+seconv movie.srt subrip --encoding:source                          # keep input's encoding on output
 seconv *.sub subrip --fps:25 --output-folder:./out                 # frame-based → time-based
 
 seconv movie.mkv subrip --track-number:3                           # extract MKV text track #3

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -95,7 +95,7 @@ seconv lint *.srt --json             # CI-friendly: exit 1 on any issue
 | `--output-folder:<path>` | Output folder (default: input file's directory) |
 | `--output-filename:<name>` | Output file name (single input only) |
 | `--overwrite` | Overwrite existing files (default: rotate to `name_2.ext`, `_3.ext`, ...) |
-| `--encoding:<name>` | Encoding name or codepage. Special values: `utf-8`, `utf-8-no-bom` (also `utf-8-nobom`, `utf8-nobom`), or a code page number. Defaults: auto-detect on input, UTF-8 BOM on output |
+| `--encoding:<name>` | Encoding name or codepage. Special values: `utf-8`, `utf-8-no-bom` (also `utf-8-nobom`, `utf8-nobom`), a code page number, or `source` to keep the input file's detected encoding. Defaults: auto-detect on input, UTF-8 BOM on output |
 
 ### Time / frame
 

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -47,7 +47,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         public string? EbuHeaderFile { get; init; }
 
         [CommandOption("--encoding")]
-        [Description("Encoding name")]
+        [Description("Encoding name (e.g. utf-8, utf-8-no-bom, windows-1252, 1252). Use 'source' to keep the input file's detected encoding.")]
         public string? Encoding { get; init; }
 
         [CommandOption("--input-encoding-fallback|--inputencodingfallback")]
@@ -273,6 +273,19 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 AnsiConsole.MarkupLine(
                     $"[red]Error: OCR engine '{settings.OcrEngine.EscapeMarkup()}' is not supported (pass via --ocr-engine). " +
                     $"Use one of: {string.Join(", ", supportedEngines)}.[/]");
+                return 1;
+            }
+
+            // Fail fast on a typo in --encoding so we don't silently substitute UTF-8 and
+            // decode the input incorrectly without the user noticing. The literal "source"
+            // is a sentinel — resolved per-file from the input's detected encoding.
+            if (!string.IsNullOrWhiteSpace(settings.Encoding) &&
+                !LibSEIntegration.IsSourceEncodingSentinel(settings.Encoding) &&
+                !LibSEIntegration.TryGetEncoding(settings.Encoding, out _))
+            {
+                AnsiConsole.MarkupLine(
+                    $"[red]Error: Unknown encoding '{settings.Encoding.EscapeMarkup()}' for --encoding.[/]");
+                AnsiConsole.MarkupLine("[dim]Use 'seconv list-encodings' to see supported encodings, or 'source' to keep the input file's encoding.[/]");
                 return 1;
             }
 

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -845,6 +845,49 @@ internal static class LibSEIntegration
     }
 
     /// <summary>
+    /// True when the user passed <c>--encoding:source</c> (case-insensitive) — a sentinel
+    /// meaning "save with the same encoding the input file was read in". Resolved per-file
+    /// via <see cref="DetectSourceEncodingName"/> before the load/save calls.
+    /// </summary>
+    internal static bool IsSourceEncodingSentinel(string? encodingName)
+        => !string.IsNullOrWhiteSpace(encodingName) &&
+           string.Equals(encodingName.Trim(), "source", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolves <c>--encoding:source</c> for a given input file: runs the same detection
+    /// <see cref="LoadSubtitleWithFormat"/> would and returns a name that round-trips
+    /// through <see cref="GetEncoding"/> (preserving the UTF-8 BOM/no-BOM distinction the
+    /// raw <see cref="Encoding"/> object would lose on save).
+    /// </summary>
+    internal static string DetectSourceEncodingName(string filePath, string? fallbackEncodingName)
+    {
+        var encoding = !string.IsNullOrWhiteSpace(fallbackEncodingName)
+            ? DetectEncodingWithFallback(filePath, fallbackEncodingName)
+            : LanguageAutoDetect.GetEncodingFromFile(filePath);
+
+        if (encoding.CodePage == 65001)
+        {
+            return FileStartsWithUtf8Bom(filePath) ? "utf-8" : "utf-8-no-bom";
+        }
+
+        return encoding.CodePage.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static bool FileStartsWithUtf8Bom(string filePath)
+    {
+        try
+        {
+            using var fs = File.OpenRead(filePath);
+            Span<byte> bom = stackalloc byte[3];
+            return fs.Read(bom) >= 3 && bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Non-throwing variant of <see cref="GetEncoding"/> used to validate user input. Returns
     /// false (and a null out) for an unrecognized name or code page so the CLI can report
     /// a typo instead of silently substituting UTF-8 and producing mojibake.

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -153,16 +153,26 @@ internal class SubtitleConverter
 
             await Task.Run(() =>
             {
+                // --encoding:source means "use the input file's detected encoding for both
+                // read and write". Resolve it per-file before the load so the same encoding
+                // name flows into the save side too.
+                var resolvedOptions = options;
+                if (LibSEIntegration.IsSourceEncodingSentinel(options.Encoding))
+                {
+                    var detected = LibSEIntegration.DetectSourceEncodingName(inputFile, options.InputEncodingFallback);
+                    resolvedOptions = options with { Encoding = detected };
+                }
+
                 // Load subtitle file using LibSE — keep the detected format so the
                 // save side can apply RemoveNativeFormatting when the target differs.
-                var (subtitle, sourceFormat) = LibSEIntegration.LoadSubtitleWithFormat(inputFile, options.Encoding, options.InputEncodingFallback);
+                var (subtitle, sourceFormat) = LibSEIntegration.LoadSubtitleWithFormat(inputFile, resolvedOptions.Encoding, resolvedOptions.InputEncodingFallback);
 
                 if (subtitle == null || subtitle.Paragraphs.Count == 0)
                 {
                     throw new InvalidOperationException($"No subtitles found in file: {inputFile}");
                 }
 
-                ApplyTransformsAndSave(subtitle, sourceFormat, outputFile, options);
+                ApplyTransformsAndSave(subtitle, sourceFormat, outputFile, resolvedOptions);
             });
         }
         finally
@@ -340,7 +350,7 @@ internal class SubtitleConverter
     }
 }
 
-internal class ConversionOptions
+internal record class ConversionOptions
 {
     public required IReadOnlyList<string> Patterns { get; init; }
     public required string Format { get; init; }

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -22,7 +22,7 @@ internal static class HelpDisplay
         ShowParameter("--assa-style-file:<file name>", "ASSA style file");
         ShowParameter("--change-speed:<percent>", "Change speed by percent (e.g. 125 = 1.25x faster)");
         ShowParameter("--ebu-header-file:<file name>", "EBU header file");
-        ShowParameter("--encoding:<encoding name>", "Character encoding (e.g., utf-8, windows-1252)");
+        ShowParameter("--encoding:<encoding name>", "Character encoding (e.g., utf-8, windows-1252, or 'source' to keep the input file's encoding)");
         ShowParameter("--input-encoding-fallback:<name>", "Assumed input encoding when no BOM and not UTF-8 (skips ANSI guess)");
         ShowParameter("--forced-only", "Process forced subtitles only");
         ShowParameter("--fps:<frame rate>", "Frame rate for conversion");

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -35,6 +35,7 @@ seconv <pattern> --format <name> [options]   # alternative syntax
 ```bash
 seconv *.srt sami                                              # SRT → SAMI
 seconv movie.srt subrip --encoding:windows-1252                # encoding override
+seconv movie.srt subrip --encoding:source                      # keep input's encoding on output
 seconv *.srt subrip --input-encoding-fallback:windows-1250     # UTF-8 wins; CP1250 only if not UTF-8
 seconv *.sub subrip --fps:25 --output-folder ./out             # frame-based → time-based
 

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -85,7 +85,7 @@ seconv lint *.srt --json                    # CI-friendly: exit 1 on any issue
 | `--output-folder:<path>` | Output folder (default: input file's directory) |
 | `--output-filename:<name>` | Output file name (single input only) |
 | `--overwrite` | Overwrite existing files (default: rotate to `name_2.ext`, `_3.ext`, ...) |
-| `--encoding:<name>` | Encoding name or codepage (defaults: auto-detect on input, UTF-8 BOM on output) |
+| `--encoding:<name>` | Encoding name or codepage (defaults: auto-detect on input, UTF-8 BOM on output). Use `source` to keep the input file's detected encoding. |
 | `--input-encoding-fallback:<name>` | Encoding to assume when input has no BOM and is not detected as UTF-8 (replaces the ANSI codepage heuristic). Ignored when `--encoding` is set. |
 
 ### Time / Frame


### PR DESCRIPTION
## Summary
- Fail fast on a typo in `--encoding` (mirrors the existing `--input-encoding-fallback` validation) instead of silently substituting UTF-8 and producing mojibake. Error message hints at the new `source` value and `seconv list-encodings`.
- Add `--encoding:source` — a sentinel that resolves per-file to the input file's detected encoding (preserving UTF-8 BOM vs. no-BOM), restoring the behavior the old SE CLI offered.

Addresses points 4 and 5 of #11037.

## Test plan
- [x] `seconv file.srt sami --encoding:NONSENSE` exits 1 with a clear error
- [x] `seconv file.srt sami --encoding:utf-8` still works (regression)
- [x] `--encoding:source` on a UTF-8-with-BOM input preserves the BOM on output
- [x] `--encoding:source` on a UTF-8-no-BOM input preserves no-BOM on output
- [x] `--encoding:source --input-encoding-fallback:windows-1252` round-trips Windows-1252 bytes correctly
- [x] `--encoding:SOURCE` (case-insensitive) works
- [x] Help text and docs mention `source`

🤖 Generated with [Claude Code](https://claude.com/claude-code)