### PR TITLE
Fix missing JSON encoding for prompt in DeepSeekTranslate

### DIFF
--- a/src/libse/AutoTranslate/DeepSeekTranslate.cs
+++ b/src/libse/AutoTranslate/DeepSeekTranslate.cs
@@ -71,7 +71,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 Configuration.Settings.Tools.DeepSeekPrompt = new ToolsSettings().DeepSeekPrompt;
             }
             var prompt = string.Format(Configuration.Settings.Tools.DeepSeekPrompt, sourceLanguageCode, targetLanguageCode);
-            var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+            var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
             HttpResponseMessage result = null;


### PR DESCRIPTION
 When using a multi-line or custom prompt in DeepSeek translation, the request fails (404/400) because the `prompt` variable in the JSON payload was missing `Json.EncodeJsonText()`.
     
     This PR wraps the prompt variable with `Json.EncodeJsonText(prompt)`, aligning the logic with `ChatGptTranslate` and others.