### PR TITLE
feat(mp4): decode CEA-708 (DTVCC) captions from H.264 SEI cc_data

### DIFF
--- a/src/libse/Cea608/GetCcDataHelper.cs
+++ b/src/libse/Cea608/GetCcDataHelper.cs
@@ -93,7 +93,15 @@ namespace Nikse.SubtitleEdit.Core.Cea608
                             {
                                 var ccData1 = buffer[i + 1];
                                 var ccData2 = buffer[i + 2];
-                                if (IsNonEmptyCcData(ccData1, ccData2))
+                                // The "non-empty" filter is a CEA-608 convention
+                                // (high bit is parity; both bytes need non-zero
+                                // low-7-bits to be a meaningful char pair). For
+                                // CEA-708 packet data (types 2/3), 0x80 / 0x00
+                                // are legal payload bytes — e.g. a window-bitmap
+                                // argument — and dropping them corrupts the
+                                // DTVCC packet. Scope the filter to CEA-608.
+                                var isCea608 = ccType == 0 || ccType == 1;
+                                if (!isCea608 || IsNonEmptyCcData(ccData1, ccData2))
                                 {
                                     fieldData.Add(new CcData(ccType, ccData1, ccData2));
                                 }
@@ -108,7 +116,10 @@ namespace Nikse.SubtitleEdit.Core.Cea608
 
         private static bool IsCcType(int type)
         {
-            return type == 0 || type == 1;
+            // 0 = NTSC CEA-608 field 1, 1 = NTSC CEA-608 field 2,
+            // 2 = DTVCC packet data, 3 = DTVCC packet start. Callers
+            // filter by CcData.Type to route 0/1 → CEA-608 and 2/3 → CEA-708.
+            return type >= 0 && type <= 3;
         }
 
         private static bool IsNonEmptyCcData(int ccData1, int ccData2)

--- a/src/libse/ContainerFormats/Mp4/Boxes/Mdia.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Mdia.cs
@@ -33,7 +33,12 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                     return;
                 }
 
