### PR TITLE
Plugin manager: 'Update all' button (visible when updates are available)

### DIFF
--- a/src/ui/Features/Options/Plugins/PluginDisplayItem.cs
+++ b/src/ui/Features/Options/Plugins/PluginDisplayItem.cs
@@ -18,9 +18,24 @@ public partial class PluginDisplayItem : ObservableObject
     public string FolderPath => Plugin.FolderPath;
     public bool CanRun => Plugin.CanRun;
 
+    /// <summary>Catalog entry providing a newer version, or null when up to date / no catalog match.</summary>
+    public PluginIndexEntry? AvailableUpdate { get; private set; }
+
+    public bool UpdateAvailable => AvailableUpdate != null;
+
     public string StatusText => !Plugin.CanRun
         ? Se.Language.Plugins.NotSupportedOnThisOs
-        : IsEnabled ? Se.Language.Plugins.Enabled : Se.Language.Plugins.Disabled;
+        : UpdateAvailable
+            ? string.Format(Se.Language.Plugins.UpdateAvailableXToY, Version, AvailableUpdate!.Version)
+            : IsEnabled ? Se.Language.Plugins.Enabled : Se.Language.Plugins.Disabled;
+
+    public void SetAvailableUpdate(PluginIndexEntry? entry)
+    {
+        AvailableUpdate = entry;
+        OnPropertyChanged(nameof(AvailableUpdate));
+        OnPropertyChanged(nameof(UpdateAvailable));
+        OnPropertyChanged(nameof(StatusText));
+    }
 
     /// <summary>Raised when the user toggles the enabled checkbox.</summary>
     public Action<PluginDisplayItem>? EnabledChanged { get; set; }

--- a/src/ui/Features/Options/Plugins/PluginManagerViewModel.cs
+++ b/src/ui/Features/Options/Plugins/PluginManagerViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
@@ -8,9 +9,11 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Plugins;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Options.Plugins;
@@ -19,24 +22,35 @@ public partial class PluginManagerViewModel : ObservableObject
 {
     [ObservableProperty] private ObservableCollection<PluginDisplayItem> _plugins;
     [ObservableProperty] private PluginDisplayItem? _selectedPlugin;
+    [ObservableProperty] private int _updateAvailableCount;
+    [ObservableProperty] private bool _isUpdating;
+    [ObservableProperty] private string _updateAllButtonText = string.Empty;
+
+    public bool HasUpdates => UpdateAvailableCount > 0;
+    public bool CanUpdateAll => HasUpdates && !IsUpdating;
 
     public Window? Window { get; set; }
 
     private readonly IPluginCatalog _pluginCatalog;
+    private readonly IPluginDownloadService _downloadService;
     private readonly IFolderHelper _folderHelper;
     private readonly IWindowService _windowService;
+    private CancellationTokenSource? _checkCts;
 
-    public PluginManagerViewModel(IPluginCatalog pluginCatalog, IFolderHelper folderHelper, IWindowService windowService)
+    public PluginManagerViewModel(IPluginCatalog pluginCatalog, IPluginDownloadService downloadService, IFolderHelper folderHelper, IWindowService windowService)
     {
         _pluginCatalog = pluginCatalog;
+        _downloadService = downloadService;
         _folderHelper = folderHelper;
         _windowService = windowService;
         _plugins = new ObservableCollection<PluginDisplayItem>();
+        RefreshUpdateAllButtonText();
     }
 
     public void Initialize()
     {
         LoadPlugins();
+        _ = CheckForUpdatesAsync();
     }
 
     private void LoadPlugins()
@@ -53,6 +67,128 @@ public partial class PluginManagerViewModel : ObservableObject
         }
 
         SelectedPlugin = Plugins.FirstOrDefault();
