### PR TITLE
feat(waveform): configurable snap-to-shot-change offset (frames)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1163,9 +1163,11 @@ public class AudioVisualizer : Control
                     if (nearestShotChange != null)
                     {
                         var nearest = (double)nearestShotChange;
-                        if (nearest != newStart && Math.Abs(newStart - nearest) < ShotChangeSnapSeconds)
+                        var offsetSeconds = GetShotChangeSnapOffsetSeconds();
+                        var snapTarget = nearest + offsetSeconds;
+                        if (snapTarget != newStart && Math.Abs(newStart - snapTarget) < ShotChangeSnapSeconds)
                         {
-                            newStart = nearest;
+                            newStart = snapTarget;
                             snappedToShotLeft = true;
                         }
                     }
@@ -1194,14 +1196,15 @@ public class AudioVisualizer : Control
                 var snappedToShotRight = false;
                 if (SnapToShotChanges)
                 {
-                    var oneFrameSeconds = 0; // Or should it be one frame before, like  0.042 (Get fps from video)
                     var nearestShotChange = ShotChangesHelper.GetClosestShotChange(_shotChanges, TimeCode.FromSeconds(newEnd));
                     if (nearestShotChange != null)
                     {
                         var nearest = (double)nearestShotChange;
-                        if (nearest != newEnd && Math.Abs(newEnd - nearest + oneFrameSeconds) < ShotChangeSnapSeconds)
+                        var offsetSeconds = GetShotChangeSnapOffsetSeconds();
+                        var snapTarget = nearest - offsetSeconds;
+                        if (snapTarget != newEnd && Math.Abs(newEnd - snapTarget) < ShotChangeSnapSeconds)
                         {
-                            newEnd = nearest - oneFrameSeconds;
+                            newEnd = snapTarget;
                             snappedToShotRight = true;
                         }
                     }
@@ -1275,6 +1278,18 @@ public class AudioVisualizer : Control
 
         frameDur = 1.0 / fps;
         return true;
+    }
+
+    private static double GetShotChangeSnapOffsetSeconds()
+    {
+        var frames = Se.Settings.Waveform.SnapToShotChangeOffsetFrames;
+        if (frames <= 0)
+        {
+            return 0;
+        }
+
+        var fps = Se.Settings.General.CurrentFrameRate;
+        return fps >= 1 ? frames / fps : 0;
     }
 
     private void UpdateCursor(Point point)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6299,6 +6299,8 @@ public partial class MainViewModel :
             return;
         }
 
+        var offsetSeconds = GetShotChangeSnapOffsetSeconds();
+
         foreach (var line in selectedLines)
         {
             var idx = Subtitles.IndexOf(line);
@@ -6320,11 +6322,12 @@ public partial class MainViewModel :
 
             if (nearestStartShotChange == 0)
             {
-                var newDuration = TimeSpan.FromSeconds(nearestEndShotChange) - line.StartTime;
+                var endTarget = nearestEndShotChange - offsetSeconds;
+                var newDuration = TimeSpan.FromSeconds(endTarget) - line.StartTime;
                 if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds &&
                     newDuration.TotalMilliseconds >= Se.Settings.General.SubtitleMinimumDisplayMilliseconds)
                 {
-                    line.EndTime = TimeSpan.FromSeconds(nearestEndShotChange);
+                    line.EndTime = TimeSpan.FromSeconds(endTarget);
                 }
 
                 continue;
@@ -6332,11 +6335,12 @@ public partial class MainViewModel :
 
             if (nearestEndShotChange == 0)
             {
-                var newDuration = line.EndTime - TimeSpan.FromSeconds(nearestStartShotChange);
+                var startTarget = nearestStartShotChange + offsetSeconds;
+                var newDuration = line.EndTime - TimeSpan.FromSeconds(startTarget);
                 if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds &&
                     newDuration.TotalMilliseconds >= Se.Settings.General.SubtitleMinimumDisplayMilliseconds)
                 {
-                    line.StartTime = TimeSpan.FromSeconds(nearestStartShotChange);
+                    line.StartTime = TimeSpan.FromSeconds(startTarget);
                 }
 
                 continue;
@@ -6348,16 +6352,16 @@ public partial class MainViewModel :
                     .OrderBy(s => Math.Abs(s - line.EndTime.TotalSeconds))
                     .FirstOrDefault(s => Math.Abs(s - line.EndTime.TotalSeconds) < 0.5); //TODO: customizable
 
-                if (nearestEndShotChange > 0 && nearestEndShotChange > line.StartTime.TotalSeconds)
+                if (nearestEndShotChange > 0 && nearestEndShotChange - offsetSeconds > line.StartTime.TotalSeconds)
                 {
-                    line.EndTime = TimeSpan.FromSeconds(nearestEndShotChange);
+                    line.EndTime = TimeSpan.FromSeconds(nearestEndShotChange - offsetSeconds);
                 }
 
                 continue;
             }
 
