### PR TITLE
Add TTS Cast: per-actor voice + model + instruction mapping

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -135,6 +135,7 @@ using Nikse.SubtitleEdit.Features.Video.OpenFromUrl.PickOnlineSubtitle;
 using Nikse.SubtitleEdit.Features.Video.ReEncodeVideo;
 using Nikse.SubtitleEdit.Features.Video.ShotChanges;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
@@ -451,6 +452,8 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<SurroundWithViewModel>();
         collection.AddTransient<SyntaxColorTooWideSettingsViewModel>();
         collection.AddTransient<TextToSpeechViewModel>();
+        collection.AddTransient<ActorVoiceMappingViewModel>();
+        collection.AddTransient<ActorVoiceRowSettingsViewModel>();
         collection.AddTransient<TimedText10PropertiesViewModel>();
         collection.AddTransient<TimedTextImsc11PropertiesViewModel>();
         collection.AddTransient<TmpegEncXmlPropertiesViewModel>();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5912,8 +5912,11 @@ public partial class MainViewModel :
 
         await ShowDialogAsync<TextToSpeechWindow, TextToSpeechViewModel>(vm =>
         {
-            vm.Initialize(GetUpdateSubtitle(), _videoFileName ?? string.Empty, AudioVisualizer?.WavePeaks,
-                Path.GetTempPath());
+            // Pass SelectedSubtitleFormat explicitly so the TTS window's cast detection uses the
+            // user's *current* selection (the editor normalises subtitles to ASSA internally, so
+            // subtitle.OriginalFormat doesn't reflect what's shown in the format combo).
+            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat,
+                _videoFileName ?? string.Empty, AudioVisualizer?.WavePeaks, Path.GetTempPath());
         });
     }
 

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceDetector.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceDetector.cs
@@ -114,9 +114,9 @@ public static class ActorVoiceDetector
     }
 
     // Drops engines that aren't usable right now — missing API key, missing runtime/models, etc.
