### PR TITLE
Fix: remove ultrafast/superfast presets for h264_qsv and hevc_qsv codecs

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -1510,6 +1510,19 @@ public partial class BurnInViewModel : ObservableObject
                 "p7",
             };
         }
+        else if (videoCodec == "h264_qsv" || videoCodec == "hevc_qsv")
+        {
+            items = new List<string>
+            {
+                "veryfast",
+                "faster",
+                "fast",
+                "medium",
+                "slow",
+                "slower",
+                "veryslow",
+            };
+        }
         else if (videoCodec == "h264_amf")
         {
             items = new List<string> { string.Empty };


### PR DESCRIPTION
## What changed

Added a dedicated preset list for h264_qsv and hevc_qsv in BurnInViewModel.FillPreset() that excludes ultrafast and superfast.

## Why

Intel QSV encoders (h264_qsv, hevc_qsv) do not support ultrafast or superfast presets - those are software encoder presets for libx264/libx265. When a user selected either of those presets with a QSV codec, FFmpeg would fail with: 'Unable to parse option value ultrafast' / 'Error opening output files: Invalid argument'.

## Fix

h264_qsv and hevc_qsv now show only the presets valid for QSV: veryfast, faster, fast, medium, slow, slower, veryslow.

## Verification

- Build succeeds.
- The invalid presets (ultrafast, superfast) are no longer available in the dropdown when a QSV codec is selected.

Fixes #11156

Note: This change was materially AI-assisted via GitHub Copilot.