### PR TITLE
Use a shared ProgressBar for download and progress windows

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -16,6 +16,7 @@ v5.0.0-beta29 (xth May 2026)
 * Get spell check dictionaries from the maintained LibreOffice repository and redesign the dialog
 * Select first row after OCR completes - thx LurkingNinja
 * Trim long paths in the Reopen menu and tighten menu spacing
+* Use a consistent, thicker progress bar across download and progress windows
 * seconv: reject unknown --encoding values and add --encoding:source
 * Update Bulgarian translation - thx jekovcar
 * Update Russian translation - thx jekovcar
@@ -23,6 +24,7 @@ v5.0.0-beta29 (xth May 2026)
 * Fix Text-to-speech async and Piper engine bugs
 * Fix Edge TTS crash on bad rate format and retry transient failures - thx KevinHa59
 * Fix shortcut window not receiving focus
+* Fix Cancel button being clipped in the llama.cpp and speech-to-text engine download windows
 
 -----------------------------------------------------------------------------------------------------
 

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -552,32 +552,9 @@ public class ExportImageBasedWindow : Window
 
     private static Grid MakeProgressView(ExportImageBasedViewModel vm)
     {
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
@@ -600,7 +577,7 @@ public class ExportImageBasedWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
 
         return grid;

--- a/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrWindow.cs
+++ b/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrWindow.cs
@@ -26,32 +26,9 @@ public class DownloadGoogleLensOcrWindow : Window
             FontWeight = FontWeight.Bold,
         }.WithBindText(vm, nameof(vm.StatusText));
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 450,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 450;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
@@ -66,7 +43,7 @@ public class DownloadGoogleLensOcrWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrWindow.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrWindow.cs
@@ -26,33 +26,10 @@ public class DownloadPaddleOcrWindow : Window
             FontWeight = FontWeight.Bold,
         }.WithBindText(vm, nameof(vm.StatusText));
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
@@ -67,7 +44,7 @@ public class DownloadPaddleOcrWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelWindow.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelWindow.cs
@@ -56,33 +56,10 @@ public class DownloadTesseractModelWindow : Window
         };
         panelPickDictionary.Bind(Panel.IsVisibleProperty, new Binding(nameof(vm.IsProgressVisible)) { Converter = new InverseBooleanConverter() });
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(DownloadFfmpegViewModel.Progress)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsProgressVisible)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(DownloadFfmpegViewModel.Progress)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsProgressVisible)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(DownloadFfmpegViewModel.StatusText)));
@@ -99,7 +76,7 @@ public class DownloadTesseractModelWindow : Window
             {
                 titleText,
                 panelPickDictionary,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Ocr/Download/DownloadTesseractWindow.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractWindow.cs
@@ -28,32 +28,9 @@ public class DownloadTesseractWindow : Window
             FontWeight = FontWeight.Bold,
         };
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(DownloadFfmpegViewModel.Progress)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(DownloadFfmpegViewModel.Progress)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(DownloadFfmpegViewModel.StatusText)));
@@ -68,7 +45,7 @@ public class DownloadTesseractWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -905,34 +905,11 @@ public class OcrWindow : Window
 
     private static Grid MakeBottomView(OcrViewModel vm)
     {
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm });
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Width = double.NaN;
+        progressBar.HorizontalAlignment = HorizontalAlignment.Stretch;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm });
 
         var statusText = new TextBlock().WithMarginTop(22);
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
@@ -976,7 +953,7 @@ public class OcrWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
         grid.Add(buttonStart, 0, 1);
         grid.Add(buttonPause, 0, 2);

