### PR TITLE
Make OpenAI-compatible STT 'stream' opt-in (fixes #11123)

### DIFF
--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -89,6 +89,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public decimal OpenAiCompatibleSttTemperature { get; set; }
         public string OpenAiCompatibleSttPrompt { get; set; }
         public bool OpenAiCompatibleSttAutoTranscribeOnAudioSelection { get; set; }
+        public bool OpenAiCompatibleSttStream { get; set; }
 
         public string OpenRouterUrl { get; set; }
         public string OpenRouterPrompt { get; set; }
@@ -519,6 +520,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             OpenAiCompatibleSttLanguage = string.Empty;
             OpenAiCompatibleSttTemperature = 0;
             OpenAiCompatibleSttPrompt = string.Empty;
+            OpenAiCompatibleSttStream = false;
 
             VoskPostProcessing = true;
             WhisperChoice = Configuration.IsRunningOnWindows ? AudioToText.WhisperChoice.PurfviewFasterWhisperXxl : AudioToText.WhisperChoice.OpenAi;

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -165,20 +165,24 @@ public class OpenAiSttService
         {
             var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
             var statusCode = (int)response.StatusCode;
+            var temperatureSummary = _settings.Temperature > 0
+                ? _settings.Temperature.ToString("F2", CultureInfo.InvariantCulture)
+                : "(not sent)";
             var paramSummary =
                 $"model={_settings.Model}, language={languageToUse}, " +
                 $"response_format=json, timestamp_granularities=[segment,word], " +
                 $"stream={(_settings.Stream ? "true" : "(not sent)")}, " +
-                $"temperature={_settings.Temperature.ToString("F2", CultureInfo.InvariantCulture)}, " +
+                $"temperature={temperatureSummary}, " +
                 $"promptLen={_settings.Prompt?.Length ?? 0}, file={fileName}";
-            Se.WriteToolsLog(
-                $"OpenAI-compatible STT failed: POST {_settings.EndpointUrl}{Environment.NewLine}" +
+            var safeEndpoint = SanitizeEndpointForLog(_settings.EndpointUrl);
+            _settings.Logger?.Invoke(
+                $"OpenAI-compatible STT failed: POST {safeEndpoint}{Environment.NewLine}" +
                 $"Status: {statusCode} {response.StatusCode}{Environment.NewLine}" +
                 $"RequestParams: {paramSummary}{Environment.NewLine}" +
                 $"ResponseBody: {errorContent}");
             throw new HttpRequestException(
                 $"STT request failed with status {statusCode} ({response.StatusCode}) " +
-                $"calling {_settings.EndpointUrl}. Response: {errorContent}");
+                $"calling {safeEndpoint}. Response: {errorContent}");
         }
 
         // Check if streaming (SSE)
@@ -371,6 +375,66 @@ public class OpenAiSttService
         };
     }
 
