### PR TITLE
Fix freeze toggling Show stop button in Settings (#10815)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -165,6 +165,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6887,6 +6888,29 @@ public partial class MainViewModel :
         {
             var firstSelectedIndex = SubtitleGrid.SelectedIndex;
 
+            // Apply video-player visibility toggles directly on the existing
+            // VideoPlayerControl. StopIsVisible / FullScreenIsVisible are plain
+            // Avalonia styled properties, so writing to them updates the button
+            // bar in place — no new control, no new native HWND, no layout
+            // rebuild. The full ApplySettings path below only runs when
+            // *other* settings changed, which is what avoided #10815 in beta 26
+            // via the Dispatcher.Post defer but apparently still races the
+            // modal teardown on some Windows configurations (re-reported in
+            // beta 30, comment 4526345049 on the issue). Removing the trigger
+            // entirely for these toggles is more robust than tightening the
+            // defer priority.
+            var vp = GetVideoPlayerControl();
+            if (vp != null)
+            {
+                vp.StopIsVisible = Se.Settings.Video.ShowStopButton;
+                vp.FullScreenIsVisible = Se.Settings.Video.ShowFullscreenButton;
+            }
+
+            if (OnlyVideoPlayerVisibilityFlagsChanged(oldSettngsSerialized, newSettingsSerialized))
+            {
+                return;
+            }
+
             // Defer to a fresh dispatcher cycle: ApplySettings rebuilds the layout, which
             // destroys and recreates the video player control (a native Win32 HWND on Windows
             // with mpv-wid/VLC). Doing that inside the ShowDialog continuation races the modal
@@ -6896,6 +6920,54 @@ public partial class MainViewModel :
                 ApplySettings();
                 SelectAndScrollToRow(firstSelectedIndex);
             });
+        }
+    }
+
+    /// <summary>
+    /// True iff the two serialized <see cref="Se.Settings"/> snapshots differ
+    /// only in <c>Video.ShowStopButton</c> and/or <c>Video.ShowFullscreenButton</c>.
+    /// Callers use this to skip the heavyweight <see cref="ApplySettings"/>
+    /// path (which rebuilds the entire layout and recreates the video player's
+    /// native HWND) when the only changes are visibility flags that can be
+    /// applied in place on the existing <see cref="VideoPlayerControl"/>.
+    /// Conservative on parse failure: returns false so the caller still
+    /// performs the full rebuild.
+    /// </summary>
+    private static bool OnlyVideoPlayerVisibilityFlagsChanged(string oldJson, string newJson)
+    {
+        try
+        {
+            var oldNode = JsonNode.Parse(oldJson);
+            var newNode = JsonNode.Parse(newJson);
+            if (oldNode is null || newNode is null)
+            {
+                return false;
+            }
+
+            // Mask both flag fields to the same canonical value in both trees.
+            // If the trees are equal after masking, those flags were the only
+            // differences. The fields may legitimately be absent from a JSON
+            // snapshot (older settings file), in which case the masking is a
+            // no-op and the comparison is still correct.
+            MaskVideoVisibilityFlags(oldNode);
+            MaskVideoVisibilityFlags(newNode);
+
+            return string.Equals(oldNode.ToJsonString(), newNode.ToJsonString(), StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void MaskVideoVisibilityFlags(JsonNode root)
+    {
+        if (root is JsonObject rootObj
+            && rootObj.TryGetPropertyValue("Video", out var videoNode)
+            && videoNode is JsonObject videoObj)
+        {
+            videoObj["ShowStopButton"] = false;
+            videoObj["ShowFullscreenButton"] = false;
         }
     }
 


### PR DESCRIPTION
## Summary

bichitoxxx reports on [issue #10815 (comment)](https://github.com/SubtitleEdit/subtitleedit/issues/10815#issuecomment-4526345049) that the "Show stop button" video-player toggle still freezes the main window on **beta 30** when the user clicks OK on Settings:

> *"I am having the same problem with version beta 30, as soon as you click Ok after applying the changes it freezes, however if after applying the changes you just close from X it does not freeze."*

The original fix from #10863 — deferring `ApplySettings` to a fresh dispatcher cycle (`MainViewModel.cs:6890-6898`) — fixed it for beta 26 but isn't enough on all Windows configurations.

## Root cause

`ApplySettings` unconditionally calls `SetLayout` → `InitLayout.MakeLayout` → constructs a fresh `VideoPlayerControl` with a fresh native HWND (mpv-wid / VLC), even when the only setting that changed is `Se.Settings.Video.ShowStopButton`. The HWND creation races the modal-dialog teardown that just returned from `ShowDialogAsync`, intermittently leaving the main window disabled — a full UI freeze.

The previous Post-deferral attempt only pushes the rebuild to the next dispatcher message at `DispatcherPriority.Normal`, which on some configurations still overlaps modal teardown.

## Fix

`StopIsVisible` and `FullScreenIsVisible` on `VideoPlayerControl` are plain Avalonia `StyledProperty<bool>` (verified at `VideoPlayerControl.cs:54`). Writing to them at runtime updates the existing button bar in place — no new control, no new HWND.

So:

1. Apply the two flags directly to the existing `VideoPlayerControl` returned by `GetVideoPlayerControl()`.
2. Short-circuit out of `OpenSettings` before the `Dispatcher.UIThread.Post(ApplySettings, ...)` block when the JSON snapshot diff shows only those two flags changed. A new `OnlyVideoPlayerVisibilityFlagsChanged` helper masks both flag fields to the same canonical value in the old/new snapshots and compares — the trees match iff no other field differs. Conservative on parse failure (returns false → falls through to the rebuild path).

The full `ApplySettings` path is **unchanged** for every other setting. The fix is surgical — it only removes the rebuild trigger for these specific toggles.

## Why this is better than tightening the dispatcher priority

Lower-priority deferral would push the rebuild further but doesn't eliminate the race — on a busy system the same race could still hit. Removing the trigger entirely for this setting is more robust, and as a bonus the toggle is now instantaneous (no jank, no waveform/audio-track reload churn).

Also fixes the analogous case for `ShowFullscreenButton` which had the same underlying issue.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` — succeeds, 0 warnings / 0 errors
- [x] `dotnet test tests/UI/UITests.csproj` — 241/241 pass
- [ ] Windows smoke test (the OS where the freeze reproduces):
  - Open SE with a video loaded
  - Settings → Video player → toggle "Show stop button" → OK → main window remains responsive, button appears/disappears immediately
  - Repeat with "Show fullscreen button"
  - Repeat with the video player **undocked** (uses `_videoPlayerUndockedViewModel`)
- [ ] Regression: change a non-video setting (e.g., a color) → OK → ApplySettings still runs (layout still rebuilds correctly)

Fixes #10815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)