### PR TITLE
Add snap-to-frames option for waveform drag

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1114,6 +1114,8 @@ public class AudioVisualizer : Control
                     newStart = 0;
                 }
 
+                newStart = SnapToFrame(newStart);
+
                 if (_activeParagraph != null)
                 {
                     _activeParagraph.StartTime = TimeSpan.FromSeconds(newStart);
@@ -1123,6 +1125,9 @@ public class AudioVisualizer : Control
             case InteractionMode.ResizeLeftAnd:
                 newStart = _originalStartSeconds + deltaSeconds - StartPositionSeconds;
                 var newPrevEnd = _originalPreviousEndSeconds + deltaSeconds - StartPositionSeconds;
+                var snappedLeft = SnapToFrame(newStart);
+                newPrevEnd += snappedLeft - newStart;
+                newStart = snappedLeft;
                 if (_activeParagraphPrevious != null)
                 {
                     _activeParagraph.SetStartTimeOnly(TimeSpan.FromSeconds(newStart));
@@ -1133,6 +1138,9 @@ public class AudioVisualizer : Control
             case InteractionMode.ResizeRightAnd:
                 newEnd = _originalEndSeconds + deltaSeconds - StartPositionSeconds;
                 var newNextStart = _originalNextStartSeconds + deltaSeconds - StartPositionSeconds;
+                var snappedRight = SnapToFrame(newEnd);
+                newNextStart += snappedRight - newEnd;
+                newEnd = snappedRight;
                 if (_activeParagraphNext != null)
                 {
                     _activeParagraph.EndTime = TimeSpan.FromSeconds(newEnd);
@@ -1148,6 +1156,7 @@ public class AudioVisualizer : Control
                     newStart = 0;
                 }
 
+                var snappedToShotLeft = false;
                 if (SnapToShotChanges)
                 {
                     var nearestShotChange = ShotChangesHelper.GetClosestShotChange(_shotChanges, TimeCode.FromSeconds(newStart));
@@ -1157,8 +1166,14 @@ public class AudioVisualizer : Control
                         if (nearest != newStart && Math.Abs(newStart - nearest) < ShotChangeSnapSeconds)
                         {
                             newStart = nearest;
+                            snappedToShotLeft = true;
                         }
                     }
+                }
+
+                if (!snappedToShotLeft)
+                {
+                    newStart = SnapToFrame(newStart);
                 }
 
                 if (previous != null && newStart < previous.EndTime.TotalSeconds + MinGapSeconds)
@@ -1175,6 +1190,7 @@ public class AudioVisualizer : Control
             case InteractionMode.ResizingRight:
                 newEnd = _originalEndSeconds + deltaSeconds - StartPositionSeconds;
 
+                var snappedToShotRight = false;
                 if (SnapToShotChanges)
                 {
                     var oneFrameSeconds = 0; // Or should it be one frame before, like  0.042 (Get fps from video)
@@ -1185,8 +1201,14 @@ public class AudioVisualizer : Control
                         if (nearest != newEnd && Math.Abs(newEnd - nearest + oneFrameSeconds) < ShotChangeSnapSeconds)
                         {
                             newEnd = nearest - oneFrameSeconds;
+                            snappedToShotRight = true;
                         }
                     }
+                }
+
+                if (!snappedToShotRight)
+                {
+                    newEnd = SnapToFrame(newEnd);
                 }
 
                 if (next != null && newEnd > next.StartTime.TotalSeconds - MinGapSeconds)
@@ -1203,6 +1225,23 @@ public class AudioVisualizer : Control
         }
 
         InvalidateVisual();
+    }
+
+    private static double SnapToFrame(double seconds)
+    {
+        if (!Se.Settings.Waveform.SnapToFrames)
+        {
+            return seconds;
+        }
+
+        var fps = Se.Settings.General.CurrentFrameRate;
+        if (fps < 1)
+        {
+            return seconds;
+        }
+
+        var frameDur = 1.0 / fps;
+        return Math.Round(seconds / frameDur) * frameDur;
     }
 
     private void UpdateCursor(Point point)

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1082,6 +1082,8 @@ public class AudioVisualizer : Control
                 // (previous and next are already null if _isShiftDown or Se.Settings.Waveform.AllowOverlap)
                 bool allowOverlap = (previous == null && next == null) || alreadyOverlapping;
 
