### PR TITLE
Add "Qwen3 TTS (CrispASR)" engine + rename Chatterbox TTS

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -8,6 +8,8 @@ v5.0.0-beta30 (xth May 2026)
 * Add voice-design keyword picker to Text-to-speech for OmniVoice TTS - thx subof
 * Update CrispASR to v0.6.9 - restores Windows CPU and CPU-Legacy builds
 * Update Qwen3 TTS to v0.4.6 - unblocks the cstr CrispASR-converted VoiceDesign GGUF on all platforms
+* Add "Qwen3 TTS (CrispASR)" engine (1.7B VoiceDesign + CustomVoice via the CrispASR runtime)
+* Rename "Chatterbox TTS" to "Chatterbox TTS (CrispASR)" so the runtime is explicit
 
 v5.0.0-beta29 (20th May 2026)
 

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -142,6 +142,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ChatterboxTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
@@ -386,6 +387,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<OcrViewModel>();
         collection.AddTransient<OmniVoiceSettingsViewModel>();
         collection.AddTransient<Qwen3TtsSettingsViewModel>();
+        collection.AddTransient<Qwen3TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<KokoroTtsSettingsViewModel>();
         collection.AddTransient<ChatterboxTtsSettingsViewModel>();
         collection.AddTransient<OpenFromUrlViewModel>();

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
@@ -83,25 +84,43 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
 
         InstallFolder = _engine.GetAndCreateWhisperFolder();
         IsInstalled = _engine.IsEngineInstalled();
-        BackendLabel = IsInstalled ? AppendVersion(_engine, DetectBackend(_engine, InstallFolder)) : Se.Language.General.NotInstalled;
+        var backendLabel = IsInstalled ? DetectBackend(_engine, InstallFolder) : Se.Language.General.NotInstalled;
+        BackendLabel = backendLabel;
         EngineUpdateStatus = IsInstalled ? ComputeStatus(_engine, InstallFolder) : DownloadHashManager.UpdateStatus.Unknown;
         ApplyStatus(EngineUpdateStatus, IsInstalled);
-    }
 
-    // For CrispASR engines, append the installed runtime version (probed once via
-    // `crispasr --version`) so users can tell at a glance which build they have.
-    // Other engines stay as-is.
-    private static string AppendVersion(ISpeechToTextEngine engine, string backendLabel)
-    {
-        if (engine is not ICrispAsrEngine crispAsr)
+        // For CrispASR engines, append the installed runtime version once it's been probed.
+        // The probe shells out to `crispasr --version` with a 5 s timeout, so do it off the
+        // UI thread and patch BackendLabel via the dispatcher when the result lands. First
+        // call is uncached (a few hundred ms typically); subsequent ones hit the cache and
+        // return immediately, but we still go through Task.Run for consistency.
+        if (IsInstalled && _engine is ICrispAsrEngine crispAsr)
         {
-            return backendLabel;
+            var exe = crispAsr.GetExecutable();
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    var withVersion = $"{backendLabel}, v{version}";
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (BackendLabel == backendLabel)
+                        {
+                            BackendLabel = withVersion;
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "SpeechToTextEngineSettings: CrispASR version probe failed");
+                }
+            });
         }
-
-        var version = CrispAsrVersion.TryGet(crispAsr.GetExecutable());
-        return string.IsNullOrEmpty(version)
-            ? backendLabel
-            : $"{backendLabel}, v{version}";
     }
 
     private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -83,9 +83,25 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
 
         InstallFolder = _engine.GetAndCreateWhisperFolder();
         IsInstalled = _engine.IsEngineInstalled();
-        BackendLabel = IsInstalled ? DetectBackend(_engine, InstallFolder) : Se.Language.General.NotInstalled;
+        BackendLabel = IsInstalled ? AppendVersion(_engine, DetectBackend(_engine, InstallFolder)) : Se.Language.General.NotInstalled;
         EngineUpdateStatus = IsInstalled ? ComputeStatus(_engine, InstallFolder) : DownloadHashManager.UpdateStatus.Unknown;
         ApplyStatus(EngineUpdateStatus, IsInstalled);
+    }
+
+    // For CrispASR engines, append the installed runtime version (probed once via
+    // `crispasr --version`) so users can tell at a glance which build they have.
+    // Other engines stay as-is.
+    private static string AppendVersion(ISpeechToTextEngine engine, string backendLabel)
+    {
+        if (engine is not ICrispAsrEngine crispAsr)
+        {
+            return backendLabel;
+        }
+
+        var version = CrispAsrVersion.TryGet(crispAsr.GetExecutable());
+        return string.IsNullOrEmpty(version)
+            ? backendLabel
+            : $"{backendLabel}, v{version}";
     }
 
     private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrVersion.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrVersion.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// Cached <c>crispasr --version</c> probe. Used by the speech-to-text engine settings