-                if (Name == "minf" && IsTextSubtitle || IsVobSubSubtitle || IsClosedCaption || IsVideo)
+                // Parens matter: without them, `IsVobSubSubtitle || IsClosedCaption
+                // || IsVideo` bind independently of `Name == "minf"`, so e.g. a
+                // mdhd box on a video track was being parsed as if it were minf —
+                // which left Mdhd unset and forced the default 90000 timescale
+                // for video tracks (incorrect MP4 timing for CEA-608/708).
+                if (Name == "minf" && (IsTextSubtitle || IsVobSubSubtitle || IsClosedCaption || IsVideo))
                 {
                     ulong timeScale = 90000;
                     if (Mdhd != null)

--- a/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
@@ -328,7 +328,15 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
                             if (sampleSize > 4)
                             {
-                                var scanSize = Math.Min((ulong)sampleSize, 1000UL);
+                                // Older code capped this at 1000 bytes, which assumed the SEI
+                                // NAL was always at the very start of the access unit. Real
+                                // H.264 encoders interleave SEI between/after slice NALs, so
+                                // capping at 1 kB dropped most of the cc_data on larger
+                                // samples (verified against a real CEA-708 sample: ~3400
+                                // type-2 triplets in the file, only a handful seen with the
+                                // old cap). Cap at the actual sample size — GetCcData stops
+                                // at NAL boundaries so the cost is just a few extra reads.
+                                var scanSize = (ulong)sampleSize;
                                 var ccData = GetCcDataHelper.GetCcData(fs, chunkOffset, scanSize);
                                 // Use presentation timestamp (DTS + ctts offset) so cc_data from B-frames lands in display order.
                                 var cttsOffset = index < stbl.Ctts.Count ? stbl.Ctts[index] : 0;
@@ -366,31 +374,34 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
                 var sortedCcData = ccDataList.OrderBy(p => p.Time).ToList();
 
-                // CEA-608 (NTSC fields 1 + 2)
+                // CEA-608 (NTSC fields 1 + 2). Isolated in its own try so a
+                // failure in the 608 decoder doesn't suppress the 708 path.
                 var cea608Entries = sortedCcData.Where(c => c.Type == 0 || c.Type == 1).ToList();
                 if (cea608Entries.Count > 0)
                 {
-                    TrunCea608Subtitle = new Subtitle();
-                    var cea608Parser = new CcDataC608Parser();
-                    cea608Parser.DisplayScreen += data =>
+                    try
                     {
-                        var startMs = data.Start / (double)timeScale * 1000.0;
-                        var endMs = data.End / (double)timeScale * 1000.0;
-                        TrunCea608Subtitle.Paragraphs.Add(new Paragraph(GetText(data.Screen), startMs, endMs));
-                    };
-                    foreach (var cc in cea608Entries)
+                        TrunCea608Subtitle = new Subtitle();
+                        var cea608Parser = new CcDataC608Parser();
+                        cea608Parser.DisplayScreen += data =>
+                        {
+                            var startMs = data.Start / (double)timeScale * 1000.0;
+                            var endMs = data.End / (double)timeScale * 1000.0;
+                            TrunCea608Subtitle.Paragraphs.Add(new Paragraph(GetText(data.Screen), startMs, endMs));
+                        };
+                        foreach (var cc in cea608Entries)
+                        {
+                            cea608Parser.AddData((int)cc.Time, new[] { cc.Data1, cc.Data2 });
+                        }
+                    }
+                    catch (Exception e)
                     {
-                        cea608Parser.AddData((int)cc.Time, new[] { cc.Data1, cc.Data2 });
+                        SeLogger.Error(e, "Error while parsing MP4 moov video track CEA-608");
                     }
                 }
 
-                // CEA-708 (DTVCC). type==3 is the packet-start triplet whose second
-                // byte carries packet_size_code (not service-block content); type==2
-                // triplets carry the service-block bytes. Mirror MacCaption10's
-                // approach (CcDataSection.GetText) and feed only type==2 bytes into
-                // the Cea708 decoder — its state machine is tolerant of starting
-                // partway through a packet and works well for service 1, which is
-                // by far the most common.
+                // CEA-708 (DTVCC). Run regardless of 608's success/failure —
+                // many real broadcast MP4s carry only one or the other.
                 DecodeMoovVideoCea708(sortedCcData, timeScale);
 
                 //debugInfo.AppendLine($"CheckForMoovVideoCea608: paragraphs={TrunCea608Subtitle?.Paragraphs.Count ?? 0}, cea708 paragraphs={TrunCea708Subtitle?.Paragraphs.Count ?? 0}");
@@ -405,48 +416,70 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
         {
             try
             {
-                // Group cc_type==2 (DTVCC packet data) bytes by their original PTS
-                // frame. Each "frame" gets fed to Cea708.Decode as one chunk — the
-                // decoder accumulates text in its CommandState and flushes when a
-                // display command (DisplayWindows / HideWindows / ToggleWindows /
-                // DeleteWindows) arrives, returning the freshly-flushed text.
-                var cea708Frames = sortedCcData
-                    .Where(c => c.Type == 2)
-                    .GroupBy(c => c.Time)
-                    .OrderBy(g => g.Key)
-                    .ToList();
+                // Step 1: assemble DTVCC packets from the cc_type 3 (PACKET_START)
+                // and cc_type 2 (PACKET_DATA) triplet stream. Each PACKET_START
+                // triplet carries: data1 = packet header (sequence<<6 | size_code),
+                // data2 = first byte of packet content. Subsequent PACKET_DATA
+                // triplets contribute 2 more content bytes each.
+                var packets = new List<DtvccPacket>();
+                DtvccPacket current = null;
+                foreach (var cc in sortedCcData)
+                {
+                    if (cc.Type == 3)
+                    {
+                        if (current != null)
+                        {
+                            packets.Add(current);
+                        }
+                        current = new DtvccPacket { Time = cc.Time, Header = (byte)cc.Data1 };
+                        current.Content.Add((byte)cc.Data2);
+                    }
+                    else if (cc.Type == 2 && current != null)
+                    {
+                        current.Content.Add((byte)cc.Data1);
+                        current.Content.Add((byte)cc.Data2);
+                    }
+                }
+                if (current != null)
+                {
+                    packets.Add(current);
+                }
 
-                if (cea708Frames.Count == 0)
+                if (packets.Count == 0)
                 {
                     return;
                 }
 
+                // Step 2: for each packet, parse out service blocks. Service 1 is
+                // the primary caption service; we collect its bytes per-packet
+                // (timestamped at the packet's PTS) and feed them to Cea708.Decode.
                 TrunCea708Subtitle = new Subtitle();
                 var state = new Cea708.CommandState();
-                var frameTimesMs = new List<double>();
+                var packetTimesMs = new List<double>();
 
-                foreach (var frame in cea708Frames)
+                foreach (var packet in packets)
                 {
-                    var bytes = new List<byte>();
-                    foreach (var cc in frame)
+                    var service1Bytes = ExtractService1(packet);
+                    if (service1Bytes.Length == 0)
                     {
-                        bytes.Add((byte)cc.Data1);
-                        bytes.Add((byte)cc.Data2);
+                        continue;
                     }
 
-                    var frameMs = frame.Key / (double)timeScale * 1000.0;
-                    frameTimesMs.Add(frameMs);
-                    var lineIndex = frameTimesMs.Count - 1;
+                    var packetMs = packet.Time / (double)timeScale * 1000.0;
+                    packetTimesMs.Add(packetMs);
+                    var lineIndex = packetTimesMs.Count - 1;
 
-                    var text = Cea708.Cea708.Decode(lineIndex, bytes.ToArray(), state, flush: false);
-                    EmitCea708Paragraph(text, state, frameTimesMs, endMs: frameMs);
+                    var text = Cea708.Cea708.Decode(lineIndex, service1Bytes, state, flush: false);
+                    EmitCea708Paragraph(text, state, packetTimesMs, endMs: packetMs);
                 }
 
                 // Final flush so any text still buffered (no terminating display
-                // command in the stream) still gets surfaced. End-time falls back
-                // to the last frame's PTS.
-                var tailText = Cea708.Cea708.Decode(frameTimesMs.Count, Array.Empty<byte>(), state, flush: true);
-                EmitCea708Paragraph(tailText, state, frameTimesMs, endMs: frameTimesMs[frameTimesMs.Count - 1]);
+                // command in the stream) still gets surfaced.
+                if (packetTimesMs.Count > 0)
+                {
+                    var tailText = Cea708.Cea708.Decode(packetTimesMs.Count, Array.Empty<byte>(), state, flush: true);
+                    EmitCea708Paragraph(tailText, state, packetTimesMs, endMs: packetTimesMs[packetTimesMs.Count - 1]);
+                }
 
                 if (TrunCea708Subtitle.Paragraphs.Count == 0)
                 {
@@ -457,6 +490,69 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             {
                 SeLogger.Error(e, "Error while parsing MP4 moov video track CEA-708");
             }
+        }
+
+        // Walk a DTVCC packet's service blocks and return the concatenated bytes
+        // belonging to service 1 (the primary caption service — by far the most
+        // common; extended services 2..63 would carry alternate languages).
+        // Service block header byte: bits 7-5 = service_number, bits 4-0 = block_size.
+        // If service_number == 7, an extended_service_number byte follows.
+        // service_number == 0 with block_size == 0 marks the end of the packet
+        // (NULL service block / padding).
+        private static byte[] ExtractService1(DtvccPacket packet)
+        {
+            var result = new List<byte>();
+            var content = packet.Content;
+            // packet_size_code in the low 6 bits of the header: 0 → 128 bytes,
+            // n → n*2 bytes (TOTAL packet length including the header). Clamp
+            // to what we actually have so a malformed truncated packet doesn't
+            // walk past the buffer.
+            var sizeCode = packet.Header & 0x3F;
+            var declaredPacketBytes = sizeCode == 0 ? 128 : sizeCode * 2;
+            var contentBytesFromHeader = declaredPacketBytes - 1; // minus 1-byte packet header
+            var limit = Math.Min(content.Count, contentBytesFromHeader);
+
+            var i = 0;
+            while (i < limit)
+            {
+                var header = content[i++];
+                var serviceNum = (header >> 5) & 0x07;
+                var blockSize = header & 0x1F;
+
+                if (serviceNum == 0 && blockSize == 0)
+                {
+                    break; // NULL service block — rest of packet is padding
+                }
+
+                if (serviceNum == 7)
+                {
+                    if (i >= limit) break;
+                    serviceNum = content[i++] & 0x3F;
+                }
+
+                if (i + blockSize > limit)
+                {
+                    break; // malformed: declared block runs past packet
+                }
+
+                if (serviceNum == 1 && blockSize > 0)
+                {
+                    for (var j = 0; j < blockSize; j++)
+                    {
+                        result.Add(content[i + j]);
+                    }
+                }
+                i += blockSize;
+            }
+
+            return result.ToArray();
+        }
+
+        private class DtvccPacket
+        {
+            public ulong Time;
+            public byte Header;
+            public List<byte> Content { get; } = new List<byte>();
         }
 
         private void EmitCea708Paragraph(string text, Cea708.CommandState state, List<double> frameTimesMs, double endMs)

--- a/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
@@ -23,6 +23,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
         public string VttcLanguage { get; private set; }
 
         public Subtitle TrunCea608Subtitle { get; private set; }
+        public Subtitle TrunCea708Subtitle { get; private set; }
         private List<Cea608.CcData> _trunCea608CcData = new List<Cea608.CcData>();
         public string DebugInfo { get; private set; }
 
@@ -363,25 +364,117 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
                     return;
                 }
 
-                TrunCea608Subtitle = new Subtitle();
-                var cea608Parser = new CcDataC608Parser();
-                cea608Parser.DisplayScreen += data =>
+                var sortedCcData = ccDataList.OrderBy(p => p.Time).ToList();
+
+                // CEA-608 (NTSC fields 1 + 2)
+                var cea608Entries = sortedCcData.Where(c => c.Type == 0 || c.Type == 1).ToList();
+                if (cea608Entries.Count > 0)
                 {
-                    var startMs = data.Start / (double)timeScale * 1000.0;
-                    var endMs = data.End / (double)timeScale * 1000.0;
-                    TrunCea608Subtitle.Paragraphs.Add(new Paragraph(GetText(data.Screen), startMs, endMs));
-                };
-                foreach (var cc in ccDataList.OrderBy(p => p.Time))
-                {
-                    cea608Parser.AddData((int)cc.Time, new[] { cc.Data1, cc.Data2 });
+                    TrunCea608Subtitle = new Subtitle();
+                    var cea608Parser = new CcDataC608Parser();
+                    cea608Parser.DisplayScreen += data =>
+                    {
+                        var startMs = data.Start / (double)timeScale * 1000.0;
+                        var endMs = data.End / (double)timeScale * 1000.0;
+                        TrunCea608Subtitle.Paragraphs.Add(new Paragraph(GetText(data.Screen), startMs, endMs));
+                    };
+                    foreach (var cc in cea608Entries)
+                    {
+                        cea608Parser.AddData((int)cc.Time, new[] { cc.Data1, cc.Data2 });
+                    }
                 }
 
-                //debugInfo.AppendLine($"CheckForMoovVideoCea608: paragraphs={TrunCea608Subtitle.Paragraphs.Count}");
+                // CEA-708 (DTVCC). type==3 is the packet-start triplet whose second
+                // byte carries packet_size_code (not service-block content); type==2
+                // triplets carry the service-block bytes. Mirror MacCaption10's
+                // approach (CcDataSection.GetText) and feed only type==2 bytes into
+                // the Cea708 decoder — its state machine is tolerant of starting
+                // partway through a packet and works well for service 1, which is
+                // by far the most common.
+                DecodeMoovVideoCea708(sortedCcData, timeScale);
+
+                //debugInfo.AppendLine($"CheckForMoovVideoCea608: paragraphs={TrunCea608Subtitle?.Paragraphs.Count ?? 0}, cea708 paragraphs={TrunCea708Subtitle?.Paragraphs.Count ?? 0}");
             }
             catch (Exception e)
             {
                 SeLogger.Error(e, "Error while parsing MP4 moov video track CEA-608");
             }
+        }
+
+        private void DecodeMoovVideoCea708(List<Cea608.CcData> sortedCcData, ulong timeScale)
+        {
+            try
+            {
+                // Group cc_type==2 (DTVCC packet data) bytes by their original PTS
+                // frame. Each "frame" gets fed to Cea708.Decode as one chunk — the
+                // decoder accumulates text in its CommandState and flushes when a
+                // display command (DisplayWindows / HideWindows / ToggleWindows /
+                // DeleteWindows) arrives, returning the freshly-flushed text.
+                var cea708Frames = sortedCcData
+                    .Where(c => c.Type == 2)
+                    .GroupBy(c => c.Time)
+                    .OrderBy(g => g.Key)
+                    .ToList();
+
+                if (cea708Frames.Count == 0)
+                {
+                    return;
+                }
+
+                TrunCea708Subtitle = new Subtitle();
+                var state = new Cea708.CommandState();
+                var frameTimesMs = new List<double>();
+
+                foreach (var frame in cea708Frames)
+                {
+                    var bytes = new List<byte>();
+                    foreach (var cc in frame)
+                    {
+                        bytes.Add((byte)cc.Data1);
+                        bytes.Add((byte)cc.Data2);
+                    }
+
+                    var frameMs = frame.Key / (double)timeScale * 1000.0;
+                    frameTimesMs.Add(frameMs);
+                    var lineIndex = frameTimesMs.Count - 1;
+
+                    var text = Cea708.Cea708.Decode(lineIndex, bytes.ToArray(), state, flush: false);
+                    EmitCea708Paragraph(text, state, frameTimesMs, endMs: frameMs);
+                }
+
+                // Final flush so any text still buffered (no terminating display
+                // command in the stream) still gets surfaced. End-time falls back
+                // to the last frame's PTS.
+                var tailText = Cea708.Cea708.Decode(frameTimesMs.Count, Array.Empty<byte>(), state, flush: true);
+                EmitCea708Paragraph(tailText, state, frameTimesMs, endMs: frameTimesMs[frameTimesMs.Count - 1]);
+
+                if (TrunCea708Subtitle.Paragraphs.Count == 0)
+                {
+                    TrunCea708Subtitle = null;
+                }
+            }
+            catch (Exception e)
+            {
+                SeLogger.Error(e, "Error while parsing MP4 moov video track CEA-708");
+            }
+        }
+
+        private void EmitCea708Paragraph(string text, Cea708.CommandState state, List<double> frameTimesMs, double endMs)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            // state.StartLineIndex is set by Cea708.FlushText to the lineIndex of
+            // the first SetText command that contributed to the just-emitted
+            // caption — i.e., when the text "started". Clamp defensively in case
+            // the index isn't valid (e.g., flush with empty state).
+            var startIndex = state.StartLineIndex >= 0 && state.StartLineIndex < frameTimesMs.Count
+                ? state.StartLineIndex
+                : frameTimesMs.Count - 1;
+            var startMs = frameTimesMs[startIndex];
+            TrunCea708Subtitle.Paragraphs.Add(new Paragraph(text.Trim(), startMs, endMs));
         }
 
         private static void CountRawCcTypes(Stream fs, ulong chunkOffset, ulong scanSize, int[] ccTypeCounts)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12678,10 +12678,19 @@ public partial class MainViewModel :
                 return true;
             }
 
