### PR TITLE
Prettify llama.cpp OCR settings + wire up llama.cpp hashes

### DIFF
--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -1,11 +1,14 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using System;
 using System.Threading.Tasks;
 
@@ -19,12 +22,47 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
     [ObservableProperty] private string _url;
     [ObservableProperty] private string _prompt;
     [ObservableProperty] private int _timeoutMinutes;
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Brushes.Gray;
+    [ObservableProperty] private bool _isEngineInstalled;
 
     public LlamaCppOcrSettingsViewModel()
     {
         _url = Se.Settings.Ocr.LlamaCppUrl ?? string.Empty;
         _prompt = Se.Settings.Ocr.LlamaCppOcrPrompt ?? string.Empty;
         _timeoutMinutes = Math.Max(1, Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
+    }
+
+    public void Initialize()
+    {
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        IsEngineInstalled = LlamaCppServerManager.IsEngineInstalled();
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = "Not installed";
+            EngineBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
+            return;
+        }
+
+        switch (LlamaCppServerManager.GetEngineUpdateStatus())
+        {
+            case DownloadHashManager.UpdateStatus.UpToDate:
+                EngineLabel = "Installed (latest)";
+                EngineBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
+                break;
+            case DownloadHashManager.UpdateStatus.UpdateAvailable:
+                EngineLabel = "Update available";
+                EngineBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
+                break;
+            default:
+                EngineLabel = "Installed (unknown version)";
+                EngineBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
+                break;
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -43,24 +43,24 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
         IsEngineInstalled = LlamaCppServerManager.IsEngineInstalled();
         if (!IsEngineInstalled)
         {
-            EngineLabel = "Not installed";
-            EngineBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
+            EngineLabel = Se.Language.General.NotInstalled;
+            EngineBrush = new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36)); // red
             return;
         }
 
         switch (LlamaCppServerManager.GetEngineUpdateStatus())
         {
             case DownloadHashManager.UpdateStatus.UpToDate:
-                EngineLabel = "Installed (latest)";
+                EngineLabel = Se.Language.General.UpToDate;
                 EngineBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
                 break;
             case DownloadHashManager.UpdateStatus.UpdateAvailable:
-                EngineLabel = "Update available";
+                EngineLabel = Se.Language.General.UpdateAvailable;
                 EngineBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
                 break;
             default:
-                EngineLabel = "Installed (unknown version)";
-                EngineBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
+                EngineLabel = Se.Language.General.UnknownNoInstallRecord;
+                EngineBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }
     }

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
@@ -1,7 +1,9 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using Avalonia.Data;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -9,23 +11,25 @@ namespace Nikse.SubtitleEdit.Features.Ocr;
 
 public class LlamaCppOcrSettingsWindow : Window
 {
+    private const int LabelWidth = 130;
+
     public LlamaCppOcrSettingsWindow(LlamaCppOcrSettingsViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = Se.Language.Ocr.LlamaCppOcrSettingsTitle;
-        Width = 640;
-        Height = 320;
-        MinWidth = 480;
-        MinHeight = 240;
+        Width = 680;
+        Height = 460;
+        MinWidth = 540;
+        MinHeight = 400;
         CanResize = true;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
         vm.Window = this;
         DataContext = vm;
 
-        var labelUrl = UiUtil.MakeTextBlock(Se.Language.General.Url);
         var textBoxUrl = new TextBox
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Center,
             DataContext = vm,
         };
         textBoxUrl.Bind(TextBox.TextProperty, new Binding(nameof(vm.Url))
@@ -34,17 +38,16 @@ public class LlamaCppOcrSettingsWindow : Window
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
         });
 
-        var labelTimeout = UiUtil.MakeTextBlock(Se.Language.Ocr.LlamaCppOcrTimeoutMinutes);
-        var numericTimeout = UiUtil.MakeNumericUpDownInt(1, 120, 5, 100, vm, nameof(vm.TimeoutMinutes));
+        var numericTimeout = UiUtil.MakeNumericUpDownInt(1, 120, 5, 140, vm, nameof(vm.TimeoutMinutes));
 
