### PR TITLE
Add voice instructions to Text-to-speech (Qwen3 VoiceDesign + OmniVoice)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -2,6 +2,11 @@
 Subtitle Edit Changelog
 
 
+v5.0.0-beta30 (xth May 2026)
+
+* Add Qwen3 TTS 1.7B VoiceDesign model with natural-language voice instructions - thx subof
+* Add voice-design keyword picker to Text-to-speech for OmniVoice TTS - thx subof
+
 v5.0.0-beta29 (20th May 2026)
 
 * Add Engine settings dialog for Qwen3 TTS, Kokoro TTS, and Chatterbox TTS

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -29,7 +29,14 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
     [ObservableProperty] private string _statusLabel = string.Empty;
     [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
     [ObservableProperty] private string _installFolder = string.Empty;
-    [ObservableProperty] private bool _isInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private bool _isInstalled;
+
+    public string DownloadButtonLabel => IsInstalled
+        ? Se.Language.General.Redownload
+        : Se.Language.General.Download;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsWindow.cs
@@ -158,7 +158,8 @@ public class SpeechToTextEngineSettingsWindow : Window
 
     private static Grid BuildActions(SpeechToTextEngineSettingsViewModel vm)
     {
-        var redownload = UiUtil.MakeButton(Se.Language.General.Redownload, vm.RedownloadCommand).WithIconLeft(IconNames.Download);
+        var redownload = UiUtil.MakeButton(string.Empty, vm.RedownloadCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonLabel));
         var openFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenFolderCommand).WithIconLeft(IconNames.FolderOpen);
         var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -29,6 +29,50 @@ public class OmniVoiceTtsCpp : ITtsEngine
     public bool HasModel => false;
     public bool HasKeyFile => false;
 
+    // Voice-design attribute keywords accepted by omnivoice-tts' --instruct flag (English set).
+    // The CLI rejects free text - only these values, comma+space separated, are valid. Grouped
+    // because each group is mutually exclusive (one gender, one age, one pitch, one accent).
+    public static readonly string[] InstructionGenders =
+    {
+        "female",
+        "male",
+    };
+
+    public static readonly string[] InstructionAges =
+    {
+        "child",
+        "teenager",
+        "young adult",
+        "middle-aged",
+        "elderly",
+    };
+
+    public static readonly string[] InstructionPitches =
+    {
+        "very low pitch",
+        "low pitch",
+        "moderate pitch",
+        "high pitch",
+        "very high pitch",
+    };
+
+    public static readonly string[] InstructionAccents =
+    {
+        "american accent",
+        "australian accent",
+        "british accent",
+        "canadian accent",
+        "chinese accent",
+        "indian accent",
+        "japanese accent",
+        "korean accent",
+        "portuguese accent",
+        "russian accent",
+    };
+
+    // Stand-alone toggle - not part of any mutually-exclusive group.
+    public const string InstructionWhisper = "whisper";
+
     public Task<bool> IsInstalled(string? region)
     {
         return Task.FromResult(File.Exists(GetExecutableFileName()));
@@ -242,7 +286,8 @@ public class OmniVoiceTtsCpp : ITtsEngine
         // The transcript is captured at import time; if it has been deleted out from under
         // us we fail loudly so the user knows custom voice cloning isn't happening, rather
         // than silently producing the default speaker.
-        if (!string.IsNullOrEmpty(omniVoice.FilePath) && File.Exists(omniVoice.FilePath))
+        var usingReference = !string.IsNullOrEmpty(omniVoice.FilePath) && File.Exists(omniVoice.FilePath);
+        if (usingReference)
         {
             var refTextPath = Path.ChangeExtension(omniVoice.FilePath, ".txt");
             if (!File.Exists(refTextPath))
@@ -257,6 +302,18 @@ public class OmniVoiceTtsCpp : ITtsEngine
             psi.ArgumentList.Add(omniVoice.FilePath);
             psi.ArgumentList.Add("--ref-text");
             psi.ArgumentList.Add(refTextPath);
+        }
+
+        // Voice-design keywords (--instruct) only shape the voice when there is no reference
+        // audio - with --ref-wav omnivoice-tts takes the voice from the clone and ignores them.
+        if (!usingReference)
+        {
+            var instruction = (Se.Settings.Video.TextToSpeech.OmniVoiceTtsCppInstruction ?? string.Empty).Trim();
+            if (!string.IsNullOrEmpty(instruction))
+            {
+                psi.ArgumentList.Add("--instruct");
+                psi.ArgumentList.Add(instruction);
+            }
         }
 
         Se.WriteToolsLog($"OmniVoice TTS: {exe} {string.Join(' ', psi.ArgumentList)} (voice={omniVoice}, textLen={text.Length})");

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -30,15 +30,18 @@ public class Qwen3TtsCpp : ITtsEngine
 
     public const string ModelKey06B = "0.6B";
     public const string ModelKey17BBase = "1.7B Base";
+    public const string ModelKey17BVoiceDesign = "1.7B Voice Design";
     public const string DefaultModelKey = ModelKey06B;
 
     public const string TtsModelFileName06B = "qwen3-tts-0.6b-q8_0.gguf";
     public const string TtsModelFileName17BBase = "Qwen3-TTS-12Hz-1.7B-Base-q8_0.gguf";
+    public const string TtsModelFileName17BVoiceDesign = "qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf";
     public const string TokenizerModelFileName = "qwen3-tts-tokenizer-q8_0.gguf";
 
     public static string GetModelFileName(string? modelKey) => modelKey switch
     {
         ModelKey17BBase => TtsModelFileName17BBase,
+        ModelKey17BVoiceDesign => TtsModelFileName17BVoiceDesign,
         _ => TtsModelFileName06B,
     };
 
@@ -52,6 +55,15 @@ public class Qwen3TtsCpp : ITtsEngine
         return modelKey;
     }
 
