### PR TITLE
Switch Hunspell dictionary downloads to LibreOffice/dictionaries

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -13,6 +13,7 @@ v5.0.0-beta29 (xth May 2026)
 * Add Macedonian translation - thx kirepp-cmd
 * Find and offer a matching subtitle when a video file is dropped - thx GrampaWildWilly
 * Redesign llama.cpp OCR settings dialog and localize engine status labels
+* Get spell check dictionaries from the maintained LibreOffice repository and redesign the dialog
 * Select first row after OCR completes - thx LurkingNinja
 * Trim long paths in the Reopen menu and tighten menu spacing
 * seconv: reject unknown --encoding values and add --encoding:source

--- a/src/ui/Assets/HunspellDictionaries.json
+++ b/src/ui/Assets/HunspellDictionaries.json
@@ -2,379 +2,788 @@
   {
     "EnglishName": "Afrikaans",
     "NativeName": "Afrikaans",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1109/0/dict-af.oxt?r=http%3A%2F%2Fextensions.services.openoffice.org%2Fen%2Fproject%2Fafrikaans-spell-checker&amp;ts=1373917891&amp;use_mirror=kent",
-    "Description": "Afrikaans spell checker"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/af_ZA/af_ZA.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/af_ZA/af_ZA.dic"
+    ],
+    "Description": "Afrikaans spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Albanian",
     "NativeName": "Shqip",
-    "DownloadLink": "https://sourceforge.net/projects/aoo-extensions/files/3393/1/dict-sq.oxt/download",
-    "Description": "Albanian Spell Checker Dictionary"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sq_AL/sq_AL.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sq_AL/sq_AL.dic"
+    ],
+    "Description": "Albanian spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Aragonese",
+    "NativeName": "Aragonés",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/an_ES/an_ES.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/an_ES/an_ES.dic"
+    ],
+    "Description": "Aragonese spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Arabic",
     "NativeName": "عربي",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-ar-3-2.oxt",
-    "Description": "Arabic spell checker 3.2"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ar/ar.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ar/ar.dic"
+    ],
+    "Description": "Arabic spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Assamese",
+    "NativeName": "অসমীয়া",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/as_IN/as_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/as_IN/as_IN.dic"
+    ],
+    "Description": "Assamese spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Basque",
     "NativeName": "Euskara",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/xuxeniv-lo4-1-1.oxt",
+    "Files": [
+      "https://extensions.libreoffice.org/assets/downloads/z/xuxeniv-lo4-1-1.oxt"
+    ],
     "Description": "Xuxen: Basque spell checking dictionary - v4.0"
   },
   {
     "EnglishName": "Belarusian",
     "NativeName": "Беларуская мова",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/4611/15/dict-be-0.56.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fbelarusian-spell-checking-dictionary-recent-official-orthography&amp;ts=1373918638&amp;use_mirror=kent",
-    "Description": "Belarusian dictionary(spelling, hyphenation) - classic orthography"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/be_BY/be-official.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/be_BY/be-official.dic"
+    ],
+    "Description": "Belarusian spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Bengali",
+    "NativeName": "বাংলা",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bn_BD/bn_BD.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bn_BD/bn_BD.dic"
+    ],
+    "Description": "Bengali spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Bosnian",
     "NativeName": "Bosanski",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-bs.oxt",
-    "Description": "Spellchecking dictionary for Bosnian language - 1.0 (Jan 24, 2013)"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bs_BA/bs_BA.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bs_BA/bs_BA.dic"
+    ],
+    "Description": "Bosnian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Breton",
     "NativeName": "Brezhoneg",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-br-0-8.oxt",
-    "Description": "An Drouizig Breton Spell Checker"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/br_FR/br_FR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/br_FR/br_FR.dic"
+    ],
+    "Description": "Breton spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Bulgarian",
     "NativeName": "Български",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/744/8/dictionaries-bg.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fbulgarian-dictionaries-blgarski-rechnici&amp;ts=1435654358&amp;use_mirror=freefr",
-    "Description": "Bulgarian Dictionaries (български речници) v4.3.2 (22/09/2010)"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bg_BG/bg_BG.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bg_BG/bg_BG.dic"
+    ],
+    "Description": "Bulgarian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Catalan",
     "NativeName": "català",
-    "DownloadLink": "https://github.com/Softcatala/catalan-dict-tools/releases/download/v3.0.1/ca-valencia.3.0.1.oxt",
-    "Description": "Catalan spellchecking dictionaries, July 2015"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/dictionaries/ca.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/dictionaries/ca.dic"
+    ],
+    "Description": "Catalan spell checker (LibreOffice)"
   },
   {
-    "EnglishName": "Catalan",
+    "EnglishName": "Catalan (Valencian)",
     "NativeName": "català-valencià",
-    "DownloadLink": "http://softcatala.org/diccionaris/actualitzacions/OOo/avl.oxt",
-    "Description": "Spelling dictionary for Catalan (Valencian version)"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/dictionaries/ca-valencia.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/dictionaries/ca-valencia.dic"
+    ],
+    "Description": "Catalan (Valencian) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Central Kurdish (Sorani)",
+    "NativeName": "کوردیی ناوەندی",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ckb/dictionaries/ckb.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ckb/dictionaries/ckb.dic"
+    ],
+    "Description": "Central Kurdish (Sorani) spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Croatian",
     "NativeName": "Hrvatski",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1052/2/dict-hr.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fcroatian-dictionary-and-hyphenation-patterns&amp;ts=1373918817&amp;use_mirror=surfnet",
-    "Description": "Croatian dictionary and hyphenation patterns"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hr_HR/hr_HR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hr_HR/hr_HR.dic"
+    ],
+    "Description": "Croatian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Czech",
     "NativeName": "Čeština",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1078/0/dict-cs-2.0.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fczech-dictionary-pack-%25C4%258Desk%25C3%25A9-slovn%25C3%25ADky&amp;ts=1373918869&amp;use_mirror=freefr",
-    "Description": "Czech dictionary pack / České slovníky"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/cs_CZ/cs_CZ.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/cs_CZ/cs_CZ.dic"
+    ],
+    "Description": "Czech spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Danish",
     "NativeName": "Dansk",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-da-2-4.oxt",
-    "Description": "Stavekontrolden version 2.2 - 2014-12-22"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/da_DK/da_DK.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/da_DK/da_DK.dic"
+    ],
+    "Description": "Danish spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Dutch",
     "NativeName": "Nederlands",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1456/6/nl-dict-v2.00g.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fdutch-spelling-and-hyphenation-dictionary&amp;ts=1373918951&amp;use_mirror=garr",
-    "Description": "Dutch spelling and hyphenation Dictionary"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/nl_NL/nl_NL.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/nl_NL/nl_NL.dic"
+    ],
+    "Description": "Dutch spell checker (LibreOffice)"
   },
   {
-    "EnglishName": "English",
-    "NativeName": "English/British",
-    "DownloadLink": "https://github.com/marcoagpinto/aoo-mozilla-en-dict/archive/master.zip",
-    "Description": "All English dictionaries (AU, CA, GB, US, ZA), 2018-04-16+"
+    "EnglishName": "English (Australia)",
+    "NativeName": "English (Australia)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_AU.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_AU.dic"
+    ],
+    "Description": "English (Australia) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "English (Canada)",
+    "NativeName": "English (Canada)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_CA.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_CA.dic"
+    ],
+    "Description": "English (Canada) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "English (South Africa)",
+    "NativeName": "English (South Africa)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_ZA.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_ZA.dic"
+    ],
+    "Description": "English (South Africa) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "English (United Kingdom)",
+    "NativeName": "English (United Kingdom)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_GB.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_GB.dic"
+    ],
+    "Description": "English (United Kingdom) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "English (United States)",
+    "NativeName": "English (United States)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_US.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_US.dic"
+    ],
+    "Description": "English (United States) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Esperanto",
+    "NativeName": "Esperanto",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/eo/eo.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/eo/eo.dic"
+    ],
+    "Description": "Esperanto spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Estonian",
     "NativeName": "Eesti keel",
