### PR TITLE
Fix #11181: parameters textbox scrollbar overlapping text + rename title

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedWindow.cs
@@ -28,6 +28,11 @@ public class SpeechToTextAdvancedWindow : Window
         {
             AcceptsReturn = true,
             AcceptsTab = true,
+            // Long single-line parameter strings used to trigger a horizontal
+            // scrollbar that overlapped the text inside this otherwise-tiny
+            // multi-line textbox (#11181). Reserve enough vertical room so the
+            // scrollbar sits below the text, not on top of it.
+            MinHeight = 60,
             DataContext = vm,
         };
         textBoxParameters.Bind(TextBox.TextProperty, new Binding(nameof(vm.Parameters))

--- a/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
@@ -45,7 +45,7 @@ public class LanguageAudioToText
         Transcribing = "Transcribing...";
         TranscribingXOfY = "Transcribing {0} of {1}...";
         InputLanguage = "Input language";
-        AdvancedWhisperSettings = "Advanced Whisper settings";
+        AdvancedWhisperSettings = "Advanced speech-to-text parameters";
         DownloadingSpeechToTextEngine = "Downloading speech-to-text engine";
         UnpackingSpeechToTextEngine = "Unpacking speech-to-text engine";
         EnableVad = "Enable VAD";


### PR DESCRIPTION
Fixes #11181.

## 1. Scrollbar overlapping text
The Parameters TextBox in `SpeechToTextAdvancedWindow` sits in an `Auto`-sized grid row with `AcceptsReturn = true` but no `MinHeight`. With a long single-line parameter string, the horizontal scrollbar pops up *inside* the (tiny) textbox and overlays the last few pixels of text — exactly what the issue's screenshot shows.

Set `MinHeight = 60` on the textbox so the scrollbar sits below the text instead of on top of it. The row is still `Auto`-sized, so the box will continue to grow if the user enters multiple lines.

## 2. Title rename
The dialog title currently says "Advanced Whisper settings", but the dialog also handles CrispASR / Whisper.cpp / CTranslate2 / etc. Rename the English default to "Advanced speech-to-text parameters" to match what it actually covers. `English.json` doesn't override the key, so English users see the new wording immediately; other languages keep their existing translations until translators update.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` — clean
- [ ] Manual: open the advanced parameters dialog with a long parameter string → scrollbar no longer overlays the text
- [ ] Manual: confirm the dialog title reads "Advanced speech-to-text parameters" in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)