### PR TITLE
Use the shared ColorPickerWindow dialog everywhere

### DIFF
--- a/src/ui/Features/Assa/AssaDraw/AssaDrawWindow.cs
+++ b/src/ui/Features/Assa/AssaDraw/AssaDrawWindow.cs
@@ -441,24 +441,7 @@ public class AssaDrawWindow : Window
         };
         panel.Children.Add(changeLayerButton);
 
-        var colorPicker = new ColorPicker
-        {
-            Width = 200,
-            IsAlphaEnabled = true,
-            IsAlphaVisible = true,
-            IsColorSpectrumSliderVisible = false,
-            IsColorComponentsVisible = true,
-            IsColorModelVisible = false,
-            IsColorPaletteVisible = false,
-            IsAccentColorsVisible = false,
-            IsColorSpectrumVisible = true,
-            IsComponentTextInputVisible = true,
-            [!ColorPicker.ColorProperty] = new Binding(nameof(vm.LayerColor))
-            {
-                Source = vm,
-                Mode = BindingMode.TwoWay
-            },
-        };
+        var colorPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.LayerColor));
         panel.Children.Add(colorPicker);
 
         return panel;

--- a/src/ui/Features/Assa/AssaProgressBar/AssaProgressBarWindow.cs
+++ b/src/ui/Features/Assa/AssaProgressBar/AssaProgressBarWindow.cs
@@ -194,7 +194,7 @@ public class AssaProgressBarWindow : Window
         Grid.SetRow(fgLabel, 3);
         grid.Children.Add(fgLabel);
 
-        var fgPicker = UiUtil.MakeColorPicker(vm, nameof(vm.ForegroundColor));
+        var fgPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.ForegroundColor));
         fgPicker.HorizontalAlignment = HorizontalAlignment.Left;
         Grid.SetRow(fgPicker, 3);
         Grid.SetColumn(fgPicker, 1);
@@ -204,7 +204,7 @@ public class AssaProgressBarWindow : Window
         Grid.SetRow(bgLabel, 4);
         grid.Children.Add(bgLabel);
 
-        var bgPicker = UiUtil.MakeColorPicker(vm, nameof(vm.BackgroundColor));
+        var bgPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.BackgroundColor));
         bgPicker.HorizontalAlignment = HorizontalAlignment.Left;
         Grid.SetRow(bgPicker, 4);
         Grid.SetColumn(bgPicker, 1);
@@ -462,7 +462,7 @@ public class AssaProgressBarWindow : Window
         var colorLabel = new TextBlock { Text = Se.Language.General.Color + ":", VerticalAlignment = VerticalAlignment.Center };
         grid.Add(colorLabel, 5);
 
-        var colorPicker = UiUtil.MakeColorPicker(vm, nameof(vm.TextColor));
+        var colorPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.TextColor));
         colorPicker.HorizontalAlignment = HorizontalAlignment.Left;
         grid.Add(colorPicker, 5, 1);
 

--- a/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundWindow.cs
+++ b/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundWindow.cs
@@ -309,7 +309,7 @@ public class AssSetBackgroundWindow : Window
         var boxLabel = new TextBlock { Text = Se.Language.Assa.BackgroundBoxBoxColor, VerticalAlignment = VerticalAlignment.Center };
         grid.Add(boxLabel, 1, 0);
 
-        var boxPicker = UiUtil.MakeColorPicker(vm, nameof(vm.BoxColor));
+        var boxPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.BoxColor));
         boxPicker.HorizontalAlignment = HorizontalAlignment.Left;
         grid.Add(boxPicker, 1, 1);
 
@@ -317,7 +317,7 @@ public class AssSetBackgroundWindow : Window
         var outlineLabel = new TextBlock { Text = Se.Language.General.Outline, VerticalAlignment = VerticalAlignment.Center };
         grid.Add(outlineLabel, 2, 0);
 
-        var outlinePicker = UiUtil.MakeColorPicker(vm, nameof(vm.OutlineColor));
+        var outlinePicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.OutlineColor));
         outlinePicker.HorizontalAlignment = HorizontalAlignment.Left;
         grid.Add(outlinePicker, 2, 1);
 
@@ -325,7 +325,7 @@ public class AssSetBackgroundWindow : Window
         var shadowLabel = new TextBlock { Text = Se.Language.General.Shadow, VerticalAlignment = VerticalAlignment.Center };
         grid.Add(shadowLabel, 3, 0);
 
-        var shadowPicker = UiUtil.MakeColorPicker(vm, nameof(vm.ShadowColor));
+        var shadowPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.ShadowColor));
         shadowPicker.HorizontalAlignment = HorizontalAlignment.Left;
         grid.Add(shadowPicker, 3, 1);
 

