### PR TITLE
Expose CrispASR wav2vec2 forced-aligner zoo (WhisperX style)

### DIFF
--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -107,7 +107,9 @@ Used for GPU-accelerated AI-based speech recognition.
 ### SE5 Speech-to-Text Engines
 Subtitle Edit 5 can download additional ASR engines directly from the **Speech to text** window.
 
-*   **Crisp ASR:** Stored in `[Data Folder]/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, and Kyutai. For word-level timestamps the speech-to-text dialog also offers a **Forced aligner** combo with Canary CTC, Qwen3, and 12 language-specific wav2vec2 aligners (the WhisperX aligner zoo: en, de, fr, es, it, ja, zh, nl, pt, ar, uk, cs). The wav2vec2 aligner matching the selected ASR language is suggested automatically when the current aligner is the built-in one.
+*   **Crisp ASR:** Stored in `[Data Folder]/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, and Kyutai.
+    *   The speech-to-text dialog also offers a **Forced aligner** combo for word-level timestamps. Built-in (where the backend supports it), Canary CTC, Qwen3, and 12 language-specific wav2vec2 aligners (the WhisperX aligner zoo): `en`, `de`, `fr`, `es`, `it`, `ja`, `zh`, `nl`, `pt`, `ar`, `uk`, `cs`.
+    *   When you pick an ASR language and haven't explicitly chosen an aligner, the wav2vec2 aligner matching that language is suggested automatically. Explicit picks — including the built-in aligner — are preserved across language changes.
 *   **Qwen3 ASR CPP:** Stored in `[Data Folder]/Qwen3ASR`. Models go into `[Data Folder]/Qwen3ASR/models`.
 *   **Parakeet.cpp:** Stored in `[Data Folder]/parakeet.cpp`. Each model has its own folder because the model weights and `vocab.txt` must stay together.
 

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -107,7 +107,7 @@ Used for GPU-accelerated AI-based speech recognition.
 ### SE5 Speech-to-Text Engines
 Subtitle Edit 5 can download additional ASR engines directly from the **Speech to text** window.
 
-*   **Crisp ASR:** Stored in `[Data Folder]/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, and Kyutai.
+*   **Crisp ASR:** Stored in `[Data Folder]/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, and Kyutai. For word-level timestamps the speech-to-text dialog also offers a **Forced aligner** combo with Canary CTC, Qwen3, and 12 language-specific wav2vec2 aligners (the WhisperX aligner zoo: en, de, fr, es, it, ja, zh, nl, pt, ar, uk, cs). The wav2vec2 aligner matching the selected ASR language is suggested automatically when the current aligner is the built-in one.
 *   **Qwen3 ASR CPP:** Stored in `[Data Folder]/Qwen3ASR`. Models go into `[Data Folder]/Qwen3ASR/models`.
 *   **Parakeet.cpp:** Stored in `[Data Folder]/parakeet.cpp`. Each model has its own folder because the model weights and `vocab.txt` must stay together.
 

