### PR TITLE
Gate STT WAV short-circuit on target format, not on engine

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3214,13 +3214,22 @@ public partial class SpeechToTextViewModel : ObservableObject
             return false;
         }
 
-        // Local whisper engines read the file directly and want 16 kHz PCM, so
-        // a pre-extracted 16 kHz WAV can be handed to them as-is. The OpenAI-
-        // compatible engine uploads the file instead, and a 16 kHz WAV easily
-        // exceeds the 25 MB cap on long audio — skip the short-circuit and
-        // transcode through ffmpeg into the chosen compressed format.
-        var isOpenAiEngine = GetEffectiveSelectedEngine() is OpenAiCompatibleSttEngine;
-        if (!isOpenAiEngine && videoFileName.EndsWith(".wav", StringComparison.OrdinalIgnoreCase))
+        // OpenAI's STT endpoint caps uploads at 25 MB and a 2-hour WAV blows
+        // past that. When the OpenAI-compatible engine is selected, transcode
+        // to the user's chosen compressed format (mp3 by default) so the
+        // upload stays under the limit; other engines (whisper.cpp, faster-
+        // whisper, ...) keep getting WAV because they read the file locally
+        // and expect PCM.
+        var sttAudioFormat = GetEffectiveSelectedEngine() is OpenAiCompatibleSttEngine
+            ? OpenAiCompatibleSttAudioFormat
+            : "wav";
+        var extension = OpenAiSttService.GetFileExtensionForFormat(sttAudioFormat);
+
+        // Skip ffmpeg only when no conversion is needed: target format is wav
+        // and the input is already a 16 kHz WAV. If the user picked a
+        // compressed target (mp3/m4a/webm) we must still transcode — uploading
+        // the original WAV would defeat the whole point of the format choice.
+        if (extension == "wav" && videoFileName.EndsWith(".wav", StringComparison.OrdinalIgnoreCase))
         {
             try
             {
@@ -3239,17 +3248,6 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         _ffmpegLog = new StringBuilder();
-
-        // OpenAI's STT endpoint caps uploads at 25 MB and a 2-hour WAV blows
-        // past that. When the OpenAI-compatible engine is selected, transcode
-        // to the user's chosen compressed format (mp3 by default) so the
-        // upload stays under the limit; other engines (whisper.cpp, faster-
-        // whisper, ...) keep getting WAV because they read the file locally
-        // and expect PCM.
-        var sttAudioFormat = isOpenAiEngine
-            ? OpenAiCompatibleSttAudioFormat
-            : "wav";
-        var extension = OpenAiSttService.GetFileExtensionForFormat(sttAudioFormat);
         _audioFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + "." + extension);
         _filesToDelete.Add(_audioFileName);
         _audioExtractProcess = GetFfmpegProcess(videoFileName, audioTrackNumber, _audioFileName, sttAudioFormat);


### PR DESCRIPTION
## Summary

Follow-up to #11152. The 16 kHz WAV short-circuit in `GenerateAudioFile` was gated on engine (skip ffmpeg only when engine isn't OpenAI-compatible). That was over-restrictive — when an OpenAI-compatible user picks `wav` as their upload format (e.g. for a local server that doesn't accept compressed formats), we'd still re-run ffmpeg even though no conversion was needed.

The short-circuit now triggers whenever the target format is `wav` and the input is already a 16 kHz WAV, regardless of engine:

- whisper.cpp / faster-whisper (always target wav) + 16 kHz WAV input → skip ffmpeg ✓
- OpenAI + `wav` format + 16 kHz WAV input → skip ffmpeg ✓ (previously over-restricted)
- OpenAI + `mp3`/`m4a`/`webm` + 16 kHz WAV input → still transcode (must, to honor the format choice)

## Test plan

- [x] `dotnet build src/ui/UI.csproj` — clean
- [x] `dotnet test tests/UI/UITests.csproj` — 254 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)