### PR TITLE
Beautify window: move profile button to bottom + tighten layout

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1479,7 +1479,7 @@
       "minGapEnforced": "min. gap enforced",
       "minDurationEnforced": "min. duration enforced",
       "maxDurationEnforced": "max. duration enforced",
-      "noReasonNote": "Adjusted by beautify profile",
+      "noReasonNote": "refined by profile rules",
       "previousChange": "Previous change",
       "nextChange": "Next change",
       "editProfile": "Edit profile..."

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1479,9 +1479,10 @@
       "minGapEnforced": "min. gap enforced",
       "minDurationEnforced": "min. duration enforced",
       "maxDurationEnforced": "max. duration enforced",
-      "noReasonNote": "—",
+      "noReasonNote": "Adjusted by beautify profile",
       "previousChange": "Previous change",
-      "nextChange": "Next change"
+      "nextChange": "Next change",
+      "editProfile": "Edit profile..."
     },
     "beautifyTimeCodesProfile": {
       "title": "Edit beautify time codes profile",

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -283,21 +283,15 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         var startChanged = Math.Abs(beautified.StartTime.TotalMilliseconds - original.StartTime.TotalMilliseconds) > 0.5;
         if (startChanged)
         {
-            var reason = DetectStartReason(original, beautified, prevB);
-            if (reason != null)
-            {
-                parts.Add(Se.Language.General.StartTime + ": " + reason);
-            }
+            var reason = DetectStartReason(original, beautified, prevB) ?? lang.NoReasonNote;
+            parts.Add(Se.Language.General.StartTime + ": " + reason);
         }
 
         var endChanged = Math.Abs(beautified.EndTime.TotalMilliseconds - original.EndTime.TotalMilliseconds) > 0.5;
         if (endChanged)
         {
-            var reason = DetectEndReason(original, beautified, nextB);
-            if (reason != null)
-            {
-                parts.Add(Se.Language.General.EndTime + ": " + reason);
-            }
+            var reason = DetectEndReason(original, beautified, nextB) ?? lang.NoReasonNote;
+            parts.Add(Se.Language.General.EndTime + ": " + reason);
         }
 
         // Duration reason — applies regardless of which side moved
@@ -307,7 +301,7 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
             parts.Add(Se.Language.General.Duration + ": " + durationReason);
         }
 
-        return parts.Count == 0 ? lang.NoReasonNote : string.Join("    ·    ", parts);
+        return string.Join("    ·    ", parts);
     }
 
     private string? DetectStartReason(SubtitleLineViewModel original, SubtitleLineViewModel beautified, SubtitleLineViewModel? prev)

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesWindow.cs
@@ -17,9 +17,9 @@ public class BeautifyTimeCodesWindow : Window
         Title = Se.Language.Tools.BeautifyTimeCodes.Title;
         CanResize = true;
         Width = 1100;
-        Height = 680;
+        Height = 600;
         MinWidth = 900;
-        MinHeight = 520;
+        MinHeight = 460;
         vm.Window = this;
         DataContext = vm;
 
@@ -51,10 +51,6 @@ public class BeautifyTimeCodesWindow : Window
 
     private static Control BuildTopBar(BeautifyTimeCodesViewModel vm)
     {
-        var l = Se.Language.Tools.BeautifyTimeCodesProfile;
-
-        var buttonEditProfile = UiUtil.MakeButton(l.Title, vm.EditProfileCommand);
-
         var stats = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,
@@ -66,10 +62,9 @@ public class BeautifyTimeCodesWindow : Window
 
         var grid = new Grid
         {
-            ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto"),
+            ColumnDefinitions = new ColumnDefinitions("*"),
         };
-        grid.Add(buttonEditProfile, 0, 0);
-        grid.Add(stats, 0, 2);
+        grid.Add(stats, 0, 0);
         return grid;
     }
 
@@ -197,8 +192,9 @@ public class BeautifyTimeCodesWindow : Window
 
     private static Control BuildButtonBar(BeautifyTimeCodesViewModel vm)
     {
+        var buttonEditProfile = UiUtil.MakeButton(Se.Language.Tools.BeautifyTimeCodes.EditProfile, vm.EditProfileCommand);
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        return UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        return UiUtil.MakeButtonBar(buttonEditProfile, buttonOk, buttonCancel);
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageBeautifyTimeCodes.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBeautifyTimeCodes.cs
@@ -47,7 +47,7 @@ public class LanguageBeautifyTimeCodes
         MinGapEnforced = "min. gap enforced";
         MinDurationEnforced = "min. duration enforced";
         MaxDurationEnforced = "max. duration enforced";
-        NoReasonNote = "Adjusted by beautify profile";
+        NoReasonNote = "refined by profile rules";
         PreviousChange = "Previous change";
         NextChange = "Next change";
         EditProfile = "Edit profile...";

--- a/src/ui/Logic/Config/Language/Tools/LanguageBeautifyTimeCodes.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBeautifyTimeCodes.cs
@@ -24,6 +24,7 @@ public class LanguageBeautifyTimeCodes
     public string NoReasonNote { get; set; }
     public string PreviousChange { get; set; }
     public string NextChange { get; set; }
+    public string EditProfile { get; set; }
 
     public LanguageBeautifyTimeCodes()
     {
@@ -46,8 +47,9 @@ public class LanguageBeautifyTimeCodes
         MinGapEnforced = "min. gap enforced";
         MinDurationEnforced = "min. duration enforced";
         MaxDurationEnforced = "max. duration enforced";
-        NoReasonNote = "—";
+        NoReasonNote = "Adjusted by beautify profile";
         PreviousChange = "Previous change";
         NextChange = "Next change";
+        EditProfile = "Edit profile...";
     }
 }


### PR DESCRIPTION
## Summary
- Renamed the top-bar **"Edit beautify time codes profile"** button to **"Edit profile..."** and moved it to the bottom button row, next to OK/Cancel.
- Top bar now only carries the stats line.
- Reduced default window height from 680 to 600 (MinHeight 520 → 460) — the visualizers didn't need that much vertical room.
- The change-notes line in the change navigator was falling back to `"—"` when none of the detected reasons matched. Replaced with a per-side fallback so the line now always labels which cue moved, e.g. `Start time: snapped to frame  ·  End time: refined by profile rules`. The per-side fallback text is `"refined by profile rules"`.

## Test plan
- [ ] Open **Tools → Beautify time codes** on a subtitle with shot changes.
- [ ] Verify the bottom button row shows **Edit profile... / OK / Cancel** and the top bar only shows the stats text.
- [ ] Click **Edit profile...** — the profile editor opens; changes re-trigger the beautify preview on close.
- [ ] Step through changes — every change shows a non-blank second line that labels start/end (and any specific known reason still wins over the `refined by profile rules` fallback).
- [ ] Window opens at the smaller default height and is still usable at the new min height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)