### PR TITLE
Plugin contract: settingsVersion + video duration/resolution

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -159,6 +159,9 @@ launched as `dotnet <entry> <requestFilePath>`.
   "selectedIndices": [3, 4, 5],
   "videoFileName": "C:\\videos\\episode01.mkv",
   "frameRate": 23.976,
+  "videoDurationSeconds": 1432.5,
+  "videoWidth": 1920,
+  "videoHeight": 1080,
   "uiLanguage": "English",
   "theme": "Dark",
   "themeColors": {
@@ -171,7 +174,8 @@ launched as `dotnet <entry> <requestFilePath>`.
     "bookmarkColor": "#FFFFD700"
   },
   "seVersion": "5.0.0",
-  "settings": { "lastUsedOption": true }
+  "settings": { "lastUsedOption": true },
+  "settingsVersion": 2
 }
 ```
 
@@ -181,6 +185,13 @@ launched as `dotnet <entry> <requestFilePath>`.
 - `selectedIndices` are zero-based line indices selected in the grid (empty if none).
 - `settings` is whatever JSON your plugin returned in its previous response;
   it is `null` on first run. Use it to persist plugin-private settings.
+- `settingsVersion` is the schema version your plugin attached to `settings` in
+  its previous response, handed back unchanged. Use it to migrate or reset old
+  settings when you change your own schema. Null on first run, and on older SE
+  versions that don't track it.
+- `videoDurationSeconds`, `videoWidth`, `videoHeight` describe the loaded video.
+  Null when no video is loaded (or on older SE versions). Saves you from
+  re-opening the video file just to read these.
 - `theme` and `uiLanguage` let your plugin's own UI match Subtitle Edit.
 - `themeColors` carries the active theme's colors as `#AARRGGBB` hex strings so
   your plugin's own UI can match Subtitle Edit. May be omitted in older SE
@@ -200,6 +211,7 @@ Write this file to `responseFilePath` before exiting with code `0`.
     "native": "1\n00:00:01,000 --> 00:00:03,000\nHELLO WORLD\n\n..."
   },
   "settings": { "lastUsedOption": true },
