### PR TITLE
VibeVoice / IndexTTS: speed slider in engine settings

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
@@ -386,17 +386,21 @@ public class IndexTtsCrispAsr : ITtsEngine
         //   - `input`             — the text to synthesise
         //   - `response_format`   — "wav"
         //   - `voice`             — absolute WAV path or filename in --voice-dir
+        //   - `speed`             — server-side linear resample of the synth output (0.25-4.0).
+        //                           Default is 1.0; the user can override in the engine settings.
         // The server-mode indextts backend ignores the request `voice` field, so we still
         // pass it (for logging / future server fix) but the reference audio actually used
         // is the --voice path baked in at server startup — see EnsureServerRunningAsync.
         // IndexTTS handles transcription internally (BigVGAN + ECAPA-TDNN), so unlike
         // Qwen3 CustomVoice there is no `ref-text` parameter. v1.5 has no `instructions`
         // (emotion control) — that's IndexTTS-2 which isn't in CrispASR yet.
+        var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrSpeed, 0.25, 4.0);
         var payload = new Dictionary<string, object>
         {
             ["input"] = inputText,
             ["response_format"] = "wav",
             ["voice"] = indexVoice.FilePath,
+            ["speed"] = speed,
         };
 
         var body = JsonSerializer.Serialize(payload);

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -374,12 +374,17 @@ public class VibeVoiceCrispAsr : ITtsEngine
         //   - `input`             — the text to synthesise
         //   - `response_format`   — "wav"
         //   - `voice`             — absolute WAV path or filename in --voice-dir
+        //   - `speed`             — server-side linear resample of the synth output (0.25-4.0).
+        //                           VibeVoice 1.5B tends to be on the slow side; default is 1.1
+        //                           and the user can override in the engine settings dialog.
         // VibeVoice does not use `instructions` or `ref-text` (those are qwen3-tts-only).
+        var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.VibeVoiceCrispAsrSpeed, 0.25, 4.0);
         var payload = new Dictionary<string, object>
         {
             ["input"] = inputText,
             ["response_format"] = "wav",
             ["voice"] = vibeVoice.FilePath,
+            ["speed"] = speed,
         };
 
         var body = JsonSerializer.Serialize(payload);

--- a/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsViewModel.cs
@@ -48,6 +48,16 @@ public partial class IndexTtsCrispAsrSettingsViewModel : ObservableObject
 
     [ObservableProperty] private string _voicesLabel = string.Empty;
 
+    [ObservableProperty] private double _speed = 1.0;
+
+    public string SpeedLabel => $"Speed {Speed:0.00}x";
+
+    partial void OnSpeedChanged(double value)
+    {
+        OnPropertyChanged(nameof(SpeedLabel));
+        Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrSpeed = Math.Clamp(value, 0.25, 4.0);
+    }
+
     [ObservableProperty] private string _modelsFolder = string.Empty;
     [ObservableProperty] private string _voicesFolder = string.Empty;
     [ObservableProperty] private bool _isEngineInstalled;
@@ -65,6 +75,7 @@ public partial class IndexTtsCrispAsrSettingsViewModel : ObservableObject
     {
         ModelsFolder = IndexTtsCrispAsr.GetSetModelsFolder();
         VoicesFolder = IndexTtsCrispAsr.GetSetVoicesFolder();
+        Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrSpeed, 0.25, 4.0);
         Refresh();
     }
 

--- a/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsWindow.cs
@@ -105,6 +105,7 @@ public class IndexTtsCrispAsrSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 12,
             RowSpacing = 10,
@@ -140,7 +141,10 @@ public class IndexTtsCrispAsrSettingsWindow : Window
         };
         grid.Add(voicesText, 5, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 6, 0);
