### PR TITLE
Restore focus correctly when Find/Replace dialog is dismissed

### DIFF
--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -24,6 +24,7 @@ public partial class FindViewModel : ObservableObject
 
     public bool FindNextPressed { get; private set; }
     public bool FindPreviousPressed { get; private set; }
+    public bool ResultFound { get; set; }
 
     private IFindService? _findService;
     private List<string> _subs = new List<string>();

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -28,6 +28,7 @@ public partial class ReplaceViewModel : ObservableObject
     public bool FindNextPressed { get; private set; }
     public bool ReplacePressed { get; private set; }
     public bool ReplaceAllPressed { get; private set; }
+    public bool ResultFound { get; set; }
 
     private IFindService? _findService;
     private List<string> _subs = new List<string>();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -284,6 +284,7 @@ public partial class MainViewModel :
     VideoPlayerUndockedViewModel? _videoPlayerUndockedViewModel;
     AudioVisualizerUndockedViewModel? _audioVisualizerUndockedViewModel;
     FindViewModel? _findViewModel;
+    Control? _findPreviousFocus;
     ReplaceViewModel? _replaceViewModel;
     AdjustAllTimesViewModel? _adjustAllTimesViewModel;
 
@@ -9212,10 +9213,12 @@ public partial class MainViewModel :
 
         if (_findViewModel != null && _findViewModel.Window != null && _findViewModel.Window.IsVisible)
         {
+            _findPreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
             _findViewModel.Window.Activate();
             return;
         }
 
+        _findPreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
         var subs = Subtitles.Select(p => p.Text).ToList();
         var result = _windowService.ShowWindow<FindWindow, FindViewModel>(Window!, (window, vm) =>
         {
@@ -9234,6 +9237,17 @@ public partial class MainViewModel :
             }
 
             vm.InitializeFindData(_findService, subs, selectedText, this);
+            window.Closed += (_, _) =>
+            {
+                if (vm.ResultFound)
+                {
+                    FocusEditTextBox();
+                }
+                else
+                {
+                    Dispatcher.UIThread.Post(() => _findPreviousFocus?.Focus());
+                }
+            };
         });
 
         _shortcutManager.ClearKeys();
@@ -9287,6 +9301,11 @@ public partial class MainViewModel :
             {
                 ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));
                 return;
+            }
+
+            if (_findViewModel != null)
+            {
+                _findViewModel.ResultFound = true;
             }
 
             Dispatcher.UIThread.Post(() =>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9470,7 +9470,7 @@ public partial class MainViewModel :
 
         _replacePreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
         var subs = Subtitles.Select(p => p.Text).ToList();
-        var result = _windowService.ShowWindow<ReplaceWindow, ReplaceViewModel>(Window, (window, vm) =>
+        var result = _windowService.ShowWindow<ReplaceWindow, ReplaceViewModel>(Window!, (window, vm) =>
         {
             window.Topmost = true;
             _replaceViewModel = vm;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -286,6 +286,7 @@ public partial class MainViewModel :
     FindViewModel? _findViewModel;
     Control? _findPreviousFocus;
     ReplaceViewModel? _replaceViewModel;
+    Control? _replacePreviousFocus;
     AdjustAllTimesViewModel? _adjustAllTimesViewModel;
 
     private static Color _errorColor = Se.Settings.General.ErrorColor.FromHexToColor();
@@ -9462,10 +9463,12 @@ public partial class MainViewModel :
 
         if (_replaceViewModel != null && _replaceViewModel.Window != null && _replaceViewModel.Window.IsVisible)
         {
+            _replacePreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
             _replaceViewModel.Window.Activate();
             return;
         }
 
+        _replacePreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
         var subs = Subtitles.Select(p => p.Text).ToList();
         var result = _windowService.ShowWindow<ReplaceWindow, ReplaceViewModel>(Window, (window, vm) =>
         {
@@ -9484,6 +9487,17 @@ public partial class MainViewModel :
             }
 
             vm.InitializeFindData(_findService, subs, selectedText, this);
+            window.Closed += (_, _) =>
+            {
+                if (vm.ResultFound)
+                {
+                    FocusEditTextBox();
+                }
+                else
+                {
+                    Dispatcher.UIThread.Post(() => _replacePreviousFocus?.Focus());
+                }
+            };
         });
 
         _shortcutManager.ClearKeys();
@@ -9541,6 +9555,11 @@ public partial class MainViewModel :
             {
                 ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));
                 return;
+            }
+
+            if (_replaceViewModel != null)
+            {
+                _replaceViewModel.ResultFound = true;
             }
 
             var foundText = _findService.CurrentTextFound;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9390,6 +9390,7 @@ public partial class MainViewModel :
             EditTextBox.SelectionEnd = foundIndex + foundText.Length;
         });
 
