### PR TITLE
Use PhysicalKey for shortcut Oem* keys on non-US layouts (#11082)

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -135,6 +135,27 @@ public partial class ShortcutsViewModel : ObservableObject
         }
     }
 
+    // Punctuation tokens emitted by ShortcutManager.GetShortcutKeyName when it
+    // falls back to PhysicalKey for layout-dependent Key.Oem* values (see
+    // ShortcutManager). The manual-pick dropdown must offer the same tokens
+    // the capture path produces, otherwise dropdown picks won't match runtime
+    // matching.
+    private static readonly string[] PhysicalPunctuationKeys =
+    [
+        "Backquote",
+        "Minus",
+        "Equal",
+        "BracketLeft",
+        "BracketRight",
+        "Backslash",
+        "Semicolon",
+        "Quote",
+        "Comma",
+        "Period",
+        "Slash",
+        "IntlBackslash",
+    ];
+
     private static List<string> GetShortcutKeys()
     {
         var result = new List<string>();
@@ -147,7 +168,8 @@ public partial class ShortcutsViewModel : ObservableObject
                 key == nameof(Key.LeftAlt) ||
                 key == nameof(Key.RightAlt) ||
                 key == nameof(Key.LeftShift) ||
-                key == nameof(Key.RightShift))
+                key == nameof(Key.RightShift) ||
+                key.StartsWith("Oem", StringComparison.Ordinal))
             {
                 continue;
             }
@@ -155,6 +177,7 @@ public partial class ShortcutsViewModel : ObservableObject
             result.Add(key);
         }
 
+        result.AddRange(PhysicalPunctuationKeys);
         return result;
     }
 

