### PR TITLE
Tighten Re-encode video window progress layout

### DIFF
--- a/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
+++ b/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
@@ -158,14 +158,12 @@ public class ReEncodeVideoWindow : Window
     private static Grid MakeProgressView(ReEncodeVideoViewModel vm)
     {
         var progressBar = UiUtil.MakeProgressBar();
-        progressBar.VerticalAlignment = VerticalAlignment.Top;
-        progressBar.Margin = new Thickness(0, 5, 0, 0);
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
         progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
-            Margin = new Thickness(5, 25, 0, 0),
+            Margin = new Thickness(5, 0, 0, 0),
         };
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
         statusText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
@@ -174,18 +172,21 @@ public class ReEncodeVideoWindow : Window
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
             },
+            RowSpacing = 10,
+            Margin = new Thickness(0, 5, 0, 0),
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
         grid.Add(progressBar, 0, 0);
-        grid.Add(statusText, 0, 0);
+        grid.Add(statusText, 1, 0);
 
         return grid;
     }

--- a/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
+++ b/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
@@ -20,6 +20,7 @@ public class ReEncodeVideoWindow : Window
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = Se.Language.Video.ReEncodeVideoForBetterSubtitlingTitle;
         SizeToContent = SizeToContent.WidthAndHeight;
+        MinWidth = 600;
         CanResize = false;
 
         _vm = vm;
@@ -66,7 +67,7 @@ public class ReEncodeVideoWindow : Window
             },
             ColumnDefinitions =
             {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
             },
             Margin = UiUtil.MakeWindowMargin(),
             Width = double.NaN,
@@ -157,12 +158,14 @@ public class ReEncodeVideoWindow : Window
     private static Grid MakeProgressView(ReEncodeVideoViewModel vm)
     {
         var progressBar = UiUtil.MakeProgressBar();
+        progressBar.VerticalAlignment = VerticalAlignment.Top;
+        progressBar.Margin = new Thickness(0, 5, 0, 0);
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
         progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
-            Margin = new Thickness(5, 20, 0, 0),
+            Margin = new Thickness(5, 25, 0, 0),
         };
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
         statusText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));


### PR DESCRIPTION
## Summary

- Anchor the progress bar to the top of its cell (`VerticalAlignment.Top`) — the bar has explicit `Height=10` and was drifting downward when the status-text cell grew.
- Pad 5px above the bar and place the status text 10px below it for clearer separation.
- Set `MinWidth = 600` on the window and switch the outer column from `Auto` to `Star` so the wider window actually expands the inner content instead of leaving empty space on the right.

## Test plan

- [x] Builds clean (no warnings).
- [ ] Open Video → Re-encode video; confirm the bar sits a few px from the top of its cell, the status text has a small gap below it, and the window respects the 600px minimum width with the form stretching to fill it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)