### PR TITLE
Fix TTS async/Piper bugs and clean up Text-to-speech code

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -649,19 +649,6 @@ public class ChatterboxTtsCpp : ITtsEngine
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
 
-    public static void StopServer()
-    {
-        ServerLock.Wait();
-        try
-        {
-            StopServerInternal();
-        }
-        finally
-        {
-            ServerLock.Release();
-        }
-    }
-
     private static void StopServerInternal()
     {
         var p = _serverProcess;

--- a/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
@@ -269,9 +269,7 @@ public class EdgeTts : ITtsEngine
         using var process = new Process { StartInfo = startInfo };
         try
         {
-#pragma warning disable CA1416
-            process.Start();
-#pragma warning restore CA1416
+            process.StartProcess();
         }
         catch
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -420,19 +420,6 @@ public class KokoroTtsCpp : ITtsEngine
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
 
-    public static void StopServer()
-    {
-        ServerLock.Wait();
-        try
-        {
-            StopServerInternal();
-        }
-        finally
-        {
-            ServerLock.Release();
-        }
-    }
-
     private static void StopServerInternal()
     {
         var p = _serverProcess;

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -198,9 +198,22 @@ public class Piper : ITtsEngine
                 + (string.IsNullOrWhiteSpace(stderrOutput) ? string.Empty : $", StdErr: {stderrOutput.Trim()}");
             Se.LogError(msg);
             Se.WriteToolsLog(msg);
+            return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
         var fileName = Path.Combine(GetSetPiperFolder(), fileNameOnly);
+        if (!File.Exists(fileName) || new FileInfo(fileName).Length == 0)
+        {
+            var msg = $"Piper exited successfully but produced no audio - Parameters: "
+                + $"Voice: {piperVoice}, "
+                + $"FileName: {process.StartInfo.FileName}, "
+                + $"Parameters: {process.StartInfo.Arguments}"
+                + (string.IsNullOrWhiteSpace(stderrOutput) ? string.Empty : $", StdErr: {stderrOutput.Trim()}");
+            Se.LogError(msg);
+            Se.WriteToolsLog(msg);
+            return new TtsResult { Text = text, FileName = string.Empty, Error = true };
+        }
+
         return new TtsResult(fileName, text);
     }
 
@@ -229,7 +242,7 @@ public class Piper : ITtsEngine
             throw new PlatformNotSupportedException("Process.Start() is not supported on this platform.");
         }
 
-        var streamWriter = new StreamWriter(processPiper.StandardInput.BaseStream, Encoding.UTF8);
+        var streamWriter = new StreamWriter(processPiper.StandardInput.BaseStream, new UTF8Encoding(false));
         var text = Utilities.UnbreakLine(inputText);
         streamWriter.Write(text);
         streamWriter.Flush();

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -436,19 +436,6 @@ public class Qwen3TtsCpp : ITtsEngine
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
 
