### PR TITLE
Fix Alt+O/Alt+C/Alt+D shortcuts on standard buttons

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -25,7 +25,7 @@ v5.0.0-beta29 (xth May 2026)
 * Fix Edge TTS crash on bad rate format and retry transient failures - thx KevinHa59
 * Fix shortcut window not receiving focus
 * Fix Cancel button being clipped in the llama.cpp and speech-to-text engine download windows
-* Fix Alt+O / Alt+C / Alt+D shortcuts not firing standard OK / Cancel / Done buttons - thx LurkingNinja
+* Fix Alt-key access shortcuts not firing on buttons - underscore in label now drives the access key - thx LurkingNinja
 
 -----------------------------------------------------------------------------------------------------
 

--- a/change-log.txt
+++ b/change-log.txt
@@ -25,6 +25,7 @@ v5.0.0-beta29 (xth May 2026)
 * Fix Edge TTS crash on bad rate format and retry transient failures - thx KevinHa59
 * Fix shortcut window not receiving focus
 * Fix Cancel button being clipped in the llama.cpp and speech-to-text engine download windows
+* Fix Alt+O / Alt+C / Alt+D shortcuts not firing standard OK / Cancel / Done buttons - thx LurkingNinja
 
 -----------------------------------------------------------------------------------------------------
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -835,7 +835,7 @@ public class LanguageGeneral
         Dictionary = "Dictionary";
         DiskSpace = "Disk space";
         DoNoChange = "Do not change";
-        Done = "Done";
+        Done = "_Done";
         DoubleWords = "Double words";
         DoubleLines = "Double lines";
         Download = "Download";

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -279,13 +279,11 @@ public static class UiUtil
         var upper = char.ToUpperInvariant(c);
         if (upper >= 'A' && upper <= 'Z')
         {
-            key = (Key)((int)Key.A + (upper - 'A'));
-            return true;
+            return Enum.TryParse(upper.ToString(), out key);
         }
         if (upper >= '0' && upper <= '9')
         {
-            key = (Key)((int)Key.D0 + (upper - '0'));
-            return true;
+            return Enum.TryParse("D" + upper, out key);
         }
         key = Key.None;
         return false;

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -221,9 +221,11 @@ public static class UiUtil
 
     public static Button MakeButton(string text, IRelayCommand? command, object? parameter = null)
     {
+        var (displayText, accessKey) = ParseAccessKey(text);
+
         var button = new Button
         {
-            Content = text,
+            Content = displayText,
             Margin = new Thickness(4, 0),
             Padding = new Thickness(12, 6),
             MinWidth = 80,
@@ -232,8 +234,13 @@ public static class UiUtil
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = command,
-            CommandParameter = parameter
+            CommandParameter = parameter,
         };
+
+        if (accessKey.HasValue)
+        {
+            button.HotKey = new KeyGesture(accessKey.Value, KeyModifiers.Alt);
+        }
 
         if (Se.Settings.Appearance.UseFocusedButtonBackgroundColor)
         {
@@ -244,6 +251,44 @@ public static class UiUtil
         }
 
         return button;
+    }
+
+    // Parses a single `_` access-key marker out of a button label and returns the visible text plus
+    // the matching Avalonia Key. Mirrors the WinForms `&` convention used in the language files
+    // (e.g. "_OK" → display "OK", Alt+O; "C_ancel" → display "Cancel", Alt+A).
+    private static (string Display, Key? AccessKey) ParseAccessKey(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return (text ?? string.Empty, null);
+        }
+
+        var idx = text.IndexOf('_');
+        if (idx < 0 || idx + 1 >= text.Length)
+        {
+            return (text, null);
+        }
+
+        var accessChar = text[idx + 1];
+        var display = text.Remove(idx, 1);
+        return TryGetAccessKey(accessChar, out var key) ? (display, key) : (display, null);
+    }
+
+    private static bool TryGetAccessKey(char c, out Key key)
+    {
+        var upper = char.ToUpperInvariant(c);
+        if (upper >= 'A' && upper <= 'Z')
+        {
+            key = (Key)((int)Key.A + (upper - 'A'));
+            return true;
+        }
+        if (upper >= '0' && upper <= '9')
+        {
+            key = (Key)((int)Key.D0 + (upper - '0'));
+            return true;
+        }
+        key = Key.None;
+        return false;
     }
 
     public static Button MakeBrowseButton(IRelayCommand? command)