--- a/src/ui/Features/Shared/DownloadFfmpegWindow.cs
+++ b/src/ui/Features/Shared/DownloadFfmpegWindow.cs
@@ -27,32 +27,9 @@ public class DownloadFfmpegWindow : Window
             FontWeight = FontWeight.Bold,
         };
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(DownloadFfmpegViewModel.Progress)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(DownloadFfmpegViewModel.Progress)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(DownloadFfmpegViewModel.StatusText)));
@@ -67,7 +44,7 @@ public class DownloadFfmpegWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Shared/DownloadLibMpvWindow.cs
+++ b/src/ui/Features/Shared/DownloadLibMpvWindow.cs
@@ -27,32 +27,9 @@ public class DownloadLibMpvWindow : Window
             FontWeight = FontWeight.Bold,
         };
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(DownloadLibMpvViewModel.Progress)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(DownloadLibMpvViewModel.Progress)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(DownloadLibMpvViewModel.StatusText)));
@@ -67,7 +44,7 @@ public class DownloadLibMpvWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Shared/DownloadLibVlcWindow.cs
+++ b/src/ui/Features/Shared/DownloadLibVlcWindow.cs
@@ -27,33 +27,10 @@ public class DownloadLibVlcWindow : Window
             FontWeight = FontWeight.Bold,
         }.WithBindText(vm, nameof(vm.StatusText));
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 450,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 450;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
@@ -68,7 +45,7 @@ public class DownloadLibVlcWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Shared/DownloadYtDlpWindow.cs
+++ b/src/ui/Features/Shared/DownloadYtDlpWindow.cs
@@ -28,32 +28,9 @@ public class DownloadYtDlpWindow : Window
             FontWeight = FontWeight.Bold,
         };
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(DownloadLibMpvViewModel.Progress)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(DownloadLibMpvViewModel.Progress)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(DownloadLibMpvViewModel.StatusText)));
@@ -68,7 +45,7 @@ public class DownloadYtDlpWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Shared/GetAudioClips/GetAudioClipsWindow.cs
+++ b/src/ui/Features/Shared/GetAudioClips/GetAudioClipsWindow.cs
@@ -28,32 +28,9 @@ public class GetAudioClipsWindow : Window
             FontWeight = FontWeight.Bold,
         };
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(DownloadFfmpegViewModel.Progress)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(DownloadFfmpegViewModel.Progress)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(DownloadFfmpegViewModel.StatusText)));
@@ -68,7 +45,7 @@ public class GetAudioClipsWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
@@ -142,14 +142,9 @@ public class GetDictionariesWindow : Window
 
     private static StackPanel BuildProgress(GetDictionariesViewModel vm)
     {
-        var bar = new ProgressBar
-        {
-            Minimum = 0,
-            Maximum = 100,
-            Height = 8,
-            [!ProgressBar.ValueProperty] = new Binding(nameof(vm.Progress)),
-            [!Visual.OpacityProperty] = new Binding(nameof(vm.ProgressOpacity)),
-        };
+        var bar = UiUtil.MakeProgressBar();
+        bar[!ProgressBar.ValueProperty] = new Binding(nameof(vm.Progress));
+        bar[!Visual.OpacityProperty] = new Binding(nameof(vm.ProgressOpacity));
 
         var status = new TextBlock
         {

--- a/src/ui/Features/Translate/DownloadLlamaCppWindow.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppWindow.cs
@@ -17,7 +17,7 @@ public class DownloadLlamaCppWindow : Window
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = string.Format(Se.Language.General.DownloadingX, "llama.cpp");
         Width = 500;
-        Height = 190;
+        SizeToContent = SizeToContent.Height;
         CanResize = false;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
         DataContext = vm;
@@ -29,31 +29,8 @@ public class DownloadLlamaCppWindow : Window
         };
         titleText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.TitleText)));
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
@@ -75,7 +52,7 @@ public class DownloadLlamaCppWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 errorText,
                 buttonBar,

