### PR TITLE
Show original video audio waveform in TTS review window

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewRow.cs
@@ -1,5 +1,6 @@
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Features.Main;
 using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
@@ -19,6 +20,10 @@ public partial class ReviewRow : ObservableObject
 
     public TtsStepResult StepResult { get; set; }
     public List<ReviewHistoryRow> HistoryItems { get; set; }
+
+    // Mirror of StepResult.Paragraph used by the AudioVisualizer in ReviewSpeechWindow. Stored
+    // on the row itself so lookup is direct (no Lines.IndexOf, which would break under sorting).
+    public SubtitleLineViewModel? WaveformParagraph { get; set; }
 
     public ReviewRow()
     {

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -3,7 +3,9 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
@@ -16,6 +18,7 @@ using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -83,7 +86,18 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
     public Window? Window { get; set; }
     public DataGrid LineGrid { get; internal set; }
+    public AudioVisualizer? AudioVisualizer { get; set; }
     public TtsStepResult[] StepResults { get; set; }
+
+    // Source-of-truth peaks (of the original video audio) for the waveform shown next to the
+    // review grid. May be null when no video is loaded — the visualizer then sits idle.
+    [ObservableProperty] private WavePeakData2? _wavePeakData;
+
+    // Each ReviewRow's paragraph projected as a SubtitleLineViewModel so AudioVisualizer drag
+    // logic (which writes to SubtitleLineViewModel.StartTime/EndTime) works unchanged. We push
+    // edits back to the source StepResult.Paragraph in OnWaveformParagraphChanged.
+    public List<SubtitleLineViewModel> WaveformParagraphs { get; } = new();
+    private readonly Dictionary<SubtitleLineViewModel, ReviewRow> _waveformParagraphToRow = new();
 
     // Cast travelling with the audio. Populated by the main TTS VM via SetActorVoiceMappings;
     // round-tripped through SubtitleEditTts.json so a future Import re-applies the same voices.
@@ -259,7 +273,26 @@ public partial class ReviewSpeechViewModel : ObservableObject
             };
             row.StartHistory();
             Lines.Add(row);
+
+            // Mirror this row's paragraph as a SubtitleLineViewModel so the AudioVisualizer can
+            // draw + drag it. The visualizer's drag handlers mutate StartTime/EndTime on the VM,
+            // so OnWaveformParagraphChanged below forwards those edits back to row.StepResult.Paragraph.
+            var waveformParagraph = new SubtitleLineViewModel
+            {
+                Number = p.Paragraph.Number,
+                Text = p.Text,
+                StartTime = TimeSpan.FromMilliseconds(p.Paragraph.StartTime.TotalMilliseconds),
+                EndTime = TimeSpan.FromMilliseconds(p.Paragraph.EndTime.TotalMilliseconds),
+            };
+            waveformParagraph.UpdateDuration();
+            waveformParagraph.PropertyChanged += OnWaveformParagraphChanged;
+            WaveformParagraphs.Add(waveformParagraph);
+            _waveformParagraphToRow[waveformParagraph] = row;
         }
+
+        // Default to an empty placeholder so the visualizer renders an empty timeline instead of
+        // refusing to draw anything (LengthInSeconds == 0 with null peaks).
+        WavePeakData = wavePeakData;
 
         // Shared with the Cast dialog (see ActorVoiceDetector.FilterUsableEngines) so the two
         // windows always show the same set of usable engines. Add new engine availability rules
@@ -286,6 +319,68 @@ public partial class ReviewSpeechViewModel : ObservableObject
             LineGrid.SelectedIndex = 0;
             LineGrid.ScrollIntoView(LineGrid.SelectedItem, null);
         }