--- a/src/ui/Features/Assa/AssaSingleStyleWindow.cs
+++ b/src/ui/Features/Assa/AssaSingleStyleWindow.cs
@@ -112,13 +112,13 @@ public class AssaSingleStyleWindow : Window
         var panelTransform2 = UiUtil.MakeHorizontalPanel(labelSpacing, numericUpDownSpacing, labelAngle, numericUpDownAngle).WithMarginBottom(10);
 
         var labelColorPrimary = UiUtil.MakeLabel(Se.Language.Assa.Primary);
-        var colorPickerPrimary = UiUtil.MakeColorPicker(vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ColorPrimary));
+        var colorPickerPrimary = UiUtil.MakeColorPickerButton(vm.CurrentStyle!, nameof(StyleDisplay.ColorPrimary));
         var labelColorOutline = UiUtil.MakeLabel(Se.Language.General.Outline);
-        var colorPickerOutline = UiUtil.MakeColorPicker(vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ColorOutline));
+        var colorPickerOutline = UiUtil.MakeColorPickerButton(vm.CurrentStyle!, nameof(StyleDisplay.ColorOutline));
         var labelColorShadow = UiUtil.MakeLabel(Se.Language.General.Shadow);
-        var colorPickerShadow = UiUtil.MakeColorPicker(vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ColorShadow));
+        var colorPickerShadow = UiUtil.MakeColorPickerButton(vm.CurrentStyle!, nameof(StyleDisplay.ColorShadow));
         var labelColorSecondary = UiUtil.MakeLabel(Se.Language.Assa.Secondary);
-        var colorPickerSecondary = UiUtil.MakeColorPicker(vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ColorSecondary));
+        var colorPickerSecondary = UiUtil.MakeColorPickerButton(vm.CurrentStyle!, nameof(StyleDisplay.ColorSecondary));
         var panelColors = UiUtil.MakeHorizontalPanel(
             labelColorPrimary,
             colorPickerPrimary,

--- a/src/ui/Features/Assa/AssaSingleStyleWindow.cs
+++ b/src/ui/Features/Assa/AssaSingleStyleWindow.cs
@@ -112,13 +112,13 @@ public class AssaSingleStyleWindow : Window
         var panelTransform2 = UiUtil.MakeHorizontalPanel(labelSpacing, numericUpDownSpacing, labelAngle, numericUpDownAngle).WithMarginBottom(10);
 
         var labelColorPrimary = UiUtil.MakeLabel(Se.Language.Assa.Primary);
-        var colorPickerPrimary = UiUtil.MakeColorPickerButton(vm.CurrentStyle!, nameof(StyleDisplay.ColorPrimary));
+        var colorPickerPrimary = UiUtil.MakeColorPickerButton(vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ColorPrimary));
         var labelColorOutline = UiUtil.MakeLabel(Se.Language.General.Outline);
-        var colorPickerOutline = UiUtil.MakeColorPickerButton(vm.CurrentStyle!, nameof(StyleDisplay.ColorOutline));
+        var colorPickerOutline = UiUtil.MakeColorPickerButton(vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ColorOutline));
         var labelColorShadow = UiUtil.MakeLabel(Se.Language.General.Shadow);
-        var colorPickerShadow = UiUtil.MakeColorPickerButton(vm.CurrentStyle!, nameof(StyleDisplay.ColorShadow));
+        var colorPickerShadow = UiUtil.MakeColorPickerButton(vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ColorShadow));
         var labelColorSecondary = UiUtil.MakeLabel(Se.Language.Assa.Secondary);
-        var colorPickerSecondary = UiUtil.MakeColorPickerButton(vm.CurrentStyle!, nameof(StyleDisplay.ColorSecondary));
+        var colorPickerSecondary = UiUtil.MakeColorPickerButton(vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ColorSecondary));
         var panelColors = UiUtil.MakeHorizontalPanel(
             labelColorPrimary,
             colorPickerPrimary,

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -811,11 +811,6 @@ public partial class ExportImageBasedViewModel : ObservableObject
         _timerUpdatePreview.Start();
     }
 
-    internal void ColorChanged(object? sender, ColorChangedEventArgs e)
-    {
-        _dirty = true;
-    }
-
     partial void OnFontColorChanged(Color value) => _dirty = true;
     partial void OnOutlineColorChanged(Color value) => _dirty = true;
     partial void OnShadowColorChanged(Color value) => _dirty = true;

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -368,24 +368,7 @@ public class SettingsPage : UserControl
             MakeSeparator(),
             MakeCheckboxSetting(Se.Language.Options.Settings.ColorGapTooShort, nameof(_vm.ColorGapTooShort)),
             MakeSeparator(),
