### PR TITLE
Show undocked video/waveform windows as independent top-levels

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5214,13 +5214,13 @@ public partial class MainViewModel :
                 _audioVisualizerUndockedViewModel = null;
             }
 
-            _windowService.ShowWindow<VideoPlayerUndockedWindow, VideoPlayerUndockedViewModel>(Window, (window, vm) =>
+            _windowService.ShowIndependentWindow<VideoPlayerUndockedWindow, VideoPlayerUndockedViewModel>((window, vm) =>
             {
                 _videoPlayerUndockedViewModel = vm;
                 vm.Initialize(_videoFileName ?? string.Empty, position, volume, this);
             });
 
-            _windowService.ShowWindow<AudioVisualizerUndockedWindow, AudioVisualizerUndockedViewModel>(Window, (window, vm) =>
+            _windowService.ShowIndependentWindow<AudioVisualizerUndockedWindow, AudioVisualizerUndockedViewModel>((window, vm) =>
             {
                 _audioVisualizerUndockedViewModel = vm;
                 vm.Initialize(AudioVisualizer, this);

--- a/src/ui/Features/Shared/Undocked/AudioVisualizerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/AudioVisualizerUndockedViewModel.cs
@@ -36,7 +36,12 @@ public partial class AudioVisualizerUndockedViewModel : ObservableObject
 
     internal void OnClosing(object? sender, WindowClosingEventArgs e)
     {
-        if (!AllowClose && e.CloseReason != WindowCloseReason.OwnerWindowClosing)
+        // Only intercept explicit user closes (clicking the title-bar X). Owner-window
+        // and app-shutdown closes must be allowed through; otherwise the app gets stuck
+        // when the main window is closing or the OS is shutting down. Since this window
+        // is now an independent top-level (no owner), the cascade comes from
+        // MainViewModel.CleanUp() which sets AllowClose=true before calling Close().
+        if (!AllowClose && e.CloseReason == WindowCloseReason.WindowClosing)
         {
             e.Cancel = true;
 
@@ -44,11 +49,11 @@ public partial class AudioVisualizerUndockedViewModel : ObservableObject
             {
                 Window.WindowState = WindowState.Minimized;
             }
+
+            return;
         }
-        else
-        {
-            UiUtil.SaveWindowPosition(Window);
-        }
+
+        UiUtil.SaveWindowPosition(Window);
     }
 
     internal void OnKeyDown(object? sender, KeyEventArgs e)

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -64,7 +64,12 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
 
     internal void OnClosing(object? sender, WindowClosingEventArgs e)
     {
-        if (!AllowClose && e.CloseReason != WindowCloseReason.OwnerWindowClosing)
+        // Only intercept explicit user closes (clicking the title-bar X). Owner-window
+        // and app-shutdown closes must be allowed through; otherwise the app gets stuck
+        // when the main window is closing or the OS is shutting down. Since this window
+        // is now an independent top-level (no owner), the cascade comes from
+        // MainViewModel.CleanUp() which sets AllowClose=true before calling Close().
+        if (!AllowClose && e.CloseReason == WindowCloseReason.WindowClosing)
         {
             e.Cancel = true;
 
@@ -72,13 +77,13 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
             {
                 Window.WindowState = WindowState.Minimized;
             }
+
+            return;
         }
-        else
-        {
-            UiUtil.SaveWindowPosition(Window);
-            _mouseMoveDetectionTimer?.Stop();
-            _mouseMoveDetectionTimer = null;
-        }
+
+        UiUtil.SaveWindowPosition(Window);
+        _mouseMoveDetectionTimer?.Stop();
+        _mouseMoveDetectionTimer = null;
     }
 
     internal void OnKeyDown(object? sender, KeyEventArgs e)

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -32,6 +32,18 @@ namespace Nikse.SubtitleEdit.Logic
             where TViewModel : class;
 
         /// <summary>
+        /// Shows a window of type T with a specified ViewModel type as an independent top-level
+        /// window (no owner). Use this for windows that should appear in the OS Alt+Tab list
+        /// independently and not be grouped with the main window — e.g. the undocked video player
+        /// and audio visualizer. Owned windows on Windows form an Alt+Tab "group" with their
+        /// owner, which traps focus and prevents the user from Alt+Tabbing back to the main
+        /// window once one of the owned windows is active.
+        /// </summary>
+        TViewModel ShowIndependentWindow<T, TViewModel>(Action<T, TViewModel>? configure = null)
+            where T : Window
+            where TViewModel : class;
+
+        /// <summary>
         /// Shows a window of type T as a dialog.
         /// </summary>
         /// <typeparam name="T">The type of window to show as dialog.</typeparam>
@@ -101,6 +113,31 @@ namespace Nikse.SubtitleEdit.Logic
 
             window.WindowStartupLocation = WindowStartupLocation.CenterOwner; //TODO: does this work on mac?
             window.Show(owner);
+            window.Focus();
+
+            ApplyRightToLeftSettings(window);
+            UiTheme.ApplyScaleToWindow(window);
+
+            return viewModel;
+        }
+
+        /// <inheritdoc />
+        public TViewModel ShowIndependentWindow<T, TViewModel>(Action<T, TViewModel>? configureViewModel = null)
+            where T : Window
+            where TViewModel : class
+        {
+            var viewModel = _serviceProvider.GetRequiredService<TViewModel>();
+
+            var w = Activator.CreateInstance(typeof(T), viewModel);
+            if (w == null)
+            {
+                throw new InvalidOperationException($"Failed to create window of type {typeof(T).Name} with constructor param {typeof(TViewModel).Name}");
+            }
+
+            var window = (T)w;
+            configureViewModel?.Invoke(window, viewModel);
+
+            window.Show();
             window.Focus();
 
             ApplyRightToLeftSettings(window);


### PR DESCRIPTION
## Summary
Addresses the long-standing focus complaint raised in #11226:
> Undock the controls → Alt+Tab to either the audio visualizer or the video player → Alt+Tab to the main SE window doesn't work. The main window refuses to take focus back via the keyboard.

**Root cause:** `WindowsService.ShowWindow<T,VM>(owner, …)` calls `window.Show(owner)`. On Windows that makes the new window an *owned* top-level — the OS groups owner + owned windows in Alt+Tab. Once the user activates an owned window, the OS remembers it as the group's last-active member, so Alt+Tab back from any non-SE window returns to the owned window, not the main one.

**Fix:** the two undocked windows shouldn't be owned by main — they're peer top-levels, not modal sidekicks. Adds `IWindowService.ShowIndependentWindow<T,VM>` which calls `Show()` with no owner, and switches the video-player and audio-visualizer undocked windows to use it. They now appear in Alt+Tab as independent top-levels.

Owner-cascade close is no longer available, but `MainViewModel.CleanUp()` already explicitly closes both undocked windows (sets `AllowClose = true` first, then `Close()`), so the existing shutdown path keeps working. To make sure ApplicationShutdown closes (e.g. OS shutdown, last-window-close) aren't accidentally trapped in a minimize loop, the `OnClosing` handlers on both VMs are tightened to only intercept `WindowCloseReason.WindowClosing` — explicit user closes via the title-bar X.

## Test plan
- [ ] Undock the controls. Alt+Tab from main → audio visualizer → main (works).
- [ ] Alt+Tab from main → video player → main (works).
- [ ] With the undocked window active, Alt+Tab to Firefox/Notepad → back to main (works).
- [ ] Click X on an undocked window → it minimizes (existing behavior preserved).
- [ ] Redock controls → both undocked windows close cleanly, main resumes normally.
- [ ] Close main window with both undocked open → app exits, no zombie windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)