### PR TITLE
Add frame-based min-gap setting (#11084)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -2720,7 +2720,7 @@ public class AudioVisualizer : Control
 
         int length50Ms = SecondsToSampleIndex(0.050);
         double secondsPerParagraph = defaultMilliseconds / TimeCode.BaseUnit;
-        int minBetween = SecondsToSampleIndex(Se.Settings.General.MinimumMillisecondsBetweenLines / TimeCode.BaseUnit);
+        int minBetween = SecondsToSampleIndex(Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / TimeCode.BaseUnit);
         bool subtitleOn = false;
         int i = begin;
         while (i < WavePeaks.Peaks.Count)

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -63,7 +63,7 @@ public partial class ImportPlainTextViewModel : ObservableObject
         };
         SelectedSplitAtOption = SplitAtOptions[0];
         PlainText = string.Empty;
-        MinGapMs = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        MinGapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         NumberOfSubtitles = string.Empty;
         FixedDurationMs = (int)Math.Round(Se.Settings.Tools.AdjustDurations.AdjustDurationFixed * 1000.0, MidpointRounding.AwayFromZero);
 

--- a/src/ui/Features/Files/ImportPlainText/ScriptSyncService.cs
+++ b/src/ui/Features/Files/ImportPlainText/ScriptSyncService.cs
@@ -28,7 +28,7 @@ public static class ScriptSyncService
     {
         var minDurationMs = (double)Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
         var maxDurationMs = (double)Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
-        var minGapMs = (double)Se.Settings.General.MinimumMillisecondsBetweenLines;
+        var minGapMs = (double)Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
 
         var whisperWords = ExtractWordTimestamps(whisperSubtitle);
         if (whisperWords.Count == 0)

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -92,7 +92,7 @@ public class InitWaveform
                 VerticalAlignment = VerticalAlignment.Stretch,
                 Height = double.NaN, // Auto height
                 WaveformDrawStyle = GetWaveformDrawStyle(settings.WaveformDrawStyle),
-                MinGapSeconds = Se.Settings.General.MinimumMillisecondsBetweenLines / 1000.0,
+                MinGapSeconds = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0,
                 FocusOnMouseOver = settings.FocusOnMouseOver,
                 IsReadOnly = Se.Settings.General.LockTimeCodes,
                 WaveformHeightPercentage = settings.SpectrogramCombinedWaveformHeight,

--- a/src/ui/Features/Main/MainHelpers/PasteFromClipboardHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/PasteFromClipboardHelper.cs
@@ -24,7 +24,7 @@ public class PasteFromClipboardHelper : IPasteFromClipboardHelper
         ObservableCollection<SubtitleLineViewModel> subtitles, 
         SubtitleFormat subtitleFormat)
     {
-        var minGapBetweenLines = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        var minGapBetweenLines = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         var tmp = new Subtitle();
         SubtitleFormat format = new SubRip();
         var list = new List<string>(text.SplitToLines());

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5130,6 +5130,7 @@ public partial class MainViewModel :
             Se.Settings.General.SubtitleOptimalCharactersPerSeconds = (double)p.SubtitleOptimalCharactersPerSeconds;
             Se.Settings.General.SubtitleMaximumWordsPerMinute = (double)p.SubtitleMaximumWordsPerMinute;
             Se.Settings.General.MinimumBetweenLines.Milliseconds = p.MinimumMillisecondsBetweenLines;
+            Se.Settings.General.MinimumBetweenLines.Frames = SubtitleFormat.MillisecondsToFrames(p.MinimumMillisecondsBetweenLines);
             Se.Settings.General.MaxNumberOfLines = p.MaxNumberOfLines;
             Se.Settings.General.UnbreakLinesShorterThan = p.MergeLinesShorterThan;
             Se.Settings.General.DialogStyle = p.DialogStyle.ToString();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -647,7 +647,7 @@ public partial class MainViewModel :
         Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
         Configuration.Settings.General.SubtitleOptimalCharactersPerSeconds = Se.Settings.General.SubtitleOptimalCharactersPerSeconds;
         Configuration.Settings.General.SubtitleMaximumWordsPerMinute = Se.Settings.General.SubtitleMaximumWordsPerMinute;
-        Configuration.Settings.General.MinimumMillisecondsBetweenLines = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        Configuration.Settings.General.MinimumMillisecondsBetweenLines = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         Configuration.Settings.General.MaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
         Configuration.Settings.General.MergeLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
 
@@ -3150,7 +3150,7 @@ public partial class MainViewModel :
             var maxEndTime = TimeSpan.FromMilliseconds(selectedLine.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMaximumDisplayMilliseconds);
             if (nextSubtitle != null)
             {
-                var tempMaxEntTime = TimeSpan.FromMilliseconds(nextSubtitle.StartTime.TotalMilliseconds - Se.Settings.General.MinimumMillisecondsBetweenLines);
+                var tempMaxEntTime = TimeSpan.FromMilliseconds(nextSubtitle.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
                 if (tempMaxEntTime < maxEndTime)
                 {
                     maxEndTime = tempMaxEntTime;
@@ -5129,7 +5129,7 @@ public partial class MainViewModel :
             Se.Settings.General.SubtitleMaximumCharactersPerSeconds = (double)p.SubtitleMaximumCharactersPerSeconds;
             Se.Settings.General.SubtitleOptimalCharactersPerSeconds = (double)p.SubtitleOptimalCharactersPerSeconds;
             Se.Settings.General.SubtitleMaximumWordsPerMinute = (double)p.SubtitleMaximumWordsPerMinute;
-            Se.Settings.General.MinimumMillisecondsBetweenLines = p.MinimumMillisecondsBetweenLines;
+            Se.Settings.General.MinimumBetweenLines.Milliseconds = p.MinimumMillisecondsBetweenLines;
             Se.Settings.General.MaxNumberOfLines = p.MaxNumberOfLines;
             Se.Settings.General.UnbreakLinesShorterThan = p.MergeLinesShorterThan;
             Se.Settings.General.DialogStyle = p.DialogStyle.ToString();
@@ -6045,7 +6045,7 @@ public partial class MainViewModel :
                 var newDuration = next!.StartTime - line.StartTime;
                 if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
-                    line.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumMillisecondsBetweenLines);
+                    line.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
                 }
 
                 continue;
@@ -6075,7 +6075,7 @@ public partial class MainViewModel :
                 var newDuration = next.StartTime - line.StartTime;
                 if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
                 {
-                    line.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumMillisecondsBetweenLines);
+                    line.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
                 }
             }
         }
