### PR TITLE
Fix keyboard shortcut bugs: stale key state after dialog close and lost grid focus after layout change

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -818,6 +818,7 @@ public partial class MainViewModel :
         var savedAudioTrack = _audioTrack;
         Se.Settings.General.LayoutNumber = InitLayout.MakeLayout(MainView!, this, layoutNumber);
         SelectAndScrollToRow(Math.Max(0, idx));
+        Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
         RefreshSubtitlePreview();
 
         if (savedAudioTrack != null && !string.IsNullOrEmpty(_videoFileName))

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4808,9 +4808,8 @@ public partial class MainViewModel :
             return;
         }
 
-        var result = await _windowService
-            .ShowDialogAsync<SplitBreakLongLinesWindow, SplitBreakLongLinesViewModel>(
-                Window!, vm => { vm.Initialize(Subtitles.ToList()); });
+        var result = await ShowDialogAsync<SplitBreakLongLinesWindow, SplitBreakLongLinesViewModel>(
+            vm => { vm.Initialize(Subtitles.ToList()); });
 
         if (result.OkPressed && result.AllSubtitlesFixed.Count > 0)
         {
@@ -4836,9 +4835,8 @@ public partial class MainViewModel :
             return;
         }
 
-        var result = await _windowService
-            .ShowDialogAsync<MergeShortLinesWindow, MergeShortLinesViewModel>(
-                Window!, vm => { vm.Initialize(Subtitles.ToList(), AudioVisualizer?.ShotChanges ?? new List<double>()); });
+        var result = await ShowDialogAsync<MergeShortLinesWindow, MergeShortLinesViewModel>(
+            vm => { vm.Initialize(Subtitles.ToList(), AudioVisualizer?.ShotChanges ?? new List<double>()); });
 
         if (result.OkPressed)
         {
@@ -4963,9 +4961,8 @@ public partial class MainViewModel :
         }
 
         var language = Subtitles.AutoDetectGoogleLanguage();
-        var result = await _windowService
-            .ShowDialogAsync<MergeContinuationLinesWindow, MergeContinuationLinesViewModel>(
-                Window!, vm => { vm.Initialize(Subtitles.ToList(), language); });
+        var result = await ShowDialogAsync<MergeContinuationLinesWindow, MergeContinuationLinesViewModel>(
+            vm => { vm.Initialize(Subtitles.ToList(), language); });
 
         if (result.OkPressed)
         {
@@ -4991,9 +4988,8 @@ public partial class MainViewModel :
             return;
         }
 
-        var result = await _windowService
-            .ShowDialogAsync<RemoveTextForHearingImpairedWindow, RemoveTextForHearingImpairedViewModel>(
-                Window!, vm => { vm.Initialize(GetUpdateSubtitle()); });
+        var result = await ShowDialogAsync<RemoveTextForHearingImpairedWindow, RemoveTextForHearingImpairedViewModel>(
+            vm => { vm.Initialize(GetUpdateSubtitle()); });
 
         if (result.OkPressed)
         {
@@ -7319,8 +7315,8 @@ public partial class MainViewModel :
             return;
         }
 
-        var viewModel = await _windowService
-            .ShowDialogAsync<BeautifyTimeCodesWindow, BeautifyTimeCodesViewModel>(Window!, vm => { vm.Initialize(Subtitles.ToList(), AudioVisualizer, _videoFileName); });
+        var viewModel = await ShowDialogAsync<BeautifyTimeCodesWindow, BeautifyTimeCodesViewModel>(
+            vm => { vm.Initialize(Subtitles.ToList(), AudioVisualizer, _videoFileName); });
 
         if (!viewModel.OkPressed)
         {
@@ -7397,12 +7393,11 @@ public partial class MainViewModel :
         Se.Settings.General.WindowPositions = Se.Settings.General.WindowPositions.OrderBy(p => p.WindowName).ToList();
         var oldSettngsSerialized = JsonSerializer.Serialize(Se.Settings);
 
-        var viewModel = await _windowService
-            .ShowDialogAsync<SettingsWindow, SettingsViewModel>(Window!, vm => { vm.Initialize(this); });
+        var viewModel = await ShowDialogAsync<SettingsWindow, SettingsViewModel>(
+            vm => { vm.Initialize(this); });
 
         if (!viewModel.OkPressed)
         {
-            _shortcutManager.ClearKeys();
             return;
         }
 
@@ -9103,8 +9098,7 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ShowRestoreAutoBackup()
     {
-        var viewModel = await _windowService
-            .ShowDialogAsync<RestoreAutoBackupWindow, RestoreAutoBackupViewModel>(Window!);
+        var viewModel = await ShowDialogAsync<RestoreAutoBackupWindow, RestoreAutoBackupViewModel>();
 
         if (viewModel.OkPressed && !string.IsNullOrEmpty(viewModel.RestoreFileName))
         {


### PR DESCRIPTION
## Summary

Two related keyboard shortcut fixes in `MainViewModel.cs`.

  ---
  
  ### Fix 1: Dialogs reopening due to stale shortcut key state after close

  When a modal dialog was opened via a keyboard shortcut (e.g. `Cmd+Shift+H` for Remove Text for Hearing Impaired, after setting this shortcut), closing the dialog could cause it to immediately reopen on the next keypress. The root cause was that modifier/character keys held while the dialog had focus were never released from the shortcut manager's active key set — so the key combination was still considered "held" after the dialog closed, and the next `KeyDown` event completed the chord again.
  
  **To reproduce:**
  1. Open a subtitle file.
  2. Press `Cmd+Shift+H` (Remove Text for Hearing Impaired) — dialog opens.
  3. Close the dialog with `Escape` or the Cancel button.
  4. Press Cmd+Shift. The dialog reopens unexpectedly.

  **Fix:** The seven affected dialog calls (`ShowToolsRemoveTextForHearingImpaired`, `ShowToolsSplitBreakLongLines`, `ShowToolsMergeShortLines`, `ShowToolsMergeContinuationLines`, `ShowBeautifyTimeCodes`, `CommandShowSettings`, `ShowRestoreAutoBackup`) were migrated from direct `_windowService.ShowDialogAsync()` calls to the private `ShowDialogAsync()` wrapper, which calls `_shortcutManager.ClearKeys()` after each dialog returns.
  
  ---

  ### Fix 2: Subtitle grid loses focus after toolbar/panel layout change

  After switching the UI layout (via the toolbar layout buttons), keyboard shortcuts tied to the subtitle grid — those in the `SubtitleGrid` and `SubtitleGridAndTextBox` shortcut categories — stopped working. The user had to manually click a row in the grid before shortcuts would respond again.

  **To reproduce:**
  1. Open a subtitle file with at least one subtitle.
  2. Click a layout button in the toolbar to change the panel arrangement.
  3. Without clicking on the grid, press Cmd+, for opening Settings or Cmd+Shift+H for Remove Text for Hearing Impaired (these shortcuts must be defined first)
  4. Nothing happens — the shortcut is silently skipped.

  **Fix:** After `SetLayout` rebuilds the UI and `SelectAndScrollToRow` restores the selected row, a `Focus()` call is posted to the UI thread queue so the subtitle grid regains focus immediately.