@@ -263,23 +308,17 @@ public static class UiUtil
 
     public static Button MakeButtonOk(IRelayCommand? command)
     {
-        var button = MakeButton(Se.Language.General.Ok, command);
-        button.HotKey = new KeyGesture(Key.O, KeyModifiers.Alt);
-        return button;
+        return MakeButton(Se.Language.General.Ok, command);
     }
 
     public static Button MakeButtonDone(IRelayCommand? command)
     {
-        var button = MakeButton(Se.Language.General.Done, command);
-        button.HotKey = new KeyGesture(Key.D, KeyModifiers.Alt);
-        return button;
+        return MakeButton(Se.Language.General.Done, command);
     }
 
     public static Button MakeButtonCancel(IRelayCommand? command)
     {
-        var button = MakeButton(Se.Language.General.Cancel, command);
-        button.HotKey = new KeyGesture(Key.C, KeyModifiers.Alt);
-        return button;
+        return MakeButton(Se.Language.General.Cancel, command);
     }
 
     public static Button MakeButton(IRelayCommand? command, string iconName)

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -263,17 +263,23 @@ public static class UiUtil
 
     public static Button MakeButtonOk(IRelayCommand? command)
     {
-        return MakeButton(Se.Language.General.Ok, command);
+        var button = MakeButton(Se.Language.General.Ok, command);
+        button.HotKey = new KeyGesture(Key.O, KeyModifiers.Alt);
+        return button;
     }
 
     public static Button MakeButtonDone(IRelayCommand? command)
     {
-        return MakeButton(Se.Language.General.Done, command);
+        var button = MakeButton(Se.Language.General.Done, command);
+        button.HotKey = new KeyGesture(Key.D, KeyModifiers.Alt);
+        return button;
     }
 
     public static Button MakeButtonCancel(IRelayCommand? command)
     {
-        return MakeButton(Se.Language.General.Cancel, command);
+        var button = MakeButton(Se.Language.General.Cancel, command);
+        button.HotKey = new KeyGesture(Key.C, KeyModifiers.Alt);
+        return button;
     }
 
     public static Button MakeButton(IRelayCommand? command, string iconName)


### PR DESCRIPTION
Fixes #11065.

## Summary
Avalonia button mnemonics were not wired up — buttons created via `UiUtil.MakeButtonOk/Cancel/Done` (and the generic `MakeButton`) just had `Content = "OK"` with no `AccessText` and no `HotKey`, so Alt+letter never fired (most visibly on the OCR window, where no menu absorbs the Alt). The fix:

- `MakeButton` now parses a single `_` access-key marker out of the label text — the next character becomes the Alt access key, and the `_` is stripped from the displayed label. This mirrors the WinForms `&` convention.
- `MakeButtonOk` / `MakeButtonCancel` / `MakeButtonDone` no longer hardcode keys — they inherit parsing from the labels already declared in the language files.
- Added `_` to the C# fallback for `Done` (was `"Done"`, now `"_Done"`).

With the bundled English defaults:
- `_OK` → Alt+O fires the OK button
- `C_ancel` → Alt+A fires the Cancel button (matches the existing English convention in the language file; not Alt+C as my initial commit suggested)
- `_Done` → Alt+D fires the Done button

Localization works correctly: e.g. Spanish `_Aceptar` → Alt+A, German `Abb_rechen` → Alt+R, depending on where translators place the `_`.

## Note on bundled language JSONs
The runtime first reads strings from `src/ui/Assets/Languages/*.json`, falling back to the `LanguageGeneral.cs` defaults only if a key is missing. So this PR makes the parsing work, but for translations that already ship in those JSON files, the `_` would need to be added there in a follow-up for the access key to be active for users on those translations. Out of scope for this PR.

## Test plan
- [ ] Open an image-based subtitle, run OCR, press Alt+O without clicking anywhere → window closes via OK
- [ ] Press Alt+A → window cancels (English)
- [ ] Spot-check Settings, Engine Settings, and a couple of other dialogs to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)