--- a/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
@@ -131,9 +131,20 @@ public class ForcedAlignerOption
     private static string? ExtractLanguageCode(string choice)
     {
         const string prefix = "wav2vec2-aligner-";
-        return choice != null && choice.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-            ? choice.Substring(prefix.Length).ToLowerInvariant()
-            : null;
+        if (choice == null || !choice.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        // Same zh-cn → zh / zh-tw → zh collapse as Wav2Vec2ChoiceForLanguage,
+        // so e.g. a manually-edited "wav2vec2-aligner-zh-cn" still resolves to
+        // the Chinese aligner instead of falling through to BuiltIn.
+        var code = choice.Substring(prefix.Length).ToLowerInvariant();
+        if (code.StartsWith("zh", StringComparison.Ordinal))
+        {
+            code = "zh";
+        }
+        return code;
     }
 
     private readonly record struct Wav2Vec2Meta(string Choice, string Display, string FileName, string Url, string Size);

--- a/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
@@ -10,6 +10,22 @@ public class ForcedAlignerOption
     public const string CanaryCtcChoice = "canary-ctc";
     public const string Qwen3Choice = "qwen3-forced";
 
+    // wav2vec2 forced aligner choices. The choice string mirrors CrispASR's
+    // `-am wav2vec2-aligner-<code>` alias so the persisted setting is self-
+    // documenting and lines up with upstream docs.
+    public const string Wav2Vec2EnChoice = "wav2vec2-aligner-en";
+    public const string Wav2Vec2DeChoice = "wav2vec2-aligner-de";
+    public const string Wav2Vec2FrChoice = "wav2vec2-aligner-fr";
+    public const string Wav2Vec2EsChoice = "wav2vec2-aligner-es";
+    public const string Wav2Vec2ItChoice = "wav2vec2-aligner-it";
+    public const string Wav2Vec2JaChoice = "wav2vec2-aligner-ja";
+    public const string Wav2Vec2ZhChoice = "wav2vec2-aligner-zh";
+    public const string Wav2Vec2NlChoice = "wav2vec2-aligner-nl";
+    public const string Wav2Vec2PtChoice = "wav2vec2-aligner-pt";
+    public const string Wav2Vec2ArChoice = "wav2vec2-aligner-ar";
+    public const string Wav2Vec2UkChoice = "wav2vec2-aligner-uk";
+    public const string Wav2Vec2CsChoice = "wav2vec2-aligner-cs";
+
     public string BaseDisplay { get; }
     public string Display { get; set; }
     public string Choice { get; }
@@ -55,15 +71,156 @@ public class ForcedAlignerOption
             "https://huggingface.co/cstr/qwen3-forced-aligner-0.6b-GGUF/resolve/main/qwen3-forced-aligner-0.6b-q8_0.gguf",
             "986 MB");
 
-    public static IReadOnlyList<ForcedAlignerOption> All() => new[]
+    /// <summary>
+    /// 12 language-specific wav2vec2 CTC forced aligners shipped by CrispASR
+    /// ("WhisperX aligner zoo"). Same Q4_K-quantized GGUFs that WhisperX itself
+    /// uses for word-level alignment, hosted on cstr's HuggingFace namespace.
+    /// Works on top of any Crisp ASR backend via `-am &lt;path&gt;`.
+    /// </summary>
+    public static IReadOnlyList<ForcedAlignerOption> Wav2Vec2All() => new[]
     {
-        BuiltIn(),
-        CanaryCtc(),
-        Qwen3(),
+        Wav2Vec2(Wav2Vec2EnChoice),
+        Wav2Vec2(Wav2Vec2DeChoice),
+        Wav2Vec2(Wav2Vec2FrChoice),
+        Wav2Vec2(Wav2Vec2EsChoice),
+        Wav2Vec2(Wav2Vec2ItChoice),
+        Wav2Vec2(Wav2Vec2JaChoice),
+        Wav2Vec2(Wav2Vec2ZhChoice),
+        Wav2Vec2(Wav2Vec2NlChoice),
+        Wav2Vec2(Wav2Vec2PtChoice),
+        Wav2Vec2(Wav2Vec2ArChoice),
+        Wav2Vec2(Wav2Vec2UkChoice),
+        Wav2Vec2(Wav2Vec2CsChoice),
     };
