### PR TITLE
Focus subtitle grid on startup so keyboard shortcuts work immediately

### DIFF
--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -102,6 +102,7 @@ public class MainView : ViewBase
                 InitLayout.MakeLayout(this, _vm, Se.Settings.General.LayoutNumber);
                 _vm.ContentGrid.InvalidateMeasure();
                 _vm.ContentGrid.InvalidateArrange();
+                Dispatcher.UIThread.Post(() => _vm.SubtitleGrid.Focus());
             }, DispatcherPriority.Loaded);
         };
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12700,6 +12700,7 @@ public partial class MainViewModel :
             {
                 SelectAndScrollToRow(0);
             }
+            Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
 
             if (Se.Settings.Video.AutoOpen && skipLoadVideo == false)
             {


### PR DESCRIPTION
This PR fixes two cases I missed in #11220

## Problem

After launching the app or opening a subtitle file, keyboard shortcuts did not work until the user clicked inside the subtitle grid. This was because focus was not set to the grid on startup.

## Fix
  
Applied the same deferred focus pattern already used for layout changes to two startup paths:

- **Initial layout creation** (when no file is open on launch): the subtitle grid is focused after the layout is built.
- **After `SubtitleOpen()`**: the grid is focused after the first row is selected.

Both cases use `Dispatcher.UIThread.Post()` to defer the focus call until after the UI has finished rendering.