### PR TITLE
Pin OmniVoice TTS to omnivoice-2026-05-22

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -10,6 +10,7 @@ v5.0.0-beta30 (xth May 2026)
 * Update Qwen3 TTS to v0.4.6 - unblocks the cstr CrispASR-converted VoiceDesign GGUF on all platforms
 * Add "Qwen3 TTS (CrispASR)" engine (1.7B VoiceDesign + CustomVoice via the CrispASR runtime)
 * Rename "Chatterbox TTS" to "Chatterbox TTS (CrispASR)" so the runtime is explicit
+* Update OmniVoice TTS to omnivoice-2026-05-22 - fixes the macOS/Linux dyld "Library not loaded: @rpath/libggml.0.dylib" error on first launch
 
 v5.0.0-beta29 (20th May 2026)
 

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -407,31 +407,37 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [OmniVoice.WindowsCpu] = new[]
             {
-                "ea1f0c6032f5a0333103ccffa7d7478c5ee00a35867776c277d717512587766c", // omnivoice-2026-05-17 (current download URL)
+                "4af38bcb264ef34d7d39a7c76af00993e32f731a17253b7e82a9b8a6140a736b", // omnivoice-2026-05-22 (current download URL)
+                "ea1f0c6032f5a0333103ccffa7d7478c5ee00a35867776c277d717512587766c", // omnivoice-2026-05-17
             },
             [OmniVoice.WindowsVulkan] = new[]
             {
-                "b461b8535892b3e6979aec79eff4d6a0109a31184008b778b6848d7d36ea9901", // omnivoice-2026-05-17 (current download URL)
+                "ff90f8eb8c36ea64d46bd1d245e109ef80cadf234417bdc2c78b7420ab8f9a43", // omnivoice-2026-05-22 (current download URL)
+                "b461b8535892b3e6979aec79eff4d6a0109a31184008b778b6848d7d36ea9901", // omnivoice-2026-05-17
             },
             [OmniVoice.WindowsCuda] = new[]
             {
-                "79308e79bb47df9f2bd2d31c6a60fe5672b74f43c3caf9b0a09566408894789e", // omnivoice-2026-05-17 (current download URL)
+                "735d5672507b3796138cecabcde6512e6a1e60bc9e6e86efd0fa6ce13a361fa1", // omnivoice-2026-05-22 (current download URL)
+                "79308e79bb47df9f2bd2d31c6a60fe5672b74f43c3caf9b0a09566408894789e", // omnivoice-2026-05-17
             },
             [OmniVoice.MacOs] = new[]
             {
-                "bbe354cdf8995641074c46d02d7f8b9353fa4803452cb45a762de10e899aca8e", // omnivoice-2026-05-17 (current download URL)
+                "d5ce6807adc50e6e1f1f92235828bad7c139c50042090a5361d0506e069ad1ba", // omnivoice-2026-05-22 (current download URL — RPATH fix)
+                "bbe354cdf8995641074c46d02d7f8b9353fa4803452cb45a762de10e899aca8e", // omnivoice-2026-05-17
             },
             [OmniVoice.LinuxX64] = new[]
             {
-                "198046721ebcbe49ded959fd832ec4a091d899be49e2a26b549723e32b82daba", // omnivoice-2026-05-17 (current download URL)
+                "c8eec5e66b362ddd3504658021a890a8acd4d2c092ba51a847fce1e80f4807e9", // omnivoice-2026-05-22 (current download URL — RPATH fix)
+                "198046721ebcbe49ded959fd832ec4a091d899be49e2a26b549723e32b82daba", // omnivoice-2026-05-17
             },
             [OmniVoice.LinuxArm64] = new[]
             {
-                "3802d4136a6ffdc37cce72b286ab7c17422d55964fec13d4e3eb36f26e6ae1fe", // omnivoice-2026-05-17 (current download URL)
+                "a46029c360398fc8775d6a4d703df158fa6f3ee6576e6efd3be0b7be424e5276", // omnivoice-2026-05-22 (current download URL — RPATH fix)
+                "3802d4136a6ffdc37cce72b286ab7c17422d55964fec13d4e3eb36f26e6ae1fe", // omnivoice-2026-05-17
             },
             [OmniVoice.Voices] = new[]
             {
-                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-05-17 (current download URL — identical to the support-files/omnivoice-26-06 copy)
+                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-05-22 (current download URL — unchanged from -05-17, identical to support-files/omnivoice-26-06 copy)
             },
 
             // Qwen3 TTS — https://github.com/niksedk/qwen3-tts.cpp/releases

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -32,7 +32,7 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
     // omnivoice.cpp release pin. Bump in lockstep with the hashes in DownloadHashManager.OmniVoice
     // (each new release: prepend the new SHA-256 at index 0, keep the previous one for "update available").
-    public const string ReleaseTag = "omnivoice-2026-05-17";
+    public const string ReleaseTag = "omnivoice-2026-05-22";
     private const string ReleaseUrlBase = "https://github.com/niksedk/omnivoice.cpp/releases/download/" + ReleaseTag + "/";
 
     private const string WindowsCpuUrl = ReleaseUrlBase + "omnivoice-win64-cpu.zip";


### PR DESCRIPTION
## Summary
Bumps the OmniVoice TTS engine pin from `omnivoice-2026-05-17` to `omnivoice-2026-05-22`.

The new release contains a single change — [`niksedk/omnivoice.cpp#1`](https://github.com/niksedk/omnivoice.cpp/pull/1) — that bakes a relative-to-binary RPATH on macOS and Linux. Without it, every macOS / Linux install hit a first-launch dyld error:

```
dyld[83591]: Library not loaded: @rpath/libggml.0.dylib
  Referenced from: TextToSpeech/OmniVoice/omnivoice-tts
  Reason: tried: '/Users/runner/work/omnivoice.cpp/omnivoice.cpp/build/libggml.0.dylib' (no such file), ...
```

because the GitHub Actions runner's build path was baked into `LC_RPATH`. The new build ships with `LC_RPATH=@executable_path` so the dylibs sit on the search path right next to the binary.

Windows binaries are functionally unchanged (PE+ doesn't use RPATH) but bumped along with the rest so all platforms move together.

## Hash provenance
All six archive SHA-256 values verified against the [omnivoice-2026-05-22 release metadata](https://github.com/niksedk/omnivoice.cpp/releases/tag/omnivoice-2026-05-22) (`gh release view omnivoice-2026-05-22 -R niksedk/omnivoice.cpp --json assets`). New row prepended at index 0 for each platform; the previous -05-17 hash kept for "update available" detection.

The `OmniVoices.zip` voice pack is byte-identical between -05-17 and -05-22, so its hash stays as a single entry retagged to the new release.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` clean (0 warnings, 0 errors)
- [ ] On macOS: fresh OmniVoice download lands an `omnivoice-tts` with `LC_RPATH=@executable_path` (no more `/Users/runner/work/...`) — `otool -l <path>/omnivoice-tts | grep -A 2 LC_RPATH`
- [ ] On macOS: voice test produces audio without the dyld error
- [ ] On a -05-17 install: engine settings dialog reports -05-22 as an update available and successfully downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)