### PR TITLE
TTS: unbreak lines centrally before handing text to engines

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
@@ -354,7 +354,7 @@ public partial class ActorVoiceMappingViewModel : ObservableObject
         {
             row.IsPlaying = true;
             var result = await TtsInstructionSwap.RunAsync(row.SelectedEngine, row.Instruction, () =>
-                row.SelectedEngine.Speak(_voiceTestText, _waveFolder, row.SelectedVoice,
+                row.SelectedEngine.Speak(Utilities.UnbreakLine(_voiceTestText), _waveFolder, row.SelectedVoice,
                     null, null, null, _cancellationTokenSource.Token));
 
             if (!_cancellationTokenSource.IsCancellationRequested && File.Exists(result.FileName))

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -305,7 +305,7 @@ public class ChatterboxTtsCpp : ITtsEngine
         await EnsureServerRunningAsync(ResolveModelKey(model), cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
-        var inputText = Utilities.UnbreakLine(text);
+        var inputText = text;
 
         // Per /v1/audio/speech: send full reference WAV path as the `voice` field.
         // Empty string falls back to the model's baked default voice.

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
@@ -380,7 +380,7 @@ public class IndexTtsCrispAsr : ITtsEngine
         await EnsureServerRunningAsync(modelKey, indexVoice.FilePath, cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
-        var inputText = Utilities.UnbreakLine(text);
+        var inputText = text;
 
         // OpenAI-compatible /v1/audio/speech payload. CrispASR's indextts backend uses:
         //   - `input`             — the text to synthesise

--- a/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -232,7 +232,7 @@ public class KokoroTtsCpp : ITtsEngine
         await EnsureServerRunningAsync(cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
-        var inputText = Utilities.UnbreakLine(text);
+        var inputText = text;
         var voiceName = string.IsNullOrEmpty(kokoroVoice.Voice) ? DefaultVoice : kokoroVoice.Voice;
 
         var body = JsonSerializer.Serialize(new { text = inputText, voice = voiceName });

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -235,7 +235,7 @@ public class OmniVoiceTtsCpp : ITtsEngine
         }
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
-        var inputText = Utilities.UnbreakLine(text);
+        var inputText = text;
 
         var psi = new ProcessStartInfo
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -259,8 +259,7 @@ public class Piper : ITtsEngine
         }
 
         var streamWriter = new StreamWriter(processPiper.StandardInput.BaseStream, new UTF8Encoding(false));
-        var text = Utilities.UnbreakLine(inputText);
-        streamWriter.Write(text);
+        streamWriter.Write(inputText);
         streamWriter.Flush();
         streamWriter.Close();
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -231,7 +231,7 @@ public class Qwen3TtsCpp : ITtsEngine
         await EnsureServerRunningAsync(modelFileName, cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
-        var inputText = Utilities.UnbreakLine(text);
+        var inputText = text;
 
         // Voice instruction only does anything on the instruction-tuned VoiceDesign model;
         // the 0.6B and 1.7B Base models ignore it, so it is omitted there entirely.

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -407,7 +407,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         await EnsureServerRunningAsync(modelKey, cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
-        var inputText = Utilities.UnbreakLine(text);
+        var inputText = text;
         // Share the qwen3-tts.cpp instruction setting so users get the same voice description
         // regardless of which Qwen3 engine they're testing with.
         var instruction = Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty;

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -368,7 +368,7 @@ public class VibeVoiceCrispAsr : ITtsEngine
         await EnsureServerRunningAsync(modelKey, cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
-        var inputText = Utilities.UnbreakLine(text);
+        var inputText = text;
 
         // OpenAI-compatible /v1/audio/speech payload. CrispASR's vibevoice backends look at:
         //   - `input`             — the text to synthesise

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -666,7 +666,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         try
         {
             speakResult = await TtsInstructionSwap.RunAsync(engine, Instruction, () =>
-                engine.Speak(line.Text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken));
+                engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken));
 
             line.StepResult.CurrentFileName = speakResult.FileName;
             line.StepResult.Voice = voice;

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -909,6 +909,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             text = "This is a test";
         }
+        text = Utilities.UnbreakLine(text);
 
         var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
         _cancellationTokenSource = generatingAudioVm.CancellationTokenSource;
@@ -2206,9 +2207,12 @@ public partial class TextToSpeechViewModel : ObservableObject
     private ResolvedVoice ResolveVoiceForParagraph(Paragraph paragraph, CastContext ctx, ITtsEngine defaultEngine, Voice defaultVoice)
     {
         var actor = ActorVoiceDetector.GetParagraphActor(paragraph, _castKind);
-        var text = _castKind == ActorVoiceDetector.CastKind.WebVttVoices
+        var rawText = _castKind == ActorVoiceDetector.CastKind.WebVttVoices
             ? ActorVoiceDetector.StripWebVttVoiceTags(paragraph.Text)
             : paragraph.Text;
+        // Unbreak line endings centrally so every engine sees a single flowing line —
+        // many TTS engines otherwise insert weird pauses on \r\n.
+        var text = Utilities.UnbreakLine(rawText);
 
         if (string.IsNullOrEmpty(actor) || !ctx.ByActor.TryGetValue(actor, out var mapping))
         {


### PR DESCRIPTION
## Summary
Today the **8 local TTS engines** (Chatterbox, IndexTTS, Kokoro, OmniVoice, Piper, Qwen3 cpp, Qwen3 CrispASR, VibeVoice) each call `Utilities.UnbreakLine(text)` themselves, while the **cloud engines** (AllTalk, Azure, EdgeTts, ElevenLabs, Google, Mistral, Murf) pass `paragraph.Text` verbatim including `\r\n`. That inconsistency makes some engines produce odd pauses on multi-line subtitles.

Move the unbreak step **up to the TTS pipeline** so every engine sees a single flowing line:
- `ResolveVoiceForParagraph` — main TTS generation loop
- Test-voice button in `TextToSpeechViewModel`
- Review/retry path in `ReviewSpeechViewModel`
- Actor-row test button in `ActorVoiceMappingViewModel`

The 8 per-engine `Utilities.UnbreakLine` wrappers are removed.

## Why not a setting?
Line breaks in subtitles are a *presentation* hint for the eye, not a speech cue. If anyone later wants explicit pauses, they would compose SSML, not rely on raw `\n`. A setting would just be premature flexibility.

## Why not bolt onto "Merge continuous lines"?
That feature merges *across paragraphs* based on time gaps. Unbreaking removes line breaks *within* a paragraph. Conflating the two would confuse the UI.

## Test plan
- [ ] Generate TTS audio for a subtitle with at least one two-line paragraph using a **local** engine (e.g. Piper or Kokoro) — verify audio still sounds natural (no regression vs. today).
- [ ] Generate TTS audio with a **cloud** engine (e.g. EdgeTts or ElevenLabs) on the same multi-line subtitle — verify the audio no longer has the awkward mid-line pause it had before.
- [ ] Test-voice button works.
- [ ] Review-speech retry on a multi-line paragraph still works.
- [ ] Actor-voice mapping test-voice button still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)