-        var labelPrompt = UiUtil.MakeTextBlock(Se.Language.General.OpenAiCompatibleSttPrompt);
         var textBoxPrompt = new TextBox
         {
             AcceptsReturn = true,
             AcceptsTab = false,
-            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            TextWrapping = TextWrapping.Wrap,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch,
+            MinHeight = 90,
             DataContext = vm,
         };
         textBoxPrompt.Bind(TextBox.TextProperty, new Binding(nameof(vm.Prompt))
@@ -55,44 +58,130 @@ public class LlamaCppOcrSettingsWindow : Window
 
         var hintPrompt = UiUtil.MakeTextBlock(Se.Language.Ocr.LlamaCppOcrPromptHint);
         hintPrompt.Opacity = 0.7;
+        hintPrompt.FontSize = 12;
+        hintPrompt.Margin = new Thickness(0, 2, 0, 0);
+
+        var promptLabel = MakeLabel(Se.Language.General.OpenAiCompatibleSttPrompt);
+        promptLabel.VerticalAlignment = VerticalAlignment.Top;
+        promptLabel.Margin = new Thickness(0, 6, 0, 0);
+
+        var detailsGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = GridLength.Auto },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 12,
+        };
+
+        detailsGrid.Add(MakeLabel("Engine"), 0, 0);
+        detailsGrid.Add(MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel)), 0, 1);
+
+        detailsGrid.Add(MakeLabel(Se.Language.General.Url), 1, 0);
+        detailsGrid.Add(textBoxUrl, 1, 1);
+
+        detailsGrid.Add(MakeLabel(Se.Language.Ocr.LlamaCppOcrTimeoutMinutes), 2, 0);
+        detailsGrid.Add(numericTimeout, 2, 1);
+
+        detailsGrid.Add(promptLabel, 3, 0);
+        detailsGrid.Add(textBoxPrompt, 3, 1);
+
+        detailsGrid.Add(hintPrompt, 4, 1);
+
+        var detailsBorder = new Border
+        {
+            Child = detailsGrid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonBar = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
 
-        var grid = new Grid
+        var rootGrid = new Grid
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = GridLength.Auto },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = GridLength.Auto },
             },
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-            },
+            RowSpacing = 14,
             Margin = UiUtil.MakeWindowMargin(),
-            RowSpacing = 6,
         };
+        rootGrid.Add(BuildHeader(), 0, 0);
+        rootGrid.Add(detailsBorder, 1, 0);
+        rootGrid.Add(buttonBar, 2, 0);
 
-        grid.Add(labelUrl, 0, 0);
-        grid.Add(textBoxUrl, 1, 0);
-        grid.Add(labelTimeout, 2, 0);
-        grid.Add(numericTimeout, 3, 0);
-        grid.Add(labelPrompt, 4, 0);
-        grid.Add(textBoxPrompt, 5, 0);
-        grid.Add(hintPrompt, 6, 0);
-        grid.Add(buttonBar, 7, 0);
-
-        Content = grid;
+        Content = rootGrid;
 
         Activated += delegate { textBoxUrl.Focus(); };
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "llama.cpp OCR",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+        var subtitle = new TextBlock
+        {
+            Text = "Local llama.cpp server (multimodal model) used for OCR.",
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
 }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -966,7 +966,7 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<LlamaCppOcrSettingsWindow, LlamaCppOcrSettingsViewModel>(Window);