@@ -6902,7 +6902,7 @@ public partial class MainViewModel :
             AudioVisualizer.UpdateTheme();
             AudioVisualizer.IsReadOnly = LockTimeCodes;
             AudioVisualizer.WaveformDrawStyle = InitWaveform.GetWaveformDrawStyle(Se.Settings.Waveform.WaveformDrawStyle);
-            AudioVisualizer.MinGapSeconds = Se.Settings.General.MinimumMillisecondsBetweenLines / 1000.0;
+            AudioVisualizer.MinGapSeconds = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
             AudioVisualizer.WaveformHeightPercentage = Se.Settings.Waveform.SpectrogramCombinedWaveformHeight;
             AudioVisualizer.FocusOnMouseOver = Se.Settings.Waveform.FocusOnMouseOver;
             AudioVisualizer.ResetCache();
@@ -9072,7 +9072,7 @@ public partial class MainViewModel :
             if (next.StartTime.TotalMilliseconds < endMs)
             {
                 newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds -
-                                                                 Se.Settings.General.MinimumMillisecondsBetweenLines);
+                                                                 Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
             }
         }
 
@@ -9649,7 +9649,7 @@ public partial class MainViewModel :
                 if (next.StartTime.TotalMilliseconds < endMs && next.StartTime.TotalMilliseconds > newParagraph.StartTime.TotalMilliseconds + 200)
                 {
                     newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds -
-                                                                     Se.Settings.General.MinimumMillisecondsBetweenLines);
+                                                                     Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
                 }
             }
         });
@@ -9689,7 +9689,7 @@ public partial class MainViewModel :
                 if (next.StartTime.TotalMilliseconds < endMs && next.StartTime.TotalMilliseconds > newParagraph.StartTime.TotalMilliseconds + 200)
                 {
                     newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds -
-                                                                     Se.Settings.General.MinimumMillisecondsBetweenLines);
+                                                                     Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
                 }
             }
 
@@ -9808,7 +9808,7 @@ public partial class MainViewModel :
         }
 
         var videoPositionSeconds = vp.Position;
-        var gap = Se.Settings.General.MinimumMillisecondsBetweenLines / 1000.0;
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
         if (videoPositionSeconds >= s.EndTime.TotalSeconds - gap)
         {
             return;
@@ -9842,7 +9842,7 @@ public partial class MainViewModel :
         }
 
         var videoPositionSeconds = vp.Position;
-        var gap = Se.Settings.General.MinimumMillisecondsBetweenLines / 1000.0;
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
         if (videoPositionSeconds < s.StartTime.TotalSeconds + gap)
         {
             return;
@@ -9882,7 +9882,7 @@ public partial class MainViewModel :
         }
 
         var videoPositionSeconds = vp.Position;
-        var gap = Se.Settings.General.MinimumMillisecondsBetweenLines / 1000.0;
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
         if (videoPositionSeconds < s.StartTime.TotalSeconds + gap)
         {
             return;
@@ -9914,7 +9914,7 @@ public partial class MainViewModel :
         }
 
         var videoPositionSeconds = vp.Position;
-        var gapMs = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         if (videoPositionSeconds < s.StartTime.TotalSeconds + 0.001)
         {
             return;
@@ -9945,7 +9945,7 @@ public partial class MainViewModel :
         }
 
         var videoPositionSeconds = vp.Position;