-    public static void StopServer()
-    {
-        ServerLock.Wait();
-        try
-        {
-            StopServerInternal();
-        }
-        finally
-        {
-            ServerLock.Release();
-        }
-    }
-
     private static void StopServerInternal()
     {
         var p = _serverProcess;

--- a/src/ui/Features/Video/TextToSpeech/ProcessExtensions.cs
+++ b/src/ui/Features/Video/TextToSpeech/ProcessExtensions.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+
+public static class ProcessExtensions
+{
+    // Centralizes the CA1416 suppression: Process.Start() is flagged as unsupported on
+    // platforms (iOS/tvOS/browser) that Subtitle Edit does not target.
+    public static void StartProcess(this Process process)
+    {
+#pragma warning disable CA1416 // Validate platform compatibility
+        process.Start();
+#pragma warning restore CA1416 // Validate platform compatibility
+    }
+
+    public static async Task StartAndWaitAsync(this Process process, CancellationToken cancellationToken)
+    {
+        process.StartProcess();
+        await process.WaitForExitAsync(cancellationToken);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -110,72 +110,79 @@ public partial class ReviewSpeechViewModel : ObservableObject
         _timer.Start();
     }
 
-    private void OnTimerOnElapsed(object? sender, ElapsedEventArgs args)
+    private async void OnTimerOnElapsed(object? sender, ElapsedEventArgs args)
     {
-        _timer.Stop();
-
-        if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null)
+        try
         {
-            IsPlayVisible = true;
-            IsStopVisible = false;
-            foreach (var l in Lines)
+            _timer.Stop();
+
+            if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null)
             {
-                l.IsPlaying = false;
-                l.IsPlayingEnabled = true;
+                IsPlayVisible = true;
+                IsStopVisible = false;
+                foreach (var l in Lines)
+                {
+                    l.IsPlaying = false;
+                    l.IsPlayingEnabled = true;
+                }
+
+                return;
             }
 
-            return;
-        }
+            var paused = _mpvContext.IsPaused;
 
-        var paused = _mpvContext.IsPaused;
-
-        var line = SelectedLine;
-        var timeSinceStart = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - _startPlayTicks);
-        if (paused && AutoContinue && !_skipAutoContinue && line != null && timeSinceStart.TotalMilliseconds > 500)
-        {
-            Dispatcher.UIThread.Invoke<Task>(async () =>
+            var line = SelectedLine;
+            var timeSinceStart = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - _startPlayTicks);
+            if (paused && AutoContinue && !_skipAutoContinue && line != null && timeSinceStart.TotalMilliseconds > 500)
             {
-                line.IsPlaying = false;
-                var index = Lines.IndexOf(line);
-                if (index < Lines.Count - 1)
+                await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    var nextLine = Lines[index + 1];
-                    nextLine.IsPlaying = true;
-                    SelectedLine = nextLine;
-                    LineGrid.ScrollIntoView(nextLine, null);
-                    await PlayAudio(nextLine.StepResult.CurrentFileName);
-                }
-                else
-                {
-                    _skipAutoContinue = true; // no more lines to play
-
-                    IsPlayVisible = true;
-                    IsStopVisible = false;
-                    foreach (var l in Lines)
+                    line.IsPlaying = false;
+                    var index = Lines.IndexOf(line);
+                    if (index < Lines.Count - 1)
                     {
-                        l.IsPlaying = false;
-                        l.IsPlayingEnabled = true;
+                        var nextLine = Lines[index + 1];
+                        nextLine.IsPlaying = true;
+                        SelectedLine = nextLine;
+                        LineGrid.ScrollIntoView(nextLine, null);
+                        await PlayAudio(nextLine.StepResult.CurrentFileName);
                     }
-                }
-            });
+                    else
+                    {
+                        _skipAutoContinue = true; // no more lines to play
 
-            return;
-        }
+                        IsPlayVisible = true;
+                        IsStopVisible = false;
+                        foreach (var l in Lines)
+                        {
+                            l.IsPlaying = false;
+                            l.IsPlayingEnabled = true;
+                        }
+                    }
+                });
 
-        IsPlayVisible = paused;
-        IsStopVisible = !paused;
-
-        if (paused)
-        {
-            foreach (var l in Lines)
-            {
-                l.IsPlaying = false;
-                l.IsPlayingEnabled = true;
+                return;
             }
-            return;
-        }
 
-        _timer.Start();
+            IsPlayVisible = paused;
+            IsStopVisible = !paused;
+
+            if (paused)
+            {
+                foreach (var l in Lines)
+                {
+                    l.IsPlaying = false;
+                    l.IsPlayingEnabled = true;
+                }
+                return;
+            }
+
+            _timer.Start();
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, "Error in ReviewSpeech playback timer.");
+        }
     }
 
     private async Task PlayAudio(string fileName)
@@ -502,22 +509,12 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        IsRegenerateEnabled = false;
-        if (!engine.IsVoiceInstalled(voice) && voice.EngineVoice is PiperVoice piperVoice)
+        if (!await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
         {
-            var modelFileName = Path.Combine(Piper.GetSetPiperFolder(), piperVoice.ModelShort);
-            var configFileName = Path.Combine(Piper.GetSetPiperFolder(), piperVoice.ConfigShort);
-            if (!File.Exists(modelFileName) || !File.Exists(configFileName))
-            {
-                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadPiperVoice(piperVoice));
-                if (!dlResult.OkPressed)
-                {
-                    SafeDelete(modelFileName);
-                    SafeDelete(configFileName);
-                    return;
-                }
-            }
+            return;
         }
+
+        IsRegenerateEnabled = false;
 
         var oldStyle = SelectedStyle;
         if (engine is Murf && !string.IsNullOrEmpty(SelectedStyle))
@@ -579,18 +576,6 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         _skipAutoContinue = true;
         await PlayAudio(line.StepResult.CurrentFileName);
