### PR TITLE
Don't show Windows variant in Qwen3 TTS download title on Mac/Linux

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -833,7 +833,9 @@ public partial class DownloadTtsViewModel : ObservableObject
     {
         _qwen3TtsCppVariant = windowsVariant;
 
-        TitleText = $"Downloading Qwen3 TTS ({windowsVariant})";
+        TitleText = Configuration.IsRunningOnWindows
+            ? $"Downloading Qwen3 TTS ({windowsVariant})"
+            : "Downloading Qwen3 TTS";
 
         var downloadProgress = new Progress<float>(number =>
         {


### PR DESCRIPTION
## Summary
- On macOS, the Qwen3 TTS download dialog showed "Downloading Qwen3 TTS (vulkan)" even though the Mac build is Metal arm64 (not Vulkan).
- The variant string (`vulkan`/`cpu`/`cuda`) only applies to Windows — `Qwen3TtsCppDownloadService.GetUrl` picks the platform URL by `OSPlatform`, so Mac/Linux always got the right binary. The label was just misleading.
- Only suffix the title with the variant on Windows; on Mac/Linux show plain "Downloading Qwen3 TTS".

## Test plan
- [ ] Build on macOS, trigger Qwen3 TTS download, confirm title reads "Downloading Qwen3 TTS" (no "(vulkan)")
- [ ] Build on Windows, trigger Qwen3 TTS download, confirm title still reads "Downloading Qwen3 TTS (vulkan)" / "(cpu)" / "(cuda)" per the selected variant
- [ ] Confirm the downloaded archive on Mac is still `qwen3-tts-server-vX.Y.Z-macos-metal-arm64.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)