+                newStart = SnapToFrame(newStart);
+
                 if (!allowOverlap && (previous != null || next != null))
                 {
                     // Calculate available space considering MinGapSeconds
@@ -1096,15 +1098,15 @@ public class AudioVisualizer : Control
                         break;
                     }
 
-                    // Clamp to available space to prevent overlap
+                    // Clamp to available space to prevent overlap (frame-aligned when snap is on)
                     if (newStart < availableStart)
                     {
-                        newStart = availableStart;
+                        newStart = SnapToFrameCeil(availableStart);
                     }
 
-                    if (newEnd > availableEnd)
+                    if (newStart + _originalDurationSeconds > availableEnd)
                     {
-                        newStart = availableEnd - _originalDurationSeconds;
+                        newStart = SnapToFrameFloor(availableEnd - _originalDurationSeconds);
                     }
                 }
 
@@ -1113,8 +1115,6 @@ public class AudioVisualizer : Control
                 {
                     newStart = 0;
                 }
-
-                newStart = SnapToFrame(newStart);
 
                 if (_activeParagraph != null)
                 {
@@ -1179,6 +1179,7 @@ public class AudioVisualizer : Control
                 if (previous != null && newStart < previous.EndTime.TotalSeconds + MinGapSeconds)
                 {
                     newStart = previous.EndTime.TotalSeconds + MinGapSeconds + 0.001;
+                    newStart = SnapToFrameCeil(newStart);
                 }
 
                 if (newStart < _activeParagraph.EndTime.TotalSeconds - 0.1)
@@ -1214,6 +1215,7 @@ public class AudioVisualizer : Control
                 if (next != null && newEnd > next.StartTime.TotalSeconds - MinGapSeconds)
                 {
                     newEnd = next.StartTime.TotalSeconds - 0.001 - MinGapSeconds;
+                    newEnd = SnapToFrameFloor(newEnd);
                 }
 
                 if (newEnd > _activeParagraph.StartTime.TotalSeconds + 0.1)
@@ -1229,19 +1231,50 @@ public class AudioVisualizer : Control
 
     private static double SnapToFrame(double seconds)
     {
-        if (!Se.Settings.Waveform.SnapToFrames)
+        if (!TryGetFrameDuration(out var frameDur))
         {
             return seconds;
+        }
+
+        return Math.Round(seconds / frameDur, MidpointRounding.AwayFromZero) * frameDur;
+    }
+
+    private static double SnapToFrameCeil(double seconds)
+    {
+        if (!TryGetFrameDuration(out var frameDur))
+        {
+            return seconds;
+        }
+
+        return Math.Ceiling(seconds / frameDur) * frameDur;
+    }
+
+    private static double SnapToFrameFloor(double seconds)
+    {
+        if (!TryGetFrameDuration(out var frameDur))
+        {
+            return seconds;
+        }
+
+        return Math.Floor(seconds / frameDur) * frameDur;
+    }
+
+    private static bool TryGetFrameDuration(out double frameDur)
+    {
+        frameDur = 0;
+        if (!Se.Settings.Waveform.SnapToFrames)
+        {
+            return false;
         }
 
         var fps = Se.Settings.General.CurrentFrameRate;
         if (fps < 1)
         {
-            return seconds;
+            return false;
         }
 
-        var frameDur = 1.0 / fps;
-        return Math.Round(seconds / frameDur) * frameDur;
+        frameDur = 1.0 / fps;
+        return true;
     }
 
     private void UpdateCursor(Point point)

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -480,6 +480,7 @@ public class SettingsPage : UserControl
 
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformRightClickSelectsSubtitle, nameof(_vm.WaveformRightClickSelectsSubtitle)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformSnapToShotChanges, nameof(_vm.WaveformSnapToShotChanges)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.WaveformSnapToFrames, nameof(_vm.WaveformSnapToFrames)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformShotChangesAutoGenerate, nameof(_vm.WaveformShotChangesAutoGenerate)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformFocusOnMouseOver, nameof(_vm.WaveformFocusOnMouseOver)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformFocusTextboxAfterInsertNew, nameof(_vm.WaveformFocusTextboxAfterInsertNew)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -213,6 +213,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private Color _waveformFancyHighColor;
     [ObservableProperty] private bool _waveformInvertMouseWheel;
     [ObservableProperty] private bool _waveformSnapToShotChanges;
+    [ObservableProperty] private bool _waveformSnapToFrames;
     [ObservableProperty] private bool _waveformShotChangesAutoGenerate;
     [ObservableProperty] private bool _waveformAllowOverlap;
 
@@ -747,6 +748,7 @@ public partial class SettingsViewModel : ObservableObject
         WaveformFancyHighColor = Se.Settings.Waveform.WaveformFancyHighColor.FromHexToColor();
         WaveformInvertMouseWheel = Se.Settings.Waveform.InvertMouseWheel;
         WaveformSnapToShotChanges = Se.Settings.Waveform.SnapToShotChanges;
+        WaveformSnapToFrames = Se.Settings.Waveform.SnapToFrames;
         WaveformShotChangesAutoGenerate = Se.Settings.Waveform.ShotChangesAutoGenerate;
         WaveformAllowOverlap = Se.Settings.Waveform.AllowOverlap;
 
@@ -1337,6 +1339,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Waveform.WaveformFancyHighColor = WaveformFancyHighColor.FromColorToHex();
         Se.Settings.Waveform.InvertMouseWheel = WaveformInvertMouseWheel;
         Se.Settings.Waveform.SnapToShotChanges = WaveformSnapToShotChanges;
+        Se.Settings.Waveform.SnapToFrames = WaveformSnapToFrames;
         Se.Settings.Waveform.ShotChangesAutoGenerate = WaveformShotChangesAutoGenerate;
         Se.Settings.Waveform.AllowOverlap = WaveformAllowOverlap;
 

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -138,6 +138,7 @@ public class LanguageSettings
     public string WaveformFocusTextboxAfterInsertNew { get; set; }
     public string WaveformInvertMouseWheel { get; set; }
     public string WaveformSnapToShotChanges { get; set; }
+    public string WaveformSnapToFrames { get; set; }
     public string WaveformShotChangesAutoGenerate { get; set; }
     public string WaveformTextFontSize { get; set; }
     public string WaveformTextFontBold { get; set; }
@@ -428,6 +429,7 @@ public class LanguageSettings
         WaveformFocusTextboxAfterInsertNew = "Focus text box after insert";
         WaveformInvertMouseWheel = "Invert mouse-wheel";
         WaveformSnapToShotChanges = "Snap to shot changes";
+        WaveformSnapToFrames = "Snap to frames";
         WaveformShotChangesAutoGenerate = "Shot changes auto-generate";
         WaveformTextFontSize = "Waveform text font size";
         WaveformTextFontBold = "Waveform text font bold";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -31,6 +31,7 @@ public class SeWaveform
     public double ShotChangesSensitivity { get; set; }
     public string ShotChangesImportTimeCodeFormat { get; set; }
     public bool SnapToShotChanges { get; set; }
+    public bool SnapToFrames { get; set; }
     public bool ShotChangesAutoGenerate { get; set; }
     public int SnapToShotChangesPixels { get; set; }
     public bool FocusOnMouseOver { get; set; }
@@ -76,6 +77,7 @@ public class SeWaveform
         ShotChangesImportTimeCodeFormat = "Seconds";
         SnapToShotChangesPixels = 8;
         SnapToShotChanges = true;
+        SnapToFrames = false;
         ShotChangesAutoGenerate = false;
 
         SpectrogramStyle = nameof(SeSpectrogramStyle.Classic);


### PR DESCRIPTION
## Summary
- Adds a "Snap to frames" toggle under Options > Settings > Waveform/Spectrogram
- When enabled, dragging a paragraph edge (or whole paragraph) in the waveform snaps to the nearest video frame
- Uses the normalized frame rate (`_mediaInfo.FramesRate` → `Se.Settings.General.CurrentFrameRate`)
- Shot-change snap still wins where both could apply
- Disabled by default

Fixes #11075

## Test plan
- [ ] Load a video with a known fps (e.g. 25 or 23.976)
- [ ] Open Options > Settings > Waveform/Spectrogram and enable "Snap to frames"
- [ ] Drag the left edge of a paragraph in the waveform — start time should land on an integer-frame offset
- [ ] Drag the right edge — end time should land on an integer-frame offset
- [ ] Drag the whole paragraph (middle) — start should land on an integer-frame offset
- [ ] Disable the toggle and verify drag is free again
- [ ] With both "Snap to shot changes" and "Snap to frames" enabled, dragging near a shot change should still snap to the shot change

🤖 Generated with [Claude Code](https://claude.com/claude-code)