-    }
-
-    private static void SafeDelete(string fileName)
-    {
-        try
-        {
-            File.Delete(fileName);
-        }
-        catch
-        {
-            // ignore
-        }
     }
 
     [RelayCommand]
@@ -676,7 +661,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
             });
         }
 
-        StepResults = Enumerable.Where<ReviewRow>(Lines, p => p.Include).Select(p => p.StepResult).ToArray();
+        StepResults = Lines.Where(p => p.Include).Select(p => p.StepResult).ToArray();
 
 
         Se.SaveSettings();
@@ -709,10 +694,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         // Step 1: Trim silence from start and end
         var outputFileNameTrim = Path.Combine(_waveFolder, Guid.NewGuid() + ".wav");
         var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileNameTrim);
-#pragma warning disable CA1416 // Validate platform compatibility
-        _ = trimProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-        await trimProcess.WaitForExitAsync(_cancellationToken);
+        await trimProcess.StartAndWaitAsync(_cancellationToken);
 
         var currentFile = outputFileNameTrim;
 
@@ -721,10 +703,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             var vadOutput = Path.Combine(_waveFolder, $"vad_{Guid.NewGuid()}.wav");
             var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence);
-#pragma warning disable CA1416 // Validate platform compatibility
-            _ = vadProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-            await vadProcess.WaitForExitAsync(_cancellationToken);
+            await vadProcess.StartAndWaitAsync(_cancellationToken);
 
             if (File.Exists(vadOutput) && new FileInfo(vadOutput).Length > 0)
             {
@@ -789,19 +768,13 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             speedProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
         }
-#pragma warning disable CA1416 // Validate platform compatibility
-        _ = speedProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-        await speedProcess.WaitForExitAsync(_cancellationToken);
+        await speedProcess.StartAndWaitAsync(_cancellationToken);
 
         // Fallback: if rubberband failed, retry with atempo
         if (doHighQualityStretch && (!File.Exists(outputFileName2) || new FileInfo(outputFileName2).Length == 0))
         {
             var fallbackProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
-#pragma warning disable CA1416 // Validate platform compatibility
-            _ = fallbackProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-            await fallbackProcess.WaitForExitAsync(_cancellationToken);
+            await fallbackProcess.StartAndWaitAsync(_cancellationToken);
         }
 
         return new TtsStepResult
@@ -835,7 +808,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 return;
             }
 
-            RegenerateAudio(SelectedLine).ConfigureAwait(false);
+            if (RegenerateAudioCommand.CanExecute(line))
+            {
+                RegenerateAudioCommand.Execute(line);
+            }
         }
     }
 
@@ -852,7 +828,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        Dispatcher.UIThread.Post(async () =>
+        Dispatcher.UIThread.PostSafe(async () =>
         {
             var voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
             Voices.Clear();
@@ -861,14 +837,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 Voices.Add(vo);
             }
 
-            var lastVoice = Enumerable.FirstOrDefault<Voice>(Voices, v => v.Name == Se.Settings.Video.TextToSpeech.Voice);
+            var lastVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice);
             if (lastVoice == null)
             {
-                lastVoice = Enumerable.FirstOrDefault<Voice>(Voices, p => p.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase) ||
-                                                                          p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
+                lastVoice = Voices.FirstOrDefault(p => p.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase) ||
+                                                      p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
             }
 
-            SelectedVoice = lastVoice ?? Enumerable.First<Voice>(Voices);
+            SelectedVoice = lastVoice ?? Voices.First();
 
             if (engine.HasLanguageParameter)
             {
@@ -879,7 +855,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     Languages.Add(language);
                 }
 
-                SelectedLanguage = Enumerable.FirstOrDefault<TtsLanguage>(Languages);
+                SelectedLanguage = Languages.FirstOrDefault();
             }
 
             if (engine.HasRegion)
@@ -891,7 +867,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     Regions.Add(region);
                 }
 
-                SelectedRegion = Enumerable.FirstOrDefault<string>(Regions);
+                SelectedRegion = Regions.FirstOrDefault();
             }
 
             if (engine.HasModel)
@@ -903,7 +879,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     Models.Add(model);
                 }
 
-                SelectedModel = Enumerable.FirstOrDefault<string>(Models);
+                SelectedModel = Models.FirstOrDefault();
             }
 
             IsElevenLabsControlsVisible = false;
