### PR TITLE
Defensive: BluRaySup OdsData + Matroska short-read on truncated files

### DIFF
--- a/src/libse/BluRaySup/BluRaySupParser.cs
+++ b/src/libse/BluRaySup/BluRaySupParser.cs
@@ -720,6 +720,16 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             var info = new ImageObjectFragment();
             if (first)
             {
+                // First-fragment ODS layout: 11 bytes of header (object id+ver+seq+
+                // 3-byte length + 2-byte width + 2-byte height) before the image
+                // bytes. A malformed / truncated PGS file can advertise a Size
+                // smaller than that — `new byte[Size - 11]` then throws
+                // OverflowException and aborts the whole SUP parse. Bail out with
+                // an empty fragment instead so the rest of the file is still read.
+                if (segment.Size < 11 || buffer.Length < 11)
+                {
+                    return new OdsData { IsFirst = true, Fragment = info, ObjectId = objId, ObjectVersion = objVer, Message = "ODS too short" };
+                }
                 var width = BigEndianInt16(buffer, 7);      // object_width
                 var height = BigEndianInt16(buffer, 9);     // object_height
 
@@ -739,6 +749,12 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 };
             }
 
+            // Continuation-fragment ODS layout: 4-byte header before image bytes.
+            // Same defensive guard as the first-fragment branch above.
+            if (segment.Size < 4 || buffer.Length < 4)
+            {
+                return new OdsData { IsFirst = false, Fragment = info, ObjectId = objId, ObjectVersion = objVer, Message = "ODS too short" };
+            }
             info.ImagePacketSize = segment.Size - 4;
             info.ImageBuffer = new byte[info.ImagePacketSize];
             Buffer.BlockCopy(buffer, 4, info.ImageBuffer, 0, info.ImagePacketSize);

--- a/src/libse/BluRaySup/BluRaySupParser.cs
+++ b/src/libse/BluRaySup/BluRaySupParser.cs
@@ -717,7 +717,10 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             var first = (objSeq & 0x80) == 0x80 || forceFirst;
             var last = (objSeq & 0x40) == 0x40;
 
-            var info = new ImageObjectFragment();
+            var info = new ImageObjectFragment
+            {
+                ImageBuffer = Array.Empty<byte>(),
+            };
             if (first)
             {
                 // First-fragment ODS layout: 11 bytes of header (object id+ver+seq+

--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -785,10 +785,19 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         /// Reads a fixed length unsigned integer as int from the current stream.
         /// </summary>
         /// <param name="length">The length in bytes of the integer.</param>
-        /// <returns>An integer.</returns>
+        /// <returns>An integer, or 0 if the stream is too short.</returns>
         private int ReadUIntAsInt(long length)
         {
-            _stream.Read(_buffer, 0, (int)length);
+            // Stream.Read may legitimately return fewer bytes than requested
+            // (truncated file, network stream, etc.). The previous code ignored
+            // the count and folded stale _buffer bytes left over from prior
+            // reads into the integer — silent garbage track numbers / pixel
+            // dimensions / durations on truncated MKV files.
+            var bytesRead = _stream.Read(_buffer, 0, (int)length);
+            if (bytesRead < length)
+            {
+                return 0;
+            }
             var result = 0;
             for (var i = 0; i < length; i++)
             {
@@ -801,10 +810,15 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         /// Reads a fixed length unsigned integer as long from the current stream.
         /// </summary>
         /// <param name="length">The length in bytes of the integer.</param>
-        /// <returns>A long integer.</returns>
+        /// <returns>A long integer, or 0 if the stream is too short.</returns>
         private long ReadUIntAsLong(long length)
         {
-            _stream.Read(_buffer, 0, (int)length);
+            // Same short-read concern as ReadUIntAsInt above.
+            var bytesRead = _stream.Read(_buffer, 0, (int)length);
+            if (bytesRead < length)
+            {
+                return 0L;
+            }
             var result = 0L;
             for (var i = 0; i < length; i++)
             {


### PR DESCRIPTION
Two unrelated parser bugs surfaced while pre-RC1 fuzzing.

## 1. `BluRaySupParser.ParseOds` crashes on malformed/truncated PGS

`ParseOds` did `new byte[segment.Size - 11]` (or `- 4` for a continuation fragment) without lower-bound checking `segment.Size`. A malformed / truncated PGS whose ODS segment advertised a `Size` smaller than the 11-byte header (or 4-byte continuation header) produced a negative length, and `new byte[..]` rejected it with `OverflowException` — aborting the whole SUP parse instead of skipping the bad segment. Now we return an empty fragment and let the caller move on.

## 2. `MatroskaFile.ReadUIntAsInt` / `ReadUIntAsLong` ignore short reads

Both methods called `_stream.Read(_buffer, 0, length)` but ignored the return value. `Stream.Read` may legitimately return fewer bytes than requested (truncated file, network stream, slow pipe). The old code folded stale `_buffer` bytes from prior reads into the integer — **silent garbage track numbers / pixel dimensions / durations on truncated MKV files**. Now we return 0 when the read comes up short.

## Tests
Couldn't add a regression test for either, and shipping a misleading test is worse than no test:
- BluRay: `ParseOds` is only dispatched once a valid PCS has been processed earlier in the stream; constructing the full PCS prelude is a lot of scaffolding for one assertion.
- Matroska: `ReadUIntAsInt` is private; testing requires a `Stream` wrapper that fakes short reads, which is its own surface area.

Both fixes are pure defensive bounds-checking around existing invariants.

## Test plan
- [x] `dotnet test tests/libse/LibSETests.csproj` — 352/352 pass
- [x] `dotnet build src/libse/LibSE.csproj` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)