+        FocusEditTextBox();
         _shortcutManager.ClearKeys();
     }
 
@@ -9444,6 +9445,7 @@ public partial class MainViewModel :
             EditTextBox.SelectionEnd = foundIndex + foundText.Length;
         });
 
+        FocusEditTextBox();
         _shortcutManager.ClearKeys();
     }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -285,8 +285,10 @@ public partial class MainViewModel :
     AudioVisualizerUndockedViewModel? _audioVisualizerUndockedViewModel;
     FindViewModel? _findViewModel;
     Control? _findPreviousFocus;
+    bool _findClosingProgrammatically;
     ReplaceViewModel? _replaceViewModel;
     Control? _replacePreviousFocus;
+    bool _replaceClosingProgrammatically;
     AdjustAllTimesViewModel? _adjustAllTimesViewModel;
 
     private static Color _errorColor = Se.Settings.General.ErrorColor.FromHexToColor();
@@ -9208,6 +9210,7 @@ public partial class MainViewModel :
 
         if (_replaceViewModel != null)
         {
+            _replaceClosingProgrammatically = true;
             _replaceViewModel.Window?.Close();
             _replaceViewModel = null;
         }
@@ -9215,6 +9218,7 @@ public partial class MainViewModel :
         if (_findViewModel != null && _findViewModel.Window != null && _findViewModel.Window.IsVisible)
         {
             _findPreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
+            _findViewModel.ResultFound = false;
             _findViewModel.Window.Activate();
             return;
         }
@@ -9240,6 +9244,12 @@ public partial class MainViewModel :
             vm.InitializeFindData(_findService, subs, selectedText, this);
             window.Closed += (_, _) =>
             {
+                if (_findClosingProgrammatically)
+                {
+                    _findClosingProgrammatically = false;
+                    return;
+                }
+
                 if (vm.ResultFound)
                 {
                     FocusEditTextBox();
@@ -9459,6 +9469,7 @@ public partial class MainViewModel :
 
         if (_findViewModel != null)
         {
+            _findClosingProgrammatically = true;
             _findViewModel.Window?.Close();
             _findViewModel = null;
         }
@@ -9466,6 +9477,7 @@ public partial class MainViewModel :
         if (_replaceViewModel != null && _replaceViewModel.Window != null && _replaceViewModel.Window.IsVisible)
         {
             _replacePreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
+            _replaceViewModel.ResultFound = false;
             _replaceViewModel.Window.Activate();
             return;
         }
@@ -9491,6 +9503,12 @@ public partial class MainViewModel :
             vm.InitializeFindData(_findService, subs, selectedText, this);
             window.Closed += (_, _) =>
             {
+                if (_replaceClosingProgrammatically)
+                {
+                    _replaceClosingProgrammatically = false;
+                    return;
+                }
+
                 if (vm.ResultFound)
                 {
                     FocusEditTextBox();


### PR DESCRIPTION
## Problem

  Dismissing the Find or Replace dialog (via Escape or the close button) left focus on the now-invisible dialog window. The user had to click back into the editor or the subtitle list before keyboard shortcuts or typing would work again.

This is inconsistent with SE 4 behavior, and usability suffers because of the extra clicking required.

 Also, focus edit text box after Find Next/Previous shortcut.

  ## Behaviour after this change

  **If a match was found and navigated to** (Find Next, Replace):
  → focus goes to the text editor, where the found/replaced text is selected.

  **If nothing was found, or the dialog was closed without searching, or Replace All was used** (which replaces in-place without navigating):
  → focus returns to whichever control was active before the dialog was opened — the subtitle list, a time field, the text editor, etc.

  The previously-active control is also refreshed when an already-open dialog is re-activated via the keyboard shortcut, so the restored focus always reflects the most recent invocation.

  For the Find Next/Previous shortcut, when text is found, call FocusEditTextBox() so the subtitle edit box receives focus and the highlighted match is immediately editable.

  ## Changes

  - `FindViewModel` / `ReplaceViewModel` — add `ResultFound` flag, set synchronously when a match is confirmed (before any dispatcher post, to avoid a race with the window-closed event).
  - `MainViewModel.ShowFind` / `ShowReplace` — capture the focused control before opening (and on each re-activation), attach a `window.Closed` handler that restores focus based on `ResultFound`.
  - call `FocusEditTextBox()` for the Find Next/Previous shortcut, when text is found