### PR TITLE
Update CrispASR to v0.6.8

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -18,6 +18,7 @@ v5.0.0-beta29 (xth May 2026)
 * Trim long paths in the Reopen menu and tighten menu spacing
 * Use a consistent, thicker progress bar across download and progress windows
 * seconv: reject unknown --encoding values and add --encoding:source
+* Add Crisp ASR Fun-ASR MLT Nano speech-to-text engine - 31 languages with native LID
 * Update CrispASR to v0.6.8 - adds funasr, fun-asr-mlt-nano, and sensevoice (FunAudioLLM) backends; voxcpm2 TTS ~5-10x speedup
 * Update Bulgarian translation - thx jekovcar
 * Update Russian translation - thx jekovcar

--- a/change-log.txt
+++ b/change-log.txt
@@ -18,6 +18,7 @@ v5.0.0-beta29 (xth May 2026)
 * Trim long paths in the Reopen menu and tighten menu spacing
 * Use a consistent, thicker progress bar across download and progress windows
 * seconv: reject unknown --encoding values and add --encoding:source
+* Update CrispASR to v0.6.8 - adds funasr, fun-asr-mlt-nano, and sensevoice (FunAudioLLM) backends; voxcpm2 TTS ~5-10x speedup
 * Update Bulgarian translation - thx jekovcar
 * Update Russian translation - thx jekovcar
 * Update Portuguese (Brazil) translation - thx igorruckert

--- a/src/libse/AudioToText/WhisperChoice.cs
+++ b/src/libse/AudioToText/WhisperChoice.cs
@@ -21,6 +21,7 @@
         public const string CrispAsrQwen3 = "Crisp ASR Qwen3";
         public const string CrispAsrGlm = "Crisp ASR GLM";
         public const string CrispAsrFireRed = "Crisp ASR Fire Red";
+        public const string CrispAsrFunAsrMltNano = "Crisp ASR Fun-ASR MLT Nano";
         public const string CrispAsrGranite = "Crisp ASR Granite";
         public const string CrispAsrOmni = "Crisp ASR Omni";
         public const string CrispAsrKyutai = "Crisp ASR Kyutai";

--- a/src/ui/Assets/SpeechToText/CrispASRFun-ASRMLTNano.txt
+++ b/src/ui/Assets/SpeechToText/CrispASRFun-ASRMLTNano.txt
@@ -1,0 +1,6 @@
+
+🌐 Fun-ASR MLT Nano
+
+Type: Speech-LLM (SANM encoder + Qwen3-0.6B AR decoder)
+Focus: 🎯 Multilingual ASR with native LID, 31 languages
+

--- a/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
+++ b/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
@@ -98,11 +98,25 @@ public static class CrispAsrTranslateDownloadHelper
 
         if (!engine.IsEngineInstalled())
         {
+            // CrispASR no longer ships a CPU build for Windows; ask the user whether to grab the
+            // Vulkan or CUDA archive — the same prompt the speech-to-text and TTS flows use — so
+            // we don't silently download a runtime the machine can't actually use.
+            string variant = "vulkan";
+            if (Configuration.IsRunningOnWindows)
+            {
+                var chosen = await ChooseCrispAsrWindowsVariantAsync(owner);
+                if (chosen == null)
+                {
+                    return null;
+                }
+                variant = chosen;
+            }
+
             var engineVm = await windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
                 owner, vm =>
                 {
                     vm.Engine = engine;
-                    vm.CrispAsrWindowsVariant = "vulkan";
+                    vm.CrispAsrWindowsVariant = variant;
                     vm.StartDownload();
                 });
 
@@ -211,5 +225,47 @@ public static class CrispAsrTranslateDownloadHelper
         await DownloadAsync(owner, windowService, preselectModelName, autoStartModelDownload: !string.IsNullOrEmpty(preselectModelName));
 
         return IsReady(preselectModelName);
+    }
+
+    private static async Task<string?> ChooseCrispAsrWindowsVariantAsync(Window owner)
+    {
+        var answer = await MessageBox.Show(
+            owner,
+            "Download CrispASR?",
+            $"{System.Environment.NewLine}\"{CrispAsrMadladTranslate.StaticName}\" requires downloading the CrispASR engine.{System.Environment.NewLine}{System.Environment.NewLine}Select a version to download:",
+            MessageBoxButtons.Cancel,
+            MessageBoxIcon.Question,
+            "Vulkan",
+            "CUDA");
+
+        if (answer == MessageBoxResult.None || answer == MessageBoxResult.Cancel)
+        {
+            return null;
+        }
+
+        var variant = answer == MessageBoxResult.Custom2 ? "cuda" : "vulkan";
+
+        if (variant == "vulkan" && !VulkanHelper.IsInstalled())
+        {
+            var vulkanAnswer = await MessageBox.Show(
+                owner,
+                "Vulkan SDK may be required",
+                $"The Vulkan version requires the Vulkan SDK to be installed.{System.Environment.NewLine}{System.Environment.NewLine}You can download it from:{System.Environment.NewLine}https://vulkan.lunarg.com/sdk/home{System.Environment.NewLine}{System.Environment.NewLine}Continue with Vulkan download?",
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (vulkanAnswer == MessageBoxResult.No)
+            {
+                UiUtil.OpenUrl("https://vulkan.lunarg.com/sdk/home");
+                return null;
+            }
+
+            if (vulkanAnswer != MessageBoxResult.Yes)
+            {
+                return null;
+            }
+        }
+
+        return variant;
     }
 }