-        var gapMs = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         if (videoPositionSeconds < s.StartTime.TotalSeconds + 0.001)
         {
             return;
@@ -9978,7 +9978,7 @@ public partial class MainViewModel :
         }
 
         var videoPositionSeconds = vp.Position;
-        var gapMs = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         if (videoPositionSeconds > s.EndTime.TotalSeconds - 0.001)
         {
             return;
@@ -10418,7 +10418,7 @@ public partial class MainViewModel :
         }
 
         var prev = Subtitles[idx.Value - 1];
-        s.SetStartTimeOnly(TimeSpan.FromMilliseconds(prev.EndTime.TotalMilliseconds + Se.Settings.General.MinimumMillisecondsBetweenLines));
+        s.SetStartTimeOnly(TimeSpan.FromMilliseconds(prev.EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds()));
         _updateAudioVisualizer = true;
     }
 
@@ -10440,7 +10440,7 @@ public partial class MainViewModel :
 
         ;
         s.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds -
-                                              Se.Settings.General.MinimumMillisecondsBetweenLines);
+                                              Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
         _updateAudioVisualizer = true;
     }
 
@@ -12430,7 +12430,7 @@ public partial class MainViewModel :
             if (next != null && next.StartTime.TotalMilliseconds < p.EndTime.TotalMilliseconds)
             {
                 p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds -
-                                              Se.Settings.General.MinimumMillisecondsBetweenLines;
+                                              Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
             }
         }
 

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -376,7 +376,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         get
         {
             if (Se.Settings.General.ColorGapTooShort &&
-                Gap < Se.Settings.General.MinimumMillisecondsBetweenLines)
+                Gap < Se.Settings.General.MinimumBetweenLines.GetMilliseconds())
             {
                 return _errorBrush;
             }
@@ -590,11 +590,11 @@ public partial class SubtitleLineViewModel : ObservableObject
                     errors.AppendLine("Overlap from previous: " + Math.Round(-gapPrev, 3));
                 }
             }
-            else if (gapPrev < general.MinimumMillisecondsBetweenLines)
+            else if (gapPrev < general.MinimumBetweenLines.GetMilliseconds())
             {
                 if (Se.Settings.General.ColorGapTooShort)
                 {
-                    errors.AppendLine("Min gap to previous: " + Math.Round(gapPrev, 3) + " < " + general.MinimumMillisecondsBetweenLines);
+                    errors.AppendLine("Min gap to previous: " + Math.Round(gapPrev, 3) + " < " + general.MinimumBetweenLines.GetMilliseconds());
                 }
             }
         }
@@ -612,11 +612,11 @@ public partial class SubtitleLineViewModel : ObservableObject
                 errors.AppendLine("Overlap to next: " + Math.Round(-gapNext, 3));
             }
         }
-        else if (gapNext < general.MinimumMillisecondsBetweenLines)
+        else if (gapNext < general.MinimumBetweenLines.GetMilliseconds())
         {
             if (Se.Settings.General.ColorGapTooShort)
             {
-                errors.AppendLine("Min gap to next: " + Math.Round(gapNext, 3) + " < " + general.MinimumMillisecondsBetweenLines);
+                errors.AppendLine("Min gap to next: " + Math.Round(gapNext, 3) + " < " + general.MinimumBetweenLines.GetMilliseconds());
             }
         }
 

--- a/src/ui/Features/Options/Settings/ProfileDisplay.cs
+++ b/src/ui/Features/Options/Settings/ProfileDisplay.cs
@@ -92,7 +92,7 @@ public partial class ProfileDisplay : ObservableObject
             SubtitleMaximumWordsPerMinute = (decimal)(MaxWordsPerMin ?? s.SubtitleMaximumWordsPerMinute),
             SubtitleMinimumDisplayMilliseconds = MinDurationMs ?? s.SubtitleMinimumDisplayMilliseconds,
             SubtitleMaximumDisplayMilliseconds = MaxDurationMs ?? s.SubtitleMaximumDisplayMilliseconds,
-            MinimumMillisecondsBetweenLines = MinGapMs ?? s.MinimumMillisecondsBetweenLines,
+            MinimumMillisecondsBetweenLines = MinGapMs ?? s.MinimumBetweenLines.Milliseconds,
             MaxNumberOfLines = MaxLines ?? s.MaxNumberOfLines,
             MergeLinesShorterThan = UnbreakLinesShorterThan ?? s.UnbreakLinesShorterThan,
             DialogStyle = Enum.Parse<DialogType>(DialogStyle.Code),

--- a/src/ui/Features/Options/Settings/SettingsItem.cs
+++ b/src/ui/Features/Options/Settings/SettingsItem.cs
@@ -10,6 +10,8 @@ public class SettingsItem
 {
     private readonly string _label;
     private readonly Func<Control> _controlFactory;
+    private readonly object? _labelBindingSource;
+    private readonly string? _labelBindingPath;
     public bool IsVisible { get; private set; } = true;
     public string? IsVisibleBinding { get; set; }
     public bool IsHidden { get; set; } = false;
@@ -30,6 +32,14 @@ public class SettingsItem
         IsHidden = isHidden;
     }
 
