### PR TITLE
Fix Find and Replace dialogs floating above other apps on macOS

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9288,7 +9288,7 @@ public partial class MainViewModel :
         var subs = Subtitles.Select(p => p.Text).ToList();
         var result = _windowService.ShowWindow<FindWindow, FindViewModel>(Window!, (window, vm) =>
         {
-            window.Topmost = true;
+            window.Topmost = !OperatingSystem.IsMacOS();
             _findViewModel = vm;
 
             var selectedText = string.Empty;
@@ -9615,7 +9615,7 @@ public partial class MainViewModel :
         var subs = Subtitles.Select(p => p.Text).ToList();
         var result = _windowService.ShowWindow<ReplaceWindow, ReplaceViewModel>(Window!, (window, vm) =>
         {
-            window.Topmost = true;
+            window.Topmost = !OperatingSystem.IsMacOS();
             _replaceViewModel = vm;
 
             var selectedText = string.Empty;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9584,7 +9584,7 @@ public partial class MainViewModel :
         }
         finally
         {
-            if (dialogWindow != null) dialogWindow.Topmost = true;
+            if (dialogWindow != null) dialogWindow.Topmost = !OperatingSystem.IsMacOS();
         }
     }
 


### PR DESCRIPTION
This change is specific to macOS and aims to align the user experience with the other two supported platforms. I have only tested this on macOS; on Windows and Linux the behavior is unchanged.

#### Before
Opening the Find or Replace dialog set Topmost=true, which Avalonia maps to NSWindowLevel.Floating on macOS. This caused the dialog to float above every application system-wide — so switching to another app (e.g. a video player or text editor to reference source material) would leave the dialog obstructing that app's window, with no way to dismiss it without returning to Subtitle Edit.

#### After
The dialog behaves as a proper owned window. It stays above the Subtitle Edit main window but is not modal so you can keep it open while editing the found text, but when you switch to another app it no longer floats on top of it. On Windows and Linux the behavior is unchanged.