### PR TITLE
Scrub video position via mouse wheel over video surface

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -255,7 +255,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             // is captured to this control — routing wouldn't reach mainGrid in that case.
             this.AddHandler(InputElement.PointerReleasedEvent, OnMainGridPointerReleased, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
             // Scrub the video by scrolling the mouse wheel over the video surface (issue #11080).
-            this.AddHandler(InputElement.PointerWheelChangedEvent, OnVideoWheelChanged, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
+            this.AddHandler(InputElement.PointerWheelChangedEvent, OnVideoWheelChanged, RoutingStrategies.Bubble, handledEventsToo: true);
 
             // Buttons
             var stackPanel = new StackPanel

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -254,6 +254,8 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             // Release handler is on `this` (not mainGrid) so it still fires when the pointer
             // is captured to this control — routing wouldn't reach mainGrid in that case.
             this.AddHandler(InputElement.PointerReleasedEvent, OnMainGridPointerReleased, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
+            // Scrub the video by scrolling the mouse wheel over the video surface (issue #11080).
+            this.AddHandler(InputElement.PointerWheelChangedEvent, OnVideoWheelChanged, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
 
             // Buttons
             var stackPanel = new StackPanel
@@ -576,6 +578,67 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 _surfaceLeftButtonDown = false;
                 e.Pointer.Capture(null);
             }
+        }
+
+        private void OnVideoWheelChanged(object? sender, PointerWheelEventArgs e)
+        {
+            // Ignore wheel events over the controls row (sliders, buttons).
+            try
+            {
+                if (_gridProgress.IsVisible)
+                {
+                    var ptInControls = e.GetPosition(_gridProgress);
+                    if (ptInControls.X >= 0 && ptInControls.Y >= 0 &&
+                        ptInControls.X <= _gridProgress.Bounds.Width &&
+                        ptInControls.Y <= _gridProgress.Bounds.Height)
+                    {
+                        return;
+                    }
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+
+            var delta = e.Delta.Y;
+            if (Math.Abs(delta) < 0.1 && Math.Abs(e.Delta.X) > 0.1)
+            {
+                delta = e.Delta.X;
+            }
+
+            if (Math.Abs(delta) < 0.0001)
+            {
+                return;
+            }
+
+            if (Se.Settings.Waveform.InvertMouseWheel)
+            {
+                delta = -delta;
+            }
+
+            const double stepSeconds = 0.5;
+            var newPosition = Position + delta * stepSeconds;
+
+            var duration = Duration;
+            if (newPosition < 0)
+            {
+                newPosition = 0;
+            }
+            else if (duration > 0 && newPosition > duration)
+            {
+                newPosition = duration;
+            }
+
+            NotifyPositionChanged(newPosition);
+            UserSeeked?.Invoke(newPosition);
+
+            if (IsFullScreen)
+            {
+                OnUserActivity();
+            }
+
+            e.Handled = true;
         }
 
         public event Action? PlayPauseRequested;


### PR DESCRIPTION
## Summary
- Restores SE4 behavior where scrolling the mouse wheel over the video window moves the playhead forward/backward (fixes #11080).
- Adds a `PointerWheelChanged` handler on `VideoPlayerControl` that seeks the player by ±0.5s per wheel notch (matches the waveform's `scrollDelta / 2`).
- Respects the existing `Se.Settings.Waveform.InvertMouseWheel` setting and falls back to `e.Delta.X` for trackpad horizontal scroll, same as `AudioVisualizer.OnPointerWheelChanged`.
- Ignores wheel events over the controls row (`_gridProgress`) so the volume/position sliders keep their native wheel behavior.
- Routes the new position through `NotifyPositionChanged` (which seeks the player) and raises `UserSeeked` so the waveform recenters — same path the position slider uses.

## Test plan
- [ ] macOS: scroll wheel / trackpad two-finger gesture over video surface scrubs the playhead (the platform from the issue reporter)
- [ ] Windows with mpv-OpenGL / mpv-software: wheel scrubs the playhead
- [ ] Windows with mpv-wid (native HWND backend): wheel scrubs the playhead
- [ ] Wheel over the volume slider still changes volume, not playhead
- [ ] Wheel over the position slider still moves the slider, not double-seeks
- [ ] `Waveform.InvertMouseWheel = true` inverts the scrub direction
- [ ] At t=0 wheel backward stays at 0; at t=Duration wheel forward stays clamped
- [ ] Waveform follows the new playhead position after scrubbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)