### PR TITLE
Show install-status dot in TTS/STT/translate engine and model combos

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -217,7 +217,8 @@ public class AutoTranslateWindow : Window
     {
         if (string.IsNullOrEmpty(model.Model.Url))
         {
-            return string.IsNullOrEmpty(model.Model.Size) ? "custom" : $"custom, {model.Model.Size}";
+            var custom = Se.Language.General.Custom;
+            return string.IsNullOrEmpty(model.Model.Size) ? custom : $"{custom}, {model.Model.Size}";
         }
 
         return string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size;

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -5,8 +5,13 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.AutoTranslate;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using System.ComponentModel;
 
 namespace Nikse.SubtitleEdit.Features.Translate;
@@ -111,6 +116,10 @@ public class AutoTranslateWindow : Window
 
         var engineCombo = UiUtil.MakeComboBox(vm.AutoTranslators, vm, nameof(vm.SelectedAutoTranslator));
         engineCombo.MinWidth = 220;
+        engineCombo.ItemTemplate = StatusDots.ComboItemTemplate<IAutoTranslator>(
+            translator => translator.Name,
+            _ => null,
+            GetTranslatorDotStatus);
         engineCombo.SelectionChanged += (s, e) =>
         {
             vm.AutoTranslatorChanged(engineCombo);
@@ -178,14 +187,70 @@ public class AutoTranslateWindow : Window
         return MakeCard(stack);
     }
 
+    // Install-status dot for the auto-translate engine combo. Only the two engines that Subtitle
+    // Edit downloads itself - llama.cpp and CrispASR/MADLAD - get a dot; cloud/API translators
+    // (Google, DeepL, ChatGPT, ...) and externally-hosted servers have nothing to install.
+    private static DownloadDotStatus GetTranslatorDotStatus(IAutoTranslator translator)
+    {
+        switch (translator)
+        {
+            case LlamaCppTranslate:
+                return StatusDots.From(
+                    LlamaCppServerManager.IsEngineInstalled(),
+                    LlamaCppServerManager.GetEngineUpdateStatus());
+            case CrispAsrMadladTranslate:
+                var crispAsr = new CrispAsrMadlad();
+                if (!crispAsr.IsEngineInstalled())
+                {
+                    return DownloadDotStatus.NotInstalled;
+                }
+
+                return StatusDots.From(true, DownloadHashManager.GetSidecarStatus(crispAsr.GetAndCreateWhisperFolder()));
+            default:
+                return DownloadDotStatus.None;
+        }
+    }
+
+    // A custom *.gguf the user dropped into the models folder has no Url - it is already on disk,
+    // so it shows a green dot and a "custom" size tag rather than a download size.
+    private static string? GetLlamaCppModelSize(LlamaCppModelDisplay model)
+    {
+        if (string.IsNullOrEmpty(model.Model.Url))
+        {
+            return string.IsNullOrEmpty(model.Model.Size) ? "custom" : $"custom, {model.Model.Size}";
+        }
+
+        return string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size;
+    }
+
+    private static DownloadDotStatus GetLlamaCppModelDotStatus(LlamaCppModelDisplay model)
+    {
+        if (string.IsNullOrEmpty(model.Model.Url) || LlamaCppServerManager.IsModelInstalled(model.Model))
+        {
+            return DownloadDotStatus.UpToDate;
+        }
+
+        return DownloadDotStatus.NotInstalled;
+    }
+
     private static Border BuildApiConfigCard(AutoTranslateViewModel vm)
     {
         var buttonDownloadCrispAsr = UiUtil.MakeButton(Se.Language.General.Download, vm.DownloadCrispAsrCommand).WithMarginLeft(5);
         buttonDownloadCrispAsr.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.ButtonDownloadIsVisible)));
 
         var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