-    "DownloadLink": "https://extensions.openoffice.org/en/download/1329",
-    "Description": "Estonian spellchecking and hyphenation (13 October, 2008)"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/et_EE/et_EE.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/et_EE/et_EE.dic"
+    ],
+    "Description": "Estonian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Farsi (Persian)",
-    "NativeName": "Persian/Farsi",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/2359/1/dict-fa.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fprojectrelease%2Fpersian-spellchecker-dictionary-20090707&amp;ts=1435690384&amp;use_mirror=freefr",
-    "Description": "Persian Spellchecker Dictionary - 2009.07.07"
+    "NativeName": "فارسی",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fa_IR/fa-IR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fa_IR/fa-IR.dic"
+    ],
+    "Description": "Persian (Farsi) spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Finnish",
     "NativeName": "Suomi",
-    "DownloadLink": "https://github.com/fginter/hunspell-fi/releases/download/0.2/fi-spell-0.2.xpi",
+    "Files": [
+      "https://github.com/fginter/hunspell-fi/releases/download/0.2/fi-spell-0.2.xpi"
+    ],
     "Description": "Finnish Spellchecker Dictionary - Dec 6, 2023"
   },
   {
     "EnglishName": "French",
     "NativeName": "Français",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/lo-oo-ressources-linguistiques-fr-v5-7.oxt",
-    "Description": "Dictionnaires francais 5.3 (28/02/2015)"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr.dic"
+    ],
+    "Description": "French spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Galician",
+    "NativeName": "Galego",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/gl/gl_ES.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/gl/gl_ES.dic"
+    ],
+    "Description": "Galician spell checker (LibreOffice)"
   },
   {
     "EnglishName": "German (Austria)",
     "NativeName": "Deutsch (Österreich)",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-de-at-frami-2017-01-12.oxt",
-    "Description": "German (de-AT frami) dictionaries 2013.12.06 (08/12/2013)"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_AT_frami.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_AT_frami.dic"
+    ],
+    "Description": "German (Austria) spell checker (LibreOffice)"
   },
   {
     "EnglishName": "German (Germany)",
-    "NativeName": "German (de-DE frami) dictionaries - [de] Deutsche (de-DE frami) Rechtschreibung",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-de-de-frami-2017-01-12.oxt",
-    "Description": "German (de-DE igerman98) dictionaries"
+    "NativeName": "Deutsch (Deutschland)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_DE_frami.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_DE_frami.dic"
+    ],
+    "Description": "German (Germany) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "German (Switzerland)",
+    "NativeName": "Deutsch (Schweiz)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_CH_frami.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_CH_frami.dic"
+    ],
+    "Description": "German (Switzerland) spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Greek",
     "NativeName": "Ελληνικά",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1411/2/el_gr_v110.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fprojectrelease%2Fhellenic-greek-dictionary-spell-check-and-hyphenation-110&amp;ts=1435654652&amp;use_mirror=freefr",
-    "Description": "Hellenic (Greek) Dictionary (Spell Check and Hyphenation) - v1.1.0"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/el_GR/el_GR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/el_GR/el_GR.dic"
+    ],
+    "Description": "Greek spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Gujarati",
+    "NativeName": "ગુજરાતી",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/gu_IN/gu_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/gu_IN/gu_IN.dic"
+    ],
+    "Description": "Gujarati spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Guarani",
+    "NativeName": "Avañe'ẽ",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/gug/gug.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/gug/gug.dic"
+    ],
+    "Description": "Guarani spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Hebrew",
-    "NativeName": "Hebrew (he) spell check dictionary 2012-08-15",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-he-2012-08-15.oxt",
-    "Description": "Hebrew (he) spell check dictionary (Aug 15, 2012)"
+    "NativeName": "עברית",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/he_IL/he_IL.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/he_IL/he_IL.dic"
+    ],
+    "Description": "Hebrew spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Hindi",
-    "NativeName": "हिंदी",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/2367/1/dict-hi.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fhindi-spellchecker-dictionary&amp;ts=1435678775&amp;use_mirror=garr",
-    "Description": "Hindi Spellchecker Dictionary"
+    "NativeName": "हिन्दी",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hi_IN/hi_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hi_IN/hi_IN.dic"
+    ],
+    "Description": "Hindi spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Hungarian",
     "NativeName": "Magyar",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1283/9/dict-hu.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fprojectrelease%2Fhungarian-dictionary-pack-20101019&amp;ts=1435690641&amp;use_mirror=freefr",
-    "Description": "Hungarian Dictionary Pack - (2010.10.19)"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hu_HU/hu_HU.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hu_HU/hu_HU.dic"
+    ],
+    "Description": "Hungarian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Icelandic",
     "NativeName": "íslenska",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/hunspell-is-2014-08-18.oxt",
-    "Description": "Icelandic spelling dictionary &amp; thesaurus 2013.05.11"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/is/is.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/is/is.dic"
+    ],
+    "Description": "Icelandic spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Indonesian",
     "NativeName": "Indonesia",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/id-id.oxt",
-    "Description": "Indonesian dictionary - Kamus Indonesia 1.0"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/id/id_ID.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/id/id_ID.dic"
+    ],
+    "Description": "Indonesian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Irish",
     "NativeName": "Gaeilge",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/focloiri-gaeilge-5-0.oxt",
+    "Files": [
+      "https://extensions.libreoffice.org/assets/downloads/z/focloiri-gaeilge-5-0.oxt"
+    ],
     "Description": "Irish language spell checker, thesaurus, and hyphenation patterns 4.5"
   },
   {
     "EnglishName": "Italian",
     "NativeName": "Italiano",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/874d181c_dict-it.oxt",
-    "Description": "Italian and Latin spelling dictionaries 2013.03.31"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/it_IT/it_IT.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/it_IT/it_IT.dic"
+    ],
+    "Description": "Italian spell checker (LibreOffice)"
   },
   {
-    "EnglishName": "Italian",
-    "NativeName": "Italiano",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1204/13/dict-it.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fprojectrelease%2Fitalian-dictionary-thesaurus-hyphenation-patterns-20130905&amp;ts=1435690929&amp;use_mirror=freefr",
-    "Description": "Italian dictionary, thesaurus, hyphenation patterns - (2013.09.05)"
+    "EnglishName": "Kannada",
+    "NativeName": "ಕನ್ನಡ",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/kn_IN/kn_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/kn_IN/kn_IN.dic"
+    ],
+    "Description": "Kannada spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Khmer",
-    "NativeName": "Khmer",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/5067/2/dict-km.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fkhmer-spelling-dictionary&amp;ts=1373998173&amp;use_mirror=netcologne",
+    "NativeName": "ខ្មែរ",
+    "Files": [
+      "http://downloads.sourceforge.net/project/aoo-extensions/5067/2/dict-km.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fkhmer-spelling-dictionary&amp;ts=1373998173&amp;use_mirror=netcologne"
+    ],
     "Description": "Khmer spelling dictionary 2011.05.11"
   },
   {
     "EnglishName": "Korean",
-    "NativeName": "한글",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/korean-spell-checker-0-7-91-libo.oxt",
-    "Description": "Korean spellchecker 0.5.6"
+    "NativeName": "한국어",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ko_KR/ko_KR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ko_KR/ko_KR.dic"
+    ],
+    "Description": "Korean spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Lao",
+    "NativeName": "ລາວ",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lo_LA/lo_LA.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lo_LA/lo_LA.dic"
+    ],
+    "Description": "Lao spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Latin",
     "NativeName": "Latina",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-la-2013-03-31.oxt",
