### PR TITLE
Add fallback OCR database picker to OCR window

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2731,6 +2731,8 @@
     "nOcrBinaryOcrFallbackDatabase": "BinaryOCR fallback database",
     "nOcrBinaryOcrFallbackNone": "(none)",
     "binaryOcrNOcrFallbackDatabase": "nOCR fallback database",
+    "pickFallbackDatabase": "Pick fallback OCR database",
+    "fallbackOcrDatabase": "Fallback OCR database",
     "showAllOllamaModels": "Show all models (not just vision-capable)",
     "ollamaModelLikelyWrong": "Ollama returned no text - the selected model may not support OCR / vision"
   },

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -413,6 +413,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<PointSyncViaOtherViewModel>();
         collection.AddTransient<PointSyncViewModel>();
         collection.AddTransient<PreProcessingViewModel>();
+        collection.AddTransient<Features.Ocr.FallbackDatabase.OcrFallbackDatabaseViewModel>();
         collection.AddTransient<VobSubColorChooserViewModel>();
         collection.AddTransient<ProfilesExportViewModel>();
         collection.AddTransient<ProfilesViewModel>();

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseViewModel.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseViewModel.cs
@@ -11,7 +11,6 @@ namespace Nikse.SubtitleEdit.Features.Ocr.FallbackDatabase;
 public partial class OcrFallbackDatabaseViewModel : ObservableObject
 {
     [ObservableProperty] private string _title;
-    [ObservableProperty] private string _engineName;
     [ObservableProperty] private string _label;
     [ObservableProperty] private ObservableCollection<string> _databases;
     [ObservableProperty] private string? _selectedDatabase;
@@ -22,14 +21,12 @@ public partial class OcrFallbackDatabaseViewModel : ObservableObject
     public OcrFallbackDatabaseViewModel()
     {
         Title = Se.Language.Ocr.PickFallbackDatabase;
-        EngineName = string.Empty;
         Label = Se.Language.Ocr.FallbackOcrDatabase;
         Databases = new ObservableCollection<string>();
     }
 
-    public void Initialize(string engineName, string label, IEnumerable<string> databases, string? selected)
+    public void Initialize(string label, IEnumerable<string> databases, string? selected)
     {
-        EngineName = engineName;
         Label = label;
         Databases = new ObservableCollection<string>(databases);
         SelectedDatabase = !string.IsNullOrEmpty(selected) && Databases.Contains(selected)

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseViewModel.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseViewModel.cs
@@ -11,6 +11,7 @@ namespace Nikse.SubtitleEdit.Features.Ocr.FallbackDatabase;
 public partial class OcrFallbackDatabaseViewModel : ObservableObject
 {
     [ObservableProperty] private string _title;
+    [ObservableProperty] private string _engineName;
     [ObservableProperty] private string _label;
     [ObservableProperty] private ObservableCollection<string> _databases;
     [ObservableProperty] private string? _selectedDatabase;
@@ -21,12 +22,14 @@ public partial class OcrFallbackDatabaseViewModel : ObservableObject
     public OcrFallbackDatabaseViewModel()
     {
         Title = Se.Language.Ocr.PickFallbackDatabase;
+        EngineName = string.Empty;
         Label = Se.Language.Ocr.FallbackOcrDatabase;
         Databases = new ObservableCollection<string>();
     }
 
-    public void Initialize(string label, IEnumerable<string> databases, string? selected)
+    public void Initialize(string engineName, string label, IEnumerable<string> databases, string? selected)
     {
+        EngineName = engineName;
         Label = label;
         Databases = new ObservableCollection<string>(databases);
         SelectedDatabase = !string.IsNullOrEmpty(selected) && Databases.Contains(selected)

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseViewModel.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseViewModel.cs
@@ -1,0 +1,63 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.FallbackDatabase;
+
+public partial class OcrFallbackDatabaseViewModel : ObservableObject
+{
+    [ObservableProperty] private string _title;
+    [ObservableProperty] private string _label;
+    [ObservableProperty] private ObservableCollection<string> _databases;
+    [ObservableProperty] private string? _selectedDatabase;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public OcrFallbackDatabaseViewModel()
+    {
+        Title = Se.Language.Ocr.PickFallbackDatabase;
+        Label = Se.Language.Ocr.FallbackOcrDatabase;
+        Databases = new ObservableCollection<string>();
+    }
+
+    public void Initialize(string label, IEnumerable<string> databases, string? selected)
+    {
+        Label = label;
+        Databases = new ObservableCollection<string>(databases);
+        SelectedDatabase = !string.IsNullOrEmpty(selected) && Databases.Contains(selected)
+            ? selected
+            : Databases.Count > 0 ? Databases[0] : null;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+        else if (e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            Ok();
+        }
+    }
+}

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
@@ -2,9 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
-using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
-using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.FallbackDatabase;
 
@@ -20,28 +18,10 @@ public class OcrFallbackDatabaseWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var labelEngineCaption = new TextBlock
-        {
-            Text = Se.Language.Ocr.OcrEngine,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        var labelEngineName = new TextBlock
-        {
-            FontWeight = FontWeight.Bold,
-            VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(5, 0, 0, 0),
-        };
-        labelEngineName.Bind(TextBlock.TextProperty, new Binding(nameof(vm.EngineName)));
-        var panelEngine = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Children = { labelEngineCaption, labelEngineName },
-        };
-
         var labelDatabase = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 6, 0, 2),
+            Margin = new Thickness(0, 0, 0, 2),
         };
         labelDatabase.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Label)));
 