+/// dialog and by Chatterbox / Qwen3 (CrispASR) TTS settings to show the user which
+/// CrispASR runtime they have installed. <c>crispasr --version</c> on v0.6.9 prints:
+///
+///   <c>=== build info ===</c>
+///   <c>  version       : 0.6.9</c>
+///   <c>  git sha       : 801bed59</c>
+///   <c>  ...</c>
+///
+/// Older releases printed a single banner line like
+/// <c>crispasr 0.6.7 (git ..., Release) [backends: ...]</c>; we accept either form.
+/// </summary>
+public static class CrispAsrVersion
+{
+    // Path -> (mtime, version). Cache invalidates when the binary on disk changes
+    // (re-download / update) so we don't show a stale version after an update.
+    private static readonly object _cacheLock = new();
+    private static string? _cachedExePath;
+    private static DateTime _cachedExeMtimeUtc;
+    private static string? _cachedVersion;
+
+    // Matches either `version : 0.6.9` (structured --version output) or
+    // `crispasr 0.6.9` (legacy single-line banner).
+    private static readonly Regex VersionRegex = new(
+        @"(?:^\s*version\s*:\s*|\bcrispasr\s+)([\w.\-+]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+    /// <summary>
+    /// Returns the CrispASR version string (e.g. "0.6.9") for the binary at
+    /// <paramref name="exePath"/>, or null when the binary is missing, fails to launch,
+    /// or doesn't emit a recognisable version line within a short timeout. Safe to
+    /// call repeatedly — each unique (path, mtime) pair is probed at most once.
+    /// </summary>
+    public static string? TryGet(string exePath)
+    {
+        if (string.IsNullOrEmpty(exePath) || !File.Exists(exePath))
+        {
+            return null;
+        }
+
+        DateTime mtime;
+        try
+        {
+            mtime = File.GetLastWriteTimeUtc(exePath);
+        }
+        catch
+        {
+            return null;
+        }
+
+        lock (_cacheLock)
+        {
+            if (_cachedExePath == exePath && _cachedExeMtimeUtc == mtime)
+            {
+                return _cachedVersion;
+            }
+        }
+
+        var version = Probe(exePath);
+
+        lock (_cacheLock)
+        {
+            _cachedExePath = exePath;
+            _cachedExeMtimeUtc = mtime;
+            _cachedVersion = version;
+        }
+
+        return version;
+    }
+
+    private static string? Probe(string exePath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = exePath,
+                WorkingDirectory = Path.GetDirectoryName(exePath) ?? string.Empty,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            psi.ArgumentList.Add("--version");
+
+            using var process = Process.Start(psi);
+            if (process == null)
+            {
+                return null;
+            }
+
+            // --version exits immediately after printing one line; 5 s is generous.
+            if (!process.WaitForExit(5000))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                return null;
+            }
+
+            // Some builds print the banner on stdout, others on stderr — read both.
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            var combined = stdout + "\n" + stderr;
+
+            var match = VersionRegex.Match(combined);
+            return match.Success ? match.Groups[1].Value : null;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"CrispAsrVersion: failed to probe '{exePath}'");
+            return null;
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsViewModel.cs
@@ -8,6 +8,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic;
@@ -53,7 +54,12 @@ public partial class ChatterboxTtsSettingsViewModel : ObservableObject
 
     private void Refresh()
     {
-        IsEngineInstalled = File.Exists(ChatterboxTtsCpp.GetCrispAsrExecutable());
+        var exe = ChatterboxTtsCpp.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+        var versionSuffix = IsEngineInstalled
+            ? (CrispAsrVersion.TryGet(exe) is { Length: > 0 } v ? $" v{v}" : string.Empty)
+            : string.Empty;
+
         if (!IsEngineInstalled)
         {
             EngineLabel = "CrispASR not installed";
@@ -62,19 +68,19 @@ public partial class ChatterboxTtsSettingsViewModel : ObservableObject
         }
         else if (!ChatterboxTtsCpp.IsCrispAsrChatterboxCapable())
         {
-            EngineLabel = "CrispASR too old - update required";
+            EngineLabel = $"CrispASR{versionSuffix} too old - update required";
             EngineBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
             EngineDownloadButtonText = "Update CrispASR";
         }
         else if (ChatterboxTtsCpp.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
         {
-            EngineLabel = "CrispASR - update available";
+            EngineLabel = $"CrispASR{versionSuffix} - update available";
             EngineBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
             EngineDownloadButtonText = "Update CrispASR";
         }
         else
         {
-            EngineLabel = "CrispASR (Chatterbox-capable)";
+            EngineLabel = $"CrispASR{versionSuffix} (Chatterbox-capable)";
             EngineBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
             EngineDownloadButtonText = "Re-download CrispASR";
         }

--- a/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsViewModel.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
@@ -56,9 +57,6 @@ public partial class ChatterboxTtsSettingsViewModel : ObservableObject
     {
         var exe = ChatterboxTtsCpp.GetCrispAsrExecutable();
         IsEngineInstalled = File.Exists(exe);
-        var versionSuffix = IsEngineInstalled
-            ? (CrispAsrVersion.TryGet(exe) is { Length: > 0 } v ? $" v{v}" : string.Empty)
-            : string.Empty;
 
         if (!IsEngineInstalled)
         {
@@ -68,21 +66,51 @@ public partial class ChatterboxTtsSettingsViewModel : ObservableObject
         }
         else if (!ChatterboxTtsCpp.IsCrispAsrChatterboxCapable())
         {
-            EngineLabel = $"CrispASR{versionSuffix} too old - update required";
+            EngineLabel = "CrispASR too old - update required";
             EngineBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
             EngineDownloadButtonText = "Update CrispASR";
         }
         else if (ChatterboxTtsCpp.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
         {
-            EngineLabel = $"CrispASR{versionSuffix} - update available";
+            EngineLabel = "CrispASR - update available";
             EngineBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
             EngineDownloadButtonText = "Update CrispASR";
         }
         else
         {
-            EngineLabel = $"CrispASR{versionSuffix} (Chatterbox-capable)";
+            EngineLabel = "CrispASR (Chatterbox-capable)";
             EngineBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
             EngineDownloadButtonText = "Re-download CrispASR";
+        }
+
+        // Append the installed CrispASR version asynchronously so the `crispasr --version`
+        // probe doesn't block the dialog opening. Label gets patched in once the result is
+        // available. Skip when CrispASR isn't installed (nothing to probe).
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "ChatterboxTtsSettings: CrispASR version probe failed");
+                }
+            });
         }
 
         var baseInstalled = ChatterboxTtsCpp.AreModelsInstalled(ChatterboxTtsCpp.ModelKeyBase);

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -32,7 +32,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// </summary>
 public class ChatterboxTtsCpp : ITtsEngine
 {
-    public string Name => "Chatterbox TTS";
+    public string Name => "Chatterbox TTS (CrispASR)";
     public string Description => "via CrispASR (Base or Turbo model + voice cloning)";
     public bool HasLanguageParameter => false;
     public bool HasApiKey => false;

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -111,6 +111,27 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         return new CrispAsrCohere().GetExecutable();
     }
 