+    "Files": [
+      "https://extensions.libreoffice.org/assets/downloads/z/dict-la-2013-03-31.oxt"
+    ],
     "Description": "Latin spelling and hyphenation dictionaries 2013.03.31"
   },
   {
     "EnglishName": "Latvian",
     "NativeName": "Latviešu",
-    "DownloadLink": "http://ftp.nluug.nl/office/openoffice/contrib/dictionaries/hyph_lv_LV.zip",
-    "Description": "Latviešu valodas pareizrakstības pārbaudes modulis 0.9.6"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lv_LV/lv_LV.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lv_LV/lv_LV.dic"
+    ],
+    "Description": "Latvian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Lithuanian",
     "NativeName": "Lietuvių",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/openoffice-spellcheck-lt-1-3.oxt",
-    "Description": "Lithuanian spellcheck and hyphenation dictionaries 1.3"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lt_LT/lt.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lt_LT/lt.dic"
+    ],
+    "Description": "Lithuanian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Lower Sorbian",
     "NativeName": "dolnoserbšćina",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/lower-sorbian-spelling-dictionary-1-5-0.oxt",
+    "Files": [
+      "https://extensions.libreoffice.org/assets/downloads/z/lower-sorbian-spelling-dictionary-1-5-0.oxt"
+    ],
     "Description": "Lower Sorbian dictionary 1.4.6"
   },
   {
+    "EnglishName": "Macedonian",
+    "NativeName": "Македонски",
+    "Files": [
+      "http://downloads.sourceforge.net/project/aoo-extensions/3403/0/dict-mk.oxt"
+    ],
+    "Description": "Macedonian dictionary was created by Taras Bendik"
+  },
+  {
     "EnglishName": "Malay",
-    "NativeName": "Malay",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/3904/0/ms_my.oxt",
+    "NativeName": "Bahasa Melayu",
+    "Files": [
+      "http://downloads.sourceforge.net/project/aoo-extensions/3904/0/ms_my.oxt"
+    ],
     "Description": "Malay Spell Checker v0.1 - 07/10/04"
   },
   {
     "EnglishName": "Malayalam",
-    "NativeName": "Malayalam",
-    "DownloadLink": "https://master.dl.sourceforge.net/project/aoo-extensions/2741/3/ml_in_dict-1-1.oxt",
+    "NativeName": "മലയാളം",
+    "Files": [
+      "https://master.dl.sourceforge.net/project/aoo-extensions/2741/3/ml_in_dict-1-1.oxt"
+    ],
     "Description": "Malayalam Spellchecker 1.1.0"
   },
   {
-    "EnglishName": "Macedonian",
-    "NativeName": "Macedonian",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/3403/0/dict-mk.oxt",
-    "Description": "Macedonian dictionary was created by Taras Bendik"
+    "EnglishName": "Marathi",
+    "NativeName": "मराठी",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/mr_IN/mr_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/mr_IN/mr_IN.dic"
+    ],
+    "Description": "Marathi spell checker (LibreOffice)"
   },
   {
-    "EnglishName": "Norwegian",
-    "NativeName": "Norsk",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dictionary-no-no-1-0.oxt",
-    "Description": "Norsk stavekontroll (bokmål og nynorsk) 2.0.10"
+    "EnglishName": "Mongolian",
+    "NativeName": "Монгол",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/mn_MN/mn_MN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/mn_MN/mn_MN.dic"
+    ],
+    "Description": "Mongolian spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Nepali",
+    "NativeName": "नेपाली",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ne_NP/ne_NP.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ne_NP/ne_NP.dic"
+    ],
+    "Description": "Nepali spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Northern Kurdish (Kurmanji)",
+    "NativeName": "Kurmancî",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/kmr_Latn/kmr_Latn.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/kmr_Latn/kmr_Latn.dic"
+    ],
+    "Description": "Northern Kurdish (Kurmanji) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Norwegian (Bokmål)",
+    "NativeName": "Norwegian (Bokmål)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/no/nb_NO.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/no/nb_NO.dic"
+    ],
+    "Description": "Norwegian (Bokmål) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Norwegian (Nynorsk)",
+    "NativeName": "Norwegian (Nynorsk)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/no/nn_NO.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/no/nn_NO.dic"
+    ],
+    "Description": "Norwegian (Nynorsk) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Occitan",
+    "NativeName": "Occitan",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/oc_FR/oc_FR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/oc_FR/oc_FR.dic"
+    ],
+    "Description": "Occitan spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Odia",
+    "NativeName": "ଓଡ଼ିଆ",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/or_IN/or_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/or_IN/or_IN.dic"
+    ],
+    "Description": "Odia spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Polish",
     "NativeName": "polski",
-    "DownloadLink": "https://github.com/SubtitleEdit/support-files/releases/download/hunspell/pl_PL_2026-04-01.zip",
+    "Files": [
+      "https://github.com/SubtitleEdit/support-files/releases/download/hunspell/pl_PL_2026-04-01.zip"
+    ],
     "Description": "Polish by https://sjp.pl - 2026-04-01"
   },
   {
-    "EnglishName": "Portuguese (Brazilian) - Libreoffice",
-    "NativeName": "Português (do Brasil)",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/veroptbrv320aoc.oxt",
-    "Description": "Brazilian Portuguese Spelling Dictionary V3.2 - Libreoffice"
+    "EnglishName": "Portuguese (Brazil)",
+    "NativeName": "Português (Brasil)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_BR/pt_BR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_BR/pt_BR.dic"
+    ],
+    "Description": "Portuguese (Brazil) spell checker (LibreOffice)"
   },
   {
-    "EnglishName": "Portuguese (Brazilian) - Firefox",
-    "NativeName": "Português (do Brasil)",
-    "DownloadLink": "https://hg.mozilla.org/releases/l10n/mozilla-aurora/pt-BR/archive/81d9d556fa78.zip/extensions/spellcheck/hunspell/",
-    "Description": "Brazilian Portuguese Spelling Dictionary 2009 José João de Almeida - Firefox"
-  },
-  {
-    "EnglishName": "Portuguese (European Portuguese Dictionary)",
+    "EnglishName": "Portuguese (Portugal)",
     "NativeName": "Português",
-    "DownloadLink": "http://natura.di.uminho.pt/download/sources/Dictionaries/libreoffice/oo3x-pt_PT.oxt",
-    "Description": "Dicionário em versão Acordo Ortográfico para Português de Portugal - LibreOffice"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_PT/pt_PT.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_PT/pt_PT.dic"
+    ],
+    "Description": "Portuguese (Portugal) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Punjabi",
+    "NativeName": "ਪੰਜਾਬੀ",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pa_IN/pa_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pa_IN/pa_IN.dic"
+    ],
+    "Description": "Punjabi spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Romanian",
-    "NativeName": "română",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1392/10/dict-ro.1.7.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fprojectrelease%2Fromanian-dictionary-pack-spell-checker-hyphenation-thesaurus-17&amp;ts=1435689394&amp;use_mirror=freefr",
-    "Description": "Romanian Dictionary Pack (spell checker, hyphenation, thesaurus) - v1.7"
+    "NativeName": "Română",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ro/ro_RO.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ro/ro_RO.dic"
+    ],
+    "Description": "Romanian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Russian",
     "NativeName": "Русский",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/dict-ru-ru-aot-0-4-3.oxt",