@@ -63,7 +43,6 @@ public class OcrFallbackDatabaseWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -76,10 +55,9 @@ public class OcrFallbackDatabaseWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(panelEngine, 0);
-        grid.Add(labelDatabase, 1);
-        grid.Add(comboBoxDatabases, 2);
-        grid.Add(buttonPanel, 3);
+        grid.Add(labelDatabase, 0);
+        grid.Add(comboBoxDatabases, 1);
+        grid.Add(buttonPanel, 2);
 
         Content = grid;
 

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
@@ -20,7 +20,11 @@ public class OcrFallbackDatabaseWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var labelEngineCaption = UiUtil.MakeLabel(Se.Language.Ocr.OcrEngine);
+        var labelEngineCaption = new TextBlock
+        {
+            Text = Se.Language.Ocr.OcrEngine,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
         var labelEngineName = new TextBlock
         {
             FontWeight = FontWeight.Bold,
@@ -34,9 +38,12 @@ public class OcrFallbackDatabaseWindow : Window
             Children = { labelEngineCaption, labelEngineName },
         };
 
-        var labelDatabase = UiUtil.MakeLabel(string.Empty);
+        var labelDatabase = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 6, 0, 2),
+        };
         labelDatabase.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Label)));
-        labelDatabase.Margin = new Thickness(0, 10, 0, 0);
 
         var comboBoxDatabases = new ComboBox
         {

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
@@ -34,8 +34,9 @@ public class OcrFallbackDatabaseWindow : Window
             Children = { labelEngineCaption, labelEngineName },
         };
 
-        var labelDatabase = UiUtil.MakeLabel(string.Empty).WithMarginTop(10);
+        var labelDatabase = UiUtil.MakeLabel(string.Empty);
         labelDatabase.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Label)));
+        labelDatabase.Margin = new Thickness(0, 10, 0, 0);
 
         var comboBoxDatabases = new ComboBox
         {
@@ -63,7 +64,7 @@ public class OcrFallbackDatabaseWindow : Window
             },
             Margin = UiUtil.MakeWindowMargin(),
             ColumnSpacing = 2,
-            RowSpacing = 4,
+            RowSpacing = 0,
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
@@ -1,0 +1,62 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.FallbackDatabase;
+
+public class OcrFallbackDatabaseWindow : Window
+{
+    public OcrFallbackDatabaseWindow(OcrFallbackDatabaseViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = vm.Title;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 400;
+        vm.Window = this;
+        DataContext = vm;
+
+        var labelDatabase = UiUtil.MakeLabel(string.Empty);
+        labelDatabase.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Label)));
+
+        var comboBoxDatabases = new ComboBox
+        {
+            Width = 300,
+            [!ComboBox.SelectedItemProperty] = new Binding(nameof(vm.SelectedDatabase)) { Mode = BindingMode.TwoWay },
+            [!ComboBox.ItemsSourceProperty] = new Binding(nameof(vm.Databases)) { Mode = BindingMode.TwoWay },
+        };
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 2,
+            RowSpacing = 4,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(labelDatabase, 0);
+        grid.Add(comboBoxDatabases, 1);
+        grid.Add(buttonPanel, 2);
+
+        Content = grid;
+
+        Activated += delegate { comboBoxDatabases.Focus(); };
+        KeyDown += vm.KeyDown;
+    }
+}

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
@@ -1,7 +1,10 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.FallbackDatabase;
 