+    }
+
+    // Drag/edit done on the waveform mutates the SubtitleLineViewModel mirror; this writes the
+    // new times back to the underlying TtsStepResult.Paragraph so OK/Export see the change.
+    private void OnWaveformParagraphChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is not SubtitleLineViewModel waveformParagraph)
+        {
+            return;
+        }
+
+        if (e.PropertyName != nameof(SubtitleLineViewModel.StartTime) &&
+            e.PropertyName != nameof(SubtitleLineViewModel.EndTime))
+        {
+            return;
+        }
+
+        if (!_waveformParagraphToRow.TryGetValue(waveformParagraph, out var row))
+        {
+            return;
+        }
+
+        var paragraph = row.StepResult.Paragraph;
+        paragraph.StartTime = new TimeCode(waveformParagraph.StartTime);
+        paragraph.EndTime = new TimeCode(waveformParagraph.EndTime);
+
+        // Cps depends on duration; refresh so the grid stays consistent with the dragged times.
+        row.Cps = Math.Round(paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture);
+    }
+
+    // Centers the visualizer on the currently selected paragraph and marks it as selected so the
+    // user can grab its start/end handles. Safe to call before AudioVisualizer is attached.
+    public void RefreshWaveformPosition()
+    {
+        var av = AudioVisualizer;
+        if (av == null || WavePeakData == null)
+        {
+            return;
+        }
+
+        var row = SelectedLine;
+        if (row == null || WaveformParagraphs.Count == 0)
+        {
+            return;
+        }
+
+        var index = Lines.IndexOf(row);
+        if (index < 0 || index >= WaveformParagraphs.Count)
+        {
+            return;
+        }
+
+        var waveformParagraph = WaveformParagraphs[index];
+        var startSeconds = Math.Max(0, waveformParagraph.StartTime.TotalSeconds - 2.0);
+
+        av.SetPosition(
+            startSeconds,
+            WaveformParagraphs,
+            waveformParagraph.StartTime.TotalSeconds,
+            index,
+            new List<SubtitleLineViewModel> { waveformParagraph });
+        av.InvalidateVisual();
     }
 
     [RelayCommand]
@@ -1062,6 +1157,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
     // voice).
     partial void OnSelectedLineChanged(ReviewRow? value)
     {
+        // Re-center the waveform on the newly selected row regardless of the left-panel sync
+        // state — the visual cue should follow the user's click immediately.
+        RefreshWaveformPosition();
+
         if (value == null)
         {
             return;
@@ -1282,5 +1381,6 @@ public partial class ReviewSpeechViewModel : ObservableObject
     internal void Loaded()
     {
         UiUtil.RestoreWindowPosition(Window);
+        RefreshWaveformPosition();
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -94,8 +94,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
     [ObservableProperty] private WavePeakData2? _wavePeakData;
 
     // Each ReviewRow's paragraph projected as a SubtitleLineViewModel so AudioVisualizer drag
-    // logic (which writes to SubtitleLineViewModel.StartTime/EndTime) works unchanged. We push
-    // edits back to the source StepResult.Paragraph in OnWaveformParagraphChanged.
+    // logic (which writes to SubtitleLineViewModel.StartTime/EndTime) works unchanged. The
+    // canonical link is ReviewRow.WaveformParagraph (set in Initialize); this list is the
+    // sorted-by-start-time view the visualizer needs, and the dictionary is the reverse lookup
+    // used by OnWaveformParagraphChanged to find the row that owns a mirror VM.
     public List<SubtitleLineViewModel> WaveformParagraphs { get; } = new();
     private readonly Dictionary<SubtitleLineViewModel, ReviewRow> _waveformParagraphToRow = new();
 
@@ -286,12 +288,15 @@ public partial class ReviewSpeechViewModel : ObservableObject
             };
             waveformParagraph.UpdateDuration();
             waveformParagraph.PropertyChanged += OnWaveformParagraphChanged;
+            row.WaveformParagraph = waveformParagraph;
             WaveformParagraphs.Add(waveformParagraph);
             _waveformParagraphToRow[waveformParagraph] = row;
         }
 
-        // Default to an empty placeholder so the visualizer renders an empty timeline instead of
-        // refusing to draw anything (LengthInSeconds == 0 with null peaks).
+        // The caller passes either real peaks of the source video, an empty placeholder (when
+        // there's no video yet), or null. The visualizer renders nothing when peaks are missing;
+        // background generation in TextToSpeechViewModel.Import pushes real peaks into this
+        // property once ffmpeg finishes, at which point the binding refreshes the visualizer.
         WavePeakData = wavePeakData;
 
         // Shared with the Cast dialog (see ActorVoiceDetector.FilterUsableEngines) so the two
@@ -360,18 +365,20 @@ public partial class ReviewSpeechViewModel : ObservableObject
         }
 
         var row = SelectedLine;