-    "Description": "Russian spellcheck dictionary. Based on works of AOT group. 0.4.0"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ru_RU/ru_RU.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ru_RU/ru_RU.dic"
+    ],
+    "Description": "Russian spell checker (LibreOffice)"
   },
   {
-    "EnglishName": "Serbian",
-    "NativeName": "српски",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/bb01ff21_dict-sr.oxt",
-    "Description": "Serbian (Cyrillic and Latin) Spelling and Hyphenation, Aug 08, 2019"
+    "EnglishName": "Sanskrit",
+    "NativeName": "संस्कृतम्",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sa_IN/sa_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sa_IN/sa_IN.dic"
+    ],
+    "Description": "Sanskrit spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Scottish Gaelic",
+    "NativeName": "Gàidhlig",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/gd_GB/gd_GB.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/gd_GB/gd_GB.dic"
+    ],
+    "Description": "Scottish Gaelic spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Serbian (Cyrillic)",
+    "NativeName": "Serbian (Cyrillic)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sr/sr.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sr/sr.dic"
+    ],
+    "Description": "Serbian (Cyrillic) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Serbian (Latin)",
+    "NativeName": "Serbian (Latin)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sr/sr-Latn.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sr/sr-Latn.dic"
+    ],
+    "Description": "Serbian (Latin) spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Sinhala",
-    "NativeName": "Sinhala",
-    "DownloadLink": "https://extensions.openoffice.org/en/download/3940",
-    "Description": "Sinhala by chamendri"
+    "NativeName": "සිංහල",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/si_LK/si_LK.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/si_LK/si_LK.dic"
+    ],
+    "Description": "Sinhala spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Slovak",
-    "NativeName": "slovenčina",
-    "DownloadLink": "http://www.sk-spell.sk.cx/files/hunspell-sk-20110228.zip",
-    "Description": "Slovak dictionary package / Slovenské slovníky"
+    "NativeName": "Slovenčina",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sk_SK/sk_SK.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sk_SK/sk_SK.dic"
+    ],
+    "Description": "Slovak spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Slovenian",
-    "NativeName": "slovenski",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/8b7ba8bb_pack-sl.oxt",
-    "Description": "Slovenian Dictionary Pack - 2018.01.04"
+    "NativeName": "Slovenščina",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sl_SI/sl_SI.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sl_SI/sl_SI.dic"
+    ],
+    "Description": "Slovenian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Spanish",
-    "NativeName": "España",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/spanish-dictionary.oxt",
-    "Description": "Diccionario del idioma español - 1.0 (Dec 28, 2011)"
-  },
-  {
-    "EnglishName": "Spanish",
-    "NativeName": "Español Genérico",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/e217baa9_es-any.oxt",
-    "Description": "Genérico v2.1 (Apr 05, 2016)"
+    "NativeName": "Español",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_ES.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_ES.dic"
+    ],
+    "Description": "Spanish spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Swahili",
     "NativeName": "Kiswahili",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/swahilidictionary-2013-03-12.oxt",
-    "Description": "Swahili Dictionary 2013.03.12"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sw_TZ/sw_TZ.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sw_TZ/sw_TZ.dic"
+    ],
+    "Description": "Swahili spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Swedish",
     "NativeName": "Svenska",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/5959/1/dict-sv.oxt",
-    "Description": "Swedish 2.16"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_SE.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_SE.dic"
+    ],
+    "Description": "Swedish spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Swedish (Finland)",
+    "NativeName": "Svenska (Finland)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_FI.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_FI.dic"
+    ],
+    "Description": "Swedish (Finland) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Tamil",
+    "NativeName": "தமிழ்",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ta_IN/ta_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ta_IN/ta_IN.dic"
+    ],
+    "Description": "Tamil spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Telugu",
+    "NativeName": "తెలుగు",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/te_IN/te_IN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/te_IN/te_IN.dic"
+    ],
+    "Description": "Telugu spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Thai",
     "NativeName": "ภาษาไทย",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/2365/0/dict-th.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fthai-spellchecker-dictionary&amp;ts=1373919459&amp;use_mirror=netcologne",
-    "Description": "Thai Spell Checker Dictionary"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/th_TH/th_TH.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/th_TH/th_TH.dic"
+    ],
+    "Description": "Thai spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Tibetan",
+    "NativeName": "བོད་སྐད་",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bo/bo.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bo/bo.dic"
+    ],
+    "Description": "Tibetan spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Turkish",
-    "NativeName": "Turkish",
-    "DownloadLink": "https://extensions.libreoffice.org/assets/downloads/z/oo-turkish-dict-v1-2.oxt",
-    "Description": "Turkish Spellcheck Dictionary - 1.2"
+    "NativeName": "Türkçe",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/tr_TR/tr_TR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/tr_TR/tr_TR.dic"
+    ],
+    "Description": "Turkish spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Ukrainian",
     "NativeName": "Українська",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/975/6/dict-uk_ua-1.7.1.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fprojectrelease%2Fukrainian-dictionary-171&amp;ts=1435691238&amp;use_mirror=freefr",
-    "Description": "Ukrainian Dictionary - v1.7.1 (27/03/2014)"
-  },
-  {
-    "EnglishName": "Valencian",
-    "NativeName": "valencià",
-    "DownloadLink": "http://downloads.sourceforge.net/project/aoo-extensions/1475/1/ca-valencia.3.0.0.oxt",
-    "Description": "Spelling dictionary for Catalan (Valencian version) - v3.0.0 (25/05/2015)"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/uk_UA/uk_UA.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/uk_UA/uk_UA.dic"
+    ],
+    "Description": "Ukrainian spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Vietnamese",
     "NativeName": "Tiếng Việt",