+    /// <summary>
+    /// True when the resolved model is the instruction-tuned VoiceDesign variant. Only this
+    /// model honors the voice instruction; the 0.6B and 1.7B Base models ignore it.
+    /// </summary>
+    public static bool IsVoiceDesignModel(string? modelKey)
+    {
+        return ResolveModelKey(modelKey) == ModelKey17BVoiceDesign;
+    }
+
     private static readonly HttpClient HttpClient = new()
     {
         Timeout = TimeSpan.FromMinutes(5),
@@ -61,6 +73,7 @@ public class Qwen3TtsCpp : ITtsEngine
     private static int _serverPort;
     private static string? _serverModelFileName;
     private static bool _processExitHooked;
+    private static StringBuilder? _serverStderr;
 
     private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
 
@@ -187,7 +200,7 @@ public class Qwen3TtsCpp : ITtsEngine
 
     public Task<string[]> GetModels()
     {
-        return Task.FromResult(new[] { ModelKey06B, ModelKey17BBase });
+        return Task.FromResult(new[] { ModelKey06B, ModelKey17BBase, ModelKey17BVoiceDesign });
     }
 
     public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model)
@@ -220,44 +233,75 @@ public class Qwen3TtsCpp : ITtsEngine
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
         var inputText = Utilities.UnbreakLine(text);
 
+        // Voice instruction only does anything on the instruction-tuned VoiceDesign model;
+        // the 0.6B and 1.7B Base models ignore it, so it is omitted there entirely.
+        var instruction = IsVoiceDesignModel(model)
+            ? (Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty).Trim()
+            : string.Empty;
+
         var endpoint = string.IsNullOrEmpty(qwen3Voice.FilePath) ? "/v1/synthesize" : "/v1/synthesize_with_voice";
-        Se.WriteToolsLog($"Qwen3 TTS: POST {ServerBaseUrl}{endpoint} (voice={qwen3Voice}, model={modelFileName}, textLen={text.Length})");
+        Se.WriteToolsLog($"Qwen3 TTS: POST {ServerBaseUrl}{endpoint} (voice={qwen3Voice}, model={modelFileName}, textLen={text.Length}, instructionLen={instruction.Length})");
 
-        using HttpResponseMessage response = string.IsNullOrEmpty(qwen3Voice.FilePath)
-            ? await SynthesizeAsync(inputText, cancellationToken)
-            : await SynthesizeWithVoiceAsync(inputText, qwen3Voice.FilePath, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
+        HttpResponseMessage response;
+        try
         {
-            var errorBody = await SafeReadErrorAsync(response, cancellationToken);
-            var errMsg = $"Qwen3 TTS server error {(int)response.StatusCode} {response.StatusCode} - "
-                + $"Voice: {qwen3Voice}, Text: {text}, Body: {errorBody}";
-            Se.LogError(errMsg);
-            Se.WriteToolsLog(errMsg);
-            throw new InvalidOperationException(
-                $"Qwen3 TTS synthesis failed ({(int)response.StatusCode}): {errorBody}");
+            response = string.IsNullOrEmpty(qwen3Voice.FilePath)
+                ? await SynthesizeAsync(inputText, instruction, cancellationToken)
+                : await SynthesizeWithVoiceAsync(inputText, qwen3Voice.FilePath, instruction, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A crashed/exited server surfaces here as a bare connection error - attach whatever
+            // the server printed (model-load / synthesis failures land in its stdout/stderr).
+            var serverOutput = SnapshotServerStderr();
+            var msg = $"Qwen3 TTS request failed: {ex.Message}"
+                + (serverOutput.Length == 0 ? string.Empty : $"{Environment.NewLine}Server output:{Environment.NewLine}{serverOutput}");
+            Se.LogError(ex, msg);
+            Se.WriteToolsLog(msg);
+            throw new InvalidOperationException(msg, ex);
         }
 
-        await using (var fileStream = File.Create(outputFileName))
-        await using (var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken))
+        using (response)
         {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverOutput = SnapshotServerStderr();
+                var errMsg = $"Qwen3 TTS server error {(int)response.StatusCode} {response.StatusCode} - "
+                    + $"Voice: {qwen3Voice}, Text: {text}, Body: {errorBody}"
+                    + (serverOutput.Length == 0 ? string.Empty : $"{Environment.NewLine}Server output:{Environment.NewLine}{serverOutput}");
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"Qwen3 TTS synthesis failed ({(int)response.StatusCode}): {errorBody}");
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
             await contentStream.CopyToAsync(fileStream, cancellationToken);
         }
 
         return new TtsResult(outputFileName, text);
     }
 
-    private static async Task<HttpResponseMessage> SynthesizeAsync(string text, CancellationToken ct)
+    private static async Task<HttpResponseMessage> SynthesizeAsync(string text, string instruction, CancellationToken ct)
     {
-        var body = JsonSerializer.Serialize(new { text });
+        object payload = string.IsNullOrEmpty(instruction)
+            ? new { text }
+            : new { text, instruction };
+        var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
         return await HttpClient.PostAsync($"{ServerBaseUrl}/v1/synthesize", content, ct);
     }
 
-    private static async Task<HttpResponseMessage> SynthesizeWithVoiceAsync(string text, string referenceWav, CancellationToken ct)
+    private static async Task<HttpResponseMessage> SynthesizeWithVoiceAsync(string text, string referenceWav, string instruction, CancellationToken ct)
     {
         using var form = new MultipartFormDataContent();
         form.Add(new StringContent(text, Encoding.UTF8), "text");
+        if (!string.IsNullOrEmpty(instruction))
+        {
+            form.Add(new StringContent(instruction, Encoding.UTF8), "instruction");
+        }
         var refBytes = await File.ReadAllBytesAsync(referenceWav, ct);
         var fileContent = new ByteArrayContent(refBytes);
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
@@ -358,6 +402,7 @@ public class Qwen3TtsCpp : ITtsEngine
             _serverProcess = process;
             _serverPort = port;
             _serverModelFileName = modelFileName;
+            _serverStderr = stderrBuffer;
             HookProcessExitOnce();
 
             var deadline = DateTime.UtcNow.AddSeconds(120);
@@ -398,6 +443,14 @@ public class Qwen3TtsCpp : ITtsEngine
             var s = buffer.ToString().TrimEnd();
             return s.Length > 2000 ? s[^2000..] : s;
         }