--- a/src/ui/Logic/Shortcut.cs
+++ b/src/ui/Logic/Shortcut.cs
@@ -19,6 +19,7 @@ public class ShortCut
 
     public ShortCut(string name, List<string> keys, ShortcutCategory category, IRelayCommand action)
     {
+        ShortcutManager.MigrateLegacyOemKeys(keys);
         Name = name;
         Keys = keys;
         Category = category;
@@ -42,6 +43,9 @@ public class ShortCut
 
     public ShortCut(ShortcutsMain.AvailableShortcut shortcut, SeShortCut keys)
     {
+        // Mutates the underlying SeShortCut.Keys list so the migrated names
+        // also get persisted on the next save — drops legacy "Oem*" tokens.
+        ShortcutManager.MigrateLegacyOemKeys(keys.Keys);
         Keys = keys.Keys;
         Action = shortcut.RelayCommand;
         Category = shortcut.Category;

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -98,15 +98,66 @@ public class ShortcutManager : IShortcutManager
 
     public static string GetShortcutKeyName(Key key, PhysicalKey physicalKey)
     {
-        if (!IsNumPadPhysicalKey(physicalKey))
+        if (IsNumPadPhysicalKey(physicalKey))
         {
-            return key.ToString();
+            var keyName = key.ToString();
+            return keyName.StartsWith("NumPad", StringComparison.Ordinal)
+                ? keyName
+                : "NumPad" + keyName;
         }
 
-        var keyName = key.ToString();
-        return keyName.StartsWith("NumPad", StringComparison.Ordinal)
-            ? keyName
-            : "NumPad" + keyName;
+        // Avalonia's Key enum derives Oem* values from the character produced
+        // against a US-keyboard table, so Shift+. on a Swedish layout reports
+        // as OemSemicolon (because ':' lives on the semicolon key in US) and
+        // collides with Shift+,. The non-ASCII '<' next to Z is mis-reported
+        // as OemComma for the same reason. Fall back to the layout-independent
+        // PhysicalKey so each physical key gets a unique, stable token.
+        if (key.ToString().StartsWith("Oem", StringComparison.Ordinal))
+        {
+            return physicalKey.ToString();
+        }
+
+        return key.ToString();
+    }
+
+    // Maps tokens that were stored before the PhysicalKey fix onto the modern
+    // PhysicalKey names. Existing user shortcut files have entries like
+    // "OemPeriod" / "Oem1"; without this migration they would silently stop
+    // matching after the upgrade.
+    private static readonly Dictionary<string, string> LegacyOemKeyMap = new(StringComparer.Ordinal)
+    {
+        ["OemPeriod"] = "Period",
+        ["OemComma"] = "Comma",
+        ["OemSemicolon"] = "Semicolon",
+        ["Oem1"] = "Semicolon",
+        ["OemQuestion"] = "Slash",
+        ["Oem2"] = "Slash",
+        ["OemTilde"] = "Backquote",
+        ["Oem3"] = "Backquote",
+        ["OemOpenBrackets"] = "BracketLeft",
+        ["Oem4"] = "BracketLeft",
+        ["OemPipe"] = "Backslash",
+        ["Oem5"] = "Backslash",
+        ["OemCloseBrackets"] = "BracketRight",
+        ["Oem6"] = "BracketRight",
+        ["OemQuotes"] = "Quote",
+        ["Oem7"] = "Quote",
+        ["Oem8"] = "IntlBackslash",
+        ["OemMinus"] = "Minus",
+        ["OemPlus"] = "Equal",
+        ["OemBackslash"] = "IntlBackslash",
+        ["Oem102"] = "IntlBackslash",
+    };
+
+    public static void MigrateLegacyOemKeys(List<string> keys)
+    {
+        for (var i = 0; i < keys.Count; i++)
+        {
+            if (LegacyOemKeyMap.TryGetValue(keys[i], out var modern))
+            {
+                keys[i] = modern;
+            }
+        }
     }
 
     private static bool IsNumPadPhysicalKey(PhysicalKey physicalKey)

--- a/tests/UI/Logic/ShortcutManagerTests.cs
+++ b/tests/UI/Logic/ShortcutManagerTests.cs
@@ -1,5 +1,6 @@
 using Avalonia.Input;
 using Nikse.SubtitleEdit.Logic;
+using System.Collections.Generic;
 
 namespace UITests.Logic;
 
@@ -64,5 +65,58 @@ public class ShortcutManagerTests
         var main = ShortcutManager.GetShortcutKeyName(Key.Delete, PhysicalKey.Delete);
 
         Assert.NotEqual(numpad, main);
+    }
+
+    // Bug #11082: on a non-US layout (e.g. Swedish) Avalonia's Key enum is
+    // derived from the produced character mapped against a US-keyboard table,
+    // so Shift+. ('=>:') reports Key.OemSemicolon and Shift+, ('=>;') also
+    // reports Key.OemSemicolon. Falling back to PhysicalKey for any Oem* key
+    // gives each physical key a unique, layout-independent token.
+    [Theory]
+    [InlineData(Key.OemPeriod, PhysicalKey.Period, "Period")]
+    [InlineData(Key.OemComma, PhysicalKey.Comma, "Comma")]
+    [InlineData(Key.OemSemicolon, PhysicalKey.Period, "Period")]      // Swedish Shift+.
+    [InlineData(Key.OemSemicolon, PhysicalKey.Comma, "Comma")]        // Swedish Shift+,
+    [InlineData(Key.OemComma, PhysicalKey.IntlBackslash, "IntlBackslash")] // Swedish '<' next to Z
+    [InlineData(Key.OemMinus, PhysicalKey.Minus, "Minus")]
+    [InlineData(Key.OemPlus, PhysicalKey.Equal, "Equal")]
+    [InlineData(Key.OemQuestion, PhysicalKey.Slash, "Slash")]
+    [InlineData(Key.OemTilde, PhysicalKey.Backquote, "Backquote")]
+    public void GetShortcutKeyNameUsesPhysicalKeyForOemKeys(Key key, PhysicalKey physicalKey, string expected)
+    {
+        var result = ShortcutManager.GetShortcutKeyName(key, physicalKey);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetShortcutKeyNameSwedishShiftPeriodNotEqualSwedishShiftComma()
+    {
+        // The collision behind #11082: both produce Key.OemSemicolon on Swedish,
+        // so before the fix they shared a token and second-bound shortcut won.
+        var shiftPeriod = ShortcutManager.GetShortcutKeyName(Key.OemSemicolon, PhysicalKey.Period);
+        var shiftComma = ShortcutManager.GetShortcutKeyName(Key.OemSemicolon, PhysicalKey.Comma);
+
+        Assert.NotEqual(shiftPeriod, shiftComma);
+    }
+
+    [Fact]
+    public void MigrateLegacyOemKeysRewritesKnownTokensInPlace()
+    {
+        var keys = new List<string> { "Shift", "OemPeriod", "OemComma", "Oem1", "A" };
+
+        ShortcutManager.MigrateLegacyOemKeys(keys);
+
+        Assert.Equal(new[] { "Shift", "Period", "Comma", "Semicolon", "A" }, keys);
+    }
+
+    [Fact]
+    public void MigrateLegacyOemKeysLeavesUnknownTokensUnchanged()
+    {
+        var keys = new List<string> { "Control", "F5", "NumPad7", "Period" };
+
+        ShortcutManager.MigrateLegacyOemKeys(keys);
+
+        Assert.Equal(new[] { "Control", "F5", "NumPad7", "Period" }, keys);
     }
 }


### PR DESCRIPTION
## Summary
- Bug: on a Swedish (and other non-US) keyboard, `Shift+.` and `Shift+,` both detect as `OemSemicolon` because Avalonia derives `Key.Oem*` from the produced character against a US-keyboard table. The two physical keys collide on one token and the second-bound shortcut silently wins. The Swedish `<` next to `Z` lands on the same path and reports as `OemComma`.
- Fix: when `Key.ToString()` starts with `Oem`, fall back to `PhysicalKey.ToString()` in `ShortcutManager.GetShortcutKeyName`. PhysicalKey is the layout-independent physical position — each physical key now gets a unique, stable token.
- Migration: existing user shortcut JSON stores the old `Oem*` tokens. `MigrateLegacyOemKeys` rewrites the `SeShortCut.Keys` list in place when a `ShortCut` is constructed, so old bindings keep working and the modern names get persisted on the next save.

Closes #11082.

## Test plan
- [x] Existing 226 UI tests still pass.
- [x] New tests cover the Swedish collision (`Shift+.` vs `Shift+,` produce different tokens), the `<` mis-report case, and the legacy migration mapping.
- [ ] On a Swedish-layout Mac: assign `Shift+Ctrl+.` to one action and `Shift+Ctrl+,` to another — both should fire independently.
- [ ] Existing users with `OemPeriod`/`OemComma` saved shortcuts should still trigger after upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)