### PR TITLE
Add "Set duration to max CPS" shortcut for selected lines

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3225,6 +3225,59 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void SetDurationMaxCpsSelectedLines()
+    {
+        var selectedLines = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        if (selectedLines.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var selectedLine in selectedLines)
+        {
+            var idx = Subtitles.IndexOf(selectedLine);
+            if (idx < 0)
+            {
+                continue;
+            }
+
+            var charCount = selectedLine.Text?.Length ?? 0;
+            if (charCount == 0)
+            {
+                continue;
+            }
+
+            var nextSubtitle = Subtitles.GetOrNull(idx + 1);
+            var targetDuration = TimeSpan.FromSeconds(charCount / Se.Settings.General.SubtitleMaximumCharactersPerSeconds);
+            var newEndTime = selectedLine.StartTime + targetDuration;
+
+            var minEndTime = TimeSpan.FromMilliseconds(selectedLine.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMinimumDisplayMilliseconds);
+            if (newEndTime < minEndTime)
+            {
+                newEndTime = minEndTime;
+            }
+
+            var maxEndTime = TimeSpan.FromMilliseconds(selectedLine.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMaximumDisplayMilliseconds);
+            if (nextSubtitle != null)
+            {
+                var gapBound = TimeSpan.FromMilliseconds(nextSubtitle.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
+                if (gapBound < maxEndTime)
+                {
+                    maxEndTime = gapBound;
+                }
+            }
+            if (newEndTime > maxEndTime)
+            {
+                newEndTime = maxEndTime;
+            }
+
+            selectedLine.EndTime = newEndTime;
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
     private void DoWaveformCenter()
     {
         var vp = GetVideoPlayerControl();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3247,17 +3247,15 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var nextSubtitle = Subtitles.GetOrNull(idx + 1);
-            var targetDuration = TimeSpan.FromSeconds(charCount / Se.Settings.General.SubtitleMaximumCharactersPerSeconds);
-            var newEndTime = selectedLine.StartTime + targetDuration;
-
-            var minEndTime = TimeSpan.FromMilliseconds(selectedLine.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMinimumDisplayMilliseconds);
-            if (newEndTime < minEndTime)
+            var maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
+            if (maxCps <= 0)
             {
-                newEndTime = minEndTime;
+                continue;
             }
 
+            var minEndTime = TimeSpan.FromMilliseconds(selectedLine.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMinimumDisplayMilliseconds);
             var maxEndTime = TimeSpan.FromMilliseconds(selectedLine.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMaximumDisplayMilliseconds);
+            var nextSubtitle = Subtitles.GetOrNull(idx + 1);
             if (nextSubtitle != null)
             {
                 var gapBound = TimeSpan.FromMilliseconds(nextSubtitle.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
@@ -3265,6 +3263,17 @@ public partial class MainViewModel :
                 {
                     maxEndTime = gapBound;
                 }
+            }
+
+            if (maxEndTime < minEndTime)
+            {
+                continue;
+            }
+
+            var newEndTime = selectedLine.StartTime + TimeSpan.FromSeconds(charCount / maxCps);
+            if (newEndTime < minEndTime)
+            {
+                newEndTime = minEndTime;
             }
             if (newEndTime > maxEndTime)
             {

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -269,6 +269,7 @@ public class LanguageSettingsShortcuts
     public string AssaAttachments { get; set; }
     public string AssaVideoColorPicker { get; set; }
     public string RecalculateDurationSelectedLines { get; set; }
+    public string SetDurationMaxCpsSelectedLines { get; set; }
     public string ToggleWaveformAndSpectrogramHeight { get; set; }
     public string ToggleSpectrogramStyle { get; set; }
     public string CopyMsRelativeToCurrentSubtitleLineToClipboard { get; set; }
@@ -559,6 +560,7 @@ public class LanguageSettingsShortcuts
         AssaProperties = "ASSA Properties";
         AssaVideoColorPicker = "ASSA Video color picker";
         RecalculateDurationSelectedLines = "Recalculate duration (selected lines)";
+        SetDurationMaxCpsSelectedLines = "Set duration to max CPS (selected lines)";
         ToggleWaveformAndSpectrogramHeight = "Toggle waveform/spectrogram divided height";
         ToggleSpectrogramStyle = "Toggle spectrogram style";
         CopyMsRelativeToCurrentSubtitleLineToClipboard = "Copy milliseconds relative to current subtitle line to clipboard";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -390,6 +390,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.ShowAssaPropertiesCommand), Se.Language.Options.Shortcuts.AssaProperties },
         { nameof(MainViewModel.ShowAssaAttachmentsCommand), Se.Language.Options.Shortcuts.AssaAttachments },
         { nameof(MainViewModel.RecalculateDurationSelectedLinesCommand), Se.Language.Options.Shortcuts.RecalculateDurationSelectedLines },
+        { nameof(MainViewModel.SetDurationMaxCpsSelectedLinesCommand), Se.Language.Options.Shortcuts.SetDurationMaxCpsSelectedLines },
         { nameof(MainViewModel.WaveformToggleWaveformSpectrogramHeightCommand), Se.Language.Options.Shortcuts.ToggleWaveformAndSpectrogramHeight },
         { nameof(MainViewModel.SpectrogramToggleStyleCommand), Se.Language.Options.Shortcuts.ToggleSpectrogramStyle },
         { nameof(MainViewModel.ShowBeautifyTimeCodesCommand), Se.Language.Tools.BeautifyTimeCodes.Title },
@@ -714,6 +715,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ShowAssaPropertiesCommand, nameof(vm.ShowAssaPropertiesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowAssaAttachmentsCommand, nameof(vm.ShowAssaAttachmentsCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.RecalculateDurationSelectedLinesCommand, nameof(vm.RecalculateDurationSelectedLinesCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.SetDurationMaxCpsSelectedLinesCommand, nameof(vm.SetDurationMaxCpsSelectedLinesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.FillSelectedLinesWithClipboardCommand, nameof(vm.FillSelectedLinesWithClipboardCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.WaveformToggleWaveformSpectrogramHeightCommand, nameof(vm.WaveformToggleWaveformSpectrogramHeightCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SpectrogramToggleStyleCommand, nameof(vm.SpectrogramToggleStyleCommand), ShortcutCategory.General);


### PR DESCRIPTION
Calculates the shortest legal duration from SubtitleMaximumCharactersPerSeconds, clamped by SubtitleMinimumDisplayMilliseconds and bounded by the next line gap or SubtitleMaximumDisplayMilliseconds.