+    public SettingsItem(string label, object labelBindingSource, string labelBindingPath, Func<Control> controlFactory)
+    {
+        _label = label;
+        _controlFactory = controlFactory;
+        _labelBindingSource = labelBindingSource;
+        _labelBindingPath = labelBindingPath;
+    }
+
     public void Filter(string filter)
     {
         if (IsHidden)
@@ -44,6 +54,21 @@ public class SettingsItem
 
     public Control Build()
     {
+        var labelTextBlock = new TextBlock
+        {
+            Text = _label,
+            MinWidth = 200,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        if (_labelBindingPath != null && _labelBindingSource != null)
+        {
+            labelTextBlock.Bind(TextBlock.TextProperty, new Binding(_labelBindingPath)
+            {
+                Source = _labelBindingSource,
+            });
+        }
+
         var stackPanel = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -51,12 +76,7 @@ public class SettingsItem
             Margin = new Thickness(0, 0, 0, 15),
             Children =
             {
-                new TextBlock
-                {
-                    Text = _label,
-                    MinWidth = 200,
-                    VerticalAlignment = VerticalAlignment.Center,
-                },
+                labelTextBlock,
                 _controlFactory()
             }
         };

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -200,7 +200,24 @@ public class SettingsPage : UserControl
             new SettingsItem(Se.Language.Options.Settings.MaxWordsPerMin, () => MakeNumericUpDown(nameof(_vm.MaxWordsPerMin), _vm.RuleValueChanged)),
             new SettingsItem(Se.Language.Options.Settings.MinDurationMs, () => MakeNumericUpDownInt(nameof(_vm.MinDurationMs), _vm.RuleValueChanged)),
             new SettingsItem(Se.Language.Options.Settings.MaxDurationMs, () => MakeNumericUpDownInt(nameof(_vm.MaxDurationMs), _vm.RuleValueChanged)),
-            new SettingsItem(Se.Language.Options.Settings.MinGapMs, () => MakeNumericUpDownInt(nameof(_vm.MinGapMs), _vm.RuleValueChanged)),
+            new SettingsItem(Se.Language.Options.Settings.MinGapMs, _vm, nameof(_vm.MinGapLabel), () => new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 5,
+                Children =
+                {
+                    MakeNumericUpDownInt(nameof(_vm.MinGapMs), _vm.RuleValueChanged)
+                        .WithBindIsVisible(_vm, nameof(_vm.IsMsMode)),
+                    MakeNumericUpDownInt(nameof(_vm.MinGapFrames), _vm.RuleValueChanged)
+                        .WithBindIsVisible(_vm, nameof(_vm.UseFrameMode)),
+                    new TextBlock
+                    {
+                        VerticalAlignment = VerticalAlignment.Center,
+                        Opacity = 0.6,
+                        [!TextBlock.TextProperty] = new Binding(nameof(_vm.MinGapFramesAsMs)) { Source = _vm },
+                    }.WithBindIsVisible(_vm, nameof(_vm.UseFrameMode)),
+                }
+            }),
             new SettingsItem(Se.Language.Options.Settings.MaxLines, () => MakeNumericUpDownInt(nameof(_vm.MaxLines), _vm.RuleValueChanged)),
             new SettingsItem(Se.Language.Options.Settings.UnbreakSubtitlesShortThan, () => MakeNumericUpDownInt(nameof(_vm.UnbreakLinesShorterThan), _vm.RuleValueChanged)),
 

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -200,7 +200,7 @@ public class SettingsPage : UserControl
             new SettingsItem(Se.Language.Options.Settings.MaxWordsPerMin, () => MakeNumericUpDown(nameof(_vm.MaxWordsPerMin), _vm.RuleValueChanged)),
             new SettingsItem(Se.Language.Options.Settings.MinDurationMs, () => MakeNumericUpDownInt(nameof(_vm.MinDurationMs), _vm.RuleValueChanged)),
             new SettingsItem(Se.Language.Options.Settings.MaxDurationMs, () => MakeNumericUpDownInt(nameof(_vm.MaxDurationMs), _vm.RuleValueChanged)),
-            new SettingsItem(Se.Language.Options.Settings.MinGapMs, _vm, nameof(_vm.MinGapLabel), () => new StackPanel
+            new SettingsItem(Se.Language.Options.Settings.MinGapMs + " " + Se.Language.Options.Settings.MinGapFrames, _vm, nameof(_vm.MinGapLabel), () => new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 Spacing = 5,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -28,6 +28,7 @@ using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -54,10 +55,20 @@ public partial class SettingsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(MinGapFramesAsMs))]
     private int? _minGapFrames;
 
-    public string MinGapFramesAsMs =>
-        MinGapFrames.HasValue
-            ? $"= {SubtitleFormat.FramesToMilliseconds(MinGapFrames.Value)} ms"
-            : string.Empty;
+    public string MinGapFramesAsMs
+    {
+        get
+        {
+            if (!MinGapFrames.HasValue)
+            {
+                return string.Empty;
+            }
+
+            var fps = Configuration.Settings.General.CurrentFrameRate;
+            var ms = SubtitleFormat.FramesToMilliseconds(MinGapFrames.Value, fps);
+            return $"= {ms} ms (at {fps.ToString("0.###", CultureInfo.InvariantCulture)} fps)";
+        }
+    }
     [ObservableProperty] private int? _maxLines;
     [ObservableProperty] private int? _unbreakLinesShorterThan;
     [ObservableProperty] private ObservableCollection<DialogStyleDisplay> _dialogStyles;

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -49,6 +49,15 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private int? _minDurationMs;
     [ObservableProperty] private int? _maxDurationMs;
     [ObservableProperty] private int? _minGapMs;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(MinGapFramesAsMs))]