+  "settingsVersion": 2,
   "undoDescription": "Uppercase Selected Lines 1.0.0"
 }
 ```
@@ -215,6 +227,11 @@ Write this file to `responseFilePath` before exiting with code `0`.
 - If `subtitle.native` cannot be parsed, Subtitle Edit aborts with an error and
   makes no changes.
 - `settings` is stored by Subtitle Edit and handed back in the next request.
+- `settingsVersion` is stored alongside `settings` and handed back via
+  `request.settingsVersion` on the next run. Bump it whenever you change the
+  shape of `settings` so you can detect (and migrate or discard) stale data
+  written by an older build of your plugin. Optional; if you don't write it,
+  SE clears any previously-stored version for this plugin.
 - `undoDescription` is optional; it labels the undo-history entry.
 
 ## Notes for plugin authors

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4612,6 +4612,12 @@ public partial class MainViewModel :
             }
         }
 
+        int? settingsVersion = null;
+        if (Se.Settings.Plugins.SettingsVersions.TryGetValue(plugin.Manifest.Name, out var storedVersion))
+        {
+            settingsVersion = storedVersion;
+        }
+
         return new PluginRequest
         {
             Subtitle = new PluginSubtitle
@@ -4624,11 +4630,15 @@ public partial class MainViewModel :
             SelectedIndices = selectedIndices,
             VideoFileName = _videoFileName ?? string.Empty,
             FrameRate = frameRate,
+            VideoDurationSeconds = _mediaInfo?.Duration?.TotalSeconds,
+            VideoWidth = _mediaInfo?.Dimension.Width,
+            VideoHeight = _mediaInfo?.Dimension.Height,
             UiLanguage = Se.Settings.General.Language ?? string.Empty,
             Theme = UiTheme.ThemeName,
             ThemeColors = PluginThemeColorsFactory.Build(),
             SeVersion = Se.Version,
             Settings = settings,
+            SettingsVersion = settingsVersion,
         };
     }
 
@@ -4666,6 +4676,14 @@ public partial class MainViewModel :
         try
         {
             Se.Settings.Plugins.Settings[plugin.Manifest.Name] = response.Settings.Value.GetRawText();
+            if (response.SettingsVersion.HasValue)
+            {
+                Se.Settings.Plugins.SettingsVersions[plugin.Manifest.Name] = response.SettingsVersion.Value;
+            }
+            else
+            {
+                Se.Settings.Plugins.SettingsVersions.Remove(plugin.Manifest.Name);
+            }
             Se.SaveSettings();
         }
         catch (Exception exception)

--- a/src/ui/Features/Options/Plugins/PluginManagerViewModel.cs
+++ b/src/ui/Features/Options/Plugins/PluginManagerViewModel.cs
@@ -257,6 +257,7 @@ public partial class PluginManagerViewModel : ObservableObject
 
         Se.Settings.Plugins.DisabledPluginNames.Remove(item.Name);
         Se.Settings.Plugins.Settings.Remove(item.Name);
+        Se.Settings.Plugins.SettingsVersions.Remove(item.Name);
         Se.SaveSettings();
 
         Plugins.Remove(item);

--- a/src/ui/Logic/Config/SePlugins.cs
+++ b/src/ui/Logic/Config/SePlugins.cs
@@ -10,6 +10,13 @@ public class SePlugins
     /// </summary>
     public Dictionary<string, string> Settings { get; set; } = new();
 
+    /// <summary>
+    /// Per-plugin settings schema version, keyed by plugin name. Stored verbatim from
+    /// the plugin's response and handed back in the next request so the plugin can
+    /// migrate (or reset) old settings when it changes its own schema.
+    /// </summary>
+    public Dictionary<string, int> SettingsVersions { get; set; } = new();
+
     /// <summary>Names of installed plugins the user has disabled; they are hidden from the menu.</summary>
     public List<string> DisabledPluginNames { get; set; } = new();
 }

--- a/src/ui/Logic/Plugins/PluginRequest.cs
+++ b/src/ui/Logic/Plugins/PluginRequest.cs
@@ -29,6 +29,15 @@ public class PluginRequest
 
     public double FrameRate { get; set; }
 
+    /// <summary>Total duration of the video in seconds. Null when no video is loaded.</summary>
+    public double? VideoDurationSeconds { get; set; }
+
+    /// <summary>Video frame width in pixels. Null when no video is loaded.</summary>
+    public int? VideoWidth { get; set; }
+
+    /// <summary>Video frame height in pixels. Null when no video is loaded.</summary>
+    public int? VideoHeight { get; set; }
+
     /// <summary>Current UI language name, e.g. "English".</summary>
     public string UiLanguage { get; set; } = string.Empty;
 
@@ -42,4 +51,12 @@ public class PluginRequest
 
     /// <summary>The plugin's own settings as last persisted by Subtitle Edit (null on first run).</summary>
     public JsonElement? Settings { get; set; }
+
+    /// <summary>
+    /// Schema version the plugin attached to <see cref="Settings"/> in its last response.
+    /// Null when the plugin has never persisted settings (or persisted them with no version).
+    /// The plugin owns the value; SE just round-trips it so the plugin can migrate or
+    /// reset stale settings when it changes its own schema.
+    /// </summary>
+    public int? SettingsVersion { get; set; }
 }

--- a/src/ui/Logic/Plugins/PluginResponse.cs
+++ b/src/ui/Logic/Plugins/PluginResponse.cs
@@ -24,6 +24,14 @@ public class PluginResponse
     /// <summary>Plugin settings to persist; handed back unchanged in the next request.</summary>
     public JsonElement? Settings { get; set; }
 
+    /// <summary>
+    /// Schema version for <see cref="Settings"/>. Stored verbatim by Subtitle Edit and
+    /// handed back in the next request via <see cref="PluginRequest.SettingsVersion"/>
+    /// so the plugin can migrate (or reset) stale settings when it changes its own
+    /// schema. Optional; null means "unversioned".
+    /// </summary>
+    public int? SettingsVersion { get; set; }
+
     /// <summary>Optional description used for the undo history entry.</summary>
     public string? UndoDescription { get; set; }
 }


### PR DESCRIPTION
## Summary
Two small additive fields on the SE5 plugin contract, both fully backward-compatible (apiVersion stays at 1, missing on older SE = null on the plugin side).

### `settingsVersion` (request + response) — schema versioning for plugin settings
Today `PluginResponse.settings` is a raw `JsonElement` that SE round-trips opaquely. When a plugin author renames or restructures a field, an old SE → new plugin run silently hands over stale JSON with no way to detect the mismatch.

- `PluginResponse.settingsVersion: int?` — plugin owns the value, increments it when its schema changes.
- SE stores it alongside the JSON in a new `SePlugins.SettingsVersions` dictionary (also cleared on plugin removal).
- `PluginRequest.settingsVersion: int?` hands the stored value back on the next run, so the plugin can migrate or reset.

### `videoDurationSeconds` / `videoWidth` / `videoHeight` (request) — video metadata
Today plugins get `videoFileName` + `frameRate` only. Anything else (duration, resolution) requires re-opening the video, which is wasteful and may not work for non-local files.

Populated from the existing `MainViewModel._mediaInfo`. Null when no video is loaded or on older SE versions.

## Docs
`docs/plugin.md` updated with both fields in the request/response examples and a sentence each in the field descriptions.

## Test plan
- [ ] Build clean (verified locally).
- [ ] Run any v1.1 plugin (e.g. WordCensor) — works as before, settings round-trip unchanged, no `settingsVersion` saved unless the plugin starts returning one.
- [ ] Write a tiny test plugin that returns `settingsVersion: 1` then later `settingsVersion: 2` — confirm SE persists each value and hands it back on the next run.
- [ ] Open SE with a video loaded → dispatch any plugin → confirm `request.json` in the plugin's temp dir contains the new video fields with sensible values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)