-    "DownloadLink": "https://downloads.sourceforge.net/project/aoo-extensions/917/3/vi_spellchecker_ooo3.oxt?ts=gAAAAABl8woSclxfXr9wpnYVtNEpNTbz5KrZTMETetNi3tcVaxsJmHo7YC66hYQ9knqcRO317eqyZOCvUsuMyFzTvZwZNk0vZw%3D%3D&amp;r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Faoo-extensions%2Ffiles%2F917%2F3%2Fvi_spellchecker_ooo3.oxt%2Fdownload%3Fuse_mirror%3Dmaster",
-    "Description": "Vietnamese SpellChecker"
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/vi/vi_VN.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/vi/vi_VN.dic"
+    ],
+    "Description": "Vietnamese spell checker (LibreOffice)"
   },
   {
     "EnglishName": "Vietnamese and English",
     "NativeName": "Tiếng Việt and English",
-    "DownloadLink": "https://github.com/SubtitleEdit/support-files/raw/master/hunspell/vi_VN-and-English.zip",
+    "Files": [
+      "https://github.com/SubtitleEdit/support-files/raw/master/hunspell/vi_VN-and-English.zip"
+    ],
     "Description": "Vietnamese/English by MMT Gouenji Tech - 2022-02-12"
   },
   {
-    "EnglishName": "Welsh (Wales)",
-    "NativeName": "Welsh (Wales)",
-    "DownloadLink": "https://downloads.sourceforge.net/project/aoo-extensions/1583/1/geiriadur-cy.oxt",
-    "Description": "Xhosa spell checker"
+    "EnglishName": "Welsh",
+    "NativeName": "Cymraeg",
+    "Files": [
+      "https://downloads.sourceforge.net/project/aoo-extensions/1583/1/geiriadur-cy.oxt"
+    ],
+    "Description": "Welsh spell checker"
   },
   {
-    "EnglishName": "Xhosa (South Africa)",
-    "NativeName": "Xhosa (South Africa)",
-    "DownloadLink": "https://sourceforge.net/projects/aoo-extensions/files/3133/0/dict-xh_za-2009.10.30.oxt/download",
+    "EnglishName": "Xhosa",
+    "NativeName": "isiXhosa",
+    "Files": [
+      "https://sourceforge.net/projects/aoo-extensions/files/3133/0/dict-xh_za-2009.10.30.oxt/download"
+    ],
     "Description": "Xhosa spell checker"
   },
   {
     "EnglishName": "Zulu",
-    "NativeName": "IsiZulu",
-    "DownloadLink": "https://downloads.sourceforge.net/project/aoo-extensions/3132/3/dict-zu_za-2010.01.26.oxt?ts=gAAAAABl8wwk0LSrL-Co9B6dhwP__TVfnFtKRlLCcpi7LQ95GaviSGizVP6yGTHQpmPbvamIUfkt3Pqx79EvbTFP1GSBGlEdGQ%3D%3D&amp;r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Faoo-extensions%2Ffiles%2F3132%2F3%2Fdict-zu_za-2010.01.26.oxt%2Fdownload",
+    "NativeName": "isiZulu",
+    "Files": [
+      "https://downloads.sourceforge.net/project/aoo-extensions/3132/3/dict-zu_za-2010.01.26.oxt?ts=gAAAAABl8wwk0LSrL-Co9B6dhwP__TVfnFtKRlLCcpi7LQ95GaviSGizVP6yGTHQpmPbvamIUfkt3Pqx79EvbTFP1GSBGlEdGQ%3D%3D&amp;r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Faoo-extensions%2Ffiles%2F3132%2F3%2Fdict-zu_za-2010.01.26.oxt%2Fdownload"
+    ],
     "Description": "Zulu spell checker"
   }
 ]

--- a/src/ui/Assets/HunspellDictionaries.json
+++ b/src/ui/Assets/HunspellDictionaries.json
@@ -387,7 +387,7 @@
     "EnglishName": "Khmer",
     "NativeName": "ខ្មែរ",
     "Files": [
-      "http://downloads.sourceforge.net/project/aoo-extensions/5067/2/dict-km.oxt?r=http%3A%2F%2Fextensions.openoffice.org%2Fen%2Fproject%2Fkhmer-spelling-dictionary&amp;ts=1373998173&amp;use_mirror=netcologne"
+      "https://downloads.sourceforge.net/project/aoo-extensions/5067/2/dict-km.oxt"
     ],
     "Description": "Khmer spelling dictionary 2011.05.11"
   },
@@ -447,7 +447,7 @@
     "EnglishName": "Macedonian",
     "NativeName": "Македонски",
     "Files": [
-      "http://downloads.sourceforge.net/project/aoo-extensions/3403/0/dict-mk.oxt"
+      "https://downloads.sourceforge.net/project/aoo-extensions/3403/0/dict-mk.oxt"
     ],
     "Description": "Macedonian dictionary was created by Taras Bendik"
   },
@@ -455,7 +455,7 @@
     "EnglishName": "Malay",
     "NativeName": "Bahasa Melayu",
     "Files": [
-      "http://downloads.sourceforge.net/project/aoo-extensions/3904/0/ms_my.oxt"
+      "https://downloads.sourceforge.net/project/aoo-extensions/3904/0/ms_my.oxt"
     ],
     "Description": "Malay Spell Checker v0.1 - 07/10/04"
   },
@@ -782,7 +782,7 @@
     "EnglishName": "Zulu",
     "NativeName": "isiZulu",
     "Files": [
-      "https://downloads.sourceforge.net/project/aoo-extensions/3132/3/dict-zu_za-2010.01.26.oxt?ts=gAAAAABl8wwk0LSrL-Co9B6dhwP__TVfnFtKRlLCcpi7LQ95GaviSGizVP6yGTHQpmPbvamIUfkt3Pqx79EvbTFP1GSBGlEdGQ%3D%3D&amp;r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Faoo-extensions%2Ffiles%2F3132%2F3%2Fdict-zu_za-2010.01.26.oxt%2Fdownload"
+      "https://downloads.sourceforge.net/project/aoo-extensions/3132/3/dict-zu_za-2010.01.26.oxt"
     ],
     "Description": "Zulu spell checker"
   }

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -112,45 +112,60 @@ public partial class GetDictionariesViewModel : ObservableObject
     {
         lock (_lockObj)
         {
-            if (_done)
+            if (_done || _downloadTask == null)
             {
                 return;
             }
 
-            if (_downloadTask is { IsFaulted: true } or { IsCanceled: true })
+            var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
+            if (_downloadTask.IsCanceled || ex is OperationCanceledException)
             {
                 _timer.Stop();
                 _done = true;
-                var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
-                if (_downloadTask.IsCanceled || ex is OperationCanceledException)
-                {
-                    StatusText = "Download canceled";
-                    Close();
-                }
-                else
-                {
-                    StatusText = "Download failed";
-                }
+                StatusText = "Download canceled";
+                Close();
+            }
+            else if (_downloadTask is { IsFaulted: true })
+            {
+                HandleDownloadFailure();
             }
             else if (_downloadTask is { IsCompletedSuccessfully: true })
             {
-                _timer.Stop();
-                _done = true;
-
                 if (string.IsNullOrEmpty(DictionaryFileName))
                 {
-                    StatusText = "Download failed";
-                    return;
+                    HandleDownloadFailure();
                 }
-
-                OkPressed = true;
-                Close();
+                else
+                {
+                    _timer.Stop();
+                    _done = true;
+                    OkPressed = true;
+                    Close();
+                }
             }
         }
     }
 
+    /// <summary>
+    /// Resets the window to its idle state after a failed download so the user can
+    /// retry or close it normally. The timer keeps running to pick up a retry.
+    /// </summary>
+    private void HandleDownloadFailure()
+    {
+        _downloadTask = null;
+        Dispatcher.UIThread.Post(() =>
+        {
+            StatusText = "Download failed";
+            Progress = 0;
+            ProgressOpacity = 0;
+            IsProgressVisible = false;
+            IsDownloadEnabled = true;
+        });
+    }
+
     private void Close()
     {
+        _timer.Stop();
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();
@@ -350,8 +365,8 @@ public partial class GetDictionariesViewModel : ObservableObject
         }
 
         SelectedStatusBrush = selected.IsInstalled ? InstalledBrush : NotInstalledBrush;
-        SelectedStatusText = selected.IsInstalled ? "Installed" : "Not installed";
-        DownloadButtonText = selected.IsInstalled ? "Re-download" : Se.Language.General.Download;
+        SelectedStatusText = selected.IsInstalled ? Se.Language.General.Installed : Se.Language.General.NotInstalled;
+        DownloadButtonText = selected.IsInstalled ? Se.Language.General.Redownload : Se.Language.General.Download;
     }
 
     private static bool IsEntryInstalled(GetSpellCheckDictionaryDisplay entry, List<string> installedDicFiles)

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -32,6 +33,10 @@ public partial class GetDictionariesViewModel : ObservableObject
     [ObservableProperty] private bool _isDownloadEnabled;
     [ObservableProperty] private bool _isProgressVisible;
     [ObservableProperty] private double _progressOpacity;