@@ -921,23 +897,23 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 SelectedModel = Se.Settings.Video.TextToSpeech.ElevenLabsModel;
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
-                    SelectedModel = Enumerable.First<string>(Models);
+                    SelectedModel = Models.First();
                 }
             }
             else if (engine is Qwen3TtsCpp)
             {
-                SelectedModel = Enumerable.FirstOrDefault<string>(Models, p => p == Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel);
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
-                    SelectedModel = Enumerable.FirstOrDefault<string>(Models);
+                    SelectedModel = Models.FirstOrDefault();
                 }
             }
             else if (engine is ChatterboxTtsCpp)
             {
-                SelectedModel = Enumerable.FirstOrDefault<string>(Models, p => p == Se.Settings.Video.TextToSpeech.ChatterboxModel);
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.ChatterboxModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
-                    SelectedModel = Enumerable.FirstOrDefault<string>(Models);
+                    SelectedModel = Models.FirstOrDefault();
                 }
             }
         });
@@ -953,20 +929,20 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         if (engine is Murf murf)
         {
-            Dispatcher.UIThread.Post(async () =>
+            Dispatcher.UIThread.PostSafe(async () =>
             {
                 var voices = await murf.GetVoices(SelectedLanguage?.Code ?? string.Empty);
                 Voices.Clear();
                 ObservableCollectionExtensions.AddRange(Voices, voices);
 
-                var lastVoice = Enumerable.FirstOrDefault<Voice>(Voices, v => v.Name == Se.Settings.Video.TextToSpeech.Voice);
+                var lastVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice);
                 if (lastVoice == null)
                 {
-                    lastVoice = Enumerable.FirstOrDefault<Voice>(Voices, p => p.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase) ||
-                                                                              p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
+                    lastVoice = Voices.FirstOrDefault(p => p.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase) ||
+                                                          p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
                 }
 
-                SelectedVoice = lastVoice ?? Enumerable.First<Voice>(Voices);
+                SelectedVoice = lastVoice ?? Voices.First();
             });
         }
     }
@@ -982,7 +958,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        Dispatcher.UIThread.Post(async () =>
+        Dispatcher.UIThread.PostSafe(async () =>
         {
             if (engine is ElevenLabs && model == "eleven_v3")
             {
@@ -998,10 +974,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     Languages.Add(language);
                 }
 
-                SelectedLanguage = Enumerable.FirstOrDefault<TtsLanguage>(Languages, p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage);
+                SelectedLanguage = Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage);
                 if (SelectedLanguage == null)
                 {
-                    SelectedLanguage = Enumerable.FirstOrDefault<TtsLanguage>(Languages, p => p.Code == "en");
+                    SelectedLanguage = Languages.FirstOrDefault(p => p.Code == "en");
                 }
             }
         });

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -344,40 +344,6 @@ public class ReviewSpeechWindow : Window
 
         var elevenLabsControls = MakeElevenLabsControls(vm);
 
-        var buttonRegenerateAudio = new Button
-        {
-            Content = Se.Language.Video.TextToSpeech.RegenerateAudioSelectedLine,
-            Command = vm.RegenerateAudioCommand,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            Width = double.NaN,
-            VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 0, 5),
-        }.WithIconLeft(IconNames.Recycle);
-
-        //var buttonPlay = new Button
-        //{
-        //    Content = Se.Language.General.PlaySelectedLine,
-        //    Command = vm.PlayCommand,
-        //    HorizontalAlignment = HorizontalAlignment.Stretch,
-        //    Width = double.NaN,
-        //    VerticalAlignment = VerticalAlignment.Center,
-        //}.WithIconLeft(IconNames.PlayCircle).WithBindIsVisible(nameof(vm.IsPlayVisible));
-
-        var buttonStop = new Button
-        {
-            Content = Se.Language.General.Stop,
-            Command = vm.StopCommand,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            Width = double.NaN,
-            VerticalAlignment = VerticalAlignment.Center,
-        }.WithIconLeft(IconNames.StopCircle).WithBindIsVisible(nameof(vm.IsStopVisible));
-
-        //var checkBoxAutoContinue = new CheckBox
-        //{
-        //    Content = Se.Language.General.AutoContinue,
-        //    [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.AutoContinue)) { Mode = BindingMode.TwoWay },
-        //};
-
         var grid = new Grid
         {
             RowDefinitions =
@@ -389,9 +355,6 @@ public class ReviewSpeechWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // filler
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -410,10 +373,6 @@ public class ReviewSpeechWindow : Window
         grid.Add(panelLanguage, 4, 0);
         grid.Add(elevenLabsControls, 5, 0);
         // 6 is filler
-        //grid.Add(buttonRegenerateAudio, 7, 0);
-        //grid.Add(buttonPlay, 8, 0);
-        // grid.Add(buttonStop, 8, 0);
-        //  grid.Add(checkBoxAutoContinue, 9, 0);
 
         return UiUtil.MakeBorderForControl(grid);
     }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -310,6 +310,12 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