+    private int? _minGapFrames;
+
+    public string MinGapFramesAsMs =>
+        MinGapFrames.HasValue
+            ? $"= {SubtitleFormat.FramesToMilliseconds(MinGapFrames.Value)} ms"
+            : string.Empty;
     [ObservableProperty] private int? _maxLines;
     [ObservableProperty] private int? _unbreakLinesShorterThan;
     [ObservableProperty] private ObservableCollection<DialogStyleDisplay> _dialogStyles;
@@ -77,7 +86,15 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _lockTimeCodes;
     [ObservableProperty] private bool _rememberPositionAndSize;
     [ObservableProperty] private bool _openLastFileOnStart;
-    [ObservableProperty] private bool _useFrameMode;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsMsMode))]
+    [NotifyPropertyChangedFor(nameof(MinGapLabel))]
+    private bool _useFrameMode;
+
+    public bool IsMsMode => !UseFrameMode;
+    public string MinGapLabel => UseFrameMode
+        ? Se.Language.Options.Settings.MinGapFrames
+        : Se.Language.Options.Settings.MinGapMs;
     [ObservableProperty] private bool _textBoxLimitNewLines;
     [ObservableProperty] private bool _autoBackupOn;
     [ObservableProperty] private int? _autoBackupIntervalMinutes;
@@ -562,7 +579,8 @@ public partial class SettingsViewModel : ObservableObject
         MaxWordsPerMin = general.SubtitleMaximumWordsPerMinute;
         MinDurationMs = general.SubtitleMinimumDisplayMilliseconds;
         MaxDurationMs = general.SubtitleMaximumDisplayMilliseconds;
-        MinGapMs = general.MinimumMillisecondsBetweenLines;
+        MinGapMs = general.MinimumBetweenLines.Milliseconds;
+        MinGapFrames = general.MinimumBetweenLines.Frames;
         MaxLines = general.MaxNumberOfLines;
         UnbreakLinesShorterThan = general.UnbreakLinesShorterThan;
         DialogStyle = DialogStyles.FirstOrDefault(p => p.Code == general.DialogStyle) ?? DialogStyles.First();
@@ -1178,7 +1196,8 @@ public partial class SettingsViewModel : ObservableObject
         general.SubtitleMaximumWordsPerMinute = MaxWordsPerMin ?? general.SubtitleMaximumWordsPerMinute;
         general.SubtitleMinimumDisplayMilliseconds = MinDurationMs ?? general.SubtitleMinimumDisplayMilliseconds;
         general.SubtitleMaximumDisplayMilliseconds = MaxDurationMs ?? general.SubtitleMaximumDisplayMilliseconds;
-        general.MinimumMillisecondsBetweenLines = MinGapMs ?? general.MinimumMillisecondsBetweenLines;
+        general.MinimumBetweenLines.Milliseconds = MinGapMs ?? general.MinimumBetweenLines.Milliseconds;
+        general.MinimumBetweenLines.Frames = MinGapFrames ?? general.MinimumBetweenLines.Frames;
         general.MaxNumberOfLines = MaxLines ?? general.MaxNumberOfLines;
         general.UnbreakLinesShorterThan = UnbreakLinesShorterThan ?? general.UnbreakLinesShorterThan;
         general.DialogStyle = DialogStyle.Code;
@@ -1409,7 +1428,7 @@ public partial class SettingsViewModel : ObservableObject
                 SubtitleMaximumWordsPerMinute = (decimal?)profile.MaxWordsPerMin ?? (decimal)general.SubtitleMaximumWordsPerMinute,
                 SubtitleMinimumDisplayMilliseconds = profile.MinDurationMs ?? general.SubtitleMinimumDisplayMilliseconds,
                 SubtitleMaximumDisplayMilliseconds = profile.MaxDurationMs ?? general.SubtitleMaximumDisplayMilliseconds,