+        var result = await _windowService.ShowDialogAsync<LlamaCppOcrSettingsWindow, LlamaCppOcrSettingsViewModel>(Window, vm => vm.Initialize());
         if (result.OkPressed)
         {
             LlamaCppUrl = Se.Settings.Ocr.LlamaCppUrl;

--- a/src/ui/Logic/Download/LlamaCppDownloadService.cs
+++ b/src/ui/Logic/Download/LlamaCppDownloadService.cs
@@ -26,6 +26,34 @@ public class LlamaCppDownloadService(HttpClient httpClient) : ILlamaCppDownloadS
     public async Task DownloadEngine(Stream stream, string variant, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         await DownloadHelper.DownloadFileAsync(httpClient, GetEngineUrl(variant), stream, progress, cancellationToken);
+        VerifyArchive(stream, DownloadHashManager.ResolveLlamaCppKey(variant), "engine");
+    }
+
+    // Compares the downloaded bytes against the known SHA-256 for this key and throws on mismatch
+    // so the caller's IsFaulted branch surfaces "Download failed" instead of silently unpacking a
+    // truncated or tampered file. Mirrors Qwen3TtsCppDownloadService.VerifyArchive.
+    private static void VerifyArchive(Stream stream, string? key, string label)
+    {
+        if (string.IsNullOrEmpty(key) || stream.Length == 0)
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        stream.Position = 0;
+        var actual = DownloadHashManager.ComputeSha256(stream);
+        stream.Position = 0;
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"llama.cpp {label} download failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
     }
 
     public async Task DownloadCudaRuntime(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)

--- a/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -124,6 +125,40 @@ public static class LlamaCppServerManager
     public static bool IsEngineInstalled()
     {
         return File.Exists(GetExecutable());
+    }
+
+    /// <summary>
+    /// Returns the update status of the installed llama-server binary relative to the version
+    /// pinned in <see cref="LlamaCppDownloadService"/>. The check hashes the executable on disk
+    /// directly (no install-time sidecar needed) because <see cref="DownloadHashManager.LlamaCpp"/>
+    /// tracks SHA-256s of the unpacked llama-server binary per OS/arch. Returns
+    /// <see cref="DownloadHashManager.UpdateStatus.Unknown"/> when nothing is installed, the
+    /// platform key cannot be resolved, or the on-disk hash does not match any known release —
+    /// so callers do not false-positive an update prompt.
+    /// </summary>
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var key = DownloadHashManager.ResolveLlamaCppExecutableKey();
+        if (string.IsNullOrEmpty(key))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        try
+        {
+            var hash = DownloadHashManager.ComputeSha256(exe);
+            return DownloadHashManager.GetStatus(key, hash);
+        }
+        catch
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
     }
 
     public static string GetModelPath(string fileName)


### PR DESCRIPTION
## Summary

- **Redesigned `LlamaCppOcrSettingsWindow`** — header (title + subtitle), bordered details panel, more vertical spacing (`RowSpacing = 12`), and a wider Timeout `NumericUpDown` (100 → 140). Matches the Chatterbox TTS settings layout.
- **Added an "Engine" status row** to the new details panel — colored dot (`Ellipse`) + bold label bound to `EngineBrush` / `EngineLabel`, mirroring `ChatterboxTtsSettingsWindow.MakeStatusPanel`.
- **Wired up the previously-unused `LlamaCpp.*` hashes** in `DownloadHashManager`:
  - `LlamaCppDownloadService.DownloadEngine` now calls a new `VerifyArchive` after download — compares the downloaded bytes against `DownloadHashManager.GetLatestKnownHash(ResolveLlamaCppKey(variant))` and throws `IOException` on mismatch, so the caller's `IsFaulted` branch surfaces "Download failed" instead of silently unpacking a truncated or tampered file. Mirrors `Qwen3TtsCppDownloadService.VerifyArchive`.
  - New `LlamaCppServerManager.GetEngineUpdateStatus()` SHA-256s the installed `llama-server` binary on disk and calls `DownloadHashManager.GetStatus(ResolveLlamaCppExecutableKey(), hash)`. No sidecar needed because `LlamaCpp.{Os}Executable` keys already track hashes of the unpacked binary per OS/arch.
- The OCR settings dot now shows three states: grey "Not installed", green "Installed (latest)" / "Installed (unknown version)", amber "Update available". Unknown installs (sideloaded / custom build / future untracked version) deliberately fall back to green so users don't get false-positive update prompts.

## Test plan

- [ ] Open OCR window → select llama.cpp → click Settings cog → verify the new window layout matches Chatterbox TTS settings styling
- [ ] Verify the Engine row shows green "Installed (latest)" when running pinned `b9174`
- [ ] Verify amber "Update available" when an older known build (e.g. `b9145` from the executable hash list) is on disk
- [ ] Verify grey "Not installed" when `llama-server` is absent
- [ ] Trigger a llama.cpp download and verify the integrity check passes; manually corrupt the stream to confirm `IOException` is raised
- [ ] Confirm Timeout numeric up-down and Prompt multi-line text box still bind/save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)