-        if (row == null || WaveformParagraphs.Count == 0)
+        var waveformParagraph = row?.WaveformParagraph;
+        if (waveformParagraph == null || WaveformParagraphs.Count == 0)
         {
             return;
         }
 
-        var index = Lines.IndexOf(row);
-        if (index < 0 || index >= WaveformParagraphs.Count)
+        // SetPosition still wants an index into the list it's given — we know the mirror is in
+        // WaveformParagraphs because Initialize put it there.
+        var index = WaveformParagraphs.IndexOf(waveformParagraph);
+        if (index < 0)
         {
             return;
         }
 
-        var waveformParagraph = WaveformParagraphs[index];
         var startSeconds = Math.Max(0, waveformParagraph.StartTime.TotalSeconds - 2.0);
 
         av.SetPosition(

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -663,7 +663,7 @@ public class ReviewSpeechWindow : Window
         return new Border
         {
             Margin = new Thickness(2),
-            Height = 180,
+            Height = 120,
             Child = audioVisualizer,
         };
     }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -5,6 +5,8 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic;
@@ -617,10 +619,52 @@ public class ReviewSpeechWindow : Window
 
     private static Border MakeWaveform(ReviewSpeechViewModel vm)
     {
+        // Mirror the main window's waveform theme so the review waveform looks the same as the
+        // one users are already used to.
+        var settings = Se.Settings.Waveform;
+        var audioVisualizer = new AudioVisualizer
+        {
+            DrawGridLines = settings.DrawGridLines,
+            WaveformColor = settings.WaveformColor.FromHexToColor(),
+            WaveformBackgroundColor = settings.WaveformBackgroundColor.FromHexToColor(),
+            WaveformSelectedColor = settings.WaveformSelectedColor.FromHexToColor(),
+            WaveformCursorColor = settings.WaveformCursorColor.FromHexToColor(),
+            WaveformShotChangeColor = settings.WaveformShotChangeColor.FromHexToColor(),
+            WaveformParagraphLeftColor = settings.WaveformParagraphLeftColor.FromHexToColor(),
+            WaveformParagraphRightColor = settings.WaveformParagraphRightColor.FromHexToColor(),
+            WaveformFancyHighColor = settings.WaveformFancyHighColor.FromHexToColor(),
+            ParagraphBackground = settings.ParagraphBackground.FromHexToColor(),
+            ParagraphSelectedBackground = settings.ParagraphSelectedBackground.FromHexToColor(),
+            InvertMouseWheel = settings.InvertMouseWheel,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Height = double.NaN,
+            WaveformDrawStyle = InitWaveform.GetWaveformDrawStyle(settings.WaveformDrawStyle),
+            MinGapSeconds = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0,
+            FocusOnMouseOver = settings.FocusOnMouseOver,
+            IsReadOnly = Se.Settings.General.LockTimeCodes,
+            WaveformHeightPercentage = settings.SpectrogramCombinedWaveformHeight,
+        };
+
+        vm.AudioVisualizer = audioVisualizer;
+        audioVisualizer.Bind(AudioVisualizer.WavePeaksProperty, new Binding(nameof(vm.WavePeakData)));
+
+        // Re-center on the selected paragraph whenever peaks arrive (e.g., async-loaded) or the
+        // user picks a different row. SelectedLine changes also call RefreshWaveformPosition via
+        // the VM's partial OnSelectedLineChanged.
+        audioVisualizer.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == AudioVisualizer.WavePeaksProperty)
+            {
+                vm.RefreshWaveformPosition();
+            }
+        };
+
         return new Border
         {
             Margin = new Thickness(2),
-            //          Child = new TextBlock { Text = "Waveform placeholder" } // Placeholder for waveform control
+            Height = 180,
+            Child = audioVisualizer,
         };
     }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1125,38 +1125,36 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
