### PR TITLE
Frame-align waveform gridlines + timeline labels in frame mode

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1590,6 +1590,13 @@ public class AudioVisualizer : Control
             return;
         }
 
+        var fps = Se.Settings.General.CurrentFrameRate;
+        if (Se.Settings.General.UseFrameMode && fps >= 1)
+        {
+            DrawFrameAlignedTimeLine(context, ref renderCtx, fps);
+            return;
+        }
+
         var seconds = Math.Ceiling(renderCtx.StartPositionSeconds) - renderCtx.StartPositionSeconds;
         var position = SecondsToXPositionOptimized(seconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
         var imageHeight = renderCtx.Height;
@@ -1631,6 +1638,75 @@ public class AudioVisualizer : Control
 
         DrawVerticalLineBatch(context, _paintTimeLine, majorTicks);
         DrawVerticalLineBatch(context, _paintTimeLine, minorTicks);
+    }
+
+    private void DrawFrameAlignedTimeLine(DrawingContext context, ref RenderContext renderCtx, double fps)
+    {
+        var imageHeight = renderCtx.Height;
+        var width = renderCtx.Width;
+        var pixelsPerFrame = renderCtx.SampleRate * renderCtx.ZoomFactor / fps;
+        if (pixelsPerFrame <= 0)
+        {
+            return;
+        }
+
+        // Mirror the time-mode density: majors >= 38 px apart, minors at half-step
+        // (and only when the half-step lands on a whole frame and stays >= 24 px apart).
+        var majorStepFrames = PickFramesPerStep(pixelsPerFrame, 38);
+        var minorStepFrames = (majorStepFrames > 1 && majorStepFrames % 2 == 0 && pixelsPerFrame * (majorStepFrames / 2) >= 24)
+            ? majorStepFrames / 2
+            : 0;
+
+        var majorTicks = _timeLineMajorTicks;
+        var minorTicks = _timeLineMinorTicks;
+        majorTicks.Clear();
+        minorTicks.Clear();
+
+        // First major boundary (absolute frame index) at-or-before the visible start.
+        var firstAbsFrame = Math.Floor(renderCtx.StartPositionSeconds * fps / majorStepFrames) * majorStepFrames;
+
+        for (var absFrame = firstAbsFrame; ; absFrame += majorStepFrames)
+        {
+            var relSeconds = absFrame / fps - renderCtx.StartPositionSeconds;
+            var xPosition = SecondsToXPositionOptimized(relSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+            if (xPosition >= width)
+            {
+                break;
+            }
+
+            if (xPosition >= 0)
+            {
+                majorTicks.Add(new FancyLine(xPosition, imageHeight - 10, imageHeight));
+
+                var timeText = GetFrameDisplayTime(absFrame / fps);
+                var formattedText = GetCachedTimeLineText(timeText);
+                var textY = Math.Max(0, imageHeight - formattedText.Height - 2);
+                context.DrawText(formattedText, new Point(xPosition + 2, textY));
+            }
+
+            if (minorStepFrames > 0)
+            {
+                var minorRelSeconds = (absFrame + minorStepFrames) / fps - renderCtx.StartPositionSeconds;
+                var minorX = SecondsToXPositionOptimized(minorRelSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+                if (minorX >= 0 && minorX < width)
+                {
+                    minorTicks.Add(new FancyLine(minorX, imageHeight - 5, imageHeight));
+                }
+            }
+        }
+
+        DrawVerticalLineBatch(context, _paintTimeLine, majorTicks);
+        DrawVerticalLineBatch(context, _paintTimeLine, minorTicks);
+    }
+
+    private static string GetFrameDisplayTime(double seconds)
+    {
+        if (Se.Settings.General.CurrentVideoOffsetInMs > 0.00001)
+        {
+            seconds = seconds + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0;
+        }
+
+        return new TimeCode(seconds * 1000.0).ToShortStringHHMMSSFF();
     }
 
     private readonly Pen _paintTimeLine = new Pen(Brushes.Gray, 1);
@@ -1687,15 +1763,41 @@ public class AudioVisualizer : Control
             for (var i = 0; i < width; i += 10)
             {
                 context.DrawLine(_paintGridLines, new Point(i, 0), new Point(i, height));
-                context.DrawLine(_paintGridLines, new Point(0, i), new Point(width, i));
+            }
+            return;
+        }
+
+        var fps = Se.Settings.General.CurrentFrameRate;
+        if (Se.Settings.General.UseFrameMode && fps >= 1)
+        {
+            var pixelsPerFrame = renderCtx.SampleRate * renderCtx.ZoomFactor / fps;
+            if (pixelsPerFrame <= 0)
+            {
+                return;
+            }
+
+            var framesPerStep = PickFramesPerStep(pixelsPerFrame, minPixelGap: 8);
+            var stepSeconds = framesPerStep / fps;
+
+            // First frame boundary (absolute frame index) at-or-before the visible start.
+            var firstAbsFrame = Math.Floor(renderCtx.StartPositionSeconds * fps / framesPerStep) * framesPerStep;
+            var relSeconds = firstAbsFrame / fps - renderCtx.StartPositionSeconds;
+            var xPosition = SecondsToXPositionOptimized(relSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+
+            while (xPosition < width)
+            {
+                if (xPosition >= 0)
+                {
+                    context.DrawLine(_paintGridLines, new Point(xPosition, 0), new Point(xPosition, height));
+                }
+                relSeconds += stepSeconds;
+                xPosition = SecondsToXPositionOptimized(relSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
             }
         }
         else
         {
             var seconds = Math.Ceiling(renderCtx.StartPositionSeconds) - renderCtx.StartPositionSeconds - 1;
             var xPosition = SecondsToXPositionOptimized(seconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
-            var yPosition = 0;
-            var yCounter = 0d;
             var interval = renderCtx.ZoomFactor >= 0.4d
                 ? 0.1d
                 : // a pixel is 0.1 second
@@ -1707,14 +1809,21 @@ public class AudioVisualizer : Control
                 seconds += interval;
                 xPosition = SecondsToXPositionOptimized(seconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
             }
+        }
+    }
 
-            while (yPosition < height)
+    private static readonly int[] FrameStepCandidates = { 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000 };
+
+    private static int PickFramesPerStep(double pixelsPerFrame, double minPixelGap)
+    {
+        foreach (var c in FrameStepCandidates)
+        {
+            if (pixelsPerFrame * c >= minPixelGap)
             {
-                context.DrawLine(_paintGridLines, new Point(0, yPosition), new Point(width, yPosition));
-                yCounter += interval;
-                yPosition = Convert.ToInt32(yCounter * renderCtx.SampleRate * renderCtx.ZoomFactor);
+                return c;
             }
         }
+        return FrameStepCandidates[^1];
     }
 
     private void DrawWaveForm(DrawingContext context, ref RenderContext renderCtx)

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1663,8 +1663,15 @@ public class AudioVisualizer : Control
         minorTicks.Clear();
 
         // First major boundary (absolute frame index) at-or-before the visible start.
-        var firstAbsFrame = Math.Floor(renderCtx.StartPositionSeconds * fps / majorStepFrames) * majorStepFrames;
+        // Use integer-space floor: double-space Math.Floor near a frame boundary can
+        // land on 24.9999... instead of 25, offsetting every tick by a full step.
+        var startFrame = FloorWithEpsilon(renderCtx.StartPositionSeconds * fps);
+        if (startFrame < 0)
+        {
+            startFrame = 0;
+        }
 
+        var firstAbsFrame = startFrame - startFrame % majorStepFrames;
         for (var absFrame = firstAbsFrame; ; absFrame += majorStepFrames)
         {
             var relSeconds = absFrame / fps - renderCtx.StartPositionSeconds;
@@ -1777,21 +1784,31 @@ public class AudioVisualizer : Control
             }
 
             var framesPerStep = PickFramesPerStep(pixelsPerFrame, minPixelGap: 8);
-            var stepSeconds = framesPerStep / fps;
 
             // First frame boundary (absolute frame index) at-or-before the visible start.
-            var firstAbsFrame = Math.Floor(renderCtx.StartPositionSeconds * fps / framesPerStep) * framesPerStep;
-            var relSeconds = firstAbsFrame / fps - renderCtx.StartPositionSeconds;
-            var xPosition = SecondsToXPositionOptimized(relSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
-
-            while (xPosition < width)
+            // Compute the start frame in integer space — Math.Floor in double space can land
+            // on the wrong side of a boundary when StartPositionSeconds * fps rounds to
+            // 24.9999... instead of exactly 25.0, which would offset every gridline by a step.
+            var startFrame = FloorWithEpsilon(renderCtx.StartPositionSeconds * fps);
+            if (startFrame < 0)
             {
+                startFrame = 0;
+            }
+
+            var firstAbsFrame = startFrame - startFrame % framesPerStep;
+            for (var absFrame = firstAbsFrame; ; absFrame += framesPerStep)
+            {
+                var relSeconds = absFrame / fps - renderCtx.StartPositionSeconds;
+                var xPosition = SecondsToXPositionOptimized(relSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+                if (xPosition >= width)
+                {
+                    break;
+                }
+
                 if (xPosition >= 0)
                 {
                     context.DrawLine(_paintGridLines, new Point(xPosition, 0), new Point(xPosition, height));
                 }
-                relSeconds += stepSeconds;
-                xPosition = SecondsToXPositionOptimized(relSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
             }
         }
         else
@@ -1825,6 +1842,10 @@ public class AudioVisualizer : Control
         }
         return FrameStepCandidates[^1];
     }
+
+    // floor(value) with a small positive epsilon so a value that should be an integer
+    // but came out of double math as integer - 1e-12 still floors up correctly.
+    private static long FloorWithEpsilon(double value) => (long)Math.Floor(value + 1e-6);
 
     private void DrawWaveForm(DrawingContext context, ref RenderContext renderCtx)
     {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14164,6 +14164,7 @@ public partial class MainViewModel :
             SelectedFrameRate = _mediaInfo?.FramesRate.ToString(CultureInfo.InvariantCulture) ?? FrameRates[0];
             Se.Settings.General.CurrentFrameRate = (double)(_mediaInfo?.FramesRate ?? 23.976m);
             Configuration.Settings.General.CurrentFrameRate = (double)(_mediaInfo?.FramesRate ?? 23.976m);
+            _updateAudioVisualizer = true;
 
             if (IsFormatAssa)
             {
@@ -14223,6 +14224,7 @@ public partial class MainViewModel :
         {
             Se.Settings.General.CurrentFrameRate = frameRate;
             Configuration.Settings.General.CurrentFrameRate = frameRate;
+            _updateAudioVisualizer = true;
         }
     }
 


### PR DESCRIPTION
## Summary
When `Se.Settings.General.UseFrameMode` is on, the waveform now:
- **Draws gridlines on frame boundaries** instead of at fixed 0.1 s / 1.0 s offsets. Step adapts to zoom (1 / 2 / 5 / 10 / 25 / 50 / 100 / ... frames) so adjacent gridlines stay >= ~8 px apart.
- **Draws timeline ticks on frame boundaries**, with majors >= ~38 px apart and minors at the half-step when it lands on a whole frame and stays >= ~24 px apart.
- **Formats timeline labels as HH:MM:SS:FF** via `TimeCode.ToShortStringHHMMSSFF()`, matching how the rest of the UI shows time codes in frame mode.

When `UseFrameMode` is off, behavior is unchanged.

This matters most at 23.976 / 29.97 fps, where the previous 0.1 s gridline interval never lined up with a frame; cues that snapped to frames sat *between* gridlines.

Also drops the horizontal lines that `DrawAllGridLines` was painting along the Y axis at the same time interval as the X axis — Y is amplitude on a waveform, so those lines were nonsense regardless of mode.

## Test plan
- [ ] Frame mode off → grid + timeline look unchanged (0.1 s / 0.5 s ticks, second-formatted labels).
- [ ] Frame mode on, 25 fps, default zoom → gridlines fall on every Nth frame; major timeline ticks show HH:MM:SS:FF (e.g. \`0:00:01:00\`).
- [ ] Frame mode on, 23.976 fps → grid+timeline are visibly *different* from 25 fps (frames are ~41.7 ms apart); a cue snapped to a frame sits exactly on a gridline.
- [ ] Frame mode on, 60 fps → step auto-increases at low zoom so gridlines don't become a wall.
- [ ] Zoom in/out → step adapts; no visible aliasing or runaway tick counts.
- [ ] Toggle \`Se.Settings.Waveform.DrawGridLines\` off → grid disappears in both modes.
- [ ] Horizontal Y-axis lines no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)