### PR TITLE
docs: refresh Crisp ASR install path, backend roster, and TTS engine list

### DIFF
--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -39,7 +39,7 @@ Subtitle Edit stores these components in its **Data Folder**.
 | **Parakeet.cpp** | `parakeet.exe`, model folders | `[Data Folder]/parakeet.cpp` |
 | **PaddleOCR** | `paddleocr.exe`, `models/` folder | `[Data Folder]/OCR/PaddleOCR3-1` |
 | **Qwen3 TTS (CrispASR)** | shares `crispasr.exe` from `[Data Folder]/CrispASR`; `models/`, `voices/` | `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr` |
-| **Chatterbox TTS (CrispASR)** | shares `crispasr.exe` from `[Data Folder]/CrispASR`; `models/`, `voices/` | `[Data Folder]/TextToSpeech/Chatterbox` |
+| **Chatterbox TTS (CrispASR)** | shares `crispasr.exe` + `models/` from `[Data Folder]/CrispASR`; reference voices in `voices/` | `[Data Folder]/TextToSpeech/Chatterbox` (voices only) |
 | **OmniVoice TTS** | `omnivoice-tts.exe`, `omnivoice-codec.exe`, `models/`, `voices/` | `[Data Folder]/TextToSpeech/OmniVoice` |
 | **Kokoro TTS** | `kokoro-tts-server.exe`, `models/` | `[Data Folder]/TextToSpeech/KokoroTtsCpp` |
 
@@ -124,7 +124,7 @@ Used for OCR of image-based subtitles.
 Subtitle Edit 5 can download local TTS servers and models from the **Text to speech** window.
 
 *   **Qwen3 TTS (CrispASR):** Stored in `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr`. Runs through the shared CrispASR runtime (`[Data Folder]/CrispASR/crispasr.exe`) rather than a dedicated server, so installing Crisp ASR first is recommended. Models (VoiceDesign 1.7B or CustomVoice 1.7B) go into the `models` folder; reference voices go into the `voices` folder.
-*   **Chatterbox TTS (CrispASR):** Stored in `[Data Folder]/TextToSpeech/Chatterbox`. Also runs through the shared CrispASR runtime. Base or Turbo model plus voice-cloning samples; `models/` and `voices/` subfolders.
+*   **Chatterbox TTS (CrispASR):** Reference voices are stored in `[Data Folder]/TextToSpeech/Chatterbox/voices`. The Base / Turbo model GGUFs (T3 + S3Gen) are downloaded into the shared `[Data Folder]/CrispASR/models` cache alongside the Crisp ASR speech-to-text models, not under `TextToSpeech/Chatterbox/models` — installing Crisp ASR first is therefore recommended. Older installs that still have model files under the legacy `TextToSpeech/Chatterbox/models` folder are migrated automatically on first launch.
 *   **OmniVoice TTS:** Stored in `[Data Folder]/TextToSpeech/OmniVoice`. Brings its own `omnivoice-tts` and `omnivoice-codec` binaries. Supports 646 languages and voice cloning on CPU. `models/` and `voices/` subfolders.
 *   **Kokoro TTS:** Stored in `[Data Folder]/TextToSpeech/KokoroTtsCpp`. Models go into the `models` folder.
 

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -34,11 +34,13 @@ Subtitle Edit stores these components in its **Data Folder**.
 | **Tesseract** | `tesseract.exe`, `tessdata/` folder | `[Data Folder]/Tesseract550` |
 | **Whisper CPP** | `whisper-cli.exe`, `Models/` folder | `[Data Folder]/SpeechToText/Cpp` |
 | **Purfview Faster-Whisper XXL** | `faster-whisper-xxl.exe`, `_models/` folder | `[Data Folder]/SpeechToText/Purfview-Faster-Whisper-XXL` |
-| **Crisp ASR** | `crispasr.exe`, `models/` folder | `[Data Folder]/SpeechToText/CrispASR` |
+| **Crisp ASR** | `crispasr.exe`, `models/` folder | `[Data Folder]/CrispASR` |
 | **Qwen3 ASR CPP** | `qwen3-asr-cli.exe`, `models/` folder | `[Data Folder]/Qwen3ASR` |
 | **Parakeet.cpp** | `parakeet.exe`, model folders | `[Data Folder]/parakeet.cpp` |
 | **PaddleOCR** | `paddleocr.exe`, `models/` folder | `[Data Folder]/OCR/PaddleOCR3-1` |
-| **Qwen3 TTS** | `qwen3-tts-server.exe`, `models/`, `voices/` | `[Data Folder]/TextToSpeech/Qwen3TtsCpp` |
+| **Qwen3 TTS (CrispASR)** | shares `crispasr.exe` from `[Data Folder]/CrispASR`; `models/`, `voices/` | `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr` |
+| **Chatterbox TTS (CrispASR)** | shares `crispasr.exe` from `[Data Folder]/CrispASR`; `models/`, `voices/` | `[Data Folder]/TextToSpeech/Chatterbox` |
+| **OmniVoice TTS** | `omnivoice-tts.exe`, `omnivoice-codec.exe`, `models/`, `voices/` | `[Data Folder]/TextToSpeech/OmniVoice` |
 | **Kokoro TTS** | `kokoro-tts-server.exe`, `models/` | `[Data Folder]/TextToSpeech/KokoroTtsCpp` |
 
 ---
@@ -105,7 +107,7 @@ Used for GPU-accelerated AI-based speech recognition.
 ### SE5 Speech-to-Text Engines
 Subtitle Edit 5 can download additional ASR engines directly from the **Speech to text** window.
 
