### PR TITLE
Refresh engine combo dots after download in STT and auto-translate

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -109,6 +109,13 @@ public partial class AutoTranslateViewModel : ObservableObject
     private readonly IWindowService _windowService;
     private readonly IFolderHelper _folderHelper;
 
+    /// <summary>
+    /// Hook the view wires up so the engine combobox can re-evaluate its install-status dots
+    /// after a download finishes. Without this, the FuncDataTemplate row visuals stay on the
+    /// pre-download snapshot (typically amber/grey) even though the install is now current.
+    /// </summary>
+    public Action? RefreshDownloadDots { get; set; }
+
     public AutoTranslateViewModel(IWindowService windowService, IFolderHelper folderHelper)
     {
         _windowService = windowService;
@@ -726,6 +733,8 @@ public partial class AutoTranslateViewModel : ObservableObject
             PopulateCrispAsrModels(downloadedModelName);
             SaveSettings();
         }
+
+        RefreshDownloadDots?.Invoke();
     }
 
     private void PopulateCrispAsrModels(string? selectModelName)
@@ -767,6 +776,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             PopulateCrispAsrModels(Path.GetFileName(Se.Settings.AutoTranslate.CrispAsrModel ?? string.Empty));
         }
 
+        RefreshDownloadDots?.Invoke();
         return ready;
     }
 
@@ -830,6 +840,8 @@ public partial class AutoTranslateViewModel : ObservableObject
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
             SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), selectName);
         }
+
+        RefreshDownloadDots?.Invoke();
     }
 
     [RelayCommand]
@@ -888,6 +900,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), model.FileName);
+        RefreshDownloadDots?.Invoke();
 
         try
         {
@@ -962,6 +975,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), selectName);
         }
 
+        RefreshDownloadDots?.Invoke();
         UpdateLlamaCppServerButtonText();
     }
 

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -116,14 +117,16 @@ public class AutoTranslateWindow : Window
 
         var engineCombo = UiUtil.MakeComboBox(vm.AutoTranslators, vm, nameof(vm.SelectedAutoTranslator));
         engineCombo.MinWidth = 220;
-        engineCombo.ItemTemplate = StatusDots.ComboItemTemplate<IAutoTranslator>(
-            translator => translator.Name,
-            _ => null,
-            GetTranslatorDotStatus);
+        engineCombo.ItemTemplate = BuildTranslatorItemTemplate();
         engineCombo.SelectionChanged += (s, e) =>
         {
             vm.AutoTranslatorChanged(engineCombo);
         };
+
+        // Re-evaluate the engine combo's install-status dots after a download finishes - the
+        // FuncDataTemplate caches each row's dot when first realised, so a fresh template is
+        // the simplest way to refresh. The model combos already rebuild via PopulateModels.
+        vm.RefreshDownloadDots = () => engineCombo.ItemTemplate = BuildTranslatorItemTemplate();
 
         var fromLabel = UiUtil.MakeTextBlock(Se.Language.General.From);
         fromLabel.VerticalAlignment = VerticalAlignment.Center;
@@ -185,6 +188,14 @@ public class AutoTranslateWindow : Window
         };
 
         return MakeCard(stack);
+    }
+
+    private static FuncDataTemplate<IAutoTranslator> BuildTranslatorItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<IAutoTranslator>(
+            translator => translator.Name,
+            _ => null,
+            GetTranslatorDotStatus);
     }
 
     // Install-status dot for the auto-translate engine combo. Only the two engines that Subtitle

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -164,6 +164,14 @@ public partial class SpeechToTextViewModel : ObservableObject
     private static bool _crispAsrUpdatePromptShown;
     private static bool _whisperCppUpdatePromptShown;
 
+    /// <summary>
+    /// Hook the view wires up so the engine combobox can re-evaluate its install-status dots
+    /// after a re-download. The combo's <c>FuncDataTemplate</c> snapshots the install state when
+    /// each row is realised, so without an explicit refresh the dot stays on its old colour
+    /// (typically amber) even though the sidecar now reports up-to-date.
+    /// </summary>
+    public Action? RefreshEngineCombo { get; set; }
+
     public SpeechToTextViewModel(IWindowService windowService, IFileHelper fileHelper)
     {
         _windowService = windowService;
@@ -1945,6 +1953,8 @@ public partial class SpeechToTextViewModel : ObservableObject
                 viewModel.CrispAsrWindowsVariant = crispVariant;
                 viewModel.StartDownload();
             });