+    }
+
+    // Tail of the running server's captured stdout/stderr - empty when no server is tracked.
+    // Used to surface model-load / synthesis failures that otherwise only reach the console.
+    private static string SnapshotServerStderr()
+    {
+        var buffer = _serverStderr;
+        return buffer == null ? string.Empty : SnapshotStderr(buffer);
     }
 
     private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
@@ -442,6 +495,7 @@ public class Qwen3TtsCpp : ITtsEngine
         _serverProcess = null;
         _serverPort = 0;
         _serverModelFileName = null;
+        _serverStderr = null;
         if (p == null) return;
         try
         {

--- a/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsViewModel.cs
@@ -28,7 +28,14 @@ public partial class KokoroTtsSettingsViewModel : ObservableObject
     [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
     [ObservableProperty] private string _releaseTag = KokoroTtsCppDownloadService.ReleaseTag;
     [ObservableProperty] private string _installFolder = string.Empty;
-    [ObservableProperty] private bool _isInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private bool _isInstalled;
+
+    public string DownloadButtonLabel => IsInstalled
+        ? Se.Language.General.Redownload
+        : Se.Language.General.Download;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }

--- a/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsWindow.cs
@@ -167,7 +167,8 @@ public class KokoroTtsSettingsWindow : Window
 
     private static Grid BuildActions(KokoroTtsSettingsViewModel vm)
     {
-        var redownload = UiUtil.MakeButton(Se.Language.General.Redownload, vm.RedownloadCommand).WithIconLeft(IconNames.Download);
+        var redownload = UiUtil.MakeButton(string.Empty, vm.RedownloadCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonLabel));
         var openFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenFolderCommand).WithIconLeft(IconNames.FolderOpen);
         var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
 

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
@@ -29,7 +29,14 @@ public partial class OmniVoiceSettingsViewModel : ObservableObject
     [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
     [ObservableProperty] private string _releaseTag = OmniVoiceDownloadService.ReleaseTag;
     [ObservableProperty] private string _installFolder = string.Empty;
-    [ObservableProperty] private bool _isInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private bool _isInstalled;
+
+    public string DownloadButtonLabel => IsInstalled
+        ? Se.Language.General.Redownload
+        : Se.Language.General.Download;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsWindow.cs
@@ -171,7 +171,8 @@ public class OmniVoiceSettingsWindow : Window
 
     private static Grid BuildActions(OmniVoiceSettingsViewModel vm)
     {
-        var redownload = UiUtil.MakeButton(Se.Language.General.Redownload, vm.RedownloadCommand).WithIconLeft(IconNames.Download);
+        var redownload = UiUtil.MakeButton(string.Empty, vm.RedownloadCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonLabel));
         var openFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenFolderCommand).WithIconLeft(IconNames.FolderOpen);
         var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
 

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
@@ -29,7 +29,14 @@ public partial class Qwen3TtsSettingsViewModel : ObservableObject
     [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
     [ObservableProperty] private string _releaseTag = Qwen3TtsCppDownloadService.ReleaseTag;
     [ObservableProperty] private string _installFolder = string.Empty;
-    [ObservableProperty] private bool _isInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private bool _isInstalled;
+
+    public string DownloadButtonLabel => IsInstalled
+        ? Se.Language.General.Redownload
+        : Se.Language.General.Download;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsWindow.cs
@@ -167,7 +167,8 @@ public class Qwen3TtsSettingsWindow : Window
 
     private static Grid BuildActions(Qwen3TtsSettingsViewModel vm)
     {
-        var redownload = UiUtil.MakeButton(Se.Language.General.Redownload, vm.RedownloadCommand).WithIconLeft(IconNames.Download);
+        var redownload = UiUtil.MakeButton(string.Empty, vm.RedownloadCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonLabel));
         var openFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenFolderCommand).WithIconLeft(IconNames.FolderOpen);
         var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -63,6 +63,7 @@ public partial class TextToSpeechViewModel : ObservableObject
     [ObservableProperty] private int _voiceCount;
     [ObservableProperty] private string _voiceCountInfo;
     [ObservableProperty] private bool _isVoiceTestEnabled;
+    [ObservableProperty] private bool _isVoiceComboEnabled;
     [ObservableProperty] private bool _doReviewAudioClips;
     [ObservableProperty] private bool _doGenerateVideoFile;
     [ObservableProperty] private bool _isEdgeTtsEngine;
@@ -75,9 +76,30 @@ public partial class TextToSpeechViewModel : ObservableObject
     [ObservableProperty] private string _doneOrCancelText;
     [ObservableProperty] private bool _hasKeyFile;
     [ObservableProperty] private string _keyFile;
+    [ObservableProperty] private bool _hasInstruction;
+    [ObservableProperty] private bool _isInstructionTextVisible;
+    [ObservableProperty] private bool _isInstructionPickerVisible;
+    [ObservableProperty] private bool _isInstructionPickerEnabled;
+    [ObservableProperty] private bool _isInstructionVoiceHintVisible;
+    [ObservableProperty] private string _instruction;
+    [ObservableProperty] private string _selectedOmniVoiceGender;
+    [ObservableProperty] private string _selectedOmniVoiceAge;
+    [ObservableProperty] private string _selectedOmniVoicePitch;
+    [ObservableProperty] private string _selectedOmniVoiceAccent;
+    [ObservableProperty] private bool _omniVoiceWhisper;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
+
+    // Set by the window; re-evaluates the install-status dots in the engine and model combos.
+    public Action? RefreshDownloadDots { get; set; }
+
+    // The OmniVoice TTS voice-design keyword picker - one combo box per mutually exclusive
+    // group. omnivoice-tts' --instruct only accepts these keyword values.
+    public ObservableCollection<string> OmniVoiceGenders { get; }
+    public ObservableCollection<string> OmniVoiceAges { get; }
+    public ObservableCollection<string> OmniVoicePitches { get; }
+    public ObservableCollection<string> OmniVoiceAccents { get; }
 
     private Subtitle _subtitle = new();
     private readonly IFileHelper _fileHelper;