+        var voice = SelectedVoice;
+        if (voice != null && !await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
+        {
+            return;
+        }
+
         _cancellationTokenSource = new();
         _cancellationToken = _cancellationTokenSource.Token;
         ProgressValue = 0;
@@ -428,20 +434,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
-        if (!engine.IsVoiceInstalled(voice) && voice.EngineVoice is PiperVoice piperVoice)
+        if (!await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
         {
-            var modelFileName = Path.Combine(Piper.GetSetPiperFolder(), piperVoice.ModelShort);
-            var configFileName = Path.Combine(Piper.GetSetPiperFolder(), piperVoice.ConfigShort);
-            if (!File.Exists(modelFileName) || !File.Exists(configFileName))
-            {
-                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window, vm => vm.StartDownloadPiperVoice(piperVoice));
-                if (!dlResult.OkPressed)
-                {
-                    SafeDelete(modelFileName);
-                    SafeDelete(configFileName);
-                    return;
-                }
-            }
+            return;
         }
 
         SaveSettings();
@@ -636,18 +631,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         IsNotGenerating = true;
         ProgressOpacity = 0;
         Close();
-    }
-
-    private static void SafeDelete(string fileName)
-    {
-        try
-        {
-            File.Delete(fileName);
-        }
-        catch
-        {
-            // ignore
-        }
     }
 
     private void Close()
@@ -1293,10 +1276,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         var addAudioProcess = Se.Settings.Video.TextToSpeech.AudioDuckingEnabled
             ? FfmpegGenerator.AddAudioTrackWithDucking(_videoFileName, audioFileName, outputFileName, audioEncoding, stereo, Se.Settings.Video.TextToSpeech.AudioDuckingOriginalVolume)
             : FfmpegGenerator.AddAudioTrack(_videoFileName, audioFileName, outputFileName, audioEncoding, stereo);
-#pragma warning disable CA1416 // Validate platform compatibility
-        var _ = addAudioProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-        await addAudioProcess.WaitForExitAsync(cancellationToken);
+        await addAudioProcess.StartAndWaitAsync(cancellationToken);
 
         ProgressText = string.Empty;
         return outputFileName;
@@ -1339,10 +1319,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 var mergeProcess = FfmpegGenerator.MergeAudioTracks(inputFileName, item.CurrentFileName, outputFileName, (float)item.Paragraph.StartTime.TotalSeconds, forceStereo);
                 var fileNameToDelete = inputFileName;
                 inputFileName = outputFileName;
-#pragma warning disable CA1416 // Validate platform compatibility
-                _ = mergeProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                await mergeProcess.WaitForExitAsync(cancellationToken);
+                await mergeProcess.StartAndWaitAsync(cancellationToken);
 
                 ProgressValue = (double)(index + 1) / previousStepResult.Length * 100.0;
 
@@ -1394,10 +1371,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         var silenceProcess = FfmpegGenerator.GenerateEmptyAudio(silenceFileName, durationInSeconds);
-#pragma warning disable CA1416 // Validate platform compatibility
-        _ = silenceProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-        await silenceProcess.WaitForExitAsync(cancellationToken);
+        await silenceProcess.StartAndWaitAsync(cancellationToken);
         return silenceFileName;
     }
 
@@ -1560,10 +1534,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 // Step 1: Trim silence from start and end
                 var outputFileName1 = Path.Combine(Path.GetDirectoryName(item.CurrentFileName)!, Guid.NewGuid() + ".wav");
                 var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileName1);
-#pragma warning disable CA1416 // Validate platform compatibility
-                _ = trimProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                await trimProcess.WaitForExitAsync(cancellationToken);
+                await trimProcess.StartAndWaitAsync(cancellationToken);
 
                 var currentFile = outputFileName1;
 