+        var tempWaveFileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.wav");
         try
         {
             var peakWaveFileName = WavePeakGenerator2.GetPeakWaveFileName(videoFileName);
-            var tempWaveFileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.wav");
 
-            var process = WaveFileExtractor.GetCommandLineProcess(
+            using (var process = WaveFileExtractor.GetCommandLineProcess(
                 videoFileName,
                 -1,
                 tempWaveFileName,
                 Configuration.Settings.General.VlcWaveTranscodeSettings,
-                out _);
-
-            await Task.Run(() =>
+                out _))
             {
                 process.Start();
-                process.WaitForExit();
-            });
+                await process.WaitForExitAsync();
+                if (process.ExitCode != 0)
+                {
+                    SeLogger.Error($"ffmpeg exited with code {process.ExitCode} extracting wave for TTS review: '{videoFileName}'");
+                    return;
+                }
+            }
 
             if (!File.Exists(tempWaveFileName))
             {
                 return;
             }
 
-            WavePeakData2? peaks = null;
-            try
+            WavePeakData2? peaks;
+            using (var waveFile = new WavePeakGenerator2(tempWaveFileName))
             {
-                using var waveFile = new WavePeakGenerator2(tempWaveFileName);
                 peaks = waveFile.GeneratePeaks(0, peakWaveFileName);
-            }
-            finally
-            {
-                try { File.Delete(tempWaveFileName); } catch { /* best effort */ }
             }
 
             if (peaks != null)
@@ -1167,6 +1165,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         catch (Exception ex)
         {
             SeLogger.Error(ex, $"Background wave-peak generation failed for '{videoFileName}'");
+        }
+        finally
+        {
+            try { File.Delete(tempWaveFileName); } catch { /* best effort */ }
         }
     }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1048,6 +1048,21 @@ public partial class TextToSpeechViewModel : ObservableObject
             });
         }
 
+        // Prefer the video referenced in the imported JSON — the user is reopening that specific
+        // TTS session and the main TTS window may have been opened without a video at all.
+        var videoFileNameForReview = !string.IsNullOrEmpty(importExport.VideoFileName) && File.Exists(importExport.VideoFileName)
+            ? importExport.VideoFileName
+            : _videoFileName;
+        if (string.IsNullOrEmpty(_videoFileName) && !string.IsNullOrEmpty(videoFileNameForReview))
+        {
+            _videoFileName = videoFileNameForReview;
+        }
+
+        // Try to populate _wavePeakData synchronously from the on-disk cache (fast, no ffmpeg).
+        // If the cache miss, GenerateWavePeaksIfNeededAsync below kicks off a background ffmpeg
+        // job and pushes the result into the review VM once ready.
+        var peaksForReview = TryLoadWavePeaksFromDisk(videoFileNameForReview) ?? _wavePeakData;
+
         var result = await _windowService.ShowDialogAsync<ReviewSpeechWindow, ReviewSpeechViewModel>(Window, vm =>
         {
             vm.Initialize(
@@ -1058,13 +1073,101 @@ public partial class TextToSpeechViewModel : ObservableObject
                 SelectedVoice ?? Voices.First(),
                 Languages.ToArray(),
                 SelectedLanguage,
-                _videoFileName,
+                videoFileNameForReview,
                 Path.GetDirectoryName(fileName)!,
-                _wavePeakData);
+                peaksForReview);
             // Forward the imported cast so a subsequent Export round-trips the mappings instead
             // of writing ActorVoiceMappings = [] back to SubtitleEditTts.json.
             vm.ActorVoiceMappings.AddRange(_actorVoiceMappings);
+
+            if (peaksForReview == null || peaksForReview.Peaks.Count == 0)
+            {
+                _ = GenerateWavePeaksIfNeededAsync(videoFileNameForReview, vm);
+            }
         });
