### PR TITLE
Chain voices.zip download after Qwen3 TTS (CrispASR) models

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -52,6 +52,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskKokoroTtsModels;
     private Task? _downloadTaskChatterboxModels;
     private Task? _downloadTaskQwen3TtsCrispAsrModels;
+    private Task? _downloadTaskQwen3TtsCrispAsrVoices;
     private Task? _downloadTaskOmniVoice;
     private Task? _downloadTaskOmniVoiceVoices;
     private Task? _downloadTaskOmniVoiceModels;
@@ -72,6 +73,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly MemoryStream _downloadStreamQwen3TtsCpp;
     private readonly MemoryStream _downloadStreamQwen3TtsCppVoices;
     private readonly MemoryStream _downloadStreamKokoroTtsCpp;
+    private readonly MemoryStream _downloadStreamQwen3TtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamOmniVoice;
     private readonly MemoryStream _downloadStreamOmniVoiceVoices;
     private readonly IZipUnpacker _zipUnpacker;
@@ -102,6 +104,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _downloadStreamQwen3TtsCpp = new MemoryStream();
         _downloadStreamQwen3TtsCppVoices = new MemoryStream();
         _downloadStreamKokoroTtsCpp = new MemoryStream();
+        _downloadStreamQwen3TtsCrispAsrVoices = new MemoryStream();
         _downloadStreamOmniVoice = new MemoryStream();
         _downloadStreamOmniVoiceVoices = new MemoryStream();
 
@@ -512,8 +515,38 @@ public partial class DownloadTtsViewModel : ObservableObject
             if (_downloadTaskQwen3TtsCrispAsrModels is { IsCompleted: true })
             {
                 _timer.Stop();
-                OkPressed = true;
-                Close();
+                _downloadTaskQwen3TtsCrispAsrModels = null;
+
+                // Chain the voices download, unless the user already has voices installed.
+                // Qwen3TtsCrispAsr.GetSetVoicesFolder lazily seeds from qwen3-tts.cpp's
+                // voices folder if any exist there, so users who already have them get
+                // skipped automatically.
+                var voicesFolder = Qwen3TtsCrispAsr.GetSetVoicesFolder();
+                var voicesAlreadyInstalled = Directory.Exists(voicesFolder) &&
+                                             Directory.EnumerateFiles(voicesFolder, "*.wav").Any();
+                if (voicesAlreadyInstalled)
+                {
+                    OkPressed = true;
+                    Close();
+                    return;
+                }
+
+                TitleText = "Downloading Qwen3 TTS (CrispASR) voices";
+                ProgressValue = 0;
+                ProgressText = Se.Language.General.StartingDotDotDot;
+                var voicesProgress = new Progress<float>(number =>
+                {
+                    var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+                    var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+                    ProgressValue = percentage;
+                    ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+                });
+                // Same voices.zip as qwen3-tts.cpp (24 kHz mono WAV + .txt sidecars,
+                // identical format). Reuse the Qwen3 TTS .cpp download service rather
+                // than adding a second copy of the URL/hash.
+                _downloadTaskQwen3TtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
+                    _downloadStreamQwen3TtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
+                _timer.Start();
             }
             else if (_downloadTaskQwen3TtsCrispAsrModels is { IsFaulted: true })
             {
@@ -529,6 +562,50 @@ public partial class DownloadTtsViewModel : ObservableObject
                     ProgressText = "Download failed";
                     Error = ex?.Message ?? "Unknown error";
                 }