@@ -17,7 +20,21 @@ public class OcrFallbackDatabaseWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var labelDatabase = UiUtil.MakeLabel(string.Empty);
+        var labelEngineCaption = UiUtil.MakeLabel(Se.Language.Ocr.OcrEngine);
+        var labelEngineName = new TextBlock
+        {
+            FontWeight = FontWeight.Bold,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(5, 0, 0, 0),
+        };
+        labelEngineName.Bind(TextBlock.TextProperty, new Binding(nameof(vm.EngineName)));
+        var panelEngine = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { labelEngineCaption, labelEngineName },
+        };
+
+        var labelDatabase = UiUtil.MakeLabel(string.Empty).WithMarginTop(10);
         labelDatabase.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Label)));
 
         var comboBoxDatabases = new ComboBox
@@ -38,6 +55,7 @@ public class OcrFallbackDatabaseWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -50,9 +68,10 @@ public class OcrFallbackDatabaseWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(labelDatabase, 0);
-        grid.Add(comboBoxDatabases, 1);
-        grid.Add(buttonPanel, 2);
+        grid.Add(panelEngine, 0);
+        grid.Add(labelDatabase, 1);
+        grid.Add(comboBoxDatabases, 2);
+        grid.Add(buttonPanel, 3);
 
         Content = grid;
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -20,6 +20,7 @@ using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Ocr.BinaryOcr;
 using Nikse.SubtitleEdit.Features.Ocr.Download;
 using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Features.Ocr.FallbackDatabase;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 using Nikse.SubtitleEdit.Features.Ocr.NOcr;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
@@ -129,6 +130,10 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private GuessUsedItem? _selectedAllGuess;
     [ObservableProperty] private bool _hasPreProcessingSettings;
     [ObservableProperty] private bool _hasCaptureAlignment;
+    [ObservableProperty] private bool _hasFallbackDatabase;
+    [ObservableProperty] private bool _isFallbackDatabaseVisible;
+    [ObservableProperty] private string _nOcrBinaryOcrFallbackDatabase;
+    [ObservableProperty] private string _binaryOcrNOcrFallbackDatabase;
     [ObservableProperty] private double _imageMaxHeight = 100;
     [ObservableProperty] private double _imageMaxWidth = 200;
     [ObservableProperty] private FontFamily _textBoxFontFamily;
@@ -154,6 +159,9 @@ public partial class OcrViewModel : ObservableObject
     private bool _isCtrlDown;
     private CancellationTokenSource _cancellationTokenSource;
     private NOcrDb? _nOcrDb;
+    private BinaryOcrDb? _nOcrFallbackBinaryOcrDb;
+    private BinaryOcrMatcher? _nOcrFallbackBinaryOcrMatcher;
+    private NOcrDb? _binaryOcrFallbackNOcrDb;
     private readonly List<SkipOnceChar> _runOnceChars;
     private readonly List<SkipOnceChar> _skipOnceChars;
     private readonly NOcrAddHistoryManager _nOcrAddHistoryManager;
@@ -219,6 +227,8 @@ public partial class OcrViewModel : ObservableObject
         TextBoxFontSize = 14;
         TextBoxFontWeight = FontWeight.Regular;
         UnknownWordsRemoveCurrentText = string.Empty;
+        NOcrBinaryOcrFallbackDatabase = string.Empty;
+        BinaryOcrNOcrFallbackDatabase = string.Empty;
         LoadSettings();
         EngineSelectionChanged();
         LoadDictionaries();
@@ -273,6 +283,8 @@ public partial class OcrViewModel : ObservableObject
             DoTryToGuessUnknownWords = ocr.DoTryToGuessUnknownWords;
             DoAutoBreak = ocr.DoAutoBreak;
             HasCaptureAlignment = ocr.CaptureAssaPosition;
+            NOcrBinaryOcrFallbackDatabase = ocr.NOcrBinaryOcrFallbackDatabase ?? string.Empty;
+            BinaryOcrNOcrFallbackDatabase = ocr.BinaryOcrNOcrFallbackDatabase ?? string.Empty;
         });
     }
 
