### PR TITLE
Trim long paths in Reopen menu and tighten menu spacing

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -48,7 +48,7 @@ public static class InitMenu
             Setters =
             {
                 new Setter(MenuItem.FontSizeProperty, MenuFontSize),
-                new Setter(MenuItem.PaddingProperty, new Thickness(10, 3)),
+                new Setter(MenuItem.PaddingProperty, new Thickness(10, 1)),
             },
         });
 
@@ -929,15 +929,15 @@ public static class InitMenu
                     }
                 }
 
-                // Wrap the path in an explicit TextBlock with TextTrimming.None so
-                // long file paths render in full instead of being clipped with an
-                // ellipsis. The MenuItem widens to fit.
+                // Trim the directory prefix with "…" when the path is too long so
+                // the filename stays visible. Full path is still available via tooltip.
                 var item = new MenuItem
                 {
                     Header = new TextBlock
                     {
                         Text = header,
-                        TextTrimming = TextTrimming.None,
+                        TextTrimming = TextTrimming.PrefixCharacterEllipsis,
+                        MaxWidth = 600,
                     },
                     Command = vm.CommandFileReopenCommand,
                     CommandParameter = file,

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -49,6 +49,7 @@ public static class InitMenu
             {
                 new Setter(MenuItem.FontSizeProperty, MenuFontSize),
                 new Setter(MenuItem.PaddingProperty, new Thickness(10, 1)),
+                new Setter(MenuItem.MinHeightProperty, 22.0),
             },
         });
 

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -49,7 +49,7 @@ public static class InitMenu
             {
                 new Setter(MenuItem.FontSizeProperty, MenuFontSize),
                 new Setter(MenuItem.PaddingProperty, new Thickness(10, 1)),
-                new Setter(MenuItem.MinHeightProperty, 22.0),
+                new Setter(MenuItem.MinHeightProperty, 23.0),
             },
         });
 


### PR DESCRIPTION
## Summary
- Reopen submenu entries with long paths were being clipped. Switched the `TextBlock` to `TextTrimming.PrefixCharacterEllipsis` with `MaxWidth = 600` so the directory prefix gets truncated as `…\folder\file.srt` while the filename stays visible (tooltip still shows the full path).
- Dropped the menu-wide `MenuItem` padding from `(10, 3)` to `(10, 1)` for a denser, tighter menu list.

## Test plan
- [ ] Open the File → Reopen menu with a recent file whose path is longer than the menu — verify the start is truncated with `…` and the filename is fully visible.
- [ ] Hover a truncated entry — tooltip shows the full path.
- [ ] Visually confirm all top-level menus (File, Edit, Tools, …) now have slightly less vertical spacing between items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)