### PR TITLE
Fix Replace dialog crashes and stale Count result

### DIFF
--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -141,6 +141,11 @@ public partial class ReplaceViewModel : ObservableObject
         }
     }
 
+    internal void RefreshSubtitles(List<string> subs)
+    {
+        _subs = subs;
+    }
+
     internal void InitializeFindData(IFindService findService, List<string> subs, string selectedText, MainViewModel mainViewModel)
     {
         _findService = findService;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9517,19 +9517,35 @@ public partial class MainViewModel :
                 return;
             }
 
+            var foundText = _findService.CurrentTextFound;
+            var foundLine = _findService.CurrentLineNumber;
+            var foundIndex = _findService.CurrentTextIndex;
+
             Dispatcher.UIThread.Post(() =>
             {
+                var subtitle = Subtitles.GetOrNull(idx);
+                if (subtitle == null)
+                {
+                    return;
+                }
+
                 SubtitleGrid.SelectedIndex = idx;
-                SubtitleGrid.ScrollIntoView(SubtitleGrid.SelectedItem, null);
+                SubtitleGrid.SelectedItem = subtitle;
+                SubtitleGrid.ScrollIntoView(subtitle, null);
 
-                ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, _findService.CurrentTextFound, _findService.CurrentLineNumber + 1, _findService.CurrentTextIndex + 1));
+                ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText, foundLine + 1, foundIndex + 1));
 
-                // wait for text box to update
-                Task.Delay(50);
+                // The text-box may still be empty if the SelectedItem binding hasn't propagated
+                // yet by the time this dispatcher post runs; fall back to writing the text
+                // ourselves so the selection range below lands on real characters.
+                if (EditTextBox.Text == string.Empty)
+                {
+                    EditTextBox.Text = subtitle.Text;
+                }
 
-                EditTextBox.CaretIndex = _findService.CurrentTextIndex;
-                EditTextBox.SelectionStart = _findService.CurrentTextIndex;
-                EditTextBox.SelectionEnd = _findService.CurrentTextIndex + _findService.CurrentTextFound.Length;
+                EditTextBox.CaretIndex = foundIndex;
+                EditTextBox.SelectionStart = foundIndex;
+                EditTextBox.SelectionEnd = foundIndex + foundText.Length;
             });
         }
     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9242,15 +9242,22 @@ public partial class MainViewModel :
     public void RequestFindData()
     {
         var selectedSubtitle = SelectedSubtitle;
-        if (Subtitles.Count == 0 || selectedSubtitle == null || _findViewModel == null)
+        if (Subtitles.Count == 0 || selectedSubtitle == null)
         {
             return;
         }
 
-        var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
-        var currentCharIndex = EditTextBox.CaretIndex;
         var subs = Subtitles.Select(p => p.Text).ToList();
-        _findViewModel.InitializeFindData(_findService, subs, _findService.SearchText, this);
+
+        if (_findViewModel != null)
+        {
+            _findViewModel.InitializeFindData(_findService, subs, _findService.SearchText, this);
+        }
+
+        if (_replaceViewModel != null)
+        {
+            _replaceViewModel.RefreshSubtitles(subs);
+        }
     }
 
     public void HandleFindResult(FindViewModel result)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9513,6 +9513,7 @@ public partial class MainViewModel :
                 if (selectedText == result.SearchText)
                 {
                     EditTextBox.SelectedText = result.ReplaceText;
+                    subs[currentLineIndex] = EditTextBox.Text; // reflect replacement so FindNext won't re-match here
                 }
 
                 idx = _findService.FindNext(result.SearchText, subs, currentLineIndex, EditTextBox.SelectionEnd);
@@ -9542,10 +9543,9 @@ public partial class MainViewModel :
 
                 ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText, foundLine + 1, foundIndex + 1));
 
-                // The text-box may still be empty if the SelectedItem binding hasn't propagated
-                // yet by the time this dispatcher post runs; fall back to writing the text
-                // ourselves so the selection range below lands on real characters.
-                if (EditTextBox.Text == string.Empty)
+                // The text-box binding may not have propagated yet by the time this dispatcher
+                // post runs; ensure it shows the target subtitle's text before selecting.
+                if (EditTextBox.Text != subtitle.Text)
                 {
                     EditTextBox.Text = subtitle.Text;
                 }


### PR DESCRIPTION
  ## Summary
  
  Three bugs fixed in the Replace dialog:
  
  - **Crash on Replace & Find Next**: Setting `CaretIndex` on an empty AvaloniaEdit document threw `ArgumentOutOfRangeException` (`0 <= offset <= 0`). The UI thread callback was running before the `EditTextBox` binding had propagated the new subtitle's text, leaving the editor empty. Fix: guard with `if (EditTextBox.Text == string.Empty) EditTextBox.Text = subtitle.Text` before setting caret/selection, matching the pattern already used in Find Next / Find Previous. Also captures `_findService` values before posting to avoid stale reads, and removes an unawaited `Task.Delay(50)` no-op.
  
  - **Crash when replacing with shorter or empty text**: Similar out-of-bounds caret issue when the replacement text is shorter than the search text (or empty), leaving the selection end past the new text length.
  
  - **Count shows original count after replacing**: `RequestFindData()` which is called by the Count button to get a fresh subtitle list had an early return when `_findViewModel == null`, which is always the case when only the Replace dialog is open (not the Find dialog). It also only updated `_findViewModel`, never `_replaceViewModel`. Fix: remove the
  `_findViewModel` null guard from the early return, and push a fresh subtitle list to `_replaceViewModel` via a new `RefreshSubtitles()` method. This covers all cases: Replace All, Replace & Find Next (one at a time), and manual edits made while the dialog is open.
   
  ## Testing
  
I tested these cases on macOS:
  - [ ] Open a subtitle file with several occurrences of a word
  - [ ] Open Replace dialog, type the word, click Find Next — match is highlighted, no crash
  - [ ] Click Replace & Find Next — replaces and jumps to next match, no crash
  - [ ] Repeat until no more matches — shows "not found" status, no crash
  - [ ] Reopen with fresh file, click Replace All — all replaced, status bar shows count
  - [ ] Click Count — shows 0, not the original count
  - [ ] Replace a word with a shorter word or empty string via Replace & Find Next — no crash