### PR TITLE
Fix Find Previous shortcut

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9305,8 +9305,7 @@ public partial class MainViewModel :
 
         var subs = Subtitles.Select(p => p.Text).ToList();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
-        var currentCharIndex = EditTextBox.CaretIndex;
-        var idx = _findService.FindPrevious(_findService.SearchText, subs, currentLineIndex, currentCharIndex - 1);
+        var idx = _findService.FindPrevious(_findService.SearchText, subs, currentLineIndex, EditTextBox.SelectionStart - 1);
 
         if (idx < 0)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9328,6 +9328,8 @@ public partial class MainViewModel :
             EditTextBox.SelectionStart = _findService.CurrentTextIndex;
             EditTextBox.SelectionEnd = _findService.CurrentTextIndex + _findService.CurrentTextFound.Length;
         });
+
+        _shortcutManager.ClearKeys();
     }
 
     [RelayCommand]


### PR DESCRIPTION
This PR fixes two related bugs that made the _Find Previous_ shortcut appear to do nothing after the first use.

##### Problems
  
1. Shortcut only fires once
FindNext called `_shortcutManager.ClearKeys()` after completing, but FindPrevious did not. The shortcut manager retained the Shift+F3 (or the configured shortcut) key state after the first press, so subsequent presses were silently ignored.

2. Always re-finds the same match
AvaloniaEdit places the caret at the end of a selection, so `CaretIndex` returned `SelectionEnd` rather than `SelectionStart` after a match was highlighted. The backwards search was starting from inside the current match and looping back to it every time, making the shortcut appear to do nothing even when it did fire.

##### Fix
  
- Added `_shortcutManager.ClearKeys()` to the FindPrevious handler, mirroring what FindNext already does.
- Changed the search start position from `CaretIndex - 1` to `SelectionStart - 1`, consistent with how `HandleFindResult` drives the search from the Find dialog.

Tested under macOS only.