+    /// <summary>
+    /// Strip credentials from an endpoint URL before logging or echoing it back
+    /// to the user. Removes any userinfo segment and redacts the values of
+    /// query parameters that commonly carry secrets (api_key, apikey, key,
+    /// token, access_token). Non-URL strings are returned unchanged.
+    /// </summary>
+    internal static string SanitizeEndpointForLog(string endpointUrl)
+    {
+        if (string.IsNullOrWhiteSpace(endpointUrl))
+        {
+            return endpointUrl;
+        }
+
+        if (!Uri.TryCreate(endpointUrl, UriKind.Absolute, out var uri))
+        {
+            return endpointUrl;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+        };
+
+        if (!string.IsNullOrEmpty(uri.Query))
+        {
+            var query = uri.Query.StartsWith('?') ? uri.Query[1..] : uri.Query;
+            var redacted = new StringBuilder();
+            foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (redacted.Length > 0)
+                {
+                    redacted.Append('&');
+                }
+                var eq = part.IndexOf('=');
+                var name = eq >= 0 ? part[..eq] : part;
+                if (eq >= 0 && IsSensitiveQueryParam(name))
+                {
+                    redacted.Append(name).Append("=***");
+                }
+                else
+                {
+                    redacted.Append(part);
+                }
+            }
+            builder.Query = redacted.ToString();
+        }
+
+        return builder.Uri.ToString();
+    }
+
+    private static bool IsSensitiveQueryParam(string name)
+    {
+        return name.Equals("api_key", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("apikey", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("key", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("token", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("access_token", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static void AddExtraHeaders(HttpRequestHeaders headers, string extraHeaders)
     {
         if (string.IsNullOrWhiteSpace(extraHeaders))
@@ -416,7 +480,8 @@ public class OpenAiSttService
             Language = settings.OpenAiCompatibleSttLanguage,
             Temperature = (double)settings.OpenAiCompatibleSttTemperature,
             Prompt = settings.OpenAiCompatibleSttPrompt,
-            Stream = settings.OpenAiCompatibleSttStream
+            Stream = settings.OpenAiCompatibleSttStream,
+            Logger = Se.WriteToolsLog
         };
     }
 
@@ -439,6 +504,14 @@ public class OpenAiCompatibleSettings
     public double Temperature { get; set; }
     public string Prompt { get; set; } = string.Empty;
     public bool Stream { get; set; }
+
+    /// <summary>
+    /// Optional diagnostic sink used on failure paths. Set by
+    /// <see cref="OpenAiSttService.GetSettingsFromConfiguration"/> to
+    /// <c>Se.WriteToolsLog</c>; left null in unit tests so the service
+    /// does not touch the SE data folder.
+    /// </summary>
+    public Action<string>? Logger { get; set; }
 }
 
 // SSE event models

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Settings;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
 
@@ -121,8 +122,11 @@ public class OpenAiSttService
         content.Add(new StringContent("segment"), "timestamp_granularities[]");
         content.Add(new StringContent("word"), "timestamp_granularities[]");
 
-        // Enable streaming
-        content.Add(new StringContent("true"), "stream");
+        // Enable streaming (some OpenAI-compatible servers, e.g. Groq, reject this param)
+        if (_settings.Stream)
+        {
+            content.Add(new StringContent("true"), "stream");
+        }
 
         // Add temperature if specified
         if (_settings.Temperature > 0)
@@ -160,7 +164,21 @@ public class OpenAiSttService
         if (!response.IsSuccessStatusCode)
         {
             var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            throw new HttpRequestException($"STT request failed with status {(int)response.StatusCode}: {response.StatusCode}. {errorContent}");
+            var statusCode = (int)response.StatusCode;
+            var paramSummary =
+                $"model={_settings.Model}, language={languageToUse}, " +
+                $"response_format=json, timestamp_granularities=[segment,word], " +
+                $"stream={(_settings.Stream ? "true" : "(not sent)")}, " +
+                $"temperature={_settings.Temperature.ToString("F2", CultureInfo.InvariantCulture)}, " +
+                $"promptLen={_settings.Prompt?.Length ?? 0}, file={fileName}";
+            Se.WriteToolsLog(
+                $"OpenAI-compatible STT failed: POST {_settings.EndpointUrl}{Environment.NewLine}" +
+                $"Status: {statusCode} {response.StatusCode}{Environment.NewLine}" +
+                $"RequestParams: {paramSummary}{Environment.NewLine}" +
+                $"ResponseBody: {errorContent}");
+            throw new HttpRequestException(
+                $"STT request failed with status {statusCode} ({response.StatusCode}) " +
+                $"calling {_settings.EndpointUrl}. Response: {errorContent}");
         }
 
         // Check if streaming (SSE)
@@ -397,7 +415,8 @@ public class OpenAiSttService
             TimeoutSeconds = settings.OpenAiCompatibleSttTimeoutSeconds,
             Language = settings.OpenAiCompatibleSttLanguage,
             Temperature = (double)settings.OpenAiCompatibleSttTemperature,
-            Prompt = settings.OpenAiCompatibleSttPrompt
+            Prompt = settings.OpenAiCompatibleSttPrompt,
+            Stream = settings.OpenAiCompatibleSttStream
         };
     }
 
@@ -419,6 +438,7 @@ public class OpenAiCompatibleSettings
     public string Language { get; set; } = string.Empty;
     public double Temperature { get; set; }
     public string Prompt { get; set; } = string.Empty;
+    public bool Stream { get; set; }
 }
 
 // SSE event models

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -101,6 +101,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private decimal _openAiCompatibleSttTemperature;
     [ObservableProperty] private string? _openAiCompatibleSttPrompt;
     [ObservableProperty] private string? _openAiCompatibleSttExtraHeaders;
+    [ObservableProperty] private bool _openAiCompatibleSttStream;
 
     public Window? Window { get; set; }
 
@@ -265,6 +266,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         OpenAiCompatibleSttTemperature = Se.Settings.Tools.OpenAiCompatibleSttTemperature;
         OpenAiCompatibleSttPrompt = Se.Settings.Tools.OpenAiCompatibleSttPrompt;
         OpenAiCompatibleSttExtraHeaders = Se.Settings.Tools.OpenAiCompatibleSttExtraHeaders;
+        OpenAiCompatibleSttStream = Se.Settings.Tools.OpenAiCompatibleSttStream;
 
         var savedChoice = Se.Settings.Tools.AudioToText.WhisperChoice;
         var whisperCppEngine = Engines.OfType<WhisperCppEngine>().FirstOrDefault();
@@ -310,6 +312,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         Se.Settings.Tools.OpenAiCompatibleSttTemperature = OpenAiCompatibleSttTemperature;
         Se.Settings.Tools.OpenAiCompatibleSttPrompt = OpenAiCompatibleSttPrompt ?? string.Empty;
         Se.Settings.Tools.OpenAiCompatibleSttExtraHeaders = OpenAiCompatibleSttExtraHeaders ?? string.Empty;
+        Se.Settings.Tools.OpenAiCompatibleSttStream = OpenAiCompatibleSttStream;
 
         Se.SaveSettings();
     }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -678,6 +678,10 @@ public class SpeechToTextWindow : Window
             [!TextBox.TextProperty] = new Binding(nameof(vm.OpenAiCompatibleSttExtraHeaders)) { Mode = BindingMode.TwoWay }
         }.BindIsVisible(vm, nameof(vm.IsOpenAiCompatibleSttVisible));
 