-    // Same set of checks the Review window uses, factored out so the Cast dialog gets the same
-    // filtered list. An engine in the raw list but not installable would otherwise show up in
-    // the Cast dropdown, the user picks it, and BuildCastContextAsync silently swallows the
+    // Shared between the Cast dialog and the Review window so both surface exactly the same set
+    // of engines. An engine in the raw list but not installable would otherwise show up in the
+    // Cast dropdown, the user picks it, and BuildCastContextAsync silently swallows the
     // GetVoices exception → row falls back to the global voice with no UI feedback.
     public static IEnumerable<ITtsEngine> FilterUsableEngines(IEnumerable<ITtsEngine> engines)
     {

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceDetector.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceDetector.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+
+// Pulls the set of distinct actor names (ASSA) or voice names (WebVTT) out of a subtitle, so the
+// TTS window can decide whether to expose the "Cast" button and what to pre-populate the cast
+// dialog with. WebVTT path also offers a helper to strip the <v ...> wrapper before sending text
+// to the engine, and to look up which voice owns a given paragraph.
+public static class ActorVoiceDetector
+{
+    public enum CastKind
+    {
+        None,
+        AssaActors,
+        WebVttVoices,
+    }
+
+    // Returns which cast model applies to this subtitle. Format is passed in by the caller
+    // (typically MainViewModel.SelectedSubtitleFormat) rather than read from subtitle.OriginalFormat
+    // — the editor normalises subtitles to ASSA internally, so OriginalFormat doesn't reliably
+    // reflect what the user is currently working with. Also requires actual actor/voice data so
+    // the Cast button only shows when there's something real to assign.
+    public static CastKind Detect(Subtitle? subtitle, SubtitleFormat? format)
+    {
+        if (subtitle == null || format == null || subtitle.Paragraphs.Count == 0)
+        {
+            return CastKind.None;
+        }
+
+        if (format is WebVTT)
+        {
+            return WebVTT.GetVoices(subtitle).Count > 0 ? CastKind.WebVttVoices : CastKind.None;
+        }
+
+        if (format is AdvancedSubStationAlpha || format is SubStationAlpha)
+        {
+            return subtitle.Paragraphs.Any(p => !string.IsNullOrWhiteSpace(p.Actor))
+                ? CastKind.AssaActors
+                : CastKind.None;
+        }
+
+        return CastKind.None;
+    }
+
+    public static IReadOnlyList<string> GetNames(Subtitle? subtitle, CastKind kind)
+    {
+        if (subtitle == null || kind == CastKind.None)
+        {
+            return Array.Empty<string>();
+        }
+
+        if (kind == CastKind.WebVttVoices)
+        {
+            return WebVTT.GetVoices(subtitle);
+        }
+
+        return subtitle.Paragraphs
+            .Select(p => (p.Actor ?? string.Empty).Trim())
+            .Where(a => a.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(a => a, StringComparer.CurrentCultureIgnoreCase)
+            .ToArray();
+    }
+
+    // Returns the actor/voice name for a paragraph, or empty if none. For WebVTT it reads the
+    // first <v ...> tag in the paragraph text; for ASSA it returns the Actor field.
+    public static string GetParagraphActor(Paragraph paragraph, CastKind kind)
+    {
+        if (kind == CastKind.AssaActors)
+        {
+            return (paragraph.Actor ?? string.Empty).Trim();
+        }
+
+        if (kind == CastKind.WebVttVoices)
+        {
+            return ExtractWebVttVoice(paragraph.Text);
+        }
+
+        return string.Empty;
+    }
+
+    // Removes every WebVTT <v Name> wrapper from a paragraph so the engine never speaks the
+    // tag. WebVTT.RemoveTag only strips one occurrence per call, so we loop until none remain
+    // (otherwise paragraphs with multiple speakers leak unstripped "<v Bob>...</v>" markup
+    // into the synthesized audio). Other markup (bold, italic, etc.) is left intact — the
+    // engines already ignore tags they don't understand.
+    public static string StripWebVttVoiceTags(string text)
+    {
+        if (string.IsNullOrEmpty(text) || !text.Contains("<v ", StringComparison.Ordinal))
+        {
+            return text;
+        }
+
+        var current = text;
+        while (current.Contains("<v ", StringComparison.Ordinal))
+        {
+            var stripped = WebVTT.RemoveTag("v", current);
+            if (stripped == current)
+            {
+                // RemoveTag couldn't make progress — bail out so we don't infinite-loop on
+                // malformed input.
+                break;
+            }
+            current = stripped;
+        }
+        return current;
+    }
+
+    // Drops engines that aren't usable right now — missing API key, missing runtime/models, etc.
+    // Same set of checks the Review window uses, factored out so the Cast dialog gets the same
+    // filtered list. An engine in the raw list but not installable would otherwise show up in
+    // the Cast dropdown, the user picks it, and BuildCastContextAsync silently swallows the
+    // GetVoices exception → row falls back to the global voice with no UI feedback.
+    public static IEnumerable<ITtsEngine> FilterUsableEngines(IEnumerable<ITtsEngine> engines)
+    {
+        var s = Se.Settings.Video.TextToSpeech;
+        foreach (var engine in engines)
+        {
+            switch (engine)
+            {
+                case ElevenLabs when string.IsNullOrWhiteSpace(s.ElevenLabsApiKey):
+                case Murf when string.IsNullOrWhiteSpace(s.MurfApiKey):
+                case AzureSpeech when string.IsNullOrWhiteSpace(s.AzureApiKey):
+                case GoogleSpeech when string.IsNullOrWhiteSpace(s.GoogleKeyFile):
+                case MistralSpeech when string.IsNullOrWhiteSpace(s.MistralApiKey):
+                    continue;
+
+                case Qwen3TtsCpp when !File.Exists(Qwen3TtsCpp.GetExecutableFileName())
+                    || (!Qwen3TtsCpp.IsModelsInstalled(Qwen3TtsCpp.ModelKey06B)
+                        && !Qwen3TtsCpp.IsModelsInstalled(Qwen3TtsCpp.ModelKey17BBase)):
+                    continue;
+
+                case KokoroTtsCpp when !File.Exists(KokoroTtsCpp.GetExecutableFileName())
+                    || !KokoroTtsCpp.AreModelsInstalled():
+                    continue;
+            }
+
+            yield return engine;
+        }
+    }
+
+    private static string ExtractWebVttVoice(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var start = text.IndexOf("<v ", StringComparison.Ordinal);
+        if (start < 0)
+        {
+            return string.Empty;
+        }
+
+        var end = text.IndexOf('>', start);
+        if (end <= start + 3)
+        {
+            return string.Empty;
+        }
+
+        return text.Substring(start + 3, end - start - 3).Trim();
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMapping.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMapping.cs
@@ -1,0 +1,32 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+
+// One row in the actor/voice-to-TTS-voice cast. Persisted as part of SubtitleEditTts.json
+// (round-trips with the audio export) and also kept in SeVideoTextToSpeech.LastActorVoiceMappings
+// so the next session can pre-fill the same cast even before the user has exported anything.
+public class ActorVoiceMapping
+{
+    // The ASSA Actor field or the WebVTT <v ...> voice name this row maps from.
+    public string Actor { get; set; }
+
+    // The TTS engine name (matches ITtsEngine.Name). Empty means "use the global engine".
+    public string EngineName { get; set; }
+
+    // The voice name within the engine (matches Voice.Name). Empty means "use the global voice".
+    public string VoiceName { get; set; }
+
+    // Optional engine-specific model key (e.g. "0.6B" for Qwen3, "eleven_v3" for ElevenLabs).
+    // Empty falls back to the engine's default / the main window's selected model.
+    public string Model { get; set; }
+
+    // Optional free-text instruction for engines that support voice design (Qwen3, OmniVoice).
+    public string Instruction { get; set; }
+
+    public ActorVoiceMapping()
+    {
+        Actor = string.Empty;
+        EngineName = string.Empty;
+        VoiceName = string.Empty;
+        Model = string.Empty;
+        Instruction = string.Empty;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
@@ -1,0 +1,575 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+
+// Cast dialog VM: lets the user pair each ASSA actor (or WebVTT voice name) with a TTS engine
+// and voice, optionally with a free-text voice-design instruction. Voices for an engine are
+// fetched once and cached on the VM so flipping multiple rows to the same engine doesn't refetch.
+// On OK, exposes the resulting list of ActorVoiceMapping to the caller via Mappings + OkPressed.
+public partial class ActorVoiceMappingViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<ActorVoiceRow> _rows;
+    [ObservableProperty] private ActorVoiceRow? _selectedRow;
+    [ObservableProperty] private ObservableCollection<ITtsEngine> _engines;
+    [ObservableProperty] private string _statusText;
+    [ObservableProperty] private bool _isMappingEmpty;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+    public List<ActorVoiceMapping> Mappings { get; private set; }
+    public ActorVoiceDetector.CastKind Kind { get; private set; }
+
+    private readonly IWindowService _windowService;
+    private readonly Dictionary<string, Voice[]> _voiceCache;
+    private readonly Dictionary<string, string[]> _modelCache;
+    private string _waveFolder;
+    private LibMpvDynamicPlayer? _mpvContext;
+    private readonly Lock _playLock;
+    private CancellationTokenSource _cancellationTokenSource;
+    private ITtsEngine? _fallbackEngine;
+    private Voice? _fallbackVoice;
+    private string _voiceTestText;
+
+    public ActorVoiceMappingViewModel(IWindowService windowService)
+    {
+        _windowService = windowService;
+        _voiceCache = new Dictionary<string, Voice[]>(StringComparer.OrdinalIgnoreCase);
+        _modelCache = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        _rows = new ObservableCollection<ActorVoiceRow>();
+        _engines = new ObservableCollection<ITtsEngine>();
+        _statusText = string.Empty;
+        _waveFolder = Path.GetTempPath();
+        _playLock = new Lock();
+        _cancellationTokenSource = new CancellationTokenSource();
+        Mappings = new List<ActorVoiceMapping>();
+        _voiceTestText = "Hello, how are you doing?";
+    }
+
+    public void Initialize(
+        IEnumerable<string> actorNames,
+        IEnumerable<ITtsEngine> engines,
+        IEnumerable<ActorVoiceMapping> existingMappings,
+        ITtsEngine? fallbackEngine,
+        Voice? fallbackVoice,
+        ActorVoiceDetector.CastKind kind,
+        string waveFolder)
+    {
+        Kind = kind;
+        _fallbackEngine = fallbackEngine;
+        _fallbackVoice = fallbackVoice;
+        _waveFolder = string.IsNullOrEmpty(waveFolder) ? Path.GetTempPath() : waveFolder;
+        _voiceTestText = string.IsNullOrWhiteSpace(Se.Settings.Video.TextToSpeech.VoiceTestText)
+            ? "Hello, how are you doing?"
+            : Se.Settings.Video.TextToSpeech.VoiceTestText;
+
+        Engines.Clear();
+        foreach (var engine in engines)
+        {
+            Engines.Add(engine);
+        }
+
+        var mappingByActor = (existingMappings ?? Array.Empty<ActorVoiceMapping>())
+            .Where(m => !string.IsNullOrWhiteSpace(m.Actor))
+            .GroupBy(m => m.Actor.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        Rows.Clear();
+        foreach (var actor in actorNames.Where(a => !string.IsNullOrWhiteSpace(a)).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var row = new ActorVoiceRow { Actor = actor };
+            ITtsEngine? engineForRow = null;
+            string voiceName = string.Empty;
+            string instruction = string.Empty;
+
+            string modelName = string.Empty;
+            if (mappingByActor.TryGetValue(actor, out var saved))
+            {
+                engineForRow = Engines.FirstOrDefault(e => string.Equals(e.Name, saved.EngineName, StringComparison.OrdinalIgnoreCase));
+                voiceName = saved.VoiceName ?? string.Empty;
+                modelName = saved.Model ?? string.Empty;
+                instruction = saved.Instruction ?? string.Empty;
+            }
+
+            engineForRow ??= fallbackEngine ?? Engines.FirstOrDefault();
+            row.Instruction = instruction;
+            row.HasInstruction = EngineSupportsInstruction(engineForRow);
+            row.HasAdvancedSettings = HasAdvancedSettingsForRow(engineForRow, modelName);
+            row.HasModel = engineForRow?.HasModel ?? false;
+            // Don't pre-seed row.SelectedModel here: when Rows.Add binds the ComboBox, Models is
+            // still empty, so Avalonia's SelectingItemsControl resets SelectedItem to null and
+            // (TwoWay) writes null back over our seed value. AssignEngineToRowAsync below loads
+            // the model list and applies the saved selection *after* items exist.
+            row.EngineChangedByUser += (_, newEngine) => _ = AssignEngineToRowAsync(row, newEngine, string.Empty, string.Empty);
+            row.PropertyChanged += (_, args) =>
+            {
+                if (args.PropertyName == nameof(ActorVoiceRow.SelectedVoice))
+                {
+                    UpdateStatus();
+                }
+                else if (args.PropertyName == nameof(ActorVoiceRow.SelectedModel))
+                {
+                    // Qwen3 only takes voice instructions on the VoiceDesign model. When the user
+                    // flips models the row's "..." button has to enable/disable accordingly.
+                    row.HasAdvancedSettings = HasAdvancedSettingsForRow(row.SelectedEngine, row.SelectedModel);
+                }
+            };
+
+            Rows.Add(row);
+            _ = AssignEngineToRowAsync(row, engineForRow, voiceName, modelName);
+        }
+
+        SelectedRow = Rows.FirstOrDefault();
+        UpdateStatus();
+    }
+
+    private async Task AssignEngineToRowAsync(ActorVoiceRow row, ITtsEngine? engine, string preferredVoiceName, string preferredModelName)
+    {
+        if (engine == null)
+        {
+            row.SelectedEngine = null;
+            row.Voices.Clear();
+            row.Models.Clear();
+            row.SelectedVoice = null;
+            row.SelectedModel = null;
+            row.HasModel = false;
+            row.HasInstruction = false;
+            row.HasAdvancedSettings = false;
+            return;
+        }
+
+        row.IsBusy = true;
+        try
+        {
+            var voices = await GetVoicesAsync(engine);
+            var models = engine.HasModel ? await GetModelsAsync(engine) : Array.Empty<string>();
+
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                row.SuppressEngineEvent = true;
+                try
+                {
+                    row.SelectedEngine = engine;
+                }
+                finally
+                {
+                    row.SuppressEngineEvent = false;
+                }
+
+                // Replace the collections wholesale instead of Clear()+Add. With Clear()+Add the
+                // ComboBox sees an empty ItemsSource for one dispatcher tick and resets its
+                // SelectedItem to null, which (TwoWay) writes null back to row.SelectedModel and
+                // wipes out the value we're about to apply. Reassigning the property fires a
+                // single PropertyChanged with a fully-populated collection in hand.
+                row.Voices = new ObservableCollection<Voice>(voices);
+                row.Models = new ObservableCollection<string>(models);
+
+                var pickedVoice = PickBestVoice(row.Actor, voices, preferredVoiceName, engine);
+                var pickedModel = PickBestModel(models, preferredModelName);
+
+                row.SelectedVoice = pickedVoice;
+                row.SelectedModel = pickedModel;
+                row.HasModel = engine.HasModel && models.Length > 0;
+                row.HasInstruction = EngineSupportsInstruction(engine);
+                row.HasAdvancedSettings = HasAdvancedSettingsForRow(engine, pickedModel);
+                row.IsVoiceComboEnabled = voices.Length > 1;
+                UpdateStatus();
+
+                // Defensive second pass on the next dispatcher tick: if the ComboBox happens to
+                // process a deferred SelectedItem reset *after* our assignment, re-apply it so
+                // the user (and the OK handler) sees the right value. No-op when the value is
+                // already correct.
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (pickedModel != null && !string.Equals(row.SelectedModel, pickedModel, StringComparison.Ordinal))
+                    {
+                        row.SelectedModel = pickedModel;
+                    }
+                    if (pickedVoice != null && !ReferenceEquals(row.SelectedVoice, pickedVoice))
+                    {
+                        row.SelectedVoice = pickedVoice;
+                    }
+                }, DispatcherPriority.Background);
+            });
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, $"Cast dialog: loading voices/models for {engine.Name} failed.");
+        }
+        finally
+        {
+            row.IsBusy = false;
+        }
+    }
+
+    private async Task<string[]> GetModelsAsync(ITtsEngine engine)
+    {
+        if (_modelCache.TryGetValue(engine.Name, out var cached))
+        {
+            return cached;
+        }
+
+        var models = await engine.GetModels();
+        _modelCache[engine.Name] = models;
+        return models;
+    }
+
+    private static string? PickBestModel(string[] models, string preferred)
+    {
+        if (models.Length == 0)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(preferred))
+        {
+            var match = Array.Find(models, m => string.Equals(m, preferred, StringComparison.OrdinalIgnoreCase));
+            if (match != null)
+            {
+                return match;
+            }
+        }
+
+        return models[0];
+    }
+
+
+    private async Task<Voice[]> GetVoicesAsync(ITtsEngine engine)
+    {
+        if (_voiceCache.TryGetValue(engine.Name, out var cached))
+        {
+            return cached;
+        }
+
+        var voices = await engine.GetVoices(string.Empty);
+        _voiceCache[engine.Name] = voices;
+        return voices;
+    }
+
+    // Picks the best voice for an actor:
+    //   1. the previously-saved voice name (case-insensitive) if it's still in the list
+    //   2. a voice whose name contains the actor name (e.g. actor "Aria" → "en-US-AriaNeural")
+    //   3. the global fallback voice if this row's engine is the global engine
+    //   4. the first voice
+    private Voice? PickBestVoice(string actor, Voice[] voices, string preferredVoiceName, ITtsEngine engine)
+    {
+        if (voices.Length == 0)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(preferredVoiceName))
+        {
+            var saved = voices.FirstOrDefault(v => string.Equals(v.Name, preferredVoiceName, StringComparison.OrdinalIgnoreCase));
+            if (saved != null)
+            {
+                return saved;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(actor))
+        {
+            var match = voices.FirstOrDefault(v => v.Name.Contains(actor, StringComparison.OrdinalIgnoreCase));
+            if (match != null)
+            {
+                return match;
+            }
+        }
+
+        if (_fallbackEngine != null
+            && _fallbackVoice != null
+            && string.Equals(engine.Name, _fallbackEngine.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            var fallback = voices.FirstOrDefault(v => string.Equals(v.Name, _fallbackVoice.Name, StringComparison.OrdinalIgnoreCase));
+            if (fallback != null)
+            {
+                return fallback;
+            }
+        }
+
+        return voices.First();
+    }
+
+    private static bool EngineSupportsInstruction(ITtsEngine? engine)
+    {
+        // Mirrors the engines that opt into RefreshInstructionVisibility in the main TTS VM. We
+        // expose the field unconditionally for these engines - the cast dialog doesn't know which
+        // sub-model the row will use, and an unused instruction is harmless.
+        return engine is Qwen3TtsCpp or Qwen3TtsCrispAsr or OmniVoiceTtsCpp;
+    }
+
+    // True when opening the row-settings sub-window would actually surface usable controls for
+    // this engine+model+voice combination. Used to disable the row's "..." button so users don't
+    // open an empty dialog.
+    //   - Qwen3:     only if the VoiceDesign model is selected (other Qwen3 models ignore the
+    //                instruction field)
+    //   - OmniVoice: always (cloned voices still get the disabled picker with a note)
+    //   - others:    never
+    private static bool HasAdvancedSettingsForRow(ITtsEngine? engine, string? model)
+    {
+        return engine switch
+        {
+            Qwen3TtsCpp => Qwen3TtsCpp.IsVoiceDesignModel(model),
+            Qwen3TtsCrispAsr => Qwen3TtsCrispAsr.IsVoiceDesignModel(model),
+            OmniVoiceTtsCpp => true,
+            _ => false,
+        };
+    }
+
+    [RelayCommand]
+    private async Task TestRow(ActorVoiceRow? row)
+    {
+        if (row?.SelectedEngine == null || row.SelectedVoice == null || Window == null)
+        {
+            return;
+        }
+
+        if (!await TtsVoiceInstaller.EnsureVoiceInstalled(row.SelectedEngine, row.SelectedVoice, Window, _windowService))
+        {
+            return;
+        }
+
+        var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
+        _cancellationTokenSource = generatingAudioVm.CancellationTokenSource;
+
+        try
+        {
+            row.IsPlaying = true;
+            var result = await TtsInstructionSwap.RunAsync(row.SelectedEngine, row.Instruction, () =>
+                row.SelectedEngine.Speak(_voiceTestText, _waveFolder, row.SelectedVoice,
+                    null, null, null, _cancellationTokenSource.Token));
+
+            if (!_cancellationTokenSource.IsCancellationRequested && File.Exists(result.FileName))
+            {
+                await PlayAudio(result.FileName);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // user cancelled
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, "Cast dialog: test voice failed.");
+            if (Window != null)
+            {
+                await MessageBox.Show(Window, Se.Language.General.Error, ex.Message,
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+        finally
+        {
+            row.IsPlaying = false;
+            generatingAudioVm.Close();
+        }
+    }
+
+    private async Task PlayAudio(string fileName)
+    {
+        lock (_playLock)
+        {
+            _mpvContext?.Stop();
+            _mpvContext?.Dispose();
+
+            _mpvContext = new LibMpvDynamicPlayer();
+            _mpvContext.LoadLib();
+            var err = _mpvContext.Initialize();
+            if (err < 0)
+            {
+                throw new InvalidOperationException($"Failed to initialize mpv: {_mpvContext.GetErrorString(err)}");
+            }
+        }
+
+        await _mpvContext.LoadAudio(fileName);
+    }
+
+    [RelayCommand]
+    private void ApplyDefaultToAll()
+    {
+        if (_fallbackEngine == null)
+        {
+            return;
+        }
+
+        foreach (var row in Rows)
+        {
+            if (row.SelectedEngine == _fallbackEngine)
+            {
+                // Resolve the fallback voice against the row's own Voices collection — the
+                // _fallbackVoice instance came from the main window's Voices list and may not
+                // be the same instance the row has. Setting an out-of-list reference on the
+                // ComboBox is silently rejected (binding warning, SelectedVoice stays null).
+                if (row.SelectedVoice == null && _fallbackVoice != null)
+                {
+                    row.SelectedVoice = row.Voices.FirstOrDefault(v =>
+                        string.Equals(v.Name, _fallbackVoice.Name, StringComparison.OrdinalIgnoreCase));
+                }
+                continue;
+            }
+
+            _ = AssignEngineToRowAsync(row, _fallbackEngine, _fallbackVoice?.Name ?? string.Empty, string.Empty);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ShowRowSettings(ActorVoiceRow? row)
+    {
+        if (row?.SelectedEngine == null || Window == null
+            || !HasAdvancedSettingsForRow(row.SelectedEngine, row.SelectedModel))
+        {
+            return;
+        }
+
+        var capturedRow = row;
+        var result = await _windowService.ShowDialogAsync<ActorVoiceRowSettingsWindow, ActorVoiceRowSettingsViewModel>(
+            Window!, vm => vm.Initialize(capturedRow));
+
+        if (result.OkPressed)
+        {
+            capturedRow.Instruction = result.Instruction ?? string.Empty;
+        }
+    }
+
+    [RelayCommand]
+    private async Task ClearAll()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var answer = await MessageBox.Show(
+            Window,
+            Se.Language.Video.TextToSpeech.ActorVoicesTitle,
+            Se.Language.Video.TextToSpeech.ClearAllAssignmentsConfirm,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        foreach (var row in Rows)
+        {
+            row.Instruction = string.Empty;
+            row.SelectedVoice = null;
+        }
+
+        UpdateStatus();
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        Mappings = Rows
+            .Select(r => new ActorVoiceMapping
+            {
+                Actor = r.Actor,
+                EngineName = r.SelectedEngine?.Name ?? string.Empty,
+                VoiceName = r.SelectedVoice?.Name ?? string.Empty,
+                Model = r.SelectedModel ?? string.Empty,
+                Instruction = (r.Instruction ?? string.Empty).Trim(),
+            })
+            .Where(m => !string.IsNullOrEmpty(m.EngineName) && !string.IsNullOrEmpty(m.VoiceName))
+            .ToList();
+
+        Se.Settings.Video.TextToSpeech.LastActorVoiceMappings = MergeWithPersistedMappings(Mappings);
+        Se.SaveSettings();
+
+        OkPressed = true;
+        Close();
+    }
+
+    // Keep mappings for actors not in this subtitle so a user who jumps between projects keeps
+    // their full cast remembered. New/updated rows from this dialog overwrite anything saved
+    // under the same actor name.
+    private static List<ActorVoiceMapping> MergeWithPersistedMappings(List<ActorVoiceMapping> current)
+    {
+        var previous = Se.Settings.Video.TextToSpeech.LastActorVoiceMappings ?? new List<ActorVoiceMapping>();
+        var byActor = previous
+            .Where(m => !string.IsNullOrWhiteSpace(m.Actor))
+            .GroupBy(m => m.Actor.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var m in current)
+        {
+            byActor[m.Actor.Trim()] = m;
+        }
+
+        return byActor.Values.ToList();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    private void Close()
+    {
+        StopPlayback();
+        Dispatcher.UIThread.Post(() => Window?.Close());
+    }
+
+    private void StopPlayback()
+    {
+        try
+        {
+            _cancellationTokenSource.Cancel();
+        }
+        catch
+        {
+            // ignored
+        }
+
+        lock (_playLock)
+        {
+            _mpvContext?.Stop();
+            _mpvContext?.Dispose();
+            _mpvContext = null;
+        }
+    }
+
+    private void UpdateStatus()
+    {
+        var total = Rows.Count;
+        var assigned = Rows.Count(r => r.SelectedVoice != null);
+        StatusText = total == 0
+            ? string.Empty
+            : string.Format(Se.Language.Video.TextToSpeech.ActorVoicesAssignedXOfY, assigned, total);
+        IsMappingEmpty = total == 0;
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Close();
+        }
+    }
+
+    internal void OnClosing(WindowClosingEventArgs e)
+    {
+        StopPlayback();
+        UiUtil.SaveWindowPosition(Window);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingWindow.cs
@@ -1,0 +1,348 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+using Optris.Icons.Avalonia;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+
+// The Cast dialog. Visual layout:
+//
+//   ┌──────────────────────────────────────────────────────────────────────┐
+//   │ <icon> Cast - assign a voice to each <actor|voice>                   │
+//   │ "<count>"                                                            │
+//   ├──────────────────────────────────────────────────────────────────────┤
+//   │ ┌───────────┬───────────┬───────────┬────────────────────────┬─────┐ │
+//   │ │ Actor     │ Engine    │ Voice     │ Instruction            │ ▶  │ │
+//   │ ├───────────┼───────────┼───────────┼────────────────────────┼─────┤ │
+//   │ │ Joe       │ Edge TTS  │ AriaNeu…  │                        │ ▶  │ │
+//   │ │ Maria     │ ElevenLabs│ Rachel    │                        │ ▶  │ │
+//   │ └───────────┴───────────┴───────────┴────────────────────────┴─────┘ │
+//   ├──────────────────────────────────────────────────────────────────────┤
+//   │ [Apply default to all] [Clear all]              [OK] [Cancel]        │
+//   └──────────────────────────────────────────────────────────────────────┘
+public class ActorVoiceMappingWindow : Window
+{
+    private readonly ActorVoiceMappingViewModel _vm;
+
+    public ActorVoiceMappingWindow(ActorVoiceMappingViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Video.TextToSpeech.ActorVoicesTitle;
+        Width = 950;
+        Height = 560;
+        MinWidth = 700;
+        MinHeight = 400;
+        CanResize = true;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var header = BuildHeader(vm);
+        var grid = BuildGrid(vm);
+        var buttons = BuildButtons(vm);
+
+        var root = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 12,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+
+        root.Add(header, 0, 0);
+        root.Add(grid, 1, 0);
+        root.Add(buttons, 2, 0);
+
+        Content = root;
+
+        Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
+    }
+
+    private static Control BuildHeader(ActorVoiceMappingViewModel vm)
+    {
+        var icon = new Icon
+        {
+            Value = IconNames.PoliceBadge,
+            FontSize = 28,
+            Foreground = UiUtil.GetTextColor(0.8d),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        var title = new TextBlock
+        {
+            Text = Se.Language.Video.TextToSpeech.ActorVoicesTitle,
+            FontSize = 16,
+            FontWeight = FontWeight.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = Se.Language.Video.TextToSpeech.ActorVoicesSubtitle,
+            FontSize = 12,
+            Foreground = UiUtil.GetTextColor(0.6d),
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        var status = new TextBlock
+        {
+            FontSize = 11,
+            Foreground = UiUtil.GetTextColor(0.55d),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 4, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusText)) { Mode = BindingMode.OneWay },
+        };
+
+        var textBlock = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 2,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { title, subtitle, status },
+        };
+
+        var row = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { icon, textBlock },
+        };
+
+        return new Border
+        {
+            Padding = new Thickness(4, 0),
+            Child = row,
+        };
+    }
+
+    private static Border BuildGrid(ActorVoiceMappingViewModel vm)
+    {
+        var dataGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            IsReadOnly = false,
+            HeadersVisibility = DataGridHeadersVisibility.Column,
+            GridLinesVisibility = DataGridGridLinesVisibility.Horizontal,
+            CanUserReorderColumns = false,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            RowHeight = 38,
+            [!DataGrid.ItemsSourceProperty] = new Binding(nameof(vm.Rows)),
+            [!DataGrid.SelectedItemProperty] = new Binding(nameof(vm.SelectedRow)) { Mode = BindingMode.TwoWay },
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Columns =
+            {
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.Video.TextToSpeech.ActorOrVoice,
+                    Binding = new Binding(nameof(ActorVoiceRow.Actor)),
+                    Width = new DataGridLength(180, DataGridLengthUnitType.Pixel),
+                    IsReadOnly = true,
+                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                },
+                new DataGridTemplateColumn
+                {
+                    Header = Se.Language.General.Engine,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+                    {
+                        if (row == null)
+                        {
+                            return new TextBlock();
+                        }
+
+                        var combo = new ComboBox
+                        {
+                            ItemsSource = vm.Engines,
+                            HorizontalAlignment = HorizontalAlignment.Stretch,
+                            Margin = new Thickness(4, 2),
+                            MinWidth = 160,
+                            DisplayMemberBinding = new Binding(nameof(ITtsEngine.Name)),
+                            [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedEngine))
+                            {
+                                Mode = BindingMode.TwoWay,
+                            },
+                        };
+                        return combo;
+                    }),
+                    Width = new DataGridLength(200, DataGridLengthUnitType.Pixel),
+                },
+                new DataGridTemplateColumn
+                {
+                    Header = Se.Language.General.Model,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+                    {
+                        if (row == null)
+                        {
+                            return new TextBlock();
+                        }
+
+                        // Hidden for engines without a model concept (Piper, Edge TTS, ...).
+                        // Empty cell is a clearer "n/a" than a disabled combo full of nothing.
+                        var combo = new ComboBox
+                        {
+                            HorizontalAlignment = HorizontalAlignment.Stretch,
+                            Margin = new Thickness(4, 2),
+                            MinWidth = 140,
+                            [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(ActorVoiceRow.Models)),
+                            [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedModel))
+                            {
+                                Mode = BindingMode.TwoWay,
+                            },
+                            [!Visual.IsVisibleProperty] = new Binding(nameof(ActorVoiceRow.HasModel))
+                            {
+                                Mode = BindingMode.OneWay,
+                            },
+                        };
+                        return combo;
+                    }),
+                    Width = new DataGridLength(170, DataGridLengthUnitType.Pixel),
+                },
+                new DataGridTemplateColumn
+                {
+                    Header = Se.Language.General.Voice,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+                    {
+                        if (row == null)
+                        {
+                            return new TextBlock();
+                        }
+
+                        var combo = new ComboBox
+                        {
+                            HorizontalAlignment = HorizontalAlignment.Stretch,
+                            Margin = new Thickness(4, 2),
+                            MinWidth = 200,
+                            [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(ActorVoiceRow.Voices)),
+                            [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedVoice))
+                            {
+                                Mode = BindingMode.TwoWay,
+                            },
+                            [!InputElement.IsEnabledProperty] = new Binding(nameof(ActorVoiceRow.IsVoiceComboEnabled))
+                            {
+                                Mode = BindingMode.OneWay,
+                            },
+                            DisplayMemberBinding = new Binding(nameof(Voice.Name)),
+                        };
+
+                        var busy = new TextBlock
+                        {
+                            Text = "…",
+                            VerticalAlignment = VerticalAlignment.Center,
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            Margin = new Thickness(4),
+                            Opacity = 0.6,
+                            [!Visual.IsVisibleProperty] = new Binding(nameof(ActorVoiceRow.IsBusy))
+                            {
+                                Mode = BindingMode.OneWay,
+                            },
+                        };
+                        combo.Bind(InputElement.IsEnabledProperty, new Binding(nameof(ActorVoiceRow.IsBusy))
+                        {
+                            Mode = BindingMode.OneWay,
+                            Converter = new InverseBooleanConverter(),
+                        });
+
+                        return new Grid
+                        {
+                            HorizontalAlignment = HorizontalAlignment.Stretch,
+                            Children = { combo, busy },
+                        };
+                    }),
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+                new DataGridTemplateColumn
+                {
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+                    {
+                        if (row == null)
+                        {
+                            return new TextBlock();
+                        }
+
+                        // Per-row "..." button → opens ActorVoiceRowSettingsWindow for voice
+                        // instruction + OmniVoice keyword picker. Disabled for engines that have
+                        // no advanced settings so the user doesn't open an empty dialog.
+                        var settingsBtn = UiUtil.MakeButton(vm.ShowRowSettingsCommand, IconNames.Settings,
+                            Se.Language.Video.TextToSpeech.ActorVoicesRowSettingsTitle);
+                        settingsBtn.CommandParameter = row;
+                        settingsBtn.Margin = new Thickness(4, 2);
+                        settingsBtn.Bind(InputElement.IsEnabledProperty, new Binding(nameof(ActorVoiceRow.HasAdvancedSettings))
+                        {
+                            Mode = BindingMode.OneWay,
+                        });
+
+                        var testBtn = UiUtil.MakeButton(vm.TestRowCommand, "fa-solid fa-play", Se.Language.Video.TextToSpeech.TestVoice);
+                        testBtn.CommandParameter = row;
+                        testBtn.Margin = new Thickness(4, 2);
+                        testBtn.Bind(InputElement.IsEnabledProperty, new Binding(nameof(ActorVoiceRow.SelectedVoice))
+                        {
+                            Mode = BindingMode.OneWay,
+                            Converter = new NotNullConverter(),
+                        });
+
+                        return new StackPanel
+                        {
+                            Orientation = Orientation.Horizontal,
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            Spacing = 4,
+                            Children = { settingsBtn, testBtn },
+                        };
+                    }),
+                    Width = new DataGridLength(110, DataGridLengthUnitType.Pixel),
+                },
+            },
+        };
+
+        return UiUtil.MakeBorderForControl(dataGrid);
+    }
+
+    private static StackPanel BuildButtons(ActorVoiceMappingViewModel vm)
+    {
+        var applyDefault = UiUtil.MakeButton(Se.Language.Video.TextToSpeech.ApplyDefaultToAll, vm.ApplyDefaultToAllCommand);
+        var clearAll = UiUtil.MakeButton(Se.Language.General.Clear, vm.ClearAllCommand);
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        var cancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+
+        return UiUtil.MakeButtonBar(applyDefault, clearAll, ok, cancel);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        base.OnClosing(e);
+        _vm.OnClosing(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingWindow.cs
@@ -234,6 +234,11 @@ public class ActorVoiceMappingWindow : Window
                             return new TextBlock();
                         }
 
+                        // Single IsEnabled binding via the row's combined IsVoiceComboReady
+                        // (= IsVoiceComboEnabled && !IsBusy). Avalonia's Bind() replaces an
+                        // existing binding on the same property, so binding twice (once to
+                        // IsVoiceComboEnabled and once to !IsBusy) would silently drop the
+                        // first.
                         var combo = new ComboBox
                         {
                             HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -244,7 +249,7 @@ public class ActorVoiceMappingWindow : Window
                             {
                                 Mode = BindingMode.TwoWay,
                             },
-                            [!InputElement.IsEnabledProperty] = new Binding(nameof(ActorVoiceRow.IsVoiceComboEnabled))
+                            [!InputElement.IsEnabledProperty] = new Binding(nameof(ActorVoiceRow.IsVoiceComboReady))
                             {
                                 Mode = BindingMode.OneWay,
                             },
@@ -263,11 +268,6 @@ public class ActorVoiceMappingWindow : Window
                                 Mode = BindingMode.OneWay,
                             },
                         };
