### PR TITLE
Fix #11176: dispose mpv off the UI thread to unstick BurnIn dialogs

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInLogoViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInLogoViewModel.cs
@@ -255,42 +255,51 @@ public partial class BurnInLogoViewModel : ObservableObject
 
     internal async void OnLoaded()
     {
-        if (!string.IsNullOrEmpty(BurnInLogo.LogoFileName) && File.Exists(BurnInLogo.LogoFileName))
+        // async void: any throw here lands in the dispatcher's unhandled-exception
+        // path. Catch so a bad logo file or a stuck video open can't crash the app.
+        try
         {
-            LogoFileName = BurnInLogo.LogoFileName;
-            await LoadLogo();
+            if (!string.IsNullOrEmpty(BurnInLogo.LogoFileName) && File.Exists(BurnInLogo.LogoFileName))
+            {
+                LogoFileName = BurnInLogo.LogoFileName;
+                await LoadLogo();
+            }
+
+            // Initialize video player if video file is available
+            if (!string.IsNullOrEmpty(VideoFileName) && File.Exists(VideoFileName) && VideoPlayerControl != null)
+            {
+                await VideoPlayerControl.Open(VideoFileName);
+                await VideoPlayerControl.WaitForPlayersReadyAsync();
+
+                // Seek to a position to show a frame
+                if (PositionInSeconds > 0)
+                {
+                    VideoPlayerControl.Position = PositionInSeconds;
+                }
+                else
+                {
+                    VideoPlayerControl.Position = 1.0; // Show frame at 1 second
+                }
+
+                VideoPlayerControl.VideoPlayer.Pause();
+
+                // Wait for the video player to render and have valid bounds
+                // Try multiple times with increasing delays to ensure accurate border calculation
+                for (int i = 0; i < 3; i++)
+                {
+                    await Task.Delay(50 + (i * 50)); // 50ms, 100ms, 150ms
+                    UpdateBorder();
+                }
+
+                if (HasLogo)
+                {
+                    UpdateLogoPosition();
+                }
+            }
         }
-
-        // Initialize video player if video file is available
-        if (!string.IsNullOrEmpty(VideoFileName) && File.Exists(VideoFileName) && VideoPlayerControl != null)
+        catch (Exception ex)
         {
-            await VideoPlayerControl.Open(VideoFileName);
-            await VideoPlayerControl.WaitForPlayersReadyAsync();
-
-            // Seek to a position to show a frame
-            if (PositionInSeconds > 0)
-            {
-                VideoPlayerControl.Position = PositionInSeconds;
-            }
-            else
-            {
-                VideoPlayerControl.Position = 1.0; // Show frame at 1 second
-            }
-
-            VideoPlayerControl.VideoPlayer.Pause();
-
-            // Wait for the video player to render and have valid bounds
-            // Try multiple times with increasing delays to ensure accurate border calculation
-            for (int i = 0; i < 3; i++)
-            {
-                await Task.Delay(50 + (i * 50)); // 50ms, 100ms, 150ms
-                UpdateBorder();
-            }
-
-            if (HasLogo)
-            {
-                UpdateLogoPosition();
-            }
+            Se.LogError(ex, "BurnInLogoViewModel.OnLoaded");
         }
     }
 

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicSoftwareControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicSoftwareControl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
@@ -6,6 +7,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Threading;
 using Avalonia.Input;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 
@@ -132,11 +134,33 @@ public class LibMpvDynamicSoftwareControl : Control
     {
         base.OnDetachedFromVisualTree(e);
 
-        if (_mpvPlayer != null)
+        // mpv_terminate_destroy (called from LibMpvDynamicPlayer.Dispose) stops every
+        // mpv worker and blocks until they exit. When mpv is idle this returns in
+        // milliseconds, but when a file load is still in flight on a slow or stuck
+        // path — network mount, weird codec, demuxer hung in I/O — it can stall the
+        // calling thread for many seconds. That's the UI thread here, which is what
+        // produces the "dialog opens, can only be killed from Task Manager" freeze
+        // reported in #11176 for the BurnIn logo/effect dialogs.
+        //
+        // Detach the render callback synchronously (so this control is collectible
+        // immediately) but hand the native dispose off to a worker thread; the OS
+        // reclaims the mpv resources at its own pace without holding the UI hostage.
+        var playerToDispose = _mpvPlayer;
+        _mpvPlayer = null;
+        if (playerToDispose != null)
         {
-            _mpvPlayer.RequestRender -= OnMpvRequestRender;
-            _mpvPlayer.Dispose();
-            _mpvPlayer = null;
+            playerToDispose.RequestRender -= OnMpvRequestRender;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    playerToDispose.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "LibMpvDynamicSoftwareControl background dispose");
+                }
+            });
         }
 
         _renderTarget?.Dispose();


### PR DESCRIPTION
Fixes #11176.

## Diagnosis

`LibMpvDynamicSoftwareControl.OnDetachedFromVisualTree` disposes its `LibMpvDynamicPlayer` synchronously on the UI thread:

```csharp
_mpvPlayer.Dispose();   // → mpv_terminate_destroy()
```

`mpv_terminate_destroy` stops every mpv worker and blocks until they exit. When mpv is idle it returns in milliseconds; when a file load is still in flight on a slow / stuck path (network mount, weird codec, demuxer hung in I/O) it can stall the calling thread for many seconds. That's the UI thread, on every close of the BurnIn logo / effect / select-position dialogs (each spins up a fresh `LibMpvDynamicPlayer`).

Matches the reporter's symptoms exactly: dialog opens, freezes, refuses to close, only Task Manager helps. Doesn't reproduce on machines where mpv terminates quickly.

## Fix

Detach the render callback synchronously (so the control becomes collectible immediately) but hand the native dispose to `Task.Run`. The OS reclaims the mpv resources at its own pace without holding the UI hostage.

Also wrap `BurnInLogoViewModel.OnLoaded` (`async void`) in try/catch so a throw from `Open` / `WaitForPlayersReadyAsync` doesn't bubble into the dispatcher's unhandled-exception path.

## Caveats
I can't reproduce the freeze locally, so this diagnosis is inferred from reading the close path against the reporter's symptoms. That said, the change is a strict win for any mpv state where `terminate_destroy` isn't instant — the UI thread shouldn't be blocking on native worker shutdown regardless.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` — clean, 0 warnings
- [ ] Manual smoke: open + close BurnIn logo dialog several times on a normal video → no regression
- [ ] Manual smoke: same on the dialog that triggered #11176 → reporter to confirm the freeze is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)