### PR TITLE
Plugin manager: equal-width icon buttons + cancel-X for downloads

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,10 +1,9 @@
 
 Subtitle Edit Changelog
 
+
 v5.0.0-beta31 (xth May 2026)
 
-* Add Crisp ASR "Mega" backend (Qwen3-ASR-1.7B + robustness LoRA) for noisy / degraded speech
-* Add WhisperX-style wav2vec2 forced-aligner zoo to the Speech-to-text dialog (12 language-specific CTC aligners)
 * Add scrub video position by mouse wheel over the video surface
 * Add OCR fallback database picker to the OCR window
 * Add waveform Seek Silence back/forward shortcuts
@@ -21,6 +20,8 @@ v5.0.0-beta31 (xth May 2026)
 * Fix freeze on Settings OK after toggling "Show stop/fullscreen button" - thx bichitoxxx
 * Fix invisible status dots in Qwen3 TTS (CrispASR) settings
 * Fix Save-As dropping extension after a language suffix
+* Add Crisp ASR "Mega" backend (Qwen3-ASR-1.7B + robustness LoRA) for noisy / degraded speech
+* Add WhisperX-style wav2vec2 forced-aligner zoo to the Speech-to-text dialog
 * Update llama.cpp
 
 -----------------------------------------------------------------------------------------------------

--- a/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
@@ -90,9 +90,12 @@ public partial class GetPluginsViewModel : ObservableObject
             return;
         }
 
-        item.IsBusy = true;
+        // Create the cancellation source BEFORE flipping IsBusy so the cancel button
+        // always has a token to cancel from the moment it becomes visible.
+        _cancellationTokenSource = new CancellationTokenSource();
         item.DownloadProgress = 0;
         var previousStatus = item.StatusText;
+        item.IsBusy = true;
         var progress = new Progress<float>(p =>
         {
             item.DownloadProgress = p * 100;
@@ -101,7 +104,6 @@ public partial class GetPluginsViewModel : ObservableObject
 
         try
         {
-            _cancellationTokenSource = new CancellationTokenSource();
             await _downloadService.InstallAsync(item.Entry, progress, _cancellationTokenSource.Token);
             InstalledAnything = true;
 

--- a/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
@@ -110,6 +110,11 @@ public partial class GetPluginsViewModel : ObservableObject
             item.Refresh(match?.Manifest.Version);
             StatusMessage = string.Format(Se.Language.Plugins.PluginXInstalled, item.Name);
         }
+        catch (OperationCanceledException)
+        {
+            item.StatusText = previousStatus;
+            StatusMessage = Se.Language.General.Cancelled;
+        }
         catch (Exception exception)
         {
             Se.LogError(exception, "Failed to install plugin: " + item.Name);
@@ -120,6 +125,12 @@ public partial class GetPluginsViewModel : ObservableObject
         {
             item.IsBusy = false;
         }
+    }
+
+    [RelayCommand]
+    private void CancelDownload()
+    {
+        _cancellationTokenSource?.Cancel();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
@@ -118,14 +118,27 @@ public class GetPluginsWindow : Window
             installButton.Bind(Button.CommandParameterProperty, new Binding());
             installButton.Bind(IsEnabledProperty, new Binding(nameof(GetPluginsDisplayItem.CanInstall)));
 
+            // A generous hit area: a 32x32 square with the icon inside. Without an explicit
+            // size the button can be missed during a short download (the icon glyph itself
+            // is only ~16px wide). Transparent background still receives hit-tests so the
+            // whole 32x32 area is clickable.
             var cancelButton = new Button
             {
-                Content = new Icon { Value = IconNames.Close, FontSize = 16 },
+                Content = new Icon
+                {
+                    Value = IconNames.Close,
+                    FontSize = 18,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                },
+                Width = 32,
+                Height = 32,
+                Padding = new Thickness(0),
                 VerticalAlignment = VerticalAlignment.Center,
-                Margin = new Thickness(4, 0, 0, 0),
-                Padding = new Thickness(6),
-                Background = null,
+                Margin = new Thickness(6, 0, 0, 0),
+                Background = Brushes.Transparent,
                 BorderBrush = null,
+                Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.Hand),
                 Command = vm.CancelDownloadCommand,
                 [ToolTip.TipProperty] = Se.Language.General.Cancel.Replace("_", string.Empty),
             };

--- a/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Optris.Icons.Avalonia;
 
 namespace Nikse.SubtitleEdit.Features.Options.Plugins;
 
@@ -117,16 +118,31 @@ public class GetPluginsWindow : Window
             installButton.Bind(Button.CommandParameterProperty, new Binding());
             installButton.Bind(IsEnabledProperty, new Binding(nameof(GetPluginsDisplayItem.CanInstall)));
 
+            var cancelButton = new Button
+            {
+                Content = new Icon { Value = IconNames.Close, FontSize = 16 },
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(4, 0, 0, 0),
+                Padding = new Thickness(6),
+                Background = null,
+                BorderBrush = null,
+                Command = vm.CancelDownloadCommand,
+                [ToolTip.TipProperty] = Se.Language.General.Cancel.Replace("_", string.Empty),
+            };
+            cancelButton.Bind(IsVisibleProperty, new Binding(nameof(GetPluginsDisplayItem.IsBusy)));
+
             var rowGrid = new Grid
             {
                 ColumnDefinitions =
                 {
                     new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
                     new ColumnDefinition { Width = GridLength.Auto },
+                    new ColumnDefinition { Width = GridLength.Auto },
                 },
             };
             rowGrid.Add(textPanel, 0, 0);
             rowGrid.Add(installButton, 0, 1);
+            rowGrid.Add(cancelButton, 0, 2);
 
             // Thin separator at the bottom of each row.
             return new Border

--- a/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
+++ b/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
@@ -68,9 +68,18 @@ public class PluginManagerWindow : Window
             };
         }, true);
 
