### PR TITLE
Fix IME (CJK/Korean) input issue on Find/Replace auto-focus

### DIFF
--- a/src/ui/Features/Edit/Find/FindWindow.cs
+++ b/src/ui/Features/Edit/Find/FindWindow.cs
@@ -3,8 +3,10 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Edit.Find;
 
@@ -154,7 +156,16 @@ public class FindWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxFind.Focus(); }; // hack to make OnKeyDown work
+        Activated += delegate 
+        { 
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                textBoxFind.GetVisualDescendants()
+                           .OfType<TextBox>()
+                           .FirstOrDefault()?
+                           .Focus();
+            });
+        }; // hack to make OnKeyDown work
         AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);
         Closing += (_, _) => vm.SaveSettings();
     }

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -3,9 +3,11 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Features.Edit.Find;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Edit.Replace;
 
@@ -198,7 +200,16 @@ public class ReplaceWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxFind.Focus(); }; // hack to make OnKeyDown work
+        Activated += delegate 
+        { 
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                textBoxFind.GetVisualDescendants()
+                           .OfType<TextBox>()
+                           .FirstOrDefault()?
+                           .Focus();
+            });
+        }; // hack to make OnKeyDown work
         AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);
         Closing += (_, _) => vm.SaveSettings();
     }


### PR DESCRIPTION
## Problem
When the Find/Replace dialog automatically gains focus, CJK (Korean) IME input is initially broken. Language switching only becomes possible after the focus is moved to another control and then brought back to the textbox.

## Cause & Solution
Focusing the AutoCompleteBox directly breaks the IME context in Avalonia/WPF.

To fix this, the focus logic inside the Activated event has been updated to explicitly find and focus the inner TextBox via Dispatcher.UIThread.Post. This completely resolves the IME composition issue while preserving the original auto-focus behavior.

## Screenshot

https://github.com/user-attachments/assets/a4493d9d-d9df-439a-93ef-5adc45cf873e

