### PR TITLE
Plugin manager: left-align text in the 3 side-panel buttons

### DIFF
--- a/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
+++ b/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
@@ -81,6 +81,11 @@ public class PluginManagerWindow : Window
             .WithHorizontalAlignmentStretch()
             .WithMinWidth(180);
 
+        // Left-align icon+text inside the stretched buttons so the icons line up vertically.
+        buttonGetPlugins.HorizontalContentAlignment = HorizontalAlignment.Left;
+        buttonOpenFolder.HorizontalContentAlignment = HorizontalAlignment.Left;
+        buttonRemove.HorizontalContentAlignment = HorizontalAlignment.Left;
+
         var sidePanel = new StackPanel
         {
             Orientation = Orientation.Vertical,


### PR DESCRIPTION
## Summary
Follow-up to merged #11139. The 3 stretched side-panel buttons (Get plugins online / Open folder / Remove) now have their icon+text group anchored to the left of the button instead of centered, so the icons line up vertically and the labels read as a clean column.

Single 3-line change in `PluginManagerWindow.cs` setting `HorizontalContentAlignment = HorizontalAlignment.Left` on each button after the existing chain.

## Test plan
- [ ] Open Plugin manager → confirm the icons (cloud-download / folder-open / trash) line up vertically along the left edge of each button, with labels reading down in a tidy column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)