### PR TITLE
Fix Save As dropping extension after a language suffix

### DIFF
--- a/src/ui/Logic/Media/FileHelper.cs
+++ b/src/ui/Logic/Media/FileHelper.cs
@@ -314,12 +314,45 @@ namespace Nikse.SubtitleEdit.Logic.Media
 
         private static string AddMissingExtension(string fileName, string extension)
         {
-            if (string.IsNullOrEmpty(fileName) || Path.HasExtension(fileName))
+            if (string.IsNullOrEmpty(fileName))
             {
                 return fileName;
             }
 
-            return fileName + (extension.StartsWith('.') ? extension : "." + extension);
+            var ext = extension.StartsWith('.') ? extension : "." + extension;
+
+            // Only treat the existing suffix as an "extension" if it's a known subtitle
+            // format extension - otherwise things like "Foo.sv" or "Foo.en" (language tags
+            // left over from container extraction) are misread as extensions and the chosen
+            // format extension is never appended. See issue #10349.
+            var existingExtension = Path.GetExtension(fileName);
+            if (!string.IsNullOrEmpty(existingExtension) && IsKnownSubtitleExtension(existingExtension))
+            {
+                return fileName;
+            }
+
+            return fileName + ext;
+        }
+
+        private static bool IsKnownSubtitleExtension(string extension)
+        {
+            foreach (var format in SubtitleFormat.AllSubtitleFormats)
+            {
+                if (string.Equals(format.Extension, extension, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                foreach (var alternate in format.AlternateExtensions)
+                {
+                    if (string.Equals(alternate, extension, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         public async Task<string> PickSaveSubtitleFile(

--- a/tests/UI/Logic/Media/FileHelperTests.cs
+++ b/tests/UI/Logic/Media/FileHelperTests.cs
@@ -5,13 +5,36 @@ namespace UITests.Logic.Media;
 
 public class FileHelperTests
 {
-    [Fact]
-    public void AddMissingExtension_AppendsExtensionOnlyWhenFileNameHasNoExtension()
+    [Theory]
+    // Bare filename -> append chosen extension.
+    [InlineData("subtitle", ".srt", "subtitle.srt")]
+    // Filename already ends with the chosen extension -> unchanged.
+    [InlineData("subtitle.srt", ".srt", "subtitle.srt")]
+    [InlineData("subtitle.SRT", ".srt", "subtitle.SRT")] // case-insensitive
+    // Filename ends with a DIFFERENT known subtitle extension -> preserve user intent.
+    [InlineData("subtitle.ass", ".srt", "subtitle.ass")]
+    // Filename ends with a language tag that LOOKS like an extension (issue #10349).
+    // Path.HasExtension returned true for these and the format extension was dropped.
+    [InlineData("Half Man S01E01.sv", ".srt", "Half Man S01E01.sv.srt")]
+    [InlineData("Half Man S01E01.en", ".srt", "Half Man S01E01.en.srt")]
+    [InlineData("Over Atlanten S10E05.sv", ".srt", "Over Atlanten S10E05.sv.srt")]
+    [InlineData("something.en", ".vtt", "something.en.vtt")]
+    // Extension passed without leading dot - still works.
+    [InlineData("subtitle", "srt", "subtitle.srt")]
+    public void AddMissingExtension_AppendsOnlyWhenNeeded(string fileName, string extension, string expected)
     {
         var method = typeof(FileHelper).GetMethod("AddMissingExtension", BindingFlags.NonPublic | BindingFlags.Static);
 
         Assert.NotNull(method);
-        Assert.Equal("subtitle.srt", method!.Invoke(null, ["subtitle", ".srt"]));
-        Assert.Equal("subtitle.ass", method.Invoke(null, ["subtitle.ass", ".srt"]));
+        Assert.Equal(expected, method!.Invoke(null, [fileName, extension]));
+    }
+
+    [Fact]
+    public void AddMissingExtension_EmptyFileName_ReturnsEmpty()
+    {
+        var method = typeof(FileHelper).GetMethod("AddMissingExtension", BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        Assert.Equal("", method!.Invoke(null, ["", ".srt"]));
     }
 }


### PR DESCRIPTION
Fixes #10349.

## Summary

`FileHelper.AddMissingExtension` used `Path.HasExtension` to decide whether to append the chosen format extension after the save picker returned. `Path.HasExtension` returns `true` for any dot-followed-by-1-plus chars, so:

- `Half Man S01E01.sv` (extracted from an mkv — `.sv` is a language tag, not an extension) → no `.srt` appended.
- `something.en.vtt` → stripped to `something.en` → `.en` looks like an extension → no `.srt` appended.

Switch the check from "has any extension" to "ends with a known subtitle extension" (looking at `SubtitleFormat.AllSubtitleFormats.Extension` plus their `AlternateExtensions`).

Behavior:
- `Foo.sv` + SRT → `Foo.sv.srt` ✓ (was: `Foo.sv`)
- `Foo.en` + SRT → `Foo.en.srt` ✓ (was: `Foo.en`)
- `Foo.srt` + SRT → `Foo.srt` (unchanged)
- `Foo.ass` + SRT → `Foo.ass` (preserved — matches the existing test's intent: user picked a subtitle extension, don't second-guess)
- `Foo` + SRT → `Foo.srt` ✓

The `.en`/`.sv` asymmetry one commenter reported couldn't be reproduced from the code (both go through identical paths); the underlying bug applies to any 1-3 char dot suffix that isn't a known subtitle format.

## Test plan

- [x] Expanded `FileHelperTests.AddMissingExtension_AppendsOnlyWhenNeeded` into a theory with 9 cases including the original `.ass` case and the new language-suffix cases.
- [x] Verified the new tests fail without the fix (4 failures) and pass with it (10/10).
- [x] Full UI test suite passes (235 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)