-            new SettingsItem(Se.Language.Options.Settings.ErrorBackgroundColor, () => new ColorPicker()
-            {
-                Width = 200,
-                IsAlphaEnabled = true,
-                IsAlphaVisible = true,
-                IsColorSpectrumSliderVisible = false,
-                IsColorComponentsVisible = true,
-                IsColorModelVisible = false,
-                IsColorPaletteVisible = false,
-                IsAccentColorsVisible = false,
-                IsColorSpectrumVisible = true,
-                IsComponentTextInputVisible = true,
-                [!ColorPicker.ColorProperty] = new Binding(nameof(_vm.ErrorColor))
-                {
-                    Source = _vm,
-                    Mode = BindingMode.TwoWay
-                },
-            }),
+            new SettingsItem(Se.Language.Options.Settings.ErrorBackgroundColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.ErrorColor))),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.VideoPlayer,
@@ -512,17 +495,17 @@ public class SettingsPage : UserControl
                 nameof(_vm.WaveformTextFontSize))),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformTextFontBold, nameof(_vm.WaveformTextFontBold)),
             new SettingsItem(string.Empty, () => UiUtil.MakeButton(Se.Language.Options.Settings.WaveformColorThemesDotDotDot, _vm.OpenWaveformThemesCommand)),
-            new SettingsItem(Se.Language.Options.Settings.WaveformTextColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformTextColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformParagraphBackgroundColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformParagraphBackgroundColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformBackgroundColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformBackgroundColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformParagraphSelectedBackgroundColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformParagraphSelectedBackgroundColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformSelectedColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformSelectedColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformCursorColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformCursorColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformShotChangeColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformShotChangeColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformParagraphLeftColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformParagraphLeftColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformParagraphRightColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformParagraphRightColor))),
-            new SettingsItem(Se.Language.Options.Settings.WaveformFancyHighColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.WaveformFancyHighColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformTextColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformTextColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformParagraphBackgroundColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformParagraphBackgroundColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformBackgroundColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformBackgroundColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformParagraphSelectedBackgroundColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformParagraphSelectedBackgroundColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformSelectedColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformSelectedColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformCursorColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformCursorColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformShotChangeColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformShotChangeColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformParagraphLeftColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformParagraphLeftColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformParagraphRightColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformParagraphRightColor))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformFancyHighColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.WaveformFancyHighColor))),
             MakeCheckboxSetting(Se.Language.General.OpenAiCompatibleSttAutoTranscribeOnAudioSelection, nameof(_vm.OpenAiCompatibleSttAutoTranscribeOnAudioSelection)),
             new SettingsItem(Se.Language.Options.Settings.DownloadFfmpeg, () => new StackPanel
             {
@@ -621,7 +604,7 @@ public class SettingsPage : UserControl
                 Orientation = Orientation.Horizontal,
                 Children =
                 {
-                    UiUtil.MakeColorPicker(_vm, nameof(_vm.DarkModeForegroundColor)),
+                    UiUtil.MakeColorPickerButton(_vm, nameof(_vm.DarkModeForegroundColor)),
                     UiUtil.MakeLabel(Se.Language.General.RequiresRestart).WithMarginLeft(5).WithOpacity(0.6),
                 }
             }),
@@ -630,7 +613,7 @@ public class SettingsPage : UserControl
                 Orientation = Orientation.Horizontal,
                 Children =
                 {
-                    UiUtil.MakeColorPicker(_vm, nameof(_vm.DarkModeBackgroundColor)),
+                    UiUtil.MakeColorPickerButton(_vm, nameof(_vm.DarkModeBackgroundColor)),
                     UiUtil.MakeLabel(Se.Language.General.RequiresRestart).WithMarginLeft(5).WithOpacity(0.6),
                 }
             }),
@@ -640,7 +623,7 @@ public class SettingsPage : UserControl
                 Orientation = Orientation.Horizontal,
                 Children =
                 {
-                    UiUtil.MakeColorPicker(_vm, nameof(_vm.FocusedButtonBackgroundColor)),
+                    UiUtil.MakeColorPickerButton(_vm, nameof(_vm.FocusedButtonBackgroundColor)),
                     UiUtil.MakeLabel(Se.Language.General.RequiresRestart).WithMarginLeft(5).WithOpacity(0.6),
                 }
             }),