+        crispAsrModelCombo.ItemTemplate = StatusDots.ComboItemTemplate<SpeechToTextModelDisplay>(
+            model => model.Model.Name,
+            model => string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size,
+            model => model.Engine.IsModelInstalled(model.Model)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled);
 
         var llamaCppModelCombo = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel), nameof(vm.LlamaCppModelComboIsVisible)).WithWidth(220);
+        llamaCppModelCombo.ItemTemplate = StatusDots.ComboItemTemplate<LlamaCppModelDisplay>(
+            model => model.Model.DisplayName,
+            GetLlamaCppModelSize,
+            GetLlamaCppModelDotStatus);
 
         var buttonDownloadLlamaCpp = UiUtil.MakeButton(vm.DownloadLlamaCppCommand, IconNames.Download, Se.Language.General.Download).WithMarginLeft(5);
         buttonDownloadLlamaCpp.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -11,6 +11,7 @@ using Avalonia.Styling;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
@@ -140,6 +141,7 @@ public class SpeechToTextWindow : Window
             .WithMarginTop(10)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
             .BindIsVisible(vm, nameof(vm.IsModelSelectionVisible));
+        comboModel.ItemTemplate = MakeModelItemTemplate();
 
         var buttonModelDownload = UiUtil.MakeButtonBrowse(vm.DownloadModelCommand)
             .WithMarginBottom(20)
@@ -684,67 +686,44 @@ public class SpeechToTextWindow : Window
         };
     }
 
-    // Engine combo item template: each row gets a small status icon (✓ installed,
-    // ⬇ download-required, blank for cloud-only) plus the approximate download size
-    // when relevant. The template hard-codes engine.Name/icon/size at build time
-    // instead of binding, so recycling MUST stay off — otherwise the ComboBox would
-    // reuse one visual across engines and the closed-state display would freeze on
-    // whichever engine first populated the recycled visual.
+    // Engine combo item template: each row gets a small install-status dot (green = ready,
+    // amber = update available, grey = not downloaded yet, none for cloud/API engines) plus the
+    // approximate download size for engines that still need downloading.
     private static FuncDataTemplate<ISpeechToTextEngine> MakeEngineItemTemplate()
     {
-        return new FuncDataTemplate<ISpeechToTextEngine>((engine, _) =>
+        return StatusDots.ComboItemTemplate<ISpeechToTextEngine>(
+            engine => engine.Name,
+            engine => engine.CanBeDownloaded() && !engine.IsEngineInstalled() && !string.IsNullOrEmpty(engine.DownloadSizeText)
+                ? engine.DownloadSizeText
+                : null,
+            GetEngineDotStatus);
+    }
+
+    private static DownloadDotStatus GetEngineDotStatus(ISpeechToTextEngine engine)
+    {
+        if (!engine.CanBeDownloaded())
         {
-            if (engine == null)
-            {
-                return new TextBlock();
-            }
+            return DownloadDotStatus.None; // cloud / API engine - nothing to install
+        }
 
-            var canDownload = engine.CanBeDownloaded();
-            var isInstalled = engine.IsEngineInstalled();
+        if (!engine.IsEngineInstalled())
+        {
+            return DownloadDotStatus.NotInstalled;
+        }
 
-            var iconName = !canDownload
-                ? string.Empty
-                : isInstalled
-                    ? IconNames.CheckCircle
-                    : IconNames.Download;
+        // Installed: read the cheap .installed.sha256 sidecar so an outdated build shows amber.
+        return StatusDots.From(true, DownloadHashManager.GetSidecarStatus(engine.GetAndCreateWhisperFolder()));
+    }
 
-            var iconColor = isInstalled ? Brushes.MediumSeaGreen : Brushes.Gray;
-
-            var panel = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                VerticalAlignment = VerticalAlignment.Center,
-                Spacing = 6,
-            };
-
-            if (!string.IsNullOrEmpty(iconName))
-            {
-                panel.Children.Add(new Optris.Icons.Avalonia.Icon
-                {
-                    Value = iconName,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    FontSize = 14,
-                    Foreground = iconColor,
-                });
-            }
-
-            panel.Children.Add(new TextBlock
-            {
-                Text = engine.Name,
-                VerticalAlignment = VerticalAlignment.Center,
-            });
-
-            if (canDownload && !isInstalled && !string.IsNullOrEmpty(engine.DownloadSizeText))
-            {
-                panel.Children.Add(new TextBlock
-                {
-                    Text = $"({engine.DownloadSizeText})",
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Opacity = 0.6,
-                });
-            }
-
-            return panel;
-        });
+    // Model combo item template: a dot (green = downloaded, grey = not downloaded yet) plus the
+    // model's download size, replacing the old "..., not installed" text suffix.
+    private static FuncDataTemplate<SpeechToTextModelDisplay> MakeModelItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<SpeechToTextModelDisplay>(
+            model => model.Model.Name,
+            model => string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size,
+            model => model.Engine.IsModelInstalled(model.Model)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled);
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -139,6 +139,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 {
                     _downloadStream.Position = 0;
                     _zipUnpacker.UnpackZipStream(_downloadStream, folder, "piper", false, new List<string>(), null);
+                    WriteInstalledHashSidecar(folder, _downloadStream, DownloadHashManager.ResolvePiperKey());
                     _downloadStream.Dispose();
                 }
                 catch (Exception ex)

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -93,6 +93,26 @@ public class ChatterboxTtsCpp : ITtsEngine
     }
 
     /// <summary>