@@ -92,6 +114,8 @@ public partial class TextToSpeechViewModel : ObservableObject
     private Lock _playLock;
     private readonly Timer _timer;
     private readonly IWindowService _windowService;
+    private bool _suppressKeywordSync;
+    private const string OmniVoiceAny = "(any)";
 
     public TextToSpeechViewModel(ITtsDownloadService ttsDownloadService, IWindowService windowService, IFileHelper fileHelper, IFolderHelper folderHelper)
     {
@@ -111,9 +135,23 @@ public partial class TextToSpeechViewModel : ObservableObject
         ProgressText = string.Empty;
         DoneOrCancelText = string.Empty;
         IsVoiceTestEnabled = true;
+        IsVoiceComboEnabled = true;
         IsGenerating = false;
         IsNotGenerating = true;
         KeyFile = string.Empty;
+        Instruction = string.Empty;
+
+        OmniVoiceGenders = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionGenders);
+        OmniVoiceAges = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionAges);
+        OmniVoicePitches = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionPitches);
+        OmniVoiceAccents = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionAccents);
+
+        _suppressKeywordSync = true;
+        SelectedOmniVoiceGender = OmniVoiceAny;
+        SelectedOmniVoiceAge = OmniVoiceAny;
+        SelectedOmniVoicePitch = OmniVoiceAny;
+        SelectedOmniVoiceAccent = OmniVoiceAny;
+        _suppressKeywordSync = false;
 
         _cancellationTokenSource = new CancellationTokenSource();
         _playLock = new Lock();
@@ -176,6 +214,8 @@ public partial class TextToSpeechViewModel : ObservableObject
             HasKeyFile = SelectedEngine.HasKeyFile;
             IsEdgeTtsEngine = SelectedEngine is EdgeTts;
         }
+
+        ApplyInstructionForEngine(SelectedEngine);
 
         var lastVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice);
         if (lastVoice == null)