@@ -670,7 +653,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowButtonHints, nameof(_vm.ShowButtonHints)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GridCompactMode, nameof(_vm.GridCompactMode)),
             new SettingsItem(Se.Language.Options.Settings.ShowGridLines, () => UiUtil.MakeComboBox(_vm.GridLinesVisibilities, _vm, nameof(_vm.SelectedGridLinesVisibility))),
-            new SettingsItem(Se.Language.Options.Settings.BookmarkColor, () => UiUtil.MakeColorPicker(_vm, nameof(_vm.BookmarkColor))),
+            new SettingsItem(Se.Language.Options.Settings.BookmarkColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.BookmarkColor))),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowAssaLayer, nameof(_vm.ShowAssaLayer)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowHorizontalLineAboveToolbar, nameof(_vm.ShowHorizontalLineAboveToolbar)),
         ]));
@@ -824,13 +807,13 @@ public class SettingsPage : UserControl
         numericUpDownMargin.Increment = 1;
 
         var labelColorPrimary = UiUtil.MakeLabel(Se.Language.Assa.Primary);
-        var colorPickerPrimary = UiUtil.MakeColorPicker(vm, nameof(vm.MpvPreviewColorPrimary));
+        var colorPickerPrimary = UiUtil.MakeColorPickerButton(vm, nameof(vm.MpvPreviewColorPrimary));
 
         var labelColorOutline = UiUtil.MakeLabel(Se.Language.General.Outline);
-        var colorPickerOutline = UiUtil.MakeColorPicker(vm, nameof(vm.MpvPreviewColorOutline));
+        var colorPickerOutline = UiUtil.MakeColorPickerButton(vm, nameof(vm.MpvPreviewColorOutline));
 
         var labelColorShadow = UiUtil.MakeLabel(Se.Language.General.Shadow);
-        var colorPickerShadow = UiUtil.MakeColorPicker(vm, nameof(vm.MpvPreviewColorShadow));
+        var colorPickerShadow = UiUtil.MakeColorPickerButton(vm, nameof(vm.MpvPreviewColorShadow));
 
         var grid = new Grid
         {

--- a/src/ui/Features/Shared/BinaryEdit/SetText/SetTextWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/SetText/SetTextWindow.cs
@@ -108,13 +108,13 @@ public class SetTextWindow : Window
         var labelFontColor = UiUtil.MakeLabel(Se.Language.General.TextColor);
         labelFontColor.Margin = new Thickness(5);
         
-        var colorPickerFontColor = UiUtil.MakeColorPicker(vm, nameof(vm.FontColor));
+        var colorPickerFontColor = UiUtil.MakeColorPickerButton(vm, nameof(vm.FontColor));
         colorPickerFontColor.Margin = new Thickness(5);
 
         var labelOutlineColor = UiUtil.MakeLabel(Se.Language.General.OutlineColor);
         labelOutlineColor.Margin = new Thickness(5);
         
-        var colorPickerOutlineColor = UiUtil.MakeColorPicker(vm, nameof(vm.OutlineColor));
+        var colorPickerOutlineColor = UiUtil.MakeColorPickerButton(vm, nameof(vm.OutlineColor));
         colorPickerOutlineColor.Margin = new Thickness(5);
 
         var labelOutlineWidth = UiUtil.MakeLabel(Se.Language.General.Width);
@@ -126,7 +126,7 @@ public class SetTextWindow : Window
         var labelShadowColor = UiUtil.MakeLabel(Se.Language.General.Shadow);
         labelShadowColor.Margin = new Thickness(5);
         
-        var colorPickerShadowColor = UiUtil.MakeColorPicker(vm, nameof(vm.ShadowColor));
+        var colorPickerShadowColor = UiUtil.MakeColorPickerButton(vm, nameof(vm.ShadowColor));
         colorPickerShadowColor.Margin = new Thickness(5);
 
         var labelShadowWidth = UiUtil.MakeLabel(Se.Language.General.Width);
@@ -145,7 +145,7 @@ public class SetTextWindow : Window
         var labelBackgroundColor = UiUtil.MakeLabel("Background color:");
         labelBackgroundColor.Margin = new Thickness(5);
         
-        var colorPickerBackgroundColor = UiUtil.MakeColorPicker(vm, nameof(vm.BackgroundColor));
+        var colorPickerBackgroundColor = UiUtil.MakeColorPickerButton(vm, nameof(vm.BackgroundColor));
         colorPickerBackgroundColor.Margin = new Thickness(5);
 
         var grid = new Grid

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAddFormatting.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAddFormatting.cs
@@ -25,24 +25,7 @@ public static class ViewAddFormatting
         var panelAlignment = UiUtil.MakeHorizontalPanel(checkBoxAddAlignmentTag, comboBoxAlignment);
 
         var checkBoxAddColor = UiUtil.MakeCheckBox(Se.Language.Tools.BatchConvert.AddColor, vm, nameof(vm.FormattingAddColor));
-        var colorPickerAdd = new ColorPicker()
-        {
-            Width = 200,
-            IsAlphaEnabled = true,
-            IsAlphaVisible = true,
-            IsColorSpectrumSliderVisible = false,
-            IsColorComponentsVisible = true,
-            IsColorModelVisible = false,
-            IsColorPaletteVisible = false,
-            IsAccentColorsVisible = false,
-            IsColorSpectrumVisible = true,
-            IsComponentTextInputVisible = true,
-            [!ColorPicker.ColorProperty] = new Binding(nameof(vm.FormattingAddColorValue))
-            {
-                Source = vm,
-                Mode = BindingMode.TwoWay
-            },
-        };
+        var colorPickerAdd = UiUtil.MakeColorPickerButton(vm, nameof(vm.FormattingAddColorValue));
         var panelColor = UiUtil.MakeHorizontalPanel(checkBoxAddColor, colorPickerAdd);
 
         var panel = new StackPanel

--- a/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingViewModel.cs
+++ b/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingViewModel.cs
@@ -149,8 +149,5 @@ public partial class ChangeFormattingViewModel : ObservableObject
         IsColorVisible = SelectedToType?.Type == ChangeFormattingType.Color;
     }
 