+    /// Returns the update status of the CrispASR engine Chatterbox runs on. Because Chatterbox
+    /// shares the speech-to-text CrispASR install, this reflects that engine's
+    /// <c>.installed.sha256</c> sidecar; returns <see cref="DownloadHashManager.UpdateStatus.Unknown"/>
+    /// when CrispASR is not installed or the sidecar is missing.
+    /// </summary>
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    /// <summary>
     /// Returns true when the installed crispasr executable matches a known
     /// chatterbox-capable release (currently v0.6.0+ — earlier builds neither
     /// recognise --backend chatterbox nor expose the /v1/audio/speech endpoint).

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -29,6 +29,22 @@ public class Piper : ITtsEngine
         return Task.FromResult(File.Exists(GetPiperExecutableFileName()));
     }
 
+    /// <summary>
+    /// Returns the update status of the installed Piper engine relative to the release pinned in
+    /// <c>TtsDownloadService</c>. Reads the key/hash from the <c>.installed.sha256</c> sidecar
+    /// written at install time; returns <see cref="DownloadHashManager.UpdateStatus.Unknown"/> when
+    /// Piper is not installed or the sidecar is missing (installs predating hash tracking).
+    /// </summary>
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        if (!File.Exists(GetPiperExecutableFileName()))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        return DownloadHashManager.GetSidecarStatus(GetSetPiperFolder());
+    }
+
     private readonly ITtsDownloadService _ttsDownloadService;
 
     public Piper(ITtsDownloadService ttsDownloadService)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -9,7 +9,6 @@ using Avalonia.Styling;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.Download;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 
@@ -107,8 +106,9 @@ public class TextToSpeechWindow : Window
             case OmniVoiceTtsCpp:
                 return StatusDots.From(engine.IsInstalled(null).Result, OmniVoiceTtsCpp.GetEngineUpdateStatus());
             case ChatterboxTtsCpp:
+                return StatusDots.From(engine.IsInstalled(null).Result, ChatterboxTtsCpp.GetEngineUpdateStatus());
             case Piper:
-                return StatusDots.From(engine.IsInstalled(null).Result, DownloadHashManager.UpdateStatus.Unknown);
+                return StatusDots.From(engine.IsInstalled(null).Result, Piper.GetEngineUpdateStatus());
             default:
                 return DownloadDotStatus.None;
         }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -6,8 +6,10 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Styling;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 
