### PR TITLE
Suppress cancel-error dialog in auto-translate

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -627,8 +627,8 @@ public partial class AutoTranslateViewModel : ObservableObject
     private void Cancel()
     {
         var wasTranslating = !IsTranslateEnabled;
-        _cancellationTokenSource.Cancel();
         _abort = true;
+        _cancellationTokenSource.Cancel();
         IsProgressEnabled = false;
 
         if (IsTranslateEnabled)
@@ -1249,9 +1249,11 @@ public partial class AutoTranslateViewModel : ObservableObject
             }
 
         }
-        catch (OperationCanceledException) when (_abort)
+        catch (OperationCanceledException) when (_abort || _cancellationTokenSource.IsCancellationRequested)
         {
             // User pressed Cancel — let the finally block report it; do not surface as an error.
+            // Check both _abort and the token: Cancel() sets _abort then fires the token, but the
+            // worker thread can observe cancellation before _abort is visible across threads.
         }
         catch (Exception ex)
         {

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1249,6 +1249,10 @@ public partial class AutoTranslateViewModel : ObservableObject
             }
 
         }
+        catch (OperationCanceledException) when (_abort)
+        {
+            // User pressed Cancel — let the finally block report it; do not surface as an error.
+        }
         catch (Exception ex)
         {
             _ = Dispatcher.UIThread.Invoke(async () =>


### PR DESCRIPTION
## Summary

When the user pressed **Cancel** during auto-translate (reported with llama.cpp, but applies to every engine that honors the cancellation token), the `HttpClient` call inside the translator threw `OperationCanceledException` / `TaskCanceledException`. The catch-all in `AutoTranslateViewModel.DoTranslate` surfaced this as a `TranslationErrorWindow` with a stack trace, even though the user just clicked Cancel.

Add a guarded catch for user-initiated cancellation:

\`\`\`csharp
catch (OperationCanceledException) when (_abort)
{
    // User pressed Cancel — let the finally block report it; do not surface as an error.
}
\`\`\`

- `TaskCanceledException` derives from `OperationCanceledException`, so this covers both shapes.
- The existing `finally` block still sets `StatusText = TranslationCancelled` and re-enables the UI.
- The `when (_abort)` guard means a stray non-user cancellation (e.g. an internal client timeout that we didn't initiate) still hits the regular error dialog, so genuine failures aren't masked.

## Test plan

- [x] Builds clean.
- [ ] Start a llama.cpp auto-translation, press **Cancel** mid-stream — verify no error dialog appears and the status text reads "Translation cancelled".
- [ ] Repeat with another engine (e.g. OpenAI / DeepSeek) that honors the token, to confirm the fix applies broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)