@@ -241,6 +281,11 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is Qwen3TtsCpp)
         {
             Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel = SelectedModel ?? Qwen3TtsCpp.DefaultModelKey;
+            Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction = (Instruction ?? string.Empty).Trim();
+        }
+        else if (SelectedEngine is OmniVoiceTtsCpp)
+        {
+            Se.Settings.Video.TextToSpeech.OmniVoiceTtsCppInstruction = (Instruction ?? string.Empty).Trim();
         }
         else if (SelectedEngine is ChatterboxTtsCpp)
         {
@@ -264,6 +309,152 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         Se.SaveSettings();
+    }
+
+    // The instruction control is shared in the UI; each engine that supports it keeps its own
+    // persisted value, so it always reflects the currently selected engine.
+    private static string GetInstructionForEngine(ITtsEngine? engine) => engine switch
+    {
+        Qwen3TtsCpp => Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty,
+        OmniVoiceTtsCpp => Se.Settings.Video.TextToSpeech.OmniVoiceTtsCppInstruction ?? string.Empty,
+        _ => string.Empty,
+    };
+
+    // Loads the saved instruction value for the engine and refreshes which instruction control
+    // is shown (free-text box for Qwen3 VoiceDesign, keyword picker for OmniVoice).
+    private void ApplyInstructionForEngine(ITtsEngine? engine)
+    {
+        Instruction = GetInstructionForEngine(engine);
+
+        if (engine is OmniVoiceTtsCpp)
+        {
+            SyncOmniVoicePickerFromInstruction();
+        }
+
+        RefreshInstructionVisibility();
+        UpdateVoiceLock();
+        UpdateOmniVoicePickerState();
+    }
+
+    // Qwen3's free-text instruction only does anything on the VoiceDesign model - the 0.6B and
+    // 1.7B Base models are not instruction-tuned. OmniVoice always shows its keyword picker.
+    private void RefreshInstructionVisibility()
+    {
+        IsInstructionTextVisible = SelectedEngine is Qwen3TtsCpp && Qwen3TtsCpp.IsVoiceDesignModel(SelectedModel);
+        IsInstructionPickerVisible = SelectedEngine is OmniVoiceTtsCpp;
+        HasInstruction = IsInstructionTextVisible || IsInstructionPickerVisible;
+    }
+
+    // The Qwen3 VoiceDesign model has no speaker encoder - the voice is defined entirely by the
+    // instruction. Lock the voice combo to the "Default" entry so an imported voice cannot route
+    // through the (unsupported) cloning path.
+    private void UpdateVoiceLock()
+    {
+        var isVoiceDesign = SelectedEngine is Qwen3TtsCpp && Qwen3TtsCpp.IsVoiceDesignModel(SelectedModel);
+        IsVoiceComboEnabled = !isVoiceDesign;
+
+        if (isVoiceDesign
+            && SelectedVoice?.EngineVoice is Voices.Qwen3TtsVoice currentVoice
+            && !string.IsNullOrEmpty(currentVoice.FilePath))
+        {
+            var defaultVoice = Voices.FirstOrDefault(v =>
+                v.EngineVoice is Voices.Qwen3TtsVoice q && string.IsNullOrEmpty(q.FilePath));
+            if (defaultVoice != null)
+            {
+                SelectedVoice = defaultVoice;
+            }
+        }
+    }
+
+    partial void OnSelectedModelChanged(string? value)
+    {
+        RefreshInstructionVisibility();
+        UpdateVoiceLock();
+    }
+
+    // omnivoice-tts applies voice-design keywords only without a reference WAV, so the picker
+    // is usable for the "Default" voice but disabled (with a note) for cloned voices.
+    private void UpdateOmniVoicePickerState()
+    {
+        var isOmniVoice = SelectedEngine is OmniVoiceTtsCpp;
+        var isDefaultVoice = SelectedVoice?.EngineVoice is Voices.OmniVoiceVoice omniVoice
+                             && string.IsNullOrEmpty(omniVoice.FilePath);
+
+        IsInstructionPickerEnabled = isOmniVoice && isDefaultVoice;
+        IsInstructionVoiceHintVisible = isOmniVoice && !isDefaultVoice;
+    }
+
+    partial void OnSelectedVoiceChanged(Voice? value)
+    {
+        UpdateOmniVoicePickerState();
+    }
+
+    private static ObservableCollection<string> BuildKeywordOptions(string[] keywords)
+    {
+        var options = new ObservableCollection<string> { OmniVoiceAny };
+        foreach (var keyword in keywords)
+        {
+            options.Add(keyword);
+        }
+        return options;
+    }
+
+    private static bool IsRealOmniVoiceKeyword(string? value)
+    {
+        return !string.IsNullOrEmpty(value) && value != OmniVoiceAny;
+    }
+
+    partial void OnSelectedOmniVoiceGenderChanged(string value) => OnOmniVoicePickerChanged();
+    partial void OnSelectedOmniVoiceAgeChanged(string value) => OnOmniVoicePickerChanged();
+    partial void OnSelectedOmniVoicePitchChanged(string value) => OnOmniVoicePickerChanged();
+    partial void OnSelectedOmniVoiceAccentChanged(string value) => OnOmniVoicePickerChanged();
+    partial void OnOmniVoiceWhisperChanged(bool value) => OnOmniVoicePickerChanged();
+
+    private void OnOmniVoicePickerChanged()
+    {
+        if (!_suppressKeywordSync)
+        {
+            Instruction = BuildOmniVoiceInstruction();
+        }
+    }
+
+    private string BuildOmniVoiceInstruction()
+    {
+        var parts = new List<string>();
+        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceGender)) parts.Add(SelectedOmniVoiceGender);
+        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceAge)) parts.Add(SelectedOmniVoiceAge);
+        if (IsRealOmniVoiceKeyword(SelectedOmniVoicePitch)) parts.Add(SelectedOmniVoicePitch);
+        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceAccent)) parts.Add(SelectedOmniVoiceAccent);
+        if (OmniVoiceWhisper) parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        return string.Join(", ", parts);
+    }
+
+    // Reflects the saved instruction string into the picker controls, then rewrites Instruction
+    // from the picker so any unrecognised text (e.g. legacy free-text values from before the
+    // picker existed) is dropped instead of failing omnivoice-tts.
+    private void SyncOmniVoicePickerFromInstruction()
+    {
+        var present = (Instruction ?? string.Empty)
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => s.Length > 0)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        _suppressKeywordSync = true;
+        SelectedOmniVoiceGender = MatchOmniVoiceGroup(OmniVoiceTtsCpp.InstructionGenders, present);
+        SelectedOmniVoiceAge = MatchOmniVoiceGroup(OmniVoiceTtsCpp.InstructionAges, present);
+        SelectedOmniVoicePitch = MatchOmniVoiceGroup(OmniVoiceTtsCpp.InstructionPitches, present);
+        SelectedOmniVoiceAccent = MatchOmniVoiceGroup(OmniVoiceTtsCpp.InstructionAccents, present);
+        OmniVoiceWhisper = present.Contains(OmniVoiceTtsCpp.InstructionWhisper);
+        _suppressKeywordSync = false;
+
+        Instruction = BuildOmniVoiceInstruction();
+    }
+
+    // The first keyword from the group present in the saved instruction, or "(any)" if none.
+    private static string MatchOmniVoiceGroup(string[] group, HashSet<string> present)
+    {
+        return Array.Find(group, present.Contains) ?? OmniVoiceAny;
     }
 
     public void Initialize(Subtitle subtitle, string videoFileName, WavePeakData2? wavePeakData, string waveFolder)
@@ -309,6 +500,9 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             return;
         }
+
+        // The engine and/or its models may have just been downloaded - refresh the combo dots.
+        RefreshDownloadDots?.Invoke();
 
         var voice = SelectedVoice;
         if (voice != null && !await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
@@ -394,28 +588,27 @@ public partial class TextToSpeechViewModel : ObservableObject
         if (SelectedEngine is OmniVoiceTtsCpp)
         {
             await _windowService.ShowDialogAsync<OmniVoiceSettingsWindow, OmniVoiceSettingsViewModel>(Window!, vm => vm.Initialize());
-            return;
         }
-
-        if (SelectedEngine is Qwen3TtsCpp)
+        else if (SelectedEngine is Qwen3TtsCpp)
         {
             await _windowService.ShowDialogAsync<Qwen3TtsSettingsWindow, Qwen3TtsSettingsViewModel>(Window!, vm => vm.Initialize());
-            return;
         }
-
-        if (SelectedEngine is KokoroTtsCpp)
+        else if (SelectedEngine is KokoroTtsCpp)
         {
             await _windowService.ShowDialogAsync<KokoroTtsSettingsWindow, KokoroTtsSettingsViewModel>(Window!, vm => vm.Initialize());
-            return;
         }
-
-        if (SelectedEngine is ChatterboxTtsCpp)
+        else if (SelectedEngine is ChatterboxTtsCpp)
         {
             await _windowService.ShowDialogAsync<ChatterboxTtsSettingsWindow, ChatterboxTtsSettingsViewModel>(Window!, vm => vm.Initialize());
-            return;
+        }
+        else
+        {
+            await _windowService.ShowDialogAsync<ElevenLabsSettingsWindow, ElevenLabsSettingsViewModel>(Window!, vm => { });
         }
 
-        await _windowService.ShowDialogAsync<ElevenLabsSettingsWindow, ElevenLabsSettingsViewModel>(Window!, vm => { });
+        // An engine may have been (re)downloaded inside its settings dialog - re-check the
+        // install-status dots in the engine and model combos.
+        RefreshDownloadDots?.Invoke();
     }
 
     [RelayCommand]