@@ -89,12 +91,39 @@ public class TextToSpeechWindow : Window
         Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
     }
 
+    // Install-status dot for the engine combo: green = ready, amber = a newer build is available,
+    // grey = downloadable but not on disk. Cloud/online engines (Azure, ElevenLabs, Google,
+    // Edge TTS, ...) have nothing to install and get no dot.
+    private static DownloadDotStatus GetTtsEngineDotStatus(ITtsEngine engine)
+    {
+        // IsInstalled is a Task only by interface contract; the local engines below complete it
+        // synchronously (Task.FromResult of a File.Exists check), so .Result does not block.
+        switch (engine)
+        {
+            case KokoroTtsCpp:
+                return StatusDots.From(engine.IsInstalled(null).Result, KokoroTtsCpp.GetEngineUpdateStatus());
+            case Qwen3TtsCpp:
+                return StatusDots.From(engine.IsInstalled(null).Result, Qwen3TtsCpp.GetEngineUpdateStatus());
+            case OmniVoiceTtsCpp:
+                return StatusDots.From(engine.IsInstalled(null).Result, OmniVoiceTtsCpp.GetEngineUpdateStatus());
+            case ChatterboxTtsCpp:
+            case Piper:
+                return StatusDots.From(engine.IsInstalled(null).Result, DownloadHashManager.UpdateStatus.Unknown);
+            default:
+                return DownloadDotStatus.None;
+        }
+    }
+
     private static Border MakeEngineControls(TextToSpeechViewModel vm)
     {
         var labelMinWidth = 100;
         var controlMinWidth = 200;
 
         var comboBoxEngines = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine)).WithWidth(controlMinWidth);
+        comboBoxEngines.ItemTemplate = StatusDots.ComboItemTemplate<ITtsEngine>(
+            engine => engine.Name,
+            _ => null,
+            GetTtsEngineDotStatus);
         comboBoxEngines.SelectionChanged += vm.SelectedEngineChanged;
 
         var panelEngine = new StackPanel

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -116,6 +116,7 @@ public class LanguageGeneral
     public string Cps { get; set; }
     public string CurrentSubtitle { get; set; }
     public string CurrentVideoPosition { get; set; }
+    public string Custom { get; set; }
     public string Cut { get; set; }
     public string Dark { get; set; }
     public string DateAndTime { get; set; }
@@ -818,6 +819,7 @@ public class LanguageGeneral
         Cps = "Chars/sec";
         CurrentSubtitle = "Current subtitle";
         CurrentVideoPosition = "Current video position";
+        Custom = "Custom";
         Cut = "Cut";
         Dark = "Dark";
         DateAndTime = "Date and time";

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -493,6 +493,36 @@ public static class DownloadHashManager
     }
 
     /// <summary>
+    /// Reads the <c>.installed.sha256</c> sidecar in <paramref name="installFolder"/> and returns
+    /// the update status of the recorded build. Returns <see cref="UpdateStatus.Unknown"/> when the
+    /// sidecar is missing or unreadable (e.g. installs predating hash tracking). Cheap - no file
+    /// hashing - so it is safe to call while populating a combo box.
+    /// </summary>
+    public static UpdateStatus GetSidecarStatus(string installFolder)
+    {
+        try
+        {
+            var sidecar = Path.Combine(installFolder, ".installed.sha256");
+            if (!File.Exists(sidecar))
+            {
+                return UpdateStatus.Unknown;
+            }
+
+            var lines = File.ReadAllLines(sidecar);
+            if (lines.Length < 2)
+            {
+                return UpdateStatus.Unknown;
+            }
+
+            return GetStatus(lines[0].Trim(), lines[1].Trim());
+        }
+        catch
+        {
+            return UpdateStatus.Unknown;
+        }
+    }
+
+    /// <summary>
     /// Returns the latest known SHA-256 hash for <paramref name="key"/>, or null if the key is unknown.
     /// </summary>
     public static string? GetLatestKnownHash(string key)

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -110,6 +110,17 @@ public static class DownloadHashManager
         public const string LinuxArm64 = "KokoroTtsCpp.Linux.Arm64";
     }
 
