### PR TITLE
Fix STT response_format=verbose_json when sending timestamp_granularities (#11146)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -115,12 +115,19 @@ public class OpenAiSttService
             content.Add(new StringContent(languageToUse), "language");
         }
 
-        // Add response format - use json for streaming support
-        content.Add(new StringContent("json"), "response_format");
+        // Pick response_format based on streaming: OpenAI's streaming endpoint
+        // only emits `json`, while `timestamp_granularities[]` is rejected
+        // unless `response_format=verbose_json` (issue #11146). Send the
+        // granularity hints only with verbose_json — segments come through
+        // the SSE `transcript.text.done` event anyway during streaming.
+        var responseFormat = _settings.Stream ? "json" : "verbose_json";
+        content.Add(new StringContent(responseFormat), "response_format");
 
-        // Add timestamp granularities for segment/word timing
-        content.Add(new StringContent("segment"), "timestamp_granularities[]");
-        content.Add(new StringContent("word"), "timestamp_granularities[]");
+        if (!_settings.Stream)
+        {
+            content.Add(new StringContent("segment"), "timestamp_granularities[]");
+            content.Add(new StringContent("word"), "timestamp_granularities[]");
+        }
 
         // Enable streaming (some OpenAI-compatible servers, e.g. Groq, reject this param)
         if (_settings.Stream)
@@ -168,9 +175,10 @@ public class OpenAiSttService
             var temperatureSummary = _settings.Temperature > 0
                 ? _settings.Temperature.ToString("F2", CultureInfo.InvariantCulture)
                 : "(not sent)";
+            var granularitiesSummary = _settings.Stream ? "(not sent)" : "[segment,word]";
             var paramSummary =
                 $"model={_settings.Model}, language={languageToUse}, " +
-                $"response_format=json, timestamp_granularities=[segment,word], " +
+                $"response_format={responseFormat}, timestamp_granularities={granularitiesSummary}, " +
                 $"stream={(_settings.Stream ? "true" : "(not sent)")}, " +
                 $"temperature={temperatureSummary}, " +
                 $"promptLen={_settings.Prompt?.Length ?? 0}, file={fileName}";

--- a/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
@@ -316,6 +316,31 @@ public class OpenAiSttServiceTests
     }
 
     [Fact]
+    public async Task TranscribeAsync_NonStreaming_UsesVerboseJsonWithGranularities()
+    {
+        // Issue #11146: the OpenAI API rejects timestamp_granularities[] unless
+        // response_format=verbose_json. The non-streaming path must pair them.
+        var (names, values) = await CaptureMultipartFieldNamesAndValuesAsync(MakeSettings());
+
+        Assert.Equal("verbose_json", values["response_format"]);
+        Assert.Contains("timestamp_granularities[]", names);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_StreamEnabled_UsesJsonAndOmitsGranularities()
+    {
+        // Streaming only emits response_format=json; timestamp_granularities[]
+        // is incompatible with it and must not be sent.
+        var settings = MakeSettings();
+        settings.Stream = true;
+
+        var (names, values) = await CaptureMultipartFieldNamesAndValuesAsync(settings);
+
+        Assert.Equal("json", values["response_format"]);
+        Assert.DoesNotContain("timestamp_granularities[]", names);
+    }
+
+    [Fact]
     public async Task TranscribeAsync_NonSuccessStatus_InvokesLogger_WithSanitizedUrl()
     {
         var logEntries = new List<string>();


### PR DESCRIPTION
## Summary
- OpenAI rejects `timestamp_granularities[]` unless `response_format=verbose_json`, but `OpenAiSttService` was hardcoding `json`, so non-streaming Whisper requests failed with `\`response_format\` must be \`verbose_json\` if \`timestamp_granularities[]\` is provided` (issue #11146).
- Pick `response_format` per mode: `json` when streaming (only format the streaming endpoint supports), `verbose_json` otherwise. Send `timestamp_granularities[]` only with `verbose_json` — segments still arrive via the `transcript.text.done` SSE event when streaming.
- Updated the error-log line so it reports the format/granularities actually sent.
- Added two unit tests that pin both branches so this can't regress.

Fixes #11146

## Test plan
- [x] `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~OpenAiSttServiceTests"` → 15/15 pass (including the two new ones).
- [ ] Manual: run STT against a Whisper-compatible OpenAI endpoint (e.g. Groq, `whisper-large-v3-turbo`) with streaming OFF and confirm the transcription succeeds.
- [ ] Manual: run STT against an OpenAI streaming endpoint (e.g. `gpt-4o-transcribe`) with streaming ON and confirm SSE deltas + final segments still arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)