-                        combo.Bind(InputElement.IsEnabledProperty, new Binding(nameof(ActorVoiceRow.IsBusy))
-                        {
-                            Mode = BindingMode.OneWay,
-                            Converter = new InverseBooleanConverter(),
-                        });
 
                         return new Grid
                         {

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRow.cs
@@ -45,6 +45,15 @@ public partial class ActorVoiceRow : ObservableObject
         _isVoiceComboEnabled = true;
     }
 
+    // Combined "can the user pick a voice right now?" flag bound by the row's ComboBox so we
+    // don't have to bind IsEnabled twice (the second Bind() in Avalonia overwrites the first).
+    // True only when both the voice combo is allowed (more than one voice available) and the
+    // row isn't mid-load.
+    public bool IsVoiceComboReady => IsVoiceComboEnabled && !IsBusy;
+
+    partial void OnIsVoiceComboEnabledChanged(bool value) => OnPropertyChanged(nameof(IsVoiceComboReady));
+    partial void OnIsBusyChanged(bool value) => OnPropertyChanged(nameof(IsVoiceComboReady));
+
     partial void OnSelectedEngineChanged(ITtsEngine? value)
     {
         if (SuppressEngineEvent)

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRow.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+
+// One row in the cast grid. Each row owns its own voice list (filled by the VM after the engine
+// is loaded) and instruction text so different rows can use entirely different engines, voices,
+// and instructions.
+//
+// The VM listens for EngineChangedByUser to know when the engine combo was changed by the user
+// and a new voice list needs to be loaded. The VM uses SuppressEngineEvent when it's the one
+// changing the engine (e.g. during initial population) so the event doesn't fire back into a
+// reload loop.
+public partial class ActorVoiceRow : ObservableObject
+{
+    [ObservableProperty] private string _actor;
+    [ObservableProperty] private ObservableCollection<Voice> _voices;
+    [ObservableProperty] private ObservableCollection<string> _models;
+    [ObservableProperty] private ITtsEngine? _selectedEngine;
+    [ObservableProperty] private Voice? _selectedVoice;
+    [ObservableProperty] private string? _selectedModel;
+    [ObservableProperty] private string _instruction;
+    [ObservableProperty] private bool _hasModel;
+    [ObservableProperty] private bool _hasInstruction;
+    [ObservableProperty] private bool _hasAdvancedSettings;
+    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] private bool _isPlaying;
+    [ObservableProperty] private bool _isVoiceComboEnabled;
+
+    public event EventHandler<ITtsEngine?>? EngineChangedByUser;
+
+    // Set by the VM around its own writes so OnSelectedEngineChanged doesn't fire the event back
+    // into the VM, which would cause an infinite reload loop.
+    public bool SuppressEngineEvent { get; set; }
+
+    public ActorVoiceRow()
+    {
+        _actor = string.Empty;
+        _voices = new ObservableCollection<Voice>();
+        _models = new ObservableCollection<string>();
+        _instruction = string.Empty;
+        _isVoiceComboEnabled = true;
+    }
+
+    partial void OnSelectedEngineChanged(ITtsEngine? value)
+    {
+        if (SuppressEngineEvent)
+        {
+            return;
+        }
+
+        EngineChangedByUser?.Invoke(this, value);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsViewModel.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+
+// Per-row advanced settings dialog. Shows the controls that don't fit neatly in a grid cell:
+//   - free-text voice instruction (Qwen3 VoiceDesign)
+//   - OmniVoice keyword picker (gender/age/pitch/accent/whisper) which composes into Instruction
+// On OK, the user's edits are reflected in the result so the caller can copy them back to the row.
+public partial class ActorVoiceRowSettingsViewModel : ObservableObject
+{
+    [ObservableProperty] private string _actor;
+    [ObservableProperty] private string _engineName;
+    [ObservableProperty] private string _voiceName;
+    [ObservableProperty] private string _instruction;
+    [ObservableProperty] private bool _isInstructionTextVisible;
+    [ObservableProperty] private bool _isOmniVoicePickerVisible;
+    [ObservableProperty] private bool _isOmniVoicePickerEnabled;
+    [ObservableProperty] private bool _isClonedVoiceNoteVisible;
+    [ObservableProperty] private string _selectedOmniVoiceGender;
+    [ObservableProperty] private string _selectedOmniVoiceAge;
+    [ObservableProperty] private string _selectedOmniVoicePitch;
+    [ObservableProperty] private string _selectedOmniVoiceAccent;
+    [ObservableProperty] private bool _omniVoiceWhisper;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public ObservableCollection<string> OmniVoiceGenders { get; }
+    public ObservableCollection<string> OmniVoiceAges { get; }
+    public ObservableCollection<string> OmniVoicePitches { get; }
+    public ObservableCollection<string> OmniVoiceAccents { get; }
+
+    public const string OmniVoiceAny = "(any)";
+
+    private bool _suppressKeywordSync;
+    private ITtsEngine? _engine;
+
+    public ActorVoiceRowSettingsViewModel()
+    {
+        _actor = string.Empty;
+        _engineName = string.Empty;
+        _voiceName = string.Empty;
+        _instruction = string.Empty;
+
+        OmniVoiceGenders = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionGenders);
+        OmniVoiceAges = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionAges);
+        OmniVoicePitches = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionPitches);
+        OmniVoiceAccents = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionAccents);
+
+        _selectedOmniVoiceGender = OmniVoiceAny;
+        _selectedOmniVoiceAge = OmniVoiceAny;
+        _selectedOmniVoicePitch = OmniVoiceAny;
+        _selectedOmniVoiceAccent = OmniVoiceAny;
+    }
+
+    public void Initialize(ActorVoiceRow row)
+    {
+        _engine = row.SelectedEngine;
+        Actor = row.Actor;
+        EngineName = row.SelectedEngine?.Name ?? string.Empty;
+        VoiceName = row.SelectedVoice?.Name ?? string.Empty;
+        Instruction = row.Instruction ?? string.Empty;
+
+        // Qwen3 free-text instruction only does anything on the VoiceDesign model — Base models
+        // ignore it. Don't show it for the other Qwen3 models. OmniVoice always uses the keyword
+        // picker, but the picker is informational (disabled with a note) when a cloned voice is
+        // selected because omnivoice-tts ignores --instruct in that case.
+        IsInstructionTextVisible =
+            (row.SelectedEngine is Qwen3TtsCpp && Qwen3TtsCpp.IsVoiceDesignModel(row.SelectedModel))
+            || (row.SelectedEngine is Qwen3TtsCrispAsr && Qwen3TtsCrispAsr.IsVoiceDesignModel(row.SelectedModel));
+
+        IsOmniVoicePickerVisible = row.SelectedEngine is OmniVoiceTtsCpp;
+        var isDefaultOmniVoice = row.SelectedVoice?.EngineVoice is OmniVoiceVoice ov && string.IsNullOrEmpty(ov.FilePath);
+        IsOmniVoicePickerEnabled = IsOmniVoicePickerVisible && isDefaultOmniVoice;
+        IsClonedVoiceNoteVisible = IsOmniVoicePickerVisible && !isDefaultOmniVoice;
+
+        if (IsOmniVoicePickerVisible)
+        {
+            SyncOmniVoicePickerFromInstruction();
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    private void Close()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Close();
+        }
+    }
+
+    internal void OnClosing(WindowClosingEventArgs e)
+    {
+        UiUtil.SaveWindowPosition(Window);
+    }
+
+    partial void OnSelectedOmniVoiceGenderChanged(string value) => OnOmniVoicePickerChanged();
+    partial void OnSelectedOmniVoiceAgeChanged(string value) => OnOmniVoicePickerChanged();
+    partial void OnSelectedOmniVoicePitchChanged(string value) => OnOmniVoicePickerChanged();
+    partial void OnSelectedOmniVoiceAccentChanged(string value) => OnOmniVoicePickerChanged();
+    partial void OnOmniVoiceWhisperChanged(bool value) => OnOmniVoicePickerChanged();
+
+    private void OnOmniVoicePickerChanged()
+    {
+        if (!_suppressKeywordSync && IsOmniVoicePickerVisible)
+        {
+            Instruction = BuildOmniVoiceInstruction();
+        }
+    }
+
+    private string BuildOmniVoiceInstruction()
+    {
+        var parts = new List<string>();
+        if (IsReal(SelectedOmniVoiceGender)) parts.Add(SelectedOmniVoiceGender);
+        if (IsReal(SelectedOmniVoiceAge)) parts.Add(SelectedOmniVoiceAge);
+        if (IsReal(SelectedOmniVoicePitch)) parts.Add(SelectedOmniVoicePitch);
+        if (IsReal(SelectedOmniVoiceAccent)) parts.Add(SelectedOmniVoiceAccent);
+        if (OmniVoiceWhisper) parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        return string.Join(", ", parts);
+    }
+
+    // Reflects the saved instruction string back into the picker controls so opening the dialog
+    // a second time shows the previously chosen keywords. Same parse/regenerate dance as the main
+    // TTS window's SyncOmniVoicePickerFromInstruction.
+    private void SyncOmniVoicePickerFromInstruction()
+    {
+        var present = (Instruction ?? string.Empty)
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => s.Length > 0)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        _suppressKeywordSync = true;
+        SelectedOmniVoiceGender = Match(OmniVoiceTtsCpp.InstructionGenders, present);
+        SelectedOmniVoiceAge = Match(OmniVoiceTtsCpp.InstructionAges, present);
+        SelectedOmniVoicePitch = Match(OmniVoiceTtsCpp.InstructionPitches, present);
+        SelectedOmniVoiceAccent = Match(OmniVoiceTtsCpp.InstructionAccents, present);
+        OmniVoiceWhisper = present.Contains(OmniVoiceTtsCpp.InstructionWhisper);
+        _suppressKeywordSync = false;
+
+        Instruction = BuildOmniVoiceInstruction();
+    }
+
+    private static string Match(string[] group, HashSet<string> present)
+        => Array.Find(group, present.Contains) ?? OmniVoiceAny;
+
+    private static bool IsReal(string? value)
+        => !string.IsNullOrEmpty(value) && value != OmniVoiceAny;
+
+    private static ObservableCollection<string> BuildKeywordOptions(string[] keywords)
+    {
+        var options = new ObservableCollection<string> { OmniVoiceAny };
+        foreach (var keyword in keywords)
+        {
+            options.Add(keyword);
+        }
+        return options;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsViewModel.cs
@@ -44,7 +44,6 @@ public partial class ActorVoiceRowSettingsViewModel : ObservableObject
     public const string OmniVoiceAny = "(any)";
 
     private bool _suppressKeywordSync;
-    private ITtsEngine? _engine;
 
     public ActorVoiceRowSettingsViewModel()
     {
@@ -66,7 +65,6 @@ public partial class ActorVoiceRowSettingsViewModel : ObservableObject
 
     public void Initialize(ActorVoiceRow row)
     {
-        _engine = row.SelectedEngine;
         Actor = row.Actor;
         EngineName = row.SelectedEngine?.Name ?? string.Empty;
         VoiceName = row.SelectedVoice?.Name ?? string.Empty;

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsWindow.cs
@@ -1,0 +1,230 @@
+using System.Collections.ObjectModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+
+// Per-row advanced settings dialog for one cast row.
+//
+//   ┌────────────────────────────────────────────────────────┐
+//   │ <icon> Voice settings for "Joe"                        │
+//   │        ElevenLabs / Aria                               │
+//   ├────────────────────────────────────────────────────────┤
+//   │ Voice instruction                                      │
+//   │  ┌────────────────────────────────────────────────────┐ │
+//   │  │ Speak in a calm and friendly tone...              │ │
+//   │  └────────────────────────────────────────────────────┘ │
+//   │                                                        │
+//   │ Voice design  (OmniVoice only)                         │
+//   │   Gender [Female ▾]  Age [Adult ▾]                     │
+//   │   Pitch  [Low    ▾]  Accent [British ▾]                │
+//   │   ☐ Whisper                                            │
+//   ├────────────────────────────────────────────────────────┤
+//   │                                       [OK] [Cancel]    │
+//   └────────────────────────────────────────────────────────┘
+public class ActorVoiceRowSettingsWindow : Window
+{
+    private readonly ActorVoiceRowSettingsViewModel _vm;
+
+    public ActorVoiceRowSettingsWindow(ActorVoiceRowSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Video.TextToSpeech.ActorVoicesRowSettingsTitle;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 460;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var header = BuildHeader(vm);
+        var instructionBlock = BuildInstructionBlock(vm);
+        var omniBlock = BuildOmniVoicePicker(vm);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 12,
+            Margin = UiUtil.MakeWindowMargin(),
+            Children = { header, instructionBlock, omniBlock, buttons },
+        };
+
+        Content = stack;
+
+        Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
+    }
+
+    private static Control BuildHeader(ActorVoiceRowSettingsViewModel vm)
+    {
+        var title = new TextBlock
+        {
+            FontSize = 15,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.Actor))
+            {
+                Mode = BindingMode.OneWay,
+                StringFormat = Se.Language.Video.TextToSpeech.VoiceSettingsForX,
+            },
+        };
+
+        var sub = new TextBlock
+        {
+            FontSize = 11,
+            Foreground = UiUtil.GetTextColor(0.6d),
+            [!TextBlock.TextProperty] = new MultiBinding
+            {
+                StringFormat = "{0} / {1}",
+                Bindings =
+                {
+                    new Binding(nameof(vm.EngineName)) { Mode = BindingMode.OneWay },
+                    new Binding(nameof(vm.VoiceName)) { Mode = BindingMode.OneWay },
+                },
+            },
+        };
+
+        return new StackPanel { Orientation = Orientation.Vertical, Spacing = 2, Children = { title, sub } };
+    }
+
+    private static Border BuildInstructionBlock(ActorVoiceRowSettingsViewModel vm)
+    {
+        var label = new Label
+        {
+            Content = Se.Language.Video.TextToSpeech.VoiceInstruction,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var textBox = new TextBox
+        {
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            Height = 90,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Top,
+            PlaceholderText = Se.Language.Video.TextToSpeech.VoiceInstructionHint,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.Instruction))
+            {
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+            },
+        };
+
+        var hint = new TextBlock
+        {
+            Text = Se.Language.Video.TextToSpeech.VoiceInstructionFreeTextHint,
+            FontSize = 11,
+            Foreground = UiUtil.GetTextColor(0.55d),
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        var inner = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 6,
+            Children = { label, textBox, hint },
+        };
+
+        var border = UiUtil.MakeBorderForControl(inner);
+        border.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsInstructionTextVisible)) { Mode = BindingMode.OneWay });
+        return border;
+    }
+
+    private static Border BuildOmniVoicePicker(ActorVoiceRowSettingsViewModel vm)
+    {
+        var label = new Label
+        {
+            Content = Se.Language.Video.TextToSpeech.VoiceDesign,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 10,
+            RowSpacing = 6,
+            [!InputElement.IsEnabledProperty] = new Binding(nameof(vm.IsOmniVoicePickerEnabled)) { Mode = BindingMode.OneWay },
+        };
+
+        AddPickerRow(grid, 0, Se.Language.Video.TextToSpeech.VoiceGender, vm, vm.OmniVoiceGenders, nameof(vm.SelectedOmniVoiceGender));
+        AddPickerRow(grid, 1, Se.Language.Video.TextToSpeech.VoiceAge, vm, vm.OmniVoiceAges, nameof(vm.SelectedOmniVoiceAge));
+        AddPickerRow(grid, 2, Se.Language.Video.TextToSpeech.VoicePitch, vm, vm.OmniVoicePitches, nameof(vm.SelectedOmniVoicePitch));
+        AddPickerRow(grid, 3, Se.Language.Video.TextToSpeech.VoiceAccent, vm, vm.OmniVoiceAccents, nameof(vm.SelectedOmniVoiceAccent));
+
+        var whisper = new CheckBox
+        {
+            Content = "Whisper",
+            Margin = new Thickness(0, 4, 0, 0),
+            [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.OmniVoiceWhisper)) { Mode = BindingMode.TwoWay },
+        };
+        grid.Add(whisper, 4, 0, 1, 2);
+
+        var clonedNote = new TextBlock
+        {
+            Text = Se.Language.Video.TextToSpeech.VoiceInstructionClonedVoiceNote,
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 11,
+            Foreground = UiUtil.GetTextColor(0.7d),
+            Margin = new Thickness(0, 6, 0, 0),
+            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsClonedVoiceNoteVisible)) { Mode = BindingMode.OneWay },
+        };
+
+        var inner = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 6,
+            Children = { label, grid, clonedNote },
+        };
+
+        var border = UiUtil.MakeBorderForControl(inner);
+        border.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsOmniVoicePickerVisible)) { Mode = BindingMode.OneWay });
+        return border;
+    }
+
+    private static void AddPickerRow(Grid grid, int row, string label, object vm,
+        ObservableCollection<string> items, string selectedPropertyPath)
+    {
+        grid.Add(new Label
+        {
+            Content = label,
+            VerticalAlignment = VerticalAlignment.Center,
+            MinWidth = 60,
+        }, row, 0);
+        grid.Add(UiUtil.MakeComboBox(items, vm, selectedPropertyPath).WithWidth(200), row, 1);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        base.OnClosing(e);
+        _vm.OnClosing(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -176,7 +177,8 @@ public class ActorVoiceRowSettingsWindow : Window
 
         var whisper = new CheckBox
         {
-            Content = "Whisper",
+            // Use the engine's own constant — same label as the main TTS window and Review window.
+            Content = OmniVoiceTtsCpp.InstructionWhisper,
             Margin = new Thickness(0, 4, 0, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.OmniVoiceWhisper)) { Mode = BindingMode.TwoWay },
         };

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewHistoryRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewHistoryRow.cs
@@ -14,9 +14,19 @@ public partial class ReviewHistoryRow : ObservableObject
     public Voice? Voice { get; set; }
     public float Speed { get; set; }
 
+    // Snapshot of the engine settings that produced this history entry, so picking it back from
+    // the history dialog can restore the full left-panel state (not just the voice). Empty for
+    // legacy history rows that pre-date this field.
+    public string EngineName { get; set; }
+    public string Model { get; set; }
+    public string Instruction { get; set; }
+
     public ReviewHistoryRow()
     {
         FileName = string.Empty;
         VoiceName = string.Empty;
+        EngineName = string.Empty;
+        Model = string.Empty;
+        Instruction = string.Empty;
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewRow.cs
@@ -43,10 +43,13 @@ public partial class ReviewRow : ObservableObject
             VoiceName = StepResult.Voice?.Name ?? string.Empty,
             Voice = StepResult.Voice,
             Speed = StepResult.SpeedFactor,
+            EngineName = StepResult.EngineName,
+            Model = StepResult.Model,
+            Instruction = StepResult.Instruction,
         });
     }
 
