### PR TITLE
Fix Mega-ASR speech-to-text producing empty SRT

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3084,7 +3084,9 @@ public partial class SpeechToTextViewModel : ObservableObject
             }
 
             var vadPart = string.Empty;
-            if (crispAsrEngine is CrispAsrCohere
+            // Mega-ASR (crispasr 0.6.10) silently writes a zero-byte SRT unless VAD chunking
+            // is enabled — the transcription log says it succeeded but no segments are emitted.
+            if (crispAsrEngine is CrispAsrCohere or CrispAsrMega
                 && !Regex.IsMatch(crispArgs ?? string.Empty, @"(^|\s)(--vad|-vm|--vad-model)\b"))
             {
                 var crispFolder = crispAsrEngine.GetAndCreateWhisperFolder();


### PR DESCRIPTION
## Summary
- `crispasr` v0.6.10's `mega-asr` backend silently writes a zero-byte SRT unless VAD chunking is enabled — the log reports "transcribed N s audio" but no segments are emitted, so Subtitle Edit loads an empty file and no subtitles appear.
- Extend the existing auto-append-VAD logic (already used for `CrispAsrCohere`) to also cover `CrispAsrMega`. The Silero VAD `.bin` is already downloaded alongside the CrispASR engine, so no extra install step is needed.

## Test plan
- [x] Reproduced: run Speech-to-text → Crisp ASR Mega on a 40 s clip → empty SRT, no subtitles.
- [x] Verified manually at the CLI that `--vad --vad-model "…/ggml-silero-v6.2.0.bin"` makes the same command produce a populated SRT.
- [x] `dotnet build src/ui/UI.csproj` — clean.
- [ ] Re-run Speech-to-text → Crisp ASR Mega in the UI and confirm subtitles are produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)