+        grid.Add(MakeLabel(Se.Language.General.Speed), 6, 0);
+        grid.Add(MakeSpeedPanel(), 6, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 7, 0);
         var folderText = new TextBox
         {
             IsReadOnly = true,
@@ -152,7 +156,7 @@ public class IndexTtsCrispAsrSettingsWindow : Window
             FontSize = 12,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
-        grid.Add(folderText, 6, 1);
+        grid.Add(folderText, 7, 1);
 
         return new Border
         {
@@ -161,6 +165,35 @@ public class IndexTtsCrispAsrSettingsWindow : Window
             CornerRadius = new CornerRadius(6),
             BorderThickness = new Thickness(1),
             BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static StackPanel MakeSpeedPanel()
+    {
+        // Server accepts 0.25-4.0; cap UI at 0.5-2.0 since anything outside that range is
+        // already a hack rather than a "preferred pace" choice.
+        var slider = new Slider
+        {
+            Minimum = 0.5,
+            Maximum = 2.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(IndexTtsCrispAsrSettingsViewModel.Speed)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(IndexTtsCrispAsrSettingsViewModel.SpeedLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
         };
     }
 

--- a/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsViewModel.cs
@@ -45,6 +45,16 @@ public partial class VibeVoiceCrispAsrSettingsViewModel : ObservableObject
 
     [ObservableProperty] private string _voicesLabel = string.Empty;
 
+    [ObservableProperty] private double _speed = 1.0;
+
+    public string SpeedLabel => $"Speed {Speed:0.00}x";
+
+    partial void OnSpeedChanged(double value)
+    {
+        OnPropertyChanged(nameof(SpeedLabel));
+        Se.Settings.Video.TextToSpeech.VibeVoiceCrispAsrSpeed = Math.Clamp(value, 0.25, 4.0);
+    }
+
     [ObservableProperty] private string _modelsFolder = string.Empty;
     [ObservableProperty] private string _voicesFolder = string.Empty;
     [ObservableProperty] private bool _isEngineInstalled;
@@ -62,6 +72,7 @@ public partial class VibeVoiceCrispAsrSettingsViewModel : ObservableObject
     {
         ModelsFolder = VibeVoiceCrispAsr.GetSetModelsFolder();
         VoicesFolder = VibeVoiceCrispAsr.GetSetVoicesFolder();
+        Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.VibeVoiceCrispAsrSpeed, 0.25, 4.0);
         Refresh();
     }
 

--- a/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsWindow.cs
@@ -104,6 +104,7 @@ public class VibeVoiceCrispAsrSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 12,
             RowSpacing = 10,
@@ -136,7 +137,10 @@ public class VibeVoiceCrispAsrSettingsWindow : Window
         };
         grid.Add(voicesText, 4, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 5, 0);
+        grid.Add(MakeLabel(Se.Language.General.Speed), 5, 0);
+        grid.Add(MakeSpeedPanel(), 5, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 6, 0);
         var folderText = new TextBox
         {
             IsReadOnly = true,
@@ -148,7 +152,7 @@ public class VibeVoiceCrispAsrSettingsWindow : Window
             FontSize = 12,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
-        grid.Add(folderText, 5, 1);
+        grid.Add(folderText, 6, 1);
 
         return new Border
         {
@@ -157,6 +161,35 @@ public class VibeVoiceCrispAsrSettingsWindow : Window
             CornerRadius = new CornerRadius(6),
             BorderThickness = new Thickness(1),
             BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static StackPanel MakeSpeedPanel()
+    {
+        // Server accepts 0.25-4.0; cap UI at 0.5-2.0 since anything outside that range is
+        // already a hack rather than a "preferred pace" choice.
+        var slider = new Slider
+        {
+            Minimum = 0.5,
+            Maximum = 2.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(VibeVoiceCrispAsrSettingsViewModel.Speed)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(VibeVoiceCrispAsrSettingsViewModel.SpeedLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
         };
     }
 

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -33,7 +33,9 @@ public class SeVideoTextToSpeech
     public string Qwen3TtsCppInstruction { get; set; }
     public string Qwen3TtsCrispAsrModel { get; set; }
     public string VibeVoiceCrispAsrModel { get; set; }
+    public double VibeVoiceCrispAsrSpeed { get; set; }
     public string IndexTtsCrispAsrModel { get; set; }
+    public double IndexTtsCrispAsrSpeed { get; set; }
     public string OmniVoiceTtsCppVulkanPath { get; set; }
     public string OmniVoiceTtsCppInstruction { get; set; }
     public string ChatterboxModel { get; set; }
@@ -104,7 +106,9 @@ public class SeVideoTextToSpeech
         Qwen3TtsCppInstruction = string.Empty;
         Qwen3TtsCrispAsrModel = "1.7B VoiceDesign";
         VibeVoiceCrispAsrModel = "Q8_0 (~2.8 GB)";
+        VibeVoiceCrispAsrSpeed = 1.1;
         IndexTtsCrispAsrModel = "Q8_0 (~870 MB)";
+        IndexTtsCrispAsrSpeed = 1.0;
         OmniVoiceTtsCppVulkanPath = string.Empty;
         OmniVoiceTtsCppInstruction = string.Empty;
         ChatterboxModel = "Base";


### PR DESCRIPTION
## Summary
VibeVoice 1.5B synthesizes slightly on the slow side. CrispASR's `/v1/audio/speech` endpoint accepts an OpenAI-compatible `speed` field (`0.25`–`4.0`, applied server-side as a post-synth linear resampler — `crispasr_server.cpp:853-855, 929-944`), but neither VibeVoice (CrispASR) nor IndexTTS (CrispASR) was sending it.

This change:
- Adds two persisted settings in `SeVideoTextToSpeech`: `VibeVoiceCrispAsrSpeed` (default **1.1**), `IndexTtsCrispAsrSpeed` (default **1.0**).
- Wires both engines' `Speak()` payload to send `"speed"`, clamped to the server's `[0.25, 4.0]` window.
- Surfaces the value as a **Speed slider** (`0.5`–`2.0`, step `0.05`, with a live value readout) in both the new VibeVoice and IndexTTS settings dialogs from #11218.

Server-accepted range is wider than the UI range — the slider deliberately caps at 0.5–2.0 since values outside that band stop being a "preferred pace" choice and start being a workaround.

## Test plan
- [ ] Open VibeVoice (CrispASR) engine settings → slider shows `Speed 1.10x` on a fresh install.
- [ ] Slide → "Speed X.YYx" updates live; close + reopen → value persists.
- [ ] Synth a line → noticeably faster than before for the same input.
- [ ] Same for IndexTTS, with `Speed 1.00x` as the default.
- [ ] Server log line on the CrispASR side shows the requested speed: `speed=1.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)