-    internal void ColorChanged(object? sender, ColorChangedEventArgs e)
-    {
-        _dirty = true;
-    }
+    partial void OnSelectedColorChanged(Color value) => _dirty = true;
 }

--- a/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingWindow.cs
+++ b/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingWindow.cs
@@ -33,9 +33,8 @@ public class ChangeFormattingWindow : Window
         comboBoxTo.SelectionChanged += vm.SelectionChanged;
 
         var labelColor = UiUtil.MakeLabel(Se.Language.General.Color);
-        var colorPicker = UiUtil.MakeColorPicker(vm, nameof(vm.SelectedColor));
-        colorPicker.Bind(ColorPicker.IsVisibleProperty, new Binding(nameof(vm.IsColorVisible)));
-        colorPicker.ColorChanged += vm.ColorChanged;
+        var colorPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.SelectedColor));
+        colorPicker.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsColorVisible)));
 
         var panelControls = UiUtil.MakeHorizontalPanel(
             labelFrom,

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
@@ -337,8 +337,4 @@ public partial class ConvertActorsViewModel : ObservableObject
         _dirty = true;
     }
 
-    internal void ColorChanged(object? sender, ColorChangedEventArgs e)
-    {
-        _dirty = true;
-    }
 }

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -33,9 +33,8 @@ public class ConvertActorsWindow : Window
         comboBoxTo.SelectionChanged += vm.SelectionChanged;
 
         var checkBoxSetColor = UiUtil.MakeCheckBox(Se.Language.Tools.ConvertActors.SetColor, vm, nameof(vm.SetColor));
-        var colorPicker = UiUtil.MakeColorPicker(vm, nameof(vm.SelectedColor));
-        colorPicker.Bind(ColorPicker.IsVisibleProperty, new Binding(nameof(vm.SetColor)) { Source = vm, Mode = BindingMode.OneWay });
-        colorPicker.ColorChanged += vm.ColorChanged;
+        var colorPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.SelectedColor));
+        colorPicker.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.SetColor)) { Source = vm, Mode = BindingMode.OneWay });
 
         var checkBoxChangeCasing = UiUtil.MakeCheckBox(Se.Language.General.ChangeCasing, vm, nameof(vm.ChangeCasing));
         var comboBoxCasing = new ComboBox

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -1771,11 +1771,6 @@ public partial class BurnInViewModel : ObservableObject
         ImagePreview = bitmap.CropTransparentColors().ToAvaloniaBitmap();
     }
 
-    internal void ColorChanged(object? sender, ColorChangedEventArgs e)
-    {
-        UpdateNonAssaPreview();
-    }
-
     partial void OnFontTextColorChanged(Color value) => UpdateNonAssaPreview();
     partial void OnFontOutlineColorChanged(Color value) => UpdateNonAssaPreview();
     partial void OnFontShadowColorChanged(Color value) => UpdateNonAssaPreview();

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingWindow.cs
@@ -43,24 +43,7 @@ public class SpeechToTextPostProcessingWindow : Window
 
         var labelChangeUnderlineToColor = UiUtil.MakeTextBlock(Se.Language.Video.AudioToText.ChangeUnderlineToColor);
         var checkChangeUnderlineToColor = UiUtil.MakeCheckBox(vm, nameof(SpeechToTextPostProcessingViewModel.ChangeUnderlineToColor));