-            var newStartTime = TimeSpan.FromSeconds(nearestStartShotChange);
-            var newEndTime = TimeSpan.FromSeconds(nearestEndShotChange);
+            var newStartTime = TimeSpan.FromSeconds(nearestStartShotChange + offsetSeconds);
+            var newEndTime = TimeSpan.FromSeconds(nearestEndShotChange - offsetSeconds);
             var newCombinedDuration = newEndTime - newStartTime;
             if (newCombinedDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds &&
                 newCombinedDuration.TotalMilliseconds >= Se.Settings.General.SubtitleMinimumDisplayMilliseconds)
@@ -6368,6 +6372,18 @@ public partial class MainViewModel :
         }
 
         _updateAudioVisualizer = true;
+    }
+
+    private static double GetShotChangeSnapOffsetSeconds()
+    {
+        var frames = Se.Settings.Waveform.SnapToShotChangeOffsetFrames;
+        if (frames <= 0)
+        {
+            return 0;
+        }
+
+        var fps = Se.Settings.General.CurrentFrameRate;
+        return fps >= 1 ? frames / fps : 0;
     }
 
     [RelayCommand]
@@ -6446,6 +6462,7 @@ public partial class MainViewModel :
 
         var minDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
         var maxDurationMs = Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
+        var offsetSeconds = GetShotChangeSnapOffsetSeconds();
         foreach (var line in selectedLines)
         {
             // Cast to nullable so a shot change at t=0 isn't lost to the
@@ -6458,7 +6475,7 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var newStart = TimeSpan.FromSeconds(next.Value);
+            var newStart = TimeSpan.FromSeconds(next.Value + offsetSeconds);
             if (newStart >= line.EndTime)
             {
                 continue;
@@ -6492,6 +6509,7 @@ public partial class MainViewModel :
 
         var minDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
         var maxDurationMs = Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
+        var offsetSeconds = GetShotChangeSnapOffsetSeconds();
         foreach (var line in selectedLines)
         {
             // Cast to nullable so a shot change at t=0 isn't lost to the
@@ -6504,7 +6522,7 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var newEnd = TimeSpan.FromSeconds(prev.Value);
+            var newEnd = TimeSpan.FromSeconds(prev.Value - offsetSeconds);
             if (newEnd <= line.StartTime)
             {
                 continue;

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -480,6 +480,13 @@ public class SettingsPage : UserControl
 
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformRightClickSelectsSubtitle, nameof(_vm.WaveformRightClickSelectsSubtitle)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformSnapToShotChanges, nameof(_vm.WaveformSnapToShotChanges)),
+            new SettingsItem(Se.Language.Options.Settings.WaveformSnapToShotChangeOffsetFrames, () => UiUtil.MakeNumericUpDownInt(
+                0,
+                30,
+                2,
+                120,
+                _vm,
+                nameof(_vm.WaveformSnapToShotChangeOffsetFrames))),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformSnapToFrames, nameof(_vm.WaveformSnapToFrames)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformShotChangesAutoGenerate, nameof(_vm.WaveformShotChangesAutoGenerate)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformFocusOnMouseOver, nameof(_vm.WaveformFocusOnMouseOver)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -243,6 +243,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private Color _waveformFancyHighColor;
     [ObservableProperty] private bool _waveformInvertMouseWheel;
     [ObservableProperty] private bool _waveformSnapToShotChanges;
+    [ObservableProperty] private int _waveformSnapToShotChangeOffsetFrames;
     [ObservableProperty] private bool _waveformSnapToFrames;
     [ObservableProperty] private bool _waveformShotChangesAutoGenerate;
     [ObservableProperty] private bool _waveformAllowOverlap;
@@ -781,6 +782,7 @@ public partial class SettingsViewModel : ObservableObject
         WaveformFancyHighColor = Se.Settings.Waveform.WaveformFancyHighColor.FromHexToColor();
         WaveformInvertMouseWheel = Se.Settings.Waveform.InvertMouseWheel;
         WaveformSnapToShotChanges = Se.Settings.Waveform.SnapToShotChanges;
+        WaveformSnapToShotChangeOffsetFrames = Se.Settings.Waveform.SnapToShotChangeOffsetFrames;
         WaveformSnapToFrames = Se.Settings.Waveform.SnapToFrames;
         WaveformShotChangesAutoGenerate = Se.Settings.Waveform.ShotChangesAutoGenerate;
         WaveformAllowOverlap = Se.Settings.Waveform.AllowOverlap;
@@ -1405,6 +1407,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Waveform.WaveformFancyHighColor = WaveformFancyHighColor.FromColorToHex();
         Se.Settings.Waveform.InvertMouseWheel = WaveformInvertMouseWheel;
         Se.Settings.Waveform.SnapToShotChanges = WaveformSnapToShotChanges;
+        Se.Settings.Waveform.SnapToShotChangeOffsetFrames = WaveformSnapToShotChangeOffsetFrames;
         Se.Settings.Waveform.SnapToFrames = WaveformSnapToFrames;
         Se.Settings.Waveform.ShotChangesAutoGenerate = WaveformShotChangesAutoGenerate;
         Se.Settings.Waveform.AllowOverlap = WaveformAllowOverlap;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -139,6 +139,7 @@ public class LanguageSettings
     public string WaveformFocusTextboxAfterInsertNew { get; set; }
     public string WaveformInvertMouseWheel { get; set; }
     public string WaveformSnapToShotChanges { get; set; }
+    public string WaveformSnapToShotChangeOffsetFrames { get; set; }
     public string WaveformSnapToFrames { get; set; }
     public string WaveformShotChangesAutoGenerate { get; set; }
     public string WaveformTextFontSize { get; set; }
@@ -433,6 +434,7 @@ public class LanguageSettings
         WaveformFocusTextboxAfterInsertNew = "Focus text box after insert";
         WaveformInvertMouseWheel = "Invert mouse-wheel";
         WaveformSnapToShotChanges = "Snap to shot changes";
+        WaveformSnapToShotChangeOffsetFrames = "Snap offset (frames before/after shot change)";
         WaveformSnapToFrames = "Snap to frames";
         WaveformShotChangesAutoGenerate = "Shot changes auto-generate";
         WaveformTextFontSize = "Waveform text font size";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -34,6 +34,7 @@ public class SeWaveform
     public bool SnapToFrames { get; set; }
     public bool ShotChangesAutoGenerate { get; set; }
     public int SnapToShotChangesPixels { get; set; }
+    public int SnapToShotChangeOffsetFrames { get; set; }
     public bool FocusOnMouseOver { get; set; }
     public bool GuessTimeCodeStartFromBeginning { get; set; }
     public int GuessTimeCodeScanBlockSize { get; set; }
@@ -77,6 +78,7 @@ public class SeWaveform
         ShotChangesImportTimeCodeFormat = "Seconds";
         SnapToShotChangesPixels = 8;
         SnapToShotChanges = true;
+        SnapToShotChangeOffsetFrames = 2;
         SnapToFrames = false;
         ShotChangesAutoGenerate = false;
 


### PR DESCRIPTION
## Summary
- Adds `Se.Settings.Waveform.SnapToShotChangeOffsetFrames` (default `2`) so cues never land exactly on a shot change: **in-cues snap to `shotChange + offset`**, **out-cues snap to `shotChange - offset`** (frames converted via `CurrentFrameRate`).
- Applied in two places that previously hard-snapped: the waveform drag-snap in `AudioVisualizer.cs` (resolves the long-standing `// Or should it be one frame before, like 0.042` TODO) and the three shortcut commands `SnapSelectedLinesToNearestShotChange`, `SnapSelectedLinesStartToNextShotChange`, `SnapSelectedLinesEndToPreviousShotChange`.
- New numeric input in **Settings → Waveform / Spectrogram → "Snap offset (frames before/after shot change)"** (range 0–30).

Addresses the feature request raised in discussion #11195 ("Snap to shot changes ... useless for me unless I can set a minimum frame distance"). Conceptually mirrors SE4's BeautifyTimeCodes green-zone offset.

## Test plan
- [ ] Open a video with shot changes loaded; in Settings → Waveform, set "Snap offset" to `2`.
- [ ] Drag the start edge of a subtitle near a shot change → start lands ~2 frames **after** the shot change, not exactly on it.
- [ ] Drag the end edge near a shot change → end lands ~2 frames **before** the shot change.
- [ ] Run shortcut **Snap selected lines to nearest shot change** → in/out cues respect the same `+offset`/`-offset` rule.
- [ ] Run **Snap start to next shot change** / **Snap end to previous shot change** → ditto.
- [ ] Set offset to `0` → behavior matches the previous version (snap exactly on shot change).
- [ ] Set offset to a large value (e.g. 10) → snaps further from the shot change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)