+    /// <summary>
+    /// Returns the update status of the CrispASR runtime this engine sits on top of.
+    /// Reads the speech-to-text CrispASR install's <c>.installed.sha256</c> sidecar;
+    /// returns <see cref="DownloadHashManager.UpdateStatus.Unknown"/> when CrispASR
+    /// is not installed or the sidecar is missing. Mirrors
+    /// <see cref="ChatterboxTtsCpp.GetEngineUpdateStatus"/>.
+    /// </summary>
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
     public static string GetSetFolder()
     {
         if (!Directory.Exists(Se.TextToSpeechFolder))

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -1,0 +1,591 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Qwen3-TTS run through the CrispASR runtime instead of qwen3-tts.cpp. Useful as an A/B
+/// comparison engine since CrispASR's qwen3-tts backends emit EOS reliably on short prompts
+/// where qwen3-tts.cpp 0.6B doesn't (see PR investigation notes from May 2026).
+///
+/// Two CrispASR sub-backends are wired up:
+///  - qwen3-tts-1.7b-voicedesign — VoiceDesign model, requires an `instructions` field
+///    per request (free-text voice description, e.g. "a calm female voice").
+///  - qwen3-tts-1.7b-customvoice — voice cloning, takes a reference WAV + transcription.
+///
+/// The 1.7B VoiceDesign talker GGUF is the same file the qwen3-tts.cpp engine uses (cstr's
+/// upload, new tensor names). The CrispASR-style codec/tokenizer GGUF is a different file
+/// (~986 MB) and lives in this engine's own folder — see <see cref="Qwen3TtsCrispAsrDownloadService"/>
+/// for the URLs.
+/// </summary>
+public class Qwen3TtsCrispAsr : ITtsEngine
+{
+    public string Name => "Qwen3 TTS (CrispASR)";
+    public string Description => "via CrispASR (VoiceDesign or CustomVoice 1.7B)";
+    public bool HasLanguageParameter => false;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+
+    public const string ModelKeyVoiceDesign = "1.7B VoiceDesign";
+    public const string ModelKeyCustomVoice = "1.7B CustomVoice";
+    public const string DefaultModelKey = ModelKeyVoiceDesign;
+
+    public const string VoiceDesignTalkerFileName = "qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf";
+    public const string CustomVoiceTalkerFileName = "qwen3-tts-12hz-1.7b-customvoice-q8_0.gguf";
+    public const string CodecFileName = "qwen3-tts-tokenizer-12hz.gguf";
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : saved;
+        }
+
+        return modelKey == ModelKeyCustomVoice ? ModelKeyCustomVoice : ModelKeyVoiceDesign;
+    }
+
+    public static string GetTalkerFileName(string? modelKey) =>
+        ResolveModelKey(modelKey) == ModelKeyCustomVoice ? CustomVoiceTalkerFileName : VoiceDesignTalkerFileName;
+
+    /// <summary>
+    /// CrispASR sub-backend name matching <paramref name="modelKey"/>.
+    /// VoiceDesign → qwen3-tts-1.7b-voicedesign, CustomVoice → qwen3-tts-1.7b-customvoice.
+    /// </summary>
+    public static string GetBackendName(string? modelKey) =>
+        ResolveModelKey(modelKey) == ModelKeyCustomVoice
+            ? "qwen3-tts-1.7b-customvoice"
+            : "qwen3-tts-1.7b-voicedesign";
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(5),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverModelKey;
+    private static string? _serverLaunchCommand;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Path to the crispasr executable installed by the speech-to-text feature.
+    /// Shared with Chatterbox TTS and all CrispASR ASR engines.
+    /// </summary>
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "Qwen3TtsCrispAsr");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        var modelsFolder = Path.Combine(GetSetFolder(), "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        return voicesFolder;
+    }
+
+    public static string GetTalkerPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetTalkerFileName(modelKey));
+
+    public static string GetCodecPath() =>
+        Path.Combine(GetSetModelsFolder(), CodecFileName);
+
+    public static bool AreModelsInstalled(string? modelKey = null) =>
+        File.Exists(GetTalkerPath(modelKey)) && File.Exists(GetCodecPath());
+
+    public Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>
+        {
+            // Default voice — for VoiceDesign this means "use the instruction string only";
+            // for CustomVoice it falls back to the model's baked voice.
+            new Voice(new Qwen3TtsVoice("Default", string.Empty)),
+        };
+
+        var voicesFolder = GetSetVoicesFolder();
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new Qwen3TtsVoice(name, file)));
+            }
+        }
+
+        return Task.FromResult(result.ToArray());
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyVoiceDesign, ModelKeyCustomVoice });
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not Qwen3TtsVoice qwen3Voice)
+        {
+            throw new ArgumentException("Voice is not a Qwen3TtsVoice");
+        }
+
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, cancellationToken);
+
+        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var inputText = Utilities.UnbreakLine(text);
+        // Share the qwen3-tts.cpp instruction setting so users get the same voice description
+        // regardless of which Qwen3 engine they're testing with.
+        var instruction = Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty;
+
+        // OpenAI-compatible /v1/audio/speech payload. CrispASR's qwen3-tts backends look at:
+        //   - `input`             — the text to synthesise
+        //   - `response_format`   — "wav"
+        //   - `voice`             — absolute WAV path or filename in --voice-dir
+        //                           (required for CustomVoice; ignored by VoiceDesign)
+        //   - `instructions`      — free-text style/voice description
+        //                           (required for VoiceDesign; ignored by CustomVoice)
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = inputText,
+            ["response_format"] = "wav",
+        };
+        if (!string.IsNullOrEmpty(qwen3Voice.FilePath))
+        {
+            payload["voice"] = qwen3Voice.FilePath;
+        }
+        if (!string.IsNullOrEmpty(instruction))
+        {
+            payload["instructions"] = instruction;
+        }
+        else if (modelKey == ModelKeyVoiceDesign)
+        {
+            // VoiceDesign refuses requests without an instruction. Send a neutral default
+            // so the first run doesn't surface a confusing 500 from the server.
+            payload["instructions"] = "a calm female voice";
+        }
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"Qwen3 TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={qwen3Voice}, model={modelKey}, textLen={text.Length}, instructionLen={instruction.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"Qwen3 TTS (CrispASR) request failed — Voice: {qwen3Voice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "Qwen3 TTS (CrispASR) — the crispasr server crashed during synthesis."
+                    : "Qwen3 TTS (CrispASR) request failed — the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"Qwen3 TTS (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {qwen3Voice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"Qwen3 TTS (CrispASR) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, CancellationToken ct)
+    {
+        if (_serverProcess is { HasExited: false } && _serverPort != 0 && _serverModelKey == modelKey)
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0 && _serverModelKey == modelKey)
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            var talker = GetTalkerPath(modelKey);
+            if (!File.Exists(talker))
+            {
+                throw new FileNotFoundException(
+                    $"Qwen3 TTS (CrispASR) talker GGUF not found at {talker}. "
+                    + "Place the file manually until the auto-downloader lands.", talker);
+            }
+
+            // The CrispASR-style codec/tokenizer GGUF (qwen3-tts-tokenizer-12hz.gguf, ~986 MB)
+            // is NOT the same file as qwen3-tts.cpp's tokenizer. If it's not in our engine
+            // folder, fall back to letting crispasr --auto-download fetch it into its own
+            // cache (~/.cache/crispasr/) on first run — slower the first time, instant after.
+            var codec = GetCodecPath();
+            var hasLocalCodec = File.Exists(codec);
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(GetBackendName(modelKey));
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(talker);
+            if (hasLocalCodec)
+            {
+                psi.ArgumentList.Add("--codec-model");
+                psi.ArgumentList.Add(codec);
+            }
+            else
+            {
+                psi.ArgumentList.Add("--auto-download");
+            }
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString());
+            // The crispasr server gates /v1/audio/speech requests with a `voice` field behind
+            // --voice-dir being set. Pointing at our voices folder satisfies the gate and also
+            // makes /v1/voices reflect any imported reference WAVs.
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (qwen3-tts)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog("Qwen3 TTS (CrispASR) server starting — "
+                + $"PID: {process.Id}, "
+                + $"Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelKey = modelKey;
+            HookProcessExitOnce();
+
+            // First-run codec auto-download (~986 MB) needs a generous timeout.
+            var deadline = DateTime.UtcNow.AddMinutes(hasLocalCodec ? 5 : 30);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverModelKey = null;
+                    _serverLaunchCommand = null;
+                    throw new InvalidOperationException(
+                        $"crispasr (qwen3-tts) exited during startup (code {exitCode}). Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (qwen3-tts) did not report healthy within {(hasLocalCodec ? 5 : 30)} minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked) return;
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverModelKey = null;
+        _serverLaunchCommand = null;
+        if (p == null) return;
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // CrispASR's qwen3-tts CustomVoice backend expects a 24 kHz mono reference WAV.
+        // Always resample on import via ffmpeg so the saved file is in the right shape
+        // regardless of what the user picked.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Qwen3 TTS (CrispASR) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        return File.Exists(destinationFileName);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -74,6 +74,13 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             ? "qwen3-tts-1.7b-customvoice"
             : "qwen3-tts-1.7b-voicedesign";
 
+    /// <summary>
+    /// True when the resolved model is the instruction-tuned VoiceDesign variant. Only this
+    /// model honours the voice instruction; CustomVoice ignores it and uses voice cloning.
+    /// </summary>
+    public static bool IsVoiceDesignModel(string? modelKey) =>
+        ResolveModelKey(modelKey) == ModelKeyVoiceDesign;
+
     private static readonly HttpClient HttpClient = new()
     {
         Timeout = TimeSpan.FromMinutes(5),

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -181,12 +181,16 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
     public Task<Voice[]> GetVoices(string language)
     {
-        var result = new List<Voice>
+        var result = new List<Voice>();
+
+        // VoiceDesign has a baked default voice (the instruction string drives the rest).
+        // CustomVoice is pure voice cloning and refuses requests without a reference WAV,
+        // so don't offer a "Default" entry there — the user must import a voice first.
+        var modelKey = ResolveModelKey(Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel);
+        if (modelKey == ModelKeyVoiceDesign)
         {
-            // Default voice — for VoiceDesign this means "use the instruction string only";
-            // for CustomVoice it falls back to the model's baked voice.
-            new Voice(new Qwen3TtsVoice("Default", string.Empty)),
-        };
+            result.Add(new Voice(new Qwen3TtsVoice("Default", string.Empty)));
+        }
 
         var voicesFolder = GetSetVoicesFolder();
         if (Directory.Exists(voicesFolder))
@@ -227,6 +231,18 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         }
 
         var modelKey = ResolveModelKey(model);
+
+        // CustomVoice does voice cloning and rejects requests without a `voice` field.
+        // Surface a clear up-front error instead of letting the backend return 500.
+        if (modelKey == ModelKeyCustomVoice && string.IsNullOrEmpty(qwen3Voice.FilePath))
+        {
+            throw new InvalidOperationException(
+                "Qwen3 TTS (CrispASR) CustomVoice requires a reference voice WAV. "
+                + "Import one via the voice settings, then pick it in the voice combo. "
+                + "Reference WAV should be 24 kHz mono; an adjacent .txt file with the "
+                + "spoken transcription is required for best cloning quality.");
+        }
+
         await EnsureServerRunningAsync(modelKey, cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
@@ -382,18 +398,12 @@ public class Qwen3TtsCrispAsr : ITtsEngine
                     "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
             }
 
+            // Talker and codec GGUFs: if locally staged, use directly; otherwise hand off to
+            // crispasr's --auto-download to fetch them into ~/.cache/crispasr/ on first run.
+            // Slower the first time, instant after. A proper SE-side download service is a
+            // follow-up; this keeps the engine usable without manual file placement.
             var talker = GetTalkerPath(modelKey);
-            if (!File.Exists(talker))
-            {
-                throw new FileNotFoundException(
-                    $"Qwen3 TTS (CrispASR) talker GGUF not found at {talker}. "
-                    + "Place the file manually until the auto-downloader lands.", talker);
-            }
-
-            // The CrispASR-style codec/tokenizer GGUF (qwen3-tts-tokenizer-12hz.gguf, ~986 MB)
-            // is NOT the same file as qwen3-tts.cpp's tokenizer. If it's not in our engine
-            // folder, fall back to letting crispasr --auto-download fetch it into its own
-            // cache (~/.cache/crispasr/) on first run — slower the first time, instant after.
+            var hasLocalTalker = File.Exists(talker);
             var codec = GetCodecPath();
             var hasLocalCodec = File.Exists(codec);
 
@@ -411,13 +421,13 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             psi.ArgumentList.Add("--backend");
             psi.ArgumentList.Add(GetBackendName(modelKey));
             psi.ArgumentList.Add("-m");
-            psi.ArgumentList.Add(talker);
+            psi.ArgumentList.Add(hasLocalTalker ? talker : "auto");
             if (hasLocalCodec)
             {
                 psi.ArgumentList.Add("--codec-model");
                 psi.ArgumentList.Add(codec);
             }
-            else
+            if (!hasLocalTalker || !hasLocalCodec)
             {
                 psi.ArgumentList.Add("--auto-download");
             }
@@ -457,8 +467,8 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             _serverModelKey = modelKey;
             HookProcessExitOnce();
 
-            // First-run codec auto-download (~986 MB) needs a generous timeout.
-            var deadline = DateTime.UtcNow.AddMinutes(hasLocalCodec ? 5 : 30);
+            // First-run auto-download (~2 GB talker + ~986 MB codec) needs a generous timeout.
+            var deadline = DateTime.UtcNow.AddMinutes(hasLocalTalker && hasLocalCodec ? 5 : 30);
             while (DateTime.UtcNow < deadline)
             {
                 ct.ThrowIfCancellationRequested();
@@ -486,7 +496,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             var timeoutLaunchCommand = _serverLaunchCommand;
             StopServerInternal();
             throw new TimeoutException(
-                $"crispasr (qwen3-tts) did not report healthy within {(hasLocalCodec ? 5 : 30)} minutes. Last output: {lastOutput}"
+                $"crispasr (qwen3-tts) did not report healthy within {(hasLocalTalker && hasLocalCodec ? 5 : 30)} minutes. Last output: {lastOutput}"
                 + LaunchCmdSuffix(timeoutLaunchCommand));
         }
         finally

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -684,6 +684,34 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             return false;
         }
 
-        return File.Exists(destinationFileName);
+        if (!File.Exists(destinationFileName))
+        {
+            return false;
+        }
+
+        // CustomVoice voice cloning expects a matching .txt sidecar holding the spoken
+        // transcription of the reference WAV. If the source had one (same basename, .txt),
+        // copy it alongside the imported WAV under the de-duplicated destination name.
+        try
+        {
+            var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+            if (File.Exists(sourceSidecar))
+            {
+                var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+                if (!File.Exists(destSidecar))
+                {
+                    File.Copy(sourceSidecar, destSidecar);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Sidecar copy is best-effort — log and continue. The imported WAV alone is
+            // still usable; CustomVoice quality drops without the transcription but it
+            // doesn't fail outright.
+            Se.LogError(ex, "Qwen3 TTS (CrispASR) voice import: failed to copy .txt sidecar");
+        }
+
+        return true;
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
@@ -167,7 +168,66 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             Directory.CreateDirectory(voicesFolder);
         }
 
+        SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
         return voicesFolder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort copy of WAV reference voices from the existing qwen3-tts.cpp
+    /// engine's voices folder. The same files work for both engines (just 24 kHz mono
+    /// reference audio with optional .txt sidecars), so users who already downloaded the
+    /// qwen3-tts.cpp voice pack get them for free here without a second ~10 MB download.
+    /// Users who never installed qwen3-tts.cpp start empty and can use Import Voice or wait
+    /// for the dedicated voices.zip downloader (TODO).
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+                if (!File.Exists(dest))
+                {
+                    File.Copy(src, dest);
+                }
+
+                // Copy the matching .txt sidecar too (CrispASR uses it as the reference
+                // transcription for CustomVoice cloning).
+                var sidecar = Path.ChangeExtension(src, ".txt");
+                if (File.Exists(sidecar))
+                {
+                    var sidecarDest = Path.ChangeExtension(dest, ".txt");
+                    if (!File.Exists(sidecarDest))
+                    {
+                        File.Copy(sidecar, sidecarDest);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Qwen3 TTS (CrispASR): voice seeding from qwen3-tts.cpp folder failed");
+        }
     }
 
     public static string GetTalkerPath(string? modelKey = null) =>

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
@@ -1,0 +1,206 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
+
+public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
+{
+    private static readonly IBrush Green = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static readonly IBrush Amber = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static readonly IBrush Red = new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static readonly IBrush Grey = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey;
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+
+    [ObservableProperty] private string _voiceDesignTalkerLabel = string.Empty;
+    [ObservableProperty] private IBrush _voiceDesignTalkerBrush = Grey;
+
+    [ObservableProperty] private string _customVoiceTalkerLabel = string.Empty;
+    [ObservableProperty] private IBrush _customVoiceTalkerBrush = Grey;
+
+    [ObservableProperty] private string _codecLabel = string.Empty;
+    [ObservableProperty] private IBrush _codecBrush = Grey;
+
+    [ObservableProperty] private string _voicesLabel = string.Empty;
+
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public Qwen3TtsCrispAsrSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        ModelsFolder = Qwen3TtsCrispAsr.GetSetModelsFolder();
+        VoicesFolder = Qwen3TtsCrispAsr.GetSetVoicesFolder();
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = Qwen3TtsCrispAsr.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+        var versionSuffix = IsEngineInstalled
+            ? (CrispAsrVersion.TryGet(exe) is { Length: > 0 } v ? $" v{v}" : string.Empty)
+            : string.Empty;
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = "CrispASR not installed";
+            EngineBrush = Red;
+            EngineDownloadButtonText = "Download CrispASR";
+        }
+        else if (Qwen3TtsCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = $"CrispASR{versionSuffix} - update available";
+            EngineBrush = Amber;
+            EngineDownloadButtonText = "Update CrispASR";
+        }
+        else
+        {
+            EngineLabel = $"CrispASR{versionSuffix}";
+            EngineBrush = Green;
+            EngineDownloadButtonText = "Re-download CrispASR";
+        }
+
+        // Talker GGUFs live in the engine's own models folder OR are auto-downloaded by
+        // crispasr into ~/.cache/crispasr. We can only verify the engine-folder copy here;
+        // a missing local talker isn't fatal (the engine falls back to --auto-download) so
+        // surface it as a neutral "Auto-download on first use" rather than an error.
+        var voiceDesignPath = Qwen3TtsCrispAsr.GetTalkerPath(Qwen3TtsCrispAsr.ModelKeyVoiceDesign);
+        ApplyModelStatus(File.Exists(voiceDesignPath),
+            label => VoiceDesignTalkerLabel = label,
+            brush => VoiceDesignTalkerBrush = brush);
+
+        var customVoicePath = Qwen3TtsCrispAsr.GetTalkerPath(Qwen3TtsCrispAsr.ModelKeyCustomVoice);
+        ApplyModelStatus(File.Exists(customVoicePath),
+            label => CustomVoiceTalkerLabel = label,
+            brush => CustomVoiceTalkerBrush = brush);
+
+        var codecPath = Qwen3TtsCrispAsr.GetCodecPath();
+        ApplyModelStatus(File.Exists(codecPath),
+            label => CodecLabel = label,
+            brush => CodecBrush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No voices imported"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
+    }
+
+    private static void ApplyModelStatus(bool installed, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        if (installed)
+        {
+            setLabel("Installed");
+            setBrush(Green);
+        }
+        else
+        {
+            setLabel("Auto-download on first use");
+            setBrush(Grey);
+        }
+    }
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // CrispASR is shared with Speech-to-text; piggy-back on the same redownload flow
+        // Chatterbox uses, then refresh status here. The crispasr binary itself does not
+        // care which TTS engine triggered the download.
+        await TtsVoiceInstaller.EnsureCrispAsrForChatterbox(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
@@ -66,9 +67,6 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
     {
         var exe = Qwen3TtsCrispAsr.GetCrispAsrExecutable();
         IsEngineInstalled = File.Exists(exe);
-        var versionSuffix = IsEngineInstalled
-            ? (CrispAsrVersion.TryGet(exe) is { Length: > 0 } v ? $" v{v}" : string.Empty)
-            : string.Empty;
 
         if (!IsEngineInstalled)
         {
@@ -78,33 +76,64 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
         }
         else if (Qwen3TtsCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
         {
-            EngineLabel = $"CrispASR{versionSuffix} - update available";
+            EngineLabel = "CrispASR - update available";
             EngineBrush = Amber;
             EngineDownloadButtonText = "Update CrispASR";
         }
         else
         {
-            EngineLabel = $"CrispASR{versionSuffix}";
+            EngineLabel = "CrispASR";
             EngineBrush = Green;
             EngineDownloadButtonText = "Re-download CrispASR";
         }
 
+        // Append the installed CrispASR version asynchronously - the probe is a child
+        // process and we don't want to block the dialog opening (the probe is cached
+        // after the first call but the first one can be a few hundred ms).
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "Qwen3TtsCrispAsrSettings: CrispASR version probe failed");
+                }
+            });
+        }
+
         // Talker GGUFs live in the engine's own models folder OR are auto-downloaded by
         // crispasr into ~/.cache/crispasr. We can only verify the engine-folder copy here;
-        // a missing local talker isn't fatal (the engine falls back to --auto-download) so
-        // surface it as a neutral "Auto-download on first use" rather than an error.
+        // when CrispASR is installed, a missing local file is fine ("Auto-download on first
+        // use"). When CrispASR is NOT installed, that message is misleading — there's no
+        // path to auto-download anything until the user installs the runtime first.
         var voiceDesignPath = Qwen3TtsCrispAsr.GetTalkerPath(Qwen3TtsCrispAsr.ModelKeyVoiceDesign);
-        ApplyModelStatus(File.Exists(voiceDesignPath),
+        ApplyModelStatus(File.Exists(voiceDesignPath), IsEngineInstalled,
             label => VoiceDesignTalkerLabel = label,
             brush => VoiceDesignTalkerBrush = brush);
 
         var customVoicePath = Qwen3TtsCrispAsr.GetTalkerPath(Qwen3TtsCrispAsr.ModelKeyCustomVoice);
-        ApplyModelStatus(File.Exists(customVoicePath),
+        ApplyModelStatus(File.Exists(customVoicePath), IsEngineInstalled,
             label => CustomVoiceTalkerLabel = label,
             brush => CustomVoiceTalkerBrush = brush);
 
         var codecPath = Qwen3TtsCrispAsr.GetCodecPath();
-        ApplyModelStatus(File.Exists(codecPath),
+        ApplyModelStatus(File.Exists(codecPath), IsEngineInstalled,
             label => CodecLabel = label,
             brush => CodecBrush = brush);
 
@@ -123,18 +152,26 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
         }
     }
 
-    private static void ApplyModelStatus(bool installed, Action<string> setLabel, Action<IBrush> setBrush)
+    private static void ApplyModelStatus(bool fileInstalled, bool engineInstalled, Action<string> setLabel, Action<IBrush> setBrush)
     {
-        if (installed)
+        if (fileInstalled)
         {
             setLabel("Installed");
             setBrush(Green);
+            return;
         }
-        else
+
+        if (!engineInstalled)
         {
-            setLabel("Auto-download on first use");
+            // No CrispASR runtime means there's nothing to auto-download into, so don't
+            // promise a download that can't happen until the user installs CrispASR.
+            setLabel("CrispASR required");
             setBrush(Grey);
+            return;
         }
+
+        setLabel("Auto-download on first use");
+        setBrush(Grey);
     }
 
     [RelayCommand]
@@ -145,10 +182,10 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
             return;
         }
 
-        // CrispASR is shared with Speech-to-text; piggy-back on the same redownload flow
-        // Chatterbox uses, then refresh status here. The crispasr binary itself does not
-        // care which TTS engine triggered the download.
-        await TtsVoiceInstaller.EnsureCrispAsrForChatterbox(Window, _windowService, forceRedownload: true);
+        // CrispASR is shared with Speech-to-text and Chatterbox; we use the Qwen3-specific
+        // entry point so the prompts read "Qwen3 TTS (CrispASR)" rather than "Chatterbox TTS"
+        // (the crispasr binary itself doesn't care which engine triggered the download).
+        await TtsVoiceInstaller.EnsureCrispAsrForQwen3(Window, _windowService, forceRedownload: true);
         Refresh();
     }
 

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
@@ -1,0 +1,233 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
+
+public class Qwen3TtsCrispAsrSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly Qwen3TtsCrispAsrSettingsViewModel _vm;
+
+    public Qwen3TtsCrispAsrSettingsWindow(Qwen3TtsCrispAsrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "Qwen3 TTS (CrispASR) settings";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 580;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(Qwen3TtsCrispAsrSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "Qwen3 TTS (CrispASR)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new Qwen3TtsCrispAsr().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(Qwen3TtsCrispAsrSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel("Engine"), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12);
+        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel("1.7B VoiceDesign"), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.VoiceDesignTalkerBrush), nameof(vm.VoiceDesignTalkerLabel)), 1, 1);
+
+        grid.Add(MakeLabel("1.7B CustomVoice"), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CustomVoiceTalkerBrush), nameof(vm.CustomVoiceTalkerLabel)), 2, 1);
+
+        grid.Add(MakeLabel("Codec (12 Hz)"), 3, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CodecBrush), nameof(vm.CodecLabel)), 3, 1);
+
+        grid.Add(MakeLabel("Voices"), 4, 0);
+        var voicesText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        };
+        grid.Add(voicesText, 4, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 5, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        };
+        grid.Add(folderText, 5, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Grid BuildActions(Qwen3TtsCrispAsrSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton("Open models folder", vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Open voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder, openVoicesFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
@@ -185,8 +185,8 @@ public class Qwen3TtsCrispAsrSettingsWindow : Window
 
     private static Grid BuildActions(Qwen3TtsCrispAsrSettingsViewModel vm)
     {
-        var openModelsFolder = UiUtil.MakeButton("Open models folder", vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
-        var openVoicesFolder = UiUtil.MakeButton("Open voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
         var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
 
         var leftPanel = new StackPanel

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -171,6 +171,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             new Murf(ttsDownloadService),
             new GoogleSpeech(ttsDownloadService),
             new Qwen3TtsCpp(),
+            new Qwen3TtsCrispAsr(),
             new KokoroTtsCpp(),
             new ChatterboxTtsCpp(),
             new OmniVoiceTtsCpp(),

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -201,7 +201,16 @@ public partial class TextToSpeechViewModel : ObservableObject
 
     private void LoadSettings()
     {
-        var lastEngine = Engines.FirstOrDefault(e => e.Name == Se.Settings.Video.TextToSpeech.Engine);
+        // Migrate the pre-rename engine name so users who had "Chatterbox TTS" saved
+        // before the rename to "Chatterbox TTS (CrispASR)" land on the same engine.
+        // Cheap enough to do unconditionally; only kicks in once per affected install.
+        var savedEngine = Se.Settings.Video.TextToSpeech.Engine ?? string.Empty;
+        if (savedEngine == "Chatterbox TTS")
+        {
+            savedEngine = "Chatterbox TTS (CrispASR)";
+        }
+
+        var lastEngine = Engines.FirstOrDefault(e => e.Name == savedEngine);
         if (lastEngine != null)
         {
             SelectedEngine = lastEngine;
@@ -391,11 +400,23 @@ public partial class TextToSpeechViewModel : ObservableObject
         // Qwen3 (CrispASR) returns a different voice list per model — VoiceDesign exposes
         // "Default", CustomVoice only shows imported WAVs since it can't synthesise without
         // a reference. Persist the model change first so GetVoices reads the new value, then
-        // re-pull the voice list.
+        // re-pull the voice list. Wrap the fire-and-forget in a try/catch so any throw doesn't
+        // surface later as an unobserved task exception; the worst case is the combo keeps
+        // showing the old voice list.
         if (SelectedEngine is Qwen3TtsCrispAsr engine)
         {
             Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel = value ?? Qwen3TtsCrispAsr.DefaultModelKey;
-            _ = RefreshVoices(engine);
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Dispatcher.UIThread.InvokeAsync(async () => await RefreshVoices(engine));
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "Qwen3 TTS (CrispASR): refreshing voices on model change failed");
+                }
+            });
         }
     }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -17,6 +17,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ChatterboxTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceSettings;
@@ -618,6 +619,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is Qwen3TtsCpp)
         {
             await _windowService.ShowDialogAsync<Qwen3TtsSettingsWindow, Qwen3TtsSettingsViewModel>(Window!, vm => vm.Initialize());
+        }
+        else if (SelectedEngine is Qwen3TtsCrispAsr)
+        {
+            await _windowService.ShowDialogAsync<Qwen3TtsCrispAsrSettingsWindow, Qwen3TtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
         }
         else if (SelectedEngine is KokoroTtsCpp)
         {
@@ -1939,6 +1944,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 {
                     SelectedModel = Models.FirstOrDefault();
                 }
+                IsEngineSettingsVisible = true;
             }
             else if (SelectedEngine is ChatterboxTtsCpp)
             {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -386,6 +386,16 @@ public partial class TextToSpeechViewModel : ObservableObject
     {
         RefreshInstructionVisibility();
         UpdateVoiceLock();
+
+        // Qwen3 (CrispASR) returns a different voice list per model — VoiceDesign exposes
+        // "Default", CustomVoice only shows imported WAVs since it can't synthesise without
+        // a reference. Persist the model change first so GetVoices reads the new value, then
+        // re-pull the voice list.
+        if (SelectedEngine is Qwen3TtsCrispAsr engine)
+        {
+            Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel = value ?? Qwen3TtsCrispAsr.DefaultModelKey;
+            _ = RefreshVoices(engine);
+        }
     }
 
     // omnivoice-tts applies voice-design keywords only without a reference WAV, so the picker

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -284,6 +284,13 @@ public partial class TextToSpeechViewModel : ObservableObject
             Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel = SelectedModel ?? Qwen3TtsCpp.DefaultModelKey;
             Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction = (Instruction ?? string.Empty).Trim();
         }
+        else if (SelectedEngine is Qwen3TtsCrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel = SelectedModel ?? Qwen3TtsCrispAsr.DefaultModelKey;
+            // Shared instruction text with the qwen3-tts.cpp engine so the same voice
+            // description applies whichever Qwen3 backend the user picks.
+            Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction = (Instruction ?? string.Empty).Trim();
+        }
         else if (SelectedEngine is OmniVoiceTtsCpp)
         {
             Se.Settings.Video.TextToSpeech.OmniVoiceTtsCppInstruction = (Instruction ?? string.Empty).Trim();
@@ -313,10 +320,13 @@ public partial class TextToSpeechViewModel : ObservableObject
     }
 
     // The instruction control is shared in the UI; each engine that supports it keeps its own
-    // persisted value, so it always reflects the currently selected engine.
+    // persisted value, so it always reflects the currently selected engine. Both Qwen3 engines
+    // (qwen3-tts.cpp and CrispASR) share the same Qwen3TtsCppInstruction setting so users get
+    // the same voice description whichever backend they're testing with.
     private static string GetInstructionForEngine(ITtsEngine? engine) => engine switch
     {
         Qwen3TtsCpp => Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty,
+        Qwen3TtsCrispAsr => Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty,
         OmniVoiceTtsCpp => Se.Settings.Video.TextToSpeech.OmniVoiceTtsCppInstruction ?? string.Empty,
         _ => string.Empty,
     };
@@ -341,17 +351,22 @@ public partial class TextToSpeechViewModel : ObservableObject
     // 1.7B Base models are not instruction-tuned. OmniVoice always shows its keyword picker.
     private void RefreshInstructionVisibility()
     {
-        IsInstructionTextVisible = SelectedEngine is Qwen3TtsCpp && Qwen3TtsCpp.IsVoiceDesignModel(SelectedModel);
+        IsInstructionTextVisible =
+            (SelectedEngine is Qwen3TtsCpp && Qwen3TtsCpp.IsVoiceDesignModel(SelectedModel))
+            || (SelectedEngine is Qwen3TtsCrispAsr && Qwen3TtsCrispAsr.IsVoiceDesignModel(SelectedModel));
         IsInstructionPickerVisible = SelectedEngine is OmniVoiceTtsCpp;
         HasInstruction = IsInstructionTextVisible || IsInstructionPickerVisible;
     }
 
     // The Qwen3 VoiceDesign model has no speaker encoder - the voice is defined entirely by the
     // instruction. Lock the voice combo to the "Default" entry so an imported voice cannot route
-    // through the (unsupported) cloning path.
+    // through the (unsupported) cloning path. Applies to both Qwen3 engines (qwen3-tts.cpp and
+    // CrispASR) when the VoiceDesign model is selected.
     private void UpdateVoiceLock()
     {
-        var isVoiceDesign = SelectedEngine is Qwen3TtsCpp && Qwen3TtsCpp.IsVoiceDesignModel(SelectedModel);
+        var isVoiceDesign =
+            (SelectedEngine is Qwen3TtsCpp && Qwen3TtsCpp.IsVoiceDesignModel(SelectedModel))
+            || (SelectedEngine is Qwen3TtsCrispAsr && Qwen3TtsCrispAsr.IsVoiceDesignModel(SelectedModel));
         IsVoiceComboEnabled = !isVoiceDesign;
 
         if (isVoiceDesign
@@ -1906,6 +1921,14 @@ public partial class TextToSpeechViewModel : ObservableObject
                     SelectedModel = Models.FirstOrDefault();
                 }
                 IsEngineSettingsVisible = true;
+            }
+            else if (SelectedEngine is Qwen3TtsCrispAsr)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
             }
             else if (SelectedEngine is ChatterboxTtsCpp)
             {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -109,6 +109,8 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, KokoroTtsCpp.GetEngineUpdateStatus());
             case Qwen3TtsCpp:
                 return StatusDots.From(engine.IsInstalled(null).Result, Qwen3TtsCpp.GetEngineUpdateStatus());
+            case Qwen3TtsCrispAsr:
+                return StatusDots.From(engine.IsInstalled(null).Result, Qwen3TtsCrispAsr.GetEngineUpdateStatus());
             case OmniVoiceTtsCpp:
                 return StatusDots.From(engine.IsInstalled(null).Result, OmniVoiceTtsCpp.GetEngineUpdateStatus());
             case ChatterboxTtsCpp:

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -53,7 +53,39 @@ public static class TtsVoiceInstaller
     /// already Chatterbox-capable - used by the settings "Update CrispASR" button when a newer
     /// release exists. Returns true when CrispASR ends up installed and Chatterbox-capable.
     /// </summary>
-    public static async Task<bool> EnsureCrispAsrForChatterbox(Window? window, IWindowService windowService, bool forceRedownload)
+    public static Task<bool> EnsureCrispAsrForChatterbox(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "Chatterbox TTS",
+            extraCapabilityCheck: () => ChatterboxTtsCpp.IsCrispAsrChatterboxCapable(),
+            minVersionNote: "v0.6.0 or newer");
+
+    /// <summary>
+    /// Ensures the CrispASR runtime that Qwen3 TTS (CrispASR) runs on is installed.
+    /// No extra capability check (any sufficiently recent CrispASR exposes the qwen3-tts
+    /// backends), so the dialogs read with the right engine name and don't mention
+    /// Chatterbox.
+    /// </summary>
+    public static Task<bool> EnsureCrispAsrForQwen3(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "Qwen3 TTS (CrispASR)",
+            extraCapabilityCheck: null,
+            minVersionNote: null);
+
+    /// <summary>
+    /// Shared CrispASR install/update flow used by all TTS engines that sit on the
+    /// CrispASR runtime. Prompts refer to <paramref name="engineDisplayName"/> so users
+    /// see the right engine name. <paramref name="extraCapabilityCheck"/> lets the caller
+    /// require a backend-specific minimum (Chatterbox needs the chatterbox backend to be
+    /// present in the binary, for example); returning false there triggers a re-download
+    /// even when CrispASR itself looks up to date.
+    /// </summary>
+    private static async Task<bool> EnsureCrispAsrAsync(
+        Window? window,
+        IWindowService windowService,
+        bool forceRedownload,
+        string engineDisplayName,
+        Func<bool>? extraCapabilityCheck,
+        string? minVersionNote)
     {
         if (window == null)
         {
@@ -61,7 +93,7 @@ public static class TtsVoiceInstaller
         }
 
         var isInstalled = File.Exists(ChatterboxTtsCpp.GetCrispAsrExecutable());
-        var isCapable = isInstalled && ChatterboxTtsCpp.IsCrispAsrChatterboxCapable();
+        var isCapable = isInstalled && (extraCapabilityCheck?.Invoke() ?? true);
         if (!forceRedownload && isInstalled && isCapable)
         {
             return true;
@@ -78,12 +110,16 @@ public static class TtsVoiceInstaller
                 ? DownloadHashManager.DetectCrispAsrWindowsVariant(folder)
                 : null) ?? "vulkan";
 
+            var versionRequirement = !string.IsNullOrEmpty(minVersionNote)
+                ? $" needs CrispASR {minVersionNote}"
+                : " requires a newer CrispASR runtime";
+
             var answer = await MessageBox.Show(
                 window,
                 isCapable ? "Update CrispASR" : "CrispASR update required",
                 isCapable
                     ? $"{Environment.NewLine}A newer CrispASR runtime is available. Re-download it now?"
-                    : $"{Environment.NewLine}\"Chatterbox TTS\" needs CrispASR v0.6.0 or newer. Re-download now?",
+                    : $"{Environment.NewLine}\"{engineDisplayName}\"{versionRequirement}. Re-download now?",
                 MessageBoxButtons.YesNoCancel,
                 MessageBoxIcon.Question);
 
@@ -97,7 +133,7 @@ public static class TtsVoiceInstaller
             var variantAnswer = await MessageBox.Show(
                 window,
                 "Download CrispASR?",
-                $"{Environment.NewLine}\"Chatterbox TTS\" runs through the CrispASR runtime. Select a build to download:",
+                $"{Environment.NewLine}\"{engineDisplayName}\" runs through the CrispASR runtime. Select a build to download:",
                 MessageBoxButtons.Cancel,
                 MessageBoxIcon.Question,
                 "CPU",
@@ -152,7 +188,7 @@ public static class TtsVoiceInstaller
             var answer = await MessageBox.Show(
                 window,
                 "Download CrispASR?",
-                $"{Environment.NewLine}\"Chatterbox TTS\" runs through the CrispASR runtime. Download and install now?",
+                $"{Environment.NewLine}\"{engineDisplayName}\" runs through the CrispASR runtime. Download and install now?",
                 MessageBoxButtons.YesNoCancel,
                 MessageBoxIcon.Question);
 
@@ -177,7 +213,8 @@ public static class TtsVoiceInstaller
             return false;
         }
 
-        return File.Exists(ChatterboxTtsCpp.GetCrispAsrExecutable()) && ChatterboxTtsCpp.IsCrispAsrChatterboxCapable();
+        return File.Exists(ChatterboxTtsCpp.GetCrispAsrExecutable())
+               && (extraCapabilityCheck?.Invoke() ?? true);
     }
 
     /// <summary>

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -255,6 +255,9 @@ public partial class VoiceSettingsViewModel : ObservableObject
     internal void Initialize(ITtsEngine engine)
     {
         _engine = engine;
-        IsImportVoiceVisible = engine.GetType() == typeof(Qwen3TtsCpp) || engine.GetType() == typeof(ChatterboxTtsCpp) || engine.GetType() == typeof(OmniVoiceTtsCpp);
+        IsImportVoiceVisible = engine.GetType() == typeof(Qwen3TtsCpp)
+                               || engine.GetType() == typeof(Qwen3TtsCrispAsr)
+                               || engine.GetType() == typeof(ChatterboxTtsCpp)
+                               || engine.GetType() == typeof(OmniVoiceTtsCpp);
     }
 }

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -28,6 +28,7 @@ public class SeVideoTextToSpeech
     public string Qwen3TtsCppModel { get; set; }
     public string Qwen3TtsCppVulkanPath { get; set; }
     public string Qwen3TtsCppInstruction { get; set; }