-    internal void AddHistory(Voices.Voice voice, string processedFileName)
+    internal void AddHistory(Voices.Voice voice, string processedFileName, string engineName, string model, string instruction)
     {
         HistoryItems.Add(new ReviewHistoryRow
         {
@@ -55,6 +58,9 @@ public partial class ReviewRow : ObservableObject
             VoiceName = voice.Name,
             Voice = voice,
             Speed = StepResult.SpeedFactor,
+            EngineName = engineName,
+            Model = model,
+            Instruction = instruction,
         });
 
         HasHistory = true;

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
@@ -58,9 +59,35 @@ public partial class ReviewSpeechViewModel : ObservableObject
     [ObservableProperty] private double _speed;
     [ObservableProperty] private double _styleExaggeration;
 
+    // Voice-design controls mirrored from the main TTS window. Visibility is engine+model+voice
+    // driven so the picker doesn't appear for engines that don't use it.
+    [ObservableProperty] private bool _hasInstruction;
+    [ObservableProperty] private bool _isInstructionTextVisible;
+    [ObservableProperty] private bool _isInstructionPickerVisible;
+    [ObservableProperty] private bool _isInstructionPickerEnabled;
+    [ObservableProperty] private bool _isInstructionVoiceHintVisible;
+    [ObservableProperty] private string _instruction = string.Empty;
+    [ObservableProperty] private string _selectedOmniVoiceGender = OmniVoiceAny;
+    [ObservableProperty] private string _selectedOmniVoiceAge = OmniVoiceAny;
+    [ObservableProperty] private string _selectedOmniVoicePitch = OmniVoiceAny;
+    [ObservableProperty] private string _selectedOmniVoiceAccent = OmniVoiceAny;
+    [ObservableProperty] private bool _omniVoiceWhisper;
+
+    public ObservableCollection<string> OmniVoiceGenders { get; } = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionGenders);
+    public ObservableCollection<string> OmniVoiceAges { get; } = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionAges);
+    public ObservableCollection<string> OmniVoicePitches { get; } = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionPitches);
+    public ObservableCollection<string> OmniVoiceAccents { get; } = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionAccents);
+
+    private const string OmniVoiceAny = "(any)";
+    private bool _suppressKeywordSync;
+
     public Window? Window { get; set; }
     public DataGrid LineGrid { get; internal set; }
     public TtsStepResult[] StepResults { get; set; }
+
+    // Cast travelling with the audio. Populated by the main TTS VM via SetActorVoiceMappings;
+    // round-tripped through SubtitleEditTts.json so a future Import re-applies the same voices.
+    public List<ActorVoiceMapping> ActorVoiceMappings { get; private set; } = new();
 
     public bool OkPressed { get; private set; }
 
@@ -340,7 +367,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         // Copy files
         var index = 0;
-        var exportFormat = new TtsImportExport { VideoFileName = _videoFileName };
+        var exportFormat = new TtsImportExport
+        {
+            VideoFileName = _videoFileName,
+            ActorVoiceMappings = ActorVoiceMappings.ToList(),
+        };
         foreach (var line in Lines)
         {
             index++;
@@ -373,7 +404,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 StartMs = (long)Math.Round((double)line.StepResult.Paragraph.StartTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
                 EndMs = (long)Math.Round((double)line.StepResult.Paragraph.EndTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
                 VoiceName = line.StepResult.Voice?.Name ?? string.Empty,
-                EngineName = SelectedEngine != null ? SelectedEngine.ToString() : string.Empty,
+                // Per-line engine snapshot, not the global SelectedEngine — different rows can
+                // come from different engines via the cast workflow, and on re-import we want
+                // each line to remember which engine produced it.
+                EngineName = string.IsNullOrEmpty(line.StepResult.EngineName)
+                    ? (SelectedEngine?.Name ?? string.Empty)
+                    : line.StepResult.EngineName,
+                Model = line.StepResult.Model,
+                Instruction = line.StepResult.Instruction,
                 SpeedFactor = line.StepResult.SpeedFactor,
                 Text = line.Text,
                 Include = line.Include,
@@ -414,10 +452,21 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        line.Voice = result.SelectedHistoryItem?.Voice?.Name ?? string.Empty;
-        line.StepResult.CurrentFileName = result.SelectedHistoryItem?.FileName ?? string.Empty;
-        line.StepResult.Voice = result.SelectedHistoryItem?.Voice;
-        line.Speed = Math.Round(result.SelectedHistoryItem?.Speed ?? 1.0f, 2).ToString(CultureInfo.CurrentCulture);
+        var picked = result.SelectedHistoryItem;
+        line.Voice = picked.Voice?.Name ?? string.Empty;
+        line.StepResult.CurrentFileName = picked.FileName ?? string.Empty;
+        line.StepResult.Voice = picked.Voice;
+        // Restore the full engine snapshot stored with the history row so the line knows which
+        // engine/model/instruction produced this audio. Without this, clicking the row would
+        // sync the left panel to the live (last-set) values rather than what's actually playing.
+        line.StepResult.EngineName = picked.EngineName ?? string.Empty;
+        line.StepResult.Model = picked.Model ?? string.Empty;
+        line.StepResult.Instruction = picked.Instruction ?? string.Empty;
+        line.Speed = Math.Round(picked.Speed, 2).ToString(CultureInfo.CurrentCulture);
+
+        // Mirror the click-to-sync behaviour so the left panel immediately reflects the picked
+        // history entry's engine/model/voice/instruction.
+        await ApplyLineToLeftPanelAsync(line);
     }
 
     [RelayCommand]
@@ -529,7 +578,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
         TtsResult speakResult;
         try
         {
-            speakResult = await engine.Speak(line.Text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken);
+            speakResult = await TtsInstructionSwap.RunAsync(engine, Instruction, () =>
+                engine.Speak(line.Text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken));
 
             line.StepResult.CurrentFileName = speakResult.FileName;
             line.StepResult.Voice = voice;
@@ -543,12 +593,17 @@ public partial class ReviewSpeechViewModel : ObservableObject
             }
 
             adjustSpeedStepResult.CurrentFileName = postProcessedFileName;
+            // Record which engine/model/instruction this regenerate used so the row's "click to
+            // sync left panel" feature can restore them later.
+            adjustSpeedStepResult.EngineName = engine.Name;
+            adjustSpeedStepResult.Model = SelectedModel ?? string.Empty;
+            adjustSpeedStepResult.Instruction = Instruction ?? string.Empty;
             line.Speed = Math.Round(adjustSpeedStepResult.SpeedFactor, 2).ToString(CultureInfo.CurrentCulture);
             line.Cps = Math.Round(adjustSpeedStepResult.Paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture);
             line.StepResult = adjustSpeedStepResult;
             line.Voice = voice.ToString();
 
-            line.AddHistory(voice, line.StepResult.CurrentFileName);
+            line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, SelectedModel ?? string.Empty, Instruction ?? string.Empty);
         }
         catch (HttpRequestException ex)
         {
@@ -732,6 +787,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 CurrentFileName = currentFile,
                 SpeedFactor = 1.0f,
                 Voice = item.Voice,
+                EngineName = item.EngineName,
+                Model = item.Model,
+                Instruction = item.Instruction,
             };
         }
 
@@ -745,6 +803,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 CurrentFileName = item.CurrentFileName,
                 SpeedFactor = 1.0f,
                 Voice = item.Voice,