-        var buttonGetPlugins = UiUtil.MakeButton(Se.Language.Plugins.GetPluginsOnline, vm.GetPluginsOnlineCommand).WithMinWidth(160);
-        var buttonOpenFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenPluginsFolderCommand).WithMinWidth(160);
-        var buttonRemove = UiUtil.MakeButton(Se.Language.General.Remove, vm.RemovePluginCommand).WithMinWidth(160);
+        var buttonGetPlugins = UiUtil.MakeButton(Se.Language.Plugins.GetPluginsOnline, vm.GetPluginsOnlineCommand)
+            .WithIconLeft(IconNames.CloudDownload)
+            .WithHorizontalAlignmentStretch()
+            .WithMinWidth(180);
+        var buttonOpenFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenPluginsFolderCommand)
+            .WithIconLeft(IconNames.FolderOpen)
+            .WithHorizontalAlignmentStretch()
+            .WithMinWidth(180);
+        var buttonRemove = UiUtil.MakeButton(Se.Language.General.Remove, vm.RemovePluginCommand)
+            .WithIconLeft(IconNames.Trash)
+            .WithHorizontalAlignmentStretch()
+            .WithMinWidth(180);
 
         var sidePanel = new StackPanel
         {

--- a/src/ui/Logic/Plugins/PluginDownloadService.cs
+++ b/src/ui/Logic/Plugins/PluginDownloadService.cs
@@ -47,42 +47,51 @@ public class PluginDownloadService : IPluginDownloadService
         {
             Directory.CreateDirectory(tempDirectory);
 
-            using (var zipStream = new MemoryStream())
+            using var zipStream = new MemoryStream();
+            await DownloadHelper.DownloadFileAsync(_httpClient, downloadUrl, zipStream, progress, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Unzip and the subsequent file moves are synchronous; running them on a worker
+            // thread keeps the UI responsive (notably for the cancel-download button) and lets
+            // ThrowIfCancellationRequested between phases stop work as soon as the user reacts.
+            await Task.Run(() =>
             {
-                await DownloadHelper.DownloadFileAsync(_httpClient, downloadUrl, zipStream, progress, cancellationToken);
                 zipStream.Position = 0;
                 _zipUnpacker.UnpackZipStream(zipStream, tempDirectory);
-            }
+                cancellationToken.ThrowIfCancellationRequested();
 
-            var rootEntries = Directory.GetFileSystemEntries(tempDirectory);
-            string source;
-            string targetName;
-            if (rootEntries.Length == 1 && Directory.Exists(rootEntries[0]))
-            {
-                source = rootEntries[0];
-                targetName = Path.GetFileName(rootEntries[0]);
-            }
-            else
-            {
-                source = tempDirectory;
-                targetName = SanitizeFolderName(entry.Name);
-            }
+                var rootEntries = Directory.GetFileSystemEntries(tempDirectory);
+                string source;
+                string targetName;
+                if (rootEntries.Length == 1 && Directory.Exists(rootEntries[0]))
+                {
+                    source = rootEntries[0];
+                    targetName = Path.GetFileName(rootEntries[0]);
+                }
+                else
+                {
+                    source = tempDirectory;
+                    targetName = SanitizeFolderName(entry.Name);
+                }
 
-            // Remove any previously installed copy of the same plugin.
-            var existing = _pluginCatalog.GetPlugins()
-                .FirstOrDefault(p => p.Manifest.Name.Equals(entry.Name, StringComparison.OrdinalIgnoreCase));
-            if (existing != null && Directory.Exists(existing.FolderPath))
-            {
-                Directory.Delete(existing.FolderPath, recursive: true);
-            }
+                // Remove any previously installed copy of the same plugin.
+                var existing = _pluginCatalog.GetPlugins()
+                    .FirstOrDefault(p => p.Manifest.Name.Equals(entry.Name, StringComparison.OrdinalIgnoreCase));
+                if (existing != null && Directory.Exists(existing.FolderPath))
+                {
+                    Directory.Delete(existing.FolderPath, recursive: true);
+                }
 
-            var targetPath = Path.Combine(Se.PluginsFolder, targetName);
-            if (Directory.Exists(targetPath))
-            {
-                Directory.Delete(targetPath, recursive: true);
-            }
+                cancellationToken.ThrowIfCancellationRequested();
 
-            Directory.Move(source, targetPath);
+                var targetPath = Path.Combine(Se.PluginsFolder, targetName);
+                if (Directory.Exists(targetPath))
+                {
+                    Directory.Delete(targetPath, recursive: true);
+                }
+
+                Directory.Move(source, targetPath);
+            }, cancellationToken);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- **Plugin Manager:** the 3 right-side buttons (Get plugins online / Open folder / Remove) are now the same width and have leading icons (cloud-download, folder-open, trash).
- **Get plugins:** each list row now shows a small X icon next to the Install button while a download is in progress. Clicking it cancels via the existing `CancellationTokenSource`. A user-initiated cancel now reports *Cancelled* in the status bar instead of *Failed to install*.

## Notes
- Includes a small unrelated change-log reorder commit (`772513463`) that was already on this branch when I started — happy to split it out if you want.
- No new language strings introduced; the cancel button's tooltip reuses `Se.Language.General.Cancel` with the `_` access-key marker stripped.

## Test plan
- [ ] Open Plugin manager → confirm the 3 buttons are the same width and have icons.
- [ ] Open Get plugins online → start an Install on any plugin → X button appears next to the Install button → click X → download stops and status shows *Cancelled*.
- [ ] Verify the unchanged paths still work: completed install shows *'X' installed*; close (Esc) still cancels and closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)