@@ -1574,10 +1545,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 {
                     var vadOutput = Path.Combine(Path.GetDirectoryName(item.CurrentFileName)!, $"vad_{Guid.NewGuid()}.wav");
                     var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence);
-#pragma warning disable CA1416 // Validate platform compatibility
-                    _ = vadProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                    await vadProcess.WaitForExitAsync(cancellationToken);
+                    await vadProcess.StartAndWaitAsync(cancellationToken);
 
                     if (File.Exists(vadOutput) && new FileInfo(vadOutput).Length > 0)
                     {
@@ -1661,19 +1629,13 @@ public partial class TextToSpeechViewModel : ObservableObject
                 {
                     speedProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
                 }
-#pragma warning disable CA1416 // Validate platform compatibility
-                _ = speedProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                await speedProcess.WaitForExitAsync(cancellationToken);
+                await speedProcess.StartAndWaitAsync(cancellationToken);
 
                 // Fallback: if rubberband failed (not available in FFmpeg build), retry with atempo
                 if (doHighQualityStretch && (!File.Exists(outputFileName2) || new FileInfo(outputFileName2).Length == 0))
                 {
                     var fallbackProcess = FfmpegGenerator.ChangeSpeed(currentFile, outputFileName2, (float)factor);
-#pragma warning disable CA1416 // Validate platform compatibility
-                    _ = fallbackProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                    await fallbackProcess.WaitForExitAsync(cancellationToken);
+                    await fallbackProcess.StartAndWaitAsync(cancellationToken);
                 }
             }
             ProgressValue = 100;