+        var checkStream = UiUtil.MakeCheckBox(vm, nameof(vm.OpenAiCompatibleSttStream))
+            .BindIsVisible(vm, nameof(vm.IsOpenAiCompatibleSttVisible));
+        ToolTip.SetTip(checkStream, Se.Language.General.OpenAiCompatibleSttStreamHint);
+
         return new (Control, Control)[]
         {
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttEndpoint), MakeText(nameof(vm.OpenAiCompatibleSttUrl), 400)),
@@ -688,6 +692,7 @@ public class SpeechToTextWindow : Window
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttTemperature), numericTemperature),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttPrompt), MakeText(nameof(vm.OpenAiCompatibleSttPrompt), 400)),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttExtraHeaders), textExtraHeaders),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttStream), checkStream),
         };
     }
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -692,6 +692,8 @@ public class LanguageGeneral
     public string OpenAiCompatibleSttTemperature { get; set; }
     public string OpenAiCompatibleSttPrompt { get; set; }
     public string OpenAiCompatibleSttAutoTranscribeOnAudioSelection { get; set; }
+    public string OpenAiCompatibleSttStream { get; set; }
+    public string OpenAiCompatibleSttStreamHint { get; set; }
     public string ConfigurationRequired { get; set; }
     public string TranscriptionError { get; set; }
     public string TranscriptionComplete { get; set; }
@@ -1398,6 +1400,8 @@ public class LanguageGeneral
         OpenAiCompatibleSttTemperature = "Temperature";
         OpenAiCompatibleSttPrompt = "Prompt";
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = "Auto-transcribe new waveform selection via speech-to-text";
+        OpenAiCompatibleSttStream = "Stream response";
+        OpenAiCompatibleSttStreamHint = "Send 'stream=true' to receive live text deltas (SSE). Disable for servers that reject the 'stream' parameter (e.g. Groq).";
         ConfigurationRequired = "Configuration Required";
         TranscriptionError = "Transcription Error";
         TranscriptionComplete = "Transcription complete";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -425,6 +425,7 @@ public class Se
         Configuration.Settings.Tools.OpenAiCompatibleSttTemperature = Settings.Tools.OpenAiCompatibleSttTemperature;
         Configuration.Settings.Tools.OpenAiCompatibleSttPrompt = Settings.Tools.OpenAiCompatibleSttPrompt;
         Configuration.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
