### PR TITLE
Sync windows: persist position+size; keep AdjustAllTimes open across New/Open

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1479,8 +1479,14 @@ public partial class MainViewModel :
 
         if (_adjustAllTimesViewModel != null)
         {
-            _adjustAllTimesViewModel.Window?.Close();
-            _adjustAllTimesViewModel = null;
+            if (_adjustAllTimesViewModel.Window is { IsVisible: true })
+            {
+                _adjustAllTimesViewModel.ResetForNewSubtitle();
+            }
+            else
+            {
+                _adjustAllTimesViewModel = null;
+            }
         }
 
         var vp = GetVideoPlayerControl();

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
@@ -223,4 +223,10 @@ public partial class AdjustAllTimesViewModel : ObservableObject
     {
         UiUtil.SaveWindowPosition(Window);
     }
+
+    internal void ResetForNewSubtitle()
+    {
+        _totalAdjustment = TimeSpan.Zero;
+        StatusText = string.Empty;
+    }
 }

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
@@ -221,5 +221,6 @@ public partial class AdjustAllTimesViewModel : ObservableObject
 
     internal void OnClosing(WindowClosingEventArgs e)
     {
+        UiUtil.SaveWindowPosition(Window);
     }
 }

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
@@ -106,7 +106,11 @@ public class AdjustAllTimesWindow : Window
 
         Content = grid;
 
-        Loaded += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        Loaded += delegate
+        {
+            buttonOk.Focus(); // hack to make OnKeyDown work
+            UiUtil.RestoreWindowPosition(this);
+        };
         KeyDown += (_, e) => vm.OnKeyDown(e);
         Closing += (_, e) => vm.OnClosing(e);
     }

--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs
@@ -93,6 +93,8 @@ public class ChangeFrameRateWindow : Window
         Content = grid;
         
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
+        Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
@@ -114,6 +114,8 @@ public class ChangeSpeedWindow : Window
         Content = grid;
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
+        Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
@@ -59,7 +59,9 @@ public class PointSyncWindow : Window
         Loaded += delegate
         {
             buttonCancel.Focus(); // hack to make OnKeyDown work
+            UiUtil.RestoreWindowPosition(this);
         };
+        Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -281,6 +281,7 @@ public partial class SetSyncPointViewModel : ObservableObject
 
     internal void OnClosing()
     {
+        UiUtil.SaveWindowPosition(Window);
         _positionTimer.Stop();
         VideoPlayerControl.VideoPlayer.CloseFile();
     }
@@ -303,6 +304,8 @@ public partial class SetSyncPointViewModel : ObservableObject
 
     internal async void OnLoaded()
     {
+        UiUtil.RestoreWindowPosition(Window);
+
         if (string.IsNullOrEmpty(_videoFileName))
         {
             return;

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
@@ -61,7 +61,9 @@ public class PointSyncViaOtherWindow : Window
         Loaded += delegate
         {
             buttonCancel.Focus(); // hack to make OnKeyDown work
+            UiUtil.RestoreWindowPosition(this);
         };
+        Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Sync/VisualSync/ManualSyncWindow.cs
+++ b/src/ui/Features/Sync/VisualSync/ManualSyncWindow.cs
@@ -58,6 +58,8 @@ public class ManualSyncWindow : Window
         Content = grid;
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
+        Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -470,6 +470,7 @@ public partial class VisualSyncViewModel : ObservableObject
 
     internal void OnClosing()
     {
+        UiUtil.SaveWindowPosition(Window);
         _positionTimer.Stop();
         VideoPlayerControlLeft.VideoPlayer.CloseFile();
         VideoPlayerControlRight.VideoPlayer.CloseFile();
@@ -509,6 +510,8 @@ public partial class VisualSyncViewModel : ObservableObject
 
     internal async void OnLoaded()
     {
+        UiUtil.RestoreWindowPosition(Window);
+
         if (string.IsNullOrEmpty(_videoFileName))
         {
             return;


### PR DESCRIPTION
## Summary
- Wires `UiUtil.Save/RestoreWindowPosition` into all Sync windows (AdjustAllTimes, VisualSync, ManualSync, PointSync, SetSyncPoint, PointSyncViaOther, ChangeSpeed, ChangeFrameRate) so they respect the existing `Settings.General.RememberPositionAndSize` toggle like other windows in the app.
- Stops auto-closing the **Adjust all times** window from `MainViewModel.ResetSubtitle()`. The window's `IAdjustCallback` already operates on the current `Subtitles` collection, so it correctly targets a freshly loaded subtitle.
- Resets `_totalAdjustment` + `StatusText` when the underlying subtitle is reset, so the status line doesn't carry a stale running total from the previous file.

## Test plan
- [ ] Move/resize VisualSync and PointSync — close and reopen; position+size restored.
- [ ] Move AdjustAllTimes — close and reopen; position restored (window is non-resizable, so only position matters).
- [ ] Confirm Save/Restore is gated by `Settings.General.RememberPositionAndSize` (disabling it leaves windows centered as before).
- [ ] Open AdjustAllTimes, click Show Earlier / Show Later a few times, then File → New (or open a different subtitle): window stays open, status line clears, next adjustment applies to the new subtitle.
- [ ] Repeat with File → New (keep video).
- [ ] Confirm Find/Replace still close on New/Open (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)