+
+    /// <summary>
+    /// Returns the wav2vec2 aligner choice for the given ISO-639-1 language
+    /// code (e.g. "ja"), or null when no aligner is available for that
+    /// language. Used by the speech-to-text UI to auto-suggest a matching
+    /// aligner when the user picks an ASR language.
+    /// </summary>
+    public static string? Wav2Vec2ChoiceForLanguage(string? languageCode)
+    {
+        if (string.IsNullOrEmpty(languageCode))
+        {
+            return null;
+        }
+
+        // Normalise common variants. Upstream zh-cn maps to plain "zh".
+        var code = languageCode.ToLowerInvariant();
+        if (code.StartsWith("zh", StringComparison.Ordinal))
+        {
+            code = "zh";
+        }
+
+        return Wav2Vec2MetaByCode.TryGetValue(code, out var meta) ? meta.Choice : null;
+    }
+
+    public static ForcedAlignerOption Wav2Vec2(string choice)
+    {
+        var code = ExtractLanguageCode(choice);
+        if (code != null && Wav2Vec2MetaByCode.TryGetValue(code, out var meta))
+        {
+            return new ForcedAlignerOption(meta.Display, meta.Choice, meta.FileName, meta.Url, meta.Size);
+        }
+
+        // Defensive fallback. Should not happen for any constant we ship.
+        return BuiltIn();
+    }
+
+    private static string? ExtractLanguageCode(string choice)
+    {
+        const string prefix = "wav2vec2-aligner-";
+        return choice != null && choice.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? choice.Substring(prefix.Length).ToLowerInvariant()
+            : null;
+    }
+
+    private readonly record struct Wav2Vec2Meta(string Choice, string Display, string FileName, string Url, string Size);
+
+    private const string HfBase = "https://huggingface.co/cstr/";
+
+    // The 12 aliases registered by crispasr_model_registry.cpp. All Q4_K-
+    // quantized; sizes from upstream registry. The display strings use the
+    // English language name so the combo box is readable regardless of UI
+    // language; the wav2vec2 prefix disambiguates from Canary/Qwen3.
+    private static readonly IReadOnlyDictionary<string, Wav2Vec2Meta> Wav2Vec2MetaByCode =
+        new Dictionary<string, Wav2Vec2Meta>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["en"] = new(Wav2Vec2EnChoice, "wav2vec2 aligner (English)",
+                "wav2vec2-xlsr-en-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-english-GGUF/resolve/main/wav2vec2-xlsr-en-q4_k.gguf",
+                "~212 MB"),
+            ["de"] = new(Wav2Vec2DeChoice, "wav2vec2 aligner (German)",
+                "wav2vec2-large-xlsr-53-german-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-german-GGUF/resolve/main/wav2vec2-large-xlsr-53-german-q4_k.gguf",
+                "~300 MB"),
+            ["fr"] = new(Wav2Vec2FrChoice, "wav2vec2 aligner (French)",
+                "wav2vec2-large-xlsr-53-french-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-french-GGUF/resolve/main/wav2vec2-large-xlsr-53-french-q4_k.gguf",
+                "~300 MB"),
+            ["es"] = new(Wav2Vec2EsChoice, "wav2vec2 aligner (Spanish)",
+                "wav2vec2-large-xlsr-53-spanish-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-spanish-GGUF/resolve/main/wav2vec2-large-xlsr-53-spanish-q4_k.gguf",
+                "~300 MB"),
+            ["it"] = new(Wav2Vec2ItChoice, "wav2vec2 aligner (Italian)",
+                "wav2vec2-large-xlsr-53-italian-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-italian-GGUF/resolve/main/wav2vec2-large-xlsr-53-italian-q4_k.gguf",
+                "~300 MB"),
+            ["ja"] = new(Wav2Vec2JaChoice, "wav2vec2 aligner (Japanese)",
+                "wav2vec2-large-xlsr-53-japanese-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-japanese-GGUF/resolve/main/wav2vec2-large-xlsr-53-japanese-q4_k.gguf",
+                "~300 MB"),
+            ["zh"] = new(Wav2Vec2ZhChoice, "wav2vec2 aligner (Chinese)",
+                "wav2vec2-large-xlsr-53-chinese-zh-cn-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-chinese-zh-cn-GGUF/resolve/main/wav2vec2-large-xlsr-53-chinese-zh-cn-q4_k.gguf",
+                "~300 MB"),
+            ["nl"] = new(Wav2Vec2NlChoice, "wav2vec2 aligner (Dutch)",
+                "wav2vec2-large-xlsr-53-dutch-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-dutch-GGUF/resolve/main/wav2vec2-large-xlsr-53-dutch-q4_k.gguf",
+                "~300 MB"),
+            ["pt"] = new(Wav2Vec2PtChoice, "wav2vec2 aligner (Portuguese)",
+                "wav2vec2-large-xlsr-53-portuguese-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-portuguese-GGUF/resolve/main/wav2vec2-large-xlsr-53-portuguese-q4_k.gguf",
+                "~300 MB"),
+            ["ar"] = new(Wav2Vec2ArChoice, "wav2vec2 aligner (Arabic)",
+                "wav2vec2-large-xlsr-53-arabic-q4_k.gguf",
+                HfBase + "wav2vec2-large-xlsr-53-arabic-GGUF/resolve/main/wav2vec2-large-xlsr-53-arabic-q4_k.gguf",
+                "~300 MB"),
+            ["uk"] = new(Wav2Vec2UkChoice, "wav2vec2 aligner (Ukrainian)",
+                "wav2vec2-xls-r-300m-uk-with-small-lm-q4_k.gguf",
+                HfBase + "wav2vec2-xls-r-300m-uk-with-small-lm-GGUF/resolve/main/wav2vec2-xls-r-300m-uk-with-small-lm-q4_k.gguf",
+                "~300 MB"),
+            ["cs"] = new(Wav2Vec2CsChoice, "wav2vec2 aligner (Czech)",
+                "wav2vec2-xls-r-300m-cs-250-q4_k.gguf",
+                HfBase + "wav2vec2-xls-r-300m-cs-250-GGUF/resolve/main/wav2vec2-xls-r-300m-cs-250-q4_k.gguf",
+                "~300 MB"),
+        };
+
+    public static IReadOnlyList<ForcedAlignerOption> All()
+    {
+        var list = new List<ForcedAlignerOption>
+        {
+            BuiltIn(),
+            CanaryCtc(),
+            Qwen3(),
+        };
+        list.AddRange(Wav2Vec2All());
+        return list;
+    }
 
     public static ForcedAlignerOption FromChoice(string? choice)
     {
+        if (string.IsNullOrEmpty(choice))
+        {
+            return BuiltIn();
+        }
+
+        if (choice.StartsWith("wav2vec2-aligner", StringComparison.OrdinalIgnoreCase))
+        {
+            return Wav2Vec2(choice);
+        }
+
         return choice switch
         {
             CanaryCtcChoice => CanaryCtc(),

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -354,6 +354,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
         newOptions.Add(ForcedAlignerOption.CanaryCtc());
         newOptions.Add(ForcedAlignerOption.Qwen3());
+        // wav2vec2 "WhisperX aligner zoo" — 12 language-specific CTC aligners
+        // that work on top of any Crisp ASR backend via `-am <path>`.
+        newOptions.AddRange(ForcedAlignerOption.Wav2Vec2All());
 
         foreach (var opt in newOptions)
         {
@@ -381,6 +384,47 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             SelectedForcedAligner = match;
         }
+
+        // After resetting the default, try to upgrade BuiltIn → matching
+        // wav2vec2 aligner when the selected ASR language has one.
+        AutoSuggestWav2Vec2Aligner(SelectedLanguage);
+    }
+
+    /// <summary>
+    /// When the user picks an ASR language and the current forced aligner is
+    /// the built-in one (i.e. no explicit user pick yet), switch to the
+    /// matching wav2vec2 aligner if CrispASR ships one for that language.
+    /// No-op for explicit non-builtin picks so a deliberate Canary/Qwen3
+    /// choice survives a language change.
+    /// </summary>
+    private void AutoSuggestWav2Vec2Aligner(WhisperLanguage? language)
+    {
+        if (language == null)
+        {
+            return;
+        }
+
+        if (SelectedForcedAligner != null && !SelectedForcedAligner.IsBuiltIn)
+        {
+            return;
+        }
+
+        var choice = ForcedAlignerOption.Wav2Vec2ChoiceForLanguage(language.Code);
+        if (choice == null)
+        {
+            return;
+        }
+
+        var match = ForcedAligners.FirstOrDefault(p => p.Choice == choice);
+        if (match != null && !ReferenceEquals(SelectedForcedAligner, match))
+        {
+            SelectedForcedAligner = match;
+        }
+    }
+
+    partial void OnSelectedLanguageChanged(WhisperLanguage? value)
+    {
+        AutoSuggestWav2Vec2Aligner(value);
     }
 
     private static string BuildAlignerDisplay(ForcedAlignerOption option, ICrispAsrEngine? crispEngine)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -382,24 +382,69 @@ public partial class SpeechToTextViewModel : ObservableObject
                     ?? ForcedAligners.FirstOrDefault();
         if (!ReferenceEquals(SelectedForcedAligner, match))
         {
-            SelectedForcedAligner = match;
+            SetForcedAlignerProgrammatically(match);
         }
+
+        // Engine change resets the "did the user pick this?" tracker so the
+        // language-driven auto-suggest below is allowed to fire even though
+        // we just programmatically wrote SelectedForcedAligner.
+        _userExplicitlySetForcedAligner = false;
 
         // After resetting the default, try to upgrade BuiltIn → matching
         // wav2vec2 aligner when the selected ASR language has one.
         AutoSuggestWav2Vec2Aligner(SelectedLanguage);
     }
 
