### PR TITLE
Fix TTS async/Piper bugs and clean up Text-to-speech code

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -5,9 +5,23 @@ Subtitle Edit Changelog
 v5.0.0-beta29 (xth May 2026)
 
 * Add Engine settings dialog for Qwen3 TTS, Kokoro TTS, and Chatterbox TTS
-* Track install hashes for Qwen3 TTS and Kokoro TTS so update status can be reported
+* Bundle macOS DMG with mpv and ffmpeg
+* Add "Fill selected lines with clipboard text" to the main and OCR grid (Ctrl+Shift+V)
+* Add "Three letter (ISO 639-2/B)" language code option to save-as - thx LurkingNinja
+* Add "Try to use source encoding" option to Batch Convert - thx Hlsgs
+* Add Windows CUDA variant for Qwen3 TTS
+* Add Macedonian translation - thx kirepp-cmd
+* Find and offer a matching subtitle when a video file is dropped - thx GrampaWildWilly
+* Redesign llama.cpp OCR settings dialog and localize engine status labels
+* Select first row after OCR completes - thx LurkingNinja
+* Trim long paths in the Reopen menu and tighten menu spacing
+* seconv: reject unknown --encoding values and add --encoding:source
 * Update Bulgarian translation - thx jekovcar
 * Update Russian translation - thx jekovcar
+* Update Portuguese (Brazil) translation - thx igorruckert
+* Fix Text-to-speech async and Piper engine bugs
+* Fix Edge TTS crash on bad rate format and retry transient failures - thx KevinHa59
+* Fix shortcut window not receiving focus
 
 -----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Async fixes:** route ReviewSpeech Ctrl+R through `RegenerateAudioCommand` (respects the re-entrancy guard, no longer swallows exceptions), await the playback-timer task instead of discarding it, and replace fire-and-forget `Dispatcher.UIThread.Post(async ...)` with a `PostSafe` helper that logs exceptions.
- **Piper:** honor the failure contract (`FileName=""` / `Error=true` on non-zero exit or missing output, matching EdgeTts) so a crash no longer looks like success, and stop sending a UTF-8 BOM to `piper.exe` stdin.
- **Voice download:** the main Generate command now downloads a missing Piper voice (like Test voice / Regenerate already did); install/download logic consolidated into `TtsVoiceInstaller`.
- **Cleanup:** remove dead code (unused `StopServer()` in the `*TtsCpp` engines, unused ReviewSpeech UI rows, duplicate `SafeDelete`), add `ProcessExtensions` to drop 16 repeated CA1416 pragma blocks, and update `change-log.txt` for v5.0.0-beta29.

## Test plan

- [ ] Generate TTS with the Piper engine when the selected voice is not yet installed - voice downloads, then audio generates
- [ ] Trigger a Piper failure (bad input) - error surfaces instead of silently breaking post-processing
- [ ] In Review Speech, press Ctrl+R to regenerate audio - runs once, exceptions are not swallowed
- [ ] Generate with EdgeTts to confirm no regression from the failure-contract change
- [ ] Smoke-test Qwen3 / Kokoro / Chatterbox engines after the dead-code removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)