### PR TITLE
Add setting to hide Plugins menu

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -15,6 +15,10 @@ compatible with SE5 and must be ported.
 > and update plugins from the index) are implemented. Installing, enabling, disabling,
 > and removing plugins update the **Plugins** menu live (no restart needed). A startup
 > update notification is still to come.
+>
+> The **Plugins** menu is shown by default but can be hidden via
+> **Options → Settings → Appearance → Show Plugins menu**. The menu must be enabled
+> there to run or manage plugins from the main window.
 
 ## How a plugin runs
 

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -529,6 +529,7 @@ public static class InitMenu
         });
 
         vm.MenuPlugins.Header = Se.Language.Plugins.Title;
+        vm.MenuPlugins.IsVisible = Se.Settings.Appearance.ShowPluginsMenu;
         UpdatePluginsMenu(vm);
         menu.Items.Add(vm.MenuPlugins);
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7607,6 +7607,8 @@ public partial class MainViewModel :
             }
         }
 
+        MenuPlugins.IsVisible = Se.Settings.Appearance.ShowPluginsMenu;
+
         LockTimeCodes = Se.Settings.General.LockTimeCodes;
         IsWaveformToolbarVisible = Se.Settings.Waveform.ShowToolbar;
 

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -667,6 +667,7 @@ public class SettingsPage : UserControl
             new SettingsItem(Se.Language.Options.Settings.BookmarkColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.BookmarkColor))),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowAssaLayer, nameof(_vm.ShowAssaLayer)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowHorizontalLineAboveToolbar, nameof(_vm.ShowHorizontalLineAboveToolbar)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.ShowPluginsMenu, nameof(_vm.ShowPluginsMenu)),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.Toolbar,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -184,6 +184,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _showToolbarEncoding;
     [ObservableProperty] private bool _showToolbarFrameRate;
 
+    [ObservableProperty] private bool _showPluginsMenu;
+
     [ObservableProperty] private bool _textBoxButtonShowAutoBreak;
     [ObservableProperty] private bool _textBoxButtonShowUnbreak;
     [ObservableProperty] private bool _textBoxButtonShowItalic;
@@ -687,6 +689,7 @@ public partial class SettingsViewModel : ObservableObject
         ShowToolbarHelp = appearance.ToolbarShowHelp;
         ShowToolbarEncoding = appearance.ToolbarShowEncoding;
         ShowToolbarFrameRate = appearance.ToolbarShowFrameRate;
+        ShowPluginsMenu = appearance.ShowPluginsMenu;
         SubtitleGridFontSize = appearance.SubtitleGridFontSize;
         SubtitleGridTextSingleLine = appearance.SubtitleGridTextSingleLine;
         SubtitleGridFormatting = MapGridFormattingToText(appearance.SubtitleGridFormattingType);
@@ -1328,6 +1331,7 @@ public partial class SettingsViewModel : ObservableObject
         appearance.ToolbarShowHelp = ShowToolbarHelp;
         appearance.ToolbarShowEncoding = ShowToolbarEncoding;
         appearance.ToolbarShowFrameRate = ShowToolbarFrameRate;
+        appearance.ShowPluginsMenu = ShowPluginsMenu;
         appearance.SubtitleGridFontSize = SubtitleGridFontSize;
         appearance.SubtitleGridTextSingleLine = SubtitleGridTextSingleLine;
         appearance.SubtitleGridFormattingType = MapGridFormattingToCode(SubtitleGridFormatting);

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -168,6 +168,7 @@ public class LanguageSettings
     public string ShowToolbarHelp { get; set; }
     public string ShowToolbarEncoding { get; set; }
     public string ShowToolbarFrameRate { get; set; }
+    public string ShowPluginsMenu { get; set; }
 
     // Network
     public string ProxyAddress { get; set; }
@@ -466,6 +467,7 @@ public class LanguageSettings
         ShowToolbarHelp = "Show help icon";
         ShowToolbarEncoding = "Show encoding";
         ShowToolbarFrameRate = "Show frame rate";
+        ShowPluginsMenu = "Show Plugins menu";
 
         // Network
         ProxyAddress = "Proxy address";

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -51,6 +51,7 @@ public class SeAppearance
     public bool ToolbarShowHelp { get; set; }
     public bool ToolbarShowEncoding { get; set; }
     public bool ToolbarShowFrameRate { get; set; }
+    public bool ShowPluginsMenu { get; set; }
     public bool RightToLeft { get; set; }
     public bool ShowLayer { get; set; }
     public bool ShowUpDownStartTime { get; set; }
@@ -113,6 +114,7 @@ public class SeAppearance
         ToolbarShowLayout = true;
         ToolbarShowHelp = true;
         ToolbarShowEncoding = false;
+        ShowPluginsMenu = true;
 
         TextBoxShowButtonAutoBreak = true;
         TextBoxShowButtonUnbreak = true;


### PR DESCRIPTION
## Summary
- New Appearance setting **Show Plugins menu** (default `true`) lets users hide the `Plugins` entry in the main menu.
- Wired through `SeAppearance`, `SettingsViewModel`, `SettingsPage` (Appearance section), `InitMenu`, and `MainViewModel.ApplySettings` so the change takes effect immediately after Apply/OK.
- Added `LanguageSettings.ShowPluginsMenu` for the label (no hardcoded string).
- Updated `docs/plugin.md` to note that the Plugins menu must be enabled in Settings.

## Test plan
- [ ] Open Subtitle Edit → menu shows `Plugins` by default.
- [ ] Options → Settings → Appearance → uncheck **Show Plugins menu** → Apply → `Plugins` menu disappears without restart.
- [ ] Re-check the setting → `Plugins` menu reappears.
- [ ] Restart the app with the setting unchecked → `Plugins` menu stays hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)