### PR TITLE
Say "Update" on the Qwen3 TTS settings engine button when an update i…

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -92,6 +92,8 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private bool _llamaCppModelComboIsVisible;
     [ObservableProperty] private bool _llamaCppButtonsAreVisible;
     [ObservableProperty] private string _llamaCppServerButtonText = "Start server";
+    [ObservableProperty] private string _llamaCppDownloadButtonText = string.Empty;
+    [ObservableProperty] private string _crispAsrDownloadButtonText = string.Empty;
 
     public DataGrid? RowGrid { get; set; }
 
@@ -733,12 +735,23 @@ public partial class AutoTranslateViewModel : ObservableObject
 
     partial void OnSelectedCrispAsrModelChanged(SpeechToTextModelDisplay? value)
     {
+        UpdateCrispAsrDownloadButtonText();
+
         if (value == null)
         {
             return;
         }
 
         ModelText = new CrispAsrMadlad().GetModelForCmdLine(value.Model.Name);
+    }
+
+    // "Download" when the selected model is not on disk, "Re-download" when it is.
+    private void UpdateCrispAsrDownloadButtonText()
+    {
+        var selected = SelectedCrispAsrModel;
+        CrispAsrDownloadButtonText = selected != null && selected.Engine.IsModelInstalled(selected.Model)
+            ? Se.Language.General.Redownload
+            : Se.Language.General.Download;
     }
 
     private async Task<bool> EnsureCrispAsrReady()
@@ -759,6 +772,8 @@ public partial class AutoTranslateViewModel : ObservableObject
 
     partial void OnSelectedLlamaCppModelChanged(LlamaCppModelDisplay? value)
     {
+        UpdateLlamaCppDownloadButtonText();
+
         if (value == null)
         {
             return;
@@ -766,6 +781,15 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         Se.Settings.AutoTranslate.LlamaCppModel = LlamaCppServerManager.GetModelPath(value.Model.FileName);
         Configuration.Settings.Tools.LlamaCppModel = Se.Settings.AutoTranslate.LlamaCppModel;
+    }
+
+    // "Download" when the selected model is not on disk, "Re-download" when it is.
+    private void UpdateLlamaCppDownloadButtonText()
+    {
+        var model = SelectedLlamaCppModel?.Model;
+        LlamaCppDownloadButtonText = model != null && LlamaCppServerManager.IsModelInstalled(model)
+            ? Se.Language.General.Redownload
+            : Se.Language.General.Download;
     }
 
     private void UpdateLlamaCppServerButtonText()

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -236,7 +236,9 @@ public class AutoTranslateWindow : Window
 
     private static Border BuildApiConfigCard(AutoTranslateViewModel vm)
     {
-        var buttonDownloadCrispAsr = UiUtil.MakeButton(Se.Language.General.Download, vm.DownloadCrispAsrCommand).WithMarginLeft(5);
+        var buttonDownloadCrispAsr = UiUtil.MakeButton(string.Empty, vm.DownloadCrispAsrCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.CrispAsrDownloadButtonText))
+            .WithMarginLeft(5);
         buttonDownloadCrispAsr.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.ButtonDownloadIsVisible)));
 
         var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
@@ -253,7 +255,9 @@ public class AutoTranslateWindow : Window
             GetLlamaCppModelSize,
             GetLlamaCppModelDotStatus);
 
-        var buttonDownloadLlamaCpp = UiUtil.MakeButton(vm.DownloadLlamaCppCommand, IconNames.Download, Se.Language.General.Download).WithMarginLeft(5);
+        var buttonDownloadLlamaCpp = UiUtil.MakeButton(string.Empty, vm.DownloadLlamaCppCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.LlamaCppDownloadButtonText))
+            .WithMarginLeft(5);
         buttonDownloadLlamaCpp.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
 
         var buttonLlamaCppServer = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppServerCommand).WithMarginLeft(5);

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -34,9 +34,26 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
     private bool _isInstalled;
 
-    public string DownloadButtonLabel => IsInstalled
-        ? Se.Language.General.Redownload
-        : Se.Language.General.Download;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private DownloadHashManager.UpdateStatus _engineUpdateStatus;
+
+    // "Download" when not installed, "Update" when a newer engine release is available,
+    // otherwise "Re-download".
+    public string DownloadButtonLabel
+    {
+        get
+        {
+            if (!IsInstalled)
+            {
+                return Se.Language.General.Download;
+            }
+
+            return EngineUpdateStatus == DownloadHashManager.UpdateStatus.UpdateAvailable
+                ? Se.Language.General.Update
+                : Se.Language.General.Redownload;
+        }
+    }
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -67,7 +84,8 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
         InstallFolder = _engine.GetAndCreateWhisperFolder();
         IsInstalled = _engine.IsEngineInstalled();
         BackendLabel = IsInstalled ? DetectBackend(_engine, InstallFolder) : Se.Language.General.NotInstalled;
-        ApplyStatus(IsInstalled ? ComputeStatus(_engine, InstallFolder) : DownloadHashManager.UpdateStatus.Unknown, IsInstalled);
+        EngineUpdateStatus = IsInstalled ? ComputeStatus(_engine, InstallFolder) : DownloadHashManager.UpdateStatus.Unknown;
+        ApplyStatus(EngineUpdateStatus, IsInstalled);
     }
 
     private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)