+        UpdateAvailableCount = 0;
+        RefreshUpdateAllButtonText();
+    }
+
+    /// <summary>Fetch the online catalog and mark installed plugins that have a newer version.</summary>
+    private async Task CheckForUpdatesAsync()
+    {
+        _checkCts?.Cancel();
+        _checkCts = new CancellationTokenSource();
+        var token = _checkCts.Token;
+
+        try
+        {
+            var index = await _downloadService.GetIndexAsync(token);
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await Dispatcher.UIThread.InvokeAsync(() => ApplyCatalog(index));
+        }
+        catch
+        {
+            // Opportunistic check; if the network/index is unavailable we simply
+            // don't show the update affordance. No popup, no log spam.
+        }
+    }
+
+    private void ApplyCatalog(PluginIndex index)
+    {
+        var entriesByName = index.Plugins
+            .Where(p => !string.IsNullOrEmpty(p.Name))
+            .GroupBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        var count = 0;
+        foreach (var item in Plugins)
+        {
+            if (entriesByName.TryGetValue(item.Name, out var entry) &&
+                PluginPlatform.IsSupportedByEntry(entry) &&
+                IsNewer(entry.Version, item.Version))
+            {
+                item.SetAvailableUpdate(entry);
+                count++;
+            }
+            else
+            {
+                item.SetAvailableUpdate(null);
+            }
+        }
+
+        UpdateAvailableCount = count;
+        RefreshUpdateAllButtonText();
+    }
+
+    private static bool IsNewer(string candidate, string current)
+    {
+        return System.Version.TryParse(candidate, out var c) &&
+               System.Version.TryParse(current, out var cur) &&
+               c > cur;
+    }
+
+    [RelayCommand]
+    private async Task UpdateAll()
+    {
+        if (IsUpdating)
+        {
+            return;
+        }
+
+        var toUpdate = Plugins.Where(p => p.UpdateAvailable && p.AvailableUpdate != null)
+            .Select(p => (Item: p, Entry: p.AvailableUpdate!))
+            .ToList();
+        if (toUpdate.Count == 0)
+        {
+            return;
+        }
+
+        IsUpdating = true;
+        try
+        {
+            var done = 0;
+            foreach (var (item, entry) in toUpdate)
+            {
+                done++;
+                UpdateAllButtonText = string.Format(Se.Language.Plugins.UpdatingXOfY, done, toUpdate.Count);
+                try
+                {
+                    await _downloadService.InstallAsync(entry, progress: null, CancellationToken.None);
+                }
+                catch (Exception exception)
+                {
+                    Se.LogError(exception, "Failed to update plugin: " + item.Name);
+                }
+            }
+
+            LoadPlugins();
+            await CheckForUpdatesAsync();
+        }
+        finally
+        {
+            IsUpdating = false;
+            RefreshUpdateAllButtonText();
+        }
+    }
+
+    private void RefreshUpdateAllButtonText()
+    {
+        UpdateAllButtonText = UpdateAvailableCount > 0
+            ? string.Format(Se.Language.Plugins.UpdateAllXAvailable, UpdateAvailableCount)
+            : string.Empty;
+    }
+
+    partial void OnUpdateAvailableCountChanged(int value)
+    {
+        OnPropertyChanged(nameof(HasUpdates));
+        OnPropertyChanged(nameof(CanUpdateAll));
+    }
+
+    partial void OnIsUpdatingChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanUpdateAll));
     }
 
     private static void OnPluginEnabledChanged(PluginDisplayItem item)

--- a/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
+++ b/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Options.Plugins;
 
@@ -80,11 +81,23 @@ public class PluginManagerWindow : Window
             .WithIconLeft(IconNames.Trash)
             .WithHorizontalAlignmentStretch()
             .WithMinWidth(180);
