### PR TITLE
Add Merge continuation lines tool + TTS prompt

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -115,6 +115,7 @@ using Nikse.SubtitleEdit.Features.Tools.ConvertActors;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.FixNetflixErrors;
 using Nikse.SubtitleEdit.Features.Tools.JoinSubtitles;
+using Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
 using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 using Nikse.SubtitleEdit.Features.Tools.MergeTwoSubtitles;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameText;
@@ -376,6 +377,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<MergeSameTextViewModel>();
         collection.AddTransient<MergeSameTimeCodesViewModel>();
         collection.AddTransient<MergeShortLinesViewModel>();
+        collection.AddTransient<MergeContinuationLinesViewModel>();
         collection.AddTransient<MergeTwoSubtitlesViewModel>();
         collection.AddTransient<ModifySelectionViewModel>();
         collection.AddTransient<MultipleReplaceViewModel>();

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -473,6 +473,11 @@ public static class InitMenu
             },
             new MenuItem
             {
+                Header = l.MergeContinuationLines,
+                Command = vm.ShowToolsMergeContinuationLinesCommand,
+            },
+            new MenuItem
+            {
                 Header = l.MergeTwoSubtitles,
                 Command = vm.ShowToolsMergeTwoSubtitlesCommand,
             },

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4844,6 +4844,51 @@ public partial class MainViewModel :
         }
     }
 
+    private async Task<Subtitle> PromptMergeContinuationLinesAsync(Subtitle subtitle)
+    {
+        if (Window == null || subtitle.Paragraphs.Count < 2)
+        {
+            return subtitle;
+        }
+
+        var language = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle);
+        if (MergeContinuationLinesHelper.IsLanguageSkipped(language))
+        {
+            return subtitle;
+        }
+
+        var format = subtitle.OriginalFormat ?? SelectedSubtitleFormat ?? new SubRip();
+        var viewModels = subtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, format)).ToList();
+
+        const int maxGapMs = 500;
+        const int maxCharacters = 500;
+        var candidates = MergeContinuationLinesHelper.Detect(viewModels, language, maxGapMs, maxCharacters);
+        if (candidates.Count == 0)
+        {
+            return subtitle;
+        }
+
+        var result = await _windowService
+            .ShowDialogAsync<MergeContinuationLinesWindow, MergeContinuationLinesViewModel>(
+                Window!, vm => vm.Initialize(viewModels, language, maxGapMs, maxCharacters));
+
+        if (!result.OkPressed || result.AllSubtitlesFixed.Count == subtitle.Paragraphs.Count)
+        {
+            return subtitle;
+        }
+
+        var merged = new Subtitle
+        {
+            OriginalFormat = subtitle.OriginalFormat,
+            FileName = subtitle.FileName,
+        };
+        foreach (var line in result.AllSubtitlesFixed)
+        {
+            merged.Paragraphs.Add(line.ToParagraph(subtitle.OriginalFormat));
+        }
+        return merged;
+    }
+
     [RelayCommand]
     private async Task ShowToolsMergeContinuationLines()
     {
@@ -5257,6 +5302,12 @@ public partial class MainViewModel :
             ResetSubtitle();
 
             _subtitle = result.TranscribedSubtitle;
+
+            if (Se.Settings.Tools.SpeechToTextPromptMergeContinuationLines)
+            {
+                _subtitle = await PromptMergeContinuationLinesAsync(_subtitle);
+            }
+
             if (SelectedSubtitleFormat is AdvancedSubStationAlpha)
             {
                 foreach (var p in _subtitle.Paragraphs)
@@ -5270,7 +5321,7 @@ public partial class MainViewModel :
 
             SetSubtitles(_subtitle);
             SelectAndScrollToRow(0);
-            ShowStatus(string.Format(Se.Language.Main.TranscriptionCompletedWithXLines, result.TranscribedSubtitle.Paragraphs.Count));
+            ShowStatus(string.Format(Se.Language.Main.TranscriptionCompletedWithXLines, _subtitle.Paragraphs.Count));
         }
         else if (result.OkPressed && result.IsBatchMode && result.BatchItems.Count == 1)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -121,6 +121,7 @@ using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.FixNetflixErrors;
 using Nikse.SubtitleEdit.Features.Tools.JoinSubtitles;
 using Nikse.SubtitleEdit.Features.Tools.MergeTwoSubtitles;
+using Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
 using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameText;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
@@ -4832,6 +4833,35 @@ public partial class MainViewModel :
         var result = await _windowService
             .ShowDialogAsync<MergeShortLinesWindow, MergeShortLinesViewModel>(
                 Window!, vm => { vm.Initialize(Subtitles.ToList(), AudioVisualizer?.ShotChanges ?? new List<double>()); });
+
+        if (result.OkPressed)
+        {
+            Subtitles.Clear();
+            Subtitles.AddRange(result.AllSubtitlesFixed);
+            SelectAndScrollToRow(0);
+            _updateAudioVisualizer = true;
+            RefreshSubtitlePreview();
+        }
+    }
+
+    [RelayCommand]
+    private async Task ShowToolsMergeContinuationLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        var language = Subtitles.AutoDetectGoogleLanguage();
+        var result = await _windowService
+            .ShowDialogAsync<MergeContinuationLinesWindow, MergeContinuationLinesViewModel>(
+                Window!, vm => { vm.Initialize(Subtitles.ToList(), language); });
 
         if (result.OkPressed)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4877,11 +4877,10 @@ public partial class MainViewModel :
             return subtitle;
         }
 