+    [ObservableProperty] private IBrush _selectedStatusBrush;
+    [ObservableProperty] private string _selectedStatusText;
+    [ObservableProperty] private string _downloadButtonText;
+    [ObservableProperty] private string _dictionariesFolder;
 
     public Window? Window { get; set; }
 
@@ -42,11 +47,35 @@ public partial class GetDictionariesViewModel : ObservableObject
     private bool _done;
     private readonly System.Timers.Timer _timer;
     private readonly CancellationTokenSource _cancellationTokenSource;
-    private readonly MemoryStream _downloadStream;
 
     private readonly ISpellCheckDictionaryDownloadService _spellCheckDictionaryDownloadService;
     private readonly IZipUnpacker _zipUnpacker;
     private readonly IFolderHelper _folderHelper;
+
+    private static readonly IBrush InstalledBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static readonly IBrush NotInstalledBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    /// <summary>
+    /// Legacy archive entries do not expose a .dic file name in their download URL, so the
+    /// installed state is detected by looking for a .dic file with this language prefix.
+    /// </summary>
+    private static readonly Dictionary<string, string> LegacyDicPrefixes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "Finnish", "fi" },
+        { "Polish", "pl_PL" },
+        { "Basque", "eu" },
+        { "Irish", "ga" },
+        { "Khmer", "km" },
+        { "Latin", "la" },
+        { "Lower Sorbian", "dsb" },
+        { "Malay", "ms" },
+        { "Malayalam", "ml" },
+        { "Macedonian", "mk" },
+        { "Vietnamese and English", "vi_VN-and" },
+        { "Welsh", "cy" },
+        { "Xhosa", "xh" },
+        { "Zulu", "zu" },
+    };
 
     public GetDictionariesViewModel(ISpellCheckDictionaryDownloadService spellCheckDictionaryDownloadService, IZipUnpacker zipUnpacker, IFolderHelper folderHelper)
     {
@@ -63,10 +92,15 @@ public partial class GetDictionariesViewModel : ObservableObject
         DictionaryFileName = string.Empty;
 
         _cancellationTokenSource = new CancellationTokenSource();
-        _downloadStream = new MemoryStream();
         _progressOpacity = 0;
 
+        SelectedStatusBrush = NotInstalledBrush;
+        SelectedStatusText = string.Empty;
+        DownloadButtonText = Se.Language.General.Download;
+        DictionariesFolder = Se.DictionariesFolder;
+
         LoadDictionaries();
+        RefreshInstalledStatus();
         _timer = new System.Timers.Timer(500);
         _timer.Elapsed += OnTimerOnElapsed;
         _timer.Start();
@@ -83,27 +117,12 @@ public partial class GetDictionariesViewModel : ObservableObject
                 return;
             }
 
-            if (_downloadTask is { IsCompleted: true })
-            {
-                _timer.Stop();
-                _done = true;
-
-                if (_downloadStream.Length == 0)
-                {
-                    StatusText = "Download failed";
-                    return;
-                }
-
-                DictionaryFileName = UnpackDictionary();
-                OkPressed = true;
-                Close();
-            }
-            else if (_downloadTask is { IsFaulted: true })
+            if (_downloadTask is { IsFaulted: true } or { IsCanceled: true })
             {
                 _timer.Stop();
                 _done = true;
                 var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
-                if (ex is OperationCanceledException)
+                if (_downloadTask.IsCanceled || ex is OperationCanceledException)
                 {
                     StatusText = "Download canceled";
                     Close();
@@ -112,6 +131,20 @@ public partial class GetDictionariesViewModel : ObservableObject
                 {
                     StatusText = "Download failed";
                 }
+            }
+            else if (_downloadTask is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _done = true;
+
+                if (string.IsNullOrEmpty(DictionaryFileName))
+                {
+                    StatusText = "Download failed";
+                    return;
+                }
+
+                OkPressed = true;
+                Close();
             }
         }
     }
@@ -124,41 +157,97 @@ public partial class GetDictionariesViewModel : ObservableObject
         });
     }
 
-    private string? UnpackDictionary()
+    /// <summary>
+    /// Downloads every file of the selected dictionary. A LibreOffice entry has direct
+    /// .aff/.dic links that are saved as-is; a legacy entry has a single .oxt/.zip/.xpi
+    /// archive that is unzipped. Sets <see cref="DictionaryFileName"/> to the largest .dic.
+    /// </summary>
+    private async Task DownloadAndUnpackAsync(IReadOnlyList<string> files, IProgress<float> progress, CancellationToken cancellationToken)
     {
         var folder = Se.DictionariesFolder;
-
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);
         }
 
-        var outputFileNames = new List<string>();
+        var dicFiles = new List<string>();
 
-        _downloadStream.Position = 0;
-        _zipUnpacker.UnpackZipStream(
-            _downloadStream,
-            folder,
-            string.Empty,
-            true,
-            new List<string> { ".dic", ".aff" },
-            outputFileNames);
-
-        _downloadStream.Dispose();
-        
-        var dicFiles = outputFileNames.Where(p=>p.EndsWith(".dic")).ToList();
-        if (dicFiles.Count == 0)
+        for (var i = 0; i < files.Count; i++)
         {
-            return string.Empty;
+            var url = files[i];
+            var fileIndex = i;
+            var fileProgress = new Progress<float>(p => progress.Report((fileIndex + p) / files.Count));
+
+            using var stream = new MemoryStream();
+            await _spellCheckDictionaryDownloadService.DownloadDictionary(stream, url, fileProgress, cancellationToken);
+
+            if (stream.Length == 0)
+            {
+                throw new InvalidOperationException($"Dictionary download failed: {url}");
+            }
+
+            stream.Position = 0;
+
+            if (IsHunspellFile(url))
+            {
+                var targetFileName = Path.Combine(folder, GetFileNameFromUrl(url));
+                await using (var fileStream = File.Create(targetFileName))
+                {
+                    await stream.CopyToAsync(fileStream, cancellationToken);
+                }
+
+                if (targetFileName.EndsWith(".dic", StringComparison.OrdinalIgnoreCase))
+                {
+                    dicFiles.Add(targetFileName);
+                }
+            }
+            else
+            {
+                var outputFileNames = new List<string>();
+                _zipUnpacker.UnpackZipStream(
+                    stream,
+                    folder,
+                    string.Empty,
+                    true,
+                    new List<string> { ".dic", ".aff" },
+                    outputFileNames);
+
+                dicFiles.AddRange(outputFileNames.Where(p => p.EndsWith(".dic", StringComparison.OrdinalIgnoreCase)));
+            }
         }
 