+    }
+
+    private static WavePeakData2? TryLoadWavePeaksFromDisk(string videoFileName)
+    {
+        if (string.IsNullOrEmpty(videoFileName) || !File.Exists(videoFileName))
+        {
+            return null;
+        }
+
+        try
+        {
+            var peakWaveFileName = WavePeakGenerator2.GetPeakWaveFileName(videoFileName);
+            if (File.Exists(peakWaveFileName))
+            {
+                return WavePeakData2.FromDisk(peakWaveFileName);
+            }
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, $"Failed to load cached wave peaks for '{videoFileName}'");
+        }
+
+        return null;
+    }
+
+    // Background peak generation for imported TTS sessions. The review window opens immediately
+    // with a blank waveform; when ffmpeg finishes, the resulting peaks are pushed into the VM
+    // and the AudioVisualizer's WavePeaks binding picks them up.
+    private static async Task GenerateWavePeaksIfNeededAsync(string videoFileName, ReviewSpeechViewModel reviewVm)
+    {
+        if (string.IsNullOrEmpty(videoFileName) || !File.Exists(videoFileName))
+        {
+            return;
+        }
+
+        if (!FfmpegHelper.IsFfmpegInstalled())
+        {
+            return;
+        }
+
+        try
+        {
+            var peakWaveFileName = WavePeakGenerator2.GetPeakWaveFileName(videoFileName);
+            var tempWaveFileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.wav");
+
+            var process = WaveFileExtractor.GetCommandLineProcess(
+                videoFileName,
+                -1,
+                tempWaveFileName,
+                Configuration.Settings.General.VlcWaveTranscodeSettings,
+                out _);
+
+            await Task.Run(() =>
+            {
+                process.Start();
+                process.WaitForExit();
+            });
+
+            if (!File.Exists(tempWaveFileName))
+            {
+                return;
+            }
+
+            WavePeakData2? peaks = null;
+            try
+            {
+                using var waveFile = new WavePeakGenerator2(tempWaveFileName);
+                peaks = waveFile.GeneratePeaks(0, peakWaveFileName);
+            }
+            finally
+            {
+                try { File.Delete(tempWaveFileName); } catch { /* best effort */ }
+            }
+
+            if (peaks != null)
+            {
+                await Dispatcher.UIThread.InvokeAsync(() => reviewVm.WavePeakData = peaks);
+            }
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, $"Background wave-peak generation failed for '{videoFileName}'");
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- Replace the placeholder waveform Border in the TTS review window with a real `AudioVisualizer`, themed to match the main window. Each review row is mirrored as a `SubtitleLineViewModel` so the visualizer's drag handles edit cue start/end, with changes written back to the underlying `TtsStepResult.Paragraph` for OK/Export.
- When opening an existing `SubtitleEditTts.json` via Import in the main TTS window, load peaks for the JSON's `VideoFileName` from the on-disk cache; if not cached, run ffmpeg + `WavePeakGenerator2` in the background and push the result into the open review VM via the `WavePeakData` binding.
- Addresses Franz's request: \"with waveform... where only the time can be changed, auto selected current subtitle\". The waveform is in-window (no second dialog) and re-centers on the selected row automatically.

## Test plan
- [ ] Generate TTS with a video loaded in main and open Review — confirm waveform shows the video audio for the selected row.
- [ ] Click different rows in the review grid — confirm the waveform recenters and the selected paragraph is highlighted.
- [ ] Drag the start/end handles on the selected paragraph — confirm CPS in the grid updates and that pressing OK round-trips the new times into the merged audio (start of each TTS clip).
- [ ] Use Import in the main TTS window to load an existing `SubtitleEditTts.json`. First time (no cached peaks): review opens immediately, waveform appears once ffmpeg finishes. Second time (cached peaks): waveform appears instantly.
- [ ] Import a JSON whose `VideoFileName` doesn't exist on disk — confirm the review window still opens with an empty waveform (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)