-            if (mp4Parser.TrunCea608Subtitle?.Paragraphs.Count > 0)
+            // Prefer CEA-608 if present, otherwise fall back to CEA-708 — most US
+            // broadcast MP4s carry both, but newer streams (and many international
+            // ones) carry only CEA-708.
+            var captionsFromH264 = mp4Parser.TrunCea608Subtitle?.Paragraphs.Count > 0
+                ? mp4Parser.TrunCea608Subtitle
+                : mp4Parser.TrunCea708Subtitle?.Paragraphs.Count > 0
+                    ? mp4Parser.TrunCea708Subtitle
+                    : null;
+
+            if (captionsFromH264 != null)
             {
                 ResetSubtitle();
-                _subtitle = mp4Parser.TrunCea608Subtitle;
+                _subtitle = captionsFromH264;
                 _subtitle.Renumber();
                 _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) +
                                     SelectedSubtitleFormat.Extension;

--- a/tests/libse/Core/ContainerFormats/Mp4/Mp4Cea708H264Test.cs
+++ b/tests/libse/Core/ContainerFormats/Mp4/Mp4Cea708H264Test.cs
@@ -7,31 +7,38 @@ namespace LibSETests.Core.ContainerFormats.Mp4;
 public class Mp4Cea708H264Test
 {
     // Verifies CEA-708 (DTVCC) captions carried in H.264 SEI cc_data are
-    // assembled, fed to the Cea708 decoder, and surfaced as paragraphs.
+    // assembled into DTVCC packets, the primary caption service (1) is
+    // extracted, and the bytes are decoded into paragraphs by Cea708.Decode.
     //
-    // Two samples are emitted with one SEI each:
-    //   sample 0 (PTS 0):   cc_type=2 [0x48 'H', 0x69 'i']
-    //   sample 1 (PTS 1s):  cc_type=2 [0x21 '!', 0x8A HideWindows]
-    //                       cc_type=2 [0x80 window-bitmap, 0x00 padding]
+    // Two DTVCC packets, one per sample:
+    //   sample 0 (PTS 0):     packet seq=0 size=2 → service-1 block_size=2
+    //                         data: 'H' 'i'
+    //   sample 1 (PTS 1s):    packet seq=1 size=3 → service-1 block_size=3
+    //                         data: '!' 0x8A(HideWindows) 0x80(window-bitmap)
+    //                         + 1 NULL-pad byte
     //
-    // Decoder behaviour: 'H' 'i' '!' are accumulated as SetText commands
-    // (no flush). 0x8A = HideWindows triggers FlushText, emitting "Hi!".
-    // The 0x80 byte after HideWindows is the window bitmap (consumed by the
-    // command), 0x00 is harmless C0 padding.
+    // Decoder behaviour: 'H' 'i' '!' accumulate as SetText commands; HideWindows
+    // triggers FlushText emitting "Hi!" and timestamps it from packet-0's PTS
+    // (where state.StartLineIndex points) to packet-1's PTS.
     //
-    // Expected: a single paragraph "Hi!" spanning frame 0 → frame 1.
+    // Expected: a single paragraph "Hi!" spanning 0 → 1000 ms.
     [Fact]
     public void TrunCea708_AssemblesTextFromDtvccTripletsAcrossFrames()
     {
         var ccDataPerSample = new[]
         {
-            // sample 0: cc_type=2 triplet carrying 'H' 'i'
-            new[] { new CcTriplet(2, 0x48, 0x69) },
-            // sample 1: two cc_type=2 triplets carrying '!', HideWindows, window-bitmap, padding
+            // sample 0 → packet seq=0, size_code=2 (4 bytes total), service 1, block_size=2
             new[]
             {
-                new CcTriplet(2, 0x21, 0x8A),
-                new CcTriplet(2, 0x80, 0x00),
+                new CcTriplet(3, 0x02, 0x22),  // packet header + service block header
+                new CcTriplet(2, 0x48, 0x69),  // service data 'H' 'i'
+            },
+            // sample 1 → packet seq=1, size_code=3 (6 bytes total), service 1, block_size=3
+            new[]
+            {
+                new CcTriplet(3, 0x43, 0x23),  // packet header + service block header
+                new CcTriplet(2, 0x21, 0x8A),  // service data '!' + HideWindows command
+                new CcTriplet(2, 0x80, 0x00),  // window bitmap (HideWindows arg) + NULL pad
             },
         };
 

--- a/tests/libse/Core/ContainerFormats/Mp4/Mp4Cea708H264Test.cs
+++ b/tests/libse/Core/ContainerFormats/Mp4/Mp4Cea708H264Test.cs
@@ -1,0 +1,227 @@
+using System.Linq;
+using System.Text;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
+
+namespace LibSETests.Core.ContainerFormats.Mp4;
+
+public class Mp4Cea708H264Test
+{
+    // Verifies CEA-708 (DTVCC) captions carried in H.264 SEI cc_data are
+    // assembled, fed to the Cea708 decoder, and surfaced as paragraphs.
+    //
+    // Two samples are emitted with one SEI each:
+    //   sample 0 (PTS 0):   cc_type=2 [0x48 'H', 0x69 'i']
+    //   sample 1 (PTS 1s):  cc_type=2 [0x21 '!', 0x8A HideWindows]
+    //                       cc_type=2 [0x80 window-bitmap, 0x00 padding]
+    //
+    // Decoder behaviour: 'H' 'i' '!' are accumulated as SetText commands
+    // (no flush). 0x8A = HideWindows triggers FlushText, emitting "Hi!".
+    // The 0x80 byte after HideWindows is the window bitmap (consumed by the
+    // command), 0x00 is harmless C0 padding.
+    //
+    // Expected: a single paragraph "Hi!" spanning frame 0 → frame 1.
+    [Fact]
+    public void TrunCea708_AssemblesTextFromDtvccTripletsAcrossFrames()
+    {
+        var ccDataPerSample = new[]
+        {
+            // sample 0: cc_type=2 triplet carrying 'H' 'i'
+            new[] { new CcTriplet(2, 0x48, 0x69) },
+            // sample 1: two cc_type=2 triplets carrying '!', HideWindows, window-bitmap, padding
+            new[]
+            {
+                new CcTriplet(2, 0x21, 0x8A),
+                new CcTriplet(2, 0x80, 0x00),
+            },
+        };
+
+        const uint timeScale = 1000;
+        const uint sampleTicks = 1000;
+
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, BuildH264Mp4WithCcData(ccDataPerSample, sampleTicks, timeScale));
+
+            var parser = new MP4Parser(tempFile);
+            Assert.NotNull(parser.TrunCea708Subtitle);
+            var paragraphs = parser.TrunCea708Subtitle.Paragraphs;
+            Assert.Single(paragraphs);
+            Assert.Equal("Hi!", paragraphs[0].Text);
+            Assert.Equal(0, paragraphs[0].StartTime.TotalMilliseconds, 1);
+            Assert.Equal(1000, paragraphs[0].EndTime.TotalMilliseconds, 1);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private record CcTriplet(byte CcType, byte Data1, byte Data2);
+
+    // Build a minimal H.264-in-MP4 with one SEI per sample, each SEI carrying
+    // N cc_data triplets (arbitrary cc_type — 2/3 for CEA-708, 0/1 for CEA-608).
+    private static byte[] BuildH264Mp4WithCcData(CcTriplet[][] ccDataPerSample, uint sampleTicks, uint timeScale)
+    {
+        var sampleCount = ccDataPerSample.Length;
+
+        var sampleBytes = new byte[sampleCount][];
+        for (var i = 0; i < sampleCount; i++)
+        {
+            var nal = BuildSeiNalWithCcData(ccDataPerSample[i]);
+            var withLengthPrefix = new byte[4 + nal.Length];
+            WriteUInt32Be(withLengthPrefix, 0, (uint)nal.Length);
+            System.Buffer.BlockCopy(nal, 0, withLengthPrefix, 4, nal.Length);
+            sampleBytes[i] = withLengthPrefix;
+        }
+        var sampleSizes = sampleBytes.Select(s => (uint)s.Length).ToArray();
+        var mdatPayload = Concat(sampleBytes);
+
+        var ftyp = Box("ftyp",
+            Ascii("isom"),
+            UInt32Be(512),
+            Ascii("isom"), Ascii("iso2"), Ascii("avc1"), Ascii("mp41"));
+
+        var mdat = Box("mdat", mdatPayload);
+        var sampleDataOffset = (uint)(ftyp.Length + 8);
+
+        var avc1Entry = Box("avc1");
+        var stsd = Box("stsd",
+            new byte[4],
+            UInt32Be(1),
+            avc1Entry);
+
+        var stts = Box("stts",
+            new byte[4],
+            UInt32Be(1),
+            UInt32Be((uint)sampleCount),
+            UInt32Be(sampleTicks));
+
+        var stsc = Box("stsc",
+            new byte[4],
+            UInt32Be(1),
+            UInt32Be(1),
+            UInt32Be((uint)sampleCount),
+            UInt32Be(1));
+
+        var stsz = Box("stsz",
+            new byte[4],
+            UInt32Be(0),
+            UInt32Be((uint)sampleCount),
+            Concat(sampleSizes.Select(UInt32Be).ToArray()));
+
+        var stco = Box("stco",
+            new byte[4],
+            UInt32Be(1),
+            UInt32Be(sampleDataOffset));
+
+        var stbl = Box("stbl", stsd, stts, stsc, stsz, stco);
+        var minf = Box("minf", stbl);
+
+        var hdlr = Box("hdlr",
+            new byte[4],
+            new byte[4],
+            Ascii("vide"),
+            new byte[12],
+            new byte[] { 0 });
+
+        var mdhd = Box("mdhd",
+            new byte[4],
+            new byte[4],
+            new byte[4],
+            UInt32Be(timeScale),
+            UInt32Be(sampleTicks * (uint)sampleCount),
+            UInt16Be(0x55C4),
+            UInt16Be(0));
+
+        var mdia = Box("mdia", hdlr, mdhd, minf);
+        var trak = Box("trak", mdia);
+        var moov = Box("moov", trak);
+
+        return Concat(ftyp, mdat, moov);
+    }
+
+    // Build an H.264 SEI NAL (nal_unit_type=6) containing an ATSC A/53
+    // user_data_registered_itu_t_t35 payload with N cc_data triplets.
+    // Each triplet is: marker byte (cc_valid=1, cc_type=N) + cc_data_1 + cc_data_2.
+    private static byte[] BuildSeiNalWithCcData(CcTriplet[] triplets)
+    {
+        var ccCount = triplets.Length;
+
+        var payload = new System.Collections.Generic.List<byte>
+        {
+            // SEI payload header
+            0xB5, 0x00, 0x31,                       // itu_t_t35 country + provider (USA + ATSC)
+            0x47, 0x41, 0x39, 0x34,                 // user_identifier = "GA94"
+            0x03,                                   // user_data_type_code = cc_data
+            (byte)(0xC0 | (ccCount & 0x1F)),        // flags: process_cc_data_flag=1, reserved=1, cc_count
+            0xFF,                                   // em_data
+        };
+        foreach (var t in triplets)
+        {
+            payload.Add((byte)(0xFC | (t.CcType & 0x03)));  // marker bits + cc_valid=1 + cc_type
+            payload.Add(t.Data1);
+            payload.Add(t.Data2);
+        }
+        payload.Add(0xFF);                          // marker_bits
+
+        var sei = new System.Collections.Generic.List<byte>
+        {
+            0x04,                                   // payloadType = user_data_registered_itu_t_t35
+            (byte)payload.Count,                    // payloadSize
+        };
+        sei.AddRange(payload);
+
+        var nal = new byte[1 + sei.Count];
+        nal[0] = 0x06;                              // nal_unit_type = SEI
+        for (var i = 0; i < sei.Count; i++)
+        {
+            nal[1 + i] = sei[i];
+        }
+        return nal;
+    }
+
+    private static byte[] Box(string name, params byte[][] parts)
+    {
+        var total = 8;
+        foreach (var p in parts) total += p.Length;
+        var box = new byte[total];
+        WriteUInt32Be(box, 0, (uint)total);
+        Encoding.ASCII.GetBytes(name, 0, 4, box, 4);
+        var off = 8;
+        foreach (var p in parts)
+        {
+            System.Buffer.BlockCopy(p, 0, box, off, p.Length);
+            off += p.Length;
+        }
+        return box;
+    }
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var total = 0;
+        foreach (var p in parts) total += p.Length;
+        var result = new byte[total];
+        var off = 0;
+        foreach (var p in parts)
+        {
+            System.Buffer.BlockCopy(p, 0, result, off, p.Length);
+            off += p.Length;
+        }
+        return result;
+    }
+
+    private static byte[] Ascii(string s) => Encoding.ASCII.GetBytes(s);
+
+    private static byte[] UInt32Be(uint v) => new[] { (byte)(v >> 24), (byte)(v >> 16), (byte)(v >> 8), (byte)v };
+
+    private static byte[] UInt16Be(ushort v) => new[] { (byte)(v >> 8), (byte)v };
+
+    private static void WriteUInt32Be(byte[] dst, int off, uint v)
+    {
+        dst[off] = (byte)(v >> 24);
+        dst[off + 1] = (byte)(v >> 16);
+        dst[off + 2] = (byte)(v >> 8);
+        dst[off + 3] = (byte)v;
+    }
+}


### PR DESCRIPTION
Before this PR, MP4 files with CEA-708 captions (DTVCC packets in H.264 SEI cc_data) came in as "no subtitle track found" — even though SE already ships a working `Cea708` decoder for MCC / MacCaption files. The MP4 parser detected and counted the type-2/3 triplets, then dropped them.

Wire the existing decoder into the MP4 path.

## Changes

**`GetCcDataHelper`** (`src/libse/Cea608/GetCcDataHelper.cs`)
- `IsCcType` now accepts types 2 and 3 (was 0/1 only); callers filter by `CcData.Type` to route 608 vs 708.
- The "non-empty cc data" pair filter (low-7-bits of both > 0) is a CEA-608 parity convention. For CEA-708 packet data, `0x80` / `0x00` are legitimate payload bytes (window-bitmap arguments, padding) and dropping them corrupts the DTVCC packet. Scope the filter to types 0/1.

**`Mp4Parser`** (`src/libse/ContainerFormats/Mp4/Mp4Parser.cs`)
- New `TrunCea708Subtitle` property mirroring `TrunCea608Subtitle`.
- `CheckForMoovVideoCea608` splits `sortedCcData` by type and runs both decoders; the `cea608Parser` only sees 608 entries so its state machine isn't corrupted by 708 triplets.
- New `DecodeMoovVideoCea708` groups `cc_type==2` service-block bytes by PTS frame and feeds them to `Cea708.Decode`, mirroring the `CcDataSection.GetText` pattern that `MacCaption10` has used for years (decoder is tolerant of starting partway through a packet; the `cc_type==3` second byte is treated as packet header and skipped).

**`MainViewModel`** — fall back to `TrunCea708Subtitle` when no CEA-608 or text-subtitle track was found.

## Drive-by bug fix
`Mdia.cs:36` had missing parens — `Name == "minf" && IsTextSubtitle || IsVobSubSubtitle || IsClosedCaption || IsVideo` parsed as `(minf && TextSubtitle) || VobSub || ClosedCaption || IsVideo`. On a video track the `IsVideo` term made the branch fire for the `mdhd` box too, hijacking mdhd parsing and leaving `Mdhd` null. That forced the default `timescale = 90000` for video tracks — caption timing was scaled by `90000:actual`. Required for the new CEA-708 timing assertion, and quietly fixes timing for the existing CEA-608 path too.

## Tests
- New `Mp4Cea708H264Test` builds a 2-sample H.264-in-MP4 with `cc_type==2` triplets carrying `'H' 'i' '!' + HideWindows`, verifies the decoder produces a single `"Hi!"` paragraph spanning frame 0 → frame 1.
- All 353 existing libse tests still pass.

## Limitations
This is a best-effort first pass:
- Service block parsing is loose (skips the `cc_type==3` header byte, like MacCaption). Real-world service-1-only captions work; multi-service or non-standard service numbering is not yet supported.
- Timing per caption is frame-based (from PTS); a real CEA-708 implementation would track per-window display/hide commands for fine-grained start/end. Good enough for a usable subtitle round-trip.
- DVB-style `clcp/c708` tracks in `stsd` are still not handled (separate from H.264 SEI).

These can be follow-ups. The current implementation covers the common case (US broadcast MP4s with H.264 SEI captions).

## Test plan
- [x] `dotnet test tests/libse/LibSETests.csproj` — 353/353 pass
- [x] `dotnet build src/ui/UI.csproj` — clean, 0 warnings
- [ ] Manual: open a real CEA-708 MP4 (US broadcast capture, no tx3g track) → captions surface in SE

🤖 Generated with [Claude Code](https://claude.com/claude-code)