@@ -302,6 +314,8 @@ public partial class OcrViewModel : ObservableObject
         ocr.DoTryToGuessUnknownWords = DoTryToGuessUnknownWords;
         ocr.DoAutoBreak = DoAutoBreak;
         ocr.CaptureAssaPosition = HasCaptureAlignment;
+        ocr.NOcrBinaryOcrFallbackDatabase = NOcrBinaryOcrFallbackDatabase ?? string.Empty;
+        ocr.BinaryOcrNOcrFallbackDatabase = BinaryOcrNOcrFallbackDatabase ?? string.Empty;
         ocr.TextBoxFontSize = TextBoxFontSize;
         ocr.TextBoxFontBold = TextBoxFontWeight == FontWeight.Bold;
         ocr.TextBoxFontName = TextBoxFontFamily.Name;
@@ -1416,6 +1430,96 @@ public partial class OcrViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task PickFallbackDatabase()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var et = SelectedOcrEngine?.EngineType;
+        if (et != OcrEngineType.nOcr && et != OcrEngineType.BinaryImageCompare)
+        {
+            return;
+        }
+
+        string label;
+        List<string> databases;
+        string? selected;
+
+        if (et == OcrEngineType.nOcr)
+        {
+            label = Se.Language.Ocr.NOcrBinaryOcrFallbackDatabase;
+            databases = new List<string> { Se.Language.Ocr.NOcrBinaryOcrFallbackNone };
+            databases.AddRange(BinaryOcrDb.GetDatabases(Se.OcrFolder).OrderBy(p => p));
+            selected = string.IsNullOrEmpty(NOcrBinaryOcrFallbackDatabase)
+                ? Se.Language.Ocr.NOcrBinaryOcrFallbackNone
+                : NOcrBinaryOcrFallbackDatabase;
+        }
+        else
+        {
+            label = Se.Language.Ocr.BinaryOcrNOcrFallbackDatabase;
+            databases = new List<string> { Se.Language.Ocr.NOcrBinaryOcrFallbackNone };
+            databases.AddRange(NOcrDb.GetDatabases(Se.OcrFolder).OrderBy(p => p));
+            selected = string.IsNullOrEmpty(BinaryOcrNOcrFallbackDatabase)
+                ? Se.Language.Ocr.NOcrBinaryOcrFallbackNone
+                : BinaryOcrNOcrFallbackDatabase;
+        }
+
+        var result = await _windowService.ShowDialogAsync<OcrFallbackDatabaseWindow, OcrFallbackDatabaseViewModel>(
+            Window,
+            vm => vm.Initialize(label, databases, selected));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        var picked = result.SelectedDatabase;
+        var value = string.IsNullOrEmpty(picked) || picked == Se.Language.Ocr.NOcrBinaryOcrFallbackNone
+            ? string.Empty
+            : picked;
+
+        if (et == OcrEngineType.nOcr)
+        {
+            NOcrBinaryOcrFallbackDatabase = value;
+        }
+        else
+        {
+            BinaryOcrNOcrFallbackDatabase = value;
+        }
+
+        UpdateHasFallbackDatabase();
+    }
+
+    private void UpdateHasFallbackDatabase()
+    {
+        var et = SelectedOcrEngine?.EngineType;
+        if (et == OcrEngineType.nOcr)
+        {
+            HasFallbackDatabase = !string.IsNullOrEmpty(NOcrBinaryOcrFallbackDatabase);
+        }
+        else if (et == OcrEngineType.BinaryImageCompare)
+        {
+            HasFallbackDatabase = !string.IsNullOrEmpty(BinaryOcrNOcrFallbackDatabase);
+        }
+        else
+        {
+            HasFallbackDatabase = false;
+        }
+    }
+
+    partial void OnNOcrBinaryOcrFallbackDatabaseChanged(string value)
+    {
+        UpdateHasFallbackDatabase();
+    }
+
+    partial void OnBinaryOcrNOcrFallbackDatabaseChanged(string value)
+    {
+        UpdateHasFallbackDatabase();
+    }
+
+    [RelayCommand]
     private async Task ShowPreProcessing()
     {
         if (Window == null)
@@ -2309,6 +2413,8 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
+        InitNOcrFallbackBinaryOcrDb();
+
         if (!_nOcrCaseFixer.HasWarmedUp)
         {
             NOcrWarmUp();
@@ -2317,6 +2423,56 @@ public partial class OcrViewModel : ObservableObject
 
         _skipOnceChars.Clear();
         _ = Task.Run(() => RunNOcrLoop(selectedIndices, cancellationToken));
+    }
+
+    private void InitNOcrFallbackBinaryOcrDb()
+    {
+        var name = NOcrBinaryOcrFallbackDatabase;
+        if (string.IsNullOrEmpty(name))
+        {
+            _nOcrFallbackBinaryOcrDb = null;
+            _nOcrFallbackBinaryOcrMatcher = null;
+            return;
+        }
+
+        var path = Path.Combine(Se.OcrFolder, name + BinaryOcrDb.Extension);
+        if (!File.Exists(path))
+        {
+            _nOcrFallbackBinaryOcrDb = null;
+            _nOcrFallbackBinaryOcrMatcher = null;
+            return;
+        }
+
+        if (_nOcrFallbackBinaryOcrDb == null || _nOcrFallbackBinaryOcrDb.FileName != path)
+        {
+            _nOcrFallbackBinaryOcrDb = new BinaryOcrDb(path, true);
+            _nOcrFallbackBinaryOcrMatcher = new BinaryOcrMatcher
+            {
+                IsLatinDb = name.Contains("Latin", StringComparison.OrdinalIgnoreCase),
+            };
+        }
+    }
+
+    private void InitBinaryOcrFallbackNOcrDb()
+    {
+        var name = BinaryOcrNOcrFallbackDatabase;
+        if (string.IsNullOrEmpty(name))
+        {
+            _binaryOcrFallbackNOcrDb = null;
+            return;
+        }
+
+        var path = Path.Combine(Se.OcrFolder, name + ".nocr");
+        if (!File.Exists(path))
+        {
+            _binaryOcrFallbackNOcrDb = null;
+            return;
+        }
+
+        if (_binaryOcrFallbackNOcrDb == null || _binaryOcrFallbackNOcrDb.FileName != path)
+        {
+            _binaryOcrFallbackNOcrDb = new NOcrDb(path);
+        }
     }
 
     private void NOcrWarmUp()
@@ -2385,6 +2541,28 @@ public partial class OcrViewModel : ObservableObject
                 {
                     var match = _nOcrDb!.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true,
                         SelectedNOcrMaxWrongPixels);
+
+                    if (match == null && _nOcrFallbackBinaryOcrDb != null && _nOcrFallbackBinaryOcrMatcher != null)
+                    {
+                        var compare = _nOcrFallbackBinaryOcrMatcher.GetCompareMatch(splitterItem, out _, letters, index, _nOcrFallbackBinaryOcrDb, BinaryOcrMaxErrorPercent);
+                        if (compare != null && !string.IsNullOrEmpty(compare.Text))
+                        {
+                            if (compare.ExpandCount > 0)
+                            {
+                                index += compare.ExpandCount - 1;
+                            }
+
+                            matches.Add(new NOcrChar
+                            {
+                                Text = compare.Text,
+                                Italic = compare.Italic,
+                                ExpandCount = compare.ExpandCount,
+                                ImageSplitterItem = splitterItem,
+                            });
+                            index++;
+                            continue;
+                        }
+                    }
 
                     if (NOcrDrawUnknownText && match == null)
                     {
@@ -2724,6 +2902,8 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
+        InitBinaryOcrFallbackNOcrDb();
+
         _skipOnceChars.Clear();
         _ = Task.Run(() => RunBinaryImageCompareOcrLoop(db, selectedIndices, cancellationToken));
     }
@@ -2781,6 +2961,22 @@ public partial class OcrViewModel : ObservableObject
                 else
                 {
                     var match = _binaryOcrMatcher.GetCompareMatch(splitterItem, out var secondBestMatch, letters, index, db, BinaryOcrMaxErrorPercent);
+
+                    if (match == null && _binaryOcrFallbackNOcrDb != null)
+                    {
+                        var nMatch = _binaryOcrFallbackNOcrDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, SelectedNOcrMaxWrongPixels, lastDitch: true);
+                        if (nMatch != null && !string.IsNullOrEmpty(nMatch.Text))
+                        {
+                            if (nMatch.ExpandCount > 0)
+                            {
+                                index += nMatch.ExpandCount - 1;
+                            }
+
+                            matches.Add(new BinaryOcrMatcher.CompareMatch(nMatch.Text, nMatch.Italic, nMatch.ExpandCount, "nOcrFallback"));
+                            index++;
+                            continue;
+                        }
+                    }
 
                     if (match == null)
                     {
@@ -3889,6 +4085,8 @@ public partial class OcrViewModel : ObservableObject
         IsGoogleLensVisible = et == OcrEngineType.GoogleLens || et == OcrEngineType.GoogleLensSharp;
         IsMistralOcrVisible = et == OcrEngineType.Mistral;
         IsBinaryImageCompareVisible = et == OcrEngineType.BinaryImageCompare;
+        IsFallbackDatabaseVisible = IsNOcrVisible || IsBinaryImageCompareVisible;
+        UpdateHasFallbackDatabase();
 
         if (IsNOcrVisible && NOcrDatabases.Count == 0)
         {

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1466,9 +1466,10 @@ public partial class OcrViewModel : ObservableObject
                 : BinaryOcrNOcrFallbackDatabase;
         }
 
+        var engineName = SelectedOcrEngine?.Name ?? string.Empty;
         var result = await _windowService.ShowDialogAsync<OcrFallbackDatabaseWindow, OcrFallbackDatabaseViewModel>(
             Window,
-            vm => vm.Initialize(label, databases, selected));
+            vm => vm.Initialize(engineName, label, databases, selected));
 
         if (!result.OkPressed)
         {

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1471,25 +1471,25 @@ public partial class OcrViewModel : ObservableObject
             Window,
             vm => vm.Initialize(engineName, label, databases, selected));
 
-        if (!result.OkPressed)
+        if (result.OkPressed)
         {
-            return;
+            var picked = result.SelectedDatabase;
+            var value = string.IsNullOrEmpty(picked) || picked == Se.Language.Ocr.NOcrBinaryOcrFallbackNone
+                ? string.Empty
+                : picked;
+
+            if (et == OcrEngineType.nOcr)
+            {
+                NOcrBinaryOcrFallbackDatabase = value;
+            }
+            else
+            {
+                BinaryOcrNOcrFallbackDatabase = value;
+            }
         }
 
-        var picked = result.SelectedDatabase;
-        var value = string.IsNullOrEmpty(picked) || picked == Se.Language.Ocr.NOcrBinaryOcrFallbackNone
-            ? string.Empty
-            : picked;
-
-        if (et == OcrEngineType.nOcr)
-        {
-            NOcrBinaryOcrFallbackDatabase = value;
-        }
-        else
-        {
-            BinaryOcrNOcrFallbackDatabase = value;
-        }
-
+        // ToggleButton's TwoWay IsChecked binding flips HasFallbackDatabase on click; recompute
+        // unconditionally so the checked state always reflects the underlying setting.
         UpdateHasFallbackDatabase();
     }
 