@@ -1786,7 +1748,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
-        Dispatcher.UIThread.Post(async () =>
+        Dispatcher.UIThread.PostSafe(async () =>
         {
             IsEngineSettingsVisible = false;
             var voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
@@ -1973,7 +1935,7 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         if (engine is Murf murf)
         {
-            Dispatcher.UIThread.Post(async () =>
+            Dispatcher.UIThread.PostSafe(async () =>
             {
                 var voices = await murf.GetVoices(SelectedLanguage?.Code ?? string.Empty);
                 Voices.Clear();
@@ -2000,7 +1962,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
-        Dispatcher.UIThread.Post(async () =>
+        Dispatcher.UIThread.PostSafe(async () =>
         {
             if (engine.HasLanguageParameter)
             {

--- a/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
@@ -30,10 +30,7 @@ public static class TtsPostProcessor
             {
                 var proChainOutput = Path.Combine(waveFolder, $"pro_{Guid.NewGuid()}.wav");
                 var proProcess = FfmpegGenerator.ApplyProAudioChain(currentFile, proChainOutput);
-#pragma warning disable CA1416 // Validate platform compatibility
-                _ = proProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                await proProcess.WaitForExitAsync(cancellationToken);
+                await proProcess.StartAndWaitAsync(cancellationToken);
 
                 if (File.Exists(proChainOutput))
                 {
@@ -50,17 +47,11 @@ public static class TtsPostProcessor
             {
                 var silenceFile = Path.Combine(waveFolder, $"pad_{Guid.NewGuid()}.wav");
                 var silenceProcess = FfmpegGenerator.GenerateSilence(silenceFile, silencePaddingMs);
-#pragma warning disable CA1416 // Validate platform compatibility
-                _ = silenceProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                await silenceProcess.WaitForExitAsync(cancellationToken);
+                await silenceProcess.StartAndWaitAsync(cancellationToken);
 
                 var paddedOutput = Path.Combine(waveFolder, $"padded_{Guid.NewGuid()}.wav");
                 var concatProcess = FfmpegGenerator.ConcatAudio(currentFile, silenceFile, paddedOutput);
-#pragma warning disable CA1416 // Validate platform compatibility
-                _ = concatProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                await concatProcess.WaitForExitAsync(cancellationToken);
+                await concatProcess.StartAndWaitAsync(cancellationToken);
 
                 SafeDelete(silenceFile);
                 if (File.Exists(paddedOutput))
@@ -78,10 +69,7 @@ public static class TtsPostProcessor
             {
                 var resampledOutput = Path.Combine(waveFolder, $"sr_{Guid.NewGuid()}.wav");
                 var srProcess = FfmpegGenerator.ChangeSampleRate(currentFile, resampledOutput, outputSampleRate);
-#pragma warning disable CA1416 // Validate platform compatibility
-                _ = srProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-                await srProcess.WaitForExitAsync(cancellationToken);
+                await srProcess.StartAndWaitAsync(cancellationToken);
 
                 if (File.Exists(resampledOutput))
                 {

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -1,0 +1,55 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+
+/// <summary>
+/// Shared voice-install gate for TTS engines: ensures the selected voice is present,
+/// prompting a download when it is not.
+/// </summary>
+public static class TtsVoiceInstaller
+{
+    /// <summary>
+    /// Ensures the given voice is installed, prompting a download if needed.
+    /// Returns false only when the user cancels the download.
+    /// </summary>
+    public static async Task<bool> EnsureVoiceInstalled(ITtsEngine engine, Voice voice, Window? window, IWindowService windowService)
+    {
+        if (window == null || engine.IsVoiceInstalled(voice))
+        {
+            return true;
+        }
+
+        // Only Piper has per-voice downloads; every other engine's IsVoiceInstalled is always true.
+        if (voice.EngineVoice is PiperVoice piperVoice)
+        {
+            var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(
+                window, vm => vm.StartDownloadPiperVoice(piperVoice));
+            if (!dlResult.OkPressed)
+            {
+                SafeDelete(Path.Combine(Piper.GetSetPiperFolder(), piperVoice.ModelShort));
+                SafeDelete(Path.Combine(Piper.GetSetPiperFolder(), piperVoice.ConfigShort));
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void SafeDelete(string fileName)
+    {
+        try
+        {
+            File.Delete(fileName);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -167,7 +167,7 @@ public partial class VoiceSettingsViewModel : ObservableObject
             return;
         }
 
-        Dispatcher.UIThread.Post(async () => await ImportVoiceFromFileAsync(fileName));
+        Dispatcher.UIThread.PostSafe(() => ImportVoiceFromFileAsync(fileName));
     }
 
     private static bool HasSupportedAudioFile(DragEventArgs e)

--- a/src/ui/Logic/DispatcherExtensions.cs
+++ b/src/ui/Logic/DispatcherExtensions.cs
@@ -1,0 +1,29 @@
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+public static class DispatcherExtensions
+{
+    // Use instead of Post(async () => ...): a plain Post takes an Action, so an async lambda
+    // becomes async void and any exception thrown after the first await is silently swallowed.
+    public static void PostSafe(this Dispatcher dispatcher, Func<Task> callback, [CallerMemberName] string caller = "")
+    {
+        dispatcher.Post(() => _ = RunSafeAsync(callback, caller));
+    }
+
+    private static async Task RunSafeAsync(Func<Task> callback, string caller)
+    {
+        try
+        {
+            await callback();
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, $"Unhandled exception in dispatcher callback from {caller}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes several async and reliability bugs in the Text-to-speech area, adds the missing voice-download step to the main Generate flow, and removes dead code.

- **Async fixes**: Ctrl+R regenerate, the ReviewSpeech playback timer, and `Dispatcher.UIThread.Post(async ...)` call sites no longer swallow exceptions or run unobserved fire-and-forget tasks.
- **Piper**: `Speak` now honors the failure contract (`FileName=""`, `Error=true`) on a non-zero exit / missing output instead of faking success, and no longer prepends a UTF-8 BOM to piper.exe stdin.
- **Voice download**: the main "Generate" button now downloads a missing Piper voice (previously only "Test voice" and "Regenerate" did); shared logic extracted to `TtsVoiceInstaller`.
- **Cleanup**: removed dead `StopServer()` from the three `*TtsCpp` engines, dead buttons/rows in `ReviewSpeechWindow`, and duplicate `SafeDelete`; added `ProcessExtensions` to drop 16 repeated `CA1416` pragma blocks; fluent LINQ in `ReviewSpeechViewModel`.

## Test plan
- [ ] Generate speech with a Piper voice that is **not** yet downloaded — the download prompt appears, then generation succeeds.
- [ ] Generate with a failing Piper process — a clear "Text-to-speech failed" error shows instead of silent broken output.
- [ ] Review Speech: Ctrl+R regenerates a line; rapid double Ctrl+R does not start overlapping regenerations.
- [ ] Review Speech: auto-continue playback advances through lines.
- [ ] "Test voice" / "Regenerate" still download missing Piper voices.
- [ ] Smoke-test a cloud engine (e.g. EdgeTts) for no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)