@@ -433,6 +626,8 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             return;
         }
+
+        RefreshDownloadDots?.Invoke();
 
         if (!await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
         {
@@ -746,7 +941,12 @@ public partial class TextToSpeechViewModel : ObservableObject
             var qwen3ModelKey = Qwen3TtsCpp.ResolveModelKey(SelectedModel);
             if (!Qwen3TtsCpp.IsModelsInstalled(qwen3ModelKey))
             {
-                var sizeText = qwen3ModelKey == Qwen3TtsCpp.ModelKey17BBase ? "~2.7 GB" : "~1.6 GB";
+                var sizeText = qwen3ModelKey switch
+                {
+                    Qwen3TtsCpp.ModelKey17BBase => "~2.7 GB",
+                    Qwen3TtsCpp.ModelKey17BVoiceDesign => "~2.8 GB",
+                    _ => "~1.6 GB",
+                };
                 var answer = await MessageBox.Show(
                     Window,
                     "Download Qwen3 TTS models?",
@@ -1741,6 +1941,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             HasModel = engine.HasModel;
             HasKeyFile = engine.HasKeyFile;
             IsEdgeTtsEngine = engine is EdgeTts;
+            ApplyInstructionForEngine(engine);
 
             if (HasLanguageParameter)
             {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -1,11 +1,14 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Styling;
+using System.Collections.ObjectModel;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -15,6 +18,8 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 public class TextToSpeechWindow : Window
 {
     private readonly TextToSpeechViewModel _vm;
+    private ComboBox? _comboBoxEngines;
+    private ComboBox? _comboBoxModels;
 
     public TextToSpeechWindow(TextToSpeechViewModel vm)
     {
@@ -25,6 +30,7 @@ public class TextToSpeechWindow : Window
 
         _vm = vm;
         vm.Window = this;
+        vm.RefreshDownloadDots = RefreshDownloadDots;
         DataContext = vm;
 
         var labelEngine = new Label
@@ -114,17 +120,62 @@ public class TextToSpeechWindow : Window
         }
     }
 
-    private static Border MakeEngineControls(TextToSpeechViewModel vm)
+    private static FuncDataTemplate<ITtsEngine> BuildEngineItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<ITtsEngine>(
+            engine => engine.Name,
+            _ => null,
+            GetTtsEngineDotStatus);
+    }
+
+    // Install-status dot for a model in the model combo. Local engines (Qwen3, Chatterbox) get
+    // a green/grey dot per model; cloud engines (ElevenLabs, Mistral) have nothing to install.
+    private static DownloadDotStatus GetTtsModelDotStatus(ITtsEngine? engine, string modelKey)
+    {
+        return engine switch
+        {
+            Qwen3TtsCpp => Qwen3TtsCpp.IsModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            ChatterboxTtsCpp => ChatterboxTtsCpp.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            _ => DownloadDotStatus.None,
+        };
+    }
+
+    private static FuncDataTemplate<string> BuildModelItemTemplate(TextToSpeechViewModel vm)
+    {
+        return StatusDots.ComboItemTemplate<string>(
+            modelKey => modelKey,
+            _ => null,
+            modelKey => GetTtsModelDotStatus(vm.SelectedEngine, modelKey));
+    }
+
+    // Rebuilds the engine and model combo item templates so the install-status dots are
+    // re-evaluated. Called after an engine/model may have been (re)downloaded - the dots are
+    // one-off snapshots, so a fresh template is the refresh.
+    public void RefreshDownloadDots()
+    {
+        if (_comboBoxEngines != null)
+        {
+            _comboBoxEngines.ItemTemplate = BuildEngineItemTemplate();
+        }
+        if (_comboBoxModels != null)
+        {
+            _comboBoxModels.ItemTemplate = BuildModelItemTemplate(_vm);
+        }
+    }
+
+    private Border MakeEngineControls(TextToSpeechViewModel vm)
     {
         var labelMinWidth = 100;
         var controlMinWidth = 200;
 
         var comboBoxEngines = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine)).WithWidth(controlMinWidth);
-        comboBoxEngines.ItemTemplate = StatusDots.ComboItemTemplate<ITtsEngine>(
-            engine => engine.Name,
-            _ => null,
-            GetTtsEngineDotStatus);
+        comboBoxEngines.ItemTemplate = BuildEngineItemTemplate();
         comboBoxEngines.SelectionChanged += vm.SelectedEngineChanged;
+        _comboBoxEngines = comboBoxEngines;
 
         var panelEngine = new StackPanel
         {
@@ -145,6 +196,11 @@ public class TextToSpeechWindow : Window
         };
 
         var buttonTestVoice = UiUtil.MakeButton(Se.Language.Video.TextToSpeech.TestVoice, vm.TestVoiceCommand).WithBindIsEnabled(nameof(vm.IsVoiceTestEnabled));
+
+        // The Qwen3 VoiceDesign model has no speaker encoder - the combo is locked to "Default".
+        var comboBoxVoices = UiUtil.MakeComboBox(vm.Voices, vm, nameof(vm.SelectedVoice)).WithWidth(controlMinWidth);
+        comboBoxVoices.Bind(ComboBox.IsEnabledProperty, new Binding(nameof(vm.IsVoiceComboEnabled)) { Mode = BindingMode.OneWay });
+
         var panelVoice = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -156,7 +212,7 @@ public class TextToSpeechWindow : Window
                     Content = Se.Language.General.Voice,
                     MinWidth = labelMinWidth,
                 },
-                UiUtil.MakeComboBox(vm.Voices, vm, nameof(vm.SelectedVoice)).WithWidth(controlMinWidth),
+                comboBoxVoices,
                 new Label
                 {
                     [!Label.ContentProperty] = new Binding(nameof(vm.VoiceCountInfo)) { Mode = BindingMode.TwoWay }
@@ -167,6 +223,8 @@ public class TextToSpeechWindow : Window
         };
 
         var comboBoxModels = UiUtil.MakeComboBox(vm.Models, vm, nameof(vm.SelectedModel)).WithWidth(controlMinWidth);
+        comboBoxModels.ItemTemplate = BuildModelItemTemplate(vm);
+        _comboBoxModels = comboBoxModels;
         var panelModel = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -251,6 +309,45 @@ public class TextToSpeechWindow : Window
             [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.HasKeyFile)) { Mode = BindingMode.OneWay },
         };
 