--- a/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
+++ b/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
@@ -102,7 +102,7 @@ public static class CrispAsrTranslateDownloadHelper
                 owner, vm =>
                 {
                     vm.Engine = engine;
-                    vm.CrispAsrWindowsVariant = "cpu";
+                    vm.CrispAsrWindowsVariant = "vulkan";
                     vm.StartDownload();
                 });
 

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -35,7 +35,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
     public ISpeechToTextEngine? Engine { get; internal set; }
 
     /// <summary>
-    /// CrispASR download variant. On Windows: "cpu", "cpu-legacy", "vulkan", or "cuda" (defaults to "vulkan").
+    /// CrispASR download variant. On Windows: "vulkan" or "cuda" (defaults to "vulkan").
     /// On Linux x86_64: "cuda" or null/empty for the default CPU build. Ignored on macOS / Linux ARM64.
     /// </summary>
     public string CrispAsrWindowsVariant { get; set; } = "vulkan";
@@ -176,11 +176,9 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
                                 ? "crispasr-macos"
                                 : CrispAsrWindowsVariant switch
                                 {
-                                    "cuda"       => "crispasr-windows-x86_64-cuda",
-                                    "cpu"        => "crispasr-windows-x86_64-cpu",
-                                    "cpu-legacy" => "crispasr-windows-x86_64-cpu-legacy",
-                                    "vulkan"     => "crispasr-windows-x86_64-vulkan",
-                                    _            => Engine.UnpackSkipFolder,
+                                    "cuda"   => "crispasr-windows-x86_64-cuda",
+                                    "vulkan" => "crispasr-windows-x86_64-vulkan",
+                                    _        => Engine.UnpackSkipFolder,
                                 }
                         : Engine.UnpackSkipFolder;
 