+        var buttonUpdateAll = UiUtil.MakeButton(string.Empty, vm.UpdateAllCommand)
+            .WithIconLeft(IconNames.Refresh)
+            .WithHorizontalAlignmentStretch()
+            .WithMinWidth(180);
+        // Replace the empty placeholder text with a bound TextBlock inside the icon+text panel.
+        if (buttonUpdateAll.Content is StackPanel stack && stack.Children.OfType<TextBlock>().FirstOrDefault() is { } labelTb)
+        {
+            labelTb.Bind(TextBlock.TextProperty, new Binding(nameof(vm.UpdateAllButtonText)));
+        }
+        buttonUpdateAll.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.HasUpdates)));
+        buttonUpdateAll.Bind(IsEnabledProperty, new Binding(nameof(vm.CanUpdateAll)));
 
         // Left-align icon+text inside the stretched buttons so the icons line up vertically.
         buttonGetPlugins.HorizontalContentAlignment = HorizontalAlignment.Left;
         buttonOpenFolder.HorizontalContentAlignment = HorizontalAlignment.Left;
         buttonRemove.HorizontalContentAlignment = HorizontalAlignment.Left;
+        buttonUpdateAll.HorizontalContentAlignment = HorizontalAlignment.Left;
 
         var sidePanel = new StackPanel
         {
@@ -92,7 +105,7 @@ public class PluginManagerWindow : Window
             Spacing = 5,
             Margin = new Thickness(10, 0, 0, 0),
             VerticalAlignment = VerticalAlignment.Top,
-            Children = { buttonGetPlugins, buttonOpenFolder, buttonRemove },
+            Children = { buttonGetPlugins, buttonOpenFolder, buttonRemove, buttonUpdateAll },
         };
 
         var contentGrid = new Grid

--- a/src/ui/Logic/Config/Language/LanguagePlugins.cs
+++ b/src/ui/Logic/Config/Language/LanguagePlugins.cs
@@ -33,6 +33,8 @@ public class LanguagePlugins
     public string ApplyPluginToWhichLinesX { get; set; }
     public string ApplyToSelectedLinesX { get; set; }
     public string ApplyToAllLinesX { get; set; }
+    public string UpdateAllXAvailable { get; set; }
+    public string UpdatingXOfY { get; set; }
 
     public LanguagePlugins()
     {
@@ -67,5 +69,7 @@ public class LanguagePlugins
         ApplyPluginToWhichLinesX = "Apply '{0}' to:";
         ApplyToSelectedLinesX = "Selected lines ({0})";
         ApplyToAllLinesX = "All lines ({0})";
+        UpdateAllXAvailable = "Update all ({0})";
+        UpdatingXOfY = "Updating {0}/{1}...";
     }
 }


### PR DESCRIPTION
## Summary
Answer to *do we already have one?* — no, the only update path today is the per-row Install/Update button in *Get plugins online*. This PR adds a bulk action to the main plugin manager window.

- On open, `PluginManagerViewModel` asynchronously fetches the online catalog and compares it against installed plugins. Failures are silent (opportunistic check, no popup).
- When at least one installed plugin has a newer version in the catalog, a 4th side-panel button appears below *Remove* labeled **Update all (N)**.
- Click → sequentially reinstalls each upgradable plugin from the catalog, button label flips to *Updating N/M…*, then the list refreshes and the check re-runs.
- `PluginDisplayItem.StatusText` of an outdated plugin also flips to *Update available (1.0.0 → 1.1.0)* so individual rows hint at what's about to change.

New language strings: `Plugins.UpdateAllXAvailable`, `Plugins.UpdatingXOfY`.

## Test plan
- [ ] Open Plugin manager with all plugins at latest — *Update all* button does not appear.
- [ ] Manually downgrade one plugin's `plugin.json` version (e.g. WordCensor 1.1.0 → 0.9.0), reopen — button appears as *Update all (1)*, click → that plugin reinstalls and the button disappears.
- [ ] Repeat with multiple stale plugins — button shows *(N)* with the correct count, sequential update works.
- [ ] Disconnect network and open the manager — installed plugins still load instantly, no error popup, *Update all* never appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)