+    // Flips true the moment the user picks something from the Forced aligner
+    // combo, and resets false on engine change (UpdateForcedAlignerUi). Lets
+    // AutoSuggestWav2Vec2Aligner skip override when the user has made any
+    // deliberate choice — including explicitly picking the built-in aligner
+    // to avoid the wav2vec2 download.
+    private bool _userExplicitlySetForcedAligner;
+
+    // Set while we write SelectedForcedAligner from inside the view-model so
+    // the partial-method change handler can distinguish programmatic writes
+    // from genuine user picks. Same pattern as _isUpdating*Backend above.
+    private bool _isUpdatingForcedAlignerProgrammatically;
+
+    private void SetForcedAlignerProgrammatically(ForcedAlignerOption? value)
+    {
+        _isUpdatingForcedAlignerProgrammatically = true;
+        try
+        {
+            SelectedForcedAligner = value;
+        }
+        finally
+        {
+            _isUpdatingForcedAlignerProgrammatically = false;
+        }
+    }
+
+    partial void OnSelectedForcedAlignerChanged(ForcedAlignerOption? value)
+    {
+        if (_isUpdatingForcedAlignerProgrammatically)
+        {
+            return;
+        }
+        _userExplicitlySetForcedAligner = true;
+    }
+
     /// <summary>