+    public static class Piper
+    {
+        // Hashes of the release archive (.zip / .tar.gz) - recognised from the .installed.sha256
+        // sidecar written at install time. Piper is pinned to a single fixed rhasspy/piper release,
+        // so each key currently has just one known hash.
+        public const string Windows = "Piper.Windows";
+        public const string MacOs = "Piper.MacOs";
+        public const string LinuxX64 = "Piper.Linux.X64";
+        public const string LinuxArm64 = "Piper.Linux.Arm64";
+    }
+
     public static class WhisperCpp
     {
         // Hashes of the release archive (.zip) — used when a sidecar hash exists alongside the install.
@@ -410,6 +421,25 @@ public static class DownloadHashManager
             [KokoroTtsCpp.LinuxArm64] = new[]
             {
                 "673f49ffd2c0653b195a57f566038c05b2a962defc3e1c9c2664c8306d09352d", // v0.1.2 (current download URL)
+            },
+
+            // Piper — https://github.com/rhasspy/piper/releases. Pinned to release 2023.11.14-2 in
+            // TtsDownloadService.cs; index 0 must match that release.
+            [Piper.Windows] = new[]
+            {
+                "f3c58906402b24f3a96d92145f58acba6d86c9b5db896d207f78dc80811efcea", // 2023.11.14-2 (current download URL)
+            },
+            [Piper.MacOs] = new[]
+            {
+                "ced85c0a3df13945b1e623b878a48fdc2854d5c485b4b67f62857cf551deaf8b", // 2023.11.14-2 (current download URL)
+            },
+            [Piper.LinuxX64] = new[]
+            {
+                "a50cb45f355b7af1f6d758c1b360717877ba0a398cc8cbe6d2a7a3a26e225992", // 2023.11.14-2 (current download URL)
+            },
+            [Piper.LinuxArm64] = new[]
+            {
+                "fea0fd2d87c54dbc7078d0f878289f404bd4d6eea6e7444a77835d1537ab88eb", // 2023.11.14-2 (current download URL)
             },
 
             // whisper.cpp — https://github.com/ggml-org/whisper.cpp/releases (and SE-repackaged builds
@@ -999,6 +1029,32 @@ public static class DownloadHashManager
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? KokoroTtsCpp.LinuxArm64
                 : KokoroTtsCpp.LinuxX64;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="Piper"/> archive key for the current OS/arch, matching the URL
+    /// <c>TtsDownloadService</c> downloads. Returns null on an unsupported platform.
+    /// </summary>
+    public static string? ResolvePiperKey()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Piper.Windows;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return Piper.MacOs;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? Piper.LinuxArm64
+                : Piper.LinuxX64;
         }
 
         return null;

--- a/src/ui/Logic/StatusDots.cs
+++ b/src/ui/Logic/StatusDots.cs
@@ -1,9 +1,12 @@
 using System;
+using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 
 namespace Nikse.SubtitleEdit.Logic;
@@ -28,8 +31,10 @@ public enum DownloadDotStatus
 
 /// <summary>
 /// Shared helpers for the coloured install-status dot used by the text-to-speech, speech-to-text