+        DictionaryFileName = GetLargestFile(dicFiles);
+    }
+
+    private static bool IsHunspellFile(string url)
+    {
+        var path = RemoveUrlQuery(url);
+        return path.EndsWith(".dic", StringComparison.OrdinalIgnoreCase) ||
+               path.EndsWith(".aff", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetFileNameFromUrl(string url)
+    {
+        var path = RemoveUrlQuery(url);
+        var slashIndex = path.LastIndexOf('/');
+        return slashIndex >= 0 ? path.Substring(slashIndex + 1) : path;
+    }
+
+    private static string RemoveUrlQuery(string url)
+    {
+        var queryIndex = url.IndexOf('?');
+        return queryIndex >= 0 ? url.Substring(0, queryIndex) : url;
+    }
+
+    private static string GetLargestFile(IEnumerable<string> files)
+    {
         var largestFileSize = (long)-1;
         var largestFileName = string.Empty;
 
-        foreach (var file in dicFiles)
+        foreach (var file in files)
         {
             var fi = new FileInfo(file);
-            if (fi.Length > largestFileSize)
+            if (fi.Exists && fi.Length > largestFileSize)
             {
                 largestFileSize = fi.Length;
                 largestFileName = file;
@@ -219,11 +308,73 @@ public partial class GetDictionariesViewModel : ObservableObject
         }
     }
 
+    partial void OnSelectedDictionaryChanged(GetSpellCheckDictionaryDisplay? value)
+    {
+        Description = value?.Description ?? string.Empty;
+        UpdateSelectedStatus();
+    }
+
+    /// <summary>
+    /// Marks each dictionary as installed or not by checking the dictionaries folder,
+    /// and updates the green/gray status dots accordingly.
+    /// </summary>
+    private void RefreshInstalledStatus()
+    {
+        var installedDicFiles = new List<string>();
+        if (Directory.Exists(Se.DictionariesFolder))
+        {
+            foreach (var file in Directory.GetFiles(Se.DictionariesFolder, "*.dic"))
+            {
+                installedDicFiles.Add(Path.GetFileName(file));
+            }
+        }
+
+        foreach (var dictionary in Dictionaries)
+        {
+            dictionary.IsInstalled = IsEntryInstalled(dictionary, installedDicFiles);
+            dictionary.StatusBrush = dictionary.IsInstalled ? InstalledBrush : NotInstalledBrush;
+        }
+
+        UpdateSelectedStatus();
+    }
+
+    private void UpdateSelectedStatus()
+    {
+        var selected = SelectedDictionary;
+        if (selected == null)
+        {
+            SelectedStatusBrush = NotInstalledBrush;
+            SelectedStatusText = string.Empty;
+            DownloadButtonText = Se.Language.General.Download;
+            return;
+        }
+
+        SelectedStatusBrush = selected.IsInstalled ? InstalledBrush : NotInstalledBrush;
+        SelectedStatusText = selected.IsInstalled ? "Installed" : "Not installed";
+        DownloadButtonText = selected.IsInstalled ? "Re-download" : Se.Language.General.Download;
+    }
+
+    private static bool IsEntryInstalled(GetSpellCheckDictionaryDisplay entry, List<string> installedDicFiles)
+    {
+        var dicNames = entry.Files
+            .Select(GetFileNameFromUrl)
+            .Where(name => name.EndsWith(".dic", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (dicNames.Count > 0)
+        {
+            return dicNames.Any(name => installedDicFiles.Any(f => f.Equals(name, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        return LegacyDicPrefixes.TryGetValue(entry.EnglishName, out var prefix) &&
+               installedDicFiles.Any(f => f.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+    }
+
     [RelayCommand]
     private void Download()
     {
         var selected = SelectedDictionary;
-        if (selected == null)
+        if (selected == null || selected.Files.Count == 0)
         {
             return;
         }
@@ -241,17 +392,7 @@ public partial class GetDictionariesViewModel : ObservableObject
             StatusText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
         });
 
-        var folder = Se.FfmpegFolder;
-        if (!Directory.Exists(folder))
-        {
-            Directory.CreateDirectory(folder);
-        }
-
-        _downloadTask = _spellCheckDictionaryDownloadService.DownloadDictionary(
-            _downloadStream,
-            selected.DownloadLink,
-            downloadProgress,
-            _cancellationTokenSource.Token);
+        _downloadTask = DownloadAndUnpackAsync(selected.Files, downloadProgress, _cancellationTokenSource.Token);
     }
 
     [RelayCommand]

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
@@ -1,9 +1,11 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Layout;
-using Avalonia.Styling;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -11,133 +13,254 @@ namespace Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 
 public class GetDictionariesWindow : Window
 {
+    private const int LabelWidth = 90;
+    private const int ContentWidth = 380;
+
     public GetDictionariesWindow(GetDictionariesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = Se.Language.SpellCheck.GetDictionariesTitle;
         SizeToContent = SizeToContent.WidthAndHeight;
         CanResize = false;
+        MinWidth = 520;
         vm.Window = this;
         DataContext = vm;
 
-        var label = new Label
+        var downloadButton = UiUtil.MakeButton(string.Empty, vm.DownloadCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithBindEnabled(nameof(vm.IsDownloadEnabled));
+        downloadButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.DownloadButtonText)));
+
+        var stack = new StackPanel
         {
-            Content = Se.Language.SpellCheck.GetDictionaryInstructions,
-            VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 10, 0, 0),
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children =
+            {
+                BuildHeader(),
+                BuildDetails(vm),
+                BuildProgress(vm),
+                BuildActions(vm, downloadButton),
+            },
+        };
+
+        var outerGrid = new Grid { Margin = UiUtil.MakeWindowMargin() };
+        outerGrid.Children.Add(stack);
+
+        Content = new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+
+        Activated += delegate { downloadButton.Focus(); }; // hack to make OnKeyDown work
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    private static TextBlock BuildHeader() => new()
+    {
+        Text = Se.Language.SpellCheck.GetDictionaryInstructions,
+        TextWrapping = TextWrapping.Wrap,
+        Opacity = 0.85,
+        MaxWidth = LabelWidth + ContentWidth + 12,
+    };
+
+    private static Border BuildDetails(GetDictionariesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 12,
         };
 
         var combo = new ComboBox
         {
             ItemsSource = vm.Dictionaries,
-            VerticalAlignment = VerticalAlignment.Center,
-            MinWidth = 180,
-            Margin = new Thickness(0, 10, 10, 2),
+            ItemTemplate = BuildDictionaryItemTemplate(),
+            MinWidth = ContentWidth,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            [!ComboBox.SelectedItemProperty] = new Binding(nameof(vm.SelectedDictionary)),
             [!ComboBox.IsEnabledProperty] = new Binding(nameof(vm.IsDownloadEnabled)),
-            [!ComboBox.SelectedValueProperty] = new Binding(nameof(vm.SelectedDictionary)),
         };
 
-        var buttonDownload = UiUtil
-            .MakeButton(Se.Language.General.Download, vm.DownloadCommand)
-            .WithLeftAlignment()
-            .WithMargin(0, 10, 10, 2)
-            .WithBindEnabled(nameof(vm.IsDownloadEnabled));
-
-        var panelDownload = new StackPanel
+        var description = new TextBlock
         {
-            Orientation = Orientation.Horizontal,
+            TextWrapping = TextWrapping.Wrap,
             VerticalAlignment = VerticalAlignment.Center,
+            MinHeight = 32,
+            MaxWidth = ContentWidth,
+            Opacity = 0.85,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.Description)),
+        };
+
+        var folder = new TextBox
+        {
+            IsReadOnly = true,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            MaxWidth = ContentWidth,
             HorizontalAlignment = HorizontalAlignment.Left,
-            Children =
-            {
-                combo,
-                buttonDownload
-            }
+            [!TextBox.TextProperty] = new Binding(nameof(vm.DictionariesFolder)),
         };
 
-        var labelDescription = new Label
+        grid.Add(MakeLabel("Dictionary"), 0, 0);
+        grid.Add(combo, 0, 1);
+
+        grid.Add(MakeLabel("Status"), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.SelectedStatusBrush), nameof(vm.SelectedStatusText)), 1, 1);
+
+        grid.Add(MakeLabel("Description"), 2, 0);
+        grid.Add(description, 2, 1);
+
+        grid.Add(MakeLabel("Folder"), 3, 0);
+        grid.Add(folder, 3, 1);
+
+        return new Border
         {
-            Content = "Description:",
-            VerticalAlignment = VerticalAlignment.Center,
-            [!Label.ContentProperty] = new Binding(nameof(vm.SelectedDictionary) + "." + nameof(vm.Description)),
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
         };
+    }
 
-        var sliderProgress = new Slider
+    private static StackPanel BuildProgress(GetDictionariesViewModel vm)
+    {
+        var bar = new ProgressBar
         {
             Minimum = 0,
             Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            },
-            [!Slider.OpacityProperty] = new Binding(nameof(vm.ProgressOpacity)),
-            [!Slider.ValueProperty] = new Binding(nameof(vm.Progress)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
+            Height = 8,
+            [!ProgressBar.ValueProperty] = new Binding(nameof(vm.Progress)),
+            [!Visual.OpacityProperty] = new Binding(nameof(vm.ProgressOpacity)),
         };
 
-        var labelDownloadStatus = new Label
+        var status = new TextBlock
         {
-            VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Center,
-            Width = double.NaN,
-            Margin = new Thickness(0, 20, 0, 20),
-            [!Label.ContentProperty] = new Binding(nameof(vm.StatusText)),
-            [!Label.IsVisibleProperty] = new Binding(nameof(vm.IsProgressVisible)),
+            Margin = new Thickness(0, 4, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusText)),
+            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsProgressVisible)),
         };
 
