### PR TITLE
Pass theme colors to SE5 plugins

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -161,6 +161,15 @@ launched as `dotnet <entry> <requestFilePath>`.
   "frameRate": 23.976,
   "uiLanguage": "English",
   "theme": "Dark",
+  "themeColors": {
+    "isDark": true,
+    "backgroundColor": "#FF212121",
+    "foregroundColor": "#FFDCDCDC",
+    "accentColor": "#631E90FF",
+    "backgroundColorLighter": "#FF262626",
+    "backgroundColorHeader": "#FF303030",
+    "bookmarkColor": "#FFFFD700"
+  },
   "seVersion": "5.0.0",
   "settings": { "lastUsedOption": true }
 }
@@ -173,6 +182,9 @@ launched as `dotnet <entry> <requestFilePath>`.
 - `settings` is whatever JSON your plugin returned in its previous response;
   it is `null` on first run. Use it to persist plugin-private settings.
 - `theme` and `uiLanguage` let your plugin's own UI match Subtitle Edit.
+- `themeColors` carries the active theme's colors as `#AARRGGBB` hex strings so
+  your plugin's own UI can match Subtitle Edit. May be omitted in older SE
+  versions — fall back to your platform's defaults when it is missing.
 
 ## response.json (plugin → Subtitle Edit)
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4626,6 +4626,7 @@ public partial class MainViewModel :
             FrameRate = frameRate,
             UiLanguage = Se.Settings.General.Language ?? string.Empty,
             Theme = UiTheme.ThemeName,
+            ThemeColors = PluginThemeColorsFactory.Build(),
             SeVersion = Se.Version,
             Settings = settings,
         };

--- a/src/ui/Logic/Plugins/PluginRequest.cs
+++ b/src/ui/Logic/Plugins/PluginRequest.cs
@@ -35,6 +35,9 @@ public class PluginRequest
     /// <summary>Current theme, e.g. "Dark" or "Light".</summary>
     public string Theme { get; set; } = string.Empty;
 
+    /// <summary>Colors of the active theme so the plugin's own UI can match.</summary>
+    public PluginThemeColors? ThemeColors { get; set; }
+
     public string SeVersion { get; set; } = string.Empty;
 
     /// <summary>The plugin's own settings as last persisted by Subtitle Edit (null on first run).</summary>

--- a/src/ui/Logic/Plugins/PluginThemeColors.cs
+++ b/src/ui/Logic/Plugins/PluginThemeColors.cs
@@ -1,0 +1,29 @@
+namespace Nikse.SubtitleEdit.Logic.Plugins;
+
+/// <summary>
+/// Colors of the active Subtitle Edit theme, passed to plugins so their own UI
+/// can match. All values are <c>#AARRGGBB</c> hex strings.
+/// </summary>
+public class PluginThemeColors
+{
+    /// <summary>True when the active theme is dark.</summary>
+    public bool IsDark { get; set; }
+
+    /// <summary>Main window/control background.</summary>
+    public string BackgroundColor { get; set; } = string.Empty;
+
+    /// <summary>Main text color.</summary>
+    public string ForegroundColor { get; set; } = string.Empty;
+
+    /// <summary>Accent color used for focused/default buttons.</summary>
+    public string AccentColor { get; set; } = string.Empty;
+
+    /// <summary>Slightly lighter than <see cref="BackgroundColor"/> (hover/lift variant).</summary>
+    public string BackgroundColorLighter { get; set; } = string.Empty;
+
+    /// <summary>Header/menu background (lighter than <see cref="BackgroundColor"/>).</summary>
+    public string BackgroundColorHeader { get; set; } = string.Empty;
+
+    /// <summary>Bookmark highlight color.</summary>
+    public string BookmarkColor { get; set; } = string.Empty;
+}

--- a/src/ui/Logic/Plugins/PluginThemeColorsFactory.cs
+++ b/src/ui/Logic/Plugins/PluginThemeColorsFactory.cs
@@ -1,0 +1,54 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Logic.Plugins;
+
+/// <summary>
+/// Builds <see cref="PluginThemeColors"/> for the currently active Subtitle Edit theme.
+/// Dark colors come from <see cref="SeAppearance"/>; Classic/Pastel/Light use the same
+/// hard-coded palettes as <see cref="UiTheme"/>.
+/// </summary>
+internal static class PluginThemeColorsFactory
+{
+    public static PluginThemeColors Build()
+    {
+        var appearance = Se.Settings.Appearance;
+        var themeName = UiTheme.ThemeName;
+        var isDark = themeName == UiTheme.ThemeNameDark;
+
+        Color background;
+        Color foreground;
+
+        if (isDark)
+        {
+            background = appearance.DarkModeBackgroundColor.FromHexToColor();
+            foreground = appearance.DarkModeForegroundColor.FromHexToColor();
+        }
+        else if (themeName == UiTheme.ThemeNameClassic)
+        {
+            background = Color.FromRgb(236, 233, 216);
+            foreground = Color.FromRgb(0, 0, 0);
+        }
+        else if (themeName == UiTheme.ThemeNamePastel)
+        {
+            background = Color.FromRgb(240, 235, 255);
+            foreground = Color.FromRgb(0, 0, 0);
+        }
+        else
+        {
+            background = Color.FromRgb(255, 255, 255);
+            foreground = Color.FromRgb(0, 0, 0);
+        }
+
+        return new PluginThemeColors
+        {
+            IsDark = isDark,
+            BackgroundColor = background.FromColorToHex(),
+            ForegroundColor = foreground.FromColorToHex(),
+            AccentColor = appearance.FocusedButtonBackgroundColor,
+            BackgroundColorLighter = UiUtil.LightenColor(background, 5).FromColorToHex(),
+            BackgroundColorHeader = UiUtil.LightenColor(background, 15).FromColorToHex(),
+            BookmarkColor = appearance.BookmarkColor,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `themeColors` object to the SE5 plugin request (background, foreground, accent, lighter/header variants, bookmark) so a plugin's own UI can match Subtitle Edit instead of falling back to Fluent defaults.
- Dark colors come from `SeAppearance`; Classic/Pastel/Light use the same hard-coded palettes as `UiTheme`.
- `apiVersion` stays at 1 — additive, ignored by older plugins.

## Test plan
- [ ] Build SE; verify no warnings.
- [ ] Launch SE in Dark mode, run an SE5 plugin (e.g. AmericanToBritish from the plugins repo PR), confirm the plugin window picks up SE's dark background instead of Fluent's default.
- [ ] Switch SE to Light/Classic/Pastel, repeat — plugin window background should track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)