-        var colorPickerUnderlineToColor = new ColorPicker()
-        {
-            Width = 200,
-            IsAlphaEnabled = true,
-            IsAlphaVisible = true,
-            IsColorSpectrumSliderVisible = false,
-            IsColorComponentsVisible = true,
-            IsColorModelVisible = false,
-            IsColorPaletteVisible = false,
-            IsAccentColorsVisible = false,
-            IsColorSpectrumVisible = true,
-            IsComponentTextInputVisible = true,
-            [!ColorPicker.ColorProperty] = new Binding(nameof(_vm.ChangeUnderlineToColorColor))
-            {
-                Source = _vm,
-                Mode = BindingMode.TwoWay
-            },
-        };
+        var colorPickerUnderlineToColor = UiUtil.MakeColorPickerButton(_vm, nameof(_vm.ChangeUnderlineToColorColor));
 
 
         var buttonPanel = UiUtil.MakeButtonBar(

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -1190,11 +1190,6 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         ImagePreview = bitmap.ToAvaloniaBitmap();
     }
 
-    internal void ColorChanged(object? sender, ColorChangedEventArgs e)
-    {
-        UpdateNonAssaPreview();
-    }
-
     partial void OnFontTextColorChanged(Color value) => UpdateNonAssaPreview();
     partial void OnFontOutlineColorChanged(Color value) => UpdateNonAssaPreview();
     partial void OnFontShadowColorChanged(Color value) => UpdateNonAssaPreview();

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1671,8 +1671,33 @@ public static class UiUtil
 
     internal static Button MakeColorPickerButton(object source, string colorPropertyPath, bool showAlpha = true)
     {
-        var propInfo = source.GetType().GetProperty(colorPropertyPath, BindingFlags.Public | BindingFlags.Instance);
-        var initialColor = propInfo?.GetValue(source) is Color c ? c : Colors.White;
+        var pathParts = colorPropertyPath.Split('.');
+
+        (object? Owner, PropertyInfo? Property) ResolveLeaf()
+        {
+            object? current = source;
+            for (var i = 0; i < pathParts.Length - 1; i++)
+            {
+                if (current == null)
+                {
+                    return (null, null);
+                }
+                var pi = current.GetType().GetProperty(pathParts[i], BindingFlags.Public | BindingFlags.Instance);
+                current = pi?.GetValue(current);
+            }
+            if (current == null)
+            {
+                return (null, null);
+            }
+            var leafProp = current.GetType().GetProperty(pathParts[^1], BindingFlags.Public | BindingFlags.Instance);
+            return (current, leafProp);
+        }
+
+        Color ReadColor()
+        {
+            var (owner, prop) = ResolveLeaf();
+            return prop?.GetValue(owner) is Color c ? c : Colors.White;
+        }
 
         var colorSwatch = new Border
         {
@@ -1681,7 +1706,7 @@ public static class UiUtil
             CornerRadius = new CornerRadius(CornerRadius),
             BorderThickness = new Thickness(1),
             BorderBrush = new SolidColorBrush(Colors.Gray),
-            Background = new SolidColorBrush(initialColor),
+            Background = new SolidColorBrush(ReadColor()),
             VerticalAlignment = VerticalAlignment.Center,
         };
 
@@ -1692,29 +1717,73 @@ public static class UiUtil
             VerticalAlignment = VerticalAlignment.Center,
         };
 
