### PR TITLE
Show "Allow overlap" checkbox on Waveform settings page

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -479,6 +479,7 @@ public class SettingsPage : UserControl
             }),
 
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformRightClickSelectsSubtitle, nameof(_vm.WaveformRightClickSelectsSubtitle)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.WaveformAllowOverlap, nameof(_vm.WaveformAllowOverlap)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformSnapToShotChanges, nameof(_vm.WaveformSnapToShotChanges)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformSnapToFrames, nameof(_vm.WaveformSnapToFrames)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformShotChangesAutoGenerate, nameof(_vm.WaveformShotChangesAutoGenerate)),


### PR DESCRIPTION
## Summary
- The `WaveformAllowOverlap` setting was wired up in `SettingsViewModel` and persisted to `Se.Settings.Waveform.AllowOverlap`, but the checkbox was missing from the Waveform section of the settings page, so users had no UI to toggle it.
- Adds a `MakeCheckboxSetting` row right after `WaveformRightClickSelectsSubtitle` using the existing `WaveformAllowOverlap` label ("Allow overlap (when moving/resizing)").

## Test plan
- [ ] Open Options → Settings → Waveform/Spectrogram and confirm the "Allow overlap (when moving/resizing)" checkbox appears.
- [ ] Toggle it, save, reopen — value persists.
- [ ] With it enabled, moving/resizing a subtitle in the waveform allows overlap with neighbors; with it disabled, it does not (Shift still forces overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)