+                EngineName = item.EngineName,
+                Model = item.Model,
+                Instruction = item.Instruction,
             };
         }
 
@@ -784,6 +845,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
             CurrentFileName = outputFileName2,
             SpeedFactor = (float)factor,
             Voice = item.Voice,
+            EngineName = item.EngineName,
+            Model = item.Model,
+            Instruction = item.Instruction,
         };
     }
 
@@ -820,7 +884,26 @@ public partial class ReviewSpeechViewModel : ObservableObject
         SelectedEngineChanged();
     }
 
+    // True while ApplyLineToLeftPanelAsync is in the middle of switching the engine itself. We
+    // skip the fire-and-forget refresh that the ComboBox's SelectionChanged event triggers in
+    // that case, otherwise it races our own awaited refresh and wins — overwriting the row's
+    // voice/model/instruction with the engine's defaults.
+    private bool _suppressEngineRefreshDispatch;
+
     public void SelectedEngineChanged()
+    {
+        if (_suppressEngineRefreshDispatch)
+        {
+            return;
+        }
+
+        // Fire-and-forget wrapper for the SelectionChanged event. Callers that need to wait for
+        // the refresh (e.g. ApplyLineToLeftPanelAsync) should await SelectedEngineChangedAsync()
+        // directly so they see the new Voices/Models populated before applying further changes.
+        Dispatcher.UIThread.PostSafe(async () => await SelectedEngineChangedAsync());
+    }
+
+    public async Task SelectedEngineChangedAsync()
     {
         var engine = SelectedEngine;
         if (engine == null)
@@ -828,95 +911,94 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        Dispatcher.UIThread.PostSafe(async () =>
+        var voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
+        Voices.Clear();
+        foreach (var vo in voices)
         {
-            var voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
-            Voices.Clear();
-            foreach (var vo in voices)
+            Voices.Add(vo);
+        }
+
+        var lastVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice);
+        if (lastVoice == null)
+        {
+            lastVoice = Voices.FirstOrDefault(p => p.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase) ||
+                                                  p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
+        }
+
+        SelectedVoice = lastVoice ?? Voices.First();
+
+        if (engine.HasLanguageParameter)
+        {
+            var languages = await engine.GetLanguages(SelectedVoice, null); // SelectedModel);
+            Languages.Clear();
+            foreach (var language in languages)
             {
-                Voices.Add(vo);
+                Languages.Add(language);
             }
 
-            var lastVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice);
-            if (lastVoice == null)
+            SelectedLanguage = Languages.FirstOrDefault();
+        }
+
+        if (engine.HasRegion)
+        {
+            var regions = await engine.GetRegions();
+            Regions.Clear();
+            foreach (var region in regions)
             {
-                lastVoice = Voices.FirstOrDefault(p => p.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase) ||
-                                                      p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
+                Regions.Add(region);
             }
 
-            SelectedVoice = lastVoice ?? Voices.First();
+            SelectedRegion = Regions.FirstOrDefault();
+        }
 
-            if (engine.HasLanguageParameter)
+        if (engine.HasModel)
+        {
+            var models = await engine.GetModels();
+            Models.Clear();
+            foreach (var model in models)
             {
-                var languages = await engine.GetLanguages(SelectedVoice, null); // SelectedModel);
-                Languages.Clear();
-                foreach (var language in languages)
-                {
-                    Languages.Add(language);
-                }
-
-                SelectedLanguage = Languages.FirstOrDefault();
+                Models.Add(model);
             }
 
-            if (engine.HasRegion)
-            {
-                var regions = await engine.GetRegions();
-                Regions.Clear();
-                foreach (var region in regions)
-                {
-                    Regions.Add(region);
-                }
+            SelectedModel = Models.FirstOrDefault();
+        }
 
-                SelectedRegion = Regions.FirstOrDefault();
+        IsElevenLabsControlsVisible = false;
+        UpdateInstructionVisibility();
+        LoadInstructionForEngine();
+        if (engine is AzureSpeech)
+        {
+            SelectedRegion = Se.Settings.Video.TextToSpeech.AzureRegion;
+            if (string.IsNullOrEmpty(SelectedRegion))
+            {
+                SelectedRegion = "westeurope";
             }
-
-            if (engine.HasModel)
+        }
+        else if (engine is ElevenLabs)
+        {
+            IsElevenLabsControlsVisible = true;
+            SelectedModel = Se.Settings.Video.TextToSpeech.ElevenLabsModel;
+            if (string.IsNullOrEmpty(SelectedModel))
             {
-                var models = await engine.GetModels();
-                Models.Clear();
-                foreach (var model in models)
-                {
-                    Models.Add(model);
-                }
-
+                SelectedModel = Models.First();
+            }
+        }
+        else if (engine is Qwen3TtsCpp)
+        {
+            SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel);
+            if (string.IsNullOrEmpty(SelectedModel))
+            {
                 SelectedModel = Models.FirstOrDefault();
             }
-
-            IsElevenLabsControlsVisible = false;
-            if (engine is AzureSpeech)
+        }
+        else if (engine is ChatterboxTtsCpp)
+        {
+            SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.ChatterboxModel);
+            if (string.IsNullOrEmpty(SelectedModel))
             {
-                SelectedRegion = Se.Settings.Video.TextToSpeech.AzureRegion;
-                if (string.IsNullOrEmpty(SelectedRegion))
-                {
-                    SelectedRegion = "westeurope";
-                }
+                SelectedModel = Models.FirstOrDefault();
             }
-            else if (engine is ElevenLabs)
-            {
-                IsElevenLabsControlsVisible = true;
-                SelectedModel = Se.Settings.Video.TextToSpeech.ElevenLabsModel;
-                if (string.IsNullOrEmpty(SelectedModel))
-                {
-                    SelectedModel = Models.First();
-                }
-            }
-            else if (engine is Qwen3TtsCpp)
-            {
-                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.Qwen3TtsCppModel);
-                if (string.IsNullOrEmpty(SelectedModel))
-                {
-                    SelectedModel = Models.FirstOrDefault();
-                }
-            }
-            else if (engine is ChatterboxTtsCpp)
-            {
-                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.ChatterboxModel);
-                if (string.IsNullOrEmpty(SelectedModel))
-                {
-                    SelectedModel = Models.FirstOrDefault();
-                }
-            }
-        });
+        }
     }
 
     internal void SelectedLanguageChanged(object? sender, SelectionChangedEventArgs e)
@@ -953,6 +1035,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var voice = SelectedVoice;
         var model = SelectedModel;
         IsElevenLabsEngineV3Selected = false;
+        UpdateInstructionVisibility();
         if (engine == null || voice == null || model == null)
         {
             return;
@@ -981,6 +1064,218 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 }
             }
         });
+    }
+
+    // ---- voice-design / instruction helpers -----------------------------------------------
+
+    private static ObservableCollection<string> BuildKeywordOptions(string[] keywords)
+    {
+        var options = new ObservableCollection<string> { OmniVoiceAny };
+        foreach (var k in keywords)
+        {
+            options.Add(k);
+        }
+        return options;
+    }
+
+    private static bool IsReal(string? value) => !string.IsNullOrEmpty(value) && value != OmniVoiceAny;
+
+    partial void OnSelectedVoiceChanged(Voice? value) => UpdateInstructionVisibility();
+
+    // When the user clicks a row, push that row's recorded engine/voice/model/instruction into
+    // the left-side combos so they reflect what produced the selected line. Without this the
+    // panel always shows the *current* (last-set) values, which is confusing when each line was
+    // generated from a different per-actor mapping.
+    //
+    // Guard with _suppressSelectedLineSync so the chain of engine/model writes doesn't loop
+    // back through SelectedEngineChanged (which would reset Voices and clobber our intended
+    // voice).
+    partial void OnSelectedLineChanged(ReviewRow? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        // If another apply is in flight, queue this selection — we'll re-apply at the end of the
+        // current cycle so the panel ends up on the row the user actually clicked last (not
+        // wherever the in-flight apply ends).
+        if (_suppressSelectedLineSync)
+        {
+            _pendingApplyRow = value;
+            return;
+        }
+
+        _ = ApplyLineWithFollowUpAsync(value);
+    }
+
+    private async Task ApplyLineWithFollowUpAsync(ReviewRow row)
+    {
+        await ApplyLineToLeftPanelAsync(row);
+
+        // Drain any selection changes that landed during the await. Loop until we catch up so
+        // multiple rapid clicks all resolve to the latest.
+        while (_pendingApplyRow != null && !ReferenceEquals(_pendingApplyRow, row))
+        {
+            var next = _pendingApplyRow;
+            _pendingApplyRow = null;
+            row = next;
+            await ApplyLineToLeftPanelAsync(row);
+        }
+        _pendingApplyRow = null;
+    }
+
+    private bool _suppressSelectedLineSync;
+    private ReviewRow? _pendingApplyRow;
+
+    private async Task ApplyLineToLeftPanelAsync(ReviewRow row)
+    {
+        var step = row.StepResult;
+        if (step == null)
+        {
+            return;
+        }
+
+        _suppressSelectedLineSync = true;
+        try
+        {
+            ITtsEngine? targetEngine = null;
+            if (!string.IsNullOrEmpty(step.EngineName))
+            {
+                targetEngine = Engines.FirstOrDefault(e => string.Equals(e.Name, step.EngineName, StringComparison.OrdinalIgnoreCase));
+            }
+            targetEngine ??= step.Voice != null
+                ? Engines.FirstOrDefault(e => string.Equals(e.Name, SelectedEngine?.Name, StringComparison.OrdinalIgnoreCase))
+                : SelectedEngine;
+
+            if (targetEngine != null && !ReferenceEquals(targetEngine, SelectedEngine))
+            {
+                // Switch engine and await the refill of Voices / Models / Languages / Regions
+                // before applying the row's saved selections, otherwise the SelectedVoice write
+                // below races the refresh and lands on a stale (or empty) Voices list.
+                //
+                // Setting SelectedEngine also fires the ComboBox's SelectionChanged → which
+                // dispatches its own fire-and-forget refresh. We suppress that here so the two
+                // don't race; the awaited call below does the same work and lets us apply the
+                // row's voice/model on top of it without it being immediately overwritten.
+                _suppressEngineRefreshDispatch = true;
+                try
+                {
+                    SelectedEngine = targetEngine;
+                    await SelectedEngineChangedAsync();
+                }
+                finally
+                {
+                    _suppressEngineRefreshDispatch = false;
+                }
+            }
+
+            // Voice: prefer the recorded Voice instance, otherwise match by name.
+            if (step.Voice != null)
+            {
+                var match = Voices.FirstOrDefault(v => string.Equals(v.Name, step.Voice.Name, StringComparison.OrdinalIgnoreCase));
+                SelectedVoice = match ?? step.Voice;
+            }
+
+            if (!string.IsNullOrEmpty(step.Model))
+            {
+                var matchModel = Models.FirstOrDefault(m => string.Equals(m, step.Model, StringComparison.OrdinalIgnoreCase));
+                if (matchModel != null)
+                {
+                    SelectedModel = matchModel;
+                }
+            }
+
+            Instruction = step.Instruction ?? string.Empty;
+            UpdateInstructionVisibility();
+            if (IsInstructionPickerVisible)
+            {
+                SyncOmniVoicePickerFromInstruction();
+            }
+        }
+        finally
+        {
+            _suppressSelectedLineSync = false;
+        }
+    }
+
+    partial void OnSelectedOmniVoiceGenderChanged(string value) => RebuildOmniVoiceInstruction();
+    partial void OnSelectedOmniVoiceAgeChanged(string value) => RebuildOmniVoiceInstruction();
+    partial void OnSelectedOmniVoicePitchChanged(string value) => RebuildOmniVoiceInstruction();
+    partial void OnSelectedOmniVoiceAccentChanged(string value) => RebuildOmniVoiceInstruction();
+    partial void OnOmniVoiceWhisperChanged(bool value) => RebuildOmniVoiceInstruction();
+
+    private void RebuildOmniVoiceInstruction()
+    {
+        if (_suppressKeywordSync || !IsInstructionPickerVisible)
+        {
+            return;
+        }
+
+        var parts = new List<string>();
+        if (IsReal(SelectedOmniVoiceGender)) parts.Add(SelectedOmniVoiceGender);
+        if (IsReal(SelectedOmniVoiceAge)) parts.Add(SelectedOmniVoiceAge);
+        if (IsReal(SelectedOmniVoicePitch)) parts.Add(SelectedOmniVoicePitch);
+        if (IsReal(SelectedOmniVoiceAccent)) parts.Add(SelectedOmniVoiceAccent);
+        if (OmniVoiceWhisper) parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        Instruction = string.Join(", ", parts);
+    }
+
+    private void SyncOmniVoicePickerFromInstruction()
+    {
+        var present = (Instruction ?? string.Empty)
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => s.Length > 0)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        _suppressKeywordSync = true;
+        SelectedOmniVoiceGender = MatchGroup(OmniVoiceTtsCpp.InstructionGenders, present);
+        SelectedOmniVoiceAge = MatchGroup(OmniVoiceTtsCpp.InstructionAges, present);
+        SelectedOmniVoicePitch = MatchGroup(OmniVoiceTtsCpp.InstructionPitches, present);
+        SelectedOmniVoiceAccent = MatchGroup(OmniVoiceTtsCpp.InstructionAccents, present);
+        OmniVoiceWhisper = present.Contains(OmniVoiceTtsCpp.InstructionWhisper);
+        _suppressKeywordSync = false;
+
+        RebuildOmniVoiceInstruction();
+    }
+
+    private static string MatchGroup(string[] group, HashSet<string> present)
+        => Array.Find(group, present.Contains) ?? OmniVoiceAny;
+
+    // Recomputes the three visibility/enabled flags from the current engine, model, and voice.
+    // Call after any of those change. Mirrors RefreshInstructionVisibility +
+    // UpdateOmniVoicePickerState in the main TTS VM.
+    private void UpdateInstructionVisibility()
+    {
+        var engine = SelectedEngine;
+        var model = SelectedModel;
+
+        IsInstructionTextVisible =
+            (engine is Qwen3TtsCpp && Qwen3TtsCpp.IsVoiceDesignModel(model))
+            || (engine is Qwen3TtsCrispAsr && Qwen3TtsCrispAsr.IsVoiceDesignModel(model));
+        IsInstructionPickerVisible = engine is OmniVoiceTtsCpp;
+        HasInstruction = IsInstructionTextVisible || IsInstructionPickerVisible;
+
+        var isDefaultOmniVoice = SelectedVoice?.EngineVoice is OmniVoiceVoice ov && string.IsNullOrEmpty(ov.FilePath);
+        IsInstructionPickerEnabled = IsInstructionPickerVisible && isDefaultOmniVoice;
+        IsInstructionVoiceHintVisible = IsInstructionPickerVisible && !isDefaultOmniVoice;
+    }
+
+    private void LoadInstructionForEngine()
+    {
+        Instruction = SelectedEngine switch
+        {
+            Qwen3TtsCpp => Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty,
+            Qwen3TtsCrispAsr => Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty,
+            OmniVoiceTtsCpp => Se.Settings.Video.TextToSpeech.OmniVoiceTtsCppInstruction ?? string.Empty,
+            _ => string.Empty,
+        };
+
+        if (IsInstructionPickerVisible)
+        {
+            SyncOmniVoicePickerFromInstruction();
+        }
     }
 
     internal void OnClosing(WindowClosingEventArgs e)

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -261,41 +261,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
             Lines.Add(row);
         }
 