+        // Voice instruction applied to every segment. Qwen3 TTS takes free text; OmniVoice TTS
+        // only accepts fixed voice-design keywords, so it gets a multi-select picker instead.
+        // The panel is shown for both (HasInstruction); the two controls toggle within it.
+        var textBoxInstruction = new TextBox
+        {
+            Width = 325,
+            Height = 60,
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            VerticalContentAlignment = VerticalAlignment.Top,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            PlaceholderText = Se.Language.Video.TextToSpeech.VoiceInstructionHint,
+            DataContext = vm,
+            [!TextBox.IsVisibleProperty] = new Binding(nameof(vm.IsInstructionTextVisible)) { Mode = BindingMode.OneWay },
+        };
+        textBoxInstruction.Bind(TextBox.TextProperty, new Binding(nameof(vm.Instruction))
+        {
+            Mode = BindingMode.TwoWay,
+            UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+        });
+
+        var panelInstruction = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(0, 10, 0, 0),
+            Children =
+            {
+                new Label
+                {
+                    Content = Se.Language.Video.TextToSpeech.VoiceInstruction,
+                    MinWidth = labelMinWidth,
+                    VerticalAlignment = VerticalAlignment.Top,
+                },
+                textBoxInstruction,
+                MakeInstructionKeywordPicker(vm),
+            },
+            [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.HasInstruction)) { Mode = BindingMode.OneWay },
+        };
+
         var grid = new Grid
         {
             RowDefinitions =
@@ -281,8 +378,74 @@ public class TextToSpeechWindow : Window
         grid.Add(panelLanguage, 4, 0);
         grid.Add(panelApiKey, 5, 0);
         grid.Add(panelKeyFile, 6, 0);
+        grid.Add(panelInstruction, 7, 0);
 
         return UiUtil.MakeBorderForControl(grid);
+    }
+
+    // Single-select picker of OmniVoice TTS voice-design keywords: one combo box per mutually
+    // exclusive group (gender, age, pitch, accent) plus a stand-alone "whisper" checkbox. Shown
+    // only for OmniVoice; disabled with a note for cloned voices, since omnivoice-tts ignores
+    // --instruct when a reference WAV is used.
+    private static Control MakeInstructionKeywordPicker(TextToSpeechViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 8,
+            RowSpacing = 6,
+            [!Grid.IsEnabledProperty] = new Binding(nameof(vm.IsInstructionPickerEnabled)) { Mode = BindingMode.OneWay },
+        };
+
+        AddInstructionPickerRow(grid, 0, Se.Language.Video.TextToSpeech.VoiceGender, vm, vm.OmniVoiceGenders, nameof(vm.SelectedOmniVoiceGender));
+        AddInstructionPickerRow(grid, 1, Se.Language.Video.TextToSpeech.VoiceAge, vm, vm.OmniVoiceAges, nameof(vm.SelectedOmniVoiceAge));
+        AddInstructionPickerRow(grid, 2, Se.Language.Video.TextToSpeech.VoicePitch, vm, vm.OmniVoicePitches, nameof(vm.SelectedOmniVoicePitch));
+        AddInstructionPickerRow(grid, 3, Se.Language.Video.TextToSpeech.VoiceAccent, vm, vm.OmniVoiceAccents, nameof(vm.SelectedOmniVoiceAccent));
+
+        var whisper = new CheckBox
+        {
+            Content = OmniVoiceTtsCpp.InstructionWhisper,
+            DataContext = vm,
+            Margin = new Thickness(0, 4, 0, 0),
+        };
+        whisper.Bind(CheckBox.IsCheckedProperty, new Binding(nameof(vm.OmniVoiceWhisper)) { Mode = BindingMode.TwoWay });
+        grid.Add(whisper, 4, 0, 1, 2);
+
+        var clonedVoiceNote = new TextBlock
+        {
+            Text = Se.Language.Video.TextToSpeech.VoiceInstructionClonedVoiceNote,
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+            MaxWidth = 280,
+            Margin = new Thickness(0, 6, 0, 0),
+            [!TextBlock.IsVisibleProperty] = new Binding(nameof(vm.IsInstructionVoiceHintVisible)) { Mode = BindingMode.OneWay },
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Children = { grid, clonedVoiceNote },
+            [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.IsInstructionPickerVisible)) { Mode = BindingMode.OneWay },
+        };
+    }
+
+    private static void AddInstructionPickerRow(Grid grid, int row, string label, TextToSpeechViewModel vm,
+        ObservableCollection<string> items, string selectedPropertyPath)
+    {
+        grid.Add(new Label { Content = label, MinWidth = 60, VerticalAlignment = VerticalAlignment.Center }, row, 0);
+        grid.Add(UiUtil.MakeComboBox(items, vm, selectedPropertyPath).WithWidth(200), row, 1);
     }
 
     private static Border MakeSettingsControls(TextToSpeechViewModel vm)

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -65,6 +65,13 @@ public class LanguageTextToSpeech
     public string Qwen3TtsSettings { get; set; }
     public string KokoroTtsSettings { get; set; }
     public string ChatterboxTtsSettings { get; set; }
