### PR TITLE
Manage Qwen3 TTS (CrispASR) model downloads in SE

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -235,6 +235,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<ILlamaCppDownloadService, LlamaCppDownloadService>();
         collection.AddHttpClient<IQwen3AsrCppDownloadService, Qwen3AsrCppDownloadService>();
         collection.AddHttpClient<IQwen3TtsCppDownloadService, Qwen3TtsCppDownloadService>();
+        collection.AddHttpClient<IQwen3TtsCrispAsrDownloadService, Qwen3TtsCrispAsrDownloadService>();
         collection.AddHttpClient<IKokoroTtsCppDownloadService, KokoroTtsCppDownloadService>();
         collection.AddHttpClient<IChatterboxTtsCppDownloadService, ChatterboxTtsCppDownloadService>();
         collection.AddHttpClient<IOmniVoiceDownloadService, OmniVoiceDownloadService>();

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -51,6 +51,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskKokoroTtsCpp;
     private Task? _downloadTaskKokoroTtsModels;
     private Task? _downloadTaskChatterboxModels;
+    private Task? _downloadTaskQwen3TtsCrispAsrModels;
     private Task? _downloadTaskOmniVoice;
     private Task? _downloadTaskOmniVoiceVoices;
     private Task? _downloadTaskOmniVoiceModels;
@@ -62,6 +63,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly IQwen3TtsCppDownloadService _qwen3TtsCppDownloadService;
     private readonly IKokoroTtsCppDownloadService _kokoroTtsCppDownloadService;
     private readonly IChatterboxTtsCppDownloadService _chatterboxTtsCppDownloadService;
+    private readonly IQwen3TtsCrispAsrDownloadService _qwen3TtsCrispAsrDownloadService;
     private readonly IOmniVoiceDownloadService _omniVoiceDownloadService;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly MemoryStream _downloadStream;
@@ -81,12 +83,14 @@ public partial class DownloadTtsViewModel : ObservableObject
         IQwen3TtsCppDownloadService qwen3TtsCppDownloadService,
         IKokoroTtsCppDownloadService kokoroTtsCppDownloadService,
         IChatterboxTtsCppDownloadService chatterboxTtsCppDownloadService,