+
+        RefreshEngineCombo?.Invoke();
     }
 
     /// <summary>

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2395,6 +2395,8 @@ public partial class SpeechToTextViewModel : ObservableObject
                         return;
                     }
                 }
+
+                RefreshEngineCombo?.Invoke();
             }
 
             if (!engine.IsModelInstalled(model.Model))
@@ -3643,6 +3645,8 @@ public partial class SpeechToTextViewModel : ObservableObject
                 viewModel.CrispAsrWindowsVariant = crispVariant;
                 viewModel.StartDownload();
             });
+
+        RefreshEngineCombo?.Invoke();
     }
 
     private async Task CheckWhisperCppForUpdateAsync()
@@ -3691,6 +3695,8 @@ public partial class SpeechToTextViewModel : ObservableObject
                 viewModel.Engine = engine;
                 viewModel.StartDownload();
             });
+
+        RefreshEngineCombo?.Invoke();
     }
 
     private static (string key, string hash)? TryHashWhisperCppExecutable(ISpeechToTextEngine engine)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -54,6 +54,11 @@ public class SpeechToTextWindow : Window
             .WithMarginTop(10);
         comboEngine.ItemTemplate = MakeEngineItemTemplate();
         comboEngine.SelectionChanged += vm.OnEngineChanged;
+
+        // Force the combo to rebuild its row visuals after a re-download finishes, so the
+        // install-status dot reflects the freshly-written .installed.sha256 sidecar instead
+        // of the snapshot taken when each row was first realised.
+        vm.RefreshEngineCombo = () => comboEngine.ItemTemplate = MakeEngineItemTemplate();
         var buttonEngineWebsite = UiUtil.MakeButton(vm.ShowWebLinkCommand, IconNames.Web)
             .WithMarginLeft(5)
             .WithMarginTop(10);


### PR DESCRIPTION
## Summary
After re-downloading an engine, the install-status dot in the engine combobox stays on its old colour (typically amber) even though the install is now current. The user has to close and reopen the window to see the dot turn green.

Affects two windows:
- **Speech-to-text** — after the engine settings "Update" button finishes
- **Auto-translate** — after the Download/Re-download buttons for CrispASR or llama.cpp finish

## Cause
The engine combo uses `StatusDots.ComboItemTemplate<T>`, a `FuncDataTemplate` that snapshots each row's status (green / amber / grey) when Avalonia realises the row. After a download writes a fresh `.installed.sha256` sidecar, the realised row visuals are never rebuilt, so the dot stays on its old colour.

The model combos in both windows are unaffected — `PopulateModels` clears and re-adds the `ObservableCollection`, which already forces row visuals to rebuild.

The TTS window already had this hook wired up (`TextToSpeechWindow.RefreshDownloadDots()` invoked from three callsites in `TextToSpeechViewModel`), so no changes there.

## Fix
Mirror the existing TTS pattern in the two affected windows:

- `SpeechToTextViewModel` / `AutoTranslateViewModel` expose a `RefreshDownloadDots` (or `RefreshEngineCombo`) `Action` hook
- The matching window wires it to `comboEngine.ItemTemplate = BuildTranslatorItemTemplate()` — re-assigning the template forces Avalonia to re-evaluate it for every realised row
- The hook is invoked after each download path: `ReDownloadWhisperEngine` (STT); `DownloadCrispAsr`, `DownloadLlamaCpp`, `EnsureCrispAsrReady`, `EnsureLlamaCppReady`, force-engine-download llama.cpp redownload (auto-translate)

Small (4 files, +44 / -4).

## Test plan
- [x] `dotnet build src/ui/UI.csproj` clean (0 warnings, 0 errors)
- [ ] **STT**: with a CrispASR install where an update is available, confirm the engine combo shows amber; click "Update" in the engine settings dialog; after the download dialog closes, confirm the dot turns green without needing to close/reopen the dropdown
- [ ] **Auto-translate**: with CrispASR / llama.cpp engines amber, hit the Download button; after the download dialog closes, confirm the engine combo dot turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)