-        if (source is INotifyPropertyChanged inpc)
-        {
-            void OnPropertyChanged(object? _, PropertyChangedEventArgs e)
-            {
-                if (e.PropertyName != colorPropertyPath && !string.IsNullOrEmpty(e.PropertyName))
-                {
-                    return;
-                }
+        var subscriptions = new List<(INotifyPropertyChanged Source, PropertyChangedEventHandler Handler)>();
 
-                var updated = propInfo?.GetValue(source) is Color nc ? nc : Colors.White;
-                if (Dispatcher.UIThread.CheckAccess())
+        void RefreshSwatch()
+        {
+            var updated = ReadColor();
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                colorSwatch.Background = new SolidColorBrush(updated);
+            }
+            else
+            {
+                Dispatcher.UIThread.Post(() => colorSwatch.Background = new SolidColorBrush(updated));
+            }
+        }
+
+        void Unsubscribe()
+        {
+            foreach (var (src, handler) in subscriptions)
+            {
+                src.PropertyChanged -= handler;
+            }
+            subscriptions.Clear();
+        }
+
+        void Subscribe()
+        {
+            object? current = source;
+            for (var i = 0; i < pathParts.Length; i++)
+            {
+                if (current is INotifyPropertyChanged inpc)
                 {
-                    colorSwatch.Background = new SolidColorBrush(updated);
+                    var partName = pathParts[i];
+                    var isLeaf = i == pathParts.Length - 1;
+                    PropertyChangedEventHandler handler = (_, e) =>
+                    {
+                        if (!string.IsNullOrEmpty(e.PropertyName) && e.PropertyName != partName)
+                        {
+                            return;
+                        }
+                        if (isLeaf)
+                        {
+                            RefreshSwatch();
+                        }
+                        else
+                        {
+                            Unsubscribe();
+                            Subscribe();
+                            RefreshSwatch();
+                        }
+                    };
+                    inpc.PropertyChanged += handler;
+                    subscriptions.Add((inpc, handler));
                 }
-                else
+                if (i < pathParts.Length - 1)
                 {
-                    Dispatcher.UIThread.Post(() => colorSwatch.Background = new SolidColorBrush(updated));
+                    if (current == null)
+                    {
+                        break;
+                    }
+                    var pi = current.GetType().GetProperty(pathParts[i], BindingFlags.Public | BindingFlags.Instance);
+                    current = pi?.GetValue(current);
                 }
             }
-
-            inpc.PropertyChanged += OnPropertyChanged;
-            button.DetachedFromVisualTree += (_, _) => inpc.PropertyChanged -= OnPropertyChanged;
         }
+
+        Subscribe();
+        button.DetachedFromVisualTree += (_, _) => Unsubscribe();
 
         button.Click += async (_, _) =>
         {
@@ -1723,7 +1792,13 @@ public static class UiUtil
                 return;
             }
 
-            var currentColor = propInfo?.GetValue(source) is Color cc ? cc : Colors.White;
+            var (owner, prop) = ResolveLeaf();
+            if (owner == null || prop == null)
+            {
+                return;
+            }
+
+            var currentColor = prop.GetValue(owner) is Color cc ? cc : Colors.White;
             var vm = new ColorPickerViewModel();
             vm.Initialize(currentColor);
             vm.ShowAlpha = showAlpha;
@@ -1732,7 +1807,7 @@ public static class UiUtil
 
             if (vm.OkPressed)
             {
-                propInfo?.SetValue(source, vm.SelectedColor);
+                prop.SetValue(owner, vm.SelectedColor);
                 colorSwatch.Background = new SolidColorBrush(vm.SelectedColor);
             }
         };

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -8,6 +8,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -18,6 +19,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
@@ -1667,30 +1669,7 @@ public static class UiUtil
         return new Thickness(WindowMarginWidth, WindowMarginWidth * 2, WindowMarginWidth, WindowMarginWidth);
     }
 
-    internal static ColorPicker MakeColorPicker(object vm, string colorPropertyPath)
-    {
-        return new ColorPicker
-        {
-            HorizontalAlignment = HorizontalAlignment.Left,
-            VerticalAlignment = VerticalAlignment.Center,
-            IsAlphaEnabled = true,
-            IsAlphaVisible = true,
-            IsColorSpectrumSliderVisible = false,
-            IsColorComponentsVisible = true,
-            IsColorModelVisible = false,
-            IsColorPaletteVisible = false,
-            IsAccentColorsVisible = false,
-            IsColorSpectrumVisible = true,
-            IsComponentTextInputVisible = true,
-            [!ColorPicker.ColorProperty] = new Binding(colorPropertyPath)
-            {
-                Source = vm,
-                Mode = BindingMode.TwoWay
-            },
-        };
-    }
-
-    internal static Button MakeColorPickerButton(object source, string colorPropertyPath, bool showAlpha)
+    internal static Button MakeColorPickerButton(object source, string colorPropertyPath, bool showAlpha = true)
     {
         var propInfo = source.GetType().GetProperty(colorPropertyPath, BindingFlags.Public | BindingFlags.Instance);
         var initialColor = propInfo?.GetValue(source) is Color c ? c : Colors.White;
@@ -1712,6 +1691,30 @@ public static class UiUtil
             Padding = new Thickness(4, 2),
             VerticalAlignment = VerticalAlignment.Center,
         };