-        var merged = new Subtitle
-        {
-            OriginalFormat = subtitle.OriginalFormat,
-            FileName = subtitle.FileName,
-        };
+        // Clone via copy constructor to preserve Header/Footer/OriginalEncoding, then replace
+        // Paragraphs with the merged set.
+        var merged = new Subtitle(subtitle);
+        merged.Paragraphs.Clear();
         foreach (var line in result.AllSubtitlesFixed)
         {
             merged.Paragraphs.Add(line.ToParagraph(subtitle.OriginalFormat));

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -585,6 +585,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.SpeechToTextSelectedLinesPromptFirstTimeOnly, nameof(_vm.SpeechToTextSelectedLinesPromptFistTimeOnly)),
             MakeCheckboxSetting(Se.Language.Options.Settings.MultipleReplaceShowDotDotDotButtons, nameof(_vm.MultipleReplaceShowDotDotDotButtons)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptMergeContinuationLines, nameof(_vm.TextToSpeechPromptMergeContinuationLines)),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.Appearance,

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -586,6 +586,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.MultipleReplaceShowDotDotDotButtons, nameof(_vm.MultipleReplaceShowDotDotDotButtons)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptMergeContinuationLines, nameof(_vm.TextToSpeechPromptMergeContinuationLines)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.SpeechToTextPromptMergeContinuationLines, nameof(_vm.SpeechToTextPromptMergeContinuationLines)),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.Appearance,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -152,6 +152,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _speechToTextSelectedLinesPromptFistTimeOnly;
     [ObservableProperty] private bool _multipleReplaceShowDotDotDotButtons;
     [ObservableProperty] private bool _gridFocusTextboxAfterInsertNew;
+    [ObservableProperty] private bool _textToSpeechPromptMergeContinuationLines;
     [ObservableProperty] private bool _openAiCompatibleSttAutoTranscribeOnAudioSelection;
 
     [ObservableProperty] private ObservableCollection<string> _spellCheckEngines;
@@ -653,6 +654,7 @@ public partial class SettingsViewModel : ObservableObject
         SpeechToTextSelectedLinesPromptFistTimeOnly = Se.Settings.Tools.SpeechToTextSelectedLinesPromptFirstTimeOnly;
         MultipleReplaceShowDotDotDotButtons = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
         GridFocusTextboxAfterInsertNew = Se.Settings.Tools.GridFocusTextboxAfterInsertNew;
+        TextToSpeechPromptMergeContinuationLines = Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines;
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 
         SelectedTheme = MapThemeToTranslation(appearance.Theme);
@@ -1285,6 +1287,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.SpeechToTextSelectedLinesPromptFirstTimeOnly = SpeechToTextSelectedLinesPromptFistTimeOnly;
         Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons = MultipleReplaceShowDotDotDotButtons;
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;
+        Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines = TextToSpeechPromptMergeContinuationLines;
         Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
         Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -153,6 +153,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _multipleReplaceShowDotDotDotButtons;
     [ObservableProperty] private bool _gridFocusTextboxAfterInsertNew;
     [ObservableProperty] private bool _textToSpeechPromptMergeContinuationLines;
+    [ObservableProperty] private bool _speechToTextPromptMergeContinuationLines;
     [ObservableProperty] private bool _openAiCompatibleSttAutoTranscribeOnAudioSelection;
 
     [ObservableProperty] private ObservableCollection<string> _spellCheckEngines;
@@ -655,6 +656,7 @@ public partial class SettingsViewModel : ObservableObject
         MultipleReplaceShowDotDotDotButtons = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
         GridFocusTextboxAfterInsertNew = Se.Settings.Tools.GridFocusTextboxAfterInsertNew;
         TextToSpeechPromptMergeContinuationLines = Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines;
+        SpeechToTextPromptMergeContinuationLines = Se.Settings.Tools.SpeechToTextPromptMergeContinuationLines;
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 
         SelectedTheme = MapThemeToTranslation(appearance.Theme);
@@ -1288,6 +1290,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons = MultipleReplaceShowDotDotDotButtons;
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;
         Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines = TextToSpeechPromptMergeContinuationLines;
+        Se.Settings.Tools.SpeechToTextPromptMergeContinuationLines = SpeechToTextPromptMergeContinuationLines;
         Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
         Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesCandidate.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesCandidate.cs
