### PR TITLE
Make duration field actually show min/max warning color

### DIFF
--- a/src/ui/Controls/SecondsUpDown.cs
+++ b/src/ui/Controls/SecondsUpDown.cs
@@ -50,6 +50,30 @@ public class SecondsUpDown : TemplatedControl
                 ValueChanged?.Invoke(this, newValue);
             }
         }
+        else if (change.Property == BackgroundProperty)
+        {
+            ApplyBackgroundToTextBox(change.NewValue as IBrush);
+        }
+    }
+
+    // The templated control's Background isn't drawn behind the inner TextBox —
+    // propagate it explicitly so bindings (e.g. duration min/max warning color)
+    // become visible. Transparent / null means "use default TextBox style".
+    private void ApplyBackgroundToTextBox(IBrush? brush)
+    {
+        if (_textBox == null)
+        {
+            return;
+        }
+
+        if (brush is null || (brush is SolidColorBrush solid && solid.Color == Colors.Transparent))
+        {
+            _textBox.ClearValue(TextBox.BackgroundProperty);
+        }
+        else
+        {
+            _textBox.Background = brush;
+        }
     }
 
     private static TimeSpan CoerceValue(AvaloniaObject sender, TimeSpan value)
@@ -125,6 +149,8 @@ public class SecondsUpDown : TemplatedControl
                 ChangeValue(args.Delta.Y > 0 ? +1 : -1);
                 args.Handled = true;
             };
+
+            ApplyBackgroundToTextBox(Background);
         }
     }
 


### PR DESCRIPTION
## Summary
- The duration up/down field in the main editor already binds its `Background` to `SubtitleLineViewModel.DurationBackgroundBrush`, which is supposed to flip to the error color when the current duration is **below `SubtitleMinimumDisplayMilliseconds`** or **above `SubtitleMaximumDisplayMilliseconds`** (gated by `ColorDurationTooShort` / `ColorDurationTooLong`, both `true` by default).
- But `SecondsUpDown` is a `TemplatedControl` whose template is `ButtonSpinner > Grid > TextBox` — none of those inherit the outer control's `Background`, so the warning color was never drawn.
- Propagate `Background` to the inner `TextBox` from `OnPropertyChanged` and on template apply. Transparent / null clears the override so the default `TextBox` style remains for the normal case.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` — clean
- [x] `dotnet test tests/UI/UITests.csproj` — 284/284 pass
- [x] Manual: open a subtitle, edit the duration below `SubtitleMinimumDisplayMilliseconds` (or above the max) and confirm the duration field turns red; restore an in-range value and confirm the field returns to its default appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)