--- a/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsViewModel.cs
@@ -33,9 +33,26 @@ public partial class KokoroTtsSettingsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
     private bool _isInstalled;
 
-    public string DownloadButtonLabel => IsInstalled
-        ? Se.Language.General.Redownload
-        : Se.Language.General.Download;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private DownloadHashManager.UpdateStatus _engineUpdateStatus;
+
+    // "Download" when not installed, "Update" when a newer engine release is available,
+    // otherwise "Re-download".
+    public string DownloadButtonLabel
+    {
+        get
+        {
+            if (!IsInstalled)
+            {
+                return Se.Language.General.Download;
+            }
+
+            return EngineUpdateStatus == DownloadHashManager.UpdateStatus.UpdateAvailable
+                ? Se.Language.General.Update
+                : Se.Language.General.Redownload;
+        }
+    }
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -56,7 +73,8 @@ public partial class KokoroTtsSettingsViewModel : ObservableObject
     {
         IsInstalled = File.Exists(KokoroTtsCpp.GetExecutableFileName());
         BackendLabel = IsInstalled ? DetectInstalledBackend() : Se.Language.General.NotInstalled;
-        ApplyStatus(IsInstalled ? KokoroTtsCpp.GetEngineUpdateStatus() : DownloadHashManager.UpdateStatus.Unknown, IsInstalled);
+        EngineUpdateStatus = IsInstalled ? KokoroTtsCpp.GetEngineUpdateStatus() : DownloadHashManager.UpdateStatus.Unknown;
+        ApplyStatus(EngineUpdateStatus, IsInstalled);
     }
 
     private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
@@ -34,9 +34,26 @@ public partial class OmniVoiceSettingsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
     private bool _isInstalled;
 
-    public string DownloadButtonLabel => IsInstalled
-        ? Se.Language.General.Redownload
-        : Se.Language.General.Download;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private DownloadHashManager.UpdateStatus _engineUpdateStatus;
+
+    // "Download" when not installed, "Update" when a newer engine release is available,
+    // otherwise "Re-download".
+    public string DownloadButtonLabel
+    {
+        get
+        {
+            if (!IsInstalled)
+            {
+                return Se.Language.General.Download;
+            }
+
+            return EngineUpdateStatus == DownloadHashManager.UpdateStatus.UpdateAvailable
+                ? Se.Language.General.Update
+                : Se.Language.General.Redownload;
+        }
+    }
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -57,7 +74,8 @@ public partial class OmniVoiceSettingsViewModel : ObservableObject
     {
         IsInstalled = File.Exists(OmniVoiceTtsCpp.GetExecutableFileName());
         BackendLabel = IsInstalled ? DetectInstalledBackend() : Se.Language.General.NotInstalled;
-        ApplyStatus(IsInstalled ? OmniVoiceTtsCpp.GetEngineUpdateStatus() : DownloadHashManager.UpdateStatus.Unknown, IsInstalled);
+        EngineUpdateStatus = IsInstalled ? OmniVoiceTtsCpp.GetEngineUpdateStatus() : DownloadHashManager.UpdateStatus.Unknown;
+        ApplyStatus(EngineUpdateStatus, IsInstalled);
     }
 
     private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
@@ -34,9 +34,26 @@ public partial class Qwen3TtsSettingsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
     private bool _isInstalled;
 
-    public string DownloadButtonLabel => IsInstalled
-        ? Se.Language.General.Redownload
-        : Se.Language.General.Download;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private DownloadHashManager.UpdateStatus _engineUpdateStatus;
+
+    // "Download" when not installed, "Update" when a newer engine release is available,
+    // otherwise "Re-download".
+    public string DownloadButtonLabel
+    {
+        get
+        {
+            if (!IsInstalled)
+            {
+                return Se.Language.General.Download;
+            }
+
+            return EngineUpdateStatus == DownloadHashManager.UpdateStatus.UpdateAvailable
+                ? Se.Language.General.Update
+                : Se.Language.General.Redownload;
+        }
+    }
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -57,7 +74,8 @@ public partial class Qwen3TtsSettingsViewModel : ObservableObject
     {
         IsInstalled = File.Exists(Qwen3TtsCpp.GetExecutableFileName());
         BackendLabel = IsInstalled ? DetectInstalledBackend() : Se.Language.General.NotInstalled;
-        ApplyStatus(IsInstalled ? Qwen3TtsCpp.GetEngineUpdateStatus() : DownloadHashManager.UpdateStatus.Unknown, IsInstalled);
+        EngineUpdateStatus = IsInstalled ? Qwen3TtsCpp.GetEngineUpdateStatus() : DownloadHashManager.UpdateStatus.Unknown;
+        ApplyStatus(EngineUpdateStatus, IsInstalled);
     }
 
     private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)


### PR DESCRIPTION
…s available

The engine button was two-state ("Download" / "Re-download"). It now reads "Update" when the installed engine has a newer release available (GetEngineUpdateStatus() == UpdateAvailable), matching the amber status row - "Download" when not installed, "Re-download" when up to date.