+        Configuration.Settings.Tools.OpenAiCompatibleSttStream = Settings.Tools.OpenAiCompatibleSttStream;
 
         Configuration.Settings.Tools.AutoTranslateLastName = Settings.AutoTranslate.AutoTranslateLastName;
 

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -115,6 +115,7 @@ public class SeTools
     public decimal OpenAiCompatibleSttTemperature { get; set; }
     public string OpenAiCompatibleSttPrompt { get; set; } = string.Empty;
     public bool OpenAiCompatibleSttAutoTranscribeOnAudioSelection { get; set; }
+    public bool OpenAiCompatibleSttStream { get; set; }
 
     public List<string> FindHistory { get; set; } = new List<string>();
     public bool AllowSingleLetterShortcutsInTextbox { get; set; }

--- a/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
@@ -292,6 +292,141 @@ public class OpenAiSttServiceTests
         }
     }
 
+    [Fact]
+    public async Task TranscribeAsync_DefaultSettings_DoesNotSendStreamPart()
+    {
+        // Groq and some other OpenAI-compatible providers reject the `stream`
+        // multipart field with HTTP 400. The opt-in default must keep the
+        // field out of the request entirely.
+        var capturedNames = await CaptureMultipartFieldNamesAsync(MakeSettings());
+
+        Assert.DoesNotContain("stream", capturedNames);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_StreamEnabled_SendsStreamTruePart()
+    {
+        var settings = MakeSettings();
+        settings.Stream = true;
+
+        var (names, values) = await CaptureMultipartFieldNamesAndValuesAsync(settings);
+
+        Assert.Contains("stream", names);
+        Assert.Equal("true", values["stream"]);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_NonSuccessStatus_InvokesLogger_WithSanitizedUrl()
+    {
+        var logEntries = new List<string>();
+        var settings = MakeSettings();
+        settings.EndpointUrl = "https://user:secret@api.example.com/v1/audio/transcriptions?api_key=SHOULD_NOT_LEAK&model=x";
+        settings.Logger = msg => logEntries.Add(msg);
+
+        using var handler = new StubHandler((req, ct) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"error\":\"nope\"}", Encoding.UTF8, "application/json"),
+            }));
+        using var client = new HttpClient(handler);
+        var service = new OpenAiSttService(client, settings);
+
+        var ct = TestContext.Current.CancellationToken;
+        var wav = MakeTinyWav();
+        try
+        {
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(
+                () => service.TranscribeAsync(wav, cancellationToken: ct));
+
+            // Logger must have been invoked exactly once and the credentials
+            // must not appear in either the log entry or the exception message.
+            Assert.Single(logEntries);
+            Assert.DoesNotContain("secret", logEntries[0]);
+            Assert.DoesNotContain("SHOULD_NOT_LEAK", logEntries[0]);
+            Assert.Contains("api_key=***", logEntries[0]);
+            Assert.DoesNotContain("secret", ex.Message);
+            Assert.DoesNotContain("SHOULD_NOT_LEAK", ex.Message);
+        }
+        finally
+        {
+            File.Delete(wav);
+        }
+    }
+
+    [Fact]
+    public void SanitizeEndpointForLog_RedactsUserInfoAndSensitiveQueryParams()
+    {
+        var sanitized = OpenAiSttService.SanitizeEndpointForLog(
+            "https://user:pw@example.com/v1/audio/transcriptions?api_key=AAA&token=BBB&model=whisper&access_token=CCC");
+
+        Assert.DoesNotContain("user", sanitized);
+        Assert.DoesNotContain("pw@", sanitized);
+        Assert.DoesNotContain("AAA", sanitized);
+        Assert.DoesNotContain("BBB", sanitized);
+        Assert.DoesNotContain("CCC", sanitized);
+        Assert.Contains("api_key=***", sanitized);
+        Assert.Contains("token=***", sanitized);
+        Assert.Contains("access_token=***", sanitized);
+        Assert.Contains("model=whisper", sanitized);
+    }
+
+    [Fact]
+    public void SanitizeEndpointForLog_PassesThroughNonUrlOrEmpty()
+    {
+        Assert.Equal("", OpenAiSttService.SanitizeEndpointForLog(""));
+        Assert.Equal("not-a-url", OpenAiSttService.SanitizeEndpointForLog("not-a-url"));
+    }
+
+    private static async Task<HashSet<string>> CaptureMultipartFieldNamesAsync(OpenAiCompatibleSettings settings)
+    {
+        var (names, _) = await CaptureMultipartFieldNamesAndValuesAsync(settings);
+        return names;
+    }
+
+    private static async Task<(HashSet<string> Names, Dictionary<string, string> Values)>
+        CaptureMultipartFieldNamesAndValuesAsync(OpenAiCompatibleSettings settings)
+    {
+        // We need to inspect the parts before the handler returns, since
+        // MultipartFormDataContent is disposed once the request completes.
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        using var handler = new StubHandler(async (req, ct) =>
+        {
+            if (req.Content is MultipartFormDataContent multipart)
+            {
+                foreach (var part in multipart)
+                {
+                    var name = part.Headers.ContentDisposition?.Name?.Trim('"') ?? string.Empty;
+                    if (string.IsNullOrEmpty(name))
+                    {
+                        continue;
+                    }
+                    names.Add(name);
+                    // Only read string-valued parts, not the file stream.
+                    if (part is StringContent)
+                    {
+                        values[name] = await part.ReadAsStringAsync(ct);
+                    }
+                }
+            }
+            return JsonResponse("""{"text":"ok"}""");
+        });
+        using var client = new HttpClient(handler);
+        var service = new OpenAiSttService(client, settings);
+
+        var ct = TestContext.Current.CancellationToken;
+        var wav = MakeTinyWav();
+        try
+        {
+            await service.TranscribeAsync(wav, cancellationToken: ct);
+        }
+        finally
+        {
+            File.Delete(wav);
+        }
+        return (names, values);
+    }
+
     private static HttpResponseMessage JsonResponse(string body, string contentType = "application/json")
     {
         var resp = new HttpResponseMessage(HttpStatusCode.OK)


### PR DESCRIPTION
## Summary
- Some OpenAI-compatible servers (Groq, in the reported case) reject the `stream` multipart field on `/v1/audio/transcriptions` with HTTP 400 `unknown param 'stream'`. The previous code always sent `stream=true`, so transcription failed against any such endpoint.
- Add a new `OpenAiCompatibleSttStream` setting (default **off**) and only append `stream=true` when enabled. Exposed as a "Stream response" checkbox in the STT settings panel, with a tooltip explaining when to leave it off.
- On non-2xx responses, write the endpoint URL, status, request param summary (model/language/temperature/`stream`/promptLen/filename) and response body to `tools-log.txt`. The thrown exception message also includes the endpoint URL so it shows in the UI message box.

The default is off because streaming on this endpoint is recent and inconsistently implemented across OpenAI-compatible providers — off-by-default means new endpoints just work; users on OpenAI-proper can opt in for live text deltas. The final transcription result is identical either way.

Fixes #11123.

## Test plan
- [ ] Configure an OpenAI-compatible STT endpoint that does **not** accept `stream` (e.g. Groq `https://api.groq.com/openai/v1/audio/transcriptions` with `whisper-large-v3-turbo`) and confirm transcription succeeds with the default setting.
- [ ] Toggle the new "Stream response" checkbox on against OpenAI proper and confirm live text deltas still appear during transcription.
- [ ] Force a 400/401 response (bad API key) and verify `tools-log.txt` gets a new entry containing the URL, status code, request param summary and response body.
- [ ] Verify the error message box in the UI now shows the endpoint URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)