--- a/src/ui/Features/Video/BlankVideo/BlankVideoWindow.cs
+++ b/src/ui/Features/Video/BlankVideo/BlankVideoWindow.cs
@@ -207,32 +207,9 @@ public class BlankVideoWindow : Window
 
     private static Grid MakeProgressView(BlankVideoViewModel vm)
     {
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
@@ -255,7 +232,7 @@ public class BlankVideoWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
 
         return grid;

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -791,33 +791,10 @@ public class BurnInWindow : Window
 
     private static Grid MakeProgressView(BurnInViewModel vm)
     {
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Margin = new Thickness(0, 0, 5, 0),
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Margin = new Thickness(0, 0, 5, 0);
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
@@ -840,7 +817,7 @@ public class BurnInWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
 
         return grid;

--- a/src/ui/Features/Video/CutVideo/CutVideoWindow.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoWindow.cs
@@ -231,32 +231,9 @@ public class CutVideoWindow : Window
 
     private static Grid MakeProgressView(CutVideoViewModel vm)
     {
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
@@ -279,7 +256,7 @@ public class CutVideoWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
 
         return grid;

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditWindow.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditWindow.cs
@@ -230,32 +230,9 @@ public class EmbeddedSubtitlesEditWindow : Window
 
     private static Grid MakeProgressView(EmbeddedSubtitlesEditViewModel vm)
     {
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
@@ -278,7 +255,7 @@ public class EmbeddedSubtitlesEditWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
 
         return grid;

--- a/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlWindow.cs
+++ b/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlWindow.cs
@@ -38,27 +38,10 @@ public class DownloadVideoFromUrlWindow : Window
             [!TextBlock.TextProperty] = new Binding(nameof(vm.FileNameDisplay)),
         };
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Margin = new Thickness(0, 4, 0, 0),
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters = { new Setter(Thumb.IsVisibleProperty, false) }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters = { new Setter(Track.HeightProperty, 6.0) }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.Progress)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Margin = new Thickness(0, 4, 0, 0);
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.Progress)));
 
         var statusText = new TextBlock { Opacity = 0.85 };
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusText)));
@@ -85,7 +68,7 @@ public class DownloadVideoFromUrlWindow : Window
             {
                 heading,
                 fileName,
-                progressSlider,
+                progressBar,
                 statusText,
                 errorText,
                 buttonBar,

--- a/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
+++ b/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
@@ -156,32 +156,9 @@ public class ReEncodeVideoWindow : Window
 
     private static Grid MakeProgressView(ReEncodeVideoViewModel vm)
     {
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
@@ -204,7 +181,7 @@ public class ReEncodeVideoWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
 
         return grid;

--- a/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
@@ -160,33 +160,9 @@ public class ShotChangesWindow : Window
             }
         };
 
-        var sliderProgress = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 2.0)
-                    }
-                },
-            },
-            [!Slider.ValueProperty] = new Binding(nameof(vm.ProgressValue)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
-            
-        };
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar[!ProgressBar.ValueProperty] = new Binding(nameof(vm.ProgressValue)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged };
         var progressText = UiUtil.MakeLabel().WithBindText(vm, nameof(ShotChangesViewModel.ProgressText)).WithAlignmentCenter().WithMarginTop(14); 
         var gridProgress = new Grid
         {
@@ -201,7 +177,7 @@ public class ShotChangesWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
         };
-        gridProgress.Add(sliderProgress, 0);    
+        gridProgress.Add(progressBar, 0);
         gridProgress.Add(progressText, 0);
 
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 0);

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineWindow.cs
@@ -17,7 +17,7 @@ public class DownloadSpeechToTextEngineWindow : Window
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = Se.Language.Video.AudioToText.DownloadingSpeechToTextEngine;
         Width = 500;
-        Height = 190;
+        SizeToContent = SizeToContent.Height;
         CanResize = false;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
         DataContext = vm;
@@ -30,32 +30,9 @@ public class DownloadSpeechToTextEngineWindow : Window
         };
         titleText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.TitleText)));
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
@@ -70,7 +47,7 @@ public class DownloadSpeechToTextEngineWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
@@ -56,34 +56,10 @@ public class DownloadSpeechToTextModelsWindow : Window
         };
 
 
-        var progressSlider = new Slider
-        {
-            Height = 8,
-            Margin = new Thickness(0, 0, 0, 0),
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Margin = new Thickness(0, 0, 0, 0);
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
         var statusText = new TextBlock
         {
             Margin = new Thickness(0, 1, 0, 1),
@@ -106,7 +82,7 @@ public class DownloadSpeechToTextModelsWindow : Window
             Margin = new Thickness(0, 35, 0, 10),
             Children =
             {
-                progressSlider,
+                progressBar,
                 statusText,
                 fileText,
             }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -213,43 +213,19 @@ public class SpeechToTextWindow : Window
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
         });
 