@@ -1,0 +1,16 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
+
+public partial class MergeContinuationLinesCandidate : ObservableObject
+{
+    [ObservableProperty] private bool _isSelected;
+
+    public int Index { get; set; }
+    public int Number { get; set; }
+    public int NextNumber { get; set; }
+    public string Text1 { get; set; } = string.Empty;
+    public string Text2 { get; set; } = string.Empty;
+    public string MergedText { get; set; } = string.Empty;
+    public string MergedTextDisplay => (MergedText ?? string.Empty).Replace("\r\n", " ⏎ ").Replace("\n", " ⏎ ");
+}

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelper.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelper.cs
@@ -1,0 +1,129 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using System;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
+
+public static class MergeContinuationLinesHelper
+{
+    // Languages where sentence-final punctuation is routinely absent;
+    // QualifiesForMerge(onlyContinuationLines:true) would generate noise on these.
+    private static readonly HashSet<string> SkipLanguages = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "zh", "ja", "th", "lo", "my", "km", "ko", "bo",
+    };
+
+    public static bool IsLanguageSkipped(string? language)
+    {
+        return !string.IsNullOrEmpty(language) && SkipLanguages.Contains(language!);
+    }
+
+    public static List<MergeContinuationLinesCandidate> Detect(
+        IReadOnlyList<SubtitleLineViewModel> subtitles,
+        string? language,
+        int maxGapMs,
+        int maxTotalLength)
+    {
+        var result = new List<MergeContinuationLinesCandidate>();
+        if (subtitles == null || subtitles.Count < 2 || IsLanguageSkipped(language))
+        {
+            return result;
+        }
+
+        var lang = string.IsNullOrWhiteSpace(language) ? "en" : language!;
+        for (var i = 0; i < subtitles.Count - 1; i++)
+        {
+            var current = subtitles[i];
+            var next = subtitles[i + 1];
+
+            var p = current.ToParagraph();
+            var nextP = next.ToParagraph();
+
+            if (!Utilities.QualifiesForMerge(p, nextP, maxGapMs, maxTotalLength, onlyContinuationLines: true))
+            {
+                continue;
+            }
+
+            // Skip dialog lines ("- A" / "- B") — these are two speakers, not continuation.
+            if (StartsWithDashSpeaker(current.Text) || StartsWithDashSpeaker(next.Text))
+            {
+                continue;
+            }
+
+            var merged = MergeText(current.Text, next.Text, lang);
+            result.Add(new MergeContinuationLinesCandidate
+            {
+                Index = i,
+                Number = i + 1,
+                NextNumber = i + 2,
+                Text1 = current.Text ?? string.Empty,
+                Text2 = next.Text ?? string.Empty,
+                MergedText = merged,
+                IsSelected = true,
+            });
+        }
+
+        return result;
+    }
+
+    public static List<SubtitleLineViewModel> Apply(
+        IReadOnlyList<SubtitleLineViewModel> subtitles,
+        IReadOnlyList<MergeContinuationLinesCandidate> candidates,
+        string? language)
+    {
+        var lang = string.IsNullOrWhiteSpace(language) ? "en" : language!;
+        var selectedByFirstIndex = new HashSet<int>();
+        foreach (var c in candidates)
+        {
+            if (c.IsSelected)
+            {
+                selectedByFirstIndex.Add(c.Index);
+            }
+        }
+
+        var result = new List<SubtitleLineViewModel>(subtitles.Count);
+        var i = 0;
+        while (i < subtitles.Count)
+        {
+            var current = new SubtitleLineViewModel(subtitles[i]);
+            var j = i;
+            while (j + 1 < subtitles.Count && selectedByFirstIndex.Contains(j))
+            {
+                var next = subtitles[j + 1];
+                var combined = (current.Text ?? string.Empty).TrimEnd() + " " + (next.Text ?? string.Empty).TrimStart();
+                current.Text = Utilities.AutoBreakLine(combined, lang);
+                current.EndTime = next.EndTime;
+                current.UpdateDuration();
+                j++;
+            }
+            result.Add(current);
+            i = j + 1;
+        }
+
+        return result;
+    }
+
+    private static bool StartsWithDashSpeaker(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var sanitized = HtmlUtil.RemoveHtmlTags(text!, true).TrimStart();
+        if (sanitized.Length == 0)
+        {
+            return false;
+        }
+
+        var c = sanitized[0];
+        return c == '-' || c == '‐' || c == '–' || c == '—';
+    }
+
+    private static string MergeText(string? a, string? b, string language)
+    {
+        var combined = (a ?? string.Empty).TrimEnd() + " " + (b ?? string.Empty).TrimStart();
+        return Utilities.AutoBreakLine(combined, language);
+    }
+}

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
@@ -36,7 +36,7 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
         AllSubtitlesFixed = new List<SubtitleLineViewModel>();
         CandidatesInfo = string.Empty;
 
-        MaxMillisecondsBetweenLines = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
+        MaxMillisecondsBetweenLines = 500;
         MaxCharacters = Se.Settings.General.SubtitleLineMaximumLength * Se.Settings.General.MaxNumberOfLines;
 
         _previewTimer = new System.Timers.Timer(250);
@@ -52,10 +52,18 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
         };
     }
 
-    public void Initialize(List<SubtitleLineViewModel> subtitles, string? language)
+    public void Initialize(List<SubtitleLineViewModel> subtitles, string? language, int? maxGapMs = null, int? maxCharacters = null)
     {
         _allSubtitles = subtitles;
         _language = language;
+        if (maxGapMs.HasValue)
+        {
+            MaxMillisecondsBetweenLines = maxGapMs.Value;
+        }
+        if (maxCharacters.HasValue)
+        {
+            MaxCharacters = maxCharacters.Value;
+        }
         _previewTimer.Start();
         _isDirty = true;
     }

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
@@ -104,6 +104,14 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
         Window?.Close();
     }
 