-/// and auto-translate engine/model combo boxes. The green/amber/grey palette matches the status
-/// dot already shown in the engine settings dialogs.
+/// and auto-translate engine/model combo boxes. Green ("up to date") and amber ("update available")
+/// match the status dot in the engine settings dialogs; "not installed" is grey here rather than
+/// the dialogs' red, because in an engine/model picker "not downloaded yet" is a normal choice, not
+/// an error state.
 /// </summary>
 public static class StatusDots
 {
@@ -43,6 +48,18 @@ public static class StatusDots
         DownloadDotStatus.UpToDate => Green,
         DownloadDotStatus.UpdateAvailable => Amber,
         DownloadDotStatus.NotInstalled => Grey,
+        _ => null,
+    };
+
+    /// <summary>
+    /// The textual status used for the row's tooltip and accessible name, or null when no dot is
+    /// shown. Conveys the install state in text so it does not rely on dot colour alone.
+    /// </summary>
+    public static string? StatusText(DownloadDotStatus status) => status switch
+    {
+        DownloadDotStatus.UpToDate => Se.Language.General.UpToDate,
+        DownloadDotStatus.UpdateAvailable => Se.Language.General.UpdateAvailable,
+        DownloadDotStatus.NotInstalled => Se.Language.General.NotInstalled,
         _ => null,
     };
 
@@ -67,7 +84,8 @@ public static class StatusDots
     /// Builds a combo-box item template that renders "[dot] name (size)". The dot sits in a
     /// fixed-width slot so names line up whether or not a row has a dot; a
     /// <see cref="DownloadDotStatus.None"/> row leaves the slot empty. The size suffix is dropped
-    /// when null/empty.
+    /// when null/empty. The install state is also exposed as a tooltip and accessible name so it
+    /// does not depend on dot colour alone.
     /// </summary>
     /// <remarks>
     /// Recycling is left at the <see cref="FuncDataTemplate{T}"/> default (off): each row's visual
@@ -92,13 +110,16 @@ public static class StatusDots
                 VerticalAlignment = VerticalAlignment.Center,
             };
 
+            var status = getStatus(item);
+            var name = getName(item);
+
             var dotSlot = new Panel
             {
                 Width = 16,
                 VerticalAlignment = VerticalAlignment.Stretch,
             };
 