-        foreach (var engineItem in engines)
+        // Shared with the Cast dialog (see ActorVoiceDetector.FilterUsableEngines) so the two
+        // windows always show the same set of usable engines. Add new engine availability rules
+        // there, not here.
+        foreach (var engineItem in ActorVoiceDetector.FilterUsableEngines(engines))
         {
-            if (engineItem is ElevenLabs && string.IsNullOrWhiteSpace(Se.Settings.Video.TextToSpeech.ElevenLabsApiKey))
-            {
-                continue;
-            }
-
-            if (engineItem is Murf && string.IsNullOrWhiteSpace(Se.Settings.Video.TextToSpeech.MurfApiKey))
-            {
-                continue;
-            }
-
-            if (engineItem is AzureSpeech && string.IsNullOrWhiteSpace(Se.Settings.Video.TextToSpeech.AzureApiKey))
-            {
-                continue;
-            }
-
-            if (engineItem is GoogleSpeech && string.IsNullOrWhiteSpace(Se.Settings.Video.TextToSpeech.GoogleKeyFile))
-            {
-                continue;
-            }
-
-            if (engineItem is Qwen3TtsCpp && (!File.Exists(Qwen3TtsCpp.GetExecutableFileName())
-                || (!Qwen3TtsCpp.IsModelsInstalled(Qwen3TtsCpp.ModelKey06B)
-                    && !Qwen3TtsCpp.IsModelsInstalled(Qwen3TtsCpp.ModelKey17BBase))))
-            {
-                continue;
-            }
-
-            if (engineItem is KokoroTtsCpp && (!File.Exists(KokoroTtsCpp.GetExecutableFileName())
-                || !KokoroTtsCpp.AreModelsInstalled()))
-            {
-                continue;
-            }
-
             Engines.Add(engineItem);
         }
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1118,16 +1118,22 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 ? Engines.FirstOrDefault(e => string.Equals(e.Name, SelectedEngine?.Name, StringComparison.OrdinalIgnoreCase))
                 : SelectedEngine;
 
-            if (targetEngine != null && !ReferenceEquals(targetEngine, SelectedEngine))
+            // Refresh Voices / Models / Languages / Regions when:
+            //   - The row's engine differs from the current engine, OR
+            //   - We haven't loaded for this engine yet. After Initialize (Lines.Count > 0) the
+            //     Loaded-time refresh is skipped, and if the first row's engine matches the
+            //     caller-supplied SelectedEngine the engine-change branch above also skips —
+            //     leaving Models empty. We detect that with `engine.HasModel && Models.Count==0`.
+            //
+            // Setting SelectedEngine also fires the ComboBox's SelectionChanged → which would
+            // dispatch its own fire-and-forget refresh. We suppress that with the flag so the
+            // two don't race; the awaited call below does the same work and lets us apply the
+            // row's voice/model on top of it without it being immediately overwritten.
+            var needsRefresh = targetEngine != null
+                && (!ReferenceEquals(targetEngine, SelectedEngine)
+                    || (targetEngine.HasModel && Models.Count == 0));
+            if (needsRefresh)
             {
-                // Switch engine and await the refill of Voices / Models / Languages / Regions
-                // before applying the row's saved selections, otherwise the SelectedVoice write
-                // below races the refresh and lands on a stale (or empty) Voices list.
-                //
-                // Setting SelectedEngine also fires the ComboBox's SelectionChanged → which
-                // dispatches its own fire-and-forget refresh. We suppress that here so the two
-                // don't race; the awaited call below does the same work and lets us apply the
-                // row's voice/model on top of it without it being immediately overwritten.
                 _suppressEngineRefreshDispatch = true;
                 try
                 {

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -75,10 +75,18 @@ public class ReviewSpeechWindow : Window
         Content = grid;
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
-        Loaded += delegate 
+        Loaded += delegate
         {
             vm.Loaded();
-            vm.SelectedEngineChanged(); 
+            // When Initialize already selected the first row (Lines.Count > 0), that selection
+            // has already kicked off ApplyLineToLeftPanelAsync which loads the right engine's
+            // voices/models for the row. Firing SelectedEngineChanged here would post another
+            // fire-and-forget refresh that races (and wins against) the row sync, replacing the
+            // row's voice/model/instruction with the engine's defaults.
+            if (vm.Lines.Count == 0)
+            {
+                vm.SelectedEngineChanged();
+            }
         };
     }
 
@@ -343,11 +351,13 @@ public class ReviewSpeechWindow : Window
 
 
         var elevenLabsControls = MakeElevenLabsControls(vm);
+        var panelInstruction = MakeInstructionPanel(vm, labelMinWidth);
 
         var grid = new Grid
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -367,14 +377,124 @@ public class ReviewSpeechWindow : Window
         };
 
         grid.Add(panelEngine, 0, 0);
-        grid.Add(panelVoice, 1, 0);
-        grid.Add(panelModel, 2, 0);
+        // Model comes before Voice — same ordering as the main TTS window and Cast dialog so the
+        // user picks a model first (which sometimes filters the voice list) and the dropdowns
+        // line up across windows.
+        grid.Add(panelModel, 1, 0);
+        grid.Add(panelVoice, 2, 0);
         grid.Add(panelRegion, 3, 0);
         grid.Add(panelLanguage, 4, 0);
         grid.Add(elevenLabsControls, 5, 0);
-        // 6 is filler
+        grid.Add(panelInstruction, 6, 0);
+        // 7 is filler
 
         return UiUtil.MakeBorderForControl(grid);
+    }
+
+    // Voice-design controls shared with the main TTS window: free-text instruction (Qwen3
+    // VoiceDesign model) and OmniVoice keyword picker. Visibility flags on the VM mirror those
+    // in TextToSpeechViewModel — see ReviewSpeechViewModel.UpdateInstructionVisibility.
+    private static StackPanel MakeInstructionPanel(ReviewSpeechViewModel vm, int labelMinWidth)
+    {
+        var textBoxInstruction = new TextBox
+        {
+            Width = 260,
+            Height = 90,
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            VerticalContentAlignment = VerticalAlignment.Top,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            PlaceholderText = Se.Language.Video.TextToSpeech.VoiceInstructionHint,
+            DataContext = vm,
+            [!TextBox.IsVisibleProperty] = new Binding(nameof(vm.IsInstructionTextVisible)) { Mode = BindingMode.OneWay },
+        };
+        textBoxInstruction.Bind(TextBox.TextProperty, new Binding(nameof(vm.Instruction))
+        {
+            Mode = BindingMode.TwoWay,
+            UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+        });
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(0, 10, 0, 0),
+            Children =
+            {
+                new Label
+                {
+                    Content = Se.Language.Video.TextToSpeech.VoiceInstruction,
+                    MinWidth = labelMinWidth,
+                    VerticalAlignment = VerticalAlignment.Top,
+                },
+                textBoxInstruction,
+                MakeInstructionKeywordPicker(vm),
+            },
+            [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.HasInstruction)) { Mode = BindingMode.OneWay },
+        };
+    }
+
+    // OmniVoice keyword picker — gender/age/pitch/accent combos plus a whisper checkbox and a
+    // "doesn't apply to cloned voices" hint. Mirrors the picker in the main TTS window so the
+    // user sees the same control set regardless of which window they regenerate from.
+    private static Control MakeInstructionKeywordPicker(ReviewSpeechViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 8,
+            RowSpacing = 6,
+            [!Grid.IsEnabledProperty] = new Binding(nameof(vm.IsInstructionPickerEnabled)) { Mode = BindingMode.OneWay },
+        };
+
+        AddPickerRow(grid, 0, Se.Language.Video.TextToSpeech.VoiceGender, vm, vm.OmniVoiceGenders, nameof(vm.SelectedOmniVoiceGender));
+        AddPickerRow(grid, 1, Se.Language.Video.TextToSpeech.VoiceAge, vm, vm.OmniVoiceAges, nameof(vm.SelectedOmniVoiceAge));
+        AddPickerRow(grid, 2, Se.Language.Video.TextToSpeech.VoicePitch, vm, vm.OmniVoicePitches, nameof(vm.SelectedOmniVoicePitch));
+        AddPickerRow(grid, 3, Se.Language.Video.TextToSpeech.VoiceAccent, vm, vm.OmniVoiceAccents, nameof(vm.SelectedOmniVoiceAccent));
+
+        var whisper = new CheckBox
+        {
+            Content = OmniVoiceTtsCpp.InstructionWhisper,
+            DataContext = vm,
+            Margin = new Thickness(0, 4, 0, 0),
+        };
+        whisper.Bind(CheckBox.IsCheckedProperty, new Binding(nameof(vm.OmniVoiceWhisper)) { Mode = BindingMode.TwoWay });
+        grid.Add(whisper, 4, 0, 1, 2);
+
+        var clonedVoiceNote = new TextBlock
+        {
+            Text = Se.Language.Video.TextToSpeech.VoiceInstructionClonedVoiceNote,
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+            MaxWidth = 280,
+            Margin = new Thickness(0, 6, 0, 0),
+            [!TextBlock.IsVisibleProperty] = new Binding(nameof(vm.IsInstructionVoiceHintVisible)) { Mode = BindingMode.OneWay },
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Children = { grid, clonedVoiceNote },
+            [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.IsInstructionPickerVisible)) { Mode = BindingMode.OneWay },
+        };
+    }
+
+    private static void AddPickerRow(Grid grid, int row, string label, ReviewSpeechViewModel vm,
+        System.Collections.ObjectModel.ObservableCollection<string> items, string selectedPropertyPath)
+    {
+        grid.Add(new Label { Content = label, MinWidth = 60, VerticalAlignment = VerticalAlignment.Center }, row, 0);
+        grid.Add(UiUtil.MakeComboBox(items, vm, selectedPropertyPath).WithWidth(200), row, 1);
     }
 
     private static Grid MakeElevenLabsControls(ReviewSpeechViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -5,7 +5,9 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
@@ -88,6 +90,13 @@ public partial class TextToSpeechViewModel : ObservableObject
     [ObservableProperty] private string _selectedOmniVoicePitch;
     [ObservableProperty] private string _selectedOmniVoiceAccent;
     [ObservableProperty] private bool _omniVoiceWhisper;
+    [ObservableProperty] private bool _hasCast;
+    [ObservableProperty] private string _castButtonText;
+
+    // Per-actor (ASSA) or per-voice (WebVTT) mappings the user has configured via the Cast
+    // dialog. When empty, every paragraph falls back to the global SelectedEngine/SelectedVoice.
+    private readonly List<ActorVoiceMapping> _actorVoiceMappings = new();
+    private ActorVoiceDetector.CastKind _castKind = ActorVoiceDetector.CastKind.None;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -141,6 +150,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         IsNotGenerating = true;
         KeyFile = string.Empty;
         Instruction = string.Empty;
+        CastButtonText = Se.Language.Video.TextToSpeech.SetupCast;
 
         OmniVoiceGenders = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionGenders);
         OmniVoiceAges = BuildKeywordOptions(OmniVoiceTtsCpp.InstructionAges);
@@ -171,12 +181,15 @@ public partial class TextToSpeechViewModel : ObservableObject
             new MistralSpeech(ttsDownloadService),
             new Murf(ttsDownloadService),
             new GoogleSpeech(ttsDownloadService),
+            new KokoroTtsCpp(),
+            new OmniVoiceTtsCpp(),
+            // CrispASR-based engines grouped at the bottom: both share the same heavy CrispASR
+            // runtime download (~hundreds of MB) and are typically picked together, so we group
+            // them last so the lighter cloud/local engines surface first in the list.
             // Qwen3TtsCpp hidden: talker produces scrambled noise on 1.7B —
             // use Qwen3TtsCrispAsr until upstream qwen3-tts.cpp is fixed.
             new Qwen3TtsCrispAsr(),
-            new KokoroTtsCpp(),
             new ChatterboxTtsCpp(),
-            new OmniVoiceTtsCpp(),
         ];
 
         if (!OperatingSystem.IsMacOS())
@@ -507,6 +520,9 @@ public partial class TextToSpeechViewModel : ObservableObject
     }
 
     public void Initialize(Subtitle subtitle, string videoFileName, WavePeakData2? wavePeakData, string waveFolder)
+        => Initialize(subtitle, null, videoFileName, wavePeakData, waveFolder);
+
+    public void Initialize(Subtitle subtitle, SubtitleFormat? format, string videoFileName, WavePeakData2? wavePeakData, string waveFolder)
     {
         _subtitle = subtitle;
         _subtitle.RemoveEmptyLines();
@@ -521,6 +537,89 @@ public partial class TextToSpeechViewModel : ObservableObject
         ProgressText = string.Empty;
         ProgressValue = 0.0;
         _waveFolder = waveFolder;
+
+        _castKind = ActorVoiceDetector.Detect(subtitle, format);
+        // Only surface the cast button when there's actually more than one actor/voice to assign
+        // — a single-speaker subtitle uses the global engine/voice and the button would be a no-op.
+        var actorCount = _castKind == ActorVoiceDetector.CastKind.None
+            ? 0
+            : ActorVoiceDetector.GetNames(subtitle, _castKind).Count;
+        HasCast = actorCount > 1;
+        CastButtonText = HasCast
+            ? string.Format("{0} ({1})", Se.Language.Video.TextToSpeech.SetupCast.TrimEnd('.'), actorCount)
+            : Se.Language.Video.TextToSpeech.SetupCast;
+
+        // Seed from last session's persisted cast so users don't have to re-assign every time
+        // they open the same set of actors. The Cast dialog merges fresh edits back on save.
+        _actorVoiceMappings.Clear();
+        if (HasCast)
+        {
+            var actorNames = ActorVoiceDetector.GetNames(subtitle, _castKind)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var saved in Se.Settings.Video.TextToSpeech.LastActorVoiceMappings ?? new List<ActorVoiceMapping>())
+            {
+                if (saved == null || string.IsNullOrWhiteSpace(saved.Actor))
+                {
+                    continue;
+                }
+
+                // Trim before probing the set — the set was built from ActorVoiceDetector.GetNames
+                // which trims, but a legacy saved entry might have stored whitespace around the
+                // actor name and the case-insensitive Contains() still treats trailing spaces
+                // as a mismatch.
+                var actorKey = saved.Actor.Trim();
+                if (actorNames.Contains(actorKey))
+                {
+                    _actorVoiceMappings.Add(new ActorVoiceMapping
+                    {
+                        Actor = actorKey,
+                        EngineName = saved.EngineName ?? string.Empty,
+                        VoiceName = saved.VoiceName ?? string.Empty,
+                        Model = saved.Model ?? string.Empty,
+                        Instruction = saved.Instruction ?? string.Empty,
+                    });
+                }
+            }
+        }
+    }
+
+    [RelayCommand]
+    private async Task ShowCast()
+    {
+        if (Window == null || !HasCast)
+        {
+            return;
+        }
+
+        var actorNames = ActorVoiceDetector.GetNames(_subtitle, _castKind);
+        if (actorNames.Count == 0 && Window != null)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.Video.TextToSpeech.ActorVoicesTitle,
+                _castKind == ActorVoiceDetector.CastKind.AssaActors
+                    ? Se.Language.Video.TextToSpeech.NoActorsFoundMessage
+                    : Se.Language.Video.TextToSpeech.NoWebVttVoicesFoundMessage,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+            return;
+        }
+
+        // Same filter the Review window uses — only show engines that are usable right now
+        // (have credentials / are installed). Otherwise the user can pick an engine the cast
+        // can't actually drive, BuildCastContextAsync silently swallows the GetVoices failure,
+        // and the row quietly falls back to the global voice.
+        var usableEngines = ActorVoiceDetector.FilterUsableEngines(Engines).ToList();
+        var result = await _windowService.ShowDialogAsync<ActorVoiceMappingWindow, ActorVoiceMappingViewModel>(Window!, vm =>
+        {
+            vm.Initialize(actorNames, usableEngines, _actorVoiceMappings, SelectedEngine, SelectedVoice, _castKind, _waveFolder);
+        });
+
+        if (result.OkPressed)
+        {
+            _actorVoiceMappings.Clear();
+            _actorVoiceMappings.AddRange(result.Mappings);
+        }
     }
 
     [RelayCommand]
@@ -823,6 +922,13 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
+        // Restore the cast that travelled with the export so re-generating uses the same voices.
+        if (importExport.ActorVoiceMappings != null && importExport.ActorVoiceMappings.Count > 0)
+        {
+            _actorVoiceMappings.Clear();
+            _actorVoiceMappings.AddRange(importExport.ActorVoiceMappings);
+        }
+
         var stepResults = new List<TtsStepResult>();
         for (var index = 0; index < importExport.Items.Count; index++)
         {
@@ -833,8 +939,14 @@ public partial class TextToSpeechViewModel : ObservableObject
                 Text = item.Text,
                 CurrentFileName = item.AudioFileName,
                 Paragraph = paragraph,
-                SpeedFactor = 1.0f,
+                SpeedFactor = item.SpeedFactor <= 0 ? 1.0f : item.SpeedFactor,
                 Voice = Voices.FirstOrDefault(v => v.Name == item.VoiceName),
+                // Restore the per-line engine snapshot so the review window's click-to-sync
+                // (and any future regeneration) can recover the exact engine/model/instruction
+                // each line was produced with.
+                EngineName = item.EngineName ?? string.Empty,
+                Model = item.Model ?? string.Empty,
+                Instruction = item.Instruction ?? string.Empty,
             });
         }
 