+
+        if (source is INotifyPropertyChanged inpc)
+        {
+            void OnPropertyChanged(object? _, PropertyChangedEventArgs e)
+            {
+                if (e.PropertyName != colorPropertyPath && !string.IsNullOrEmpty(e.PropertyName))
+                {
+                    return;
+                }
+
+                var updated = propInfo?.GetValue(source) is Color nc ? nc : Colors.White;
+                if (Dispatcher.UIThread.CheckAccess())
+                {
+                    colorSwatch.Background = new SolidColorBrush(updated);
+                }
+                else
+                {
+                    Dispatcher.UIThread.Post(() => colorSwatch.Background = new SolidColorBrush(updated));
+                }
+            }
+
+            inpc.PropertyChanged += OnPropertyChanged;
+            button.DetachedFromVisualTree += (_, _) => inpc.PropertyChanged -= OnPropertyChanged;
+        }
 
         button.Click += async (_, _) =>
         {

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -131,12 +131,6 @@ namespace Nikse.SubtitleEdit
                     Source = new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml")
                 });
 
-                // Add ColorPicker styles
-                b.Instance.Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml", UriKind.Absolute))
-                {
-                    Source = new Uri("avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml", UriKind.Absolute)
-                });
-
                 // Set application name
                 b.Instance.Name = AppName;
 

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -25,7 +25,6 @@
 	<ItemGroup>
 		<PackageReference Include="Avalonia" Version="12.0.3" />
 		<PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
-		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.3" />
 		<PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
 		<PackageReference Include="Avalonia.Desktop" Version="12.0.3" />
 		<PackageReference Include="Avalonia.Markup.Declarative" Version="12.0.1" />

--- a/src/ui/packages.lock.json
+++ b/src/ui/packages.lock.json
@@ -22,16 +22,6 @@
           "Avalonia": "12.0.0"
         }
       },
-      "Avalonia.Controls.ColorPicker": {
-        "type": "Direct",
-        "requested": "[12.0.3, )",
-        "resolved": "12.0.3",
-        "contentHash": "Hb6AyDVpMrNaV8T14DJ9WjV64x4SXpZzhZag212Uyfyc+ZYqpbBWaptGRlalwP2hdML++ThTTqGRvbYyY6A2Vw==",
-        "dependencies": {
-          "Avalonia": "12.0.3",
-          "Avalonia.Remote.Protocol": "12.0.3"
-        }
-      },
       "Avalonia.Controls.DataGrid": {
         "type": "Direct",
         "requested": "[12.0.0, )",


### PR DESCRIPTION
## Summary
- Replace every remaining `Avalonia.Controls.ColorPicker` usage with the in-app `ColorPickerWindow` (already used by the ASSA styles window) via `UiUtil.MakeColorPickerButton`. The Settings page picks up the new dialog, as do `AssaDraw`, `AssaProgressBar`, `AssaSetBackground`, `AssaSingleStyle`, `SetText` (binary edit), `ChangeFormatting`, `ConvertActors`, `BatchConvert > AddFormatting`, and `SpeechToTextPostProcessing`.
- `MakeColorPickerButton` now subscribes to `INotifyPropertyChanged` on the source so the swatch stays in sync when the bound `Color` property is mutated from the view model.
- Drop the old `UiUtil.MakeColorPicker` helper, the `Avalonia.Controls.ColorPicker` NuGet package and its style import in `Program.cs`, and the dead `ColorChanged(object?, ColorChangedEventArgs)` handlers in `BurnInViewModel`, `TransparentSubtitlesViewModel`, `ExportImageBasedViewModel`, `ChangeFormattingViewModel`, and `ConvertActorsViewModel` (the `[ObservableProperty]` partials already cover the same work).

## Test plan
- [ ] Open *Options > Settings* and verify every color row (waveform colors, dark-mode colors, focused-button color, bookmark color, error background color, MPV preview primary/outline/shadow) opens the new dialog and that picking a color updates the swatch.
- [ ] Open *ASSA > Single style* and check the four color buttons (Primary / Outline / Shadow / Secondary) open the new dialog and persist edits to the current style.
- [ ] Run *ASSA > Progress bar*, *ASSA > Set background*, *ASSA > Draw* — confirm color buttons work.
- [ ] Run *Tools > Change formatting* and *Tools > Convert actors* — color button still hides/shows based on the relevant checkbox/combo, and changes still mark the form as dirty.
- [ ] Run *Tools > Batch convert > Add formatting* and *Video > Speech to text post-processing* — color buttons work.
- [ ] Run *Binary edit > Set text* — Font/Outline/Shadow/Background color buttons work.
- [ ] Confirm a clean restore + build succeeds (the `Avalonia.Controls.ColorPicker` package is no longer referenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)