@@ -2973,7 +2973,8 @@ public partial class OcrViewModel : ObservableObject
                                 index += nMatch.ExpandCount - 1;
                             }
 
-                            matches.Add(new BinaryOcrMatcher.CompareMatch(nMatch.Text, nMatch.Italic, nMatch.ExpandCount, "nOcrFallback"));
+                            var text = _nOcrCaseFixer.FixUppercaseLowercaseIssues(splitterItem, nMatch);
+                            matches.Add(new BinaryOcrMatcher.CompareMatch(text, nMatch.Italic, nMatch.ExpandCount, "nOcrFallback"));
                             index++;
                             continue;
                         }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1466,10 +1466,9 @@ public partial class OcrViewModel : ObservableObject
                 : BinaryOcrNOcrFallbackDatabase;
         }
 
-        var engineName = SelectedOcrEngine?.Name ?? string.Empty;
         var result = await _windowService.ShowDialogAsync<OcrFallbackDatabaseWindow, OcrFallbackDatabaseViewModel>(
             Window,
-            vm => vm.Initialize(engineName, label, databases, selected));
+            vm => vm.Initialize(label, databases, selected));
 
         if (result.OkPressed)
         {

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -181,6 +181,16 @@ public class OcrWindow : Window
         Attached.SetIcon(toggleButtonVobSubColors, IconNames.Palette);
         ToolTip.SetTip(toggleButtonVobSubColors, Se.Language.Ocr.VobSubColors);
 
+        var toggleButtonFallbackDatabase = new ToggleButton
+        {
+            Command = vm.PickFallbackDatabaseCommand,
+            Margin = new Thickness(2, 0, 0, 0),
+        };
+        toggleButtonFallbackDatabase.Bind(ToggleButton.IsCheckedProperty, new Binding(nameof(vm.HasFallbackDatabase)));
+        toggleButtonFallbackDatabase.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFallbackDatabaseVisible)));
+        Attached.SetIcon(toggleButtonFallbackDatabase, IconNames.DatabaseArrowRight);
+        ToolTip.SetTip(toggleButtonFallbackDatabase, Se.Language.Ocr.FallbackOcrDatabase);
+
         var panelRight = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -190,6 +200,7 @@ public class OcrWindow : Window
                 toggleButtonCaptureAlignment,
                 toggleButtonPreProcessing,
                 toggleButtonVobSubColors,
