### PR TITLE
Add granite-speech-4.1-2b-plus to CrispASR Granite engine

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGranite.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGranite.cs
@@ -66,6 +66,42 @@ public class CrispAsrGranite : CrispAsrEngineBase
                     "https://huggingface.co/cstr/granite-speech-4.1-2b-GGUF/resolve/main/granite-speech-4.1-2b-f16.gguf"
                 ],
             },
+            new WhisperModel
+            {
+                Name = "granite-speech-4.1-2b-plus-q4_k-mini.gguf",
+                Size = "1.54 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/granite-speech-4.1-2b-plus-GGUF/resolve/main/granite-speech-4.1-2b-plus-q4_k-mini.gguf"
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "granite-speech-4.1-2b-plus-q4_k-f16enc.gguf",
+                Size = "2.13 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/granite-speech-4.1-2b-plus-GGUF/resolve/main/granite-speech-4.1-2b-plus-q4_k-f16enc.gguf"
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "granite-speech-4.1-2b-plus-q4_k.gguf",
+                Size = "2.75 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/granite-speech-4.1-2b-plus-GGUF/resolve/main/granite-speech-4.1-2b-plus-q4_k.gguf"
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "granite-speech-4.1-2b-plus-f16.gguf",
+                Size = "5.21 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/granite-speech-4.1-2b-plus-GGUF/resolve/main/granite-speech-4.1-2b-plus-f16.gguf"
+                ],
+            },
        };
 
     public override string Extension => string.Empty;


### PR DESCRIPTION
## Summary
- Adds `granite-speech-4.1-2b-plus` (cstr's enhanced variant of `granite-speech-4.1-2b`) as 4 picker entries in the Granite engine.
- Uses the same `granite-4.1` backend and existing language list — no new engine class, no settings changes.

| Quant | Size | URL |
|---|---|---|
| q4_k-mini   | 1.54 GB | https://huggingface.co/cstr/granite-speech-4.1-2b-plus-GGUF |
| q4_k-f16enc | 2.13 GB | (same repo) |
| q4_k        | 2.75 GB | (same repo) |
| f16         | 5.21 GB | (same repo) |

## Test plan
- [ ] Open Speech-to-Text → Engine: Crisp ASR Granite → verify the 4 new "plus" entries appear in the model dropdown alongside the existing non-plus ones.
- [ ] Download e.g. `granite-speech-4.1-2b-plus-q4_k.gguf` and run transcription on a sample clip — should work identically to the non-plus variant (same backend) with potentially better accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)