+    public string Qwen3TtsCrispAsrModel { get; set; }
     public string OmniVoiceTtsCppVulkanPath { get; set; }
     public string OmniVoiceTtsCppInstruction { get; set; }
     public string ChatterboxModel { get; set; }
@@ -91,6 +92,7 @@ public class SeVideoTextToSpeech
         Qwen3TtsCppModel = "0.6B";
         Qwen3TtsCppVulkanPath = string.Empty;
         Qwen3TtsCppInstruction = string.Empty;
+        Qwen3TtsCrispAsrModel = "1.7B VoiceDesign";
         OmniVoiceTtsCppVulkanPath = string.Empty;
         OmniVoiceTtsCppInstruction = string.Empty;
         ChatterboxModel = "Base";


### PR DESCRIPTION
## Summary
Adds a second route to Qwen3 TTS, this time via the existing **CrispASR** runtime instead of `qwen3-tts.cpp`. Useful as an A/B comparison engine while the qwen3-tts.cpp EOS issue is being investigated upstream.

Also renames the existing **Chatterbox TTS** engine to **Chatterbox TTS (CrispASR)** for consistency — both run through the same `crispasr` binary now.

## Why
The qwen3-tts.cpp 0.6B model never emits EOS for short prompts (per the frame-by-frame logit dump from our earlier investigation — EOS slot is deeply negative and trends *more* negative each frame). "Hello world" runs to `max_audio_tokens=4096` and yields ~5 min of audio in ~10 min wall time.

