### PR TITLE
Qwen3 TTS: bump to v0.4.4 and add Windows CUDA variant

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
@@ -140,16 +140,20 @@ public partial class Qwen3TtsSettingsViewModel : ObservableObject
                 MessageBoxButtons.Cancel,
                 MessageBoxIcon.Question,
                 "CPU",
-                "Vulkan");
+                "Vulkan (GPU)",
+                "CUDA (NVIDIA GPU)");
 
             if (variantAnswer == MessageBoxResult.None || variantAnswer == MessageBoxResult.Cancel)
             {
                 return;
             }
 
-            variant = variantAnswer == MessageBoxResult.Custom1
-                ? Qwen3TtsCppDownloadService.WindowsVariantCpu
-                : Qwen3TtsCppDownloadService.WindowsVariantVulkan;
+            variant = variantAnswer switch
+            {
+                MessageBoxResult.Custom1 => Qwen3TtsCppDownloadService.WindowsVariantCpu,
+                MessageBoxResult.Custom3 => Qwen3TtsCppDownloadService.WindowsVariantCuda,
+                _ => Qwen3TtsCppDownloadService.WindowsVariantVulkan,
+            };
 
             if (variant == Qwen3TtsCppDownloadService.WindowsVariantVulkan && !VulkanHelper.IsInstalled())
             {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -697,16 +697,20 @@ public partial class TextToSpeechViewModel : ObservableObject
                         MessageBoxButtons.Cancel,
                         MessageBoxIcon.Question,
                         "CPU",
-                        "Vulkan");
+                        "Vulkan (GPU)",
+                        "CUDA (NVIDIA GPU)");
 
                     if (variantAnswer == MessageBoxResult.None || variantAnswer == MessageBoxResult.Cancel)
                     {
                         return false;
                     }
 
