### PR TITLE
Async fixes: flow CancellationToken, drop dup timer sub, guard OnClosing

### DIFF
--- a/src/libse/AutoTranslate/LaraTranslate.cs
+++ b/src/libse/AutoTranslate/LaraTranslate.cs
@@ -84,7 +84,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             // netstandard2.1: ReadAsByteArrayAsync has no CancellationToken
             // overload; the token is flowed through SendAsync, which is where
             // the long blocking happens.
-            var response = await _httpClient.SendAsync(request, cancellationToken);
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
 
             var bytes = await response.Content.ReadAsByteArrayAsync();
             var json = Encoding.UTF8.GetString(bytes).Trim();

--- a/src/libse/AutoTranslate/LaraTranslate.cs
+++ b/src/libse/AutoTranslate/LaraTranslate.cs
@@ -81,7 +81,10 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var signature = Sign(method, "/translate", contentMd5 ?? "", actualContentType, dateHeader);
             request.Headers.TryAddWithoutValidation("Authorization", $"Lara {_accessKeyId}:{signature}");
 
-            var response = await _httpClient.SendAsync(request);
+            // netstandard2.1: ReadAsByteArrayAsync has no CancellationToken
+            // overload; the token is flowed through SendAsync, which is where
+            // the long blocking happens.
+            var response = await _httpClient.SendAsync(request, cancellationToken);
 
             var bytes = await response.Content.ReadAsByteArrayAsync();
             var json = Encoding.UTF8.GetString(bytes).Trim();

--- a/src/libse/AutoTranslate/MyMemoryApi.cs
+++ b/src/libse/AutoTranslate/MyMemoryApi.cs
@@ -213,7 +213,13 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
 
             var url = $"?langpair={sourceLanguageCode}|{targetLanguageCode}{apiKey}&q={Utilities.UrlEncode(text)}";
-            var jsonResultString = await _httpClient.GetStringAsync(url);
+            // netstandard2.1 has no GetStringAsync(string, CancellationToken)
+            // overload, so we go via SendAsync to flow the token into the
+            // connection/send phase (cancel propagates there).
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var jsonResultString = await response.Content.ReadAsStringAsync();
             var textResult = _jsonParser.GetFirstObject(jsonResultString, "translatedText");
             var result = Json.DecodeJsonText(textResult);
 

--- a/src/libse/AutoTranslate/NoLanguageLeftBehindApi.cs
+++ b/src/libse/AutoTranslate/NoLanguageLeftBehindApi.cs
@@ -44,7 +44,10 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var content = new StringContent("{ \"text\": \"" + Json.EncodeJsonText(text) + "\",  \"source\": \"" + sourceLanguageCode + "\", \"target\": \"" + targetLanguageCode + "\" }", Encoding.UTF8, "application/json");
-            var result = await _httpClient.PostAsync("translator", content);
+            // netstandard2.1: ReadAsStringAsync has no CancellationToken
+            // overload; the token is flowed through PostAsync, which is where
+            // the long blocking happens.
+            var result = await _httpClient.PostAsync("translator", content, cancellationToken);
             result.EnsureSuccessStatusCode();
 
             var responseString = await result.Content.ReadAsStringAsync();

--- a/src/libse/AutoTranslate/NoLanguageLeftBehindApi.cs
+++ b/src/libse/AutoTranslate/NoLanguageLeftBehindApi.cs
@@ -47,7 +47,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             // netstandard2.1: ReadAsStringAsync has no CancellationToken
             // overload; the token is flowed through PostAsync, which is where
             // the long blocking happens.
-            var result = await _httpClient.PostAsync("translator", content, cancellationToken);
+            using var result = await _httpClient.PostAsync("translator", content, cancellationToken);
             result.EnsureSuccessStatusCode();
 
             var responseString = await result.Content.ReadAsStringAsync();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13782,28 +13782,48 @@ public partial class MainViewModel :
             // Cancel the closing to show the dialog
             e.Cancel = true;
 
