### PR TITLE
Fix bookmark persistence and undo/redo bookmark loss

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13870,6 +13870,8 @@ public partial class MainViewModel :
         _changeSubtitleHash = GetFastHash();
         _lastOpenSaveFormat = SelectedSubtitleFormat;
 
+        new BookmarkPersistence(GetUpdateSubtitle(), _subtitleFileName).Save();
+
         return true;
     }
 

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -100,6 +100,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         Layer = p.Layer;
         Number = p.Number;
         Extra = p.Extra;
+        Bookmark = p.Bookmark;
 
         Id = generateNewId ? Guid.NewGuid() : p.Id;
 

--- a/src/ui/Logic/UndoRedo/UndoRedoManager.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoManager.cs
@@ -248,8 +248,9 @@ public sealed class UndoRedoManager : IUndoRedoManager
             var timingChanged =
                 Math.Abs(o.StartTime.TotalMilliseconds - n.StartTime.TotalMilliseconds) > 0.5 ||
                 Math.Abs(o.EndTime.TotalMilliseconds - n.EndTime.TotalMilliseconds) > 0.5;
+            var bookmarkChanged = o.Bookmark != n.Bookmark;
 
-            if (!textChanged && !timingChanged) continue;
+            if (!textChanged && !timingChanged && !bookmarkChanged) continue;
 
             changedLines.Add(i + 1);
             if (textChanged) textChanges++;


### PR DESCRIPTION
Bookmarks were silently lost or misplaced in several common scenarios.
  
  ## Root causes
  
  **1. Copy constructor dropped `Bookmark`** (`SubtitleLineViewModel.cs`)
  Every undo/redo snapshot was created via the copy constructor, which
  copied all fields except `Bookmark`. As a result, any undo or redo
  operation wiped all bookmarks.
  
  **2. Bookmark sidecar not updated on file save** (`MainViewModel.cs`)
  The `.SE.bookmarks` sidecar file was only written when explicitly
  performing a bookmark operation (add/edit/remove/list). Operations that
  shift line indices — delete, ripple-delete, sort, merge, split, etc. —
  never updated the sidecar. On the next file open, bookmarks would land
  on the wrong lines.
  
  **3. Bookmark changes invisible to undo/redo change detection** (`UndoRedoManager.cs`)
  `HasChanges` only detected text and timing differences, not bookmark
  changes. Adding or removing a bookmark never triggered its own undo
  snapshot, so it could be silently rolled back as part of the next
  structural change.
  
  ## Fixes
  
  - Add `Bookmark = p.Bookmark` to the `SubtitleLineViewModel` copy constructor
  - Call `BookmarkPersistence.Save()` at the end of `SaveSubtitle()` so the sidecar is always in sync with the saved file (covers Save As too, since it calls `SaveSubtitle` internally)
  - Include bookmark changes in `DetectContentChanges` so they get their own undo entry
