### PR TITLE
Add 8px gap below the progress bar in two download windows

### DIFF
--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
@@ -149,7 +149,7 @@ public class GetDictionariesWindow : Window
         var status = new TextBlock
         {
             HorizontalAlignment = HorizontalAlignment.Center,
-            Margin = new Thickness(0, 4, 0, 0),
+            Margin = new Thickness(0, 8, 0, 0),
             [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusText)),
         };
 

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
@@ -57,7 +57,7 @@ public class DownloadSpeechToTextModelsWindow : Window
 
 
         var progressBar = UiUtil.MakeProgressBar();
-        progressBar.Margin = new Thickness(0, 0, 0, 0);
+        progressBar.Margin = new Thickness(0, 0, 0, 8);
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
         progressBar.Bind(ProgressBar.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
         var statusText = new TextBlock


### PR DESCRIPTION
## Summary
The speech-to-text model download window and the Get-Dictionaries window kept their progress bar visually flush against the status line below it — the surrounding StackPanel had no `Spacing` and the next element only added a 1-4 px top margin. Other download dialogs already get 8 px of breathing room from `StackPanel.Spacing = 8`.

- `DownloadSpeechToTextModelsWindow` — progress bar bottom margin `0 → 8`
- `GetDictionariesWindow` — status TextBlock top margin `4 → 8`

## Test plan
- [ ] Open Video → Audio to text → pick an engine that triggers the model download window, start a model download → progress bar has a visible gap to the status text
- [ ] Open Spell check → Get dictionaries, start a download → same gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)