-    /// When the user picks an ASR language and the current forced aligner is
-    /// the built-in one (i.e. no explicit user pick yet), switch to the
-    /// matching wav2vec2 aligner if CrispASR ships one for that language.
-    /// No-op for explicit non-builtin picks so a deliberate Canary/Qwen3
-    /// choice survives a language change.
+    /// When the user picks an ASR language and they haven't explicitly chosen
+    /// a forced aligner yet (i.e. it's still the engine-derived default),
+    /// switch to the matching wav2vec2 aligner if CrispASR ships one for that
+    /// language. Any explicit user pick — Canary, Qwen3, a wav2vec2 entry, or
+    /// even the built-in aligner picked deliberately to avoid a large
+    /// download — is preserved across language changes.
     /// </summary>
     private void AutoSuggestWav2Vec2Aligner(WhisperLanguage? language)
     {
         if (language == null)
+        {
+            return;
+        }
+
+        if (_userExplicitlySetForcedAligner)
         {
             return;
         }
@@ -418,7 +463,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         var match = ForcedAligners.FirstOrDefault(p => p.Choice == choice);
         if (match != null && !ReferenceEquals(SelectedForcedAligner, match))
         {
-            SelectedForcedAligner = match;
+            SetForcedAlignerProgrammatically(match);
         }
     }
 


