### PR TITLE
Pin Qwen3 TTS to qwen3-tts.cpp v0.4.5

### DIFF
--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -372,31 +372,37 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [Qwen3TtsCpp.WindowsVulkan] = new[]
             {
-                "697b4871b803172ef2d30682e099008c646591e59835e655c598d275163723c8", // v0.4.4 (current download URL)
+                "84bc6bfa5edeadecf969acc00f5798b12eb33a3c0b884143eafb942c2b0f6dd1", // v0.4.5 (current download URL)
+                "697b4871b803172ef2d30682e099008c646591e59835e655c598d275163723c8", // v0.4.4
                 "42dff2cb2e921a337c588e5331b5ea963b777751303729a66bf0124be242297d", // v0.4.3
             },
             [Qwen3TtsCpp.WindowsCpu] = new[]
             {
-                "e09875f4d329b1c7623af2e7ea5fae2c838c1bd880712415220323f969370975", // v0.4.4 (current download URL)
+                "9018c49f4d154ac0b1a0bc946a0689a75a6d1383c788ef4e70760609124f58c4", // v0.4.5 (current download URL)
+                "e09875f4d329b1c7623af2e7ea5fae2c838c1bd880712415220323f969370975", // v0.4.4
                 "afa9fef938ddd8d22a0f5c955b5c3a2e402f49a6d1ddc587da2d07d6993f4120", // v0.4.3
             },
             [Qwen3TtsCpp.WindowsCuda] = new[]
             {
-                "cb53effe905d05e60e61f8dcadda00544d6d427d567be017c7ed4bea2148acb2", // v0.4.4 (current download URL)
+                "e4a3f185cd5952ac9e9a092a2b490fdd3088d070681db46d98c5e2d6cd8303b1", // v0.4.5 (current download URL)
+                "cb53effe905d05e60e61f8dcadda00544d6d427d567be017c7ed4bea2148acb2", // v0.4.4
             },
             [Qwen3TtsCpp.MacOs] = new[]
             {
-                "faecc2b93d9586f8d7bdf2601343c5a14f8d6bd2546578ed2559a0e2d191412c", // v0.4.4 (current download URL)
+                "95421febb5bf04d1807e1bd6a56cf47e9b8ce2a421922a9e13103771b0fbfa6c", // v0.4.5 (current download URL)
+                "faecc2b93d9586f8d7bdf2601343c5a14f8d6bd2546578ed2559a0e2d191412c", // v0.4.4
                 "625f32817ff9e5cacea48db24ad8ae1149406e382a7e58068fc87182238baa07", // v0.4.3
             },
             [Qwen3TtsCpp.LinuxX64] = new[]
             {
-                "c9ecec169ebed93909ac72b65e0acbb8958047f08c8b9cf4f5d07d0e3bfc2844", // v0.4.4 (current download URL)
+                "cb5d3f137394688bd985835a45fd0fadabff4f450091f61f0a96423c0a21471a", // v0.4.5 (current download URL)
+                "c9ecec169ebed93909ac72b65e0acbb8958047f08c8b9cf4f5d07d0e3bfc2844", // v0.4.4
                 "4456b19fa62ac52c6ef6302f36effc1336d559be0fde200222be302746dd2579", // v0.4.3
             },
             [Qwen3TtsCpp.LinuxArm64] = new[]
             {
-                "bba376f4ead8356a496a48d37572e6c56d66161d52026f502e74afd050654f41", // v0.4.4 (current download URL)
+                "30d9e1ed411a67d300eb72ae8c7069e344aa662c1cc10d41b0b37e2ca558b84b", // v0.4.5 (current download URL)
+                "bba376f4ead8356a496a48d37572e6c56d66161d52026f502e74afd050654f41", // v0.4.4
                 "3e9bdc9d176ea13a109d8e8a813009e110df003a988d10dc317e58572517d014", // v0.4.3
             },
             [Qwen3TtsCpp.Voices] = new[]

--- a/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
@@ -25,7 +25,7 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
 
     // qwen3-tts.cpp release pin. Bump in lockstep with the hashes in
     // DownloadHashManager.Qwen3TtsCpp (each new release: prepend the new SHA-256 at index 0).
-    public const string ReleaseTag = "v0.4.4";
+    public const string ReleaseTag = "v0.4.5";
     private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-tts.cpp/releases/download/" + ReleaseTag + "/";
 
     private const string WindowsVulkanUrl = ReleaseUrlBase + "qwen3-tts-server-" + ReleaseTag + "-windows-vulkan-x64.zip";


### PR DESCRIPTION
v0.4.5 adds support for the CrispASR-converted "qwen3tts.*" GGUF metadata schema, which the 1.7B VoiceDesign model uses - v0.4.4 mis-read it and segfaulted during synthesis.

- Qwen3TtsCppDownloadService.ReleaseTag -> v0.4.5
- DownloadHashManager.Qwen3TtsCpp: prepend the v0.4.5 SHA-256 for each engine archive (Windows Vulkan/CPU/CUDA, macOS, Linux x64/ARM64) so the download integrity check accepts the new release