+    // Called from the window's Closed event. Stops the recurring preview timer so the VM
+    // (and the subtitles it references) can be garbage-collected after the dialog goes away.
+    internal void OnClosed()
+    {
+        _previewTimer.Stop();
+        _previewTimer.Dispose();
+    }
+
     [RelayCommand]
     private void SelectAll()
     {

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
@@ -1,0 +1,135 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
+
+public partial class MergeContinuationLinesViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<MergeContinuationLinesCandidate> _candidates;
+    [ObservableProperty] private MergeContinuationLinesCandidate? _selectedCandidate;
+
+    [ObservableProperty] private int _maxMillisecondsBetweenLines;
+    [ObservableProperty] private int _maxCharacters;
+    [ObservableProperty] private string _candidatesInfo;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+    public List<SubtitleLineViewModel> AllSubtitlesFixed { get; private set; }
+
+    private List<SubtitleLineViewModel> _allSubtitles;
+    private string? _language;
+    private readonly System.Timers.Timer _previewTimer;
+    private bool _isDirty;
+
+    public MergeContinuationLinesViewModel()
+    {
+        Candidates = new ObservableCollection<MergeContinuationLinesCandidate>();
+        _allSubtitles = new List<SubtitleLineViewModel>();
+        AllSubtitlesFixed = new List<SubtitleLineViewModel>();
+        CandidatesInfo = string.Empty;
+
+        MaxMillisecondsBetweenLines = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
+        MaxCharacters = Se.Settings.General.SubtitleLineMaximumLength * Se.Settings.General.MaxNumberOfLines;
+
+        _previewTimer = new System.Timers.Timer(250);
+        _previewTimer.Elapsed += (_, _) =>
+        {
+            _previewTimer.Stop();
+            if (_isDirty)
+            {
+                _isDirty = false;
+                UpdatePreview();
+            }
+            _previewTimer.Start();
+        };
+    }
+
+    public void Initialize(List<SubtitleLineViewModel> subtitles, string? language)
+    {
+        _allSubtitles = subtitles;
+        _language = language;
+        _previewTimer.Start();
+        _isDirty = true;
+    }
+
+    public bool HasAnyCandidates()
+    {
+        return MergeContinuationLinesHelper.Detect(_allSubtitles, _language, MaxMillisecondsBetweenLines, MaxCharacters).Count > 0;
+    }
+
+    private void UpdatePreview()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            Candidates.Clear();
+            var detected = MergeContinuationLinesHelper.Detect(_allSubtitles, _language, MaxMillisecondsBetweenLines, MaxCharacters);
+            foreach (var c in detected)
+            {
+                Candidates.Add(c);
+            }
+
+            CandidatesInfo = detected.Count == 0
+                ? Se.Language.Tools.MergeContinuationLines.NoCandidatesFound
+                : string.Format(Se.Language.Tools.MergeContinuationLines.CandidatesFoundX, detected.Count);
+        });
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        AllSubtitlesFixed = MergeContinuationLinesHelper.Apply(_allSubtitles, Candidates, _language);
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (var c in Candidates)
+        {
+            c.IsSelected = true;
+        }
+    }
+
+    [RelayCommand]
+    private void InverseSelection()
+    {
+        foreach (var c in Candidates)
+        {
+            c.IsSelected = !c.IsSelected;
+        }
+    }
+
+    internal void SetChanged()
+    {
+        _isDirty = true;
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+
+    internal void Loaded()
+    {
+        _isDirty = true;
+    }
+}

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -1,0 +1,205 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
+
+public class MergeContinuationLinesWindow : Window
+{
+    public MergeContinuationLinesWindow(MergeContinuationLinesViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Tools.MergeContinuationLines.Title;
+        CanResize = true;
+        Width = 1000;
+        Height = 700;
+        MinWidth = 700;
+        MinHeight = 400;
+        vm.Window = this;
+        DataContext = vm;
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(MakeControlsView(vm), 0);
+        grid.Add(MakeCandidatesView(vm), 1);
+        grid.Add(MakeSelectionButtonsView(vm), 2);
+        grid.Add(panelButtons, 3);
+
+        Content = grid;
+
+        Activated += delegate { buttonOk.Focus(); };
+        KeyDown += vm.KeyDown;
+        Loaded += delegate { vm.Loaded(); };
+    }
+
+    private static Grid MakeControlsView(MergeContinuationLinesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var labelGap = UiUtil.MakeLabel(Se.Language.Tools.MergeContinuationLines.MaxMillisecondsBetweenLines);
+        var numericGap = UiUtil.MakeNumericUpDownInt(0, 10000, 250, 150, vm, nameof(vm.MaxMillisecondsBetweenLines));
+        numericGap.ValueChanged += (_, _) => vm.SetChanged();
+
+        var labelMax = UiUtil.MakeLabel(Se.Language.Tools.MergeContinuationLines.MaxCharacters);
+        var numericMax = UiUtil.MakeNumericUpDownInt(20, 1000, 100, 150, vm, nameof(vm.MaxCharacters));
+        numericMax.ValueChanged += (_, _) => vm.SetChanged();
+
+        grid.Add(labelGap, 0, 0);
+        grid.Add(numericGap, 1, 0);
+
+        grid.Add(labelMax, 0, 1);
+        grid.Add(numericMax, 1, 1);
+
+        return grid;
+    }
+
+    private static Grid MakeCandidatesView(MergeContinuationLinesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var labelInfo = UiUtil.MakeLabel()
+            .WithBindText(vm, nameof(vm.CandidatesInfo))
+            .WithMarginTop(10)
+            .WithMarginLeft(10);
+
+        var dataGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = false,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = vm.Candidates,
+            Columns =
+            {
+                new DataGridTemplateColumn
+                {
+                    Header = Se.Language.Tools.MergeContinuationLines.ColumnMerge,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    CellTemplate = new FuncDataTemplate<MergeContinuationLinesCandidate>((_, _) =>
+                    {
+                        return new Border
+                        {
+                            Background = Brushes.Transparent,
+                            Padding = new Thickness(4),
+                            Child = new CheckBox
+                            {
+                                [!ToggleButton.IsCheckedProperty] = new Binding(nameof(MergeContinuationLinesCandidate.IsSelected))
+                                {
+                                    Mode = BindingMode.TwoWay,
+                                },
+                                HorizontalAlignment = HorizontalAlignment.Center,
+                            },
+                        };
+                    }),
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.NumberSymbol,
+                    Binding = new Binding(nameof(MergeContinuationLinesCandidate.Number)),
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.Tools.MergeContinuationLines.ColumnFirst,
+                    Binding = new Binding(nameof(MergeContinuationLinesCandidate.Text1)),
+                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.Tools.MergeContinuationLines.ColumnSecond,
+                    Binding = new Binding(nameof(MergeContinuationLinesCandidate.Text2)),
+                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.Tools.MergeContinuationLines.ColumnMerged,
+                    Binding = new Binding(nameof(MergeContinuationLinesCandidate.MergedTextDisplay)),
+                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    Width = new DataGridLength(1.4, DataGridLengthUnitType.Star),
+                    IsReadOnly = true,
+                },
+            },
+        };
+
+        grid.Add(labelInfo, 0);
+        grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);
+
+        return grid;
+    }
+
+    private static StackPanel MakeSelectionButtonsView(MergeContinuationLinesViewModel vm)
+    {
+        return UiUtil.MakeButtonBar(
+            UiUtil.MakeButton(Se.Language.General.SelectAll, vm.SelectAllCommand),
+            UiUtil.MakeButton(Se.Language.General.InvertSelection, vm.InverseSelectionCommand));
+    }
+}

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -58,6 +58,7 @@ public class MergeContinuationLinesWindow : Window
         Activated += delegate { buttonOk.Focus(); };
         KeyDown += vm.KeyDown;
         Loaded += delegate { vm.Loaded(); };