+    public string VoiceInstruction { get; set; }
+    public string VoiceInstructionHint { get; set; }
+    public string VoiceGender { get; set; }
+    public string VoiceAge { get; set; }
+    public string VoicePitch { get; set; }
+    public string VoiceAccent { get; set; }
+    public string VoiceInstructionClonedVoiceNote { get; set; }
 
     public LanguageTextToSpeech()
     {
@@ -129,5 +136,12 @@ public class LanguageTextToSpeech
         Qwen3TtsSettings = "Qwen3 TTS settings";
         KokoroTtsSettings = "Kokoro TTS settings";
         ChatterboxTtsSettings = "Chatterbox TTS settings";
+        VoiceInstruction = "Voice instruction";
+        VoiceInstructionHint = "Optional - e.g. \"Speak in a calm and friendly tone\"";
+        VoiceGender = "Gender";
+        VoiceAge = "Age";
+        VoicePitch = "Pitch";
+        VoiceAccent = "Accent";
+        VoiceInstructionClonedVoiceNote = "Voice design only affects the \"Default\" voice - a cloned voice keeps its own characteristics.";
     }
 }

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -27,7 +27,9 @@ public class SeVideoTextToSpeech
     public string MistralModel { get; set; }
     public string Qwen3TtsCppModel { get; set; }
     public string Qwen3TtsCppVulkanPath { get; set; }
+    public string Qwen3TtsCppInstruction { get; set; }
     public string OmniVoiceTtsCppVulkanPath { get; set; }
+    public string OmniVoiceTtsCppInstruction { get; set; }
     public string ChatterboxModel { get; set; }
     public string KokoroVoice { get; set; }
     public string GoogleApiKey { get; set; }
@@ -88,7 +90,9 @@ public class SeVideoTextToSpeech
         MistralModel = "voxtral-mini-tts-2603";
         Qwen3TtsCppModel = "0.6B";
         Qwen3TtsCppVulkanPath = string.Empty;
+        Qwen3TtsCppInstruction = string.Empty;
         OmniVoiceTtsCppVulkanPath = string.Empty;
+        OmniVoiceTtsCppInstruction = string.Empty;
         ChatterboxModel = "Base";
         KokoroVoice = "af_maple";
         GoogleApiKey = string.Empty;

--- a/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
@@ -44,6 +44,9 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
         // khimaros' rebuild includes the projection tensor (named code_pred.mtp_proj.*) that
         // qwen3-tts.cpp needs for the 1.7B variant. The koboldcpp upload predates that change.
         ["Qwen3-TTS-12Hz-1.7B-Base-q8_0.gguf"] = "https://huggingface.co/khimaros/Qwen3-TTS-12Hz-1.7B-Base-GGUF/resolve/main/Qwen3-TTS-12Hz-1.7B-Base-Q8_0.gguf",
+        // Instruction-tuned VoiceDesign variant - the voice is described by free-text rather
+        // than cloned or picked from a speaker table. Shares the 12Hz tokenizer above.
+        ["qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf"] = "https://huggingface.co/cstr/qwen3-tts-1.7b-voicedesign-GGUF/resolve/main/qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf",
     };
 
     private const string VoicesUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-tts-cpp-2026-4/voices.zip";

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -952,6 +952,25 @@ public static class UiUtil
         return control;
     }
 
+    // Like WithIconLeft, but the text is bound to a view-model property instead of being fixed,
+    // so the caption can change at runtime (e.g. "Download" vs "Re-download").
+    public static Button WithIconLeftBindText(this Button control, string iconName, string textPropertyPath)
+    {
+        var label = new TextBlock { Padding = new Thickness(4, 0, 0, 0) };
+        label.Bind(TextBlock.TextProperty, new Binding { Path = textPropertyPath });
+
+        var image = new ContentControl();
+        Attached.SetIcon(image, iconName);
+
+        control.Content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { image, label },
+        };
+
+        return control;
+    }
+
     public static ComboBox WithLeftAlignment(this ComboBox control)
     {
         control.HorizontalAlignment = HorizontalAlignment.Left;

--- a/tests/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCppTests.cs
@@ -5,17 +5,18 @@ namespace UITests.Features.Video.TextToSpeech.Engines;
 public class Qwen3TtsCppTests
 {
     [Fact]
-    public async Task GetModels_Returns_BothVariants()
+    public async Task GetModels_Returns_AllVariants()
     {
         var engine = new Qwen3TtsCpp();
         var models = await engine.GetModels();
 
-        Assert.Equal(new[] { Qwen3TtsCpp.ModelKey06B, Qwen3TtsCpp.ModelKey17BBase }, models);
+        Assert.Equal(new[] { Qwen3TtsCpp.ModelKey06B, Qwen3TtsCpp.ModelKey17BBase, Qwen3TtsCpp.ModelKey17BVoiceDesign }, models);
     }
 
     [Theory]
     [InlineData(Qwen3TtsCpp.ModelKey06B, Qwen3TtsCpp.TtsModelFileName06B)]
     [InlineData(Qwen3TtsCpp.ModelKey17BBase, Qwen3TtsCpp.TtsModelFileName17BBase)]
+    [InlineData(Qwen3TtsCpp.ModelKey17BVoiceDesign, Qwen3TtsCpp.TtsModelFileName17BVoiceDesign)]
     [InlineData("unknown", Qwen3TtsCpp.TtsModelFileName06B)]
     [InlineData(null, Qwen3TtsCpp.TtsModelFileName06B)]
     public void GetModelFileName_MapsKeyToFile(string? key, string expected)


### PR DESCRIPTION
- Qwen3 TTS: free-text voice instruction box, shown only for the new 1.7B VoiceDesign model (the 0.6B/1.7B Base models are not instruction- tuned and ignore it); the voice combo is locked to "Default" for the VoiceDesign model, which has no speaker encoder
- Add the Qwen3 1.7B VoiceDesign model (download URL + model picker entry)
- OmniVoice TTS: voice-design keyword picker - Gender/Age/Pitch/Accent combo boxes plus a whisper checkbox; disabled with a note for cloned voices, since omnivoice-tts ignores --instruct when a reference WAV is used
- Show install-status dots on the model combo, and refresh the engine and model dots after an engine/model is downloaded
- Engine settings dialogs: the download button now reads "Download" when nothing is installed instead of always "Re-download" (Qwen3, OmniVoice, Kokoro, and Speech-to-text engine settings)
- Surface the Qwen3 server's output on a synthesis failure, not only on a startup failure