### PR DESCRIPTION
## Summary

CrispASR doesn't have a `whisperx` backend, but it ships the two value-adds that make people reach for WhisperX as composable features: forced alignment for word-level timestamps and speaker diarization. This PR exposes the first one — the **12 language-specific wav2vec2 CTC forced aligners** (CrispASR calls this *"the WhisperX aligner zoo"*) — in SE's existing **Forced aligner** combo on the Speech-to-text dialog.

These are the same Q4_K-quantized GGUFs WhisperX itself uses for word alignment, hosted on `cstr`'s HuggingFace namespace, ~212–300 MB each. They work on top of *any* Crisp ASR backend (Whisper, Parakeet, Canary, Cohere, Qwen3, Mega, etc.) via `-am <path>` — the same plumbing SE already uses for the existing Canary CTC and Qwen3 forced aligners.

## What changes

### `ForcedAlignerOption.cs`
- 12 new constants (`Wav2Vec2EnChoice` … `Wav2Vec2CsChoice`). Choice strings mirror CrispASR's `-am wav2vec2-aligner-<code>` aliases, so the persisted `Se.Settings.Tools.AudioToText.CrispAsrForcedAligner` setting is self-documenting and lines up with upstream docs.
- One internal metadata dict keyed by ISO code (`en`, `de`, `fr`, `es`, `it`, `ja`, `zh`, `nl`, `pt`, `ar`, `uk`, `cs`) holding display name, GGUF filename, full HF URL, and size.
- `Wav2Vec2All()` returns all 12 as `ForcedAlignerOption` instances; `Wav2Vec2ChoiceForLanguage("ja")` returns the matching choice or `null`. Normalises `zh-cn` → `zh`.
- `All()` and `FromChoice()` extended; existing serialised settings unaffected.

### `SpeechToTextViewModel.cs`
- `UpdateForcedAlignerUi` now appends all 12 wav2vec2 options whenever the Forced aligner combo is rebuilt for a Crisp ASR engine.
- New `partial void OnSelectedLanguageChanged(WhisperLanguage? value)` handler + `AutoSuggestWav2Vec2Aligner` helper: when the user picks an ASR language and the current aligner is built-in, switch to the matching wav2vec2 aligner if one exists. Explicit non-builtin picks (Canary, Qwen3, any wav2vec2) are never clobbered.
- `UpdateForcedAlignerUi` also calls the auto-suggest helper after applying its engine-derived default, so engine switches respect the language pick too.

### `docs/third-party-components.md`
One-sentence addition under the Crisp ASR bullet describing the aligner combo + auto-suggest.

## What deliberately did NOT change

- **No `DownloadHashManager` entries**: matches Canary CTC / Qwen3 precedent (neither has hash entries today). Adding 12 hashes would mean a ~3.6 GB local download — happy to do in a follow-up PR if hash verification becomes a policy.
- **No new download service**: each `ForcedAlignerOption` flows through `SpeechToTextViewModel.Transcribe()`'s existing *explicit-aligner-download* path. No new download infrastructure.
- **No filename mapping for unsupported languages**: e.g. picking `ko` (Korean) leaves the aligner at whatever it was (built-in or explicit). Predictable.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` — succeeds, 0 warnings / 0 errors
- [x] `dotnet test --filter CrispAsrEngineTests` — 5/5 pass
- [x] All 12 GGUF URLs verified live with `curl -sI -L` (HTTP 200)
- [ ] Manual: open Speech-to-text → pick Crisp ASR → forced-aligner combo lists 12 wav2vec2 entries
- [ ] Manual: pick ASR language "Japanese" with default (built-in) aligner → combo switches to "wav2vec2 aligner (Japanese)"
- [ ] Manual: pick "Canary CTC aligner" then switch language to Japanese → aligner stays on Canary CTC (no clobber)
- [ ] Manual: pick wav2vec2 aligner → download prompt → file lands in `[Data Folder]/CrispASR/models` → transcription runs with `-am <path>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)