-*   **Crisp ASR:** Stored in `[Data Folder]/SpeechToText/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, and Kyutai.
+*   **Crisp ASR:** Stored in `[Data Folder]/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, and Kyutai.
 *   **Qwen3 ASR CPP:** Stored in `[Data Folder]/Qwen3ASR`. Models go into `[Data Folder]/Qwen3ASR/models`.
 *   **Parakeet.cpp:** Stored in `[Data Folder]/parakeet.cpp`. Each model has its own folder because the model weights and `vocab.txt` must stay together.
 
@@ -121,7 +123,9 @@ Used for OCR of image-based subtitles.
 ### Local Text-to-Speech Engines
 Subtitle Edit 5 can download local TTS servers and models from the **Text to speech** window.
 
-*   **Qwen3 TTS:** Stored in `[Data Folder]/TextToSpeech/Qwen3TtsCpp`. Models go into the `models` folder; imported reference voices go into the `voices` folder.
+*   **Qwen3 TTS (CrispASR):** Stored in `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr`. Runs through the shared CrispASR runtime (`[Data Folder]/CrispASR/crispasr.exe`) rather than a dedicated server, so installing Crisp ASR first is recommended. Models (VoiceDesign 1.7B or CustomVoice 1.7B) go into the `models` folder; reference voices go into the `voices` folder.
+*   **Chatterbox TTS (CrispASR):** Stored in `[Data Folder]/TextToSpeech/Chatterbox`. Also runs through the shared CrispASR runtime. Base or Turbo model plus voice-cloning samples; `models/` and `voices/` subfolders.
+*   **OmniVoice TTS:** Stored in `[Data Folder]/TextToSpeech/OmniVoice`. Brings its own `omnivoice-tts` and `omnivoice-codec` binaries. Supports 646 languages and voice cloning on CPU. `models/` and `voices/` subfolders.
 *   **Kokoro TTS:** Stored in `[Data Folder]/TextToSpeech/KokoroTtsCpp`. Models go into the `models` folder.
 
 Use [Text to Speech](features/text-to-speech.md) for engine-specific options.
@@ -181,7 +185,7 @@ Used for GPU-accelerated AI-based speech recognition.
 
 ### SE5 Speech-to-Text, OCR, and TTS Engines
 
-The same data-folder layout is used on Linux. Prefer the in-app downloaders for Crisp ASR, Qwen3 ASR, Parakeet.cpp, PaddleOCR, Qwen3 TTS, and Kokoro TTS because the required files differ by build and model.
+The same data-folder layout is used on Linux. Prefer the in-app downloaders for Crisp ASR, Qwen3 ASR, Parakeet.cpp, PaddleOCR, Qwen3 TTS (CrispASR), Chatterbox TTS (CrispASR), OmniVoice TTS, and Kokoro TTS because the required files differ by build and model.
 
 ---
 

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -105,7 +105,7 @@ Used for GPU-accelerated AI-based speech recognition.
 ### SE5 Speech-to-Text Engines
 Subtitle Edit 5 can download additional ASR engines directly from the **Speech to text** window.
 
-*   **Crisp ASR:** Stored in `[Data Folder]/SpeechToText/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, and Omni.
+*   **Crisp ASR:** Stored in `[Data Folder]/SpeechToText/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, and Kyutai.
 *   **Qwen3 ASR CPP:** Stored in `[Data Folder]/Qwen3ASR`. Models go into `[Data Folder]/Qwen3ASR/models`.
 *   **Parakeet.cpp:** Stored in `[Data Folder]/parakeet.cpp`. Each model has its own folder because the model weights and `vocab.txt` must stay together.
 


### PR DESCRIPTION
## Summary

Audit pass over `docs/third-party-components.md` against the current code in `Se.cs` and the engine classes. Three corrections:

### 1. Wrong Crisp ASR install path
The doc listed `[Data Folder]/SpeechToText/CrispASR` (table row + narrative), but `Se.CrispAsrFolder` is `Path.Combine(DataFolder, \"CrispASR\")` — i.e., `[Data Folder]/CrispASR` with no `SpeechToText/` prefix. Both occurrences fixed.

### 2. Missing Crisp ASR backends
The narrative enumerated Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, and Omni — but **Kyutai** (pre-existing) and **Mega** (added in #11127) were missing. Both added.

### 3. TTS engine list out of date
- Removed the **Qwen3 TTS** (Qwen3TtsCpp) entry. The engine class is still in the codebase, but per its sibling `Qwen3TtsCrispAsr.cs` docstring the CrispASR-runtime variant emits EOS reliably on short prompts where qwen3-tts.cpp 0.6B doesn't, so the CrispASR variant is the user-facing recommendation.
- Added three engines that ship but weren't listed:
  - **Qwen3 TTS (CrispASR)** — `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr`, shares the `crispasr` runtime
  - **Chatterbox TTS (CrispASR)** — `[Data Folder]/TextToSpeech/Chatterbox`, shares the `crispasr` runtime
  - **OmniVoice TTS** — `[Data Folder]/TextToSpeech/OmniVoice`, ships its own `omnivoice-tts` / `omnivoice-codec` binaries
- Updated the Linux engine-list paragraph to match the new TTS roster.

## Test plan
- [x] Sanity grep: no `SpeechToText/CrispASR` or `Qwen3TtsCpp` references remain.
- [ ] Render preview to double-check the table formatting (markdown table changes are easy to break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)