+            }
+
+            if (_downloadTaskQwen3TtsCrispAsrVoices is { IsCompleted: true })
+            {
+                _timer.Stop();
+
+                if (_downloadStreamQwen3TtsCrispAsrVoices.Length > 0)
+                {
+                    var voicesFolder = Qwen3TtsCrispAsr.GetSetVoicesFolder();
+                    try
+                    {
+                        _downloadStreamQwen3TtsCrispAsrVoices.Position = 0;
+                        _zipUnpacker.UnpackZipStream(_downloadStreamQwen3TtsCrispAsrVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        WriteInstalledHashSidecar(voicesFolder, _downloadStreamQwen3TtsCrispAsrVoices, DownloadHashManager.Qwen3TtsCpp.Voices);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Voices are optional; log and continue so the engine is still usable.
+                        Se.LogError(ex);
+                    }
+                    _downloadStreamQwen3TtsCrispAsrVoices.Dispose();
+                }
+
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskQwen3TtsCrispAsrVoices is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskQwen3TtsCrispAsrVoices.Exception?.InnerException ?? _downloadTaskQwen3TtsCrispAsrVoices.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                    return;
+                }
+
+                // Voices are optional — the models are already installed. Log and close with success.
+                if (ex != null)
+                {
+                    Se.LogError(ex);
+                }
+                OkPressed = true;
+                Close();
             }
 
             if (_downloadTaskOmniVoice is { IsCompleted: true })

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -591,8 +591,7 @@ public partial class DownloadTtsViewModel : ObservableObject
             else if (_downloadTaskQwen3TtsCrispAsrVoices is { IsFaulted: true })
             {
                 _timer.Stop();
-                var ex = _downloadTaskQwen3TtsCrispAsrVoices.Exception?.InnerException ?? _downloadTaskQwen3TtsCrispAsrVoices.Exception;
-                if (ex is OperationCanceledException)
+                if (_cancellationTokenSource.IsCancellationRequested)
                 {
                     ProgressText = "Download canceled";
                     Close();
@@ -600,6 +599,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 }
 
                 // Voices are optional — the models are already installed. Log and close with success.
+                var ex = _downloadTaskQwen3TtsCrispAsrVoices.Exception?.InnerException ?? _downloadTaskQwen3TtsCrispAsrVoices.Exception;
                 if (ex != null)
                 {
                     Se.LogError(ex);

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -255,8 +255,8 @@ public class Qwen3TtsCrispAsr : ITtsEngine
     /// engine's voices folder. The same files work for both engines (just 24 kHz mono
     /// reference audio with optional .txt sidecars), so users who already downloaded the
     /// qwen3-tts.cpp voice pack get them for free here without a second ~10 MB download.
-    /// Users who never installed qwen3-tts.cpp start empty and can use Import Voice or wait
-    /// for the dedicated voices.zip downloader (TODO).
+    /// Users who never installed qwen3-tts.cpp get voices.zip pulled by the
+    /// DownloadTtsViewModel flow that chains after model download.
     /// </summary>
     private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
     {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1194,7 +1194,18 @@ public partial class TextToSpeechViewModel : ObservableObject
                 }
 
                 var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadQwen3TtsCrispAsrModels(crispAsrModelKey));
-                return dlResult.OkPressed && Qwen3TtsCrispAsr.AreModelsInstalled(crispAsrModelKey);
+                if (!dlResult.OkPressed || !Qwen3TtsCrispAsr.AreModelsInstalled(crispAsrModelKey))
+                {
+                    return false;
+                }
+
+                // The download dialog also pulls voices.zip when none are present, so
+                // refresh the voice list to surface them in the combo.
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await RefreshVoices(engine);
+                });
+                return true;
             }
 
             return true;


### PR DESCRIPTION
## Summary
- After Qwen3 TTS (CrispASR) models finish downloading, chain the existing qwen3-tts.cpp `voices.zip` (same 24 kHz mono WAV + .txt sidecar format) into the CrispASR voices folder so new users have working reference voices for CustomVoice and examples for VoiceDesign.
- Skip the voices download when the folder is already populated — `Qwen3TtsCrispAsr.GetSetVoicesFolder` lazily seeds from the qwen3-tts.cpp voices folder, so existing users short-circuit automatically.
- Refresh the voice combo after the dialog closes, mirroring the Qwen3 TTS / Kokoro flow, so new entries appear without reopening the TTS window.

## Test plan
- [ ] Fresh install (no qwen3-tts.cpp voices): pick Qwen3 TTS (CrispASR), confirm voices.zip downloads after the model GGUFs and WAVs appear in the voice combo.
- [ ] Already have qwen3-tts.cpp voices installed: confirm voices.zip download is skipped (folder is pre-seeded), engine still works.
- [ ] Already have CrispASR voices: confirm no re-download.
- [ ] Cancel during the chained voices download: dialog closes cleanly, models stay installed, engine still usable.
- [ ] Network failure during voices download: error is logged but dialog closes with OK since voices are optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)