-        var progressSlider = new Slider()
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Margin = new Thickness(10, 0, 0, 0),
-            Width = double.NaN,
-            Height = 10,
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    },
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 8.0)
-                    },
-                },
-            },
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Margin = new Thickness(10, 0, 0, 0);
+        progressBar.Width = double.NaN;
+        progressBar.VerticalAlignment = VerticalAlignment.Center;
+        progressBar.HorizontalAlignment = HorizontalAlignment.Stretch;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding
         {
             Path = nameof(vm.ProgressValue),
             Mode = BindingMode.OneWay,
             Source = vm,
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
         });
-        progressSlider.Bind(Slider.OpacityProperty, new Binding
+        progressBar.Bind(ProgressBar.OpacityProperty, new Binding
         {
             Path = nameof(vm.ProgressOpacity),
             Mode = BindingMode.OneWay,
@@ -328,7 +304,7 @@ public class SpeechToTextWindow : Window
             VerticalAlignment = VerticalAlignment.Top,
             Children =
             {
-                progressSlider,
+                progressBar,
                 progressText,
                 elapsedTimeText,
                 estimatedTimeText,

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsWindow.cs
@@ -30,32 +30,9 @@ public sealed class DownloadTtsWindow : Window
             [!TextBlock.TextProperty] = new Binding(nameof(vm.TitleText)),
         };
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            MinWidth = 400,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(RangeBase.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
 
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
@@ -70,7 +47,7 @@ public sealed class DownloadTtsWindow : Window
             Children =
             {
                 titleText,
-                progressSlider,
+                progressBar,
                 statusText,
                 buttonBar,
             }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -341,36 +341,13 @@ public class TextToSpeechWindow : Window
             [!Label.ContentProperty] = new Binding(nameof(vm.ProgressText)) { Mode = BindingMode.TwoWay },
         };
 
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Width = double.NaN;
+        progressBar.HorizontalAlignment = HorizontalAlignment.Stretch;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
 
         grid.Add(label, 0, 0);
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
 
         return grid;
     }

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -603,32 +603,9 @@ public class TransparentSubtitlesWindow : Window
 
     private static Grid MakeProgressView(TransparentSubtitlesViewModel vm)
     {
-        var progressSlider = new Slider
-        {
-            Minimum = 0,
-            Maximum = 100,
-            IsHitTestVisible = false,
-            Focusable = false,
-            Styles =
-            {
-                new Style(x => x.OfType<Thumb>())
-                {
-                    Setters =
-                    {
-                        new Setter(Thumb.IsVisibleProperty, false)
-                    }
-                },
-                new Style(x => x.OfType<Track>())
-                {
-                    Setters =
-                    {
-                        new Setter(Track.HeightProperty, 6.0)
-                    }
-                },
-            }
-        };
-        progressSlider.Bind(Slider.ValueProperty, new Binding(nameof(vm.ProgressValue)));
-        progressSlider.Bind(Slider.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+        progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
@@ -651,7 +628,7 @@ public class TransparentSubtitlesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(progressSlider, 0, 0);
+        grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
 
         return grid;

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -205,6 +205,20 @@ public static class UiUtil
         };
     }
 
+    /// <summary>
+    /// Creates the standard progress bar used by download and progress windows.
+    /// </summary>
+    public static ProgressBar MakeProgressBar(double height = 10)
+    {
+        return new ProgressBar
+        {
+            Minimum = 0,
+            Maximum = 100,
+            Height = height,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+    }
+
     public static Button MakeButton(string text, IRelayCommand? command, object? parameter = null)
     {
         var button = new Button


### PR DESCRIPTION
Every download/progress window built its progress bar from a Slider with a hidden thumb and a thin 6px track. Replace that hack with a shared UiUtil.MakeProgressBar() helper - a real ProgressBar at 10px - and use it in all 25 of them plus the Get dictionaries window, for a consistent, less-thin look.

Also fix the Cancel button being clipped off the bottom of the "Download llama.cpp" and "Download speech-to-text engine" windows: both had a fixed Height=190 that a wrapped error message could overflow. Switched them to SizeToContent.Height.