@@ -473,10 +471,8 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
             {
                 _downloadTask = CrispAsrWindowsVariant switch
                 {
-                    "cuda"       => _crispAsrDownloadService.DownloadEngineWindowsCuda(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
-                    "cpu"        => _crispAsrDownloadService.DownloadEngineWindowsCpu(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
-                    "cpu-legacy" => _crispAsrDownloadService.DownloadEngineWindowsCpuLegacy(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
-                    _            => _crispAsrDownloadService.DownloadEngineWindowsVulkan(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    "cuda" => _crispAsrDownloadService.DownloadEngineWindowsCuda(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    _      => _crispAsrDownloadService.DownloadEngineWindowsVulkan(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
                 };
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -131,8 +131,6 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
             {
                 "cuda" => "Windows x64 (CUDA)",
                 "vulkan" => "Windows x64 (Vulkan)",
-                "cpu-legacy" => "Windows x64 (CPU, legacy)",
-                "cpu" => "Windows x64 (CPU)",
                 _ => "Windows x64",
             };
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -24,6 +24,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
             new CrispAsrCanary(),
             new CrispAsrCohere(),
             new CrispAsrFireRed(),
+            new CrispAsrFunAsrMltNano(),
             new CrispAsrGlm(),
             new CrispAsrGranite(),
             new CrispAsrQwen3(),

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrMltNano.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrMltNano.cs
@@ -1,0 +1,157 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+public class CrispAsrFunAsrMltNano : CrispAsrEngineBase
+{
+    public static string StaticName => "Crisp ASR Fun-ASR MLT Nano";
+    public override string Name => StaticName;
+    public override string Choice => WhisperChoice.CrispAsrFunAsrMltNano;
+    public override string BackendName => "fun-asr-mlt-nano";
+    public override string DefaultLanguage => "en";
+    public override bool IncludeLanguage => true;
+    public override string Url => "https://github.com/CrispStrobe/CrispASR";
+
+    public override List<WhisperLanguage> Languages =>
+        new()
+        {
+            new WhisperLanguage("en", "english"),
+            new WhisperLanguage("zh", "chinese"),
+            new WhisperLanguage("yue", "cantonese"),
+            new WhisperLanguage("ja", "japanese"),
+            new WhisperLanguage("ko", "korean"),
+            new WhisperLanguage("vi", "vietnamese"),
+            new WhisperLanguage("th", "thai"),
+            new WhisperLanguage("id", "indonesian"),
+            new WhisperLanguage("ms", "malay"),
+            new WhisperLanguage("tl", "tagalog"),
+            new WhisperLanguage("ar", "arabic"),
+            new WhisperLanguage("hi", "hindi"),
+            new WhisperLanguage("bg", "bulgarian"),
+            new WhisperLanguage("ru", "russian"),
+            new WhisperLanguage("de", "german"),
+            new WhisperLanguage("fr", "french"),
+            new WhisperLanguage("es", "spanish"),
+            new WhisperLanguage("it", "italian"),
+            new WhisperLanguage("pt", "portuguese"),
+            new WhisperLanguage("nl", "dutch"),
+            new WhisperLanguage("pl", "polish"),
+            new WhisperLanguage("cs", "czech"),
+            new WhisperLanguage("ro", "romanian"),
+            new WhisperLanguage("el", "greek"),
+            new WhisperLanguage("fi", "finnish"),
+            new WhisperLanguage("sv", "swedish"),
+            new WhisperLanguage("tr", "turkish"),
+            new WhisperLanguage("fa", "persian"),
+            new WhisperLanguage("da", "danish"),
+            new WhisperLanguage("hu", "hungarian"),
+            new WhisperLanguage("mk", "macedonian"),
+        };
+
+    public override List<WhisperModel> Models =>
+        new()
+        {
+            new WhisperModel
+            {
+                Name = "funasr-mlt-nano-2512-f16.gguf",
+                Size = "1.84 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/funasr-mlt-nano-GGUF/resolve/main/funasr-mlt-nano-2512-f16.gguf",
+                ],
+            },
+        };
+
+    public override string Extension => string.Empty;
+    public override string UnpackSkipFolder => string.Empty;
+
+    public override bool IsEngineInstalled()
+    {
+        var executableFile = GetExecutable();
+        return File.Exists(executableFile);
+    }
+
+    public override string ToString()
+    {
+        return CrispAsrEngine.GetBackendDisplayName(this);
+    }
+
+    public override string GetAndCreateWhisperFolder()
+    {
+        var folder = Se.CrispAsrFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = GetAndCreateWhisperFolder();
+        var modelsFolder = Path.Combine(folder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public override string GetExecutable()
+    {
+        string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+        return fullPath;
+    }
+
+    public override bool IsModelInstalled(WhisperModel model)
+    {
+        var modelFile = GetModelForCmdLine(model.Name);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string GetModelForCmdLine(string modelName)
+    {
+        var modelFileName = Path.Combine(GetAndCreateWhisperModelFolder(null), modelName);
+        return modelFileName;
+    }
+
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        var folder = GetAndCreateWhisperModelFolder(whisperModel);
+        var fileNameOnly = Path.GetFileName(url);
+        var fileName = Path.Combine(folder, fileNameOnly);
+        return fileName;
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "crispasr.exe";
+        }
+
+        return "crispasr";
+    }
+
+    public override bool CanBeDownloaded()
+    {
+        return true;
+    }
+
+    public override string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrFunAsrMltNano;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrFunAsrMltNano = value;
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1879,7 +1879,6 @@ public partial class SpeechToTextViewModel : ObservableObject
                 $"{Environment.NewLine}\"{CrispAsrEngine.StaticName}\" requires downloading the CrispASR engine.{Environment.NewLine}{Environment.NewLine}Select a version to download:",
                 MessageBoxButtons.Cancel,
                 MessageBoxIcon.Question,
-                "CPU",
                 "Vulkan",
                 "CUDA");
 
@@ -1890,20 +1889,9 @@ public partial class SpeechToTextViewModel : ObservableObject
 
             crispVariant = answer switch
             {
-                MessageBoxResult.Custom1 => "cpu",
-                MessageBoxResult.Custom3 => "cuda",
+                MessageBoxResult.Custom2 => "cuda",
                 _ => "vulkan",
             };
-
-            if (crispVariant == "cpu")
-            {
-                var cpuAnswer = await PromptCrispAsrCpuFlavorAsync();
-                if (cpuAnswer == null)
-                {
-                    return;
-                }
-                crispVariant = cpuAnswer;
-            }
 
             if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
             {
@@ -1945,30 +1933,6 @@ public partial class SpeechToTextViewModel : ObservableObject
                 viewModel.CrispAsrWindowsVariant = crispVariant;
                 viewModel.StartDownload();
             });
-    }
-
-    /// <summary>
-    /// Follow-up prompt after the user picks "CPU" in the CrispASR variant selector.
-    /// Returns "cpu" (modern, recommended), "cpu-legacy" (compatibility build for CPUs without AVX2),
-    /// or null when the user cancels.
-    /// </summary>
-    private async Task<string?> PromptCrispAsrCpuFlavorAsync()
-    {
-        var cpuAnswer = await MessageBox.Show(
-            Window!,
-            "CrispASR CPU build",
-            $"{Environment.NewLine}Standard is recommended for most machines.{Environment.NewLine}{Environment.NewLine}Legacy is a fallback for older CPUs without AVX2 support.",
-            MessageBoxButtons.Cancel,
-            MessageBoxIcon.Question,
-            "Standard",
-            "Legacy");
-
-        return cpuAnswer switch
-        {
-            MessageBoxResult.Custom1 => "cpu",
-            MessageBoxResult.Custom2 => "cpu-legacy",
-            _ => null,
-        };
     }
 
     /// <summary>
@@ -2276,7 +2240,6 @@ public partial class SpeechToTextViewModel : ObservableObject
                         $"{Environment.NewLine}\"{engine.Name}\" requires downloading the CrispASR engine.{Environment.NewLine}{Environment.NewLine}Select a version to download:",
                         MessageBoxButtons.Cancel,
                         MessageBoxIcon.Question,
-                        "CPU",
                         "Vulkan",
                         "CUDA");
 
@@ -2287,20 +2250,9 @@ public partial class SpeechToTextViewModel : ObservableObject
 
                     var crispVariant = answer switch
                     {
-                        MessageBoxResult.Custom1 => "cpu",
-                        MessageBoxResult.Custom3 => "cuda",
+                        MessageBoxResult.Custom2 => "cuda",
                         _ => "vulkan",
                     };
-
-                    if (crispVariant == "cpu")
-                    {
-                        var cpuAnswer = await PromptCrispAsrCpuFlavorAsync();
-                        if (cpuAnswer == null)
-                        {
-                            return;
-                        }
-                        crispVariant = cpuAnswer;
-                    }
 
                     if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
                     {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1086,7 +1086,6 @@ public partial class TextToSpeechViewModel : ObservableObject
                 $"{Environment.NewLine}\"Chatterbox TTS\" runs through the CrispASR runtime. Select a build to download:",
                 MessageBoxButtons.Cancel,
                 MessageBoxIcon.Question,
-                "CPU",
                 "Vulkan",
                 "CUDA");
 
@@ -1097,20 +1096,9 @@ public partial class TextToSpeechViewModel : ObservableObject
 
             crispVariant = variantAnswer switch
             {
-                MessageBoxResult.Custom1 => "cpu",
-                MessageBoxResult.Custom3 => "cuda",
+                MessageBoxResult.Custom2 => "cuda",
                 _ => "vulkan",
             };
-
-            if (crispVariant == "cpu")
-            {
-                var cpuAnswer = await PromptCrispAsrCpuFlavorAsync();
-                if (cpuAnswer == null)
-                {
-                    return false;
-                }
-                crispVariant = cpuAnswer;
-            }
 
             if (crispVariant == "vulkan" && !VulkanHelper.IsInstalled())
             {
@@ -1164,30 +1152,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         return await engine.IsInstalled(SelectedRegion) && ChatterboxTtsCpp.IsCrispAsrChatterboxCapable();
-    }
-
-    /// <summary>
-    /// Follow-up prompt after the user picks "CPU" in the CrispASR variant selector.
-    /// Returns "cpu" (modern, recommended), "cpu-legacy" (compatibility build for CPUs without AVX2),
-    /// or null when the user cancels.
-    /// </summary>
-    private async Task<string?> PromptCrispAsrCpuFlavorAsync()
-    {
-        var cpuAnswer = await MessageBox.Show(
-            Window!,
-            "CrispASR CPU build",
-            $"{Environment.NewLine}Standard is recommended for most machines.{Environment.NewLine}{Environment.NewLine}Legacy is a fallback for older CPUs without AVX2 support.",
-            MessageBoxButtons.Cancel,
-            MessageBoxIcon.Question,
-            "Standard",
-            "Legacy");
-
-        return cpuAnswer switch
-        {
-            MessageBoxResult.Custom1 => "cpu",
-            MessageBoxResult.Custom2 => "cpu-legacy",
-            _ => null,
-        };
     }
 
     private async Task MergeAndAddToVideo(TtsStepResult[] fixSpeedResult)

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -46,6 +46,7 @@ public class SeAudioToText
     public string CommandLineParameterCrispAsrCanary { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrCohere { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrFireRed { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrFunAsrMltNano { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrGlm { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrGranite { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrParakeet { get; set; } = "--max-len 50 --split-on-punct";

--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -12,8 +12,6 @@ public interface ICrispAsrDownloadService
     Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadEngineWindowsCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadEngineWindowsVulkan(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
-    Task DownloadEngineWindowsCpu(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
-    Task DownloadEngineWindowsCpuLegacy(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadEngineLinuxCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
 }
 
@@ -21,14 +19,16 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.7/crispasr-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.7/crispasr-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.7/crispasr-windows-x86_64-cpu.zip";
-    private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.7/crispasr-windows-x86_64-cpu-legacy.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.7/crispasr-macos.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.7/crispasr-linux-x86_64.tar.gz";
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.7/crispasr-linux-x86_64-cuda.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.7/crispasr-linux-arm64.tar.gz";
+    // Windows CPU and CPU-legacy builds were dropped upstream after v0.6.7; users on
+    // Windows now pick Vulkan (default) or CUDA. Existing CPU installs from older SE
+    // builds keep working — only the *download* path is gone, detection of an
+    // already-installed CPU build still lives in DownloadHashManager.
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-windows-x86_64-vulkan.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-macos.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-linux-x86_64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-linux-x86_64-cuda.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-linux-arm64.tar.gz";
 
     public CrispAsrDownloadService(HttpClient httpClient)
     {
@@ -48,16 +48,6 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
     public async Task DownloadEngineWindowsVulkan(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         await DownloadHelper.DownloadFileAsync(_httpClient, WindowsVulkanUrl, stream, progress, cancellationToken);
-    }
-
-    public async Task DownloadEngineWindowsCpu(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
-    {
-        await DownloadHelper.DownloadFileAsync(_httpClient, WindowsCpuUrl, stream, progress, cancellationToken);
-    }
-
-    public async Task DownloadEngineWindowsCpuLegacy(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
-    {
-        await DownloadHelper.DownloadFileAsync(_httpClient, WindowsCpuLegacyUrl, stream, progress, cancellationToken);
     }
 
     public async Task DownloadEngineLinuxCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)

--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -20,9 +20,10 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
     private readonly HttpClient _httpClient;
 
     // Windows CPU and CPU-legacy builds were dropped upstream after v0.6.7; users on
-    // Windows now pick Vulkan (default) or CUDA. Existing CPU installs from older SE
-    // builds keep working — only the *download* path is gone, detection of an
-    // already-installed CPU build still lives in DownloadHashManager.
+    // Windows now pick Vulkan (default) or CUDA. Detection of older CPU/CPU-legacy
+    // installs was also removed — DetectCrispAsrWindowsVariant only recognises Vulkan
+    // and CUDA, so a leftover CPU-only crispasr.exe reads as "unknown" and the engine
+    // settings page will prompt the user to re-download as Vulkan or CUDA.
     private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-windows-x86_64-cuda.zip";
     private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-windows-x86_64-vulkan.zip";
     private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.6.8/crispasr-macos.tar.gz";

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -543,7 +543,7 @@ public static class DownloadHashManager
 
     /// <summary>
     /// Resolves the CrispASR hash key for the current OS and variant.
-    /// On Windows the variant selects between cuda/vulkan/cpu/cpu-legacy.
+    /// On Windows the variant selects between cuda and vulkan.
     /// On Linux x86_64 the variant selects between cuda and the default CPU build.
     /// Returns null if the platform / variant combination is unknown.
     /// </summary>

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -33,8 +33,6 @@ public static class DownloadHashManager
         // Hashes of the release archive (.zip / .tar.gz) — used when a sidecar hash exists alongside the install.
         public const string WindowsCuda = "CrispAsr.Windows.Cuda";
         public const string WindowsVulkan = "CrispAsr.Windows.Vulkan";
-        public const string WindowsCpu = "CrispAsr.Windows.Cpu";
-        public const string WindowsCpuLegacy = "CrispAsr.Windows.CpuLegacy";
         public const string MacOs = "CrispAsr.MacOs";
         public const string Linux = "CrispAsr.Linux";
         public const string LinuxCuda = "CrispAsr.Linux.Cuda";
@@ -43,8 +41,6 @@ public static class DownloadHashManager
         // installed version when no sidecar is present (e.g. installs from older SE builds).
         public const string WindowsCudaExecutable = "CrispAsr.Windows.Cuda.Executable";
         public const string WindowsVulkanExecutable = "CrispAsr.Windows.Vulkan.Executable";
-        public const string WindowsCpuExecutable = "CrispAsr.Windows.Cpu.Executable";
-        public const string WindowsCpuLegacyExecutable = "CrispAsr.Windows.CpuLegacy.Executable";
         public const string MacOsExecutable = "CrispAsr.MacOs.Executable";
         public const string LinuxExecutable = "CrispAsr.Linux.Executable";
         public const string LinuxCudaExecutable = "CrispAsr.Linux.Cuda.Executable";
@@ -145,7 +141,8 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispAsr.WindowsCuda] = new[]
             {
-                "43dc3ed70aaac3eec976871905fadbf818d8dc34bc0d7f868d0a6b1622f4c63b", // v0.6.7 (current download URL)
+                "b2a3eb60bd674d8a176b885227783036014193a84e25f597ddf62a06ad363f2d", // v0.6.8 (current download URL)
+                "43dc3ed70aaac3eec976871905fadbf818d8dc34bc0d7f868d0a6b1622f4c63b", // v0.6.7
                 "be610e9a8bb283cc283dc3d0df45b5f110ccb350a13443e9b8e4092345d78596", // v0.6.6
                 "48d279a0d8358dde68d95ccdc6a5ac8e3eb8dd65dc2a400166f33dd072aa7202", // v0.6.2
                 "85f78707ddd072e084d89fef9b0d63c0bd2afe017b72d2f0841ceba8c89a42c7", // v0.6.0
@@ -158,7 +155,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsVulkan] = new[]
             {
-                "95dc640e612cc9cc95266268cc2fd03841f5fa82088a64bddb0c7ff881d7737d", // v0.6.7 (current download URL)
+                "da28d90f1883ea2cb0b08583b00f442a39b3732232f06ea6c9cd96e6c2d24b81", // v0.6.8 (current download URL)
+                "95dc640e612cc9cc95266268cc2fd03841f5fa82088a64bddb0c7ff881d7737d", // v0.6.7
                 "3fda38ec66b75eca1d9145787ace497a4ca56ce2d6c218773f925f458790622d", // v0.6.6
                 "b70420f6f2ed71f7390bc9f3960175ead212f41f03d0509d485902c1b2c8c882", // v0.6.2
                 "1b779c606cf514b543455a3afc72c63046d1423494045feebe5ff5ea414811d9", // v0.6.0
@@ -169,29 +167,10 @@ public static class DownloadHashManager
                 "aadb324d33dea7c28ff703a64403169a0814dc71449f7d635f270e8bc1e0b7c3", // v0.5.3
                 "b7c58fba959f8a7a013e458764cf526a4cf6595d8c6247b8893c37cb8c9dd000", // v0.5.2
             },
-            [CrispAsr.WindowsCpu] = new[]
-            {
-                "621c6e811eeba9873abfe8f01fb2f4c08c7190a14106384b3e11a4b25bc4c86d", // v0.6.7 (current download URL)
-                "05f629c4d022fb8a05a24b16cb155c45ab65e90dc0aa7eed46ae31feccf43de8", // v0.6.6
-                "4b36e5634c1acc7f7387c9bce3b1302e8fbd8441b3e10d37b5d5952064bbc552", // v0.6.2
-                "46fe3bc88966c973eef66b7c2271f95bb40b2b4bf338643e71834186cba0ae3d", // v0.6.0 (first non-legacy CPU build SE has shipped)
-            },
-            [CrispAsr.WindowsCpuLegacy] = new[]
-            {
-                "8a33a0fb0444e95f06ff1a48bb4b48436d6a59bd7c96c6e74db0221a1a215423", // v0.6.7 (current download URL)
-                "d9fd9306246cda7b4b3006441aad8ba755d617b066f6f033358b51c860d28f89", // v0.6.6
-                "eb27d98fc8051d38dca76c0e0fc2a2b1fcbfbbac18267e781dbb2839367b9f18", // v0.6.2
-                "5b59d9268f37c683cc8793322d553121d850163d7a8ac3ca8323a05270b5a999", // v0.6.0
-                "e04be09ca8fb608c54de0d823a6a761adc93a16ab9ff5d4c7025e5515e1759e7", // v0.5.7
-                "e8eddaa4a988be019919c8a0c3fae32680732f4b17ab2ee06a8756200cc4883a", // v0.5.6
-                "c111fe567df600e52754e0eab93d2cd37527623328abe2c4f8dae283ae2ae059", // v0.5.5
-                "bbc6422fb0346dc79a7be41b0800ffd67b42dfe81691084c4bc76c85a1caa985", // v0.5.4
-                "88e62281ce19047e34290680ecab35ea2e24af6fc2b9edd6244234733a228703", // v0.5.3
-                "7faa7c92b4b48a64fb653f13e0e985618d4495d6d05abc366b3fd4b27098e65c", // v0.5.2
-            },
             [CrispAsr.MacOs] = new[]
             {
-                "a2360c4c425345338cf468a19c978cabd61ddd9873d863075e882bb46695abd8", // v0.6.7 (current download URL)
+                "8fa0fc2bd7ff8889de87c5b19bcf24c5882abd1aa9a03b98a980cd944a70c914", // v0.6.8 (current download URL)
+                "a2360c4c425345338cf468a19c978cabd61ddd9873d863075e882bb46695abd8", // v0.6.7
                 "32dab6eb5f2be8150f3f66131dfdd09da5f7a2682ff1e594794bcbf51b5a3c91", // v0.6.6
                 "8d8a882cd4887c521197e03389e1cfad693ccd85a78eb66af24d348e97add41b", // v0.6.2
                 "0594f4d499f4fb78ecb2c8b25287fd61b7708339a501b4eb609cf0c508126fea", // v0.6.0
@@ -204,7 +183,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.Linux] = new[]
             {
-                "54edc828b29ab25217582d906416f07109dfd6d085f9c407521d0411268a9665", // v0.6.7 (current download URL)
+                "da3ea0675168a3c7396858ffe9c483a401e581ae3bb080f8825a5e0cbc8b5589", // v0.6.8 (current download URL)
+                "54edc828b29ab25217582d906416f07109dfd6d085f9c407521d0411268a9665", // v0.6.7
                 "2ac612bada388345c2dd9580353e2401e07924cb3fbe37c0cae6c5564b51068e", // v0.6.6
                 "52a9b6791ef23c73b0448475712611cd97bbd8598ee0101e7f28ff3e8ba5906b", // v0.6.2
                 "f63aba89b6371128d0cd11167e280d1b987853996c4110de9ce48dabe55b20f6", // v0.6.0
@@ -217,14 +197,16 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCuda] = new[]
             {
-                "0e2ebbcb8012285a8c2089c5254d61f8e4e870e3397f220bcd9708ec569f3037", // v0.6.7 (current download URL — first SE-tracked Linux CUDA build)
+                "9a493e0f19421e3b73307a48113dd18c326756dfe751bd3a9bc4bc8d049137d1", // v0.6.8 (current download URL)
+                "0e2ebbcb8012285a8c2089c5254d61f8e4e870e3397f220bcd9708ec569f3037", // v0.6.7 (first SE-tracked Linux CUDA build)
             },
 
             // SHA-256 of crispasr.exe / crispasr extracted from each archive above.
             // Windows CUDA executable hash intentionally omitted (the CUDA archive is ~700 MB; not yet hashed).
             [CrispAsr.WindowsVulkanExecutable] = new[]
             {
-                "137a80127527d4cec89a93616cf94e072b437ed4d674b4a0fe27839be26ab6a0", // v0.6.7 (current download URL)
+                "e0546b739f17b4e5fdbe732801e695006b48c6019247f4fe0b51149163ec9a00", // v0.6.8 (current download URL)
+                "137a80127527d4cec89a93616cf94e072b437ed4d674b4a0fe27839be26ab6a0", // v0.6.7
                 "fc9a592eb6cfa41d74f165e65cabe607712a06d546ba77bc3e3a93823ac9d3f3", // v0.6.6
                 "ac0b6c10d27de1d908759c4cfbbb6062937edac3f712cc51b8c2f5d37e73bcaf", // v0.6.2
                 "9b3354d3b0e5b91fa2cdcc1ce65e880426dea026671038329f44ec994fa52454", // v0.6.0
@@ -235,29 +217,10 @@ public static class DownloadHashManager
                 "6217ae5ff00fac3997225e930576aa9ff58b8708d8a66a86163c2c555bb88ec5", // v0.5.3
                 "112862f031cfc65656e282a61b0b156f8f3037a3d2f606df826fb7ed824d3d92", // v0.5.2
             },
-            [CrispAsr.WindowsCpuExecutable] = new[]
-            {
-                "a528743af75665975bd7d2ca71cdd758fa7fb261b49755a6fdf7f0c113506ec4", // v0.6.7 (current download URL)
-                "69f01b93054cf0c359eaa31f80f6ff06452f52de5306588aa2c743c0a5a6c4f5", // v0.6.6
-                "b63eb3a28ae7da8c0fcb486fa0f460a07ad85ace545359a338fc053bdea69dbf", // v0.6.2
-                "28da4dcf6e72738b408400ebdef00203f8e70dccf392446ecee90a15c971e186", // v0.6.0 (first non-legacy CPU build SE has shipped)
-            },
-            [CrispAsr.WindowsCpuLegacyExecutable] = new[]
-            {
-                "d049f9da2d5599e308cb3a6432f64271c46e8acd4989556e7b9b730c55508f64", // v0.6.7 (current download URL)
-                "352483e379cdeff5d42d2cd4f95c3c41f73f451986b26ee7a65843281cf4153c", // v0.6.6
-                "089c35a3775292e3d13c200c00612d9c26709e1007f78e0139dca1466b9d644e", // v0.6.2
-                "a399e96790cd170c95c354f152f88e9cd1dc44b4a6becb4f5eb2b7f203d8a184", // v0.6.0
-                "44c6865ac7795c6e09b65a516b0111b9fd77e72758ab25d1e1768bbb75a3a0c8", // v0.5.7
-                "f4dbf3f11245632c8f56872e1f8a56185d336c17a858fe97876fb12e76bbe2e1", // v0.5.6
-                "057e7c642f2da1cf5ddb84ddac8d740234d8b84ddf33dadcb2bae91c06692956", // v0.5.5
-                "07ae4e499abb68fd64987a617c69aa0a007753eb9409d379229a5a871584025f", // v0.5.4
-                "e05962d3fb38336f340150b285aa6c78c31fbb7c63791748934e30d9aac81a25", // v0.5.3
-                "07f8e26b7068f9af0ebe0fe2fe4d4335c9f5c2719e753620655ba9a0961a6fdc", // v0.5.2
-            },
             [CrispAsr.LinuxExecutable] = new[]
             {
-                "425bbf26de4e6f742cb191c08eef1676a167c11a8f46cc47942b50551f929d32", // v0.6.7 (current download URL)
+                "6d2ae10f068cd152f2f0d49cb4de0fca39d7085a9b71e0ef2f514ded06e47627", // v0.6.8 (current download URL)
+                "425bbf26de4e6f742cb191c08eef1676a167c11a8f46cc47942b50551f929d32", // v0.6.7
                 "31e955f45739471c5d1464d8e8c484704124715e13c944c27b6d47db6857ef06", // v0.6.6
                 "32f23c42260c0f315b51818c674505b4e7c619af1b17d13f07ccad9a76a4aed0", // v0.6.2
                 "ddc28fde90714947947f88867f45661d1e2a4a8ef578f1c2dd0c368acc2a4a44", // v0.6.0
@@ -270,7 +233,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOsExecutable] = new[]
             {
-                "7d2edd77f31882885a41956fb7c5d8e8345c5532361c98180af26cea1a2ae1b6", // v0.6.7 (current download URL)
+                "552421500735de8ccf15565e8e2bf5556c5ceb7b2f6c41609e3f91ce1f138a03", // v0.6.8 (current download URL)
+                "7d2edd77f31882885a41956fb7c5d8e8345c5532361c98180af26cea1a2ae1b6", // v0.6.7
                 "abfb92985fed2b69e25473b7dd6a39b637f7e3025d7b379077a762d7cf8df8de", // v0.6.6
                 "fc60809052f50622663ae4912088f9f547023e4b6d528e902aa0e1a6619fe387", // v0.6.2
                 "63b6a4197e74f5ddbd873f7db1e9e962fddd4a35b0fbc42eb7c898b5c9c1d964", // v0.6.0
@@ -283,7 +247,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCudaExecutable] = new[]
             {
-                "6af1d3dace190fd7047ce90634764c80bf2fb6d64094e2a5821afe8e0c74bb65", // v0.6.7 (current download URL — first SE-tracked Linux CUDA build)
+                "363864a0f41e7f61a930c8f070e1b1357dc9b86063f747b719651890b446d0a7", // v0.6.8 (current download URL)
+                "6af1d3dace190fd7047ce90634764c80bf2fb6d64094e2a5821afe8e0c74bb65", // v0.6.7 (first SE-tracked Linux CUDA build)
             },
 
             // llama.cpp — https://github.com/ggml-org/llama.cpp/releases
@@ -603,8 +568,6 @@ public static class DownloadHashManager
             return variant switch
             {
                 "cuda" => CrispAsr.WindowsCuda,
-                "cpu" => CrispAsr.WindowsCpu,
-                "cpu-legacy" => CrispAsr.WindowsCpuLegacy,
                 "vulkan" => CrispAsr.WindowsVulkan,
                 _ => null,
             };
@@ -615,7 +578,7 @@ public static class DownloadHashManager
 
     /// <summary>
     /// Reverse of <see cref="ResolveCrispAsrKey"/> — returns the variant string matching the
-    /// given hash key. For Windows: "cuda" / "vulkan" / "cpu" / "cpu-legacy". For Linux x86_64:
+    /// given hash key. For Windows: "cuda" / "vulkan". For Linux x86_64:
     /// "cuda" for the CUDA build, empty string for the default CPU build. Returns null otherwise.
     /// </summary>
     public static string? GetCrispAsrVariant(string key)
@@ -624,8 +587,6 @@ public static class DownloadHashManager
         {
             CrispAsr.WindowsCuda or CrispAsr.WindowsCudaExecutable => "cuda",
             CrispAsr.WindowsVulkan or CrispAsr.WindowsVulkanExecutable => "vulkan",
-            CrispAsr.WindowsCpu or CrispAsr.WindowsCpuExecutable => "cpu",
-            CrispAsr.WindowsCpuLegacy or CrispAsr.WindowsCpuLegacyExecutable => "cpu-legacy",
             CrispAsr.LinuxCuda or CrispAsr.LinuxCudaExecutable => "cuda",
             CrispAsr.Linux or CrispAsr.LinuxExecutable => string.Empty,
             _ => null,
@@ -642,8 +603,6 @@ public static class DownloadHashManager
         {
             CrispAsr.WindowsCuda or CrispAsr.WindowsCudaExecutable => "cuda",
             CrispAsr.WindowsVulkan or CrispAsr.WindowsVulkanExecutable => "vulkan",
-            CrispAsr.WindowsCpu or CrispAsr.WindowsCpuExecutable => "cpu",
-            CrispAsr.WindowsCpuLegacy or CrispAsr.WindowsCpuLegacyExecutable => "cpu-legacy",
             _ => null,
         };
     }
@@ -673,8 +632,6 @@ public static class DownloadHashManager
             return variant switch
             {
                 "cuda" => CrispAsr.WindowsCudaExecutable,
-                "cpu" => CrispAsr.WindowsCpuExecutable,
-                "cpu-legacy" => CrispAsr.WindowsCpuLegacyExecutable,
                 "vulkan" => CrispAsr.WindowsVulkanExecutable,
                 _ => null,
             };
@@ -685,11 +642,8 @@ public static class DownloadHashManager
 
     /// <summary>
     /// Detects which Windows CrispASR variant is installed.
-    /// Returns "cuda" / "vulkan" / "cpu" / "cpu-legacy", or null if the folder doesn't look like a CrispASR install.
-    /// CUDA and Vulkan are identified by their backend DLLs. CPU vs CPU-legacy share an identical layout
-    /// (only crispasr.exe at the top level), so we disambiguate from the .installed.sha256 sidecar
-    /// recorded at install time, falling back to hashing crispasr.exe against the known CPU-legacy set.
-    /// Unknown CPU EXE hashes default to "cpu" (the modern build).
+    /// Returns "cuda" / "vulkan", or null if the folder doesn't look like a CrispASR install.
+    /// CUDA and Vulkan are identified by their backend DLLs.
     /// </summary>
     public static string? DetectCrispAsrWindowsVariant(string installFolder)
     {
@@ -708,37 +662,7 @@ public static class DownloadHashManager
             return "vulkan";
         }
 
-        var exe = Path.Combine(installFolder, "crispasr.exe");
-        if (!File.Exists(exe))
-        {
-            return null;
-        }
-
-        var sidecarKey = TryReadInstalledKey(installFolder);
-        if (sidecarKey == CrispAsr.WindowsCpuLegacy)
-        {
-            return "cpu-legacy";
-        }
-        if (sidecarKey == CrispAsr.WindowsCpu)
-        {
-            return "cpu";
-        }
-
-        // No usable sidecar — match the EXE against known CPU-legacy hashes so older
-        // installs (made before the sidecar existed) are still recognised as legacy.
-        var exeHash = ComputeSha256(exe);
-        if (exeHash != null)
-        {
-            foreach (var legacy in GetKnownHashes(CrispAsr.WindowsCpuLegacyExecutable))
-            {
-                if (legacy.Equals(exeHash, StringComparison.OrdinalIgnoreCase))
-                {
-                    return "cpu-legacy";
-                }
-            }
-        }
-
-        return "cpu";
+        return null;
     }
 
     /// <summary>

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -156,6 +156,9 @@
 		<AvaloniaResource Include="Assets\SpeechToText\CrispASRFireRed.txt">
 		  <CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>
+		<AvaloniaResource Include="Assets\SpeechToText\CrispASRFun-ASRMLTNano.txt">
+		  <CopyToOutputDirectory></CopyToOutputDirectory>
+		</AvaloniaResource>
 		<AvaloniaResource Include="Assets\SpeechToText\CrispASRGLM.txt">
 		  <CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>


### PR DESCRIPTION
## Summary
- Bump CrispASR download URLs to [v0.6.8](https://github.com/CrispStrobe/CrispASR/releases/tag/v0.6.8) (CUDA / Vulkan on Windows; CPU / CUDA on Linux x86_64; default Linux ARM64 and macOS).
- Drop the Windows CPU and CPU-Legacy variants entirely — upstream stopped shipping those zips after v0.6.7. Removes the related URLs, hash arrays, key constants, detection branches, and engine-settings labels.
- Madlad auto-translate now defaults to the Vulkan download instead of CPU.

v0.6.8 highlights: three new ASR backends (`funasr`, `fun-asr-mlt-nano`, `sensevoice`), ~5-10× faster voxcpm2 TTS, and several parakeet-ja chunking regressions fixed. No new archive types vs v0.6.7.

## Test plan
- [ ] Windows: re-download CrispASR — prompt now offers only Vulkan / CUDA, hashes match v0.6.8
- [ ] Linux x86_64: CPU and CUDA downloads work and detect correctly in Engine Settings
- [ ] macOS: download works
- [ ] Madlad auto-translate engine downloads with the Vulkan build on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)