### PR TITLE
docs: refresh obsolete info across all markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can find the latest cross-platform builds here:
     - `mpv`
         - MacPorts: `sudo port install mpv`
     - `ffmpeg`
-        - Homebrew: `sudo port install ffmpeg`
+        - MacPorts: `sudo port install ffmpeg`
 
 
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,7 @@ You can find the latest cross-platform builds here:
 ### macOS
 
 - **Minimum macOS version**: 12 (Monterey) or newer
-- **Dependencies for Intel macs** (install via [MacPorts](https://www.macports.org/)):
-    - `mpv`
-        - MacPorts: `sudo port install mpv`
-    - `ffmpeg`
-        - MacPorts: `sudo port install ffmpeg`
-
-
+- The `.dmg` is self-contained: `libmpv` and `ffmpeg` are bundled inside `Subtitle Edit.app`, so no MacPorts or Homebrew install is required.
 
 #### Installing Subtitle Edit on macOS (Unsigned App)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,12 +10,12 @@ Yes. Subtitle Edit is released under the MIT license. It is completely free with
 
 ### What platforms does Subtitle Edit 5 run on?
 Subtitle Edit 5 is built with Avalonia UI and runs on:
-- Windows 10 and later
-- Linux
-- macOS (Apple Silicon / arm64)
+- Windows 10 (version 22H2 / build 19045) and later
+- Linux (native packages or Flatpak)
+- macOS 12 (Monterey) or later, on both Apple Silicon (arm64) and Intel (x64)
 
 ### Where is my data stored?
-Subtitle Edit stores settings and data in a platform-specific data folder. You can open it via **File → Open data folder** or the keyboard shortcut.
+Subtitle Edit stores settings and data in a platform-specific data folder. You can open it with the keyboard shortcut `Ctrl+Alt+Shift+D` (Windows/Linux) or `Cmd+Alt+Shift+D` (macOS).
 
 ### How do I report a bug or request a feature?
 Please open an issue on the [GitHub repository](https://github.com/SubtitleEdit/subtitleedit/issues).
@@ -73,12 +73,13 @@ Subtitle Edit supports several local and downloadable speech-to-text engines:
 - **Whisper.cpp** — Cross-platform, CPU-based
 - **Whisper.cpp (cuBLAS)** — GPU-accelerated (Windows, NVIDIA)
 - **Whisper.cpp (Vulkan)** — GPU-accelerated via Vulkan (Windows)
-- **Purfview's Faster Whisper XXL** — Fast GPU/CPU-based (Windows, Linux)
-- **CTranslate2** — Fast CPU/GPU-based 
+- **Purfview's Faster-Whisper-XXL** — Fast GPU/CPU-based (Windows, Linux)
+- **CTranslate2** — Fast CPU/GPU-based
 - **Const-me's Whisper** — DirectX-based (Windows)
 - **OpenAI Whisper** — Original Python implementation
-- **Chat LLM.cpp** — LLM-based transcription (Windows, Linux, macOS Apple Silicon)
-- **Qwen3 ASR CPP**, **Parakeet.cpp**, and **Crisp ASR** — Additional local engines with downloadable models
+- **OpenAI-compatible STT** — Send audio to any OpenAI-compatible speech endpoint
+- **Qwen3 ASR CPP** — Local GGUF-based engine (Windows, Linux)
+- **Crisp ASR** — Local engine with multiple backends (Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, Kyutai) and a Forced-aligner picker (built-in / Canary CTC / Qwen3 / 12 wav2vec2 language aligners) for word-level timestamps
 
 ### How do I use Speech to Text?
 1. Open a video file

--- a/docs/features/adjust-all-times.md
+++ b/docs/features/adjust-all-times.md
@@ -9,6 +9,14 @@ Shift all subtitle timings by a fixed amount.
 
 ## Options
 
-- **Time offset** — Amount to shift (positive = later, negative = earlier)
-- **Apply to** — All lines, selected lines only, or from/to a specific time
-- **Both start and end** or just start/end time
+- **Adjustment** — Time amount to shift
+- **Show earlier** / **Show later** — Apply the adjustment as a negative or positive shift
+- **Apply to** — All lines, selected lines only, or selected lines and forward
+
+The window remembers its position and stays open across New/Open, so adjustments can be made while continuing to work on the subtitle.
+
+## Keyboard shortcuts
+
+- Shift/Ctrl/Alt + Left or Right arrow — Show earlier/later by 10/100/500 ms
+
+> **Note:** "Selected lines and forward" applies the shift to the currently selected lines and every line after them.

--- a/docs/features/adjust-duration.md
+++ b/docs/features/adjust-duration.md
@@ -9,7 +9,8 @@ Adjust the display duration of subtitle lines.
 
 ## Options
 
-- **Add/subtract seconds** — Adjust all durations by a fixed amount
-- **Add/subtract percent** — Adjust durations by a percentage
-- **Fixed duration** — Set all durations to a fixed value
-- **Recalculate** — Recalculate durations based on text length and reading speed
+- **Seconds** — Adjust all durations by a fixed number of seconds (positive or negative)
+- **Percent** — Scale durations by a percentage
+- **Fixed** — Set all durations to a fixed value (in seconds)
+- **Recalculate** — Recalculate durations from text length using optimal and maximum characters/second
+  - **Extend only** — Never shorten a subtitle, only extend it

--- a/docs/features/apply-duration-limits.md
+++ b/docs/features/apply-duration-limits.md
@@ -9,6 +9,7 @@ Enforce minimum and maximum duration limits on subtitle lines.
 
 ## Options
 
-- **Minimum duration** — Set the minimum display time
-- **Maximum duration** — Set the maximum display time
-- Preview affected lines before applying
+- **Minimum duration (ms)** — Set the minimum display time in milliseconds
+- **Maximum duration (ms)** — Set the maximum display time in milliseconds
+
+The preview list updates live as you change values. Lines that cannot be fully fixed (because there is not enough room before the next subtitle) are shown as partial fixes or skipped, and the counts are reported under the list.

--- a/docs/features/apply-min-gap.md
+++ b/docs/features/apply-min-gap.md
@@ -2,13 +2,13 @@
 
 Set a minimum time gap between consecutive subtitles.
 
-- **Menu:** Tools → Apply minimum gap...
+- **Menu:** Tools → Apply min. gap between subtitles...
 
 <!-- Screenshot: Apply minimum gap window -->
 ![Apply Minimum Gap](../screenshots/apply-min-gap.png)
 
 ## Options
 
-- **Minimum gap** — The minimum time between subtitles (in milliseconds)
-- **Frames** — Set gap in frames instead of milliseconds
-- Preview affected lines before applying
+- **Min. ms between lines / Min. frames between lines** — The minimum time between subtitles. The unit (milliseconds or frames) follows the global *Use time format HH:MM:SS:FF* setting.
+
+The preview list updates live and the status text shows the number of gaps that were fixed.

--- a/docs/features/assa-apply-advanced-effects.md
+++ b/docs/features/assa-apply-advanced-effects.md
@@ -36,9 +36,14 @@ Effects range from text animations (typewriter, karaoke, bounce-in) to visual en
 | **Typewriter** | Characters appear one-by-one as if being typed |
 | **Typewriter with highlight** | Characters appear one-by-one with a glowing highlight on the active character |
 | **Word by word** | Words appear one-by-one instead of characters |
-| **Karaoke** | Classic karaoke color-wipe effect synchronized to subtitle timing |
+| **Karaoke** | Highlights each character in sequence, revealing the text left to right like karaoke lyrics |
+| **Karaoke - active word pop** | Dims inactive words and pops/glows a pre-marked active word (via `\u1` or highlight color); can auto-detect the active word |
 | **Scramble reveal** | Text starts scrambled and gradually resolves to the correct characters |
 | **Bounce in** | Each character springs in with an elastic pop animation |
+| **Slow zoom-in** | Text starts at normal size and gently grows slightly over the subtitle duration |
+| **Slow zoom-out** | Text starts slightly larger and gently shrinks to normal size over the subtitle duration |
+| **Slide in from left** | Text slides in from off-screen left, holds, then exits back to the left |
+| **Slide in from right** | Text slides in from off-screen right, holds, then exits back to the right |
 | **Word spacing** | Increases spacing between words using the `\fsp` tag for better readability |
 
 ### Visual Enhancement Effects
@@ -59,6 +64,7 @@ Effects range from text animations (typewriter, karaoke, bounce-in) to visual en
 | **Transition - fade-in** | Per-line fade-in from black at the start of each subtitle |
 | **Transition - fade-out** | Per-line fade-out to black at the end of each subtitle |
 | **Transition - TV close** | Black bars grow inward from top and bottom while the middle fades to white, then cuts to solid black — mimics an old CRT TV powering off |
+| **Fade in/out** | Text fades in at the start and fades out at the end of each subtitle |
 
 ### Decorative/Atmospheric Effects
 
@@ -140,6 +146,6 @@ Effects that involve positioning or drawing (background effects, particles, tran
 ## Related Features
 
 - [ASSA Styles](assa-styles.md) — Manage base styles for text appearance
-- [ASSA Apply Custom Override Tags](assa-override-tags.md) — Manually add override tags to specific subtitles
+- [ASSA Apply Override Tags](assa-override-tags.md) — Manually add override tags to specific subtitles
 - [ASSA Properties](assa-properties.md) — Edit script-level properties (resolution, aspect ratio, etc.)
 - [ASSA Draw](assa-draw.md) — Create custom vector shapes and drawings

--- a/docs/features/assa-attachments.md
+++ b/docs/features/assa-attachments.md
@@ -2,14 +2,14 @@
 
 Manage fonts and images embedded as attachments in an Advanced SubStation Alpha (ASS/SSA) subtitle file.
 
-**Menu:** `ASSA` → `Attachments...`
+**Menu:** `ASSA tools` → `Attachments...`
 
 ![ASSA Attachments Screenshot](../screenshots/assa-attachments.png)
 
 ## How to Use
 
 1. Open a subtitle file in ASS/SSA format.
-2. Go to **ASSA** → **Attachments...** to open the attachments manager.
+2. Go to **ASSA tools** → **Attachments...** to open the attachments manager.
 3. View the list of currently embedded fonts and images.
 4. Use **Add** to attach new font or image files.
 5. Select an attachment and use **Delete** or **Delete All** to remove attachments.

--- a/docs/features/assa-draw.md
+++ b/docs/features/assa-draw.md
@@ -2,14 +2,14 @@
 
 A vector drawing tool for creating ASSA drawing commands (\p1 ... \p0) used in Advanced SubStation Alpha subtitles.
 
-**Menu:** `ASSA` → `Draw...`
+**Menu:** `ASSA tools` → `Draw...`
 
 ![ASSA Draw Screenshot](../screenshots/assa-draw.png)
 
 ## How to Use
 
-1. Go to **ASSA** → **Draw...** to open the drawing canvas.
-2. Select a drawing tool (Line, Bézier curve, etc.) from the toolbar.
+1. Go to **ASSA tools** → **Draw...** to open the drawing canvas.
+2. Select a drawing tool (Line, Bézier curve, Rectangle, Circle, etc.) from the toolbar.
 3. Click on the canvas to create points and shapes.
 4. Use the shape tree on the side to manage layers and shapes.
 5. Adjust individual point coordinates for precise positioning.
@@ -19,9 +19,12 @@ A vector drawing tool for creating ASSA drawing commands (\p1 ... \p0) used in A
 ## Features
 
 ### Drawing Tools
+- **Select:** Selection/move tool for picking and dragging existing shapes and points.
 - **Line:** Draw straight line segments.
 - **Bézier Curve:** Draw smooth curves with control points.
-- **Eraser:** Remove shapes or points.
+- **Rectangle:** Draw rectangles.
+- **Circle:** Draw circles/ellipses.
+- **Color Picker:** Pick a color from the canvas.
 
 ### Canvas
 - Configurable canvas size (default 1920×1080).

--- a/docs/features/assa-image-color-picker.md
+++ b/docs/features/assa-image-color-picker.md
@@ -2,14 +2,14 @@
 
 Pick colors directly from a video frame screenshot for use in ASSA subtitle styles and override tags.
 
-**Menu:** `ASSA` → `Image Color Picker...`
+**Menu:** `ASSA tools` → `Image color picker...`
 
 ![ASSA Image Color Picker Screenshot](../screenshots/assa-image-color-picker.png)
 
 ## How to Use
 
 1. Load a video and select a subtitle line.
-2. Go to **ASSA** → **Image Color Picker...** to open the color picker.
+2. Go to **ASSA tools** → **Image color picker...** to open the color picker.
 3. A screenshot of the current video frame is displayed.
 4. Move the mouse over the image — the current color under the cursor is shown in real time.
 5. Click on the image to select a color.

--- a/docs/features/assa-override-tags.md
+++ b/docs/features/assa-override-tags.md
@@ -1,8 +1,8 @@
-# ASSA Apply Custom Override Tags
+# ASSA Apply Override Tags
 
-Apply custom ASSA override tags to subtitle lines with a live video preview.
+Apply ASSA override tags to subtitle lines with a live video preview.
 
-**Menu:** `ASSA` → `Apply Custom Override Tags...`
+**Menu:** `ASSA tools` → `Apply override tags...`
 
 ![ASSA Override Tags Screenshot](../screenshots/assa-override-tags.png)
 
@@ -10,7 +10,7 @@ Apply custom ASSA override tags to subtitle lines with a live video preview.
 
 1. Load a video and subtitle file in ASSA format.
 2. Optionally select specific subtitle lines to apply tags to.
-3. Go to **ASSA** → **Apply Custom Override Tags...** to open the dialog.
+3. Go to **ASSA tools** → **Apply override tags...** to open the dialog.
 4. Select an override tag from the list or enter a custom tag.
 5. Choose the scope: all lines, selected lines, or selected lines and forward.
 6. Preview the result in the built-in video player.

--- a/docs/features/assa-progress-bar.md
+++ b/docs/features/assa-progress-bar.md
@@ -2,14 +2,14 @@
 
 Generate an animated progress bar overlay in ASSA format, with optional chapter markers.
 
-**Menu:** `ASSA` → `Progress Bar...`
+**Menu:** `ASSA tools` → `Generate progress bar...`
 
 ![ASSA Progress Bar Screenshot](../screenshots/assa-progress-bar.png)
 
 ## How to Use
 
 1. Load a video and subtitle file in ASSA format.
-2. Go to **ASSA** → **Progress Bar...** to open the progress bar dialog.
+2. Go to **ASSA tools** → **Generate progress bar...** to open the progress bar dialog.
 3. Configure the bar position, height, colors, and corner style.
 4. Optionally add chapter markers with text labels.
 5. Preview the result in the built-in video player.

--- a/docs/features/assa-properties.md
+++ b/docs/features/assa-properties.md
@@ -2,14 +2,14 @@
 
 Edit the script info header properties of an Advanced SubStation Alpha (ASS/SSA) subtitle file.
 
-**Menu:** `ASSA` → `Properties...`
+**Menu:** `ASSA tools` → `Properties...`
 
 ![ASSA Properties Screenshot](../screenshots/assa-properties.png)
 
 ## How to Use
 
 1. Open a subtitle file in ASS/SSA format.
-2. Go to **ASSA** → **Properties...** to open the properties dialog.
+2. Go to **ASSA tools** → **Properties...** to open the properties dialog.
 3. Edit the script info fields as needed.
 4. Set the video resolution (PlayResX / PlayResY) — use **Get resolution from current video** if a video is loaded.
 5. Choose a wrap style and border/shadow scaling mode.

--- a/docs/features/assa-resolution-resampler.md
+++ b/docs/features/assa-resolution-resampler.md
@@ -2,14 +2,14 @@
 
 Resample ASSA subtitle styles and positions from one video resolution to another, so subtitles look correct at a different resolution.
 
-**Menu:** `ASSA` → `Resolution Resampler...`
+**Menu:** `ASSA tools` → `Change resolution...`
 
 ![ASSA Resolution Resampler Screenshot](../screenshots/assa-resolution-resampler.png)
 
 ## How to Use
 
 1. Open a subtitle file in ASS/SSA format.
-2. Go to **ASSA** → **Resolution Resampler...** to open the resampler dialog.
+2. Go to **ASSA tools** → **Change resolution...** to open the resampler dialog.
 3. The **Source resolution** is read from the subtitle header (PlayResX / PlayResY).
 4. Set the **Target resolution** — if a video is loaded, it is used as the default.
 5. Choose which elements to resample (margins, font sizes, positions, drawings).

--- a/docs/features/assa-set-background.md
+++ b/docs/features/assa-set-background.md
@@ -2,14 +2,14 @@
 
 Add styled background boxes behind subtitle text using ASSA drawing commands.
 
-**Menu:** `ASSA` → `Set Background Box...`
+**Menu:** `ASSA tools` → `Generate background boxes...`
 
 ![ASSA Set Background Screenshot](../screenshots/assa-set-background.png)
 
 ## How to Use
 
 1. Load a video and subtitle file in ASSA format.
-2. Go to **ASSA** → **Set Background Box...** to open the background dialog.
+2. Go to **ASSA tools** → **Generate background boxes...** to open the background dialog.
 3. Configure the background box style — shape, colors, padding, and outline.
 4. Preview the result in the built-in video player.
 5. Click **OK** to apply the background box to your subtitle.
@@ -20,6 +20,7 @@ Add styled background boxes behind subtitle text using ASSA drawing commands.
 - **Square corners:** Rectangular background box.
 - **Rounded corners:** Background box with configurable corner radius.
 - **Circle:** Circular background shape.
+- **Spikes**, **Bubbles**, **Wave**, **Hexagon**, **Torn paper**, **Cloud**, **Torn paper (double)**, **Starburst**, **Scroll:** Additional decorative box shapes.
 
 ### Padding
 - Configure left, right, top, and bottom padding independently.

--- a/docs/features/assa-set-position.md
+++ b/docs/features/assa-set-position.md
@@ -2,14 +2,14 @@
 
 Visually position subtitles on screen by dragging them over a video screenshot, generating the appropriate ASSA \pos override tag.
 
-**Menu:** `ASSA` → `Set Position...`
+**Menu:** `ASSA tools` → `Set position...`
 
 ![ASSA Set Position Screenshot](../screenshots/assa-set-position.png)
 
 ## How to Use
 
 1. Load a video and select a subtitle line.
-2. Go to **ASSA** → **Set Position...** to open the positioning dialog.
+2. Go to **ASSA tools** → **Set position...** to open the positioning dialog.
 3. A screenshot of the current video frame is shown with the subtitle text overlaid.
 4. Drag the subtitle text to the desired position on the screen.
 5. The position coordinates update in real time.

--- a/docs/features/assa-styles.md
+++ b/docs/features/assa-styles.md
@@ -2,14 +2,14 @@
 
 Manage Advanced SubStation Alpha (ASS/SSA) subtitle styles, including file styles and storage (template) styles.
 
-**Menu:** `ASSA` → `Styles...`
+**Menu:** `ASSA tools` → `Styles...`
 
 ![ASSA Styles Screenshot](../screenshots/assa-styles.png)
 
 ## How to Use
 
 1. Open a subtitle file in ASS/SSA format (or convert your current subtitle to ASSA format).
-2. Go to **ASSA** → **Styles...** to open the styles manager.
+2. Go to **ASSA tools** → **Styles...** to open the styles manager.
 3. The left panel shows **File Styles** (styles in the current subtitle), and the right panel shows **Storage Styles** (reusable template styles).
 4. Select a style to view and edit its properties — font, colors, border, shadow, alignment, margins, and more.
 5. Use the preview area to see how your style looks.

--- a/docs/features/audio-visualizer.md
+++ b/docs/features/audio-visualizer.md
@@ -21,7 +21,6 @@ The spectrogram can be generated and toggled independently of the waveform. If y
 | **Scroll wheel** | Scroll waveform left/right |
 | **Alt+Scroll wheel** | Horizontal zoom in/out |
 | **Shift+Scroll wheel** | Vertical zoom in/out |
-| **Middle-click drag** | Pan the waveform |
 
 ### Subtitle Timing
 
@@ -41,7 +40,7 @@ The spectrogram can be generated and toggled independently of the waveform. If y
 
 | Mouse Action | Effect |
 |--------------|--------|
-| **Click+Drag** in empty area | Create a new subtitle with the selected time range |
+| **Click+Drag** in empty area | Mark a new subtitle range; press **Enter** to insert it (Escape cancels) |
 
 ## Keyboard Shortcuts (Waveform)
 

--- a/docs/features/auto-translate.md
+++ b/docs/features/auto-translate.md
@@ -37,6 +37,7 @@ Automatically translate subtitles using various translation engines and AI servi
 - **Google Gemini** — AI translation (requires API key)
 - **NVIDIA** — AI translation (requires API key)
 - **Mistral AI Translate** — AI translation (requires API key)
+- **DeepSeek** — AI translation (requires API key)
 - **Papago Translate** — Naver Papago translation (requires API key)
 - **thammegowda-nllb-serve** — Self-hosted NLLB (No Language Left Behind) server
 - **winstxnhdw-nllb-api** — NLLB (No Language Left Behind) API

--- a/docs/features/batch-convert.md
+++ b/docs/features/batch-convert.md
@@ -39,15 +39,15 @@ You can chain multiple conversion functions:
 
 Batch Convert can OCR image-based subtitle files while converting them to text-based formats.
 
-Supported OCR workflows include:
+Supported OCR engines in Batch Convert:
 
+- nOcr
+- BinaryOcr
 - Tesseract
-- nOCR
-- Binary OCR
-- Ollama OCR
-- PaddleOCR
+- Ollama
+- PaddleOCR (Windows and Linux only)
 
-Subtitle Edit 5 can auto-detect language and pixels-are-space settings for nOCR/Binary OCR in many batch workflows. This reduces the amount of manual setup needed when converting many image-based subtitle files with similar fonts.
+Subtitle Edit 5 can auto-detect language and pixels-are-space settings for nOcr/BinaryOcr in many batch workflows. This reduces the amount of manual setup needed when converting many image-based subtitle files with similar fonts.
 
 ## Speech to Text in Batch Mode
 

--- a/docs/features/blank-video.md
+++ b/docs/features/blank-video.md
@@ -19,18 +19,14 @@ Generate a blank video file for testing or subtitle preview purposes.
 
 ## Background Options
 
-- **Checked image** — Classic checkered pattern (useful for transparency testing)
+- **Checkered image** — Classic checkered pattern (useful for transparency testing)
 - **Solid color** — A single flat color background
-- **Background image** — Use a custom image file as the background
+- **Image** — Use a custom image file as the background
 
 ## Additional Options
 
 - **Generate time codes** — Burn time code display into the video
-- **Use source resolution** — Match resolution from an existing video
-
-## Batch Mode
-
-Multiple blank videos can be queued as jobs for batch generation.
+- **Use source resolution** — Match resolution from an existing video (picked via the resolution browse button)
 
 ## Keyboard Shortcuts
 

--- a/docs/features/bridge-gaps.md
+++ b/docs/features/bridge-gaps.md
@@ -9,7 +9,8 @@ Extend subtitle durations to fill gaps between consecutive subtitles.
 
 ## Options
 
-- **Maximum gap to bridge** — Only bridge gaps smaller than this value
-- **Minimum gap after bridge** — Maintain at least this much gap
-- **Extend previous subtitle** — Extend the end of the previous subtitle
-- Preview affected lines before applying
+- **Bridge gaps smaller than** — Only bridge gaps smaller than this value
+- **Min. gap** — Keep at least this much gap between the bridged subtitles
+- **Percent for previous** — How much of the gap is given to the previous subtitle (the rest goes to the next subtitle)
+
+Values are entered in milliseconds, or in frames when the global *Use time format HH:MM:SS:FF* setting is enabled. The preview updates live and the status text shows the number of bridged gaps.

--- a/docs/features/burn-in.md
+++ b/docs/features/burn-in.md
@@ -2,7 +2,7 @@
 
 Hardcode (burn-in) subtitles permanently into a video file using FFmpeg.
 
-- **Menu:** Video → Burn-in subtitles...
+- **Menu:** Video → Generate video with burned-in subtitles...
 - **Shortcut:** Configurable
 
 <!-- Screenshot: Burn-in subtitles window -->
@@ -10,7 +10,7 @@ Hardcode (burn-in) subtitles permanently into a video file using FFmpeg.
 
 ## How to Use
 
-1. Open **Video → Burn-in subtitles...**
+1. Open **Video → Generate video with burned-in subtitles...**
 2. Select or confirm the video file
 3. Configure font settings (name, size, colors, outline, shadow)
 4. Configure video encoding settings (encoder, preset, CRF, pixel format)

--- a/docs/features/change-casing.md
+++ b/docs/features/change-casing.md
@@ -10,13 +10,15 @@ Fix the casing (capitalization) of subtitle text.
 ## Options
 
 - **Normal casing** — Capitalize first letter of each sentence
-- **Fix names** — Capitalize proper names (using a names list)
+  - **Fix names** — Also capitalize proper names using a names list
+  - **Only fix uppercase lines** — Only apply the change to lines that are entirely uppercase
+- **Fix names only** — Only fix the casing of proper names; leave other text untouched
 - **All uppercase** — Convert all text to uppercase
 - **All lowercase** — Convert all text to lowercase
 
 ## Fix Names
 
-The Fix Names feature uses a customizable list of proper names to ensure correct capitalization.
+When **Fix names** (or **Fix names only**) is selected, a follow-up window lists the proposed name fixes so you can include or exclude individual items before applying.
 
 <!-- Screenshot: Fix names window -->
 ![Fix Names](../screenshots/fix-names.png)

--- a/docs/features/change-formatting.md
+++ b/docs/features/change-formatting.md
@@ -9,6 +9,8 @@ Add or remove formatting (bold, italic, underline, etc.) from subtitle text.
 
 ## Options
 
-- **Remove formatting** — Strip selected formatting types
-- **Add formatting** — Apply formatting to all selected lines
-- Supports italic, bold, underline, and other formatting tags
+- **From** — The formatting type to convert from: Italic, Bold, Underline, or Color
+- **To** — The formatting type to convert to: Italic, Bold, Underline, or Color
+- **Color** — When *To* is Color, the color to apply (color picker)
+
+All matching subtitles are shown in a preview list with **Before** and **After** columns before any changes are applied.

--- a/docs/features/change-frame-rate.md
+++ b/docs/features/change-frame-rate.md
@@ -16,3 +16,5 @@ Convert subtitle timings from one frame rate to another.
 - 30
 - 50 (PAL interlaced)
 - 59.94 (NTSC interlaced)
+
+The window remembers its size and position between sessions.

--- a/docs/features/change-speed.md
+++ b/docs/features/change-speed.md
@@ -11,3 +11,5 @@ Adjust subtitle timings for videos with different playback speeds.
 
 - Converting between PAL (25fps) and NTSC (23.976fps) video speeds
 - Adjusting for speed-up or slow-down transfers
+
+The window remembers its size and position between sessions.

--- a/docs/features/compare.md
+++ b/docs/features/compare.md
@@ -10,13 +10,13 @@ Compare two subtitle files side by side to identify differences in text, timing,
 
 1. Go to **File** → **Compare...** to open the compare dialog.
 2. The left panel shows the currently loaded subtitle.
-3. Use **Open** to load a second subtitle file into the right panel.
+3. Use the file picker on either side (or drag-and-drop) to load a second subtitle file.
 4. Differences are highlighted with colors:
-   - **Red:** Lines that were removed or changed.
-   - **Green:** Lines that were added.
-   - **Yellow/Orange:** Lines with modifications.
-5. Click on a difference to see the details.
-6. Use the options to refine the comparison.
+   - **Red:** Lines present in only one side (added or removed).
+   - **Green:** Cells where the start time, end time, or text differs.
+   - **Orange:** Cells where the line number differs.
+5. Use **Previous difference** / **Next difference** to jump between differing rows.
+6. Use the options and view dropdown to refine the comparison.
 
 ## Features
 
@@ -27,11 +27,11 @@ Compare two subtitle files side by side to identify differences in text, timing,
 ### Visual Comparison
 - Side-by-side subtitle display with synchronized scrolling.
 - Color-coded differences for easy identification.
-- Multiple comparison views available.
+- View modes: **Show all**, **Show only differences**, **Show only differences in text**.
 
 ### Actions
-- **Reload from file:** Reload the subtitle files from disk.
-- **Export:** Export the comparison results.
+- **Reload right from file:** Reload the right pane from the same file as the left pane (useful for diffing in-memory edits against the saved file).
+- **Export:** Export the comparison as an HTML file.
 
 ## Keyboard Shortcuts
 

--- a/docs/features/copy-paste-translate.md
+++ b/docs/features/copy-paste-translate.md
@@ -11,19 +11,19 @@ Translate subtitles by copying text blocks for translation in an external tool, 
 ## How to Use
 
 1. Open **Auto translate → Copy/paste translate...**
-2. Set the **Max block size** — maximum number of lines per block
-3. Set the **Line separator** — character(s) separating lines in the copied text
-4. Click **Copy** to copy the next block of subtitle text to the clipboard
+2. Set the **Max block size** — maximum block size in characters
+3. Set the **Line separator** — character(s) used between subtitle lines in the copied text
+4. Click **Translate** to start; the next block of subtitle text is copied to the clipboard
 5. Paste the text into your preferred translation tool (e.g., Google Translate, DeepL website)
 6. Copy the translated text
-7. Click **Paste** to paste the translated text back
+7. Paste the translated text back into the dialog and confirm
 8. Repeat for all blocks
 9. Click **OK** to apply all translations
 
 ## Settings
 
-- **Max block size** — Controls how many subtitle lines are copied at once (smaller blocks give more accurate translations)
-- **Line separator** — The separator between lines in the clipboard text (default: `.`)
+- **Max block size** — Maximum number of characters per block (default 5000, range 100–500,000). Smaller blocks generally give more reliable translations.
+- **Line separator** — The separator inserted between subtitle lines in the clipboard text (default: `(...)`)
 
 ## Keyboard Shortcuts
 

--- a/docs/features/cut-video.md
+++ b/docs/features/cut-video.md
@@ -12,28 +12,28 @@ Cut segments from a video file using an audio visualizer and video player.
 
 1. Open **Video → Cut video...**
 2. The video is loaded with the audio visualizer
-3. Define cut segments by setting start and end points
-4. Choose the cut type (keep or remove selected segments)
-5. Select the output format and settings
+3. Define segments by adding entries and setting their start/end points
+4. Choose the cut type (cut or merge segments)
+5. Select the output container extension
 6. Click **Generate** to create the cut video
 
 ## Segment Controls
 
-- **Set start** — Set the start point of a segment at the current video position
-- **Set end** — Set the end point of a segment at the current video position
+- **Add** — Add a new segment
+- **Set start** — Set the start point of the selected segment at the current video position
+- **Set end** — Set the end point of the selected segment at the current video position
 - **Delete** — Remove the selected segment
+- **Import...** — Import segments from a file, or use the split-button menu to import from the current subtitle
 - The segment list shows all defined cut points
 
 ## Cut Types
 
-- **Keep selected segments** — Output only the selected portions
-- **Remove selected segments** — Output everything except the selected portions
+- **Cut segments** — Output only the selected segments
+- **Merge segments** — Concatenate the selected segments into a single output file
 
 ## Video Settings
 
-- **Resolution** — Output video width and height
-- **Frame rate** — Output frame rate
-- **Video extension** — Output container format
+- **Video extension** — Output container format (`.mkv`, `.mp4`, `.webm`, `.mp3`, `.wav`)
 
 ## Audio Visualizer
 
@@ -44,4 +44,5 @@ The built-in audio visualizer helps you precisely identify cut points by showing
 | Key | Action |
 |-----|--------|
 | Escape | Close / Cancel |
+| Space | Toggle video play/pause |
 | F1 | Open help |

--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -29,9 +29,8 @@ Search for text in the subtitle.
 - **Find previous:** `Shift+F3`
 
 Options:
-- Case sensitive
-- Whole word
-- Regular expressions
+- Whole word (checkbox)
+- Search type (radio buttons): Case sensitive, Case insensitive, or Regular expression
 
 <!-- Screenshot: Find window -->
 ![Find](../screenshots/find.png)

--- a/docs/features/embedded-subtitles.md
+++ b/docs/features/embedded-subtitles.md
@@ -2,14 +2,18 @@
 
 Add, remove, preview, and edit subtitle tracks embedded in a video file.
 
-- **Menu:** Video → More → Add/remove embedded subtitles...
+- **Menu:** Video → Add/remove embedded subtitles...
 
 ## Supported Video Files
 
-The embedded subtitle editor currently supports editing subtitle tracks in Matroska containers:
+The embedded subtitle editor edits subtitle tracks in Matroska containers:
 
 - `.mkv`
 - `.webm`
+
+Subtitle tracks can also be inspected from MP4-style containers (`.mp4`, `.m4v`, `.mov`), but the editor warns when the loaded file cannot be edited as a Matroska container.
+
+Embedded subtitle reading supports a range of sources elsewhere in Subtitle Edit, including PGS/VobSub/DVB image tracks in Matroska, MP4-embedded VobSub/WebVTT, and CEA-708 (DTVCC) captions carried in H.264 SEI messages inside MP4.
 
 FFmpeg is required. If FFmpeg is not available, Subtitle Edit will prompt you to install or configure it before generating the output video.
 
@@ -28,7 +32,7 @@ FFmpeg is required. If FFmpeg is not available, Subtitle Edit will prompt you to
 
 1. Open a video file.
 2. Open or create the subtitle you want to embed.
-3. Select **Video → More → Add/remove embedded subtitles...**.
+3. Select **Video → Add/remove embedded subtitles...**.
 4. Click **Add current**.
 5. Edit the track metadata if needed.
 6. Click **Generate** and choose an output file name.
@@ -37,7 +41,7 @@ If the current subtitle format is not suitable for Matroska embedding, Subtitle 
 
 ## Add an External Subtitle File
 
-1. Open **Video → More → Add/remove embedded subtitles...**.
+1. Open **Video → Add/remove embedded subtitles...**.
 2. Click **Add**.
 3. Choose a subtitle file.
 4. Review the detected language and title.

--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -132,7 +132,3 @@ Restore a previously auto-saved backup of a subtitle file.
 ## Open Containing Folder
 
 Open the folder containing the current subtitle file in the file manager.
-
-## Open Data Folder
-
-Open the Subtitle Edit data/settings folder.

--- a/docs/features/find-double-words.md
+++ b/docs/features/find-double-words.md
@@ -10,11 +10,11 @@ Find and fix repeated/double words in subtitle text (e.g., "the the").
 
 ## How to Use
 
-1. Open **Spell check → Find double words**
+1. Open **Spell check → Find double words...**
 2. The tool scans all subtitle lines for consecutive repeated words
-3. Each occurrence is listed with the line number and the repeated word
-4. Click on an entry to navigate to the subtitle line
-5. Fix the text manually or use the provided actions
+3. Each occurrence is listed with the line number, the subtitle text, and the repeated word
+4. Select a row and click **Go to**, press **Enter**, or double-click to jump to that subtitle in the main grid
+5. Edit the text manually in the main window
 
 ## What It Detects
 

--- a/docs/features/fix-common-errors.md
+++ b/docs/features/fix-common-errors.md
@@ -22,33 +22,49 @@ Automatically detect and fix common subtitle errors.
 1. Open **Tools → Fix common errors...**
 2. Select the language for language-specific rules
 3. Check/uncheck the rules you want to apply
-4. Click **Next** to see the proposed fixes
+4. Click **Go to apply fixes** to see the proposed fixes
 5. Review each fix and check/uncheck individual items
 6. Click **Apply selected fixes**
 
 ## Available Fixes
 
 Common fixes include:
-- Remove empty lines
-- Remove lines with only a period
+- Remove empty lines / unused line breaks
 - Fix overlapping display times
 - Fix short display times
 - Fix long display times
+- Fix short gaps
 - Fix invalid italic tags
-- Fix unbalanced bold/italic tags
-- Fix missing periods at end of lines
+- Remove unneeded spaces
 - Fix missing spaces
-- Fix double spaces
-- Fix short lines that can be merged
-- Remove blank lines between subtitles
-- Fix music symbols
-- Fix ellipsis notation
-- And many more...
+- Remove unneeded periods
+- Fix commas
+- Break long lines
+- Remove line breaks in short lines (text length / pixel width)
+- Fix double apostrophes (`''` → `"`)
+- Fix music notation
+- Add missing periods at end of lines
+- Start with uppercase letter after paragraph / period / colon
+- Add missing quotes
+- Break dialogs on one line
+- Fix hyphens / dashes in dialog
+- Fix 3+ lines
+- Fix double dash (`--` → `…`)
+- Fix double greater-than (`>>`)
+- Fix continuation style
+- Fix missing open bracket (e.g. `(`, `[`)
+- Fix common OCR errors
+- Fix uppercase `I` inside lowercase words
+- Remove space between numbers
+- Remove dialog dash on first line of non-dialog
+- Normalize strings (Unicode normalization)
+
+Additional language-specific rules are added when applicable (e.g. lowercase `i` → uppercase `I` for English, Turkish ANSI → Unicode, Danish letter `i`, inverted `¿`/`¡` for Spanish).
 
 ## Profiles
 
 You can save different sets of fix rules as profiles for different workflows (e.g., broadcast, streaming, fansubbing).
 
-- **Save profile** — Save current rule selections
-- **Load profile** — Load a previously saved profile
+- Pick the active profile from the **Profile** combo box at the top of the window
+- Click the **...** button next to the combo box to add, rename, delete, import, or export profiles
 

--- a/docs/features/join-subtitles.md
+++ b/docs/features/join-subtitles.md
@@ -9,7 +9,9 @@ Join multiple subtitle files into a single file.
 
 ## How to Use
 
-1. Add subtitle files to join
-2. Arrange them in the desired order
-3. Set time offsets if needed
-4. Click **OK** to join them
+1. Click **New** to add subtitle files (or drag-and-drop them onto the file list).
+2. Reorder, remove, or clear files as needed.
+3. Choose how to handle time codes:
+   - **Keep time codes** — Use the existing time codes from each file as-is.
+   - **Append time codes** — Shift each file so it starts after the previous one, with an optional **Add ms after each file** offset.
+4. Click **Join** to merge them into the current subtitle.

--- a/docs/features/main-window.md
+++ b/docs/features/main-window.md
@@ -21,13 +21,14 @@ The menu bar provides access to all features organized into categories:
 | **File** | New, Open, Save, Import, Export, Compare, Statistics |
 | **Edit** | Undo, Redo, Find, Replace, Multiple Replace, Modify Selection |
 | **Tools** | Fix Common Errors, Batch Convert, Change Casing, Merge/Split, etc. |
-| **Spell check** | Spell checking, dictionaries, find double words |
+| **Plugins** | Run installed plugins; manage installed plugins |
+| **Spell check** | Spell checking, dictionaries, find double words / lines |
 | **Video** | Open/close video, Speech to Text, Text to Speech, Burn-In, etc. |
 | **Sync** | Adjust All Times, Visual Sync, Point Sync, Change Frame Rate/Speed |
 | **Translate** | Auto Translate, Copy/Paste Translate |
-| **ASSA** | Styles, Properties, Attachments, Drawing, Positioning, etc. |
 | **Options** | Settings, Shortcuts, Word Lists, Language |
-| **Help** | About |
+| **Help** | Check for updates, Help, About |
+| **ASSA tools** | Styles, Properties, Attachments, Drawing, Positioning, etc. (only visible when an ASSA/SSA subtitle is loaded) |
 
 See the individual [feature pages](../index.md) for details on each menu item.
 
@@ -36,7 +37,7 @@ See the individual [feature pages](../index.md) for details on each menu item.
 
 ### 2. Toolbar
 
-The toolbar provides quick one-click access to the most common actions. You can customize which buttons appear in **Options → Settings → Appearance → Toolbar**.
+The toolbar provides quick one-click access to the most common actions. You can customize which buttons appear in **Options → Settings → Toolbar**.
 
 Available toolbar buttons include:
 
@@ -282,7 +283,7 @@ The status bar at the bottom shows:
 
 ## Layouts
 
-Subtitle Edit offers **12 predefined layouts** for arranging the main window areas. Choose a layout via **Options → Choose layout** or the keyboard shortcut.
+Subtitle Edit offers **12 predefined layouts** for arranging the main window areas. Choose a layout via the **Layout** button on the toolbar or the configurable keyboard shortcut.
 
 | Layout | Description |
 |--------|-------------|

--- a/docs/features/merge-same-text.md
+++ b/docs/features/merge-same-text.md
@@ -1,8 +1,15 @@
 # Merge Lines with Same Text
 
-Merge subtitle lines that have identical text content.
+Merge consecutive subtitle lines that have identical text content into one entry covering the combined time span.
 
 - **Menu:** Tools → Merge lines with same text...
 
 <!-- Screenshot: Merge same text window -->
 ![Merge Same Text](../screenshots/merge-same-text.png)
+
+## Options
+
+- **Max ms between lines** — Only merge lines that are at most this many milliseconds apart
+- **Include incrementing lines** — Also merge sequences where the text increments (e.g. countdowns or revealing text)
+
+The preview updates live; uncheck any group in the list to exclude it before clicking **OK**.

--- a/docs/features/merge-same-timecodes.md
+++ b/docs/features/merge-same-timecodes.md
@@ -1,8 +1,16 @@
 # Merge Lines with Same Time Codes
 
-Merge subtitle lines that share identical start and end times.
+Merge consecutive subtitle lines whose start and end times are (almost) identical into one entry that combines the texts.
 
 - **Menu:** Tools → Merge lines with same time codes...
 
 <!-- Screenshot: Merge same time codes window -->
 ![Merge Same Time Codes](../screenshots/merge-same-timecodes.png)
+
+## Options
+
+- **Max ms difference** — Maximum difference in start and end times that still counts as "same time codes"
+- **Make dialog** — Format the merged text as a two-speaker dialog (using the dash style from General settings)
+- **Auto break** — Re-break the merged text into balanced lines
+
+The preview updates live; uncheck any group in the list to exclude it before clicking **OK**.

--- a/docs/features/merge-short-lines.md
+++ b/docs/features/merge-short-lines.md
@@ -9,6 +9,8 @@ Merge consecutive short subtitle lines into single lines.
 
 ## Options
 
-- **Maximum characters** — Maximum total character count for merged lines
-- **Only merge continuation lines** — Only merge lines that are continuations
-- Preview affected lines before applying
+- **Single line max length** — Maximum character count allowed for a single merged line
+- **Max number of lines** — Maximum number of lines (1-10) the merged subtitle may span
+- **Highlight parts** — Highlight which portion of the merged text came from which source line
+
+The preview list updates live and shows all proposed merges.

--- a/docs/features/netflix-errors.md
+++ b/docs/features/netflix-errors.md
@@ -13,6 +13,7 @@ The checker can report common Netflix delivery issues, including:
 - maximum line length
 - maximum number of lines
 - minimum two-frame gaps
+- bridge short gaps
 - shot change rules
 - dialog hyphen spacing
 - ellipsis style
@@ -20,7 +21,8 @@ The checker can report common Netflix delivery issues, including:
 - allowed glyphs
 - italics rules
 - HI/sound-effect bracket style
-- numbers that should be spelled out
+- numbers 1–10 that should be spelled out
+- numbers at the start of a subtitle that should be spelled out
 - Timed Text frame-rate issues
 
 ## How to Use

--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -2,7 +2,7 @@
 
 Subtitle Edit can convert image-based subtitle formats to text using OCR.
 
-- **Menu:** File → Import image subtitle for edit (OCR)...
+- **Menu:** File → Import → Imaged-based subtitle for OCR...
 
 <!-- Screenshot: OCR window -->
 ![OCR Window](../screenshots/ocr.png)
@@ -37,44 +37,39 @@ Binary image comparison engine.
 - Fast and accurate for known fonts
 - Supports database editing, character history, max error percentage, and pixels-are-space tuning
 
-### Google Lens OCR
-Cloud-based OCR using Google Lens.
-- Requires internet connection
+### Google Lens Sharp / Google Lens Standalone
+Cloud-based OCR using Google Lens (free, but capped).
+- Requires internet connection.
+- The Standalone variant is Windows-only.
 
-### Google Vision OCR
+### Google Vision
 Cloud-based OCR using Google Cloud Vision API.
 - Requires API key
 
-### Ollama OCR
-Local LLM-based OCR using Ollama.
-- Requires Ollama installation
+### Ollama
+Local LLM-based OCR via an Ollama server (e.g. with a vision model).
+- Default endpoint: `http://localhost:11434/api/chat`
 
-### Llama.cpp OCR
-Local LLM-based OCR using a llama.cpp-compatible workflow.
+### llama.cpp
+Local LLM-based OCR using a llama.cpp-compatible server.
+- Default endpoint: `http://127.0.0.1:8080/v1/chat/completions`
 
 ### Mistral OCR
 Cloud-based OCR using Mistral API.
 - Requires a Mistral API key
 
-### PaddleOCR
+### Paddle OCR Standalone / Paddle OCR Python
 Local OCR engine.
-- Download required
-
-### Azure Vision OCR
-Cloud-based OCR using Azure AI Vision.
-- Requires Azure credentials
-
-### Amazon Rekognition OCR
-Cloud-based OCR using Amazon Rekognition.
-- Requires AWS credentials
+- Standalone (downloadable CPU/GPU builds) is available on Windows and Linux.
+- The Python variant works anywhere a Paddle OCR Python install is available.
 
 ## Engine Setup Notes
 
 - **nOCR** databases are stored in the Subtitle Edit OCR folder and can be created, renamed, edited, and deleted from the OCR window.
 - **Binary OCR** databases use image comparison and are edited separately from nOCR databases.
 - **PaddleOCR** can download standalone CPU/GPU builds and support files on Windows and Linux, or use a Python installation.
-- **Ollama OCR** and **Llama.cpp OCR** are useful when you want local AI-based OCR and have a vision-capable model available.
-- **Mistral OCR**, **Google Vision**, **Azure Vision**, and **Amazon Rekognition** require cloud credentials.
+- **Ollama** and **llama.cpp** are useful when you want local AI-based OCR and have a vision-capable model available.
+- **Mistral OCR** and **Google Vision** require cloud credentials.
 
 ## How to Use
 

--- a/docs/features/point-sync-via-other.md
+++ b/docs/features/point-sync-via-other.md
@@ -14,3 +14,5 @@ Synchronize a subtitle file using another subtitle file as reference.
 3. Select the reference subtitle file
 4. Match corresponding lines between the two files
 5. Click **OK** to apply
+
+The window remembers its size and position between sessions.

--- a/docs/features/point-sync.md
+++ b/docs/features/point-sync.md
@@ -10,8 +10,8 @@ Synchronize subtitles using multiple reference points.
 ## How to Use
 
 1. Open **Sync → Point sync...**
-2. For each sync point, match a subtitle line to its correct video position
-3. Add as many sync points as needed for accuracy
+2. Select a subtitle line in the list and click **Set sync point** to set its correct video position
+3. Repeat for additional sync points as needed for accuracy
 4. Click **OK** to apply
 
-More sync points provide better accuracy for subtitles with non-linear drift.
+More sync points provide better accuracy for subtitles with non-linear drift. The window remembers its size and position between sessions.

--- a/docs/features/re-encode-video.md
+++ b/docs/features/re-encode-video.md
@@ -11,23 +11,15 @@ Re-encode a video file with different resolution, frame rate, or container forma
 ## How to Use
 
 1. Open **Video → Re-encode video...**
-2. Select or confirm the input video file
-3. Set the output resolution (or use source resolution)
-4. Select the output frame rate
-5. Select the output container format (`.mkv`, `.mp4`, `.webm`)
-6. Click **Generate** to start re-encoding
+2. Select the output frame rate
+3. Select the output container format (`.mkv`, `.mp4`, `.webm`)
+4. Click **Generate** to start re-encoding (or use the **Generate** split-button menu to prompt for FFmpeg parameters before encoding)
 
 ## Options
 
-- **Resolution** — Output video width and height
-- **Use source resolution** — Keep the original video resolution
 - **Frame rate** — Output frame rate
 - **Video extension** — Output container format
-- **Prompt for FFmpeg parameters** — Edit the FFmpeg command line before encoding
-
-## Batch Mode
-
-Multiple re-encoding jobs can be queued for batch processing.
+- **Prompt for FFmpeg parameters and generate** — Edit the FFmpeg command line before encoding (available from the **Generate** split-button menu)
 
 ## Keyboard Shortcuts
 

--- a/docs/features/remove-text-hi.md
+++ b/docs/features/remove-text-hi.md
@@ -9,19 +9,34 @@ Remove hearing-impaired annotations such as speaker names, sound descriptions, a
 
 ## Options
 
-- **Remove text in brackets** — `[sound effect]`
-- **Remove text in parentheses** — `(laughing)`
-- **Remove text before colon** — `Speaker:`
-- **Remove music symbols** — `♪ Music ♪`
-- **Remove interjections** — Common interjections like "hmm", "uh", etc.
+### Remove text between
+
+- **[ ]** — Remove text inside square brackets, e.g. `[sound effect]`
+- **{ }** — Remove text inside curly brackets
+- **( )** — Remove text inside parentheses, e.g. `(laughing)`
+- **Custom** — Remove text between any custom start and end characters
+- **Only on separate lines** — Only remove the text when it sits on a line of its own
+
+### Remove text before colon
+
+- **Remove text before colon** — Remove speaker labels like `SPEAKER:`
+- **Only if text is uppercase** — Only remove when the label is in uppercase
+- **Only on separate lines** — Only remove when the label is on a line by itself
+
+### Other
+
+- **If line is uppercase** — Remove the whole line when it is entirely uppercase
+- **If line contains** — Remove the line when it contains a given substring
+- **If line only contains music symbols** — Remove lines that consist only of music symbols (e.g. `♪ Music ♪`)
+- **Remove interjections** — Remove common interjections like "hmm", "uh"; the dictionary used follows the selected **Language**
 
 ## Interjections
 
-You can customize the list of interjections to remove. Click **Edit interjections...** to modify the list.
+Click **Edit** next to *Remove interjections* to modify the list of interjections for the selected language.
 
 <!-- Screenshot: Interjections window -->
 ![Interjections](../screenshots/interjections.png)
 
 ## Preview
 
-All proposed removals are shown in a preview list before applying, allowing you to uncheck individual items.
+All proposed removals are shown in a preview list with **Before** and **After** columns. Uncheck individual items to exclude them before clicking **OK**.

--- a/docs/features/seconv.md
+++ b/docs/features/seconv.md
@@ -4,8 +4,10 @@
 
 ```bash
 seconv *.srt webvtt
+seconv movie.srt subrip --encoding:source --FixCommonErrors
 seconv movie.mkv subrip --track-number:3
 seconv movie.sup subrip --ocr-engine:tesseract --ocr-language:eng
+seconv movie.sup subrip --ocr-engine:binaryocr --ocr-db:Latin.db
 ```
 
 For full usage, options, OCR setup, operations pipeline, examples, and exit codes, see the canonical reference:

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -40,6 +40,7 @@ Profiles store subtitle rules and limits. You can switch between profiles for di
 - **Auto backup** — Enable automatic backups at a set interval
 - **Open file on start** — Choose whether Subtitle Edit reopens the previous file on startup
 - **Single-letter shortcuts in text boxes** — Control whether single-key shortcuts are active while editing text
+- **Focus text box after insert (grid / waveform)** — Move focus to the subtitle text box after inserting a new line from the grid or waveform
 
 ## Subtitle Defaults
 

--- a/docs/features/shortcuts.md
+++ b/docs/features/shortcuts.md
@@ -40,6 +40,7 @@ Some commands have additional configuration beyond the shortcut key:
 - **Set color 1–8** — Choose a color for each color shortcut
 - **Surround with 1–3** — Define the left/right text to surround selected text with
 - **Video move custom 1–2 back/forward** — Set the number of milliseconds to skip
+- **Set actor 1–10** — Define the actor name assigned by each actor shortcut
 
 Select a configurable command and click **Configure** to adjust its settings.
 

--- a/docs/features/shot-changes.md
+++ b/docs/features/shot-changes.md
@@ -2,15 +2,17 @@
 
 Detect scene/shot changes in a video using FFmpeg, or import them from a file.
 
-- **Menu:** Video → Shot changes → Generate / Import
+- **Menu:** Video → Generate/import shot changes
 - **Shortcut:** Configurable
+
+A second menu item, **Show shot changes list**, appears under the Video menu once the loaded video has any shot changes.
 
 <!-- Screenshot: Shot changes window -->
 ![Shot Changes](../screenshots/shot-changes.png)
 
 ## How to Use
 
-1. Open **Video → Shot changes → Generate shot changes...**
+1. Open **Video → Generate/import shot changes**
 2. Adjust the **Sensitivity** slider (higher = fewer detected changes)
 3. Click **Generate** to run FFmpeg scene detection
 4. Detected shot change times appear in the list

--- a/docs/features/sort-by.md
+++ b/docs/features/sort-by.md
@@ -1,17 +1,28 @@
 # Sort By
 
-Sort subtitle lines by various criteria.
+Sort subtitle lines by one or more criteria.
 
-- **Menu:** Tools → Sort by...
+- **Menu:** Tools → Sort subtitles...
 
 <!-- Screenshot: Sort by window -->
 ![Sort By](../screenshots/sort-by.png)
 
 ## Sort Options
 
-- Start time
-- End time
+Add one or more sort criteria from the available properties:
+
+- Number
+- Show (start time)
+- Hide (end time)
 - Duration
-- Text (alphabetical)
-- Text length
-- Number (original line number)
+- Text
+- Original text
+- Style
+- Actor
+- Layer
+- Gap
+- Characters/sec
+- Words/min
+- Pixel width
+
+Each criterion can be set to ascending or descending, and multiple criteria are applied in order (drag or use the up/down buttons to reorder).

--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -11,32 +11,23 @@ Subtitle Edit can automatically transcribe audio to text using Whisper-based and
 
 | Engine | Platform | Notes |
 |--------|----------|-------|
-| Whisper.cpp | Windows, Linux, macOS | Local CPU engine |
-| Whisper.cpp (cuBLAS) | Windows | NVIDIA CUDA build |
-| Whisper.cpp (Vulkan) | Windows | Vulkan GPU build |
-| Purfview's Faster Whisper XXL | Windows, Linux | Fast local engine, often used with NVIDIA CUDA |
-| Whisper CTranslate2 | Windows, Linux, macOS | CPU / NVIDIA CUDA depending on installation; CUDA requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive) |
-| Const-me's Whisper | Windows | DirectX-based engine |
-| OpenAI Whisper | All | Python-based OpenAI Whisper workflow |
-| Chat LLM.cpp | Windows, Linux, macOS | Local LLM transcription workflow; macOS download is for Apple Silicon |
-| Qwen3 ASR CPP | Windows, Linux, macOS | Local Qwen3 ASR engine with downloadable GGUF models |
-| Parakeet.cpp | Windows, Linux, macOS | Local Parakeet engine; some models are English-only, larger models are multilingual |
-| Crisp ASR GLM | Windows, Linux, macOS | Crisp ASR backend |
-| Crisp ASR Qwen3 | Windows, Linux, macOS | Crisp ASR backend |
-| Crisp ASR Granite | Windows, Linux, macOS | Crisp ASR backend |
-| Crisp ASR Omni | Windows, Linux, macOS | Crisp ASR backend |
-| Crisp ASR Parakeet | Windows, Linux, macOS | Crisp ASR backend |
-| Crisp ASR Canary | Windows, Linux, macOS | Crisp ASR backend |
-| Crisp ASR Cohere | Windows, Linux, macOS | Crisp ASR backend |
-| Crisp ASR Fire Red | Windows, Linux, macOS | Crisp ASR backend |
+| Whisper CPP | Windows, Linux, macOS | Local CPU engine. On Windows the cuBLAS (NVIDIA CUDA) and Vulkan GPU backends can also be selected from the Whisper CPP backend dropdown. |
+| Purfview Faster Whisper XXL | Windows, Linux | Fast local engine, often used with NVIDIA CUDA |
+| Whisper CTranslate2 | Windows, Linux (x64), macOS (Apple Silicon) | CPU / NVIDIA CUDA depending on installation; CUDA requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive) |
+| Whisper Const-me | Windows | DirectX-based engine |
+| Whisper OpenAI | All | Python-based OpenAI Whisper workflow |
+| OpenAI Compatible Server | All | Connect to any OpenAI-compatible speech-to-text endpoint |
+| Qwen3 ASR CPP | Windows, Linux | Local Qwen3 ASR engine with downloadable GGUF models |
+| Crisp ASR | Windows, Linux, macOS | Single engine with selectable backends: Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, Kyutai |
 
 Engines and models are downloaded automatically on first use.
 
 ## SE5 Engine Notes
 
+- **Whisper CPP** is shown as a single entry; the CPU / cuBLAS / Vulkan backends are selected from a secondary dropdown when Whisper CPP is selected.
 - **Qwen3 ASR CPP** includes 0.6B and 1.7B model options, plus a forced-aligner model used for timing workflows.
-- **Parakeet.cpp** stores each model in its own folder because a model needs both weights and a vocabulary file.
-- **Crisp ASR** engines share a common backend workflow and expose different model families such as GLM, Qwen3, Granite, Omni, Parakeet, Canary, Cohere, and Fire Red.
+- **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, Kyutai). Pick the backend from the Crisp ASR backend dropdown.
+- A **Forced aligner** option is shown for Crisp ASR backends and exposes the built-in aligner, Canary CTC, Qwen3, and the wav2vec2 zoo (12 language-specific CTC aligners that run on top of any Crisp ASR backend).
 - Several newer engines support automatic language selection.
 - Each engine can have separate advanced command-line parameters.
 
@@ -79,7 +70,7 @@ Click the **Advanced** button to configure custom command-line arguments for the
 - Highlight spoken words in the transcript
 - Adjust temperature or other model parameters
 
-Advanced settings are stored per engine, so you can keep separate parameters for Whisper.cpp, Qwen3 ASR, Parakeet.cpp, Crisp ASR, and other engines.
+Advanced settings are stored per engine, so you can keep separate parameters for Whisper CPP, Qwen3 ASR, Crisp ASR, and other engines.
 
 ## Post-Processing Settings
 
@@ -98,8 +89,8 @@ The console log at the bottom shows real-time output from the Whisper process, u
 
 ## Tips
 
-- For NVIDIA GPU users, use **Whisper.cpp (cuBLAS)** or **Purfview's Faster Whisper XXL** for fastest transcription
+- For NVIDIA GPU users, use the **Whisper CPP** cuBLAS backend or **Purfview Faster Whisper XXL** for fastest transcription
 - If you get "CUDA out of memory" errors, try a smaller model
-- The `--standard` parameter is automatically added for Purfview's Faster Whisper XXL
+- The `--standard` parameter is automatically added for Purfview Faster Whisper XXL
 - You can re-download an engine by right-clicking the engine area
 - If a new engine has no model installed yet, let Subtitle Edit download both the engine and the selected model before starting transcription

--- a/docs/features/spell-check.md
+++ b/docs/features/spell-check.md
@@ -18,7 +18,7 @@ Check spelling of subtitle text and correct misspelled words.
    - **Change all** — Replace all occurrences
    - **Skip once** — Ignore this occurrence
    - **Skip all** — Ignore all occurrences of this word
-   - **Add to names list** — Add the word to the names/proper nouns list
+   - **Add to names list (case sensitive)** — Add the word to the names/proper nouns list (matches the exact casing)
    - **Add to user dictionary** — Add the word to your personal dictionary
 5. The spell checker advances to the next unknown word automatically
 6. When all words have been checked, the window closes

--- a/docs/features/split-break-long-lines.md
+++ b/docs/features/split-break-long-lines.md
@@ -1,15 +1,17 @@
-# Split / Break Long Lines
+# Split / Rebalance Long Lines
 
-Split subtitle lines that exceed maximum character limits.
+Split or rebalance subtitle lines that exceed maximum character limits.
 
-- **Menu:** Tools → Split / break long lines...
+- **Menu:** Tools → Split/rebalance long lines...
 
 <!-- Screenshot: Split break long lines window -->
 ![Split Break Long Lines](../screenshots/split-break-long-lines.png)
 
 ## Options
 
-- **Maximum line length** — Lines longer than this will be split
-- **Split** — Split into separate subtitle entries
-- **Auto break** — Add line breaks within the subtitle
-- Preview affected lines before applying
+- **Split long lines** — Split subtitles whose total length exceeds the maximum
+- **Rebalance long lines** — Re-balance line breaks so lines have a more even length
+- **Single line max length** — Maximum characters allowed on a single line
+- **Max number of lines** — Maximum number of lines a subtitle may span (1-10)
+
+The preview list updates live and shows all proposed fixes.

--- a/docs/features/split-subtitle.md
+++ b/docs/features/split-subtitle.md
@@ -9,7 +9,16 @@ Split a single subtitle file into two or more parts.
 
 ## Split Options
 
-- **Split at line number** — Split at a specific line
-- **Split at time** — Split at a specific time code
-- **Split by number of equal parts** — Divide into equal segments
-- **Split by characters** — Split based on character count
+Choose how to divide the subtitle into roughly equal parts:
+
+- **Lines** — Split so each part has the same number of subtitle lines
+- **Characters** — Split so each part has roughly the same number of characters
+- **Time** — Split so each part covers roughly the same duration
+
+Then set:
+
+- **Number of equal parts** — How many output files to produce
+- **Output folder** — Where to save the split files
+- **Format** and **Encoding** — Subtitle format and text encoding used for the split files
+
+Click **Save split parts** to write all parts to the output folder.

--- a/docs/features/statistics.md
+++ b/docs/features/statistics.md
@@ -11,7 +11,7 @@ View detailed statistics about the currently loaded subtitle file, including lin
 1. Open a subtitle file.
 2. Go to **File** → **Statistics...** to open the statistics dialog.
 3. View general statistics, most used words, and most used lines.
-4. Use **Save as...** to export the statistics to a text file.
+4. Use **Export** to save the statistics to a text file.
 
 ## Features
 

--- a/docs/features/subtitle-grid.md
+++ b/docs/features/subtitle-grid.md
@@ -44,13 +44,16 @@ Right-click anywhere in the **column header row** to open the column visibility 
 ## Context Menu
 
 Right-click a line to access:
+- Delete
 - Insert before / Insert after
-- Delete selected lines
-- Duplicate selected lines
+- Column (delete text, insert text, paste from clipboard, shift cells up/down, text up/down)
 - Split line
-- Merge with previous / next
-- Set alignment
-- Toggle bookmark
+- Merge before / Merge after / Merge selected / Merge selected as dialog
+- Extend to line before / Extend to line after
+- Remove formatting (all, bold, italic, underline, color, font name, alignment)
+- Italic / Bold / Color... / Font name... / Alignment...
+- Bookmark...
+- Selected lines... (Speech to text, Auto translate, Change casing, Set layer, Fix common errors, etc.)
 
 ## Keyboard Shortcuts (Grid)
 

--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -19,16 +19,18 @@ Generate speech audio from subtitle text using various TTS engines.
 
 ## Supported Engines
 
-- **Piper** — Local, open-source TTS
-- **Edge-TTS** — Microsoft Edge online voices
+- **Piper** — Local, open-source TTS (Windows and Linux)
+- **EdgeTts** — Microsoft Edge online voices
 - **AllTalk** — Local TTS server
 - **ElevenLabs** — Cloud-based, high-quality voices (requires API key)
-- **Azure Cognitive Services** — Microsoft cloud TTS (requires API key and region)
-- **Mistral TTS** — Cloud-based Mistral speech generation (requires API key)
-- **Google Cloud** — Google cloud TTS (requires key file)
-- **Qwen3 TTS** — Local downloadable Qwen3 TTS server and models
+- **AzureSpeech** — Microsoft cloud TTS (requires API key and region)
+- **MistralSpeech** — Cloud-based Mistral speech generation (requires API key)
+- **Murf** — Cloud TTS (requires API key)
+- **GoogleSpeech** — Google cloud TTS (requires key file)
 - **Kokoro TTS** — Local downloadable Kokoro TTS server and models
-- **Murf.ai** — Cloud TTS (requires API key)
+- **OmniVoice TTS** — Local CPU TTS with voice cloning and many languages
+- **Qwen3 TTS (CrispASR)** — Local Qwen3 TTS running through the CrispASR runtime (VoiceDesign and CustomVoice 1.7B models)
+- **Chatterbox TTS (CrispASR)** — Chatterbox TTS via the CrispASR runtime, with voice cloning (Base or Turbo model)
 
 Local downloadable engines are installed into the Subtitle Edit data folder when you accept the download prompt.
 
@@ -43,14 +45,20 @@ Some engines require additional configuration:
 
 ## Local SE5 Engines
 
-### Qwen3 TTS
+### Qwen3 TTS (CrispASR)
 
-Qwen3 TTS runs a local server. Subtitle Edit can download the engine and the selected model on first use.
+Qwen3 TTS runs through the CrispASR runtime and shares the `CrispASR/models` directory with the speech-to-text Crisp ASR engines.
 
-- Available model choices include **0.6B** and **1.7B Base**.
-- The model download also requires the tokenizer model.
-- Qwen3 TTS supports imported reference WAV voices. Imported voices appear in the voice dropdown.
-- On Windows, Subtitle Edit can offer CPU or Vulkan builds depending on availability.
+- Available model choices are **1.7B VoiceDesign** (uses a free-text voice instruction) and **1.7B CustomVoice** (voice cloning from a reference WAV).
+- Subtitle Edit downloads the engine and the selected talker + codec/tokenizer GGUFs on first use.
+- Imported reference WAV voices appear in the voice dropdown.
+
+### Chatterbox TTS (CrispASR)
+
+Chatterbox TTS runs through the CrispASR runtime (shared with the speech-to-text feature) and supports voice cloning.
+
+- Available model choices are **Base** and **Turbo**.
+- Imported reference WAV voices are sent as the per-request voice for runtime cloning.
 
 ### Kokoro TTS
 
@@ -60,13 +68,17 @@ Kokoro TTS runs a local server with downloadable models.
 - Voice names are available immediately from the bundled voice list and can be refreshed from the running server.
 - It is a good choice when you want a local, multilingual TTS engine without an API key.
 
-### Mistral TTS
+### OmniVoice TTS
 
-Mistral TTS is configured with an API key and model selection. The selected model is remembered in settings.
+OmniVoice TTS runs the omnivoice-tts CLI on CPU. It supports a large set of languages and voice cloning from reference WAV files (with an accompanying transcript).
+
+### MistralSpeech
+
+MistralSpeech is configured with an API key and model selection. The selected model is remembered in settings.
 
 ## Review Audio Clips
 
-When **Review audio clips** is enabled, a dedicated review window opens after generation. This window lets you inspect, play, and regenerate audio for every subtitle line before the result is used.
+When **Review audio clips** is enabled, a dedicated review window opens after generation. This window lets you inspect, play, and regenerate audio for every subtitle line before the result is used. A 120px waveform of the original video audio is shown above the grid as a reference. Per-session review state (clips, history, includes, edits) is persisted to `SubtitleEditTts.json` so you can return to the same review later.
 
 ### The Review Grid
 

--- a/docs/features/transparent-subtitles.md
+++ b/docs/features/transparent-subtitles.md
@@ -2,7 +2,7 @@
 
 Generate a transparent video overlay with rendered subtitles that can be composited over other video.
 
-- **Menu:** Video → Generate transparent subtitles...
+- **Menu:** Video → Generate transparent video with subtitles...
 - **Shortcut:** Configurable
 
 <!-- Screenshot: Transparent subtitles window -->
@@ -10,10 +10,10 @@ Generate a transparent video overlay with rendered subtitles that can be composi
 
 ## How to Use
 
-1. Open **Video → Generate transparent subtitles...**
+1. Open **Video → Generate transparent video with subtitles...**
 2. Configure font settings (name, size, colors, outline, shadow, alignment)
 3. Set the video resolution and frame rate
-4. Select the output video extension (e.g. `.mov`, `.webm`)
+4. Select the output video extension (e.g. `.mov`, `.mkv`, `.mp4`, `.webm`)
 5. Select an output folder
 6. Click **Generate** to create the transparent video
 
@@ -34,7 +34,7 @@ Generate a transparent video overlay with rendered subtitles that can be composi
 
 - **Resolution** — Output video width and height (or use source resolution)
 - **Frame rate** — Output frame rate
-- **Extension** — Output container format (`.mov`, `.webm`)
+- **Extension** — Output container format (`.mov`, `.mkv`, `.mp4`, `.webm`)
 
 ## Cut Options
 

--- a/docs/features/video-player.md
+++ b/docs/features/video-player.md
@@ -7,7 +7,7 @@ Subtitle Edit includes an integrated video player for previewing subtitles with 
 
 ## Opening Video
 
-- **Menu:** Video → Open video file...
+- **Menu:** Video → Open video...
 - **Shortcut:** Configurable via Options → Shortcuts
 - **Drag and drop** a video file onto the Subtitle Edit window
 - You can also open video from a URL: **Video → Open video from URL...**
@@ -42,7 +42,7 @@ Subtitle Edit includes an integrated video player for previewing subtitles with 
 
 Jump to a specific time code position in the video.
 
-- **Menu:** Video → Go to video position...
+- **Shortcut:** Configurable via **Options → Shortcuts** (search for "Go to video position")
 
 ## Playback Speed
 
@@ -71,14 +71,15 @@ Use [Embedded Subtitles](embedded-subtitles.md) to add, remove, preview, and edi
 
 ## Supported Video Players
 
-Configure the video player backend in **Options → Settings → Video Player**:
-- **libmpv** — Recommended for best format support
-- **VLC** — Popular alternative
-- **None** — Disable video playback
+Configure the video player backend in **Options → Settings → Video player**:
+- **libmpv - OpenGL** — Recommended for best format support (default)
+- **libmpv - Native Window ID rendering** — Alternative mpv rendering mode (not available on macOS)
+- **libmpv - Software rendering (slow)** — Fallback mpv mode without hardware acceleration
+- **libVLC - Native Window ID rendering** — VLC backend (Windows and Linux only)
 
 ## Video Info
 
-You can view detailed information about the video file by right-clicking on the video file name.
+You can view detailed information about the video file by right-clicking the video player (or via the "Show media information" shortcut).
 
 This displays:
 - Video codec, resolution, frame rate, and bitrate

--- a/docs/features/visual-sync.md
+++ b/docs/features/visual-sync.md
@@ -9,11 +9,12 @@ Synchronize subtitles visually by matching two points in the video.
 
 ## How to Use
 
-1. Open **Sync → Visual sync...**
-2. Play the video to find where the first subtitle should appear
-3. Set the first sync point
-4. Play to where the last subtitle should appear
-5. Set the second sync point
-6. Click **OK** to apply the synchronization
+The Visual sync window shows two video player panes ("Start scene" and "End scene"), each with its own audio visualizer and a combo box for picking a subtitle line.
 
-The timing of all subtitles will be linearly adjusted to match the two sync points.
+1. Open **Sync → Visual sync...**
+2. In the **Start scene** pane, pick a subtitle line near the beginning and play the video to the position where that line should start
+3. In the **End scene** pane, pick a subtitle line near the end and play the video to the position where that line should start
+4. Click **Sync** to apply (or use **Manual sync...** from the Sync split-button for a manual offset/speed adjustment)
+5. Click **OK** to keep the result
+
+The timing of all subtitles is linearly adjusted to match the two sync points. The window remembers its size and position between sessions.

--- a/docs/features/whats-new-in-se5.md
+++ b/docs/features/whats-new-in-se5.md
@@ -42,9 +42,10 @@ Subtitle Edit 5 is the Avalonia-based, cross-platform version of Subtitle Edit. 
 
 Speech recognition is no longer limited to classic Whisper workflows. Subtitle Edit 5 includes a broader set of local and downloadable engines:
 
-- Purfview Faster-Whisper XXL, CTranslate2, Whisper.cpp, OpenAI Whisper, and Const-me's Whisper.
+- Purfview Faster-Whisper XXL, CTranslate2, Whisper.cpp (with cuBLAS and Vulkan backends on Windows), OpenAI Whisper, OpenAI-compatible STT, and Const-me's Whisper.
 - Qwen3 ASR with multiple GGUF model sizes.
-- Crisp ASR variants including GLM, Qwen3, Granite, Omni, Parakeet, Canary, Cohere, and Fire Red.
+- Crisp ASR variants including GLM, Qwen3, Granite, Omni, Parakeet, Canary, Cohere, Fire Red, Mega, and Kyutai.
+- Forced-aligner picker (built-in / Canary CTC / Qwen3 / 12 language-specific wav2vec2 aligners) for word-level timestamps.
 - Per-engine advanced parameters and batch transcription improvements.
 - Automatic language selection for several newer engines.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 ### Video
 - [Video Player](features/video-player.md) — Video playback controls
 - [Audio Visualizer / Waveform](features/audio-visualizer.md) — Waveform display and editing
-- [Speech to Text](features/speech-to-text.md) — Automatic speech recognition with Whisper, Qwen3, Parakeet, Crisp ASR, and related engines
+- [Speech to Text](features/speech-to-text.md) — Automatic speech recognition with Whisper, Qwen3 ASR, Crisp ASR, and related engines
 - [Text to Speech](features/text-to-speech.md) — Generate speech from subtitles
 - [Burn-In Subtitles](features/burn-in.md) — Hardcode subtitles into video
 - [Embedded Subtitles](features/embedded-subtitles.md) — Add, remove, preview, and edit subtitle tracks in Matroska/WebM files

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,7 +12,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. It allows you t
 
 - **Create and edit** subtitles in 300+ formats
 - **Synchronize** subtitles to video with visual tools
-- **Speech to Text** — transcribe audio using Whisper engines
+- **Speech to Text** — transcribe audio using Whisper, Qwen3 ASR, Crisp ASR, and other local/cloud engines
 - **Text to Speech** — generate audio from subtitle text
 - **Translate** subtitles automatically
 - **OCR** — convert image-based subtitles (Blu-ray, DVD, etc.) to text
@@ -27,7 +27,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. It allows you t
 
 ## System Requirements
 
-- Windows 10+ / Linux / macOS 
+- Windows 10 (version 22H2 / build 19045) or newer, Linux, or macOS 12 (Monterey) or newer
 - [FFmpeg](https://ffmpeg.org/) (for audio/video processing)
 - [libmpv](https://mpv.io/) for video playback
 

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -299,7 +299,7 @@ Operations run after the structural transforms (offset, fps, renumber, adjust-du
 | `--delete-first:<n>` | Delete first N entries |
 | `--delete-last:<n>` | Delete last N entries |
 | `--delete-contains:<word>` | Delete entries containing the given word |
-| `--fix-common-errors` | Fix common subtitle errors (all 38 rules) |
+| `--fix-common-errors` | Fix common subtitle errors (all 39 rules) |
 | `--fix-common-errors-rules:<list>` | Run a subset of FCE rules (CSV; supports `all,-RuleId`) |
 | `--fix-rtl-via-unicode-chars` | Fix RTL via Unicode characters |
 | `--merge-same-texts` | Merge entries with same text |
@@ -320,7 +320,7 @@ seconv *.srt subrip --remove-text-for-hi --merge-same-texts --split-long-lines -
 
 ### FixCommonErrors rule selection
 
-`--fix-common-errors` (no value) runs all 38 rules. Pass `--fix-common-errors-rules:<list>` to pick a subset — supplying that option implies `--fix-common-errors`.
+`--fix-common-errors` (no value) runs all 39 rules. Pass `--fix-common-errors-rules:<list>` to pick a subset — supplying that option implies `--fix-common-errors`.
 
 ```bash
 seconv movie.srt subrip --fix-common-errors                                  # all rules

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -1,6 +1,6 @@
 # Keyboard Shortcuts
 
-A complete reference of keyboard shortcuts available in Subtitle Edit. Shortcuts can be customized in **Options** → **Shortcuts**.
+A reference for the default keyboard shortcuts in Subtitle Edit. Every shortcut can be customized — and most actions ship with no default binding at all — in **Options** → **Shortcuts**. On macOS, Cmd (`Win` in the shortcut editor) is used wherever Ctrl is shown below.
 
 See also: [Shortcuts Settings](../features/shortcuts.md)
 
@@ -11,49 +11,51 @@ See also: [Shortcuts Settings](../features/shortcuts.md)
 | Ctrl+N | New subtitle |
 | Ctrl+O | Open subtitle file |
 | Ctrl+S | Save subtitle |
-| Ctrl+Shift+S | Save subtitle as |
 | Ctrl+Z | Undo |
 | Ctrl+Y | Redo |
 | Ctrl+F | Find |
-| Ctrl+H | Find and replace |
+| F3 | Find next |
+| Shift+F3 | Find previous |
+| Ctrl+H | Replace |
+| Ctrl+Shift+R | Multiple replace |
 | Ctrl+G | Go to line number |
+| Ctrl+Shift+B | Add or edit bookmark |
+| Alt+Up | Go to previous line |
+| Alt+Down | Go to next line |
 | F1 | Show help |
-| Escape | Close current dialog |
+| F2 | Show source view |
 
 ## Subtitle Grid
 
 | Shortcut | Action |
 |----------|--------|
-| Insert | Insert new line after current |
 | Delete | Delete selected line(s) |
-| Ctrl+Shift+Up | Move selected line up |
-| Ctrl+Shift+Down | Move selected line down |
 | Ctrl+A | Select all lines |
+| Ctrl+Shift+I | Inverse selection |
+| Ctrl+I | Toggle italic on selected lines or text |
+| Ctrl+X / Ctrl+C / Ctrl+V | Cut / copy / paste selected lines |
+| Ctrl+Shift+V | Fill selected lines with clipboard |
+| Ctrl+F8 | List errors |
+| F8 / Shift+F8 | Go to next / previous error |
+| Alt+F7 | Spell check |
 
 ## Video Playback
 
 | Shortcut | Action |
 |----------|--------|
-| Space | Play/Pause (when video player is focused) |
-| Ctrl+P | Play/Pause |
-| Ctrl+Space | Play/Pause |
-| Alt+Left | Skip back (small) |
-| Alt+Right | Skip forward (small) |
+| Space | Toggle play/pause |
+| Ctrl+Space | Toggle play/pause (secondary) |
+| Left | One second back |
+| Right | One second forward |
 
-## Audio Visualizer
-
-| Shortcut | Action |
-|----------|--------|
-| Ctrl+Scroll | Zoom in/out |
-| Shift+Scroll | Scroll waveform |
-| Scroll | Scroll waveform vertically |
-
-## Text Editing
+## Tools
 
 | Shortcut | Action |
 |----------|--------|
-| Ctrl+B | Toggle bold |
-| Ctrl+I | Toggle italic |
-| Ctrl+U | Toggle underline |
+| Ctrl+Shift+C | Change casing |
+| Ctrl+Shift+H | Remove text for hearing impaired |
+| Ctrl+Shift+A | Synchronization → Adjust all times |
+| Ctrl+Alt+Shift+D | Open data folder |
+| Ctrl+Alt+Shift+L | Save language file |
 
-> **Note:** All shortcuts can be customized. Go to **Options** → **Shortcuts** to view and change key bindings.
+> **Note:** Most actions (Save As, Insert before/after, Bold, Underline, shot-change snapping/extending, green-zone in/out cues, video skip-back/forward, etc.) ship without a default key. Open **Options** → **Shortcuts** to assign them, or use **Import from SE 4.x** to bring over a familiar set.

--- a/docs/reference/mouse-controls.md
+++ b/docs/reference/mouse-controls.md
@@ -19,9 +19,10 @@ See also: [Audio Visualizer](../features/audio-visualizer.md) | [Video Player](.
 | Left-click + drag on subtitle edge | Adjust start/end time of subtitle |
 | Left-click + drag in empty area | Create a new selection |
 | Right-click | Open context menu |
-| Scroll wheel | Scroll waveform |
+| Scroll wheel | Scroll waveform horizontally |
 | Alt + Scroll wheel | Horizontal zoom in/out |
 | Shift + Scroll wheel | Vertical zoom in/out |
+| Ctrl (or Cmd) + Scroll wheel | Scroll waveform and seek video to cursor |
 | Double-click on subtitle | Select the subtitle in the grid |
 
 ## Subtitle Grid

--- a/docs/reference/supported-formats.md
+++ b/docs/reference/supported-formats.md
@@ -1,41 +1,41 @@
 # Supported Subtitle Formats
 
-Subtitle Edit supports a wide range of subtitle formats for reading and writing. Below is a summary of the major categories.
+Subtitle Edit supports a wide range of subtitle formats for reading and writing. Below is a summary of the major categories. For the full machine-generated list of formats the build currently knows about, run `seconv formats` from the command line.
 
 ## Text-Based Formats
 
 | Format | Extension(s) | Documentation |
-|--------|-------------|---------------|
+|--------|--------------|---------------|
 | SubRip | .srt | [Format Reference](subrip.md) |
 | WebVTT (Web Video Text Tracks) | .vtt, .webvtt | [Format Reference](webvtt.md) |
 | Advanced SubStation Alpha (ASSA) | .ass | [Format Reference](assa.md) |
 | SubStation Alpha (SSA) | .ssa | [Format Reference](assa.md) |
+| MicroDVD | .sub | |
+| SAMI | .smi | |
+| Timed Text (TTML) | .ttml, .xml, .dfxp | |
+| iTunes Timed Text (iTT) | .itt | |
+| EBU STL | .stl | |
+| Spruce STL | .stl | |
+| Scenarist Closed Captions (SCC) | .scc | |
+| DVD Studio Pro | .txt | |
+| Cavena 890 | .890 | |
+| PAC | .pac | |
+| Cheetah | .cap | |
+| Avid DS | .txt | |
+| JSON (various) | .json | |
+| LRC (Lyrics) | .lrc | |
+| and many more... | | |
 
-> **See also:** 
+> **See also:**
 > - [SubRip Format Reference](subrip.md) — Complete guide to SRT format
 > - [WebVTT Format Reference](webvtt.md) — Complete guide to WebVTT format (HTML5 standard)
 > - [ASSA Format Reference](assa.md) — Complete guide to ASS/SSA format
 > - [ASSA Override Tags Reference](assa-override-tags.md) — Complete list of ASS/SSA override tags for styling and animation
-| MicroDVD | .sub |
-| SAMI | .smi |
-| Timed Text (TTML) | .ttml, .xml, .dfxp |
-| iTunes Timed Text (iTT) | .itt |
-| EBU STL | .stl |
-| Spruce STL | .stl |
-| Scenarist Closed Captions (SCC) | .scc |
-| DVD Studio Pro | .txt |
-| Cavena | .890 |
-| PAC | .pac |
-| Cheetah | .cap |
-| Avid DS | .txt |
-| JSON (various) | .json |
-| LRC (Lyrics) | .lrc |
-| and many more... | |
 
 ## Image-Based Formats
 
 | Format | Extension(s) |
-|--------|-------------|
+|--------|--------------|
 | Blu-ray PGS (SUP) | .sup |
 | VobSub (DVD) | .sub/.idx |
 | BDN XML | .xml |
@@ -43,15 +43,16 @@ Subtitle Edit supports a wide range of subtitle formats for reading and writing.
 ## Container Formats (with embedded subtitles)
 
 | Format | Extension(s) |
-|--------|-------------|
+|--------|--------------|
 | Matroska (MKV/MKS) | .mkv, .mks |
-| MP4 | .mp4 |
-| Transport Stream | .ts, .m2ts |
+| MP4 / MOV (text tracks) | .mp4, .m4v, .m4s, .3gp |
+| Transport Stream (teletext, DVB-sub) | .ts, .m2ts, .mts |
+| MacCaption | .mcc |
 
 ## Video Formats (for loading video)
 
 | Format | Extension(s) |
-|--------|-------------|
+|--------|--------------|
 | Matroska | .mkv |
 | MPEG-4 | .mp4 |
 | Transport Stream | .ts |
@@ -59,4 +60,4 @@ Subtitle Edit supports a wide range of subtitle formats for reading and writing.
 | MPEG | .mpeg |
 | Blu-ray Transport Stream | .m2ts |
 
-> **Note:** The full list of supported text-based formats includes 200+ formats. Subtitle Edit automatically detects the format when opening files.
+> **Note:** Subtitle Edit ships with parsers/writers for 380+ text-based formats, plus a handful of binary and image-based ones. The format is auto-detected when you open a file.

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -164,6 +164,6 @@ The following feature pages exist but have no companion screenshot. Adding these
 
 ## Counts
 
-- Top-level screenshots: **86**
-- ASSA override-tag examples (`assa/`): **34**
-- Total: **120**
+- Top-level screenshots: **87**
+- ASSA override-tag examples (`assa/`): **35**
+- Total: **122**

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -16,7 +16,7 @@ Subtitle Edit stores these components in its **Data Folder**.
 *   **Installed Version (Windows):** `%APPDATA%\Subtitle Edit`
     *   (Press `Win+R`, type `%APPDATA%\Subtitle Edit`, and hit Enter)
 *   **Linux:** `~/.config/Subtitle Edit` (or `$XDG_CONFIG_HOME/Subtitle Edit`).
-*   **macOS:** `~/Library/Application Support/Subtitle Edit`.
+*   **macOS:** `~/.config/Subtitle Edit` (or `$XDG_CONFIG_HOME/Subtitle Edit`).
 
 > **Tip:** You can open the Data Folder directly from Subtitle Edit by pressing `Ctrl+Alt+Shift+D` (Windows/Linux) or `Cmd+Alt+Shift+D` (macOS).
 

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -83,7 +83,7 @@ Save your translated file as **`{CultureName}.json`** (e.g., `de-DE.json`) and p
 | **Windows (installed)** | `%APPDATA%\Subtitle Edit\Languages\` |
 | **Windows (portable)** | `[Subtitle Edit folder]\Languages\` |
 | **Linux** | `~/.config/Subtitle Edit/Languages/` |
-| **macOS** | `~/Library/Application Support/Subtitle Edit/Languages/` |
+| **macOS** | `~/.config/Subtitle Edit/Languages/` |
 
 Create the `Languages` folder if it does not exist.
 

--- a/installer/macBundle/README.md
+++ b/installer/macBundle/README.md
@@ -19,7 +19,7 @@ If no arguments are provided, it uses default paths:
 1. Extracts the version from Se.cs (e.g., `"v5.0.0-beta32"`)
 2. Converts it to macOS-compatible formats:
    - **CFBundleShortVersionString**: user-visible version (e.g., `5.0.0-beta32`; for `preview` versions a dot is inserted, so `v5.0.0-preview95` becomes `5.0.0-preview.95`)
-   - **CFBundleVersion**: numeric-only build number derived from the digits in the version (e.g., `5032` for `v5.0.0-beta32`, `500095` for `v5.0.0-preview95`)
+   - **CFBundleVersion**: numeric-only build number derived from the digits in the version (e.g., `50032` for `v5.0.0-beta32`, `500095` for `v5.0.0-preview95`)
 3. Updates the Info.plist file with these values
 
 ### Example
@@ -31,7 +31,7 @@ public static string Version { get; set; } = "v5.0.0-beta32";
 
 The script will update Info.plist with:
 - `CFBundleShortVersionString`: `5.0.0-beta32`
-- `CFBundleVersion`: `5032`
+- `CFBundleVersion`: `50032`
 
 ### Integration
 

--- a/installer/macBundle/README.md
+++ b/installer/macBundle/README.md
@@ -16,22 +16,22 @@ If no arguments are provided, it uses default paths:
 
 ### What it does
 
-1. Extracts the version from Se.cs (e.g., `"v5.0.0-preview95"`)
+1. Extracts the version from Se.cs (e.g., `"v5.0.0-beta32"`)
 2. Converts it to macOS-compatible formats:
-   - **CFBundleShortVersionString**: `5.0.0-preview.95` (user-visible version)
-   - **CFBundleVersion**: `500095` (numeric-only build number)
+   - **CFBundleShortVersionString**: user-visible version (e.g., `5.0.0-beta32`; for `preview` versions a dot is inserted, so `v5.0.0-preview95` becomes `5.0.0-preview.95`)
+   - **CFBundleVersion**: numeric-only build number derived from the digits in the version (e.g., `5032` for `v5.0.0-beta32`, `500095` for `v5.0.0-preview95`)
 3. Updates the Info.plist file with these values
 
 ### Example
 
 If Se.cs contains:
 ```csharp
-public static string Version { get; set; } = "v5.0.0-preview95";
+public static string Version { get; set; } = "v5.0.0-beta32";
 ```
 
 The script will update Info.plist with:
-- `CFBundleShortVersionString`: `5.0.0-preview.95`
-- `CFBundleVersion`: `500095`
+- `CFBundleShortVersionString`: `5.0.0-beta32`
+- `CFBundleVersion`: `5032`
 
 ### Integration
 

--- a/src/libse/Readme.md
+++ b/src/libse/Readme.md
@@ -10,7 +10,7 @@ var firstStartMilliseconds = subtitle.Paragraphs.First().StartTime.TotalMillisec
 
 ## How to save a subtitle file
 ```csharp
-File.WriteAllText(@"C:\Data\new.srt", new SubRip().ToText(subtitle, "untitled"));
+File.WriteAllText("new.srt", new SubRip().ToText(subtitle, "untitled"));
 ```
 
 ## License

--- a/tests/UI/README.md
+++ b/tests/UI/README.md
@@ -1,6 +1,6 @@
 # UI Tests
 
-This project contains unit tests for the UI project, specifically for OCR fix engine features.
+This project contains unit tests for the UI project, covering areas such as OCR, spell-check, shortcuts, merge/split, find/replace, color services, downloads, undo/redo, and media helpers.
 
 ## SpellCheckRegexTests
 


### PR DESCRIPTION
## Summary

Reviewed all 89 markdown docs against the current SE 5 codebase (Avalonia 12, .NET 10) and corrected what had drifted out of date. 74 files updated; no new sections added — only mistakes fixed.

## What changed (by group)

- **Overview / top-level** — min OS versions, macOS data-folder path (`~/.config/Subtitle Edit`), STT engine list (drop standalone Parakeet.cpp; add OpenAI-compatible STT, Mega + Kyutai Crisp ASR, forced-aligner picker), README macOS dependency line.
- **ASSA** — menu renamed to **ASSA tools**; submenu entries (Generate background boxes, Generate progress bar, Change resolution, Image color picker, Apply override tags); effect / box-shape / drawing-tool lists rebuilt from source.
- **Reference** — `keyboard-shortcuts.md` rewritten against `ShortcutsMain.cs` defaults; mouse-controls Ctrl/Cmd+wheel seek; FCE rule count 38 → 39; `supported-formats.md` table fix + MacCaption + MP4/TS extensions.
- **Sync + video** — dialog UIs rewritten to match real controls; window position+size persistence noted; video-player backend list fixed; `blank-video` / `re-encode` / `cut-video` bogus "batch mode" sections removed; cut-video segment labels corrected.
- **Speech / TTS / OCR / burn / shot / embedded / batch** — STT engine table rebuilt (Purfview-Faster-Whisper-XXL rename, dropped dead engines, Crisp ASR collapsed to one engine with backend list); TTS list adds OmniVoice + Chatterbox; OCR menu path, engines, default endpoints; burn-in / transparent / embedded / shot-changes menu labels; batch-convert OCR engine list.
- **Editing / spell / errors** — file/edit/grid/main-window menus and context menus rebuilt against the actual flyout; fix-common-errors rule list + Profile-manager UI; netflix-errors check list.
- **Tools / timing** — 14 dialogs realigned to actual radio buttons, checkboxes, and sub-options (`adjust-duration`, `bridge-gaps`, `merge-*`, `split-*`, `sort-by`, `change-casing`, `change-formatting`, `remove-text-hi`, etc.).
- **Translate + misc** — auto-translate adds DeepSeek; copy-paste-translate block-size unit + separator default; compare color legend; statistics Export button; settings adds focus-text-box-after-insert; shortcuts adds Set actor 1–10; seconv quick examples for `--encoding:source`, `--FixCommonErrors`, `binaryocr`.
- **Dev / installer READMEs** — screenshot counts; mac installer version examples (`v5.0.0-beta32`); libse cross-platform sample path; tests/UI intro line.

## Test plan

- [ ] Skim the rendered docs site to spot-check the largest rewrites (`keyboard-shortcuts.md`, `speech-to-text.md`, `text-to-speech.md`, `fix-common-errors.md`, `remove-text-hi.md`).
- [ ] Verify no broken internal `.md` links in `docs/`.
- [ ] Confirm screenshot references still resolve (no screenshots were added/removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)