-            var brush = BrushFor(getStatus(item));
+            var brush = BrushFor(status);
             if (brush != null)
             {
                 dotSlot.Children.Add(new Ellipse
@@ -115,7 +136,7 @@ public static class StatusDots
 
             panel.Children.Add(new TextBlock
             {
-                Text = getName(item),
+                Text = name,
                 VerticalAlignment = VerticalAlignment.Center,
             });
 
@@ -124,10 +145,19 @@ public static class StatusDots
             {
                 panel.Children.Add(new TextBlock
                 {
-                    Text = $"  ({size})",
+                    Text = $"({size})",
                     Opacity = 0.6,
+                    Margin = new Thickness(6, 0, 0, 0),
                     VerticalAlignment = VerticalAlignment.Center,
                 });
+            }
+
+            // Convey the install state in text too (tooltip + screen reader), not colour alone.
+            var statusText = StatusText(status);
+            if (statusText != null)
+            {
+                ToolTip.SetTip(panel, statusText);
+                AutomationProperties.SetName(panel, $"{name}, {statusText}");
             }
 
             return panel;

--- a/src/ui/Logic/StatusDots.cs
+++ b/src/ui/Logic/StatusDots.cs
@@ -1,0 +1,136 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Controls.Templates;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.Download;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Install/update state shown as a small coloured dot next to an engine or model in a combo box.
+/// </summary>
+public enum DownloadDotStatus
+{
+    /// <summary>Nothing to install (e.g. a cloud/API engine) - no dot is shown.</summary>
+    None,
+
+    /// <summary>Downloadable but not on disk yet - grey dot.</summary>
+    NotInstalled,
+
+    /// <summary>Installed and ready to use - green dot.</summary>
+    UpToDate,
+
+    /// <summary>Installed, but a newer build is available - amber dot.</summary>
+    UpdateAvailable,
+}
+
+/// <summary>
+/// Shared helpers for the coloured install-status dot used by the text-to-speech, speech-to-text
+/// and auto-translate engine/model combo boxes. The green/amber/grey palette matches the status
+/// dot already shown in the engine settings dialogs.
+/// </summary>
+public static class StatusDots
+{
+    public static readonly IBrush Green = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    public static readonly IBrush Amber = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    public static readonly IBrush Grey = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    /// <summary>The fill for a status dot, or null when no dot should be shown.</summary>
+    public static IBrush? BrushFor(DownloadDotStatus status) => status switch
+    {
+        DownloadDotStatus.UpToDate => Green,
+        DownloadDotStatus.UpdateAvailable => Amber,
+        DownloadDotStatus.NotInstalled => Grey,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Maps an installed flag plus a <see cref="DownloadHashManager.UpdateStatus"/> to a dot status.
+    /// An installed engine whose version cannot be determined counts as up-to-date: in a combo the
+    /// dot only flags "needs download" (grey) or "update waiting" (amber) - anything usable is green.
+    /// </summary>
+    public static DownloadDotStatus From(bool installed, DownloadHashManager.UpdateStatus updateStatus)
+    {
+        if (!installed)
+        {
+            return DownloadDotStatus.NotInstalled;
+        }
+
+        return updateStatus == DownloadHashManager.UpdateStatus.UpdateAvailable
+            ? DownloadDotStatus.UpdateAvailable
+            : DownloadDotStatus.UpToDate;
+    }
+
+    /// <summary>
+    /// Builds a combo-box item template that renders "[dot] name (size)". The dot sits in a
+    /// fixed-width slot so names line up whether or not a row has a dot; a
+    /// <see cref="DownloadDotStatus.None"/> row leaves the slot empty. The size suffix is dropped
+    /// when null/empty.
+    /// </summary>
+    /// <remarks>
+    /// Recycling is left at the <see cref="FuncDataTemplate{T}"/> default (off): each row's visual
+    /// is built from a one-off status snapshot, so a recycled visual would freeze on whichever item
+    /// first populated it.
+    /// </remarks>
+    public static FuncDataTemplate<T> ComboItemTemplate<T>(
+        Func<T, string> getName,
+        Func<T, string?> getSize,
+        Func<T, DownloadDotStatus> getStatus) where T : class
+    {
+        return new FuncDataTemplate<T>((item, _) =>
+        {
+            if (item == null)
+            {
+                return new TextBlock();
+            }
+
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+
+            var dotSlot = new Panel
+            {
+                Width = 16,
+                VerticalAlignment = VerticalAlignment.Stretch,
+            };
+
+            var brush = BrushFor(getStatus(item));
+            if (brush != null)
+            {
+                dotSlot.Children.Add(new Ellipse
+                {
+                    Width = 10,
+                    Height = 10,
+                    Fill = brush,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+            }
+
+            panel.Children.Add(dotSlot);
+
+            panel.Children.Add(new TextBlock
+            {
+                Text = getName(item),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+
+            var size = getSize(item);
+            if (!string.IsNullOrEmpty(size))
+            {
+                panel.Children.Add(new TextBlock
+                {
+                    Text = $"  ({size})",
+                    Opacity = 0.6,
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+            }
+
+            return panel;
+        });
+    }
+}


### PR DESCRIPTION
The coloured status dot (green = ready, amber = update available, grey = not downloaded) previously lived only in the engine settings dialogs. The engine/model combo boxes either had no install indicator at all or spelled the status out as "..., not installed" text.

Add a shared StatusDots helper that builds a "[dot] name (size)" combo item template, and wire it into:

- STT engine combo (replaces the check/download icon; now shows amber for an outdated build)
- STT model combo (drops the ", not installed" text suffix)
- TTS engine combo (no indicator before)
- Auto-translate engine combo (no indicator before)
- Auto-translate llama.cpp and CrispASR model combos (drop the text suffix)

Update status in the combos is read from the cheap .installed.sha256 sidecar via the new DownloadHashManager.GetSidecarStatus, so no file hashing happens while a combo populates. Cloud/API engines have nothing to install and get no dot.