### PR TITLE
Fix 3 RC1 bugs: negative video offset, DCinema clamp, F4Text rounding

### DIFF
--- a/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
@@ -1054,7 +1054,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public static int MsToFramesMaxFrameRate(double milliseconds, double frameRate)
         {
             var frames = (int)Math.Round(milliseconds / (TimeCode.BaseUnit / frameRate));
-            if (frames >= Configuration.Settings.General.CurrentFrameRate)
+            // Clamp against the parameter, not the global CurrentFrameRate setting.
+            // Using the global produced the wrong cap when exporting at a frame
+            // rate that differed from the active project setting.
+            if (frames >= frameRate)
             {
                 frames = (int)(frameRate - 0.01);
             }

--- a/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
@@ -980,7 +980,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public static int MsToFramesMaxFrameRate(double milliseconds, double frameRate)
         {
             var frames = (int)Math.Round(milliseconds / (TimeCode.BaseUnit / frameRate));
-            if (frames >= Configuration.Settings.General.CurrentFrameRate)
+            // Clamp against the parameter, not the global CurrentFrameRate setting.
+            // Using the global produced the wrong cap when exporting at a frame
+            // rate that differed from the active project setting.
+            if (frames >= frameRate)
             {
                 frames = (int)(frameRate - 0.01);
             }

--- a/src/libse/SubtitleFormats/F4Text.cs
+++ b/src/libse/SubtitleFormats/F4Text.cs
@@ -46,7 +46,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string EncodeTimeCode(TimeCode time)
         {
-            return $" #{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00}-{Math.Round(time.Milliseconds / 100.0, 0):0}# ";
+            // The format only allows a single decisecond digit (see RegexTimeCodes,
+            // "^\d\d:\d\d:\d\d-\d$"). Math.Round on 9.5..9.99 returns 10, which
+            // would emit "..-10" — invalid per the regex, so the file fails to
+            // re-parse and those subtitles disappear on reload. Clamp to 9.
+            var ds = Math.Min(9, (int)Math.Round(time.Milliseconds / 100.0));
+            return $" #{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00}-{ds}# ";
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1708,7 +1708,10 @@ public class AudioVisualizer : Control
 
     private static string GetFrameDisplayTime(double seconds)
     {
-        if (Se.Settings.General.CurrentVideoOffsetInMs > 0.00001)
+        // CurrentVideoOffsetInMs is signed; the previous `> 0.00001` guard silently
+        // dropped negative offsets so the timeline labels were wrong whenever the
+        // audio leads the video.
+        if (Math.Abs(Se.Settings.General.CurrentVideoOffsetInMs) > 0.00001)
         {
             seconds = seconds + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0;
         }
@@ -1720,7 +1723,7 @@ public class AudioVisualizer : Control
 
     private static string GetDisplayTime(double seconds)
     {
-        if (Se.Settings.General.CurrentVideoOffsetInMs > 0.00001)
+        if (Math.Abs(Se.Settings.General.CurrentVideoOffsetInMs) > 0.00001)
         {
             seconds = seconds + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0;
         }

--- a/tests/libse/SubtitleFormats/DCinemaSmpteTest.cs
+++ b/tests/libse/SubtitleFormats/DCinemaSmpteTest.cs
@@ -1,0 +1,47 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class DCinemaSmpteTest
+{
+    // Regression: MsToFramesMaxFrameRate used to clamp against the global
+    // Configuration.Settings.General.CurrentFrameRate instead of the parameter,
+    // so calling the helper at a different frame rate than the active project
+    // setting produced an out-of-range frame number on the last frame of a
+    // second.
+    [Fact]
+    public void MsToFramesMaxFrameRate_2014_ClampsAgainstParameter_NotGlobal()
+    {
+        var originalGlobal = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            // Global is 25 fps, but we ask for frames at 24 fps. 999 ms at 24 fps
+            // rounds to frame 24 — invalid (valid range 0..23) — and must clamp
+            // to 23. Previously this saw `24 >= 25` (false) and returned 24.
+            Configuration.Settings.General.CurrentFrameRate = 25.0;
+            var frames = DCinemaSmpte2014.MsToFramesMaxFrameRate(999, 24);
+            Assert.Equal(23, frames);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = originalGlobal;
+        }
+    }
+
+    [Fact]
+    public void MsToFramesMaxFrameRate_2010_ClampsAgainstParameter_NotGlobal()
+    {
+        var originalGlobal = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25.0;
+            var frames = DCinemaSmpte2010.MsToFramesMaxFrameRate(999, 24);
+            Assert.Equal(23, frames);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = originalGlobal;
+        }
+    }
+}

--- a/tests/libse/SubtitleFormats/F4TextTest.cs
+++ b/tests/libse/SubtitleFormats/F4TextTest.cs
@@ -1,0 +1,37 @@
+using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class F4TextTest
+{
+    // Regression: EncodeTimeCode used Math.Round on Milliseconds / 100, so any
+    // value in 950..999 ms rounded to 10 deciseconds and produced "..-10",
+    // which violates the format regex "^\d\d:\d\d:\d\d-\d$". The writer fix
+    // clamps to 9 so every emitted timecode stays single-digit.
+    [Theory]
+    [InlineData(0)]
+    [InlineData(499)]
+    [InlineData(949)]
+    [InlineData(950)]   // boundary that used to round up to 10
+    [InlineData(999)]   // worst case
+    public void EncodedTimecode_DecisecondIsAlwaysSingleDigit(int milliseconds)
+    {
+        var src = new Subtitle();
+        src.Paragraphs.Add(new Paragraph("hello", 0, 1000 + milliseconds));
+
+        var text = F4Text.ToF4Text(src);
+
+        // Every emitted timecode must satisfy the format regex (one decisecond
+        // digit only). Use the same shape the parser uses to validate.
+        var perTc = new Regex(@"#(\d\d:\d\d:\d\d-\d)#");
+        foreach (Match m in perTc.Matches(text))
+        {
+            Assert.Matches(@"^\d\d:\d\d:\d\d-\d$", m.Groups[1].Value);
+        }
+
+        // And there must be at least one timecode emitted.
+        Assert.Matches(@"#\d\d:\d\d:\d\d-\d#", text);
+    }
+}


### PR DESCRIPTION
Three independent bugs found in a pre-RC1 sweep.

## 1. `AudioVisualizer` waveform labels ignore negative video offsets
`AudioVisualizer.cs:1711, 1723` — `if (Se.Settings.General.CurrentVideoOffsetInMs > 0.00001)` silently dropped every negative offset. `CurrentVideoOffsetInMs` is signed (users can set negative offsets when the audio leads the video), so the waveform's timeline labels and frame-aligned gridlines were wrong for those files. Introduced in 9bc6afaff (frame-aligned gridlines). Fix: `Math.Abs(...) > 0.00001`.

## 2. `DCinemaSmpte{2010,2014}.MsToFramesMaxFrameRate` clamps against the wrong frame rate
The overflow guard compared `frames >= Configuration.Settings.General.CurrentFrameRate` instead of the method's `frameRate` **parameter**. Whenever the export frame rate differed from the active project setting (e.g., a 24 fps DCinema export with the project at 25 fps), the clamp either fired when it shouldn't or failed to fire when it should — producing an out-of-range frame number on the last frame of every second. Fix: compare against the parameter.

## 3. `F4Text` writes invalid timecodes for 950–999 ms
`F4Text.cs:49` used `Math.Round(time.Milliseconds / 100.0, 0):0`. With banker's rounding, 950..999 ms rounds to 10 deciseconds, and `:0` formats that as `"10"`. The format regex on L15 requires exactly **one** decisecond digit — so the writer was emitting files that the parser silently dropped on reload. Affected the last 50 ms of every second. Fix: clamp to 9 before formatting.

## Tests
- `tests/libse/SubtitleFormats/DCinemaSmpteTest.cs` — 2 cases (2010 + 2014). Each sets a global frame rate that differs from the parameter, calls the helper, asserts the clamp uses the parameter.
- `tests/libse/SubtitleFormats/F4TextTest.cs` — 5 `[InlineData]` cases (0, 499, 949, 950, 999). Encodes through `ToF4Text` and asserts every emitted timecode matches the single-digit format regex.

Bug 1 lives in a private static helper on a UI control with no UI test harness in this repo, so it's covered by code review only.

## Test plan
- [x] `dotnet test tests/libse/LibSETests.csproj` — 352/352 pass (7 new)
- [x] `dotnet build src/ui/UI.csproj` — clean, 0 warnings
- [ ] Manual: set a negative video offset, open waveform → timeline labels reflect the offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)