@@ -851,6 +963,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 _videoFileName,
                 Path.GetDirectoryName(fileName)!,
                 _wavePeakData);
+            // Forward the imported cast so a subsequent Export round-trips the mappings instead
+            // of writing ActorVoiceMappings = [] back to SubtitleEditTts.json.
+            vm.ActorVoiceMappings.AddRange(_actorVoiceMappings);
         });
     }
 
@@ -1547,18 +1662,40 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             var resultList = new List<TtsStepResult>();
             ProgressValue = 0;
+
+            // Resolved per-actor cast (engine + voice + instruction). When _actorVoiceMappings is
+            // empty, every paragraph falls back to the globally selected engine/voice.
+            var castContext = await BuildCastContextAsync();
+
             for (var index = 0; index < _subtitle.Paragraphs.Count; index++)
             {
                 ProgressText = $"Generating speech: segment {index + 1} of {_subtitle.Paragraphs.Count}";
                 var paragraph = _subtitle.Paragraphs[index];
-                var speakResult = await engine.Speak(paragraph.Text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, cancellationToken);
+                var resolution = ResolveVoiceForParagraph(paragraph, castContext, engine, voice);
+                // When the row's engine differs from the globally selected engine, the global
+                // SelectedLanguage/SelectedRegion/SelectedModel were resolved for a different
+                // engine and don't apply (e.g. ElevenLabs voice IDs would be passed to Edge
+                // TTS). Pass null in that case and let the row's engine fall back to its own
+                // defaults.
+                var isCrossEngine = !ReferenceEquals(resolution.Engine, engine);
+                var language = isCrossEngine ? null : SelectedLanguage;
+                var region = isCrossEngine ? null : SelectedRegion;
+                var model = resolution.Model ?? (isCrossEngine ? null : SelectedModel);
+                var speakResult = await TtsInstructionSwap.RunAsync(
+                    resolution.Engine,
+                    resolution.Instruction,
+                    () => resolution.Engine.Speak(resolution.Text, _waveFolder, resolution.Voice,
+                        language, region, model, cancellationToken));
                 resultList.Add(new TtsStepResult
                 {
-                    Text = paragraph.Text,
+                    Text = resolution.Text,
                     CurrentFileName = speakResult.FileName,
                     Paragraph = paragraph,
                     SpeedFactor = 1.0f,
-                    Voice = voice,
+                    Voice = resolution.Voice,
+                    EngineName = resolution.Engine.Name,
+                    Model = resolution.Model ?? SelectedModel ?? string.Empty,
+                    Instruction = resolution.Instruction,
                 });
                 ProgressValue = (double)(index + 1) / _subtitle.Paragraphs.Count * 100.0;
 
@@ -1632,6 +1769,110 @@ public partial class TextToSpeechViewModel : ObservableObject
             });
             return null;
         }
+    }
+
+    private sealed class CastContext
+    {
+        public Dictionary<string, ActorVoiceMapping> ByActor { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, ITtsEngine> EnginesByName { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, Voice[]> VoicesByEngine { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    // Loads voices for every engine referenced by a mapping once, so the per-paragraph lookup
+    // in the generate loop is a cheap dictionary hit. Engines whose GetVoices() throws (e.g.
+    // missing API key) are skipped silently — those mappings fall through to the global voice.
+    private async Task<CastContext> BuildCastContextAsync()
+    {
+        var ctx = new CastContext();
+        if (_actorVoiceMappings.Count == 0 || _castKind == ActorVoiceDetector.CastKind.None)
+        {
+            return ctx;
+        }
+
+        foreach (var m in _actorVoiceMappings)
+        {
+            if (!string.IsNullOrWhiteSpace(m.Actor))
+            {
+                ctx.ByActor[m.Actor.Trim()] = m;
+            }
+        }
+
+        var engineNames = _actorVoiceMappings
+            .Select(m => m.EngineName)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in engineNames)
+        {
+            var engine = Engines.FirstOrDefault(e => string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (engine == null)
+            {
+                continue;
+            }
+
+            ctx.EnginesByName[name] = engine;
+            try
+            {
+                ctx.VoicesByEngine[name] = await engine.GetVoices(string.Empty);
+            }
+            catch (Exception ex)
+            {
+                SeLogger.Error(ex, $"Cast: loading voices for engine '{name}' failed - mappings using it will fall back to the global voice.");
+            }
+        }
+
+        return ctx;
+    }
+
+    private readonly struct ResolvedVoice
+    {
+        public ResolvedVoice(ITtsEngine engine, Voice voice, string? model, string text, string instruction)
+        {
+            Engine = engine;
+            Voice = voice;
+            Model = model;
+            Text = text;
+            Instruction = instruction;
+        }
+
+        public ITtsEngine Engine { get; }
+        public Voice Voice { get; }
+        public string? Model { get; }
+        public string Text { get; }
+        public string Instruction { get; }
+    }
+
+    // Picks engine + voice + text for a paragraph. For WebVTT it also strips the <v ...> wrapper
+    // out of the text so the engine doesn't speak the tag. Falls back to the global engine/voice
+    // when the paragraph has no actor, the mapping points at an unknown engine, or that engine's
+    // voice list couldn't be loaded.
+    private ResolvedVoice ResolveVoiceForParagraph(Paragraph paragraph, CastContext ctx, ITtsEngine defaultEngine, Voice defaultVoice)
+    {
+        var actor = ActorVoiceDetector.GetParagraphActor(paragraph, _castKind);
+        var text = _castKind == ActorVoiceDetector.CastKind.WebVttVoices
+            ? ActorVoiceDetector.StripWebVttVoiceTags(paragraph.Text)
+            : paragraph.Text;
+
+        if (string.IsNullOrEmpty(actor) || !ctx.ByActor.TryGetValue(actor, out var mapping))
+        {
+            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, string.Empty);
+        }
+
+        if (!ctx.EnginesByName.TryGetValue(mapping.EngineName, out var mappedEngine)
+            || !ctx.VoicesByEngine.TryGetValue(mapping.EngineName, out var voices))
+        {
+            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, string.Empty);
+        }
+
+        var mappedVoice = voices.FirstOrDefault(v => string.Equals(v.Name, mapping.VoiceName, StringComparison.OrdinalIgnoreCase));
+        if (mappedVoice == null)
+        {
+            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, string.Empty);
+        }
+
+        // Per-row model overrides the global one; empty string means "use the global model".
+        var modelOverride = string.IsNullOrWhiteSpace(mapping.Model) ? null : mapping.Model;
+        return new ResolvedVoice(mappedEngine, mappedVoice, modelOverride, text, mapping.Instruction ?? string.Empty);
     }
 
     private async Task<TtsStepResult[]?> FixSpeed(TtsStepResult[] previousStepResult, CancellationToken cancellationToken)
@@ -1715,6 +1956,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                         CurrentFileName = currentFile,
                         SpeedFactor = 1.0f,
                         Voice = item.Voice,
+                        EngineName = item.EngineName,
+                        Model = item.Model,
+                        Instruction = item.Instruction,
                     });
                     continue;
                 }
@@ -1729,6 +1973,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                         CurrentFileName = item.CurrentFileName,
                         SpeedFactor = 1.0f,
                         Voice = item.Voice,
+                        EngineName = item.EngineName,
+                        Model = item.Model,
+                        Instruction = item.Instruction,
                     });
 
                     SeLogger.Error($"TextToSpeech: Duration is zero (skipping): {item.CurrentFileName}, {p}");
@@ -1752,6 +1999,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                     CurrentFileName = outputFileName2,
                     SpeedFactor = (float)factor,
                     Voice = item.Voice,
+                    EngineName = item.EngineName,
+                    Model = item.Model,
+                    Instruction = item.Instruction,
                 });
 
                 // Use rubberband (WSOLA) for high-quality pitch-preserving stretch, or atempo as fallback
@@ -1819,6 +2069,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                     CurrentFileName = processedFile,
                     SpeedFactor = item.SpeedFactor,
                     Voice = item.Voice,
+                    EngineName = item.EngineName,
+                    Model = item.Model,
+                    Instruction = item.Instruction,
                 });
 
                 ProgressValue = (double)(index + 1) / previousStepResult.Length * 100.0;
@@ -1865,6 +2118,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 _videoFileName,
                 _waveFolder,
                 _wavePeakData);
+            vm.ActorVoiceMappings.AddRange(_actorVoiceMappings);
         });
 
         if (result.OkPressed)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -929,18 +929,52 @@ public partial class TextToSpeechViewModel : ObservableObject
             _actorVoiceMappings.AddRange(importExport.ActorVoiceMappings);
         }
 
+        // Resolve each line's Voice against the engine that *generated* it (per-line
+        // EngineName), not the currently selected engine — otherwise cast lines from another
+        // engine would land with Voice = null and click-to-sync/regenerate would break. Load
+        // each distinct engine's voice list once and reuse it for every line referencing that
+        // engine.
+        var voicesByEngine = new Dictionary<string, Voice[]>(StringComparer.OrdinalIgnoreCase);
+        var engineNames = importExport.Items
+            .Select(i => i.EngineName ?? string.Empty)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        foreach (var engineName in engineNames)
+        {
+            var matchingEngine = Engines.FirstOrDefault(e => string.Equals(e.Name, engineName, StringComparison.OrdinalIgnoreCase));
+            if (matchingEngine == null)
+            {
+                continue;
+            }
+            try
+            {
+                voicesByEngine[engineName] = await matchingEngine.GetVoices(string.Empty);
+            }
+            catch (Exception ex)
+            {
+                SeLogger.Error(ex, $"Import: loading voices for engine '{engineName}' failed — lines using it will fall back to the global voice list.");
+            }
+        }
+
         var stepResults = new List<TtsStepResult>();
         for (var index = 0; index < importExport.Items.Count; index++)
         {
             var item = importExport.Items[index];
             var paragraph = new Paragraph(item.Text, item.StartMs, item.EndMs) { Number = index + 1 };
+            Voice? voice = null;
+            if (!string.IsNullOrEmpty(item.EngineName)
+                && voicesByEngine.TryGetValue(item.EngineName, out var perEngineVoices))
+            {
+                voice = perEngineVoices.FirstOrDefault(v => string.Equals(v.Name, item.VoiceName, StringComparison.OrdinalIgnoreCase));
+            }
+            voice ??= Voices.FirstOrDefault(v => v.Name == item.VoiceName);
             stepResults.Add(new TtsStepResult
             {
                 Text = item.Text,
                 CurrentFileName = item.AudioFileName,
                 Paragraph = paragraph,
                 SpeedFactor = item.SpeedFactor <= 0 ? 1.0f : item.SpeedFactor,
-                Voice = Voices.FirstOrDefault(v => v.Name == item.VoiceName),
+                Voice = voice,
                 // Restore the per-line engine snapshot so the review window's click-to-sync
                 // (and any future regeneration) can recover the exact engine/model/instruction
                 // each line was produced with.
@@ -1694,7 +1728,11 @@ public partial class TextToSpeechViewModel : ObservableObject
                     SpeedFactor = 1.0f,
                     Voice = resolution.Voice,
                     EngineName = resolution.Engine.Name,
-                    Model = resolution.Model ?? SelectedModel ?? string.Empty,
+                    // Record the model the engine actually saw: empty for cross-engine lines
+                    // with no per-row override (which used the engine's own default), the
+                    // override when set, or the global SelectedModel for same-engine lines.
+                    // Avoids snapshotting a global model that belongs to a different engine.
+                    Model = model ?? string.Empty,
                     Instruction = resolution.Instruction,
                 });
                 ProgressValue = (double)(index + 1) / _subtitle.Paragraphs.Count * 100.0;

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -49,12 +49,23 @@ public class TextToSpeechWindow : Window
 
         var settingsLayout = MakeSettingsControls(vm);
 
-        var progressBarLayout = MakeProgressBarControls(vm);
+        // Wrap the progress bar layout in WidthIgnoringPanel so its measured width never feeds
+        // back up into the outer grid's column sizing. See the panel's class comment for why.
+        var progressBarLayout = new WidthIgnoringPanel { Children = { MakeProgressBarControls(vm) } };
 
         var buttonDone = UiUtil.MakeButtonDone(vm.DoneCommand).WithBindIsVisible(nameof(vm.IsNotGenerating));
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand).WithBindIsVisible(nameof(vm.IsGenerating));
+        var buttonCast = UiUtil.MakeButton(string.Empty, vm.ShowCastCommand)
+            .WithIconLeftBindText(IconNames.PoliceBadge, nameof(vm.CastButtonText))
+            .WithBindIsVisible(nameof(vm.HasCast))
+            .WithBindIsEnabled(nameof(vm.IsNotGenerating));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonCast, Se.Language.Video.TextToSpeech.SetupCastHint);
+        }
         var buttonPanel = UiUtil.MakeButtonBar(
             UiUtil.MakeButton(Se.Language.Video.TextToSpeech.GenerateSpeechFromText, vm.GenerateTtsCommand).WithBindIsEnabled(nameof(vm.IsNotGenerating)),
+            buttonCast,
             UiUtil.MakeButton(Se.Language.General.ImportDotDotDot, vm.ImportCommand).WithBindIsEnabled(nameof(vm.IsNotGenerating)),
             buttonCancel,
             buttonDone
@@ -385,7 +396,12 @@ public class TextToSpeechWindow : Window
         grid.Add(panelKeyFile, 6, 0);
         grid.Add(panelInstruction, 7, 0);
 
-        return UiUtil.MakeBorderForControl(grid);
+        // Give the left (Engine/Voice/Model/...) panel a sensible minimum so the window doesn't
+        // collapse into a narrow column when the right-side panel happens to be wider than the
+        // engine controls' intrinsic size.
+        var border = UiUtil.MakeBorderForControl(grid);
+        border.MinWidth = 500;
+        return border;
     }
 
     // Single-select picker of OmniVoice TTS voice-design keywords: one combo box per mutually
@@ -485,6 +501,9 @@ public class TextToSpeechWindow : Window
 
         var buttonAdvanced = UiUtil.MakeButton(Se.Language.General.AdvancedDotDotDot, vm.ShowAdvancedSettingsCommand)
             .WithMarginTop(5);
+        // MakeButton defaults to Center; the right-side settings panel reads more cleanly with
+        // the Advanced button left-aligned under the checkboxes above it.
+        buttonAdvanced.HorizontalAlignment = HorizontalAlignment.Left;
 
         var grid = new Grid
         {
@@ -513,38 +532,51 @@ public class TextToSpeechWindow : Window
 
     private static Grid MakeProgressBarControls(TextToSpeechViewModel vm)
     {
+        // Two rows so the status label and the progress bar stack vertically instead of
+        // overlapping in the same cell. Two columns so the progress text can explicitly span
+        // both — same shape as the outer window grid, so the text gets the full available
+        // width when long messages render (e.g. "Generating speech: segment 999 of 1000").
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
             },
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            Margin = new Thickness(0, 0, 0, 20),
+            Margin = new Thickness(0, 5, 0, 7),
             [!Grid.OpacityProperty] = new Binding(nameof(vm.ProgressOpacity)) { Mode = BindingMode.OneWay },
         };
 
-        var label = new Label
+        // TextBlock (not Label) so we can use TextTrimming for overflow rendering. The actual
+        // "don't grow the window" guarantee comes from the WidthIgnoringPanel wrapper around
+        // this whole grid below — that panel reports 0 desired width up the layout chain so the
+        // outer grid's Star columns never see the progress text's natural width.
+        var label = new TextBlock
         {
-            Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Bottom,
-            Margin = new Thickness(0, 20, 0, 0),
-            [!Label.ContentProperty] = new Binding(nameof(vm.ProgressText)) { Mode = BindingMode.TwoWay },
+            VerticalAlignment = VerticalAlignment.Center,
+            TextAlignment = TextAlignment.Left,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            Margin = new Thickness(0, 6, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.ProgressText)) { Mode = BindingMode.OneWay },
         };
 
         var progressBar = UiUtil.MakeProgressBar();