+        Closed += delegate { vm.OnClosed(); };
     }
 
     private static Grid MakeControlsView(MergeContinuationLinesViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -6,7 +6,9 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
@@ -634,6 +636,54 @@ public partial class TextToSpeechViewModel : ObservableObject
         KeyFile = fileName;
     }
 
+    private async Task PromptMergeContinuationLines()
+    {
+        if (Window == null || _subtitle.Paragraphs.Count < 2)
+        {
+            return;
+        }
+
+        var language = LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitle);
+        if (MergeContinuationLinesHelper.IsLanguageSkipped(language))
+        {
+            return;
+        }
+
+        var format = _subtitle.OriginalFormat ?? new SubRip();
+        var viewModels = _subtitle.Paragraphs
+            .Select(p => new SubtitleLineViewModel(p, format))
+            .ToList();
+
+        var maxGap = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
+        var maxLen = Se.Settings.General.SubtitleLineMaximumLength * Se.Settings.General.MaxNumberOfLines;
+        var candidates = MergeContinuationLinesHelper.Detect(viewModels, language, maxGap, maxLen);
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        var result = await _windowService
+            .ShowDialogAsync<MergeContinuationLinesWindow, MergeContinuationLinesViewModel>(
+                Window!, vm => vm.Initialize(viewModels, language));
+
+        if (!result.OkPressed || result.AllSubtitlesFixed.Count == _subtitle.Paragraphs.Count)
+        {
+            return;
+        }
+
+        // Build a new working subtitle from the merged lines so the caller's Subtitle reference is untouched.
+        var merged = new Subtitle
+        {
+            OriginalFormat = _subtitle.OriginalFormat,
+            FileName = _subtitle.FileName,
+        };
+        foreach (var line in result.AllSubtitlesFixed)
+        {
+            merged.Paragraphs.Add(line.ToParagraph(_subtitle.OriginalFormat));
+        }
+        _subtitle = merged;
+    }
+
     [RelayCommand]
     public async Task GenerateTts()
     {
@@ -651,6 +701,11 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         // The engine and/or its models may have just been downloaded - refresh the combo dots.
         RefreshDownloadDots?.Invoke();
+
+        if (Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines)
+        {
+            await PromptMergeContinuationLines();
+        }
 
         var voice = SelectedVoice;
         if (voice != null && !await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -654,9 +654,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             .Select(p => new SubtitleLineViewModel(p, format))
             .ToList();
 
-        var maxGap = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
-        var maxLen = Se.Settings.General.SubtitleLineMaximumLength * Se.Settings.General.MaxNumberOfLines;
-        var candidates = MergeContinuationLinesHelper.Detect(viewModels, language, maxGap, maxLen);
+        const int maxGapMs = 500;
+        const int maxCharacters = 500;
+        var candidates = MergeContinuationLinesHelper.Detect(viewModels, language, maxGapMs, maxCharacters);
         if (candidates.Count == 0)
         {
             return;
@@ -664,7 +664,7 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         var result = await _windowService
             .ShowDialogAsync<MergeContinuationLinesWindow, MergeContinuationLinesViewModel>(
-                Window!, vm => vm.Initialize(viewModels, language));
+                Window!, vm => vm.Initialize(viewModels, language, maxGapMs, maxCharacters));
 
         if (!result.OkPressed || result.AllSubtitlesFixed.Count == _subtitle.Paragraphs.Count)
         {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -662,6 +662,17 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
+        var explain = await MessageBox.Show(
+            Window!,
+            Se.Language.Video.TextToSpeech.MergeContinuationLinesPromptTitle,
+            Se.Language.Video.TextToSpeech.MergeContinuationLinesPromptMessage,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+        if (explain != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
         var result = await _windowService
             .ShowDialogAsync<MergeContinuationLinesWindow, MergeContinuationLinesViewModel>(
                 Window!, vm => vm.Initialize(viewModels, language, maxGapMs, maxCharacters));

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -682,12 +682,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
-        // Build a new working subtitle from the merged lines so the caller's Subtitle reference is untouched.
-        var merged = new Subtitle
-        {
-            OriginalFormat = _subtitle.OriginalFormat,
-            FileName = _subtitle.FileName,
-        };
+        // Clone via copy constructor to preserve Header/Footer/OriginalEncoding and any other
+        // metadata, then replace Paragraphs with the merged set. The caller's Subtitle is untouched.
+        var merged = new Subtitle(_subtitle);
+        merged.Paragraphs.Clear();
         foreach (var line in result.AllSubtitlesFixed)
         {
             merged.Paragraphs.Add(line.ToParagraph(_subtitle.OriginalFormat));

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -54,6 +54,7 @@ public class LanguageMainMenu
     public string MergeLinesWithSameTimeCodes { get; set; }
     public string SplitBreakLongLines { get; set; }
     public string MergeShortLines { get; set; }
+    public string MergeContinuationLines { get; set; }
     public string Renumber { get; set; }
     public string RemoveTextForHearingImpaired { get; set; }
     public string ConvertActors { get; set; }
@@ -177,6 +178,7 @@ public class LanguageMainMenu
         MergeLinesWithSameTimeCodes = "Merge lines with same time codes...";
         SplitBreakLongLines = "Split/rebalance long lines...";
         MergeShortLines = "Merge short lines...";
+        MergeContinuationLines = "Merge continuation lines...";
         Renumber = "Renumber...";
         RemoveTextForHearingImpaired = "_Remove text for hearing impaired...";
         ConvertActors = "Convert actors...";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -268,6 +268,7 @@ public class LanguageSettings
     public string SpeechToTextSelectedLinesPromptFirstTimeOnly { get; set; }
     public string MultipleReplaceShowDotDotDotButtons { get; set; }
     public string GridFocusTextboxAfterInsertNew { get; set; }
+    public string TextToSpeechPromptMergeContinuationLines { get; set; }
     public string UseFocusedButtonBackgroundColor { get; set; }
     public string FocusedButtonBackgroundColor { get; set; }
     public string ForceCrLfOnSave { get; set; }
@@ -558,6 +559,7 @@ public class LanguageSettings
         SpeechToTextSelectedLinesPromptFirstTimeOnly = "Speech to text: selected lines, prompt for language/engine first time only";
         MultipleReplaceShowDotDotDotButtons = "Multiple replace: show context menu buttons";
         GridFocusTextboxAfterInsertNew = "Grid: focus text box after insert new subtitle";
+        TextToSpeechPromptMergeContinuationLines = "Text to speech: prompt to merge continuation lines";
         UseFocusedButtonBackgroundColor = "Use focused button background color";
         FocusedButtonBackgroundColor = "Focused button background color";
         ForceCrLfOnSave = "Force CR+LF on save (text subtitle files)";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -269,6 +269,7 @@ public class LanguageSettings
     public string MultipleReplaceShowDotDotDotButtons { get; set; }
     public string GridFocusTextboxAfterInsertNew { get; set; }
     public string TextToSpeechPromptMergeContinuationLines { get; set; }
+    public string SpeechToTextPromptMergeContinuationLines { get; set; }
     public string UseFocusedButtonBackgroundColor { get; set; }
     public string FocusedButtonBackgroundColor { get; set; }
     public string ForceCrLfOnSave { get; set; }
@@ -560,6 +561,7 @@ public class LanguageSettings
         MultipleReplaceShowDotDotDotButtons = "Multiple replace: show context menu buttons";
         GridFocusTextboxAfterInsertNew = "Grid: focus text box after insert new subtitle";
         TextToSpeechPromptMergeContinuationLines = "Text to speech: prompt to merge continuation lines";
+        SpeechToTextPromptMergeContinuationLines = "Speech to text: prompt to merge continuation lines";
         UseFocusedButtonBackgroundColor = "Use focused button background color";
         FocusedButtonBackgroundColor = "Focused button background color";
         ForceCrLfOnSave = "Force CR+LF on save (text subtitle files)";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -179,6 +179,7 @@ public class LanguageSettingsShortcuts
     public string MergeLinesWithSameTimeCodes { get; set; }
     public string SplitBreakLongLines { get; set; }
     public string MergeShortLines { get; set; }
+    public string MergeContinuationLines { get; set; }
     public string RemoveTextForHearingImpaired { get; set; }
     public string JoinSubtitles { get; set; }
     public string SplitSubtitle { get; set; }
@@ -467,6 +468,7 @@ public class LanguageSettingsShortcuts
         MergeLinesWithSameTimeCodes = "Merge lines with same time codes";
         SplitBreakLongLines = "Split/rebalance long lines";
         MergeShortLines = "Merge short lines";
+        MergeContinuationLines = "Merge continuation lines";
         RemoveTextForHearingImpaired = "Remove text for hearing impaired";
         JoinSubtitles = "Join subtitles";
         SplitSubtitle = "Split subtitle";

--- a/src/ui/Logic/Config/Language/Tools/LanguageMergeContinuationLines.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageMergeContinuationLines.cs
@@ -19,8 +19,8 @@ public class LanguageMergeContinuationLines
         Title = "Merge continuation lines";
         CandidatesFoundX = "Continuation candidates found: {0}";
         NoCandidatesFound = "No continuation candidates found";
-        MaxMillisecondsBetweenLines = "Maximum milliseconds between lines";
-        MaxCharacters = "Maximum characters in one paragraph";
+        MaxMillisecondsBetweenLines = "Max gap between lines (ms)";
+        MaxCharacters = "Max characters per paragraph";
         ColumnMerge = "Merge";
         ColumnFirst = "First line";
         ColumnSecond = "Second line";

--- a/src/ui/Logic/Config/Language/Tools/LanguageMergeContinuationLines.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageMergeContinuationLines.cs
@@ -1,0 +1,31 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language;
+
+public class LanguageMergeContinuationLines
+{
+    public string Title { get; set; }
+    public string CandidatesFoundX { get; set; }
+    public string NoCandidatesFound { get; set; }
+    public string MaxMillisecondsBetweenLines { get; set; }
+    public string MaxCharacters { get; set; }
+    public string ColumnMerge { get; set; }
+    public string ColumnFirst { get; set; }
+    public string ColumnSecond { get; set; }
+    public string ColumnMerged { get; set; }
+    public string SelectAll { get; set; }
+    public string InverseSelection { get; set; }
+
+    public LanguageMergeContinuationLines()
+    {
+        Title = "Merge continuation lines";
+        CandidatesFoundX = "Continuation candidates found: {0}";
+        NoCandidatesFound = "No continuation candidates found";
+        MaxMillisecondsBetweenLines = "Maximum milliseconds between lines";
+        MaxCharacters = "Maximum characters in one paragraph";
+        ColumnMerge = "Merge";
+        ColumnFirst = "First line";
+        ColumnSecond = "Second line";
+        ColumnMerged = "Merged";
+        SelectAll = "Select all";
+        InverseSelection = "Inverse selection";
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
@@ -19,6 +19,7 @@ public class LanguageTools
     public LanguageSplitSubtitle SplitSubtitle { get; set; } = new();
     public LanguageSplitBreakLongLines SplitBreakLongLines { get; set; } = new();
     public LanguageMergeShortLines MergeShortLines { get; set; } = new();
+    public LanguageMergeContinuationLines MergeContinuationLines { get; set; } = new();
     public LanguageMergeLineswithSameText MergeLinesWithSameText { get; set; } = new();
     public LanguageMergeLineswithSameTimeCodes MergeLinesWithSameTimeCodes { get; set; } = new();
     public LanguageNetflixCheckAndFix NetflixCheckAndFix { get; set; } = new();

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -88,6 +88,8 @@ public class LanguageTextToSpeech
     public string VoiceDesign { get; set; }
     public string NoActorsFoundMessage { get; set; }
     public string NoWebVttVoicesFoundMessage { get; set; }
+    public string MergeContinuationLinesPromptTitle { get; set; }
+    public string MergeContinuationLinesPromptMessage { get; set; }
 
     public LanguageTextToSpeech()
     {
@@ -174,5 +176,9 @@ public class LanguageTextToSpeech
         VoiceDesign = "Voice design";
         NoActorsFoundMessage = "No actors found. Set the Actor field on subtitle lines first.";
         NoWebVttVoicesFoundMessage = "No <v Name> voices found in the WebVTT file.";
+        MergeContinuationLinesPromptTitle = "Merge continuation lines?";
+        MergeContinuationLinesPromptMessage = "Some lines appear to be a single sentence split across multiple subtitles." + Environment.NewLine + Environment.NewLine +
+                                              "Merging them before generation lets the TTS engine speak each thought as one breath group, which usually sounds more natural." + Environment.NewLine + Environment.NewLine +
+                                              "Review and apply merges now?";
     }
 }

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -105,6 +105,7 @@ public class SeTools
     public bool MultipleReplaceShowDotDotDotButtons { get; set; }
     public bool GridFocusTextboxAfterInsertNew { get; set; }
     public bool TextToSpeechPromptMergeContinuationLines { get; set; }
+    public bool SpeechToTextPromptMergeContinuationLines { get; set; }
 
     // OpenAI Compatible STT settings
     public string OpenAiCompatibleSttUrl { get; set; } = "http://localhost:8000/v1/audio/transcriptions";
@@ -195,6 +196,7 @@ public class SeTools
         AllowSingleLetterShortcutsInTextbox = false;
         WriteToolsLog = true;
         TextToSpeechPromptMergeContinuationLines = true;
+        SpeechToTextPromptMergeContinuationLines = true;
 
         LastColorPickerColor = Colors.Yellow.FromColorToHex();
         LastColorPickerColor1 = Colors.Red.FromColorToHex();

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -104,6 +104,7 @@ public class SeTools
     public bool SpeechToTextSelectedLinesPromptFirstTimeOnly { get; set; }
     public bool MultipleReplaceShowDotDotDotButtons { get; set; }
     public bool GridFocusTextboxAfterInsertNew { get; set; }
+    public bool TextToSpeechPromptMergeContinuationLines { get; set; }
 
     // OpenAI Compatible STT settings
     public string OpenAiCompatibleSttUrl { get; set; } = "http://localhost:8000/v1/audio/transcriptions";
@@ -193,6 +194,7 @@ public class SeTools
         GridFocusTextboxAfterInsertNew = true;
         AllowSingleLetterShortcutsInTextbox = false;
         WriteToolsLog = true;
+        TextToSpeechPromptMergeContinuationLines = true;
 
         LastColorPickerColor = Colors.Yellow.FromColorToHex();
         LastColorPickerColor1 = Colors.Red.FromColorToHex();

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -152,6 +152,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.ShowToolsMergeLinesWithSameTimeCodesCommand), Se.Language.Options.Shortcuts.MergeLinesWithSameTimeCodes },
         { nameof(MainViewModel.ShowToolsSplitBreakLongLinesCommand), Se.Language.Options.Shortcuts.SplitBreakLongLines },
         { nameof(MainViewModel.ShowToolsMergeShortLinesCommand), Se.Language.Options.Shortcuts.MergeShortLines },
+        { nameof(MainViewModel.ShowToolsMergeContinuationLinesCommand), Se.Language.Options.Shortcuts.MergeContinuationLines },
         { nameof(MainViewModel.ShowToolsRemoveTextForHearingImpairedCommand), Se.Language.Options.Shortcuts.RemoveTextForHearingImpaired },
         { nameof(MainViewModel.ShowToolsJoinCommand), Se.Language.Options.Shortcuts.JoinSubtitles },
         { nameof(MainViewModel.ShowToolsSplitCommand), Se.Language.Options.Shortcuts.SplitSubtitle },
@@ -513,6 +514,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ShowToolsMergeLinesWithSameTimeCodesCommand, nameof(vm.ShowToolsMergeLinesWithSameTimeCodesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowToolsSplitBreakLongLinesCommand, nameof(vm.ShowToolsSplitBreakLongLinesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowToolsMergeShortLinesCommand, nameof(vm.ShowToolsMergeShortLinesCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowToolsMergeContinuationLinesCommand, nameof(vm.ShowToolsMergeContinuationLinesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowToolsRemoveTextForHearingImpairedCommand, nameof(vm.ShowToolsRemoveTextForHearingImpairedCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowToolsJoinCommand, nameof(vm.ShowToolsJoinCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowToolsSplitCommand, nameof(vm.ShowToolsSplitCommand), ShortcutCategory.General);


### PR DESCRIPTION
## Summary
- New **Tools → Merge continuation lines...** dialog (pattern mirrors Merge short lines): preview-list of candidate pairs with a per-row checkbox, OK applies to the subtitle grid.
- TTS window: optional prompt before generation that runs the same dialog on a **working copy** of the subtitle — the user's grid is never mutated. Gated by a new setting under **Options → Settings → Tools** ("Text to speech: prompt to merge continuation lines", default on); dialog is only shown when continuation candidates actually exist.
- Detection reuses `Utilities.QualifiesForMerge(onlyContinuationLines: true)` from libse. Skips CJK / no-period languages (zh, ja, th, lo, my, km, ko, bo) where line-end punctuation is omitted by convention, and filters out dialog-dash speaker lines.

## Test plan
- [ ] Tools menu: load a subtitle with continuations, open Merge continuation lines, toggle checkboxes, OK applies merges correctly (incl. 3+ consecutive lines chaining into one).
- [ ] Tools menu: load a Chinese/Japanese subtitle — dialog opens but reports "No continuation candidates found" (skipped languages).
- [ ] Tools menu: Cancel leaves the subtitle untouched.
- [ ] TTS window: with setting ON and continuations present, prompt appears before generation; accepting it merges only for the TTS run (main grid untouched after closing TTS).
- [ ] TTS window: with setting ON but no candidates, no prompt appears; generation proceeds.
- [ ] TTS window: with setting OFF, no prompt appears.
- [ ] Settings page → Tools section: new checkbox is visible, persists across restart, defaults to on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)