### PR TITLE
Add burn-in icon to main toolbar

### DIFF
--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -192,6 +192,19 @@ public static class InitToolbar
             isLastSeparator = false;
         }
 
+        if (appearance.ToolbarShowBurnIn)
+        {
+            stackPanelLeft.Children.Add(new Button
+            {
+                Content = MakeImage("BurnIn"),
+                Command = vm.ShowVideoBurnInCommand,
+                Background = Brushes.Transparent,
+                [AutomationProperties.NameProperty] = languageHints.BurnInHint,
+                [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.BurnInHint, shortcuts, nameof(vm.ShowVideoBurnInCommand)),
+            });
+            isLastSeparator = false;
+        }
+
 
         if (appearance.ToolbarShowSettings)
         {

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -680,6 +680,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowToolbarReplace, nameof(_vm.ShowToolbarReplace)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowToolbarSpellCheck, nameof(_vm.ShowToolbarSpellCheck)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowToolbarFixCommonErrors, nameof(_vm.ShowToolbarFixCommonErrors)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.ShowToolbarBurnIn, nameof(_vm.ShowToolbarBurnIn)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowToolbarSettings, nameof(_vm.ShowToolbarSettings)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowToolbarLayout, nameof(_vm.ShowToolbarLayout)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowToolbarHelp, nameof(_vm.ShowToolbarHelp)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -174,6 +174,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _showToolbarReplace;
     [ObservableProperty] private bool _showToolbarSpellCheck;
     [ObservableProperty] private bool _showToolbarFixCommonErrors;
+    [ObservableProperty] private bool _showToolbarBurnIn;
     [ObservableProperty] private bool _showToolbarSettings;
     [ObservableProperty] private bool _showToolbarLayout;
     [ObservableProperty] private bool _showToolbarHelp;
@@ -674,6 +675,7 @@ public partial class SettingsViewModel : ObservableObject
         ShowToolbarReplace = appearance.ToolbarShowReplace;
         ShowToolbarSpellCheck = appearance.ToolbarShowSpellCheck;
         ShowToolbarFixCommonErrors = appearance.ToolbarShowFixCommonErrors;
+        ShowToolbarBurnIn = appearance.ToolbarShowBurnIn;
         ShowToolbarSettings = appearance.ToolbarShowSettings;
         ShowToolbarLayout = appearance.ToolbarShowLayout;
         ShowToolbarHelp = appearance.ToolbarShowHelp;
@@ -1311,6 +1313,7 @@ public partial class SettingsViewModel : ObservableObject
         appearance.ToolbarShowReplace = ShowToolbarReplace;
         appearance.ToolbarShowSpellCheck = ShowToolbarSpellCheck;
         appearance.ToolbarShowFixCommonErrors = ShowToolbarFixCommonErrors;
+        appearance.ToolbarShowBurnIn = ShowToolbarBurnIn;
         appearance.ToolbarShowSettings = ShowToolbarSettings;
         appearance.ToolbarShowLayout = ShowToolbarLayout;
         appearance.ToolbarShowHelp = ShowToolbarHelp;

--- a/src/ui/Logic/Config/Language/Main/LanguageMainToolbar.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainToolbar.cs
@@ -11,6 +11,7 @@ public class LanguageMainToolbar
     public string ReplaceHint { get; set; }
     public string SpellCheckHint { get; set; }
     public string FixCommonErrorsHint { get; set; }
+    public string BurnInHint { get; set; }
     public string SettingsHint { get; set; }
     public string LayoutHint { get; set; }
     public string HelpHint { get; set; }
@@ -33,6 +34,7 @@ public class LanguageMainToolbar
         ReplaceHint = "Find and replace text {0}";
         SpellCheckHint = "Check subtitles for spelling errors {0}";
         FixCommonErrorsHint = "Fix common subtitle errors {0}";
+        BurnInHint = "Burn subtitles into a video file {0}";
         SettingsHint = "Adjust program settings and preferences {0}";
         LayoutHint = "Change toolbar and panel layout {0}";
         HelpHint = "Open help website {0}";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -159,6 +159,7 @@ public class LanguageSettings
     public string ShowToolbarReplace { get; set; }
     public string ShowToolbarSpellCheck { get; set; }
     public string ShowToolbarFixCommonErrors { get; set; }
+    public string ShowToolbarBurnIn { get; set; }
     public string ShowToolbarSettings { get; set; }
     public string ShowToolbarLayout { get; set; }
     public string ShowToolbarHelp { get; set; }
@@ -453,6 +454,7 @@ public class LanguageSettings
         ShowToolbarReplace = "Show replace icon";
         ShowToolbarSpellCheck = "Show spell check icon";
         ShowToolbarFixCommonErrors = "Show fix common errors icon";
+        ShowToolbarBurnIn = "Show burn-in icon";
         ShowToolbarSettings = "Show settings icon";
         ShowToolbarLayout = "Show layout icon";
         ShowToolbarHelp = "Show help icon";

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -42,6 +42,7 @@ public class SeAppearance
     public bool ToolbarShowReplace { get; set; }
     public bool ToolbarShowFixCommonErrors { get; set; }
     public bool ToolbarShowSpellCheck { get; set; }
+    public bool ToolbarShowBurnIn { get; set; }
     public bool ToolbarShowSettings { get; set; }
     public bool ToolbarShowLayout { get; set; }
     public bool ToolbarShowHelp { get; set; }
@@ -101,6 +102,7 @@ public class SeAppearance
         ToolbarShowReplace = true;
         ToolbarShowFixCommonErrors = false;
         ToolbarShowSpellCheck = true;
+        ToolbarShowBurnIn = false;
         ToolbarShowSettings = true;
         ToolbarShowLayout = true;
         ToolbarShowHelp = true;


### PR DESCRIPTION
## Summary
- Adds a Burn-In button to the main toolbar that invokes the existing `ShowVideoBurnInCommand`. Uses the existing `BurnIn.png` already shipped in all three themes (Classic/Dark/Light).
- Adds a `Show burn-in icon` checkbox under Options → Settings → Toolbar (off by default to keep the toolbar uncluttered for users who don't burn in subtitles).
- Adds matching language strings (`BurnInHint` on the toolbar, `ShowToolbarBurnIn` on the settings page).

Closes #11202.

## Test plan
- [ ] Launch SE; verify the toolbar shows no Burn-In icon by default.
- [ ] Options → Settings → Toolbar → enable "Show burn-in icon"; verify icon appears between Fix Common Errors and Settings.
- [ ] Hover the new icon and confirm tooltip text + shortcut (if assigned).
- [ ] Click the icon and verify the Burn-In window opens (with ffmpeg available).
- [ ] Toggle the setting off again and verify the icon disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)