-        progressBar.Width = double.NaN;
         progressBar.HorizontalAlignment = HorizontalAlignment.Stretch;
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
 
-        grid.Add(label, 0, 0);
-        grid.Add(progressBar, 0, 0);
+        // Both rows explicitly span the two columns so the bar and status text use the full
+        // window width (matching the engine + settings panels above), and so the text doesn't
+        // need to grow horizontally when messages get longer.
+        grid.Add(progressBar, 0, 0, 1, 2);
+        grid.Add(label, 1, 0, 1, 2);
 
         return grid;
     }
@@ -565,5 +597,47 @@ public class TextToSpeechWindow : Window
     {
         base.OnLoaded(e);
         _vm.OnLoaded(e);
+    }
+}
+
+// Wraps a child whose width should not influence the parent's measure. We use this for the
+// progress text + bar at the bottom of the TTS window.
+//
+// Without it, the progress TextBlock's natural text width feeds up through the inner grid into
+// the outer 2-column grid, where colSpan=2 distributes that desired width across both Star
+// columns. Each column then grows to max(natural, distributedShare), so when the progress text
+// gets longer mid-generation (e.g. "Adding audio to video file..."), the column with the
+// smaller natural content (the settings panel) is pushed wider — making the whole window jump.
+// TextTrimming on the TextBlock doesn't help because trimming runs at render time, not measure.
+//
+// MeasureOverride still measures the child (so it can lay itself out correctly in arrange and
+// know its height), but reports Size(0, childHeight) as our own desired. ArrangeOverride gives
+// the child the final size we were allocated — which the outer grid computed purely from the
+// engine/settings panels and the button bar, not from our child's text content. Net effect: the
+// outer grid's column widths are stable across progress-text changes, and the bar/text simply
+// trim within whatever width the engine/settings rows decided.
+internal sealed class WidthIgnoringPanel : Panel
+{
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var height = 0d;
+        foreach (var child in Children)
+        {
+            child.Measure(availableSize);
+            if (child.DesiredSize.Height > height)
+            {
+                height = child.DesiredSize.Height;
+            }
+        }
+        return new Size(0, height);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        foreach (var child in Children)
+        {
+            child.Arrange(new Rect(finalSize));
+        }
+        return finalSize;
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/TtsImportExport.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsImportExport.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 
@@ -7,9 +8,14 @@ public class TtsImportExport
     public string VideoFileName { get; set; }
     public List<TtsImportExportItem> Items { get; set; }
 
+    // Saved with the export so the cast travels with the audio. May be null/empty in older
+    // exports — load paths must tolerate that.
+    public List<ActorVoiceMapping> ActorVoiceMappings { get; set; }
+
     public TtsImportExport()
     {
         VideoFileName = string.Empty;
         Items = new List<TtsImportExportItem>();
+        ActorVoiceMappings = new List<ActorVoiceMapping>();
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/TtsImportExportItem.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsImportExportItem.cs
@@ -9,6 +9,14 @@ public class TtsImportExportItem
     public float SpeedFactor { get; set; }
     public string EngineName { get; set; }
     public string VoiceName { get; set; }
+
+    // Per-line engine snapshot — needed so the review window's "click-to-sync left panel" can
+    // restore the exact settings a line was generated with after a round-trip through
+    // SubtitleEditTts.json. Without these the lookup falls back to the global selection and the
+    // user loses their per-actor model/instruction. May be empty for legacy exports.
+    public string Model { get; set; }
+    public string Instruction { get; set; }
+
     public bool Include { get; set; }
 
     public TtsImportExportItem()
@@ -20,6 +28,8 @@ public class TtsImportExportItem
         SpeedFactor = 1.0f;
         EngineName = string.Empty;
         VoiceName = string.Empty;
+        Model = string.Empty;
+        Instruction = string.Empty;
         Include = true;
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/TtsInstructionSwap.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsInstructionSwap.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+
+// Engines read voice-design instruction text out of Se.Settings during Speak(). To temporarily
+// substitute a different instruction (per-line in Generate, per-row in the Cast Test/Regenerate
+// buttons, per-line in Review Regenerate) we have to swap the global field, run the engine call,
+// then put the original back.
+//
+// Three places used to keep private copies of this swap. The duplication was harmless on its own
+// but the swap is GLOBAL: if two callers ran concurrently (e.g. user clicks Test in the Cast
+// dialog while a Generate loop is mid-paragraph) their swap/restore pairs would interleave and
+// one would restore the *other's* swap as if it were the original — leaving stale instruction
+// text in Se.Settings.
+//
+// The semaphore here serialises the entire swap → speak → restore critical section so concurrent
+// callers wait their turn. Side-effect: parallel Speak() calls that share the swap field are
+// effectively serialised, which is acceptable given how rarely both happen at once.
+public static class TtsInstructionSwap
+{
+    private static readonly SemaphoreSlim Gate = new(1, 1);
+
+    // Runs `speak` with the given instruction temporarily applied to Se.Settings. Returns
+    // whatever `speak` returns. Settings are always restored, even when `speak` throws.
+    public static async Task<T> RunAsync<T>(ITtsEngine? engine, string? instruction, Func<Task<T>> speak)
+    {
+        await Gate.WaitAsync();
+        var previous = Swap(engine, instruction);
+        try
+        {
+            return await speak();
+        }
+        finally
+        {
+            Restore(engine, previous);
+            Gate.Release();
+        }
+    }
+
+    private static string? Swap(ITtsEngine? engine, string? instruction)
+    {
+        var s = Se.Settings.Video.TextToSpeech;
+        switch (engine)
+        {
+            case Qwen3TtsCpp:
+            case Qwen3TtsCrispAsr:
+                var prevQwen = s.Qwen3TtsCppInstruction;
+                s.Qwen3TtsCppInstruction = instruction ?? string.Empty;
+                return prevQwen;
+            case OmniVoiceTtsCpp:
+                var prevOmni = s.OmniVoiceTtsCppInstruction;
+                s.OmniVoiceTtsCppInstruction = instruction ?? string.Empty;
+                return prevOmni;
+            default:
+                return null;
+        }
+    }
+
+    private static void Restore(ITtsEngine? engine, string? previous)
+    {
+        if (previous == null)
+        {
+            return;
+        }
+
+        var s = Se.Settings.Video.TextToSpeech;
+        switch (engine)
+        {
+            case Qwen3TtsCpp:
+            case Qwen3TtsCrispAsr:
+                s.Qwen3TtsCppInstruction = previous;
+                break;
+            case OmniVoiceTtsCpp:
+                s.OmniVoiceTtsCppInstruction = previous;
+                break;
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TtsStepResult.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsStepResult.cs
@@ -11,11 +11,22 @@ public class TtsStepResult
     public float SpeedFactor { get; set; }
     public Voice? Voice { get; set; }
 
+    // Recorded so the review window can show which engine/model/instruction produced each line
+    // and restore them to the left panel when the user clicks the row. Engine name is used (not
+    // the engine instance) so it survives serialization to/from SubtitleEditTts.json. May be
+    // empty for lines that didn't go through the per-actor cast.
+    public string EngineName { get; set; }
+    public string Model { get; set; }
+    public string Instruction { get; set; }
+
     public TtsStepResult()
     {
         Paragraph = new Paragraph();
         Text = string.Empty;
         CurrentFileName = string.Empty;
         SpeedFactor = 1.0f;
+        EngineName = string.Empty;
+        Model = string.Empty;
+        Instruction = string.Empty;
     }
 }

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -73,6 +73,22 @@ public class LanguageTextToSpeech
     public string VoiceAccent { get; set; }
     public string VoiceInstructionClonedVoiceNote { get; set; }
 
+    // Cast dialog
+    public string ActorVoicesTitle { get; set; }
+    public string ActorVoicesSubtitle { get; set; }
+    public string ActorVoicesAssignedXOfY { get; set; }
+    public string ActorOrVoice { get; set; }
+    public string ApplyDefaultToAll { get; set; }
+    public string ClearAllAssignmentsConfirm { get; set; }
+    public string SetupCast { get; set; }
+    public string SetupCastHint { get; set; }
+    public string ActorVoicesRowSettingsTitle { get; set; }
+    public string VoiceSettingsForX { get; set; }
+    public string VoiceInstructionFreeTextHint { get; set; }
+    public string VoiceDesign { get; set; }
+    public string NoActorsFoundMessage { get; set; }
+    public string NoWebVttVoicesFoundMessage { get; set; }
+
     public LanguageTextToSpeech()
     {
         Title = "Text to speech";
@@ -136,12 +152,27 @@ public class LanguageTextToSpeech
         Qwen3TtsSettings = "Qwen3 TTS settings";
         KokoroTtsSettings = "Kokoro TTS settings";
         ChatterboxTtsSettings = "Chatterbox TTS settings";
-        VoiceInstruction = "Voice instruction";
+        VoiceInstruction = "Voice design";
         VoiceInstructionHint = "Optional - e.g. \"Speak in a calm and friendly tone\"";
         VoiceGender = "Gender";
         VoiceAge = "Age";
         VoicePitch = "Pitch";
         VoiceAccent = "Accent";
         VoiceInstructionClonedVoiceNote = "Voice design only affects the \"Default\" voice - a cloned voice keeps its own characteristics.";
+
+        ActorVoicesTitle = "TTS - Cast";
+        ActorVoicesSubtitle = "Assign a TTS voice (and optional voice-design instruction) to each actor or voice.";
+        ActorVoicesAssignedXOfY = "{0} of {1} assigned";
+        ActorOrVoice = "Actor / Voice";
+        ApplyDefaultToAll = "Apply default to all";
+        ClearAllAssignmentsConfirm = "Clear all voice assignments?";
+        SetupCast = "Cast...";
+        SetupCastHint = "Assign a TTS voice to each actor (ASSA) or voice (WebVTT).";
+        ActorVoicesRowSettingsTitle = "TTS - Voice settings";
+        VoiceSettingsForX = "Voice settings for \"{0}\"";
+        VoiceInstructionFreeTextHint = "Free text used by the engine to shape the voice's tone.";
+        VoiceDesign = "Voice design";
+        NoActorsFoundMessage = "No actors found. Set the Actor field on subtitle lines first.";
+        NoWebVttVoicesFoundMessage = "No <v Name> voices found in the WebVTT file.";
     }
 }

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -1,4 +1,7 @@
-﻿namespace Nikse.SubtitleEdit.Logic.Config;
+﻿using System.Collections.Generic;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+
+namespace Nikse.SubtitleEdit.Logic.Config;
 
 public class SeVideoTextToSpeech
 {
@@ -64,6 +67,11 @@ public class SeVideoTextToSpeech
     // Output sample rate (0 = default)
     public int OutputSampleRate { get; set; }
 
+    // Remembered actor/voice mappings. Pre-fills the cast dialog so users don't have to
+    // re-assign the same character voices every time they open a new subtitle. Keyed by actor
+    // name; matches happen case-insensitively.
+    public List<ActorVoiceMapping> LastActorVoiceMappings { get; set; }
+
     public SeVideoTextToSpeech()
     {
         Engine = "Piper";
@@ -111,5 +119,6 @@ public class SeVideoTextToSpeech
         HighQualityTimeStretchEnabled = false;
         SilencePaddingMs = 0;
         OutputSampleRate = 0;
+        LastActorVoiceMappings = new List<ActorVoiceMapping>();
     }
 }


### PR DESCRIPTION
## Summary

Adds a **Cast** feature to the Text-to-Speech window that lets the user assign a different TTS engine, voice, model, and voice-design instruction to each ASSA `Actor` or WebVTT `<v ...>` voice in a subtitle.

- **Cast button** appears in the TTS window when the currently-selected subtitle format is ASSA/SSA with `Actor` fields filled in, or WebVTT with `<v Name>` tags — and more than one distinct actor/voice is present.
- **Cast dialog**: a grid of `Actor | Engine | Model | Voice | ⚙ ▶` rows. The engine dropdown is filtered to engines that are usable right now (have credentials / are installed). Voice list is pre-populated by name match (`actor "Aria"` → `en-US-AriaNeural`). The ⚙ button opens a sub-dialog for engine-specific advanced settings — Qwen3 voice-instruction text, OmniVoice gender/age/pitch/accent/whisper picker — and the ▶ button tests the row's voice.
- **Per-line generation**: `TextToSpeechViewModel.GenerateSpeech` resolves each paragraph against the cast and runs each through its mapped engine + voice + model + instruction (falls back to the global selection for unmapped lines). Cross-engine rows correctly pass `null` for Language/Region so they don't reuse the global engine's resolved values.
- **WebVTT support**: `<v Name>...</v>` tags are stripped from the text before the engine speaks it (all of them — multi-voice paragraphs no longer leak unstripped tags).
- **Review window sync**: clicking a row in the Review grid (or picking a history entry) now updates the left-side Engine/Model/Voice/Instruction controls to whatever produced that line. `TtsStepResult` records the engine snapshot used per line, propagated through every pipeline stage. The OmniVoice gender/age/pitch/accent picker is also synced back from the stored instruction.
- **Persistence**: mappings travel through `SubtitleEditTts.json` (Export ↔ Import) and a "last mappings" copy lives in `SeVideoTextToSpeech.LastActorVoiceMappings` so the next session pre-fills the same cast even before any export.
- **Engine list reorder**: the two CrispASR-based engines (Qwen3 CrispASR, Chatterbox) are grouped at the bottom since they share the same heavy runtime download.

### Notable bug fixes along the way
- Progress bar in the TTS window no longer makes the window briefly jump wider mid-generation. Root cause was the progress TextBlock's measured text width feeding through colSpan=2 distribution and growing both grid columns. Fixed with a `WidthIgnoringPanel` that reports `Size(0, height)` for measure but arranges its child to fill the row.
- Concurrent Test + Generate + Regenerate calls no longer corrupt `Se.Settings.Video.TextToSpeech.*Instruction` — the three duplicate Swap/Restore copies are consolidated into `TtsInstructionSwap.RunAsync` with a `SemaphoreSlim` serialising the swap → speak → restore critical section.
- Cast detection now takes `SubtitleFormat` explicitly from `MainViewModel.SelectedSubtitleFormat` (Subtitle Edit normalises subtitles to ASSA internally, so `subtitle.OriginalFormat` wasn't reflecting the user's selection — SubRip files were showing the button).
- Rapid row clicks in the Review window during an in-flight engine refresh are no longer dropped — pending selections are queued and drained.

## Files

New: 7 files under `src/ui/Features/Video/TextToSpeech/ActorVoices/` + `TtsInstructionSwap.cs`.
Modified: `TextToSpeechViewModel/Window.cs`, `ReviewSpeechViewModel/Window.cs`, `ReviewRow.cs`, `ReviewHistoryRow.cs`, `TtsImportExport.cs`, `TtsImportExportItem.cs`, `TtsStepResult.cs`, `MainViewModel.cs` (ShowVideoTextToSpeech pass-through), `DependencyInjectionExtensions.cs`, `LanguageTextToSpeech.cs`, `SeVideoTextToSpeech.cs`.

## Test plan

- [ ] Load a SubRip file → open TTS → **Cast button hidden**
- [ ] Load an ASSA file with no Actor fields filled → open TTS → **Cast button hidden**
- [ ] Load an ASSA file with one filled Actor → open TTS → **Cast button hidden**
- [ ] Load an ASSA file with two or more actors → open TTS → **Cast button visible** with `Cast (N)` label
- [ ] Load a WebVTT file with multiple `<v Name>` voices → open TTS → **Cast button visible**
- [ ] Open the Cast dialog → engines without credentials are not in the engine dropdown
- [ ] Assign different engines to different actors (e.g. ElevenLabs + Edge TTS) → Generate → verify each actor uses its mapped engine + voice
- [ ] Generate with Qwen3 VoiceDesign model → enter an instruction in a row → verify the engine receives it
- [ ] OmniVoice row → open ⚙ → pick gender/age → the picker keywords compose into the instruction text
- [ ] Click rows in Review → left panel reflects each row's settings
- [ ] Open a row's history → pick an older entry → left panel updates to that entry's settings
- [ ] Export from Review → Import in TTS → cast is preserved → Export again → still preserved
- [ ] Run a long generation → window does **not** widen when progress text changes mid-generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)