+                toggleButtonFallbackDatabase,
             }
         };
 

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -100,6 +100,8 @@ public class LanguageOcr
     public string NOcrBinaryOcrFallbackDatabase { get; set; }
     public string NOcrBinaryOcrFallbackNone { get; set; }
     public string BinaryOcrNOcrFallbackDatabase { get; set; }
+    public string PickFallbackDatabase { get; set; }
+    public string FallbackOcrDatabase { get; set; }
     public string ShowAllOllamaModels { get; set; }
     public string OllamaModelLikelyWrong { get; set; }
 
@@ -203,6 +205,8 @@ public class LanguageOcr
         NOcrBinaryOcrFallbackDatabase = "BinaryOCR fallback database";
         NOcrBinaryOcrFallbackNone = "(none)";
         BinaryOcrNOcrFallbackDatabase = "nOCR fallback database";
+        PickFallbackDatabase = "Pick fallback OCR database";
+        FallbackOcrDatabase = "Fallback OCR database";
 
         ShowAllOllamaModels = "Show all models (not just vision-capable)";
         OllamaModelLikelyWrong = "Ollama returned no text - the selected model may not support OCR / vision";

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -7,6 +7,8 @@ public class SeOcr
 {
     public string Engine { get; set; }
     public string NOcrDatabase { get; set; }
+    public string NOcrBinaryOcrFallbackDatabase { get; set; }
+    public string BinaryOcrNOcrFallbackDatabase { get; set; }
     public int NOcrMaxWrongPixels { get; set; }
     public int NOcrPixelsAreSpace { get; set; }
     public bool NOcrDrawUnknownText { get; set; }
@@ -56,6 +58,8 @@ public class SeOcr
         DoTryToGuessUnknownWords = true;
 
         NOcrDatabase = "Latin";
+        NOcrBinaryOcrFallbackDatabase = string.Empty;
+        BinaryOcrNOcrFallbackDatabase = string.Empty;
         NOcrMaxWrongPixels = 25;
         NOcrPixelsAreSpace = 12;
         NOcrDrawUnknownText = true;

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -27,6 +27,7 @@ internal class IconNames
     public const string CheckCircle = "mdi-check-circle";
     public const string Download = "mdi-download";
     public const string CloudDownload = "mdi-cloud-download-outline";
+    public const string DatabaseArrowRight = "mdi-database-arrow-right";
     public const string DockTop = "mdi-dock-top";
     public const string DotsHorizontal = "mdi-dots-horizontal";
     public const string DotsVertical = "mdi-dots-vertical";


### PR DESCRIPTION
## Summary
- Adds a fourth top-right icon button in the OCR window that opens a small dialog to pick a fallback OCR database
- For nOCR engine: pick a BinaryOCR DB; for BinaryImageCompare: pick an nOCR DB (mirrors the existing batch-convert option)
- When the primary engine returns no match, the fallback DB is tried before prompting the user, matching batch-convert behavior
- Settings stored independently in `SeOcr.NOcrBinaryOcrFallbackDatabase` / `SeOcr.BinaryOcrNOcrFallbackDatabase`

## Test plan
- [ ] Open OCR window on a Blu-ray/VobSub source
- [ ] Select **nOCR** engine — verify the new fallback button (database-arrow icon) appears in the top-right
- [ ] Click button → dialog opens with the list of BinaryOCR databases + "(none)"; pick one
- [ ] Verify the toggle button shows as checked while a fallback DB is set
- [ ] Run OCR; verify characters not found by nOCR fall back to BinaryOCR before prompting
- [ ] Switch to **BinaryImageCompare** engine — verify dialog lists nOCR databases instead
- [ ] Switch to a different engine (Tesseract / Ollama / etc.) — verify the fallback button is hidden
- [ ] Close and re-open the OCR window — verify the fallback selection persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)