-                MinimumMillisecondsBetweenLines = profile.MinGapMs ?? general.MinimumMillisecondsBetweenLines,
+                MinimumMillisecondsBetweenLines = profile.MinGapMs ?? general.MinimumBetweenLines.Milliseconds,
                 MaxNumberOfLines = profile.MaxLines ?? general.MaxNumberOfLines,
                 MergeLinesShorterThan = profile.UnbreakLinesShorterThan ?? general.UnbreakLinesShorterThan,
                 DialogStyle = Enum.Parse<DialogType>(profile.DialogStyle.Code),
@@ -1988,7 +2007,7 @@ public partial class SettingsViewModel : ObservableObject
                 Se.Settings.General.SubtitleMaximumWordsPerMinute = g.SubtitleMaximumWordsPerMinute;
                 Se.Settings.General.SubtitleMinimumDisplayMilliseconds = g.SubtitleMinimumDisplayMilliseconds;
                 Se.Settings.General.SubtitleMaximumDisplayMilliseconds = g.SubtitleMaximumDisplayMilliseconds;
-                Se.Settings.General.MinimumMillisecondsBetweenLines = g.MinimumMillisecondsBetweenLines;
+                Se.Settings.General.MinimumBetweenLines = g.MinimumBetweenLines;
                 Se.Settings.General.MaxNumberOfLines = g.MaxNumberOfLines;
                 Se.Settings.General.UnbreakLinesShorterThan = g.UnbreakLinesShorterThan;
                 Se.Settings.General.DialogStyle = g.DialogStyle;
@@ -2098,7 +2117,7 @@ public partial class SettingsViewModel : ObservableObject
                 MaxWordsPerMin = (double)g.SubtitleMaximumWordsPerMinute,
                 MinDurationMs = g.SubtitleMinimumDisplayMilliseconds,
                 MaxDurationMs = g.SubtitleMaximumDisplayMilliseconds,
-                MinGapMs = g.MinimumMillisecondsBetweenLines,
+                MinGapMs = g.MinimumBetweenLines.Milliseconds,
                 MaxLines = g.MaxNumberOfLines,
                 UnbreakLinesShorterThan = g.UnbreakLinesShorterThan,
                 DialogStyle = DialogStyles.FirstOrDefault(p => p.Code == g.DialogStyle) ?? DialogStyles.First(),

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -703,7 +703,7 @@ public partial class BinaryEditViewModel : ObservableObject
             if (next != null && next.StartTime.TotalMilliseconds < p.EndTime.TotalMilliseconds)
             {
                 p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds -
-                                              Se.Settings.General.MinimumMillisecondsBetweenLines;
+                                              Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
             }
         }
 