-                    qwen3Variant = variantAnswer == MessageBoxResult.Custom1
-                        ? Qwen3TtsCppDownloadService.WindowsVariantCpu
-                        : Qwen3TtsCppDownloadService.WindowsVariantVulkan;
+                    qwen3Variant = variantAnswer switch
+                    {
+                        MessageBoxResult.Custom1 => Qwen3TtsCppDownloadService.WindowsVariantCpu,
+                        MessageBoxResult.Custom3 => Qwen3TtsCppDownloadService.WindowsVariantCuda,
+                        _ => Qwen3TtsCppDownloadService.WindowsVariantVulkan,
+                    };
 
                     if (qwen3Variant == Qwen3TtsCppDownloadService.WindowsVariantVulkan && !VulkanHelper.IsInstalled())
                     {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -97,6 +97,7 @@ public static class DownloadHashManager
         // misreported as "update available" immediately after a fresh download.
         public const string WindowsVulkan = "Qwen3TtsCpp.Windows.Vulkan";
         public const string WindowsCpu = "Qwen3TtsCpp.Windows.Cpu";
+        public const string WindowsCuda = "Qwen3TtsCpp.Windows.Cuda";
         public const string MacOs = "Qwen3TtsCpp.MacOs";
         public const string LinuxX64 = "Qwen3TtsCpp.Linux.X64";
         public const string LinuxArm64 = "Qwen3TtsCpp.Linux.Arm64";
@@ -395,23 +396,32 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [Qwen3TtsCpp.WindowsVulkan] = new[]
             {
-                "42dff2cb2e921a337c588e5331b5ea963b777751303729a66bf0124be242297d", // v0.4.3 (current download URL)
+                "697b4871b803172ef2d30682e099008c646591e59835e655c598d275163723c8", // v0.4.4 (current download URL)
+                "42dff2cb2e921a337c588e5331b5ea963b777751303729a66bf0124be242297d", // v0.4.3
             },
             [Qwen3TtsCpp.WindowsCpu] = new[]
             {
-                "afa9fef938ddd8d22a0f5c955b5c3a2e402f49a6d1ddc587da2d07d6993f4120", // v0.4.3 (current download URL)
+                "e09875f4d329b1c7623af2e7ea5fae2c838c1bd880712415220323f969370975", // v0.4.4 (current download URL)
+                "afa9fef938ddd8d22a0f5c955b5c3a2e402f49a6d1ddc587da2d07d6993f4120", // v0.4.3
+            },
+            [Qwen3TtsCpp.WindowsCuda] = new[]
+            {
+                "cb53effe905d05e60e61f8dcadda00544d6d427d567be017c7ed4bea2148acb2", // v0.4.4 (current download URL)
             },
             [Qwen3TtsCpp.MacOs] = new[]
             {
-                "625f32817ff9e5cacea48db24ad8ae1149406e382a7e58068fc87182238baa07", // v0.4.3 (current download URL)
+                "faecc2b93d9586f8d7bdf2601343c5a14f8d6bd2546578ed2559a0e2d191412c", // v0.4.4 (current download URL)
+                "625f32817ff9e5cacea48db24ad8ae1149406e382a7e58068fc87182238baa07", // v0.4.3
             },
             [Qwen3TtsCpp.LinuxX64] = new[]
             {
-                "4456b19fa62ac52c6ef6302f36effc1336d559be0fde200222be302746dd2579", // v0.4.3 (current download URL)
+                "c9ecec169ebed93909ac72b65e0acbb8958047f08c8b9cf4f5d07d0e3bfc2844", // v0.4.4 (current download URL)
+                "4456b19fa62ac52c6ef6302f36effc1336d559be0fde200222be302746dd2579", // v0.4.3
             },
             [Qwen3TtsCpp.LinuxArm64] = new[]
             {
-                "3e9bdc9d176ea13a109d8e8a813009e110df003a988d10dc317e58572517d014", // v0.4.3 (current download URL)
+                "bba376f4ead8356a496a48d37572e6c56d66161d52026f502e74afd050654f41", // v0.4.4 (current download URL)
+                "3e9bdc9d176ea13a109d8e8a813009e110df003a988d10dc317e58572517d014", // v0.4.3
             },
             [Qwen3TtsCpp.Voices] = new[]
             {
@@ -984,7 +994,7 @@ public static class DownloadHashManager
 
     /// <summary>
     /// Resolves the Qwen3 TTS archive hash key for the current OS, architecture and
-    /// (Windows-only) variant ("cpu" / "vulkan"). Returns null when the combination is unknown.
+    /// (Windows-only) variant ("cpu" / "vulkan" / "cuda"). Returns null when the combination is unknown.
     /// </summary>
     public static string? ResolveQwen3TtsCppKey(string? windowsVariant)
     {
@@ -994,6 +1004,7 @@ public static class DownloadHashManager
             {
                 "cpu" => Qwen3TtsCpp.WindowsCpu,
                 "vulkan" => Qwen3TtsCpp.WindowsVulkan,
+                "cuda" => Qwen3TtsCpp.WindowsCuda,
                 _ => Qwen3TtsCpp.WindowsVulkan, // Vulkan is the recommended default on Windows.
             };
         }

--- a/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
@@ -21,14 +21,16 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
 
     public const string WindowsVariantVulkan = "vulkan";
     public const string WindowsVariantCpu = "cpu";
+    public const string WindowsVariantCuda = "cuda";
 
     // qwen3-tts.cpp release pin. Bump in lockstep with the hashes in
     // DownloadHashManager.Qwen3TtsCpp (each new release: prepend the new SHA-256 at index 0).
-    public const string ReleaseTag = "v0.4.3";
+    public const string ReleaseTag = "v0.4.4";
     private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/" + ReleaseTag + "/";
 
     private const string WindowsVulkanUrl = ReleaseUrlBase + "qwen3-tts-server-" + ReleaseTag + "-windows-vulkan-x64.zip";
     private const string WindowsCpuUrl    = ReleaseUrlBase + "qwen3-tts-server-" + ReleaseTag + "-windows-cpu-x64.zip";
+    private const string WindowsCudaUrl   = ReleaseUrlBase + "qwen3-tts-server-" + ReleaseTag + "-windows-cuda-x64.zip";
     private const string MacUrl           = ReleaseUrlBase + "qwen3-tts-server-" + ReleaseTag + "-macos-metal-arm64.zip";
     private const string LinuxUrl         = ReleaseUrlBase + "qwen3-tts-server-" + ReleaseTag + "-linux-vulkan-x64.zip";
     private const string LinuxArmUrl      = ReleaseUrlBase + "qwen3-tts-server-" + ReleaseTag + "-linux-arm64.zip";
@@ -122,7 +124,12 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return windowsVariant == WindowsVariantCpu ? WindowsCpuUrl : WindowsVulkanUrl;
+            return windowsVariant switch
+            {
+                WindowsVariantCpu => WindowsCpuUrl,
+                WindowsVariantCuda => WindowsCudaUrl,
+                _ => WindowsVulkanUrl,
+            };
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))


### PR DESCRIPTION
## Summary
- Bump `Qwen3TtsCppDownloadService.ReleaseTag` from `v0.4.3` to `v0.4.4` and refresh SHA-256 hashes for all five existing platform archives (new hash at index 0, v0.4.3 kept at index 1).
- Add `windows-cuda-x64` as a third Windows variant alongside Vulkan and CPU — v0.4.4 ships a new NVIDIA CUDA build (cuBLAS).
- Download prompts in `TextToSpeechViewModel` and `Qwen3TtsSettingsViewModel` now offer three buttons: **CPU / Vulkan (GPU) / CUDA (NVIDIA GPU)** — same pattern as `LlamaCppDownloadHelper`.

## Test plan
- [ ] Trigger a fresh Qwen3 TTS download on Windows — prompt shows CPU/Vulkan/CUDA buttons.
- [ ] Pick **CUDA** → confirm `qwen3-tts-server-v0.4.4-windows-cuda-x64.zip` downloads, SHA-256 verifies, extracts (includes `cudart64_12.dll`, `cublas64_12.dll`, `cublasLt64_12.dll`).
- [ ] Pick **Vulkan** → existing flow still works against the v0.4.4 zip.
- [ ] Pick **CPU** → existing flow still works against the v0.4.4 zip.
- [ ] Re-download via Qwen3 TTS settings: same three-button prompt, same outcomes.
- [ ] Non-Windows platforms (macOS, Linux x64, Linux ARM64) still download/verify the v0.4.4 archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)