### PR TITLE
Reload cached language strings after UI language change

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -768,6 +768,9 @@ public partial class MainViewModel :
     {
         _shortcutManager.ClearShortcuts();
         Se.Settings.InitializeMainShortcuts(this);
+        // Rebuild shortcut display names so the Shortcuts window reflects the current
+        // UI language (the dictionary captured Se.Language strings at type init).
+        ShortcutsMain.ReloadCommandTranslations();
         foreach (var shortCut in ShortcutsMain.GetUsedShortcuts(this))
         {
             _shortcutManager.RegisterShortcut(shortCut);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7457,6 +7457,9 @@ public partial class MainViewModel :
 
         Se.Language = language ?? new SeLanguage();
 
+        // Rebuild settings-page dropdown labels that capture Se.Language at type init.
+        SettingsViewModel.ReloadLanguageMaps();
+
         // reload current layout
         InitMenu.Make(this);
         SetLayout(Se.Settings.General.LayoutNumber);

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -858,7 +858,9 @@ public partial class SettingsViewModel : ObservableObject
             .IsVisible;
     }
 
-    private static readonly Dictionary<string, string> _waveformSingleClickActionToTextMap = new Dictionary<string, string>
+    private static readonly Dictionary<string, string> _waveformSingleClickActionToTextMap = BuildWaveformSingleClickActionToTextMap();
+
+    private static Dictionary<string, string> BuildWaveformSingleClickActionToTextMap() => new Dictionary<string, string>
     {
         { WaveformSingleClickActionType.SetVideoPositionAndPauseAndSelectSubtitle.ToString(), Se.Language.Waveform.SetVideoPositionAndPauseAndSelectSubtitle },
         { WaveformSingleClickActionType.SetVideopositionAndPauseAndSelectSubtitleAndCenter.ToString(), Se.Language.Waveform.SetVideopositionAndPauseAndSelectSubtitleAndCenter },
@@ -881,7 +883,9 @@ public partial class SettingsViewModel : ObservableObject
             : Se.Language.Waveform.SetVideoPositionAndPauseAndSelectSubtitle;
     }
 
-    private static readonly Dictionary<string, string> _waveformDoubleClickActionToTextMap = new Dictionary<string, string>
+    private static readonly Dictionary<string, string> _waveformDoubleClickActionToTextMap = BuildWaveformDoubleClickActionToTextMap();
+
+    private static Dictionary<string, string> BuildWaveformDoubleClickActionToTextMap() => new Dictionary<string, string>
     {
         { WaveformDoubleClickActionType.None.ToString(), Se.Language.General.None },
         { WaveformDoubleClickActionType.SelectSubtitle.ToString(), Se.Language.General.SelectSubtitle },
@@ -1092,7 +1096,9 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
-    private static readonly Dictionary<string, string> _keyEnterActionToTextMap = new Dictionary<string, string>
+    private static readonly Dictionary<string, string> _keyEnterActionToTextMap = BuildKeyEnterActionToTextMap();
+
+    private static Dictionary<string, string> BuildKeyEnterActionToTextMap() => new Dictionary<string, string>
     {
         { SubtitleEnterKeyActionType.GoToSubtitleAndSetVideoPosition.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition },
         { SubtitleEnterKeyActionType.GoToNextLine.ToString(), Se.Language.Options.Settings.GridGoToNextLine },
@@ -1124,7 +1130,9 @@ public partial class SettingsViewModel : ObservableObject
             : SubtitleSingleClickActionType.None.ToString();
     }
 
-    private static readonly Dictionary<string, string> _singleClickActionToTextMap = new Dictionary<string, string>
+    private static readonly Dictionary<string, string> _singleClickActionToTextMap = BuildSingleClickActionToTextMap();
+
+    private static Dictionary<string, string> BuildSingleClickActionToTextMap() => new Dictionary<string, string>
     {
         { SubtitleSingleClickActionType.None.ToString(), Se.Language.General.None },
         { SubtitleSingleClickActionType.GoToWaveformOnlyNoVideoPosition.ToString(), Se.Language.Options.Settings.GridGoToSubtitleOnlyWaveformOnly },
@@ -1160,7 +1168,9 @@ public partial class SettingsViewModel : ObservableObject
             : SubtitleSingleClickActionType.None.ToString();
     }
 
-    private static readonly Dictionary<string, string> _actionToTextMap = new Dictionary<string, string>
+    private static readonly Dictionary<string, string> _actionToTextMap = BuildDoubleClickActionToTextMap();
+
+    private static Dictionary<string, string> BuildDoubleClickActionToTextMap() => new Dictionary<string, string>
     {
         { SubtitleDoubleClickActionType.None.ToString(), Se.Language.General.None },
         { SubtitleDoubleClickActionType.GoToSubtitleAndPause.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPause },
@@ -1168,6 +1178,26 @@ public partial class SettingsViewModel : ObservableObject
         { SubtitleDoubleClickActionType.GoToSubtitleOnly.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition },
         { SubtitleDoubleClickActionType.GoToSubtitleAndPauseAndFocusTextBox.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox },
     };
+
+    // Rebuilds the static language-dependent maps in place so callers keep their reference.
+    // Call after Se.Language has been swapped (UI language change).
+    public static void ReloadLanguageMaps()
+    {
+        Refill(_waveformSingleClickActionToTextMap, BuildWaveformSingleClickActionToTextMap());
+        Refill(_waveformDoubleClickActionToTextMap, BuildWaveformDoubleClickActionToTextMap());
+        Refill(_keyEnterActionToTextMap, BuildKeyEnterActionToTextMap());
+        Refill(_singleClickActionToTextMap, BuildSingleClickActionToTextMap());
+        Refill(_actionToTextMap, BuildDoubleClickActionToTextMap());
+    }
+
+    private static void Refill(Dictionary<string, string> target, Dictionary<string, string> source)
+    {
+        target.Clear();
+        foreach (var kv in source)
+        {
+            target[kv.Key] = kv.Value;
+        }
+    }
 
     private static Dictionary<string, string> TextToActionMap => _actionToTextMap.ToDictionary(x => x.Value, x => x.Key);
 

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -54,7 +54,24 @@ public static class ShortcutsMain
         list.Add(new AvailableShortcut(command, name, category));
     }
 
-    public static readonly Dictionary<string, string> CommandTranslationLookup = new Dictionary<string, string>
+    public static readonly Dictionary<string, string> CommandTranslationLookup = BuildCommandTranslations();
+
+    // Rebuilds CommandTranslationLookup in place so callers keep their reference to
+    // the same dictionary instance. Call after Se.Language has been swapped (e.g.,
+    // user changed UI language) so cached display names pick up the new strings.
+    public static void ReloadCommandTranslations()
+    {
+        var fresh = BuildCommandTranslations();
+        CommandTranslationLookup.Clear();
+        foreach (var kv in fresh)
+        {
+            CommandTranslationLookup[kv.Key] = kv.Value;
+        }
+    }
+
+    private static Dictionary<string, string> BuildCommandTranslations()
+    {
+        return new Dictionary<string, string>
     {
         { nameof(MainViewModel.DeleteSelectedLinesCommand), Se.Language.Options.Shortcuts.ListDeleteSelection },
         { nameof(MainViewModel.FillSelectedLinesWithClipboardCommand), Se.Language.Options.Shortcuts.FillSelectedLinesWithClipboard },
@@ -350,6 +367,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.OpenSecondarySubtitleCommand), Se.Language.Video.OpenSecondarySubtitleOnVideoPlayer },
         { nameof(MainViewModel.ToggleCurrentSubtitleWhilePlayingCommand), Se.Language.Video.ToggleCurrentSubtitleWhilePlaying },
     };