@@ -1534,7 +1534,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         var newItem = new BinarySubtitleItem(selectedItem);
-        newItem.EndTime = TimeSpan.FromMilliseconds(selectedItem.StartTime.TotalMilliseconds + Se.Settings.General.MinimumMillisecondsBetweenLines);
+        newItem.EndTime = TimeSpan.FromMilliseconds(selectedItem.StartTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
         newItem.StartTime = TimeSpan.FromMilliseconds(newItem.EndTime.TotalMilliseconds - Se.Settings.General.NewEmptyDefaultMs);
         var selectedIndex = SubtitleGrid.SelectedIndex;
         Subtitles.Insert(selectedIndex, newItem);
@@ -1557,7 +1557,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         var newItem = new BinarySubtitleItem(selectedItem);
-        newItem.StartTime = TimeSpan.FromMilliseconds(selectedItem.EndTime.TotalMilliseconds + Se.Settings.General.MinimumMillisecondsBetweenLines);
+        newItem.StartTime = TimeSpan.FromMilliseconds(selectedItem.EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
         newItem.EndTime = TimeSpan.FromMilliseconds(newItem.StartTime.TotalMilliseconds + Se.Settings.General.NewEmptyDefaultMs);
         var selectedIndex = SubtitleGrid.SelectedIndex;
         Subtitles.Insert(selectedIndex + 1, newItem);

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
@@ -132,7 +132,7 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
                         var newEndTime = TimeSpan.FromMilliseconds(item.StartTime.TotalMilliseconds + minMs);
                         if (newEndTime > next.StartTime)
                         {
-                            var cappedEndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumMillisecondsBetweenLines);
+                            var cappedEndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
                             if (cappedEndTime > item.EndTime)
                             {
                                 // improved, but not fixed

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
@@ -119,9 +119,9 @@ public partial class ApplyMinGapViewModel : ObservableObject
 
     private void LoadSettings()
     {
-        MinGapMsOrFrames = Se.Settings.General.UseFrameMode 
-            ? SubtitleFormat.MillisecondsToFrames(Se.Settings.General.MinimumMillisecondsBetweenLines) 
-            : Se.Settings.General.MinimumMillisecondsBetweenLines;
+        MinGapMsOrFrames = Se.Settings.General.UseFrameMode
+            ? Se.Settings.General.MinimumBetweenLines.Frames
+            : Se.Settings.General.MinimumBetweenLines.Milliseconds;
     }
 
     private void SaveSettings()

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -107,7 +107,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
         Configuration.Settings.General.MaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
         Configuration.Settings.General.SubtitleOptimalCharactersPerSeconds = Se.Settings.General.SubtitleOptimalCharactersPerSeconds;
-        Configuration.Settings.General.MinimumMillisecondsBetweenLines = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        Configuration.Settings.General.MinimumMillisecondsBetweenLines = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
 
         InitStep1(languageCode, subtitle);
         LoadProfiles();

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -1218,7 +1218,7 @@ public partial class CutVideoViewModel : ObservableObject
         }
 
         var videoPositionSeconds = vp.Position;
-        var gap = Se.Settings.General.MinimumMillisecondsBetweenLines / 1000.0;
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
         if (videoPositionSeconds < s.StartTime.TotalSeconds + gap)
         {
             return;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -99,6 +99,7 @@ public class LanguageSettings
     public string MinDurationMs { get; set; }
     public string MaxDurationMs { get; set; }
     public string MinGapMs { get; set; }
+    public string MinGapFrames { get; set; }
     public string MaxLines { get; set; }
     public string UnbreakSubtitlesShortThan { get; set; }
     public string NewEmptyDefaultMs { get; set; }
@@ -389,6 +390,7 @@ public class LanguageSettings
         MinDurationMs = "Min duration (ms)";
         MaxDurationMs = "Max duration (ms)";
         MinGapMs = "Min gap (ms)";
+        MinGapFrames = "Min gap (frames)";
         MaxLines = "Max number of lines";
         UnbreakSubtitlesShortThan = "Unbreak subtitles shorter than";
         NewEmptyDefaultMs = "Default new subtitle duration (ms)";

--- a/src/ui/Logic/Config/MsOrFramesValue.cs
+++ b/src/ui/Logic/Config/MsOrFramesValue.cs
@@ -1,0 +1,16 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace Nikse.SubtitleEdit.Logic.Config;
+
+public class MsOrFramesValue
+{
+    public int Milliseconds { get; set; }
+    public int Frames { get; set; }
+
+    public int GetMilliseconds()
+    {
+        return Se.Settings.General.UseFrameMode
+            ? SubtitleFormat.FramesToMilliseconds(Frames)
+            : Milliseconds;
+    }
+}

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -67,7 +67,7 @@ public class SeGeneral
     public int MaxNumberOfLinesPlusAbort { get; set; }
     public int SubtitleMinimumDisplayMilliseconds { get; set; }
     public int SubtitleMaximumDisplayMilliseconds { get; set; }
-    public int MinimumMillisecondsBetweenLines { get; set; }
+    public MsOrFramesValue MinimumBetweenLines { get; set; } = new() { Milliseconds = 24, Frames = 2 };
     public int NewEmptyDefaultMs { get; set; }
     public bool PromptBeforeDelete { get; set; }
     public bool LockTimeCodes { get; set; }
@@ -123,7 +123,6 @@ public class SeGeneral
         UnbreakLinesShorterThan = 33;
         SubtitleMinimumDisplayMilliseconds = 1000;
         SubtitleMaximumDisplayMilliseconds = 8 * 1000;
-        MinimumMillisecondsBetweenLines = 24;
         SubtitleMaximumCharactersPerSeconds = 25.0;
         SubtitleOptimalCharactersPerSeconds = 15.0;
         SubtitleMaximumWordsPerMinute = 400;
@@ -164,7 +163,7 @@ public class SeGeneral
             SubtitleMinimumDisplayMilliseconds = SubtitleMinimumDisplayMilliseconds,
             SubtitleMaximumWordsPerMinute = (decimal)SubtitleMaximumWordsPerMinute,
             CpsLineLengthStrategy = CpsLineLengthStrategy,
-            MinimumMillisecondsBetweenLines = MinimumMillisecondsBetweenLines,
+            MinimumMillisecondsBetweenLines = MinimumBetweenLines.Milliseconds,
             DialogStyle = Enum.Parse<DialogType>(DialogStyle),
             ContinuationStyle = Enum.Parse<ContinuationStyle>(ContinuationStyle),
         });

--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -27,7 +27,7 @@ public class SplitManager : ISplitManager
         }
 
         var newSubtitle = new SubtitleLineViewModel(subtitle, true);
-        var gap = Se.Settings.General.MinimumMillisecondsBetweenLines / 2.0;
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 2.0;
 
         var dividePositionMs = subtitle.StartTime.TotalMilliseconds + subtitle.Duration.TotalMilliseconds / 2.0 + gap;
         if (videoPositionSeconds > 0 && videoPositionSeconds > subtitle.StartTime.TotalSeconds && videoPositionSeconds < subtitle.EndTime.TotalSeconds)