-            var result = await MessageBox.Show(
-                Window,
-                Se.Language.General.SaveChangesTitle,
-                Se.Language.General.SaveChangesMessage,
-                MessageBoxButtons.YesNoCancel,
-                MessageBoxIcon.Question);
-
-            if (result == MessageBoxResult.Cancel)
+            // This is an async-void event handler — any throw from the awaits
+            // below (MessageBox or SaveSubtitle: disk full, permission denied,
+            // OneDrive sync conflict, ...) lands in the dispatcher's
+            // unhandled-exception path and leaves the user staring at a
+            // half-closed window. Catch, log, and force-close so shutdown
+            // always progresses.
+            try
             {
-                // Stay cancelled - window won't close
-                return;
-            }
+                var result = await MessageBox.Show(
+                    Window,
+                    Se.Language.General.SaveChangesTitle,
+                    Se.Language.General.SaveChangesMessage,
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
 
-            if (result == MessageBoxResult.Yes)
+                if (result == MessageBoxResult.Cancel)
+                {
+                    // Stay cancelled - window won't close
+                    return;
+                }
+
+                if (result == MessageBoxResult.Yes)
+                {
+                    await SaveSubtitle();
+                }
+
+                CleanUp();
+
+                Window.Closing -= OnClosing;
+                Window.Close();
+            }
+            catch (Exception ex)
             {
-                await SaveSubtitle();
+                Se.LogError(ex, "MainViewModel.OnClosing");
+                // Don't trap the user in a frozen window — clean up and let it close.
+                CleanUp();
+                if (Window != null)
+                {
+                    Window.Closing -= OnClosing;
+                    Window.Close();
+                }
             }
-
-            CleanUp();
-
-            Window.Closing -= OnClosing;
-            Window.Close();
         }
         else
         {

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -253,7 +253,9 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
         _downloadFileName = GetDownloadFileName(model.Model, _downloadUrls[_downloadIndex]);
         _downloadTask = _whisperDownloadService.DownloadFile(_downloadUrls[_downloadIndex], _downloadFileName, MakeDownloadProgress(), _cancellationTokenSource.Token);
         _timer.Interval = 500;
-        _timer.Elapsed += OnTimerOnElapsed;
+        // Constructor already subscribed OnTimerOnElapsed; re-subscribing here
+        // duplicated the handler on every Download() call, so a cancel-and-retry
+        // caused the state-machine tick to fire 2x (then 3x, 4x ...).
         _timer.Start();
 
         ProgressFileName = string.Format(Se.Language.General.FileNameX, Path.GetFileName(_downloadUrls[_downloadIndex]));


### PR DESCRIPTION
Three independent async correctness bugs found in a pre-RC1 sweep.

## 1. AutoTranslate providers ignore `CancellationToken` (3 files)
`MyMemoryApi`, `NoLanguageLeftBehindApi`, and `LaraTranslate` all accept a `CancellationToken` in their `Translate(...)` signature but never flow it into the actual HTTP call. User clicks Cancel mid-translation → the HTTP request keeps running to completion.

Caveat: `libse` targets `netstandard2.1`, where `ReadAsStringAsync(CancellationToken)` / `ReadAsByteArrayAsync(CancellationToken)` / `GetStringAsync(string, CancellationToken)` don't exist. So we flow the token through `SendAsync` / `PostAsync` (the long phase) and leave the body-read calls bare. `MyMemoryApi` was using `GetStringAsync` — switched to an explicit `SendAsync` so the token has a place to go.

## 2. `DownloadSpeechToTextModelsViewModel`: timer handler subscribed twice
The constructor wires `_timer.Elapsed += OnTimerOnElapsed;`, and so did `Download()`. Cancel-and-retry on a download caused the state-machine tick to fire **2x per timer interval** (then 3x, 4x...). The doubled invocations race the file-move / index-advance and produce flaky behaviour — double "download failed" toasts, files moved twice, progress jumping back. Dropped the redundant re-subscription.

## 3. `MainViewModel.OnClosing` async-void event handler with no try/catch
`OnClosing` is `async void` with two awaits (`MessageBox.Show`, `SaveSubtitle`). Both can throw — disk full, permission denied, OneDrive sync conflict. With `async void`, an unhandled exception bypasses dispatcher flow and the user is left staring at a half-closed window with `e.Cancel = true`. Wrapped in try/catch + log + force-close. Same shape as the `BurnInLogoViewModel.OnLoaded` guard from PR #11178.

## Out of scope (kept narrow)
- `MicrosoftTranslator.cs:136, :158` use `.Result` on async (sync-over-async deadlock risk). Fixing them properly cascades through several private static call sites — separate PR if anyone wants to chase it.

## Test plan
- [x] `dotnet build src/libse/LibSE.csproj` + `dotnet build src/ui/UI.csproj` — clean, 0 warnings
- [x] `dotnet test tests/libse/LibSETests.csproj` — 352/352 pass
- [ ] Manual: cancel an in-flight MyMemory / NLLB / Lara translation → request actually stops
- [ ] Manual: download a Whisper model, cancel, re-download → no "doubled" UI updates
- [ ] Manual: close main window with unsaved changes and trigger a save failure → window still closes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)