### PR TITLE
Fix changelog so beta29 users aren't offered beta28 (#11103)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -13,6 +13,8 @@ v5.0.0-beta30 (xth May 2026)
 * Update Japanese translation - thx hisui3393
 * Add frame-based min-gap setting - thx p33t3r
 
+-----------------------------------------------------------------------------------------------------
+
 v5.0.0-beta29 (20th May 2026)
 
 * Add Engine settings dialog for Qwen3 TTS, Kokoro TTS, and Chatterbox TTS


### PR DESCRIPTION
## Summary
- `change-log.txt` was missing the separator between the in-progress `v5.0.0-beta30` block and the released `v5.0.0-beta29` block, so both lived above the first separator. `CheckForUpdatesViewModel.ParseLatestChangeLog` looks at that whole top block, sees beta30's `xth May 2026` placeholder via the unreleased-regex, decides "skip the unreleased top block," and lands on the *next* released block — beta28. beta29 users then get told "v5.0.0-beta28 is available."
- Adding the separator restores the invariant the parser expects: top block = at most one in-progress entry. Result: beta30 is correctly skipped as unreleased and beta29 is read as the current released version.

Closes #11103.

## Follow-ups worth doing in code (not in this PR)
- `CheckForUpdates` currently does a string-inequality check against `Se.Version`, so any mismatch reads as "new version available" — including downgrades. A semver-style "is this actually newer than mine" check would prevent the same class of bug if the changelog ever drifts again.
- `ParseLatestChangeLog` only walks one block when the top is flagged unreleased; if two unreleased entries ever pile up the same way, the bug recurs. Walking forward through blocks until a released one is found would be more robust.

## Test plan
- [ ] On a beta29 build, open Help → Check for updates and confirm it says "Up to date" (or offers the next real release if one lands).