CrispASR's `qwen3-tts-1.7b-voicedesign` backend, on the same M4 hardware with the same cstr-uploaded 1.7B VoiceDesign GGUF, cleanly emits EOS:

```
qwen3_tts: produced 12 frames × 16 codebooks = 192 codes
crispasr-server: synthesized 1.0s audio in 1.44s (RTF=1.50) voice='<startup>' speed=1.00
HTTP 200 body=46124 time=1.444497s
```

That's a working baseline while the qwen3-tts.cpp EOS bug remains open.

## How
- New `Qwen3TtsCrispAsr` engine spawns `crispasr --server --backend qwen3-tts-1.7b-voicedesign|customvoice -m <talker> [--codec-model <codec> | --auto-download] --voice-dir <voices>` and POSTs to `/v1/audio/speech` (OpenAI-compatible).
- VoiceDesign: requires `instructions` (defaults to "a calm female voice" if the user hasn't set one). Reuses `Qwen3TtsCppInstruction` so the same description applies to both Qwen3 engines.
- CustomVoice: takes a reference WAV from the voices folder; an adjacent `.txt` sidecar (matching filename) provides the reference transcription that CrispASR's qwen3-tts-customvoice expects.
- Voice import resamples to 24 kHz mono via ffmpeg (same convention as Chatterbox).
- Engine folder layout (kept separate per user direction):

  ```
  TextToSpeech/Qwen3TtsCrispAsr/models/  talker GGUF + 12Hz codec
  TextToSpeech/Qwen3TtsCrispAsr/voices/  reference WAVs (+ .txt sidecars)
  ```

## Known limitations / follow-ups
- **No download UX yet.** The talker GGUF must be manually placed (or symlinked from the existing qwen3-tts.cpp install — the 1.7B VoiceDesign file is bit-for-bit compatible). The CrispASR-style 12Hz codec (~986 MB, different file from qwen3-tts.cpp's tokenizer) gets fetched by `crispasr --auto-download` into `~/.cache/crispasr/` on first run — first-run timeout bumped to 30 min for that case. A proper SE-side download service is a follow-up.
- **No engine-settings dialog yet.** Model selection (VoiceDesign vs CustomVoice) currently only via direct setting edit / dropdown in the main TTS UI. The Qwen3 instruction string is shared with the existing qwen3-tts.cpp engine.
- **0.6B not supported.** The koboldcpp 0.6B GGUF uses the old tensor names and won't load in CrispASR (mirror of the qwen3-tts.cpp PR #14 issue, opposite direction). Only the cstr 1.7B variants work.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` clean (0 warnings, 0 errors)
- [x] End-to-end smoke: symlink existing 1.7B VoiceDesign GGUF, let crispasr auto-download the 12Hz codec, POST `/v1/audio/speech` with `instructions: "a calm female voice"` — HTTP 200, valid 24 kHz mono WAV, 1 s audio in 1.4 s wall time.
- [ ] Manual UI test on Mac/Windows: select "Qwen3 TTS (CrispASR)" in the engine combo, run the voice test
- [ ] Manual UI test: verify "Chatterbox TTS (CrispASR)" rename appears in the engine combo and engine settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)