--- a/src/ui/Logic/InsertService.cs
+++ b/src/ui/Logic/InsertService.cs
@@ -25,7 +25,7 @@ public class InsertService : IInsertService
             firstSelectedIndex = index.Value;
         }
 
-        var minGapBetweenLines = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        var minGapBetweenLines = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         int addMilliseconds = minGapBetweenLines + 1;
         if (addMilliseconds < 1)
         {
@@ -128,7 +128,7 @@ public class InsertService : IInsertService
         var prev = subtitles.GetOrNull(firstSelectedIndex);
         var next = subtitles.GetOrNull(firstSelectedIndex + 1);
 
-        var minGapBetweenLines = Se.Settings.General.MinimumMillisecondsBetweenLines;
+        var minGapBetweenLines = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         var addMilliseconds = minGapBetweenLines;
         if (addMilliseconds < 1)
         {

--- a/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
+++ b/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
@@ -56,13 +56,13 @@ internal static class SubtitleGridCopyPasteHelper
         var addTimeMilliseconds = (double)0;
         if (subtitles.Count > 0 && index >= 0 && index < subtitles.Count)
         {
-            addTimeMilliseconds = (double)subtitles[index].EndTime.TotalMilliseconds + Se.Settings.General.MinimumMillisecondsBetweenLines;
+            addTimeMilliseconds = (double)subtitles[index].EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
             index++;
         }
         else if (subtitles.Count > 0)
         {
              // If index is invalid (e.g. -1), append to end
-             addTimeMilliseconds = (double)subtitles[subtitles.Count - 1].EndTime.TotalMilliseconds + Se.Settings.General.MinimumMillisecondsBetweenLines;
+             addTimeMilliseconds = (double)subtitles[subtitles.Count - 1].EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
              index = subtitles.Count;
         }
 
@@ -98,7 +98,7 @@ internal static class SubtitleGridCopyPasteHelper
                 };
                 subtitles.Insert(index, p);
                 index++;
-                addTimeMilliseconds += Se.Settings.General.NewEmptyDefaultMs + Se.Settings.General.MinimumMillisecondsBetweenLines;
+                addTimeMilliseconds += Se.Settings.General.NewEmptyDefaultMs + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
             }
         }
     }

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1194,6 +1194,28 @@ public static class UiUtil
         return control;
     }
 
+    public static T WithBindIsVisible<T>(this T control, string isVisiblePropertyPath) where T : Control
+    {
+        control.Bind(Visual.IsVisibleProperty, new Binding
+        {
+            Path = isVisiblePropertyPath,
+            Mode = BindingMode.TwoWay,
+        });
+
+        return control;
+    }
+
+    public static T WithBindIsVisible<T>(this T control, object source, string isVisiblePropertyPath) where T : Control
+    {
+        control.Bind(Visual.IsVisibleProperty, new Binding(isVisiblePropertyPath)
+        {
+            Source = source,
+            Mode = BindingMode.TwoWay,
+        });
+
+        return control;
+    }
+
     public static Button WithBindIsEnabled(this Button control, string isEnabledPropertyPath)
     {
         control.Bind(Button.IsEnabledProperty, new Binding

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1199,7 +1199,7 @@ public static class UiUtil
         control.Bind(Visual.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1210,7 +1210,7 @@ public static class UiUtil
         control.Bind(Visual.IsVisibleProperty, new Binding(isVisiblePropertyPath)
         {
             Source = source,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;


### PR DESCRIPTION
## Summary
- Adds a frame value alongside the existing ms value for the minimum gap between lines, stored together in a new `MsOrFramesValue` wrapper on `SeGeneral`.
- When `UseFrameMode` is on, the Settings UI shows a frames input (with the ms equivalent rendered next to it at lower opacity); when off, the existing ms input is shown. The row label swaps to match.
- All consumers of the old `MinimumMillisecondsBetweenLines` (~30 sites across `MainViewModel`, `BinaryEdit`, `AudioVisualizer`, `InsertService`, etc.) now go through `MinimumBetweenLines.GetMilliseconds()` so frame mode actually takes effect, and the two libse-sync sites push the effective ms through too.

Closes #11084.

## Test plan
- [ ] Toggle **Use frame mode** in Settings → General; confirm the Min gap row label changes between "Min gap (ms)" and "Min gap (frames)" and that the right control + the "= N ms" hint appears.
- [ ] In frame mode, set Min gap to 2 frames at 23.976 fps and verify the hint shows 83 ms.
- [ ] Switch the project frame rate; confirm the hint updates and that gap enforcement (e.g. paste from clipboard, apply min gaps) uses the new ms value.
- [ ] Settings load/save round-trip preserves both `Milliseconds` and `Frames`.

> ⚠️ Settings.json migration: the old top-level `MinimumMillisecondsBetweenLines` key is no longer mapped, so users with a customized value will reset to the default (24 ms / 2 frames). Happy to add a setter-only legacy property if you want to preserve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)