+    }
 
     private static List<AvailableShortcut> GetAllAvailableShortcuts(MainViewModel vm)
     {


### PR DESCRIPTION
## Summary
Several `private static readonly Dictionary<string, string>` fields captured `Se.Language.*` strings at type initialization. When the user switched UI language mid-session, `Se.Language` was replaced but the dictionaries still held references to the old strings — so the affected UI stayed in the previous language.

This PR covers two call sites:

### `ShortcutsMain.CommandTranslationLookup`
Backs the Shortcuts window display names. Most visible: opening Shortcuts after a language switch showed almost everything in the previous language.

### `SettingsViewModel` (5 dictionaries)
Back the dropdowns in the Settings page for:
- Waveform single-click action
- Waveform double-click action
- Subtitle Enter-key action
- Subtitle single-click action
- Subtitle double-click action

## Approach
For each dictionary: move the literal into a private `Build...()` method, then add a public `Reload...()` that calls `Clear()` and refills the existing dictionary instance (so any caller holding the reference is unaffected).

Call the reloads from:
- `MainViewModel.ReloadShortcuts()` — already runs after a language change, plus other shortcut-related triggers.
- `MainViewModel.LoadLanguage()` — for `SettingsViewModel.ReloadLanguageMaps()`, right after `Se.Language` is swapped.

## Notes for reviewer
- The `ShortcutsMain` dictionary literal body keeps its original 8-space indent inside the new method to keep the diff minimal — only the wrapper changes, the ~300 entries are byte-identical.
- Spot-checked the rest of the codebase: other places that reference `Se.Language` use computed properties (re-evaluate per access) or instance fields in dialogs that are reconstructed each open — neither pattern needs a fix.

## Test plan
- [ ] Start app in English → open Shortcuts → entries are English
- [ ] Switch UI language to Korean (or any other) → reopen Shortcuts → entries are in the new language
- [ ] Switch back to English → reopen Shortcuts → entries are English again
- [ ] After language switch, reopen Settings → waveform click-action dropdowns show new language
- [ ] After language switch, reopen Settings → subtitle click-action and Enter-key dropdowns show new language
- [ ] Shortcut key bindings still work after language switch
- [ ] Surround-with shortcuts still show the correct prefix/suffix after both a language change and a prefix change in the Shortcuts dialog
- [ ] UI tests still pass (verified: 240/240)

🤖 Generated with [Claude Code](https://claude.com/claude-code)