-        var linkOpenFolder = UiUtil.MakeLink(Se.Language.General.OpenDictionaryFolder, vm.OpenFolderCommand);
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Children = { bar, status },
+        };
+    }
 
-        var buttonOk = UiUtil.MakeButtonDone(vm.OkCommand);
-        buttonOk.WithBindIsVisible(nameof(vm.IsDownloadEnabled));
-        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        buttonCancel.WithBindIsVisible(nameof(vm.IsProgressVisible));
-        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+    private static Grid BuildActions(GetDictionariesViewModel vm, Button downloadButton)
+    {
+        var openFolder = UiUtil.MakeButton(Se.Language.General.OpenDictionaryFolder, vm.OpenFolderCommand)
+            .WithIconLeft(IconNames.FolderOpen);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { downloadButton, openFolder },
+        };
+
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand)
+            .WithBindIsVisible(nameof(vm.IsDownloadEnabled));
+        var cancel = UiUtil.MakeButtonCancel(vm.CancelCommand)
+            .WithBindIsVisible(nameof(vm.IsProgressVisible));
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close, cancel },
+        };
 
         var grid = new Grid
         {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-            },
             ColumnDefinitions =
             {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = GridLength.Auto },
             },
-            Margin = UiUtil.MakeWindowMargin(),
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static FuncDataTemplate<GetSpellCheckDictionaryDisplay> BuildDictionaryItemTemplate()
+    {
+        return new FuncDataTemplate<GetSpellCheckDictionaryDisplay>((_, _) =>
+        {
+            var dot = new Ellipse
+            {
+                Width = 10,
+                Height = 10,
+                VerticalAlignment = VerticalAlignment.Center,
+                [!Shape.FillProperty] = new Binding(nameof(GetSpellCheckDictionaryDisplay.StatusBrush)),
+            };
+
+            var text = new TextBlock
+            {
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(8, 0, 0, 0),
+                [!TextBlock.TextProperty] = new Binding(nameof(GetSpellCheckDictionaryDisplay.DisplayName)),
+            };
+
+            return new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Children = { dot, text },
+            };
+        }, true);
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string textBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Shape.FillProperty] = new Binding(brushBindingPath),
         };
 
-        grid.Add(label, 0, 0);
-        grid.Add(panelDownload, 1, 0);
-        grid.Add(labelDescription, 2, 0);
-        grid.Add(sliderProgress, 3, 0);
-        grid.Add(labelDownloadStatus, 3, 0);
-        grid.Add(linkOpenFolder, 4, 0);
-        grid.Add(panelButtons, 4, 0);
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(textBindingPath),
+        };
 
-        Content = grid;
-
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
-        KeyDown += (_, e) => vm.OnKeyDown(e);
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
     }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
 }

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
@@ -118,16 +118,16 @@ public class GetDictionariesWindow : Window
             [!TextBox.TextProperty] = new Binding(nameof(vm.DictionariesFolder)),
         };
 
-        grid.Add(MakeLabel("Dictionary"), 0, 0);
+        grid.Add(MakeLabel(Se.Language.General.Dictionary), 0, 0);
         grid.Add(combo, 0, 1);
 
-        grid.Add(MakeLabel("Status"), 1, 0);
+        grid.Add(MakeLabel(Se.Language.General.Status), 1, 0);
         grid.Add(MakeStatusPanel(nameof(vm.SelectedStatusBrush), nameof(vm.SelectedStatusText)), 1, 1);
 
-        grid.Add(MakeLabel("Description"), 2, 0);
+        grid.Add(MakeLabel(Se.Language.General.Description), 2, 0);
         grid.Add(description, 2, 1);
 
-        grid.Add(MakeLabel("Folder"), 3, 0);
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 3, 0);
         grid.Add(folder, 3, 1);
 
         return new Border
@@ -156,7 +156,6 @@ public class GetDictionariesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Center,
             Margin = new Thickness(0, 4, 0, 0),
             [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusText)),
-            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsProgressVisible)),
         };
 
         return new StackPanel

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetSpellCheckDictionaryDisplay.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetSpellCheckDictionaryDisplay.cs
@@ -1,4 +1,6 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.Generic;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 
@@ -6,17 +8,31 @@ public partial class GetSpellCheckDictionaryDisplay : ObservableObject
 {
     [ObservableProperty] private string _englishName;
     [ObservableProperty] private string _nativeName;
-    [ObservableProperty] private string _downloadLink;
     [ObservableProperty] private string _description;
 
+    /// <summary>True when the dictionary is already present in the dictionaries folder.</summary>
+    [ObservableProperty] private bool _isInstalled;
+
+    /// <summary>Green when installed, gray when not - shown as a dot in the dictionary list.</summary>
+    [ObservableProperty] private IBrush _statusBrush;
+
+    /// <summary>
+    /// One or more download URLs for the dictionary. A LibreOffice entry has a direct
+    /// .aff and .dic link, while a legacy entry has a single .oxt/.zip/.xpi archive link.
+    /// </summary>
+    public List<string> Files { get; set; }
+
     public bool UseShortName { get; set; }
+
+    public string DisplayName => ToString();
 
     public GetSpellCheckDictionaryDisplay()
     {
         EnglishName = string.Empty;
         NativeName = string.Empty;
-        DownloadLink = string.Empty;
         Description = string.Empty;
+        Files = new List<string>();
+        StatusBrush = Brushes.Gray;
     }
 
     public override string ToString()


### PR DESCRIPTION
The previous dictionary sources were mostly frozen .oxt/.xpi snapshots (many from 2009-2015). Switch them to the actively-maintained github.com/LibreOffice/dictionaries repo.

- Rewrite HunspellDictionaries.json: 75 entries now download raw .aff/.dic files directly from LibreOffice/dictionaries (pinned to master, so they auto-track upstream); 14 languages not on LibreOffice keep their existing archive links
- Replace the DownloadLink string with a Files array so an entry can carry its .aff + .dic pair; the downloader saves plain hunspell files directly and still unzips legacy .oxt/.zip/.xpi archives
- Add ~24 new languages now available upstream
- One dictionary per download: split English into AU/CA/GB/US/ZA, Norwegian into Bokmal/Nynorsk, Serbian into Cyrillic/Latin
- Redesign the Get dictionaries window in the TTS-settings style with green/gray dots showing which dictionaries are already installed