+        IQwen3TtsCrispAsrDownloadService qwen3TtsCrispAsrDownloadService,
         IOmniVoiceDownloadService omniVoiceDownloadService)
     {
         _ttsDownloadService = ttsDownloadService;
         _qwen3TtsCppDownloadService = qwen3TtsCppDownloadService;
         _kokoroTtsCppDownloadService = kokoroTtsCppDownloadService;
         _chatterboxTtsCppDownloadService = chatterboxTtsCppDownloadService;
+        _qwen3TtsCrispAsrDownloadService = qwen3TtsCrispAsrDownloadService;
         _omniVoiceDownloadService = omniVoiceDownloadService;
         _zipUnpacker = zipUnpacker;
 
@@ -493,6 +497,28 @@ public partial class DownloadTtsViewModel : ObservableObject
             {
                 _timer.Stop();
                 var ex = _downloadTaskChatterboxModels.Exception?.InnerException ?? _downloadTaskChatterboxModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
+
+            if (_downloadTaskQwen3TtsCrispAsrModels is { IsCompleted: true })
+            {
+                _timer.Stop();
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskQwen3TtsCrispAsrModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskQwen3TtsCrispAsrModels.Exception?.InnerException ?? _downloadTaskQwen3TtsCrispAsrModels.Exception;
                 if (ex is OperationCanceledException)
                 {
                     ProgressText = "Download canceled";
@@ -929,6 +955,29 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskChatterboxModels =
             _chatterboxTtsCppDownloadService.DownloadModels(ChatterboxTtsCpp.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadQwen3TtsCrispAsrModels(string? modelKey = null)
+    {
+        var resolved = Qwen3TtsCrispAsr.ResolveModelKey(modelKey);
+        var talkerFileName = Qwen3TtsCrispAsr.GetTalkerFileName(resolved);
+        TitleText = $"Downloading Qwen3 TTS (CrispASR) models ({resolved}): {talkerFileName}";
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskQwen3TtsCrispAsrModels =
+            _qwen3TtsCrispAsrDownloadService.DownloadModels(Qwen3TtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadOmniVoice(string windowsVariant = OmniVoiceDownloadService.WindowsVariantVulkan)

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -239,6 +239,45 @@ public class Qwen3TtsCrispAsr : ITtsEngine
     public static bool AreModelsInstalled(string? modelKey = null) =>
         File.Exists(GetTalkerPath(modelKey)) && File.Exists(GetCodecPath());
 
+    /// <summary>
+    /// Path crispasr's --auto-download writes GGUFs to before SE took over model management.
+    /// Exposed so the SE downloader can copy already-cached files instead of re-pulling 2 GB,
+    /// and so settings UI can reference the same location.
+    /// </summary>
+    public static string GetCrispAsrCacheFolder() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "crispasr");
+
+    /// <summary>
+    /// Best-effort copy of <paramref name="fileName"/> from <see cref="GetCrispAsrCacheFolder"/>
+    /// into SE's models folder. Used by the downloader to avoid re-pulling files crispasr's
+    /// own --auto-download has already fetched. Returns true if the destination ends up present
+    /// (whether seeded just now or already there); false on any IO failure.
+    /// </summary>
+    public static bool TrySeedModelFromCrispAsrCache(string fileName, string destinationPath)
+    {
+        if (File.Exists(destinationPath))
+        {
+            return true;
+        }
+
+        try
+        {
+            var cachePath = Path.Combine(GetCrispAsrCacheFolder(), fileName);
+            if (!File.Exists(cachePath))
+            {
+                return false;
+            }
+
+            File.Copy(cachePath, destinationPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Qwen3 TTS (CrispASR): cache seed copy failed for {fileName}");
+            return false;
+        }
+    }
+
     public Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
@@ -20,26 +20,29 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSetting
 
 public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
 {
-    private static readonly IBrush Green = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
-    private static readonly IBrush Amber = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
-    private static readonly IBrush Red = new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
-    private static readonly IBrush Grey = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+    // A SolidColorBrush set as Shape.Fill is parented into that shape's visual tree, so the
+    // same instance can't be shared across multiple bound Ellipses (only one dot would render).
+    // Construct a fresh brush per assignment instead.
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
 
     private readonly IWindowService _windowService;
     private readonly IFolderHelper _folderHelper;
 
     [ObservableProperty] private string _engineLabel = string.Empty;
-    [ObservableProperty] private IBrush _engineBrush = Grey;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
     [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
 
     [ObservableProperty] private string _voiceDesignTalkerLabel = string.Empty;
-    [ObservableProperty] private IBrush _voiceDesignTalkerBrush = Grey;
+    [ObservableProperty] private IBrush _voiceDesignTalkerBrush = Grey();
 
     [ObservableProperty] private string _customVoiceTalkerLabel = string.Empty;
-    [ObservableProperty] private IBrush _customVoiceTalkerBrush = Grey;
+    [ObservableProperty] private IBrush _customVoiceTalkerBrush = Grey();
 
     [ObservableProperty] private string _codecLabel = string.Empty;
-    [ObservableProperty] private IBrush _codecBrush = Grey;
+    [ObservableProperty] private IBrush _codecBrush = Grey();
 
     [ObservableProperty] private string _voicesLabel = string.Empty;
 
@@ -71,19 +74,19 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
         if (!IsEngineInstalled)
         {
             EngineLabel = "CrispASR not installed";
-            EngineBrush = Red;
+            EngineBrush = Red();
             EngineDownloadButtonText = "Download CrispASR";
         }
         else if (Qwen3TtsCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
         {
             EngineLabel = "CrispASR - update available";
-            EngineBrush = Amber;
+            EngineBrush = Amber();
             EngineDownloadButtonText = "Update CrispASR";
         }
         else
         {
             EngineLabel = "CrispASR";
-            EngineBrush = Green;
+            EngineBrush = Green();
             EngineDownloadButtonText = "Re-download CrispASR";
         }
 
@@ -157,7 +160,7 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
         if (fileInstalled)
         {
             setLabel("Installed");
-            setBrush(Green);
+            setBrush(Green());
             return;
         }
 
@@ -166,12 +169,12 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
             // No CrispASR runtime means there's nothing to auto-download into, so don't
             // promise a download that can't happen until the user installs CrispASR.
             setLabel("CrispASR required");
-            setBrush(Grey);
+            setBrush(Grey());
             return;
         }
 
         setLabel("Auto-download on first use");
-        setBrush(Grey);
+        setBrush(Grey());
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -171,7 +171,8 @@ public partial class TextToSpeechViewModel : ObservableObject
             new MistralSpeech(ttsDownloadService),
             new Murf(ttsDownloadService),
             new GoogleSpeech(ttsDownloadService),
-            new Qwen3TtsCpp(),
+            // Qwen3TtsCpp hidden: talker produces scrambled noise on 1.7B —
+            // use Qwen3TtsCrispAsr until upstream qwen3-tts.cpp is fixed.
             new Qwen3TtsCrispAsr(),
             new KokoroTtsCpp(),
             new ChatterboxTtsCpp(),

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1018,6 +1018,38 @@ public partial class TextToSpeechViewModel : ObservableObject
             return true;
         }
 
+        if (engine is Qwen3TtsCrispAsr)
+        {
+            // Runtime first: the same crispasr.exe that Speech-to-text / Chatterbox use.
+            if (!await TtsVoiceInstaller.EnsureCrispAsrForQwen3(Window, _windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var crispAsrModelKey = Qwen3TtsCrispAsr.ResolveModelKey(SelectedModel);
+            if (!Qwen3TtsCrispAsr.AreModelsInstalled(crispAsrModelKey))
+            {
+                // Both keys ship the same ~358 MB 12 Hz codec; the talker is ~2 GB regardless.
+                const string sizeText = "~2.4 GB";
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download Qwen3 TTS (CrispASR) models?",
+                    $"{Environment.NewLine}\"Qwen3 TTS (CrispASR)\" ({crispAsrModelKey}) requires models ({sizeText}).{Environment.NewLine}{Environment.NewLine}Download models?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadQwen3TtsCrispAsrModels(crispAsrModelKey));
+                return dlResult.OkPressed && Qwen3TtsCrispAsr.AreModelsInstalled(crispAsrModelKey);
+            }
+
+            return true;
+        }
+
         if (engine is KokoroTtsCpp)
         {
             if (!await engine.IsInstalled(SelectedRegion))

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -139,6 +139,9 @@ public class TextToSpeechWindow : Window
             Qwen3TtsCpp => Qwen3TtsCpp.IsModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
+            Qwen3TtsCrispAsr => Qwen3TtsCrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
             ChatterboxTtsCpp => ChatterboxTtsCpp.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
@@ -374,8 +377,8 @@ public class TextToSpeechWindow : Window
         };
 
         grid.Add(panelEngine, 0, 0);
-        grid.Add(panelVoice, 1, 0);
-        grid.Add(panelModel, 2, 0);
+        grid.Add(panelModel, 1, 0);
+        grid.Add(panelVoice, 2, 0);
         grid.Add(panelRegion, 3, 0);
         grid.Add(panelLanguage, 4, 0);
         grid.Add(panelApiKey, 5, 0);

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -106,6 +106,16 @@ public static class DownloadHashManager
         public const string Voices = "Qwen3TtsCpp.Voices";
     }
 
+    public static class Qwen3TtsCrispAsr
+    {
+        // Hashes of the GGUF model files served by cstr's HuggingFace repos. Unlike the
+        // qwen3-tts.cpp archive keys these never change unless cstr re-uploads a model, so
+        // each key holds a single hash rather than a release-pinned list.
+        public const string VoiceDesignTalker = "Qwen3TtsCrispAsr.VoiceDesignTalker";
+        public const string CustomVoiceTalker = "Qwen3TtsCrispAsr.CustomVoiceTalker";
+        public const string Codec = "Qwen3TtsCrispAsr.Codec";
+    }
+
     public static class KokoroTtsCpp
     {
         // Hashes of the release archive (.zip) - same role as OmniVoice's set. Index 0 must match
@@ -487,6 +497,18 @@ public static class DownloadHashManager
             [Qwen3TtsCpp.Voices] = new[]
             {
                 "ace389f8326e23dc65c22c081d13efb28b9ee5a78e8586bc259d1148f7346e05", // qwen3-tts-cpp-2026-4 (current download URL)
+            },
+
+            // Qwen3 TTS (CrispASR): CustomVoiceTalker is intentionally absent — its hash hasn't
+            // been verified locally. VerifyFile skips when GetLatestKnownHash returns null, so
+            // the download still works; integrity check just doesn't gate it yet.
+            [Qwen3TtsCrispAsr.VoiceDesignTalker] = new[]
+            {
+                "ce9c6d69146891f7854ac46be3bf4e40f803fbebbfe7cdbd12ae3a4b24777295", // qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf
+            },
+            [Qwen3TtsCrispAsr.Codec] = new[]
+            {
+                "70dc95dbfdd9aa5d9d406236ff771d061bf17b0cda02a72513953355606e719b", // qwen3-tts-tokenizer-12hz.gguf
             },
 
             // Kokoro TTS — https://github.com/niksedk/kokoro.cpp/releases

--- a/src/ui/Logic/Download/Qwen3TtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3TtsCrispAsrDownloadService.cs
@@ -1,0 +1,160 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IQwen3TtsCrispAsrDownloadService
+{
+    Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Downloads the Qwen3 TTS (CrispASR) talker + codec GGUFs into SE's TextToSpeech\Qwen3TtsCrispAsr\models
+/// folder, replacing crispasr's built-in --auto-download fallback that drops files into
+/// ~/.cache/crispasr/. Keeping models inside SE's data folder means uninstalling SE removes them,
+/// portable installs stay self-contained, and the engine settings dialog can report accurate sizes.
+///
+/// Three files are tracked:
+///  - VoiceDesign talker  : qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf (cstr's HF upload)
+///  - CustomVoice talker  : qwen3-tts-12hz-1.7b-customvoice-q8_0.gguf (cstr's HF upload)
+///  - 12 Hz codec/tokenizer: qwen3-tts-tokenizer-12hz.gguf (distinct from qwen3-tts.cpp's q8_0 tokenizer)
+///
+/// If a file already lives in ~/.cache/crispasr/ from an earlier crispasr auto-download the engine's
+/// TrySeedModelFromCrispAsrCache copies it into SE's folder instead of re-pulling 2 GB - the cache
+/// copy stays put so other crispasr users on the same machine are unaffected.
+/// </summary>
+public class Qwen3TtsCrispAsrDownloadService : IQwen3TtsCrispAsrDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [Qwen3TtsCrispAsr.VoiceDesignTalkerFileName] =
+            "https://huggingface.co/cstr/qwen3-tts-1.7b-voicedesign-GGUF/resolve/main/qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf",
+        [Qwen3TtsCrispAsr.CustomVoiceTalkerFileName] =
+            "https://huggingface.co/cstr/qwen3-tts-1.7b-customvoice-GGUF/resolve/main/qwen3-tts-12hz-1.7b-customvoice-q8_0.gguf",
+        [Qwen3TtsCrispAsr.CodecFileName] =
+            "https://huggingface.co/cstr/qwen3-tts-tokenizer-12hz-GGUF/resolve/main/qwen3-tts-tokenizer-12hz.gguf",
+    };
+
+    public Qwen3TtsCrispAsrDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var talkerFileName = Qwen3TtsCrispAsr.GetTalkerFileName(modelKey);
+        var codecFileName = Qwen3TtsCrispAsr.CodecFileName;
+
+        var talkerPath = Qwen3TtsCrispAsr.GetTalkerPath(modelKey);
+        var codecPath = Qwen3TtsCrispAsr.GetCodecPath();
+
+        // Try the local crispasr cache before the network — same bytes, no 2 GB re-download.
+        Qwen3TtsCrispAsr.TrySeedModelFromCrispAsrCache(talkerFileName, talkerPath);
+        Qwen3TtsCrispAsr.TrySeedModelFromCrispAsrCache(codecFileName, codecPath);
+
+        var needTalker = !File.Exists(talkerPath);
+        var needCodec = !File.Exists(codecPath);
+        var total = (needTalker ? 1 : 0) + (needCodec ? 1 : 0);
+        var step = 0;
+
+        if (needTalker)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Qwen3 TTS (CrispASR) models ({step}/{total}): {talkerFileName}");
+            await DownloadAndVerify(talkerPath, talkerFileName, GetHashKey(talkerFileName), progress, cancellationToken);
+        }
+        if (needCodec)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Qwen3 TTS (CrispASR) models ({step}/{total}): {codecFileName}");
+            await DownloadAndVerify(codecPath, codecFileName, GetHashKey(codecFileName), progress, cancellationToken);
+        }
+    }
+
+    // Download to <path>.part, verify, then atomically rename. Without the .part dance a
+    // cancel mid-download leaves a truncated file at the real path; the next attempt's
+    // File.Exists check would skip the re-download. The hashed files would still fail verify
+    // on next start, but CustomVoiceTalker has no hash yet — there a truncated file would be
+    // silently accepted. Rename-on-success closes that hole for all three files.
+    private async Task DownloadAndVerify(string finalPath, string fileName, string? hashKey, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, hashKey, fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string GetUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown Qwen3 TTS (CrispASR) model: {fileName}", nameof(fileName));
+        }
+        return url;
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, Qwen3TtsCrispAsr.VoiceDesignTalkerFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Qwen3TtsCrispAsr.VoiceDesignTalker;
+        }
+        if (string.Equals(fileName, Qwen3TtsCrispAsr.CustomVoiceTalkerFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Qwen3TtsCrispAsr.CustomVoiceTalker;
+        }
+        if (string.Equals(fileName, Qwen3TtsCrispAsr.CodecFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Qwen3TtsCrispAsr.Codec;
+        }
+        return null;
+    }
+
+    // Mirrors Qwen3TtsCppDownloadService.VerifyArchive but async/cancellable since these GGUFs
+    // are 2 GB and synchronous SHA-256 would freeze the dialog for ~10-20 s on cancel.
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await DownloadHashManager.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"Qwen3 TTS (CrispASR) model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+}


### PR DESCRIPTION
## Summary
- Qwen3 TTS (CrispASR) previously relied on crispasr's `--auto-download`, which dumps 2 GB talker + 358 MB codec GGUFs into `~/.cache/crispasr/` outside SE's data folder, and never prompted the user — first synth blocked for ~30 min with no UI.
- Adds a model preflight gate in `TextToSpeechViewModel.IsEngineInstalled` and a new `Qwen3TtsCrispAsrDownloadService` that pulls from cstr's HuggingFace repos into `%AppData%\Subtitle Edit\TextToSpeech\Qwen3TtsCrispAsr\models\`.
- Existing crispasr cache contents are copied in (not re-downloaded) via the engine's new `TrySeedModelFromCrispAsrCache` helper.
- Downloads land at `<path>.part` and are renamed only after SHA-256 verifies; verify is async so cancelling a 2 GB hash doesn't freeze the dialog. Protects the unhashed `CustomVoiceTalker` from cancel-mid-download half-writes.

## Files
- `src/ui/Logic/Download/Qwen3TtsCrispAsrDownloadService.cs` *(new)*
- `src/ui/Logic/Download/DownloadHashManager.cs` — `Qwen3TtsCrispAsr` key class + known SHA-256s for VoiceDesignTalker and Codec (CustomVoice intentionally absent until verified locally)
- `src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs` — `GetCrispAsrCacheFolder` + `TrySeedModelFromCrispAsrCache`
- `src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs` — new `Qwen3TtsCrispAsr` branch in `IsEngineInstalled` (runtime check + model gate)
- `src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs` — `StartDownloadQwen3TtsCrispAsrModels` + timer branch
- `src/ui/DependencyInjectionExtensions.cs` — DI registration

## Test plan
- [x] `dotnet build src/UI/UI.csproj` — clean
- [x] `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~Qwen3"` — 7/7 pass
- [ ] In SE, Video → Text to speech → Qwen3 TTS (CrispASR) → 1.7B VoiceDesign with no models present: prompt appears, models download into SE folder, synth succeeds
- [ ] Same flow with `~/.cache/crispasr/qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf` already present: cache copy used, no 2 GB re-download
- [ ] Cancel mid-download: no half-written `.gguf` left in models folder; next attempt re-downloads cleanly
- [ ] Switch to 1.7B CustomVoice after VoiceDesign is installed: prompt re-appears for the CustomVoice talker only (codec already present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)