### PR TITLE
Add native macOS menu bar

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -1053,7 +1053,7 @@ public static class InitMenu
         return null;
     }
 
-    private static KeyGesture? ToKeyGesture(ShortCut shortcut)
+    internal static KeyGesture? ToKeyGesture(ShortCut shortcut)
     {
         if (shortcut.Keys == null || shortcut.Keys.Count == 0)
         {

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -304,7 +304,12 @@ public static class InitNativeMacMenu
         RegisterUpdater(v => assaMenu.IsEnabled = v.IsFormatAssa, nameof(vm.IsFormatAssa));
 
         // ── Assemble ─────────────────────────────────────────────────────────
-        var root = new NativeMenu();
+        // Reuse the root NativeMenu registered during startup. Avalonia's macOS
+        // backend subscribes to the items collection on that specific object;
+        // replacing it with a new NativeMenu via NativeMenu.SetMenu does not
+        // propagate to NSApplication.mainMenu after initial setup.
+        var root = NativeMenu.GetMenu(app) ?? new NativeMenu();
+        root.Items.Clear();
         root.Items.Add(new NativeMenuItem("Subtitle Edit") { Menu = appItems });
         root.Items.Add(new NativeMenuItem(Clean(l.File)) { Menu = fileItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Edit)) { Menu = editItems });
@@ -330,7 +335,9 @@ public static class InitNativeMacMenu
         };
         vm.PropertyChanged += _handler;
 
-        NativeMenu.SetMenu(app, root);
+        if (NativeMenu.GetMenu(app) == null)
+            NativeMenu.SetMenu(app, root);
+
         UpdateRecentFiles(vm);
     }
 

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -2,319 +2,336 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.Input;
-using System.ComponentModel;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.Plugins;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
+/// <summary>
+/// Builds and maintains the native macOS menu bar.
+///
+/// Two-phase design: MakeStructure must be called during application setup
+/// (AfterSetup, before SetupWithLifetime) so Avalonia's macOS backend creates
+/// the NSMenuBar from our full menu tree. Sync is called later (OnLoaded) to
+/// set gestures, initial enabled/checked states, PropertyChanged subscriptions,
+/// and dynamic submenus once the ViewModel is available.
+/// </summary>
 public static class InitNativeMacMenu
 {
+    // Items whose Gesture must be set in Sync
+    private static readonly List<(Func<MainViewModel, IRelayCommand> GetCmd, NativeMenuItem Item)> _gestureItems = [];
+
+    // Items whose IsEnabled tracks a VM property
+    private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsEnabled, string[] Props)> _conditionals = [];
+
+    // Toggle (CheckBox) items whose IsChecked tracks a VM property
+    private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsChecked, string[] Props)> _toggles = [];
+
+    // Items with a dynamic Header string
+    private static readonly List<(NativeMenuItem Item, Func<MainViewModel, string> GetHeader, string[] Props)> _dynamicHeaders = [];
+
+    // Single PropertyChanged handler, replaced on each Sync call
     private static PropertyChangedEventHandler? _handler;
-    private static readonly List<(string PropertyName, Action<MainViewModel> Updater)> _updaters = [];
 
-    public static void Make(Application app, MainViewModel vm)
+    // References to dynamic-submenu items, surfaced so Sync/UpdateX can reach them
+    private static NativeMenuItem? _reopenItem;
+    private static NativeMenuItem? _pluginsItem;
+    private static NativeMenuItem? _audioTracksItem;
+
+    // ── Phase 1 ──────────────────────────────────────────────────────────────
+    // Called from Program.cs SetupNativeMenu (inside AfterSetup, before
+    // SetupWithLifetime). Builds the full NativeMenu tree with lazy command
+    // resolution — the ViewModel is not available yet.
+
+    public static void MakeStructure(NativeMenu root)
     {
-        if (_handler != null)
-        {
-            vm.PropertyChanged -= _handler;
-            _handler = null;
-        }
-        _updaters.Clear();
+        _gestureItems.Clear();
+        _conditionals.Clear();
+        _toggles.Clear();
+        _dynamicHeaders.Clear();
 
-        var shortcuts = ShortcutsMain.GetUsedShortcuts(vm);
         var l = Se.Language.Main.Menu;
 
-        // ── App menu ("Subtitle Edit" on macOS) ──────────────────────────────
+        // ── App menu ──────────────────────────────────────────────────────────
         var appItems = new NativeMenu();
-        appItems.Items.Add(MakeItem(Clean(Se.Language.Help.AboutSubtitleEdit), vm.ShowAboutCommand, shortcuts));
+        appItems.Items.Add(Item(Clean(Se.Language.Help.AboutSubtitleEdit), v => v.ShowAboutCommand));
         appItems.Items.Add(new NativeMenuItemSeparator());
-        var prefsItem = MakeItem(Clean(l.Settings), vm.CommandShowSettingsCommand, shortcuts);
+        var prefsItem = Item(Clean(l.Settings), v => v.CommandShowSettingsCommand);
         prefsItem.Gesture = new KeyGesture(Key.OemComma, KeyModifiers.Meta);
         appItems.Items.Add(prefsItem);
         appItems.Items.Add(new NativeMenuItemSeparator());
         var quitItem = new NativeMenuItem(Clean(l.Exit));
         quitItem.Gesture = new KeyGesture(Key.Q, KeyModifiers.Meta);
-        quitItem.Click += (_, _) => vm.CommandExitCommand.Execute(null);
+        quitItem.Click += (_, _) => GetVm()?.CommandExitCommand.Execute(null);
         appItems.Items.Add(quitItem);
 
-        // ── File ─────────────────────────────────────────────────────────────
+        // ── File ──────────────────────────────────────────────────────────────
         var fileItems = new NativeMenu();
-        fileItems.Items.Add(MakeItem(Clean(l.New), vm.CommandFileNewCommand, shortcuts));
-        fileItems.Items.Add(MakeConditional(vm, Clean(l.NewKeepVideo), vm.CommandFileNewKeepVideoCommand, shortcuts,
-            v => v.IsVideoLoaded, nameof(vm.IsVideoLoaded)));
+        fileItems.Items.Add(Item(Clean(l.New), v => v.CommandFileNewCommand));
+        fileItems.Items.Add(Conditional(Clean(l.NewKeepVideo), v => v.CommandFileNewKeepVideoCommand,
+            v => v.IsVideoLoaded, nameof(MainViewModel.IsVideoLoaded)));
         fileItems.Items.Add(new NativeMenuItemSeparator());
-        fileItems.Items.Add(MakeItem(Clean(l.Open), vm.CommandFileOpenCommand, shortcuts));
-        fileItems.Items.Add(MakeConditional(vm, Clean(l.OpenKeepVideo), vm.CommandFileOpenKeepVideoCommand, shortcuts,
-            v => v.IsVideoLoaded, nameof(vm.IsVideoLoaded)));
-        fileItems.Items.Add(MakeConditional(vm, Clean(l.OpenOriginal), vm.FileOpenOriginalCommand, shortcuts,
-            v => !v.ShowColumnOriginalText, nameof(vm.ShowColumnOriginalText)));
-        fileItems.Items.Add(MakeConditional(vm, Clean(l.CloseOriginal), vm.FileCloseOriginalCommand, shortcuts,
-            v => v.ShowColumnOriginalText, nameof(vm.ShowColumnOriginalText)));
-        fileItems.Items.Add(MakeConditional(vm, Clean(l.CloseTranslation), vm.FileCloseTranslationCommand, shortcuts,
-            v => v.ShowColumnOriginalText, nameof(vm.ShowColumnOriginalText)));
+        fileItems.Items.Add(Item(Clean(l.Open), v => v.CommandFileOpenCommand));
+        fileItems.Items.Add(Conditional(Clean(l.OpenKeepVideo), v => v.CommandFileOpenKeepVideoCommand,
+            v => v.IsVideoLoaded, nameof(MainViewModel.IsVideoLoaded)));
+        fileItems.Items.Add(Conditional(Clean(l.OpenOriginal), v => v.FileOpenOriginalCommand,
+            v => !v.ShowColumnOriginalText, nameof(MainViewModel.ShowColumnOriginalText)));
+        fileItems.Items.Add(Conditional(Clean(l.CloseOriginal), v => v.FileCloseOriginalCommand,
+            v => v.ShowColumnOriginalText, nameof(MainViewModel.ShowColumnOriginalText)));
+        fileItems.Items.Add(Conditional(Clean(l.CloseTranslation), v => v.FileCloseTranslationCommand,
+            v => v.ShowColumnOriginalText, nameof(MainViewModel.ShowColumnOriginalText)));
 
-        vm.NativeMenuReopen = new NativeMenuItem(Clean(l.Reopen)) { Menu = new NativeMenu() };
-        fileItems.Items.Add(vm.NativeMenuReopen);
-        fileItems.Items.Add(MakeItem(Clean(l.RestoreAutoBackup), vm.ShowRestoreAutoBackupCommand, shortcuts));
+        _reopenItem = new NativeMenuItem(Clean(l.Reopen)) { Menu = new NativeMenu() };
+        fileItems.Items.Add(_reopenItem);
+        fileItems.Items.Add(Item(Clean(l.RestoreAutoBackup), v => v.ShowRestoreAutoBackupCommand));
         fileItems.Items.Add(new NativeMenuItemSeparator());
-        fileItems.Items.Add(MakeItem(Clean(l.Save), vm.CommandFileSaveCommand, shortcuts));
-        fileItems.Items.Add(MakeItem(Clean(l.SaveAs), vm.CommandFileSaveAsCommand, shortcuts));
+        fileItems.Items.Add(Item(Clean(l.Save), v => v.CommandFileSaveCommand));
+        fileItems.Items.Add(Item(Clean(l.SaveAs), v => v.CommandFileSaveAsCommand));
         fileItems.Items.Add(new NativeMenuItemSeparator());
 
-        var filePropsItem = new NativeMenuItem(Clean(vm.FilePropertiesText));
-        filePropsItem.IsEnabled = vm.IsFilePropertiesVisible;
-        filePropsItem.Click += (_, _) => vm.FilePropertiesShowCommand.Execute(null);
-        RegisterUpdater(v =>
-        {
-            filePropsItem.Header = Clean(v.FilePropertiesText);
-            filePropsItem.IsEnabled = v.IsFilePropertiesVisible;
-        }, nameof(vm.FilePropertiesText), nameof(vm.IsFilePropertiesVisible));
+        var filePropsItem = new NativeMenuItem(string.Empty);
+        filePropsItem.Click += (_, _) => GetVm()?.FilePropertiesShowCommand.Execute(null);
+        _dynamicHeaders.Add((filePropsItem, v => Clean(v.FilePropertiesText),
+            [nameof(MainViewModel.FilePropertiesText)]));
+        _conditionals.Add((filePropsItem, v => v.IsFilePropertiesVisible,
+            [nameof(MainViewModel.IsFilePropertiesVisible)]));
         fileItems.Items.Add(filePropsItem);
 
-        fileItems.Items.Add(MakeItem(Clean(l.OpenContainingFolder), vm.OpenContainingFolderCommand, shortcuts));
-        fileItems.Items.Add(MakeItem(Clean(l.Compare), vm.ShowCompareCommand, shortcuts));
-        fileItems.Items.Add(MakeItem(Clean(l.Statistics), vm.ShowStatisticsCommand, shortcuts));
+        fileItems.Items.Add(Item(Clean(l.OpenContainingFolder), v => v.OpenContainingFolderCommand));
+        fileItems.Items.Add(Item(Clean(l.Compare), v => v.ShowCompareCommand));
+        fileItems.Items.Add(Item(Clean(l.Statistics), v => v.ShowStatisticsCommand));
         fileItems.Items.Add(new NativeMenuItemSeparator());
 
         var lImport = Se.Language.File.Import;
         var importItems = new NativeMenu();
-        importItems.Items.Add(MakeItem(Clean(lImport.SubtitleWithManuallyChosenEncodingDotDotDot), vm.ShowImportSubtitleWithManuallyChosenEncodingCommand, shortcuts));
+        importItems.Items.Add(Item(Clean(lImport.SubtitleWithManuallyChosenEncodingDotDotDot), v => v.ShowImportSubtitleWithManuallyChosenEncodingCommand));
         importItems.Items.Add(new NativeMenuItemSeparator());
-        importItems.Items.Add(MakeItem(Clean(lImport.ImagedBasedSubtitleForOcrDotDotDot), vm.ImportImageSubtitleForOcrCommand, shortcuts));
-        importItems.Items.Add(MakeItem(Clean(lImport.ImagedBasedSubtitleForEditDotDotDot), vm.ImportImageSubtitleForEditCommand, shortcuts));
-        importItems.Items.Add(MakeItem(Clean(lImport.ImagesForOcrDotDotDot), vm.ImportImagesCommand, shortcuts));
-        importItems.Items.Add(MakeItem(Clean(lImport.PlainTextDotDotDot), vm.ImportPlainTextCommand, shortcuts));
-        importItems.Items.Add(MakeItem(Clean(lImport.CsvXlsxCustomColumnsDotDotDot), vm.ImportCsvXlsxCustomColumnsCommand, shortcuts));
+        importItems.Items.Add(Item(Clean(lImport.ImagedBasedSubtitleForOcrDotDotDot), v => v.ImportImageSubtitleForOcrCommand));
+        importItems.Items.Add(Item(Clean(lImport.ImagedBasedSubtitleForEditDotDotDot), v => v.ImportImageSubtitleForEditCommand));
+        importItems.Items.Add(Item(Clean(lImport.ImagesForOcrDotDotDot), v => v.ImportImagesCommand));
+        importItems.Items.Add(Item(Clean(lImport.PlainTextDotDotDot), v => v.ImportPlainTextCommand));
+        importItems.Items.Add(Item(Clean(lImport.CsvXlsxCustomColumnsDotDotDot), v => v.ImportCsvXlsxCustomColumnsCommand));
         importItems.Items.Add(new NativeMenuItemSeparator());
-        importItems.Items.Add(MakeItem(Clean(lImport.TimeCodesDotDotDot), vm.ImportTimeCodesCommand, shortcuts));
-        importItems.Items.Add(MakeItem(Clean(lImport.FormattingDotDotDot), vm.ImportStylingCommand, shortcuts));
+        importItems.Items.Add(Item(Clean(lImport.TimeCodesDotDotDot), v => v.ImportTimeCodesCommand));
+        importItems.Items.Add(Item(Clean(lImport.FormattingDotDotDot), v => v.ImportStylingCommand));
         fileItems.Items.Add(new NativeMenuItem(Clean(l.Import)) { Menu = importItems });
 
         var lExport = Se.Language.File.Export;
         var exportItems = new NativeMenu();
-        exportItems.Items.Add(MakeItem(Se.Language.General.BluRaySup, vm.ExportBluRaySupCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(Se.Language.General.BdnXml, vm.ExportBdnXmlCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(new CapMakerPlus().Name, vm.ExportCapMakerPlusCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(CheetahCaption.NameOfFormat, vm.ExportCheetahCaptionCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(CheetahCaptionOld.NameOfFormat, vm.ExportCheetahCaptionOldCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(Cavena890.NameOfFormat, vm.ExportCavena890Command, shortcuts));
-        exportItems.Items.Add(MakeItem(lExport.TitleExportDCinemaInteropPng, vm.ExportDCinemaInteropPngCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(lExport.TitleExportDCinemaSmpte2014Png, vm.ExportDCinemaSmpte2014PngCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(Ebu.NameOfFormat, vm.ExportEbuStlCommand, shortcuts));
-        exportItems.Items.Add(MakeItem("DOST/png", vm.ExportDostPngCommand, shortcuts));
-        exportItems.Items.Add(MakeItem("FCP/png", vm.ExportFcpPngCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(Se.Language.General.ImagesWithTimeCode, vm.ExportImagesWithTimeCodeCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(Pac.NameOfFormat, vm.ExportPacCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(new PacUnicode().Name, vm.ExportPacUnicodeCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(lExport.TitleExportVobSub, vm.ExportVobSubCommand, shortcuts));
-        exportItems.Items.Add(MakeItem("WebVTT png", vm.ExportWebVttThumbnailsCommand, shortcuts));
+        exportItems.Items.Add(Item(Se.Language.General.BluRaySup, v => v.ExportBluRaySupCommand));
+        exportItems.Items.Add(Item(Se.Language.General.BdnXml, v => v.ExportBdnXmlCommand));
+        exportItems.Items.Add(Item(new CapMakerPlus().Name, v => v.ExportCapMakerPlusCommand));
+        exportItems.Items.Add(Item(CheetahCaption.NameOfFormat, v => v.ExportCheetahCaptionCommand));
+        exportItems.Items.Add(Item(CheetahCaptionOld.NameOfFormat, v => v.ExportCheetahCaptionOldCommand));
+        exportItems.Items.Add(Item(Cavena890.NameOfFormat, v => v.ExportCavena890Command));
+        exportItems.Items.Add(Item(lExport.TitleExportDCinemaInteropPng, v => v.ExportDCinemaInteropPngCommand));
+        exportItems.Items.Add(Item(lExport.TitleExportDCinemaSmpte2014Png, v => v.ExportDCinemaSmpte2014PngCommand));
+        exportItems.Items.Add(Item(Ebu.NameOfFormat, v => v.ExportEbuStlCommand));
+        exportItems.Items.Add(Item("DOST/png", v => v.ExportDostPngCommand));
+        exportItems.Items.Add(Item("FCP/png", v => v.ExportFcpPngCommand));
+        exportItems.Items.Add(Item(Se.Language.General.ImagesWithTimeCode, v => v.ExportImagesWithTimeCodeCommand));
+        exportItems.Items.Add(Item(Pac.NameOfFormat, v => v.ExportPacCommand));
+        exportItems.Items.Add(Item(new PacUnicode().Name, v => v.ExportPacUnicodeCommand));
+        exportItems.Items.Add(Item(lExport.TitleExportVobSub, v => v.ExportVobSubCommand));
+        exportItems.Items.Add(Item("WebVTT png", v => v.ExportWebVttThumbnailsCommand));
         exportItems.Items.Add(new NativeMenuItemSeparator());
-        exportItems.Items.Add(MakeItem(Clean(lExport.CustomTextFormatsDotDotDot), vm.ShowExportCustomTextFormatCommand, shortcuts));
-        exportItems.Items.Add(MakeItem(Clean(lExport.PlainTextDotDotDot), vm.ShowExportPlainTextCommand, shortcuts));
+        exportItems.Items.Add(Item(Clean(lExport.CustomTextFormatsDotDotDot), v => v.ShowExportCustomTextFormatCommand));
+        exportItems.Items.Add(Item(Clean(lExport.PlainTextDotDotDot), v => v.ShowExportPlainTextCommand));
         fileItems.Items.Add(new NativeMenuItem(Clean(l.Export)) { Menu = exportItems });
 
-        // ── Edit ─────────────────────────────────────────────────────────────
+        // ── Edit ──────────────────────────────────────────────────────────────
         var editItems = new NativeMenu();
-        editItems.Items.Add(MakeItem(Clean(l.Undo), vm.UndoCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(l.Redo), vm.RedoCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(l.ShowHistory), vm.ShowHistoryCommand, shortcuts));
+        editItems.Items.Add(Item(Clean(l.Undo), v => v.UndoCommand));
+        editItems.Items.Add(Item(Clean(l.Redo), v => v.RedoCommand));
+        editItems.Items.Add(Item(Clean(l.ShowHistory), v => v.ShowHistoryCommand));
         editItems.Items.Add(new NativeMenuItemSeparator());
-        editItems.Items.Add(MakeItem(Clean(l.Find), vm.ShowFindCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(l.FindNext), vm.FindNextCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(l.Replace), vm.ShowReplaceCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(l.MultipleReplace), vm.ShowMultipleReplaceCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(l.GoToLineNumber), vm.ShowGoToLineCommand, shortcuts));
+        editItems.Items.Add(Item(Clean(l.Find), v => v.ShowFindCommand));
+        editItems.Items.Add(Item(Clean(l.FindNext), v => v.FindNextCommand));
+        editItems.Items.Add(Item(Clean(l.Replace), v => v.ShowReplaceCommand));
+        editItems.Items.Add(Item(Clean(l.MultipleReplace), v => v.ShowMultipleReplaceCommand));
+        editItems.Items.Add(Item(Clean(l.GoToLineNumber), v => v.ShowGoToLineCommand));
         editItems.Items.Add(new NativeMenuItemSeparator());
-        editItems.Items.Add(MakeToggle(Clean(l.RightToLeftMode), vm.RightToLeftToggleCommand,
-            vm.IsRightToLeftEnabled, v => v.IsRightToLeftEnabled, nameof(vm.IsRightToLeftEnabled)));
-        editItems.Items.Add(MakeItem(Clean(l.FixRightToLeftViaUnicodeControlCharacters), vm.FixRightToLeftViaUnicodeControlCharactersCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(l.RemoveUnicodeControlCharacters), vm.RemoveUnicodeControlCharactersCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(l.ReverseRightToLeftStartEnd), vm.ReverseRightToLeftStartEndCommand, shortcuts));
+        editItems.Items.Add(Toggle(Clean(l.RightToLeftMode), v => v.RightToLeftToggleCommand,
+            v => v.IsRightToLeftEnabled, nameof(MainViewModel.IsRightToLeftEnabled)));
+        editItems.Items.Add(Item(Clean(l.FixRightToLeftViaUnicodeControlCharacters), v => v.FixRightToLeftViaUnicodeControlCharactersCommand));
+        editItems.Items.Add(Item(Clean(l.RemoveUnicodeControlCharacters), v => v.RemoveUnicodeControlCharactersCommand));
+        editItems.Items.Add(Item(Clean(l.ReverseRightToLeftStartEnd), v => v.ReverseRightToLeftStartEndCommand));
         editItems.Items.Add(new NativeMenuItemSeparator());
-        editItems.Items.Add(MakeItem(Clean(l.ModifySelectionDotDotDot), vm.ShowModifySelectionCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(Se.Language.General.InvertSelection), vm.InverseSelectionCommand, shortcuts));
-        editItems.Items.Add(MakeItem(Clean(Se.Language.General.SelectAll), vm.SelectAllLinesCommand, shortcuts));
+        editItems.Items.Add(Item(Clean(l.ModifySelectionDotDotDot), v => v.ShowModifySelectionCommand));
+        editItems.Items.Add(Item(Clean(Se.Language.General.InvertSelection), v => v.InverseSelectionCommand));
+        editItems.Items.Add(Item(Clean(Se.Language.General.SelectAll), v => v.SelectAllLinesCommand));
 
-        // ── Tools ────────────────────────────────────────────────────────────
+        // ── Tools ─────────────────────────────────────────────────────────────
         var toolsList = new List<NativeMenuItem>
         {
-            MakeItem(Clean(l.AdjustDurations), vm.ShowToolsAdjustDurationsCommand, shortcuts),
-            MakeItem(Clean(l.ApplyDurationLimits), vm.ShowApplyDurationLimitsCommand, shortcuts),
-            MakeItem(Clean(l.BatchConvert), vm.ShowToolsBatchConvertCommand, shortcuts),
-            MakeItem(Clean(l.BeautifyTimeCodes), vm.ShowBeautifyTimeCodesCommand, shortcuts),
-            MakeItem(Clean(l.BridgeGaps), vm.ShowBridgeGapsCommand, shortcuts),
-            MakeItem(Clean(l.ApplyMinGap), vm.ShowApplyMinGapCommand, shortcuts),
-            MakeItem(Clean(l.ChangeCasing), vm.ShowToolsChangeCasingCommand, shortcuts),
-            MakeItem(Clean(l.ChangeFormatting), vm.ShowToolsChangeFormattingCommand, shortcuts),
-            MakeItem(Clean(l.FixCommonErrors), vm.ShowToolsFixCommonErrorsCommand, shortcuts),
-            MakeItem(Clean(l.CheckAndFixNetflixErrors), vm.ShowToolsFixNetflixErrorsCommand, shortcuts),
-            MakeItem(Clean(l.MakeEmptyTranslationFromCurrentSubtitle), vm.ToolsMakeEmptyTranslationFromCurrentSubtitleCommand, shortcuts),
-            MakeItem(Clean(l.MergeLinesWithSameText), vm.ShowToolsMergeLinesWithSameTextCommand, shortcuts),
-            MakeItem(Clean(l.MergeLinesWithSameTimeCodes), vm.ShowToolsMergeLinesWithSameTimeCodesCommand, shortcuts),
-            MakeItem(Clean(l.SplitBreakLongLines), vm.ShowToolsSplitBreakLongLinesCommand, shortcuts),
-            MakeItem(Clean(l.MergeShortLines), vm.ShowToolsMergeShortLinesCommand, shortcuts),
-            MakeItem(Clean(l.MergeContinuationLines), vm.ShowToolsMergeContinuationLinesCommand, shortcuts),
-            MakeItem(Clean(l.SnapAllTimesToFrames), vm.SnapAllTimesToFramesCommand, shortcuts),
-            MakeItem(Clean(l.MergeTwoSubtitles), vm.ShowToolsMergeTwoSubtitlesCommand, shortcuts),
-            MakeItem(Clean(l.SortSubtitles), vm.ShowSortByCommand, shortcuts),
-            MakeItem(Clean(l.Renumber), vm.ShowToolsRenumberCommand, shortcuts),
-            MakeItem(Clean(l.RemoveTextForHearingImpaired), vm.ShowToolsRemoveTextForHearingImpairedCommand, shortcuts),
-            MakeItem(Clean(l.ConvertActors), vm.ShowToolsConvertActorsCommand, shortcuts),
+            Item(Clean(l.AdjustDurations), v => v.ShowToolsAdjustDurationsCommand),
+            Item(Clean(l.ApplyDurationLimits), v => v.ShowApplyDurationLimitsCommand),
+            Item(Clean(l.BatchConvert), v => v.ShowToolsBatchConvertCommand),
+            Item(Clean(l.BeautifyTimeCodes), v => v.ShowBeautifyTimeCodesCommand),
+            Item(Clean(l.BridgeGaps), v => v.ShowBridgeGapsCommand),
+            Item(Clean(l.ApplyMinGap), v => v.ShowApplyMinGapCommand),
+            Item(Clean(l.ChangeCasing), v => v.ShowToolsChangeCasingCommand),
+            Item(Clean(l.ChangeFormatting), v => v.ShowToolsChangeFormattingCommand),
+            Item(Clean(l.FixCommonErrors), v => v.ShowToolsFixCommonErrorsCommand),
+            Item(Clean(l.CheckAndFixNetflixErrors), v => v.ShowToolsFixNetflixErrorsCommand),
+            Item(Clean(l.MakeEmptyTranslationFromCurrentSubtitle), v => v.ToolsMakeEmptyTranslationFromCurrentSubtitleCommand),
+            Item(Clean(l.MergeLinesWithSameText), v => v.ShowToolsMergeLinesWithSameTextCommand),
+            Item(Clean(l.MergeLinesWithSameTimeCodes), v => v.ShowToolsMergeLinesWithSameTimeCodesCommand),
+            Item(Clean(l.SplitBreakLongLines), v => v.ShowToolsSplitBreakLongLinesCommand),
+            Item(Clean(l.MergeShortLines), v => v.ShowToolsMergeShortLinesCommand),
+            Item(Clean(l.MergeContinuationLines), v => v.ShowToolsMergeContinuationLinesCommand),
+            Item(Clean(l.SnapAllTimesToFrames), v => v.SnapAllTimesToFramesCommand),
+            Item(Clean(l.MergeTwoSubtitles), v => v.ShowToolsMergeTwoSubtitlesCommand),
+            Item(Clean(l.SortSubtitles), v => v.ShowSortByCommand),
+            Item(Clean(l.Renumber), v => v.ShowToolsRenumberCommand),
+            Item(Clean(l.RemoveTextForHearingImpaired), v => v.ShowToolsRemoveTextForHearingImpairedCommand),
+            Item(Clean(l.ConvertActors), v => v.ShowToolsConvertActorsCommand),
         };
         var toolItems = new NativeMenu();
-        foreach (var item in toolsList.OrderBy(i => i.Header?.Replace("_", string.Empty)))
-            toolItems.Items.Add(item);
+        foreach (var toolItem in toolsList.OrderBy(i => i.Header?.Replace("_", string.Empty)))
+            toolItems.Items.Add(toolItem);
         toolItems.Items.Add(new NativeMenuItemSeparator());
-        toolItems.Items.Add(MakeItem(Clean(l.JoinSubtitles), vm.ShowToolsJoinCommand, shortcuts));
-        toolItems.Items.Add(MakeItem(Clean(l.SplitSubtitle), vm.ShowToolsSplitCommand, shortcuts));
+        toolItems.Items.Add(Item(Clean(l.JoinSubtitles), v => v.ShowToolsJoinCommand));
+        toolItems.Items.Add(Item(Clean(l.SplitSubtitle), v => v.ShowToolsSplitCommand));
 
-        // ── Plugins ──────────────────────────────────────────────────────────
-        vm.NativeMenuPlugins = new NativeMenuItem(Clean(Se.Language.Plugins.Title)) { Menu = new NativeMenu() };
-        vm.NativeMenuPlugins.IsEnabled = Se.Settings.Appearance.ShowPluginsMenu;
-        UpdatePluginsMenu(vm);
+        // ── Plugins ───────────────────────────────────────────────────────────
+        _pluginsItem = new NativeMenuItem(Clean(Se.Language.Plugins.Title)) { Menu = new NativeMenu() };
 
-        // ── Spell Check ──────────────────────────────────────────────────────
+        // ── Spell Check ───────────────────────────────────────────────────────
         var spellItems = new NativeMenu();
-        spellItems.Items.Add(MakeItem(Clean(l.SpellCheck), vm.ShowSpellCheckCommand, shortcuts));
-        spellItems.Items.Add(MakeItem(Clean(l.FindDoubleWords), vm.ShowFindDoubleWordsCommand, shortcuts));
-        spellItems.Items.Add(MakeItem(Clean(l.FindDoubleLines), vm.ShowFindDoubleLinesCommand, shortcuts));
+        spellItems.Items.Add(Item(Clean(l.SpellCheck), v => v.ShowSpellCheckCommand));
+        spellItems.Items.Add(Item(Clean(l.FindDoubleWords), v => v.ShowFindDoubleWordsCommand));
+        spellItems.Items.Add(Item(Clean(l.FindDoubleLines), v => v.ShowFindDoubleLinesCommand));
         spellItems.Items.Add(new NativeMenuItemSeparator());
-        spellItems.Items.Add(MakeItem(Clean(l.AddNameToNamesList), vm.ShowAddToNameListCommand, shortcuts));
-        spellItems.Items.Add(MakeItem(Clean(l.GetDictionaries), vm.ShowSpellCheckDictionariesCommand, shortcuts));
+        spellItems.Items.Add(Item(Clean(l.AddNameToNamesList), v => v.ShowAddToNameListCommand));
+        spellItems.Items.Add(Item(Clean(l.GetDictionaries), v => v.ShowSpellCheckDictionariesCommand));
 
-        // ── Video ────────────────────────────────────────────────────────────
+        // ── Video ─────────────────────────────────────────────────────────────
         var videoItems = new NativeMenu();
-        videoItems.Items.Add(MakeItem(Clean(l.OpenVideo), vm.CommandVideoOpenCommand, shortcuts));
-        videoItems.Items.Add(MakeItem(Clean(l.OpenVideoFromUrl), vm.ShowVideoOpenFromUrlCommand, shortcuts));
-        videoItems.Items.Add(MakeItem(Clean(l.CloseVideoFile), vm.CommandVideoCloseCommand, shortcuts));
+        videoItems.Items.Add(Item(Clean(l.OpenVideo), v => v.CommandVideoOpenCommand));
+        videoItems.Items.Add(Item(Clean(l.OpenVideoFromUrl), v => v.ShowVideoOpenFromUrlCommand));
+        videoItems.Items.Add(Item(Clean(l.CloseVideoFile), v => v.CommandVideoCloseCommand));
 
-        vm.NativeMenuAudioTracks = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
-        vm.NativeMenuAudioTracks.IsEnabled = vm.IsAudioTracksVisible;
-        RegisterUpdater(v => vm.NativeMenuAudioTracks!.IsEnabled = v.IsAudioTracksVisible, nameof(vm.IsAudioTracksVisible));
-        videoItems.Items.Add(vm.NativeMenuAudioTracks);
+        _audioTracksItem = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
+        _conditionals.Add((_audioTracksItem, v => v.IsAudioTracksVisible,
+            [nameof(MainViewModel.IsAudioTracksVisible)]));
+        videoItems.Items.Add(_audioTracksItem);
 
         videoItems.Items.Add(new NativeMenuItemSeparator());
-        videoItems.Items.Add(MakeItem(Clean(l.SpeechToText), vm.ShowSpeechToTextWhisperCommand, shortcuts));
-        videoItems.Items.Add(MakeItem(Clean(l.TextToSpeech), vm.ShowVideoTextToSpeechCommand, shortcuts));
+        videoItems.Items.Add(Item(Clean(l.SpeechToText), v => v.ShowSpeechToTextWhisperCommand));
+        videoItems.Items.Add(Item(Clean(l.TextToSpeech), v => v.ShowVideoTextToSpeechCommand));
         videoItems.Items.Add(new NativeMenuItemSeparator());
-        videoItems.Items.Add(MakeItem(Clean(l.GenerateBurnIn), vm.ShowVideoBurnInCommand, shortcuts));
-        videoItems.Items.Add(MakeItem(Clean(l.GenerateTransparent), vm.ShowVideoTransparentSubtitlesCommand, shortcuts));
-        videoItems.Items.Add(MakeItem(Clean(Se.Language.Video.GenerateBlankVideoDotDotDot), vm.VideoGenerateBlankCommand, shortcuts));
-        videoItems.Items.Add(MakeItem(Clean(Se.Language.Video.EmbedSubtitlesDotDotDot), vm.VideoEmbedCommand, shortcuts));
+        videoItems.Items.Add(Item(Clean(l.GenerateBurnIn), v => v.ShowVideoBurnInCommand));
+        videoItems.Items.Add(Item(Clean(l.GenerateTransparent), v => v.ShowVideoTransparentSubtitlesCommand));
+        videoItems.Items.Add(Item(Clean(Se.Language.Video.GenerateBlankVideoDotDotDot), v => v.VideoGenerateBlankCommand));
+        videoItems.Items.Add(Item(Clean(Se.Language.Video.EmbedSubtitlesDotDotDot), v => v.VideoEmbedCommand));
         videoItems.Items.Add(new NativeMenuItemSeparator());
-        videoItems.Items.Add(MakeItem(Clean(l.GenerateImportShotChanges), vm.ShowShotChangesSubtitlesCommand, shortcuts));
-        videoItems.Items.Add(MakeConditional(vm, Clean(l.ListShotChanges), vm.ShowShotChangesListCommand, shortcuts,
-            v => v.ShowShotChangesListMenuItem, nameof(vm.ShowShotChangesListMenuItem)));
+        videoItems.Items.Add(Item(Clean(l.GenerateImportShotChanges), v => v.ShowShotChangesSubtitlesCommand));
+        videoItems.Items.Add(Conditional(Clean(l.ListShotChanges), v => v.ShowShotChangesListCommand,
+            v => v.ShowShotChangesListMenuItem, nameof(MainViewModel.ShowShotChangesListMenuItem)));
         videoItems.Items.Add(new NativeMenuItemSeparator());
-        videoItems.Items.Add(MakeConditional(vm, Clean(l.UndockVideoControls), vm.VideoUndockControlsCommand, shortcuts,
-            v => !v.AreVideoControlsUndocked, nameof(vm.AreVideoControlsUndocked)));
-        videoItems.Items.Add(MakeConditional(vm, Clean(l.DockVideoControls), vm.VideoRedockControlsCommand, shortcuts,
-            v => v.AreVideoControlsUndocked, nameof(vm.AreVideoControlsUndocked)));
-        videoItems.Items.Add(MakeToggle(Clean(l.ToggleSelectSubtitleWhilePlayingCurrentlyOff), vm.ToggleCurrentSubtitleWhilePlayingCommand,
-            vm.SelectCurrentSubtitleWhilePlaying, v => v.SelectCurrentSubtitleWhilePlaying, nameof(vm.SelectCurrentSubtitleWhilePlaying)));
+        videoItems.Items.Add(Conditional(Clean(l.UndockVideoControls), v => v.VideoUndockControlsCommand,
+            v => !v.AreVideoControlsUndocked, nameof(MainViewModel.AreVideoControlsUndocked)));
+        videoItems.Items.Add(Conditional(Clean(l.DockVideoControls), v => v.VideoRedockControlsCommand,
+            v => v.AreVideoControlsUndocked, nameof(MainViewModel.AreVideoControlsUndocked)));
+        videoItems.Items.Add(Toggle(Clean(l.ToggleSelectSubtitleWhilePlayingCurrentlyOff), v => v.ToggleCurrentSubtitleWhilePlayingCommand,
+            v => v.SelectCurrentSubtitleWhilePlaying, nameof(MainViewModel.SelectCurrentSubtitleWhilePlaying)));
 
         var lVideo = Se.Language.Video;
         var videoMoreList = new List<NativeMenuItem>
         {
-            MakeConditional(vm, Clean(lVideo.OpenSecondarySubtitleOnVideoPlayerDotDotDot), vm.OpenSecondarySubtitleCommand, shortcuts,
-                v => !v.IsSubtitleSecondaryVisible, nameof(vm.IsSubtitleSecondaryVisible)),
-            MakeConditional(vm, Clean(lVideo.RemoveSecondarySubtitleOnVideoPlayer), vm.ClearSecondarySubtitleCommand, shortcuts,
-                v => v.IsSubtitleSecondaryVisible, nameof(vm.IsSubtitleSecondaryVisible)),
-            MakeItem(Clean(lVideo.ReEncodeVideoForBetterSubtitlingDotDotDot), vm.VideoReEncodeCommand, shortcuts),
-            MakeItem(Clean(lVideo.CutVideoDotDotDot), vm.VideoCutCommand, shortcuts),
+            Conditional(Clean(lVideo.OpenSecondarySubtitleOnVideoPlayerDotDotDot), v => v.OpenSecondarySubtitleCommand,
+                v => !v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsSubtitleSecondaryVisible)),
+            Conditional(Clean(lVideo.RemoveSecondarySubtitleOnVideoPlayer), v => v.ClearSecondarySubtitleCommand,
+                v => v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsSubtitleSecondaryVisible)),
+            Item(Clean(lVideo.ReEncodeVideoForBetterSubtitlingDotDotDot), v => v.VideoReEncodeCommand),
+            Item(Clean(lVideo.CutVideoDotDotDot), v => v.VideoCutCommand),
         };
-        videoMoreList.Add(MakeToggle(Clean(Se.Language.Options.Shortcuts.ToggleWaveformToolbar), vm.ToggleIsWaveformToolbarVisibleCommand,
-            vm.IsWaveformToolbarVisible, v => v.IsWaveformToolbarVisible, nameof(vm.IsWaveformToolbarVisible)));
+        videoMoreList.Add(Toggle(Clean(Se.Language.Options.Shortcuts.ToggleWaveformToolbar), v => v.ToggleIsWaveformToolbarVisibleCommand,
+            v => v.IsWaveformToolbarVisible, nameof(MainViewModel.IsWaveformToolbarVisible)));
 
-        var setOffsetItem = new NativeMenuItem(Clean(vm.SetVideoOffsetText));
-        setOffsetItem.Click += (_, _) => vm.ShowVideoSetOffsetCommand.Execute(null);
-        RegisterUpdater(v => setOffsetItem.Header = Clean(v.SetVideoOffsetText), nameof(vm.SetVideoOffsetText));
+        var setOffsetItem = new NativeMenuItem(string.Empty);
+        setOffsetItem.Click += (_, _) => GetVm()?.ShowVideoSetOffsetCommand.Execute(null);
+        _dynamicHeaders.Add((setOffsetItem, v => Clean(v.SetVideoOffsetText),
+            [nameof(MainViewModel.SetVideoOffsetText)]));
         videoMoreList.Add(setOffsetItem);
 
-        videoMoreList.Add(MakeToggle(Clean(l.SmpteTiming), vm.ToggleSmpteTimingCommand,
-            vm.IsSmpteTimingEnabled, v => v.IsSmpteTimingEnabled, nameof(vm.IsSmpteTimingEnabled)));
+        videoMoreList.Add(Toggle(Clean(l.SmpteTiming), v => v.ToggleSmpteTimingCommand,
+            v => v.IsSmpteTimingEnabled, nameof(MainViewModel.IsSmpteTimingEnabled)));
 
         var videoMoreItems = new NativeMenu();
         foreach (var item in videoMoreList.OrderBy(i => i.Header?.TrimStart('_', ' ')))
             videoMoreItems.Items.Add(item);
 
         var videoMoreMenu = new NativeMenuItem(Clean(Se.Language.General.More)) { Menu = videoMoreItems };
-        videoMoreMenu.IsEnabled = vm.IsVideoLoaded;
-        RegisterUpdater(v => videoMoreMenu.IsEnabled = v.IsVideoLoaded, nameof(vm.IsVideoLoaded));
+        _conditionals.Add((videoMoreMenu, v => v.IsVideoLoaded, [nameof(MainViewModel.IsVideoLoaded)]));
         videoItems.Items.Add(videoMoreMenu);
 
-        // ── Synchronization ──────────────────────────────────────────────────
+        // ── Synchronization ───────────────────────────────────────────────────
         var syncItems = new NativeMenu();
-        syncItems.Items.Add(MakeItem(Clean(l.AdjustAllTimes), vm.ShowSyncAdjustAllTimesCommand, shortcuts));
-        syncItems.Items.Add(MakeItem(Clean(l.VisualSync), vm.ShowVisualSyncCommand, shortcuts));
-        syncItems.Items.Add(MakeItem(Clean(l.PointSync), vm.ShowPointSyncCommand, shortcuts));
-        syncItems.Items.Add(MakeItem(Clean(l.PointSyncViaOther), vm.ShowPointSyncViaOtherCommand, shortcuts));
-        syncItems.Items.Add(MakeItem(Clean(l.ChangeFrameRate), vm.ShowSyncChangeFrameRateCommand, shortcuts));
-        syncItems.Items.Add(MakeItem(Clean(l.ChangeSpeed), vm.ShowSyncChangeSpeedCommand, shortcuts));
+        syncItems.Items.Add(Item(Clean(l.AdjustAllTimes), v => v.ShowSyncAdjustAllTimesCommand));
+        syncItems.Items.Add(Item(Clean(l.VisualSync), v => v.ShowVisualSyncCommand));
+        syncItems.Items.Add(Item(Clean(l.PointSync), v => v.ShowPointSyncCommand));
+        syncItems.Items.Add(Item(Clean(l.PointSyncViaOther), v => v.ShowPointSyncViaOtherCommand));
+        syncItems.Items.Add(Item(Clean(l.ChangeFrameRate), v => v.ShowSyncChangeFrameRateCommand));
+        syncItems.Items.Add(Item(Clean(l.ChangeSpeed), v => v.ShowSyncChangeSpeedCommand));
 
-        // ── Translate ────────────────────────────────────────────────────────
+        // ── Translate ─────────────────────────────────────────────────────────
         var translateItems = new NativeMenu();
-        translateItems.Items.Add(MakeItem(Clean(l.AutoTranslate), vm.ShowAutoTranslateCommand, shortcuts));
-        translateItems.Items.Add(MakeItem(Clean(l.TranslateViaCopyPaste), vm.ShowTranslateViaCopyPasteCommand, shortcuts));
+        translateItems.Items.Add(Item(Clean(l.AutoTranslate), v => v.ShowAutoTranslateCommand));
+        translateItems.Items.Add(Item(Clean(l.TranslateViaCopyPaste), v => v.ShowTranslateViaCopyPasteCommand));
 
-        // ── Options ──────────────────────────────────────────────────────────
+        // ── Options ───────────────────────────────────────────────────────────
         var optionsItems = new NativeMenu();
-        optionsItems.Items.Add(MakeItem(Clean(l.Settings), vm.CommandShowSettingsCommand, shortcuts));
-        optionsItems.Items.Add(MakeItem(Clean(l.Shortcuts), vm.CommandShowSettingsShortcutsCommand, shortcuts));
-        optionsItems.Items.Add(MakeItem(Clean(l.WordLists), vm.ShowWordListsCommand, shortcuts));
-        optionsItems.Items.Add(MakeItem(Clean(l.ChooseLanguage), vm.CommandShowSettingsLanguageCommand, shortcuts));
+        optionsItems.Items.Add(Item(Clean(l.Settings), v => v.CommandShowSettingsCommand));
+        optionsItems.Items.Add(Item(Clean(l.Shortcuts), v => v.CommandShowSettingsShortcutsCommand));
+        optionsItems.Items.Add(Item(Clean(l.WordLists), v => v.ShowWordListsCommand));
+        optionsItems.Items.Add(Item(Clean(l.ChooseLanguage), v => v.CommandShowSettingsLanguageCommand));
 
-        // ── Help ─────────────────────────────────────────────────────────────
+        // ── Help ──────────────────────────────────────────────────────────────
         var helpItems = new NativeMenu();
-        helpItems.Items.Add(MakeItem(Clean(l.CheckForUpdates), vm.ShowCheckForUpdatesCommand, shortcuts));
+        helpItems.Items.Add(Item(Clean(l.CheckForUpdates), v => v.ShowCheckForUpdatesCommand));
         helpItems.Items.Add(new NativeMenuItemSeparator());
-        helpItems.Items.Add(MakeItem(Clean(l.Help), vm.ShowHelpCommand, shortcuts));
-        helpItems.Items.Add(MakeItem(Clean(l.About), vm.ShowAboutCommand, shortcuts));
+        helpItems.Items.Add(Item(Clean(l.Help), v => v.ShowHelpCommand));
+        helpItems.Items.Add(Item(Clean(l.About), v => v.ShowAboutCommand));
 
-        // ── ASSA Tools ───────────────────────────────────────────────────────
+        // ── ASSA Tools ────────────────────────────────────────────────────────
         var assaList = new List<NativeMenuItem>
         {
-            MakeItem(Clean(l.AssaProgressBar), vm.ShowAssaGenerateProgressBarCommand, shortcuts),
-            MakeItem(Clean(l.AssaChangeResolution), vm.ShowAssaChangeResolutionCommand, shortcuts),
-            MakeItem(Clean(l.AssaGenerateBackground), vm.ShowAssaGenerateBackgroundCommand, shortcuts),
-            MakeItem(Clean(l.AssaImageColorPicker), vm.ShowAssaImageColorPickerCommand, shortcuts),
-            MakeItem(Clean(l.AssaSetPosition), vm.ShowAssaSetPositionCommand, shortcuts),
-            MakeItem(Clean(l.AssaApplyAdvancedEffects), vm.ShowAssaApplyAdvancedEffectCommand, shortcuts),
-            MakeItem(Clean(l.AssaApplyCustomOverrideTags), vm.ShowAssaApplyCustomOverrideTagsCommand, shortcuts),
-            MakeItem(Clean(l.AssaDraw), vm.ShowAssaDrawCommand, shortcuts),
-            MakeItem(Clean(l.AssaProperties), vm.ShowAssaPropertiesCommand, shortcuts),
-            MakeItem(Clean(l.AssaAttachments), vm.ShowAssaAttachmentsCommand, shortcuts),
-            MakeItem(Clean(l.AssaStyles), vm.ShowAssaStylesCommand, shortcuts),
+            Item(Clean(l.AssaProgressBar), v => v.ShowAssaGenerateProgressBarCommand),
+            Item(Clean(l.AssaChangeResolution), v => v.ShowAssaChangeResolutionCommand),
+            Item(Clean(l.AssaGenerateBackground), v => v.ShowAssaGenerateBackgroundCommand),
+            Item(Clean(l.AssaImageColorPicker), v => v.ShowAssaImageColorPickerCommand),
+            Item(Clean(l.AssaSetPosition), v => v.ShowAssaSetPositionCommand),
+            Item(Clean(l.AssaApplyAdvancedEffects), v => v.ShowAssaApplyAdvancedEffectCommand),
+            Item(Clean(l.AssaApplyCustomOverrideTags), v => v.ShowAssaApplyCustomOverrideTagsCommand),
+            Item(Clean(l.AssaDraw), v => v.ShowAssaDrawCommand),
+            Item(Clean(l.AssaProperties), v => v.ShowAssaPropertiesCommand),
+            Item(Clean(l.AssaAttachments), v => v.ShowAssaAttachmentsCommand),
+            Item(Clean(l.AssaStyles), v => v.ShowAssaStylesCommand),
         };
         var assaItems = new NativeMenu();
-        foreach (var item in assaList.OrderBy(i => i.Header?.Replace("_", string.Empty)))
-            assaItems.Items.Add(item);
+        foreach (var assaItem in assaList.OrderBy(i => i.Header?.Replace("_", string.Empty)))
+            assaItems.Items.Add(assaItem);
         assaItems.Items.Add(new NativeMenuItemSeparator());
-        assaItems.Items.Add(MakeItem(Clean(l.FilterLayersForDisplayDotDotDot), vm.ShowPickLayerFilterCommand, shortcuts));
+        assaItems.Items.Add(Item(Clean(l.FilterLayersForDisplayDotDotDot), v => v.ShowPickLayerFilterCommand));
         var assaMenu = new NativeMenuItem(Clean(l.AssaTools)) { Menu = assaItems };
-        assaMenu.IsEnabled = vm.IsFormatAssa;
-        RegisterUpdater(v => assaMenu.IsEnabled = v.IsFormatAssa, nameof(vm.IsFormatAssa));
+        _conditionals.Add((assaMenu, v => v.IsFormatAssa, [nameof(MainViewModel.IsFormatAssa)]));
 
-        // ── Assemble ─────────────────────────────────────────────────────────
-        // Reuse the root NativeMenu registered during startup. Avalonia's macOS
-        // backend subscribes to the items collection on that specific object;
-        // replacing it with a new NativeMenu via NativeMenu.SetMenu does not
-        // propagate to NSApplication.mainMenu after initial setup.
-        var root = NativeMenu.GetMenu(app) ?? new NativeMenu();
-        root.Items.Clear();
+        // ── Assemble ──────────────────────────────────────────────────────────
         root.Items.Add(new NativeMenuItem("Subtitle Edit") { Menu = appItems });
         root.Items.Add(new NativeMenuItem(Clean(l.File)) { Menu = fileItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Edit)) { Menu = editItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolItems });
-        root.Items.Add(vm.NativeMenuPlugins);
+        root.Items.Add(_pluginsItem);
         root.Items.Add(new NativeMenuItem(Clean(l.SpellCheckTitle)) { Menu = spellItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Video)) { Menu = videoItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Synchronization)) { Menu = syncItems });
@@ -322,24 +339,64 @@ public static class InitNativeMacMenu
         root.Items.Add(new NativeMenuItem(Clean(l.Options)) { Menu = optionsItems });
         root.Items.Add(new NativeMenuItem(Clean(l.HelpTitle)) { Menu = helpItems });
         root.Items.Add(assaMenu);
+    }
 
+    // ── Phase 2 ──────────────────────────────────────────────────────────────
+    // Called from MainViewModel.OnLoaded (after the event loop starts).
+    // Syncs initial states, gestures, PropertyChanged subscriptions, and dynamic
+    // submenus onto the items already created by MakeStructure.
+
+    public static void Sync(Application app, MainViewModel vm)
+    {
+        if (_handler != null)
+            vm.PropertyChanged -= _handler;
+
+        // Expose dynamic submenu references on the VM
+        vm.NativeMenuReopen = _reopenItem;
+        vm.NativeMenuPlugins = _pluginsItem;
+        vm.NativeMenuAudioTracks = _audioTracksItem;
+
+        // Gestures
+        var shortcuts = ShortcutsMain.GetUsedShortcuts(vm);
+        foreach (var (getCmd, item) in _gestureItems)
+            item.Gesture = FindGesture(getCmd(vm), shortcuts);
+
+        // Initial conditional states
+        foreach (var (item, isEnabled, _) in _conditionals)
+            item.IsEnabled = isEnabled(vm);
+
+        // Initial toggle states
+        foreach (var (item, isChecked, _) in _toggles)
+            item.IsChecked = isChecked(vm);
+
+        // Initial dynamic headers
+        foreach (var (item, getHeader, _) in _dynamicHeaders)
+            item.Header = getHeader(vm);
+
+        // Plugins visibility
+        if (_pluginsItem != null)
+            _pluginsItem.IsEnabled = Se.Settings.Appearance.ShowPluginsMenu;
+
+        // PropertyChanged handler
         _handler = (s, e) =>
         {
             if (s is not MainViewModel v2 || e.PropertyName is null)
                 return;
-            foreach (var (propName, updater) in _updaters)
-            {
-                if (propName == e.PropertyName)
-                    updater(v2);
-            }
+            foreach (var (item, isEnabled, props) in _conditionals)
+                if (props.Contains(e.PropertyName)) item.IsEnabled = isEnabled(v2);
+            foreach (var (item, isChecked, props) in _toggles)
+                if (props.Contains(e.PropertyName)) item.IsChecked = isChecked(v2);
+            foreach (var (item, getHeader, props) in _dynamicHeaders)
+                if (props.Contains(e.PropertyName)) item.Header = getHeader(v2);
         };
         vm.PropertyChanged += _handler;
 
-        if (NativeMenu.GetMenu(app) == null)
-            NativeMenu.SetMenu(app, root);
-
+        // Dynamic submenus
         UpdateRecentFiles(vm);
+        UpdatePluginsMenu(vm);
     }
+
+    // ── Dynamic submenu updaters ──────────────────────────────────────────────
 
     public static void UpdateRecentFiles(MainViewModel vm)
     {
@@ -371,8 +428,8 @@ public static class InitNativeMacMenu
                 header = "…" + header[^77..];
 
             var recentItem = new NativeMenuItem(header);
-            var capturedFile = file;
-            recentItem.Click += (_, _) => vm.CommandFileReopenCommand.Execute(capturedFile);
+            var captured = file;
+            recentItem.Click += (_, _) => vm.CommandFileReopenCommand.Execute(captured);
             menu.Items.Add(recentItem);
         }
 
@@ -444,37 +501,42 @@ public static class InitNativeMacMenu
 
     public static void UpdateShortcuts(MainViewModel vm)
     {
-        if (Application.Current is { } app)
-            Make(app, vm);
+        if (Avalonia.Application.Current is not { } app)
+            return;
+
+        var shortcuts = ShortcutsMain.GetUsedShortcuts(vm);
+        foreach (var (getCmd, item) in _gestureItems)
+            item.Gesture = FindGesture(getCmd(vm), shortcuts);
     }
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
+    // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private static NativeMenuItem MakeItem(string? header, IRelayCommand command, List<ShortCut> shortcuts)
+    private static MainViewModel? GetVm() =>
+        Locator.Services?.GetService<MainViewModel>();
+
+    private static NativeMenuItem Item(string? header, Func<MainViewModel, IRelayCommand> getCmd)
     {
         var item = new NativeMenuItem(header ?? string.Empty);
-        item.Click += (_, _) => command.Execute(null);
-        item.Gesture = FindGesture(command, shortcuts);
+        item.Click += (_, _) => { var v = GetVm(); if (v != null) getCmd(v).Execute(null); };
+        _gestureItems.Add((getCmd, item));
         return item;
     }
 
-    private static NativeMenuItem MakeConditional(MainViewModel vm, string? header, IRelayCommand command,
-        List<ShortCut> shortcuts, Func<MainViewModel, bool> isEnabled, params string[] propertyNames)
+    private static NativeMenuItem Conditional(string? header, Func<MainViewModel, IRelayCommand> getCmd,
+        Func<MainViewModel, bool> isEnabled, params string[] propertyNames)
     {
-        var item = MakeItem(header, command, shortcuts);
-        item.IsEnabled = isEnabled(vm);
-        RegisterUpdater(v => item.IsEnabled = isEnabled(v), propertyNames);
+        var item = Item(header, getCmd);
+        _conditionals.Add((item, isEnabled, propertyNames));
         return item;
     }
 
-    private static NativeMenuItem MakeToggle(string? header, IRelayCommand command, bool initialChecked,
+    private static NativeMenuItem Toggle(string? header, Func<MainViewModel, IRelayCommand> getCmd,
         Func<MainViewModel, bool> isChecked, params string[] propertyNames)
     {
         var item = new NativeMenuItem(header ?? string.Empty);
         item.ToggleType = MenuItemToggleType.CheckBox;
-        item.IsChecked = initialChecked;
-        item.Click += (_, _) => command.Execute(null);
-        RegisterUpdater(v => item.IsChecked = isChecked(v), propertyNames);
+        item.Click += (_, _) => { var v = GetVm(); if (v != null) getCmd(v).Execute(null); };
+        _toggles.Add((item, isChecked, propertyNames));
         return item;
     }
 
@@ -486,12 +548,6 @@ public static class InitNativeMacMenu
                 return InitMenu.ToKeyGesture(sc);
         }
         return null;
-    }
-
-    private static void RegisterUpdater(Action<MainViewModel> updater, params string[] propertyNames)
-    {
-        foreach (var name in propertyNames)
-            _updaters.Add((name, updater));
     }
 
     private static string Clean(string? s) => s?.Replace("_", string.Empty) ?? string.Empty;

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -21,12 +21,18 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 ///   - SetMenu(Application, menu) → _factory.SetAppMenu()  → the "Subtitle Edit" app menu dropdown only
 ///   - SetMenu(Window, menu)      → avnWindow.SetMainMenu() → the full NSMenuBar with separate menus
 ///
-/// Two-phase design:
+/// Two-phase init:
 ///   SetupAppMenu + MakeStructure: called from Program.cs after SetupMainWindow.
 ///     The Window-level menu creates the full NSMenuBar (File, Edit, etc.).
 ///     The Application-level menu populates the App menu (About, Preferences).
-///   Sync: called from OnLoaded once the ViewModel is available to wire up
-///     initial states, gestures, PropertyChanged subscriptions, and dynamic submenus.
+///   Sync: called from MainViewModel.OnLoaded to wire up initial states,
+///     gestures, PropertyChanged subscriptions, and dynamic submenus.
+///
+/// Post-init updaters (called as state changes):
+///   Rebuild: rebuilds the full structure after a language switch.
+///   UpdateShortcuts: re-resolves gestures after shortcut settings change.
+///   UpdateRecentFiles / UpdatePluginsMenu / UpdateAudioTracksMenu: refresh
+///     dynamic submenus on demand.
 /// </summary>
 public static class InitNativeMacMenu
 {

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -1,0 +1,491 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.Input;
+using System.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Plugins;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Main.Layout;
+
+public static class InitNativeMacMenu
+{
+    private static PropertyChangedEventHandler? _handler;
+    private static readonly List<(string PropertyName, Action<MainViewModel> Updater)> _updaters = [];
+
+    public static void Make(Application app, MainViewModel vm)
+    {
+        if (_handler != null)
+        {
+            vm.PropertyChanged -= _handler;
+            _handler = null;
+        }
+        _updaters.Clear();
+
+        var shortcuts = ShortcutsMain.GetUsedShortcuts(vm);
+        var l = Se.Language.Main.Menu;
+
+        // ── App menu ("Subtitle Edit" on macOS) ──────────────────────────────
+        var appItems = new NativeMenu();
+        appItems.Items.Add(MakeItem(Clean(Se.Language.Help.AboutSubtitleEdit), vm.ShowAboutCommand, shortcuts));
+        appItems.Items.Add(new NativeMenuItemSeparator());
+        var prefsItem = MakeItem(Clean(l.Settings), vm.CommandShowSettingsCommand, shortcuts);
+        prefsItem.Gesture = new KeyGesture(Key.OemComma, KeyModifiers.Meta);
+        appItems.Items.Add(prefsItem);
+        appItems.Items.Add(new NativeMenuItemSeparator());
+        var quitItem = new NativeMenuItem(Clean(l.Exit));
+        quitItem.Gesture = new KeyGesture(Key.Q, KeyModifiers.Meta);
+        quitItem.Click += (_, _) => vm.CommandExitCommand.Execute(null);
+        appItems.Items.Add(quitItem);
+
+        // ── File ─────────────────────────────────────────────────────────────
+        var fileItems = new NativeMenu();
+        fileItems.Items.Add(MakeItem(Clean(l.New), vm.CommandFileNewCommand, shortcuts));
+        fileItems.Items.Add(MakeConditional(vm, Clean(l.NewKeepVideo), vm.CommandFileNewKeepVideoCommand, shortcuts,
+            v => v.IsVideoLoaded, nameof(vm.IsVideoLoaded)));
+        fileItems.Items.Add(new NativeMenuItemSeparator());
+        fileItems.Items.Add(MakeItem(Clean(l.Open), vm.CommandFileOpenCommand, shortcuts));
+        fileItems.Items.Add(MakeConditional(vm, Clean(l.OpenKeepVideo), vm.CommandFileOpenKeepVideoCommand, shortcuts,
+            v => v.IsVideoLoaded, nameof(vm.IsVideoLoaded)));
+        fileItems.Items.Add(MakeConditional(vm, Clean(l.OpenOriginal), vm.FileOpenOriginalCommand, shortcuts,
+            v => !v.ShowColumnOriginalText, nameof(vm.ShowColumnOriginalText)));
+        fileItems.Items.Add(MakeConditional(vm, Clean(l.CloseOriginal), vm.FileCloseOriginalCommand, shortcuts,
+            v => v.ShowColumnOriginalText, nameof(vm.ShowColumnOriginalText)));
+        fileItems.Items.Add(MakeConditional(vm, Clean(l.CloseTranslation), vm.FileCloseTranslationCommand, shortcuts,
+            v => v.ShowColumnOriginalText, nameof(vm.ShowColumnOriginalText)));
+
+        vm.NativeMenuReopen = new NativeMenuItem(Clean(l.Reopen)) { Menu = new NativeMenu() };
+        fileItems.Items.Add(vm.NativeMenuReopen);
+        fileItems.Items.Add(MakeItem(Clean(l.RestoreAutoBackup), vm.ShowRestoreAutoBackupCommand, shortcuts));
+        fileItems.Items.Add(new NativeMenuItemSeparator());
+        fileItems.Items.Add(MakeItem(Clean(l.Save), vm.CommandFileSaveCommand, shortcuts));
+        fileItems.Items.Add(MakeItem(Clean(l.SaveAs), vm.CommandFileSaveAsCommand, shortcuts));
+        fileItems.Items.Add(new NativeMenuItemSeparator());
+
+        var filePropsItem = new NativeMenuItem(Clean(vm.FilePropertiesText));
+        filePropsItem.IsEnabled = vm.IsFilePropertiesVisible;
+        filePropsItem.Click += (_, _) => vm.FilePropertiesShowCommand.Execute(null);
+        RegisterUpdater(v =>
+        {
+            filePropsItem.Header = Clean(v.FilePropertiesText);
+            filePropsItem.IsEnabled = v.IsFilePropertiesVisible;
+        }, nameof(vm.FilePropertiesText), nameof(vm.IsFilePropertiesVisible));
+        fileItems.Items.Add(filePropsItem);
+
+        fileItems.Items.Add(MakeItem(Clean(l.OpenContainingFolder), vm.OpenContainingFolderCommand, shortcuts));
+        fileItems.Items.Add(MakeItem(Clean(l.Compare), vm.ShowCompareCommand, shortcuts));
+        fileItems.Items.Add(MakeItem(Clean(l.Statistics), vm.ShowStatisticsCommand, shortcuts));
+        fileItems.Items.Add(new NativeMenuItemSeparator());
+
+        var lImport = Se.Language.File.Import;
+        var importItems = new NativeMenu();
+        importItems.Items.Add(MakeItem(Clean(lImport.SubtitleWithManuallyChosenEncodingDotDotDot), vm.ShowImportSubtitleWithManuallyChosenEncodingCommand, shortcuts));
+        importItems.Items.Add(new NativeMenuItemSeparator());
+        importItems.Items.Add(MakeItem(Clean(lImport.ImagedBasedSubtitleForOcrDotDotDot), vm.ImportImageSubtitleForOcrCommand, shortcuts));
+        importItems.Items.Add(MakeItem(Clean(lImport.ImagedBasedSubtitleForEditDotDotDot), vm.ImportImageSubtitleForEditCommand, shortcuts));
+        importItems.Items.Add(MakeItem(Clean(lImport.ImagesForOcrDotDotDot), vm.ImportImagesCommand, shortcuts));
+        importItems.Items.Add(MakeItem(Clean(lImport.PlainTextDotDotDot), vm.ImportPlainTextCommand, shortcuts));
+        importItems.Items.Add(MakeItem(Clean(lImport.CsvXlsxCustomColumnsDotDotDot), vm.ImportCsvXlsxCustomColumnsCommand, shortcuts));
+        importItems.Items.Add(new NativeMenuItemSeparator());
+        importItems.Items.Add(MakeItem(Clean(lImport.TimeCodesDotDotDot), vm.ImportTimeCodesCommand, shortcuts));
+        importItems.Items.Add(MakeItem(Clean(lImport.FormattingDotDotDot), vm.ImportStylingCommand, shortcuts));
+        fileItems.Items.Add(new NativeMenuItem(Clean(l.Import)) { Menu = importItems });
+
+        var lExport = Se.Language.File.Export;
+        var exportItems = new NativeMenu();
+        exportItems.Items.Add(MakeItem(Se.Language.General.BluRaySup, vm.ExportBluRaySupCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(Se.Language.General.BdnXml, vm.ExportBdnXmlCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(new CapMakerPlus().Name, vm.ExportCapMakerPlusCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(CheetahCaption.NameOfFormat, vm.ExportCheetahCaptionCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(CheetahCaptionOld.NameOfFormat, vm.ExportCheetahCaptionOldCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(Cavena890.NameOfFormat, vm.ExportCavena890Command, shortcuts));
+        exportItems.Items.Add(MakeItem(lExport.TitleExportDCinemaInteropPng, vm.ExportDCinemaInteropPngCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(lExport.TitleExportDCinemaSmpte2014Png, vm.ExportDCinemaSmpte2014PngCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(Ebu.NameOfFormat, vm.ExportEbuStlCommand, shortcuts));
+        exportItems.Items.Add(MakeItem("DOST/png", vm.ExportDostPngCommand, shortcuts));
+        exportItems.Items.Add(MakeItem("FCP/png", vm.ExportFcpPngCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(Se.Language.General.ImagesWithTimeCode, vm.ExportImagesWithTimeCodeCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(Pac.NameOfFormat, vm.ExportPacCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(new PacUnicode().Name, vm.ExportPacUnicodeCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(lExport.TitleExportVobSub, vm.ExportVobSubCommand, shortcuts));
+        exportItems.Items.Add(MakeItem("WebVTT png", vm.ExportWebVttThumbnailsCommand, shortcuts));
+        exportItems.Items.Add(new NativeMenuItemSeparator());
+        exportItems.Items.Add(MakeItem(Clean(lExport.CustomTextFormatsDotDotDot), vm.ShowExportCustomTextFormatCommand, shortcuts));
+        exportItems.Items.Add(MakeItem(Clean(lExport.PlainTextDotDotDot), vm.ShowExportPlainTextCommand, shortcuts));
+        fileItems.Items.Add(new NativeMenuItem(Clean(l.Export)) { Menu = exportItems });
+
+        // ── Edit ─────────────────────────────────────────────────────────────
+        var editItems = new NativeMenu();
+        editItems.Items.Add(MakeItem(Clean(l.Undo), vm.UndoCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(l.Redo), vm.RedoCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(l.ShowHistory), vm.ShowHistoryCommand, shortcuts));
+        editItems.Items.Add(new NativeMenuItemSeparator());
+        editItems.Items.Add(MakeItem(Clean(l.Find), vm.ShowFindCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(l.FindNext), vm.FindNextCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(l.Replace), vm.ShowReplaceCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(l.MultipleReplace), vm.ShowMultipleReplaceCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(l.GoToLineNumber), vm.ShowGoToLineCommand, shortcuts));
+        editItems.Items.Add(new NativeMenuItemSeparator());
+        editItems.Items.Add(MakeToggle(Clean(l.RightToLeftMode), vm.RightToLeftToggleCommand,
+            vm.IsRightToLeftEnabled, v => v.IsRightToLeftEnabled, nameof(vm.IsRightToLeftEnabled)));
+        editItems.Items.Add(MakeItem(Clean(l.FixRightToLeftViaUnicodeControlCharacters), vm.FixRightToLeftViaUnicodeControlCharactersCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(l.RemoveUnicodeControlCharacters), vm.RemoveUnicodeControlCharactersCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(l.ReverseRightToLeftStartEnd), vm.ReverseRightToLeftStartEndCommand, shortcuts));
+        editItems.Items.Add(new NativeMenuItemSeparator());
+        editItems.Items.Add(MakeItem(Clean(l.ModifySelectionDotDotDot), vm.ShowModifySelectionCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(Se.Language.General.InvertSelection), vm.InverseSelectionCommand, shortcuts));
+        editItems.Items.Add(MakeItem(Clean(Se.Language.General.SelectAll), vm.SelectAllLinesCommand, shortcuts));
+
+        // ── Tools ────────────────────────────────────────────────────────────
+        var toolsList = new List<NativeMenuItem>
+        {
+            MakeItem(Clean(l.AdjustDurations), vm.ShowToolsAdjustDurationsCommand, shortcuts),
+            MakeItem(Clean(l.ApplyDurationLimits), vm.ShowApplyDurationLimitsCommand, shortcuts),
+            MakeItem(Clean(l.BatchConvert), vm.ShowToolsBatchConvertCommand, shortcuts),
+            MakeItem(Clean(l.BeautifyTimeCodes), vm.ShowBeautifyTimeCodesCommand, shortcuts),
+            MakeItem(Clean(l.BridgeGaps), vm.ShowBridgeGapsCommand, shortcuts),
+            MakeItem(Clean(l.ApplyMinGap), vm.ShowApplyMinGapCommand, shortcuts),
+            MakeItem(Clean(l.ChangeCasing), vm.ShowToolsChangeCasingCommand, shortcuts),
+            MakeItem(Clean(l.ChangeFormatting), vm.ShowToolsChangeFormattingCommand, shortcuts),
+            MakeItem(Clean(l.FixCommonErrors), vm.ShowToolsFixCommonErrorsCommand, shortcuts),
+            MakeItem(Clean(l.CheckAndFixNetflixErrors), vm.ShowToolsFixNetflixErrorsCommand, shortcuts),
+            MakeItem(Clean(l.MakeEmptyTranslationFromCurrentSubtitle), vm.ToolsMakeEmptyTranslationFromCurrentSubtitleCommand, shortcuts),
+            MakeItem(Clean(l.MergeLinesWithSameText), vm.ShowToolsMergeLinesWithSameTextCommand, shortcuts),
+            MakeItem(Clean(l.MergeLinesWithSameTimeCodes), vm.ShowToolsMergeLinesWithSameTimeCodesCommand, shortcuts),
+            MakeItem(Clean(l.SplitBreakLongLines), vm.ShowToolsSplitBreakLongLinesCommand, shortcuts),
+            MakeItem(Clean(l.MergeShortLines), vm.ShowToolsMergeShortLinesCommand, shortcuts),
+            MakeItem(Clean(l.MergeContinuationLines), vm.ShowToolsMergeContinuationLinesCommand, shortcuts),
+            MakeItem(Clean(l.SnapAllTimesToFrames), vm.SnapAllTimesToFramesCommand, shortcuts),
+            MakeItem(Clean(l.MergeTwoSubtitles), vm.ShowToolsMergeTwoSubtitlesCommand, shortcuts),
+            MakeItem(Clean(l.SortSubtitles), vm.ShowSortByCommand, shortcuts),
+            MakeItem(Clean(l.Renumber), vm.ShowToolsRenumberCommand, shortcuts),
+            MakeItem(Clean(l.RemoveTextForHearingImpaired), vm.ShowToolsRemoveTextForHearingImpairedCommand, shortcuts),
+            MakeItem(Clean(l.ConvertActors), vm.ShowToolsConvertActorsCommand, shortcuts),
+        };
+        var toolItems = new NativeMenu();
+        foreach (var item in toolsList.OrderBy(i => i.Header?.Replace("_", string.Empty)))
+            toolItems.Items.Add(item);
+        toolItems.Items.Add(new NativeMenuItemSeparator());
+        toolItems.Items.Add(MakeItem(Clean(l.JoinSubtitles), vm.ShowToolsJoinCommand, shortcuts));
+        toolItems.Items.Add(MakeItem(Clean(l.SplitSubtitle), vm.ShowToolsSplitCommand, shortcuts));
+
+        // ── Plugins ──────────────────────────────────────────────────────────
+        vm.NativeMenuPlugins = new NativeMenuItem(Clean(Se.Language.Plugins.Title)) { Menu = new NativeMenu() };
+        vm.NativeMenuPlugins.IsEnabled = Se.Settings.Appearance.ShowPluginsMenu;
+        UpdatePluginsMenu(vm);
+
+        // ── Spell Check ──────────────────────────────────────────────────────
+        var spellItems = new NativeMenu();
+        spellItems.Items.Add(MakeItem(Clean(l.SpellCheck), vm.ShowSpellCheckCommand, shortcuts));
+        spellItems.Items.Add(MakeItem(Clean(l.FindDoubleWords), vm.ShowFindDoubleWordsCommand, shortcuts));
+        spellItems.Items.Add(MakeItem(Clean(l.FindDoubleLines), vm.ShowFindDoubleLinesCommand, shortcuts));
+        spellItems.Items.Add(new NativeMenuItemSeparator());
+        spellItems.Items.Add(MakeItem(Clean(l.AddNameToNamesList), vm.ShowAddToNameListCommand, shortcuts));
+        spellItems.Items.Add(MakeItem(Clean(l.GetDictionaries), vm.ShowSpellCheckDictionariesCommand, shortcuts));
+
+        // ── Video ────────────────────────────────────────────────────────────
+        var videoItems = new NativeMenu();
+        videoItems.Items.Add(MakeItem(Clean(l.OpenVideo), vm.CommandVideoOpenCommand, shortcuts));
+        videoItems.Items.Add(MakeItem(Clean(l.OpenVideoFromUrl), vm.ShowVideoOpenFromUrlCommand, shortcuts));
+        videoItems.Items.Add(MakeItem(Clean(l.CloseVideoFile), vm.CommandVideoCloseCommand, shortcuts));
+
+        vm.NativeMenuAudioTracks = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
+        vm.NativeMenuAudioTracks.IsEnabled = vm.IsAudioTracksVisible;
+        RegisterUpdater(v => vm.NativeMenuAudioTracks!.IsEnabled = v.IsAudioTracksVisible, nameof(vm.IsAudioTracksVisible));
+        videoItems.Items.Add(vm.NativeMenuAudioTracks);
+
+        videoItems.Items.Add(new NativeMenuItemSeparator());
+        videoItems.Items.Add(MakeItem(Clean(l.SpeechToText), vm.ShowSpeechToTextWhisperCommand, shortcuts));
+        videoItems.Items.Add(MakeItem(Clean(l.TextToSpeech), vm.ShowVideoTextToSpeechCommand, shortcuts));
+        videoItems.Items.Add(new NativeMenuItemSeparator());
+        videoItems.Items.Add(MakeItem(Clean(l.GenerateBurnIn), vm.ShowVideoBurnInCommand, shortcuts));
+        videoItems.Items.Add(MakeItem(Clean(l.GenerateTransparent), vm.ShowVideoTransparentSubtitlesCommand, shortcuts));
+        videoItems.Items.Add(MakeItem(Clean(Se.Language.Video.GenerateBlankVideoDotDotDot), vm.VideoGenerateBlankCommand, shortcuts));
+        videoItems.Items.Add(MakeItem(Clean(Se.Language.Video.EmbedSubtitlesDotDotDot), vm.VideoEmbedCommand, shortcuts));
+        videoItems.Items.Add(new NativeMenuItemSeparator());
+        videoItems.Items.Add(MakeItem(Clean(l.GenerateImportShotChanges), vm.ShowShotChangesSubtitlesCommand, shortcuts));
+        videoItems.Items.Add(MakeConditional(vm, Clean(l.ListShotChanges), vm.ShowShotChangesListCommand, shortcuts,
+            v => v.ShowShotChangesListMenuItem, nameof(vm.ShowShotChangesListMenuItem)));
+        videoItems.Items.Add(new NativeMenuItemSeparator());
+        videoItems.Items.Add(MakeConditional(vm, Clean(l.UndockVideoControls), vm.VideoUndockControlsCommand, shortcuts,
+            v => !v.AreVideoControlsUndocked, nameof(vm.AreVideoControlsUndocked)));
+        videoItems.Items.Add(MakeConditional(vm, Clean(l.DockVideoControls), vm.VideoRedockControlsCommand, shortcuts,
+            v => v.AreVideoControlsUndocked, nameof(vm.AreVideoControlsUndocked)));
+        videoItems.Items.Add(MakeToggle(Clean(l.ToggleSelectSubtitleWhilePlayingCurrentlyOff), vm.ToggleCurrentSubtitleWhilePlayingCommand,
+            vm.SelectCurrentSubtitleWhilePlaying, v => v.SelectCurrentSubtitleWhilePlaying, nameof(vm.SelectCurrentSubtitleWhilePlaying)));
+
+        var lVideo = Se.Language.Video;
+        var videoMoreList = new List<NativeMenuItem>
+        {
+            MakeConditional(vm, Clean(lVideo.OpenSecondarySubtitleOnVideoPlayerDotDotDot), vm.OpenSecondarySubtitleCommand, shortcuts,
+                v => !v.IsSubtitleSecondaryVisible, nameof(vm.IsSubtitleSecondaryVisible)),
+            MakeConditional(vm, Clean(lVideo.RemoveSecondarySubtitleOnVideoPlayer), vm.ClearSecondarySubtitleCommand, shortcuts,
+                v => v.IsSubtitleSecondaryVisible, nameof(vm.IsSubtitleSecondaryVisible)),
+            MakeItem(Clean(lVideo.ReEncodeVideoForBetterSubtitlingDotDotDot), vm.VideoReEncodeCommand, shortcuts),
+            MakeItem(Clean(lVideo.CutVideoDotDotDot), vm.VideoCutCommand, shortcuts),
+        };
+        videoMoreList.Add(MakeToggle(Clean(Se.Language.Options.Shortcuts.ToggleWaveformToolbar), vm.ToggleIsWaveformToolbarVisibleCommand,
+            vm.IsWaveformToolbarVisible, v => v.IsWaveformToolbarVisible, nameof(vm.IsWaveformToolbarVisible)));
+
+        var setOffsetItem = new NativeMenuItem(Clean(vm.SetVideoOffsetText));
+        setOffsetItem.Click += (_, _) => vm.ShowVideoSetOffsetCommand.Execute(null);
+        RegisterUpdater(v => setOffsetItem.Header = Clean(v.SetVideoOffsetText), nameof(vm.SetVideoOffsetText));
+        videoMoreList.Add(setOffsetItem);
+
+        videoMoreList.Add(MakeToggle(Clean(l.SmpteTiming), vm.ToggleSmpteTimingCommand,
+            vm.IsSmpteTimingEnabled, v => v.IsSmpteTimingEnabled, nameof(vm.IsSmpteTimingEnabled)));
+
+        var videoMoreItems = new NativeMenu();
+        foreach (var item in videoMoreList.OrderBy(i => i.Header?.TrimStart('_', ' ')))
+            videoMoreItems.Items.Add(item);
+
+        var videoMoreMenu = new NativeMenuItem(Clean(Se.Language.General.More)) { Menu = videoMoreItems };
+        videoMoreMenu.IsEnabled = vm.IsVideoLoaded;
+        RegisterUpdater(v => videoMoreMenu.IsEnabled = v.IsVideoLoaded, nameof(vm.IsVideoLoaded));
+        videoItems.Items.Add(videoMoreMenu);
+
+        // ── Synchronization ──────────────────────────────────────────────────
+        var syncItems = new NativeMenu();
+        syncItems.Items.Add(MakeItem(Clean(l.AdjustAllTimes), vm.ShowSyncAdjustAllTimesCommand, shortcuts));
+        syncItems.Items.Add(MakeItem(Clean(l.VisualSync), vm.ShowVisualSyncCommand, shortcuts));
+        syncItems.Items.Add(MakeItem(Clean(l.PointSync), vm.ShowPointSyncCommand, shortcuts));
+        syncItems.Items.Add(MakeItem(Clean(l.PointSyncViaOther), vm.ShowPointSyncViaOtherCommand, shortcuts));
+        syncItems.Items.Add(MakeItem(Clean(l.ChangeFrameRate), vm.ShowSyncChangeFrameRateCommand, shortcuts));
+        syncItems.Items.Add(MakeItem(Clean(l.ChangeSpeed), vm.ShowSyncChangeSpeedCommand, shortcuts));
+
+        // ── Translate ────────────────────────────────────────────────────────
+        var translateItems = new NativeMenu();
+        translateItems.Items.Add(MakeItem(Clean(l.AutoTranslate), vm.ShowAutoTranslateCommand, shortcuts));
+        translateItems.Items.Add(MakeItem(Clean(l.TranslateViaCopyPaste), vm.ShowTranslateViaCopyPasteCommand, shortcuts));
+
+        // ── Options ──────────────────────────────────────────────────────────
+        var optionsItems = new NativeMenu();
+        optionsItems.Items.Add(MakeItem(Clean(l.Settings), vm.CommandShowSettingsCommand, shortcuts));
+        optionsItems.Items.Add(MakeItem(Clean(l.Shortcuts), vm.CommandShowSettingsShortcutsCommand, shortcuts));
+        optionsItems.Items.Add(MakeItem(Clean(l.WordLists), vm.ShowWordListsCommand, shortcuts));
+        optionsItems.Items.Add(MakeItem(Clean(l.ChooseLanguage), vm.CommandShowSettingsLanguageCommand, shortcuts));
+
+        // ── Help ─────────────────────────────────────────────────────────────
+        var helpItems = new NativeMenu();
+        helpItems.Items.Add(MakeItem(Clean(l.CheckForUpdates), vm.ShowCheckForUpdatesCommand, shortcuts));
+        helpItems.Items.Add(new NativeMenuItemSeparator());
+        helpItems.Items.Add(MakeItem(Clean(l.Help), vm.ShowHelpCommand, shortcuts));
+        helpItems.Items.Add(MakeItem(Clean(l.About), vm.ShowAboutCommand, shortcuts));
+
+        // ── ASSA Tools ───────────────────────────────────────────────────────
+        var assaList = new List<NativeMenuItem>
+        {
+            MakeItem(Clean(l.AssaProgressBar), vm.ShowAssaGenerateProgressBarCommand, shortcuts),
+            MakeItem(Clean(l.AssaChangeResolution), vm.ShowAssaChangeResolutionCommand, shortcuts),
+            MakeItem(Clean(l.AssaGenerateBackground), vm.ShowAssaGenerateBackgroundCommand, shortcuts),
+            MakeItem(Clean(l.AssaImageColorPicker), vm.ShowAssaImageColorPickerCommand, shortcuts),
+            MakeItem(Clean(l.AssaSetPosition), vm.ShowAssaSetPositionCommand, shortcuts),
+            MakeItem(Clean(l.AssaApplyAdvancedEffects), vm.ShowAssaApplyAdvancedEffectCommand, shortcuts),
+            MakeItem(Clean(l.AssaApplyCustomOverrideTags), vm.ShowAssaApplyCustomOverrideTagsCommand, shortcuts),
+            MakeItem(Clean(l.AssaDraw), vm.ShowAssaDrawCommand, shortcuts),
+            MakeItem(Clean(l.AssaProperties), vm.ShowAssaPropertiesCommand, shortcuts),
+            MakeItem(Clean(l.AssaAttachments), vm.ShowAssaAttachmentsCommand, shortcuts),
+            MakeItem(Clean(l.AssaStyles), vm.ShowAssaStylesCommand, shortcuts),
+        };
+        var assaItems = new NativeMenu();
+        foreach (var item in assaList.OrderBy(i => i.Header?.Replace("_", string.Empty)))
+            assaItems.Items.Add(item);
+        assaItems.Items.Add(new NativeMenuItemSeparator());
+        assaItems.Items.Add(MakeItem(Clean(l.FilterLayersForDisplayDotDotDot), vm.ShowPickLayerFilterCommand, shortcuts));
+        var assaMenu = new NativeMenuItem(Clean(l.AssaTools)) { Menu = assaItems };
+        assaMenu.IsEnabled = vm.IsFormatAssa;
+        RegisterUpdater(v => assaMenu.IsEnabled = v.IsFormatAssa, nameof(vm.IsFormatAssa));
+
+        // ── Assemble ─────────────────────────────────────────────────────────
+        var root = new NativeMenu();
+        root.Items.Add(new NativeMenuItem("Subtitle Edit") { Menu = appItems });
+        root.Items.Add(new NativeMenuItem(Clean(l.File)) { Menu = fileItems });
+        root.Items.Add(new NativeMenuItem(Clean(l.Edit)) { Menu = editItems });
+        root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolItems });
+        root.Items.Add(vm.NativeMenuPlugins);
+        root.Items.Add(new NativeMenuItem(Clean(l.SpellCheckTitle)) { Menu = spellItems });
+        root.Items.Add(new NativeMenuItem(Clean(l.Video)) { Menu = videoItems });
+        root.Items.Add(new NativeMenuItem(Clean(l.Synchronization)) { Menu = syncItems });
+        root.Items.Add(new NativeMenuItem(Clean(l.Translate)) { Menu = translateItems });
+        root.Items.Add(new NativeMenuItem(Clean(l.Options)) { Menu = optionsItems });
+        root.Items.Add(new NativeMenuItem(Clean(l.HelpTitle)) { Menu = helpItems });
+        root.Items.Add(assaMenu);
+
+        _handler = (s, e) =>
+        {
+            if (s is not MainViewModel v2 || e.PropertyName is null)
+                return;
+            foreach (var (propName, updater) in _updaters)
+            {
+                if (propName == e.PropertyName)
+                    updater(v2);
+            }
+        };
+        vm.PropertyChanged += _handler;
+
+        NativeMenu.SetMenu(app, root);
+        UpdateRecentFiles(vm);
+    }
+
+    public static void UpdateRecentFiles(MainViewModel vm)
+    {
+        if (vm.NativeMenuReopen?.Menu is not NativeMenu menu)
+            return;
+
+        menu.Items.Clear();
+
+        var files = Se.Settings.File.RecentFiles
+            .Where(p => !string.IsNullOrEmpty(p.SubtitleFileName) && System.IO.File.Exists(p.SubtitleFileName))
+            .ToList();
+
+        vm.NativeMenuReopen.IsEnabled = files.Count > 0;
+
+        if (files.Count == 0)
+            return;
+
+        foreach (var file in files)
+        {
+            var header = file.SubtitleFileName ?? string.Empty;
+            if (!string.IsNullOrEmpty(file.SubtitleFileNameOriginal) && System.IO.File.Exists(file.SubtitleFileNameOriginal))
+            {
+                header += " + ";
+                header += System.IO.Path.GetDirectoryName(file.SubtitleFileName) == System.IO.Path.GetDirectoryName(file.SubtitleFileNameOriginal)
+                    ? System.IO.Path.GetFileName(file.SubtitleFileNameOriginal)
+                    : file.SubtitleFileNameOriginal;
+            }
+            if (header.Length > 80)
+                header = "…" + header[^77..];
+
+            var recentItem = new NativeMenuItem(header);
+            var capturedFile = file;
+            recentItem.Click += (_, _) => vm.CommandFileReopenCommand.Execute(capturedFile);
+            menu.Items.Add(recentItem);
+        }
+
+        menu.Items.Add(new NativeMenuItemSeparator());
+        var clearItem = new NativeMenuItem(Clean(Se.Language.Main.Menu.ClearRecentFiles));
+        clearItem.Click += (_, _) => vm.CommandFileClearRecentFilesCommand.Execute(null);
+        menu.Items.Add(clearItem);
+    }
+
+    public static void UpdatePluginsMenu(MainViewModel vm)
+    {
+        if (vm.NativeMenuPlugins?.Menu is not NativeMenu menu)
+            return;
+
+        menu.Items.Clear();
+
+        var enabled = vm.GetInstalledPlugins()
+            .Where(p => !Se.Settings.Plugins.DisabledPluginNames.Contains(p.Manifest.Name))
+            .OrderBy(p => p.Manifest.Name)
+            .ToList();
+
+        if (enabled.Count == 0)
+        {
+            menu.Items.Add(new NativeMenuItem(Se.Language.Plugins.NoPluginsInstalled) { IsEnabled = false });
+        }
+        else
+        {
+            foreach (var plugin in enabled)
+            {
+                var pluginItem = new NativeMenuItem(plugin.Manifest.Name) { IsEnabled = plugin.CanRun };
+                var captured = plugin;
+                pluginItem.Click += (_, _) => vm.RunPluginCommand.Execute(captured);
+                menu.Items.Add(pluginItem);
+            }
+        }
+
+        menu.Items.Add(new NativeMenuItemSeparator());
+        var manageItem = new NativeMenuItem(Se.Language.Plugins.ManagePlugins);
+        manageItem.Click += (_, _) => vm.ShowPluginManagerCommand.Execute(null);
+        menu.Items.Add(manageItem);
+    }
+
+    public static void UpdateAudioTracksMenu(MainViewModel vm, IList<AudioTrackInfo> tracks, AudioTrackInfo? current)
+    {
+        if (vm.NativeMenuAudioTracks?.Menu is not NativeMenu menu)
+            return;
+
+        menu.Items.Clear();
+
+        foreach (var track in tracks)
+        {
+            var trackName = string.Format(Se.Language.Main.AudioTrackX, track.Id);
+            if (!string.IsNullOrEmpty(track.Language))
+            {
+                var lang = Iso639Dash2LanguageCode.List.FirstOrDefault(p => p.ThreeLetterCode == track.Language);
+                trackName += string.IsNullOrEmpty(lang?.EnglishName) ? $" - {track.Language}" : $" - {lang.EnglishName}";
+            }
+            if (!string.IsNullOrEmpty(track.Title))
+                trackName += $" - {track.Title}";
+
+            var item = new NativeMenuItem(trackName);
+            item.ToggleType = MenuItemToggleType.CheckBox;
+            item.IsChecked = track.FfIndex == (current?.FfIndex ?? -1);
+            var captured = track;
+            item.Click += (_, _) => vm.PickAudioTrackCommand.Execute(captured);
+            menu.Items.Add(item);
+        }
+    }
+
+    public static void UpdateShortcuts(MainViewModel vm)
+    {
+        if (Application.Current is { } app)
+            Make(app, vm);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static NativeMenuItem MakeItem(string? header, IRelayCommand command, List<ShortCut> shortcuts)
+    {
+        var item = new NativeMenuItem(header ?? string.Empty);
+        item.Click += (_, _) => command.Execute(null);
+        item.Gesture = FindGesture(command, shortcuts);
+        return item;
+    }
+
+    private static NativeMenuItem MakeConditional(MainViewModel vm, string? header, IRelayCommand command,
+        List<ShortCut> shortcuts, Func<MainViewModel, bool> isEnabled, params string[] propertyNames)
+    {
+        var item = MakeItem(header, command, shortcuts);
+        item.IsEnabled = isEnabled(vm);
+        RegisterUpdater(v => item.IsEnabled = isEnabled(v), propertyNames);
+        return item;
+    }
+
+    private static NativeMenuItem MakeToggle(string? header, IRelayCommand command, bool initialChecked,
+        Func<MainViewModel, bool> isChecked, params string[] propertyNames)
+    {
+        var item = new NativeMenuItem(header ?? string.Empty);
+        item.ToggleType = MenuItemToggleType.CheckBox;
+        item.IsChecked = initialChecked;
+        item.Click += (_, _) => command.Execute(null);
+        RegisterUpdater(v => item.IsChecked = isChecked(v), propertyNames);
+        return item;
+    }
+
+    private static KeyGesture? FindGesture(IRelayCommand command, List<ShortCut> shortcuts)
+    {
+        foreach (var sc in shortcuts)
+        {
+            if (ReferenceEquals(sc.Action, command))
+                return InitMenu.ToKeyGesture(sc);
+        }
+        return null;
+    }
+
+    private static void RegisterUpdater(Action<MainViewModel> updater, params string[] propertyNames)
+    {
+        foreach (var name in propertyNames)
+            _updaters.Add((name, updater));
+    }
+
+    private static string Clean(string? s) => s?.Replace("_", string.Empty) ?? string.Empty;
+}

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -308,7 +308,6 @@ public static class InitNativeMacMenu
         // ── Help ──────────────────────────────────────────────────────────────
         var helpItems = new NativeMenu();
         helpItems.Items.Add(Item($"{Clean(Se.Language.Title)} {Clean(l.HelpTitle)}", v => v.ShowHelpCommand));
-        helpItems.Items.Add(Item(Clean(l.About), v => v.ShowAboutCommand));
 
         // ── ASSA Tools ────────────────────────────────────────────────────────
         var assaList = new List<NativeMenuItem>

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -18,38 +18,54 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 /// <summary>
 /// Builds and maintains the native macOS menu bar.
 ///
-/// Two-phase design: MakeStructure must be called during application setup
-/// (AfterSetup, before SetupWithLifetime) so Avalonia's macOS backend creates
-/// the NSMenuBar from our full menu tree. Sync is called later (OnLoaded) to
-/// set gestures, initial enabled/checked states, PropertyChanged subscriptions,
-/// and dynamic submenus once the ViewModel is available.
+/// Avalonia routes NativeMenu.SetMenu calls differently depending on the target:
+///   - SetMenu(Application, menu) → _factory.SetAppMenu()  → the "Subtitle Edit" app menu dropdown only
+///   - SetMenu(Window, menu)      → avnWindow.SetMainMenu() → the full NSMenuBar with separate menus
+///
+/// Two-phase design:
+///   SetupAppMenu + MakeStructure: called from Program.cs after SetupMainWindow.
+///     The Window-level menu creates the full NSMenuBar (File, Edit, etc.).
+///     The Application-level menu populates the App menu (About, Preferences).
+///   Sync: called from OnLoaded once the ViewModel is available to wire up
+///     initial states, gestures, PropertyChanged subscriptions, and dynamic submenus.
 /// </summary>
 public static class InitNativeMacMenu
 {
-    // Items whose Gesture must be set in Sync
     private static readonly List<(Func<MainViewModel, IRelayCommand> GetCmd, NativeMenuItem Item)> _gestureItems = [];
-
-    // Items whose IsEnabled tracks a VM property
     private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsEnabled, string[] Props)> _conditionals = [];
-
-    // Toggle (CheckBox) items whose IsChecked tracks a VM property
     private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsChecked, string[] Props)> _toggles = [];
-
-    // Items with a dynamic Header string
     private static readonly List<(NativeMenuItem Item, Func<MainViewModel, string> GetHeader, string[] Props)> _dynamicHeaders = [];
-
-    // Single PropertyChanged handler, replaced on each Sync call
     private static PropertyChangedEventHandler? _handler;
 
-    // References to dynamic-submenu items, surfaced so Sync/UpdateX can reach them
     private static NativeMenuItem? _reopenItem;
     private static NativeMenuItem? _pluginsItem;
     private static NativeMenuItem? _audioTracksItem;
 
-    // ── Phase 1 ──────────────────────────────────────────────────────────────
-    // Called from Program.cs SetupNativeMenu (inside AfterSetup, before
-    // SetupWithLifetime). Builds the full NativeMenu tree with lazy command
-    // resolution — the ViewModel is not available yet.
+    // ── App menu ─────────────────────────────────────────────────────────────
+    // Called from Program.cs. Sets the "Subtitle Edit" app dropdown contents.
+    // Avalonia also auto-appends the standard macOS items (Hide, Quit, etc.).
+
+    public static void SetupAppMenu(Application app)
+    {
+        var appMenu = new NativeMenu();
+
+        var aboutItem = new NativeMenuItem(Clean(Se.Language.Help.AboutSubtitleEdit));
+        aboutItem.Click += (_, _) => GetVm()?.ShowAboutCommand.Execute(null);
+        appMenu.Items.Add(aboutItem);
+        appMenu.Items.Add(new NativeMenuItemSeparator());
+
+        var prefsItem = new NativeMenuItem(Clean(Se.Language.Main.Menu.Settings));
+        prefsItem.Gesture = new KeyGesture(Key.OemComma, KeyModifiers.Meta);
+        prefsItem.Click += (_, _) => GetVm()?.CommandShowSettingsCommand.Execute(null);
+        appMenu.Items.Add(prefsItem);
+
+        NativeMenu.SetMenu(app, appMenu);
+    }
+
+    // ── Full NSMenuBar ────────────────────────────────────────────────────────
+    // MakeStructure populates the root NativeMenu (passed in from Program.cs)
+    // with all top-level menus. Called before NativeMenu.SetMenu(window, root).
+    // Commands use lazy VM resolution since the ViewModel may not be ready yet.
 
     public static void MakeStructure(NativeMenu root)
     {
@@ -59,19 +75,6 @@ public static class InitNativeMacMenu
         _dynamicHeaders.Clear();
 
         var l = Se.Language.Main.Menu;
-
-        // ── App menu ──────────────────────────────────────────────────────────
-        var appItems = new NativeMenu();
-        appItems.Items.Add(Item(Clean(Se.Language.Help.AboutSubtitleEdit), v => v.ShowAboutCommand));
-        appItems.Items.Add(new NativeMenuItemSeparator());
-        var prefsItem = Item(Clean(l.Settings), v => v.CommandShowSettingsCommand);
-        prefsItem.Gesture = new KeyGesture(Key.OemComma, KeyModifiers.Meta);
-        appItems.Items.Add(prefsItem);
-        appItems.Items.Add(new NativeMenuItemSeparator());
-        var quitItem = new NativeMenuItem(Clean(l.Exit));
-        quitItem.Gesture = new KeyGesture(Key.Q, KeyModifiers.Meta);
-        quitItem.Click += (_, _) => GetVm()?.CommandExitCommand.Execute(null);
-        appItems.Items.Add(quitItem);
 
         // ── File ──────────────────────────────────────────────────────────────
         var fileItems = new NativeMenu();
@@ -99,10 +102,8 @@ public static class InitNativeMacMenu
 
         var filePropsItem = new NativeMenuItem(string.Empty);
         filePropsItem.Click += (_, _) => GetVm()?.FilePropertiesShowCommand.Execute(null);
-        _dynamicHeaders.Add((filePropsItem, v => Clean(v.FilePropertiesText),
-            [nameof(MainViewModel.FilePropertiesText)]));
-        _conditionals.Add((filePropsItem, v => v.IsFilePropertiesVisible,
-            [nameof(MainViewModel.IsFilePropertiesVisible)]));
+        _dynamicHeaders.Add((filePropsItem, v => Clean(v.FilePropertiesText), [nameof(MainViewModel.FilePropertiesText)]));
+        _conditionals.Add((filePropsItem, v => v.IsFilePropertiesVisible, [nameof(MainViewModel.IsFilePropertiesVisible)]));
         fileItems.Items.Add(filePropsItem);
 
         fileItems.Items.Add(Item(Clean(l.OpenContainingFolder), v => v.OpenContainingFolderCommand));
@@ -221,8 +222,7 @@ public static class InitNativeMacMenu
         videoItems.Items.Add(Item(Clean(l.CloseVideoFile), v => v.CommandVideoCloseCommand));
 
         _audioTracksItem = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
-        _conditionals.Add((_audioTracksItem, v => v.IsAudioTracksVisible,
-            [nameof(MainViewModel.IsAudioTracksVisible)]));
+        _conditionals.Add((_audioTracksItem, v => v.IsAudioTracksVisible, [nameof(MainViewModel.IsAudioTracksVisible)]));
         videoItems.Items.Add(_audioTracksItem);
 
         videoItems.Items.Add(new NativeMenuItemSeparator());
@@ -260,8 +260,7 @@ public static class InitNativeMacMenu
 
         var setOffsetItem = new NativeMenuItem(string.Empty);
         setOffsetItem.Click += (_, _) => GetVm()?.ShowVideoSetOffsetCommand.Execute(null);
-        _dynamicHeaders.Add((setOffsetItem, v => Clean(v.SetVideoOffsetText),
-            [nameof(MainViewModel.SetVideoOffsetText)]));
+        _dynamicHeaders.Add((setOffsetItem, v => Clean(v.SetVideoOffsetText), [nameof(MainViewModel.SetVideoOffsetText)]));
         videoMoreList.Add(setOffsetItem);
 
         videoMoreList.Add(Toggle(Clean(l.SmpteTiming), v => v.ToggleSmpteTimingCommand,
@@ -270,7 +269,6 @@ public static class InitNativeMacMenu
         var videoMoreItems = new NativeMenu();
         foreach (var item in videoMoreList.OrderBy(i => i.Header?.TrimStart('_', ' ')))
             videoMoreItems.Items.Add(item);
-
         var videoMoreMenu = new NativeMenuItem(Clean(Se.Language.General.More)) { Menu = videoMoreItems };
         _conditionals.Add((videoMoreMenu, v => v.IsVideoLoaded, [nameof(MainViewModel.IsVideoLoaded)]));
         videoItems.Items.Add(videoMoreMenu);
@@ -327,7 +325,6 @@ public static class InitNativeMacMenu
         _conditionals.Add((assaMenu, v => v.IsFormatAssa, [nameof(MainViewModel.IsFormatAssa)]));
 
         // ── Assemble ──────────────────────────────────────────────────────────
-        root.Items.Add(new NativeMenuItem("Subtitle Edit") { Menu = appItems });
         root.Items.Add(new NativeMenuItem(Clean(l.File)) { Menu = fileItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Edit)) { Menu = editItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolItems });
@@ -342,42 +339,34 @@ public static class InitNativeMacMenu
     }
 
     // ── Phase 2 ──────────────────────────────────────────────────────────────
-    // Called from MainViewModel.OnLoaded (after the event loop starts).
-    // Syncs initial states, gestures, PropertyChanged subscriptions, and dynamic
-    // submenus onto the items already created by MakeStructure.
+    // Called from MainViewModel.OnLoaded. Applies initial states, gestures,
+    // PropertyChanged subscriptions, and dynamic submenus.
 
-    public static void Sync(Application app, MainViewModel vm)
+    public static void Sync(MainViewModel vm)
     {
         if (_handler != null)
             vm.PropertyChanged -= _handler;
 
-        // Expose dynamic submenu references on the VM
         vm.NativeMenuReopen = _reopenItem;
         vm.NativeMenuPlugins = _pluginsItem;
         vm.NativeMenuAudioTracks = _audioTracksItem;
 
-        // Gestures
         var shortcuts = ShortcutsMain.GetUsedShortcuts(vm);
         foreach (var (getCmd, item) in _gestureItems)
             item.Gesture = FindGesture(getCmd(vm), shortcuts);
 
-        // Initial conditional states
         foreach (var (item, isEnabled, _) in _conditionals)
             item.IsEnabled = isEnabled(vm);
 
-        // Initial toggle states
         foreach (var (item, isChecked, _) in _toggles)
             item.IsChecked = isChecked(vm);
 
-        // Initial dynamic headers
         foreach (var (item, getHeader, _) in _dynamicHeaders)
             item.Header = getHeader(vm);
 
-        // Plugins visibility
         if (_pluginsItem != null)
             _pluginsItem.IsEnabled = Se.Settings.Appearance.ShowPluginsMenu;
 
-        // PropertyChanged handler
         _handler = (s, e) =>
         {
             if (s is not MainViewModel v2 || e.PropertyName is null)
@@ -391,7 +380,6 @@ public static class InitNativeMacMenu
         };
         vm.PropertyChanged += _handler;
 
-        // Dynamic submenus
         UpdateRecentFiles(vm);
         UpdatePluginsMenu(vm);
     }
@@ -501,9 +489,6 @@ public static class InitNativeMacMenu
 
     public static void UpdateShortcuts(MainViewModel vm)
     {
-        if (Avalonia.Application.Current is not { } app)
-            return;
-
         var shortcuts = ShortcutsMain.GetUsedShortcuts(vm);
         foreach (var (getCmd, item) in _gestureItems)
             item.Gesture = FindGesture(getCmd(vm), shortcuts);

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -259,7 +259,7 @@ public static class InitNativeMacMenu
             v => !v.AreVideoControlsUndocked, nameof(MainViewModel.AreVideoControlsUndocked)));
         videoItems.Items.Add(Conditional(Clean(l.DockVideoControls), v => v.VideoRedockControlsCommand,
             v => v.AreVideoControlsUndocked, nameof(MainViewModel.AreVideoControlsUndocked)));
-        videoItems.Items.Add(Toggle(Clean(l.ToggleSelectSubtitleWhilePlayingCurrentlyOff), v => v.ToggleCurrentSubtitleWhilePlayingCommand,
+        videoItems.Items.Add(Toggle(Clean(l.SelectSubtitleWhilePlaying), v => v.ToggleCurrentSubtitleWhilePlayingCommand,
             v => v.SelectCurrentSubtitleWhilePlaying, nameof(MainViewModel.SelectCurrentSubtitleWhilePlaying)));
 
         var lVideo = Se.Language.Video;

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -49,6 +49,9 @@ public static class InitNativeMacMenu
     // we must hold a reference to the specific instance that owns the main window.
     private static MainViewModel? _vm;
 
+    private static Window? _window;
+    private static NativeMenu? _root;
+
     // ── App menu ─────────────────────────────────────────────────────────────
     // Called from Program.cs. Sets the "Subtitle Edit" app dropdown contents.
     // Avalonia also auto-appends the standard macOS items (Hide, Quit, etc.).
@@ -79,8 +82,10 @@ public static class InitNativeMacMenu
     // with all top-level menus. Called before NativeMenu.SetMenu(window, root).
     // Commands use lazy VM resolution since the ViewModel may not be ready yet.
 
-    public static void MakeStructure(NativeMenu root)
+    public static void MakeStructure(NativeMenu root, Window window)
     {
+        _root = root;
+        _window = window;
         _gestureItems.Clear();
         _visibilities.Clear();
         _toggles.Clear();
@@ -346,6 +351,19 @@ public static class InitNativeMacMenu
         root.Items.Add(assaMenu);
     }
 
+    // Called from LoadLanguage to rebuild all menu strings after a language switch.
+    public static void Rebuild(MainViewModel vm)
+    {
+        if (_root == null || _window == null)
+            return;
+        _root.Items.Clear();
+        MakeStructure(_root, _window);
+        NativeMenu.SetMenu(_window, _root);
+        if (Application.Current != null)
+            SetupAppMenu(Application.Current);
+        Sync(vm);
+    }
+
     // ── Phase 2 ──────────────────────────────────────────────────────────────
     // Called from MainViewModel.OnLoaded. Applies initial states, gestures,
     // PropertyChanged subscriptions, and dynamic submenus.
@@ -531,6 +549,7 @@ public static class InitNativeMacMenu
         item.ToggleType = MenuItemToggleType.CheckBox;
         item.Click += (_, _) => { var v = GetVm(); if (v != null) getCmd(v).Execute(null); };
         _toggles.Add((item, isChecked, propertyNames));
+        _gestureItems.Add((getCmd, item));
         return item;
     }
 

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -7,7 +7,6 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -40,6 +39,11 @@ public static class InitNativeMacMenu
     private static NativeMenuItem? _reopenItem;
     private static NativeMenuItem? _pluginsItem;
     private static NativeMenuItem? _audioTracksItem;
+
+    // The real VM instance — set by Sync(), used by all lazy click handlers.
+    // MainViewModel is AddTransient in DI, so GetService() returns a new instance;
+    // we must hold a reference to the specific instance that owns the main window.
+    private static MainViewModel? _vm;
 
     // ── App menu ─────────────────────────────────────────────────────────────
     // Called from Program.cs. Sets the "Subtitle Edit" app dropdown contents.
@@ -344,8 +348,10 @@ public static class InitNativeMacMenu
 
     public static void Sync(MainViewModel vm)
     {
-        if (_handler != null)
-            vm.PropertyChanged -= _handler;
+        if (_handler != null && _vm != null)
+            _vm.PropertyChanged -= _handler;
+
+        _vm = vm;
 
         vm.NativeMenuReopen = _reopenItem;
         vm.NativeMenuPlugins = _pluginsItem;
@@ -496,8 +502,7 @@ public static class InitNativeMacMenu
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private static MainViewModel? GetVm() =>
-        Locator.Services?.GetService<MainViewModel>();
+    private static MainViewModel? GetVm() => _vm;
 
     private static NativeMenuItem Item(string? header, Func<MainViewModel, IRelayCommand> getCmd)
     {

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -31,7 +31,11 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 public static class InitNativeMacMenu
 {
     private static readonly List<(Func<MainViewModel, IRelayCommand> GetCmd, NativeMenuItem Item)> _gestureItems = [];
-    private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsEnabled, string[] Props)> _conditionals = [];
+    // IsVisible maps directly to NSMenuItem.setHidden: via Avalonia's SetIsVisible vtable slot.
+    // IsEnabled has no equivalent vtable slot — it only reaches the native layer through the
+    // SetAction predicate, which macOS never calls for container items (submenu, no action).
+    // All items here were IsVisible bindings in InitMenu.cs, so IsVisible is the correct mapping.
+    private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsVisible, string[] Props)> _visibilities = [];
     private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsChecked, string[] Props)> _toggles = [];
     private static readonly List<(NativeMenuItem Item, Func<MainViewModel, string> GetHeader, string[] Props)> _dynamicHeaders = [];
     private static PropertyChangedEventHandler? _handler;
@@ -56,6 +60,10 @@ public static class InitNativeMacMenu
         var aboutItem = new NativeMenuItem(Clean(Se.Language.Help.AboutSubtitleEdit));
         aboutItem.Click += (_, _) => GetVm()?.ShowAboutCommand.Execute(null);
         appMenu.Items.Add(aboutItem);
+
+        var checkForUpdatesItem = new NativeMenuItem(Clean(Se.Language.Main.Menu.CheckForUpdates));
+        checkForUpdatesItem.Click += (_, _) => GetVm()?.ShowCheckForUpdatesCommand.Execute(null);
+        appMenu.Items.Add(checkForUpdatesItem);
         appMenu.Items.Add(new NativeMenuItemSeparator());
 
         var prefsItem = new NativeMenuItem(Clean(Se.Language.Main.Menu.Settings));
@@ -74,7 +82,7 @@ public static class InitNativeMacMenu
     public static void MakeStructure(NativeMenu root)
     {
         _gestureItems.Clear();
-        _conditionals.Clear();
+        _visibilities.Clear();
         _toggles.Clear();
         _dynamicHeaders.Clear();
 
@@ -107,7 +115,7 @@ public static class InitNativeMacMenu
         var filePropsItem = new NativeMenuItem(string.Empty);
         filePropsItem.Click += (_, _) => GetVm()?.FilePropertiesShowCommand.Execute(null);
         _dynamicHeaders.Add((filePropsItem, v => Clean(v.FilePropertiesText), [nameof(MainViewModel.FilePropertiesText)]));
-        _conditionals.Add((filePropsItem, v => v.IsFilePropertiesVisible, [nameof(MainViewModel.IsFilePropertiesVisible)]));
+        _visibilities.Add((filePropsItem, v => v.IsFilePropertiesVisible, [nameof(MainViewModel.IsFilePropertiesVisible)]));
         fileItems.Items.Add(filePropsItem);
 
         fileItems.Items.Add(Item(Clean(l.OpenContainingFolder), v => v.OpenContainingFolderCommand));
@@ -226,7 +234,7 @@ public static class InitNativeMacMenu
         videoItems.Items.Add(Item(Clean(l.CloseVideoFile), v => v.CommandVideoCloseCommand));
 
         _audioTracksItem = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
-        _conditionals.Add((_audioTracksItem, v => v.IsAudioTracksVisible, [nameof(MainViewModel.IsAudioTracksVisible)]));
+        _visibilities.Add((_audioTracksItem, v => v.IsAudioTracksVisible, [nameof(MainViewModel.IsAudioTracksVisible)]));
         videoItems.Items.Add(_audioTracksItem);
 
         videoItems.Items.Add(new NativeMenuItemSeparator());
@@ -274,7 +282,7 @@ public static class InitNativeMacMenu
         foreach (var item in videoMoreList.OrderBy(i => i.Header?.TrimStart('_', ' ')))
             videoMoreItems.Items.Add(item);
         var videoMoreMenu = new NativeMenuItem(Clean(Se.Language.General.More)) { Menu = videoMoreItems };
-        _conditionals.Add((videoMoreMenu, v => v.IsVideoLoaded, [nameof(MainViewModel.IsVideoLoaded)]));
+        _visibilities.Add((videoMoreMenu, v => v.IsVideoLoaded, [nameof(MainViewModel.IsVideoLoaded)]));
         videoItems.Items.Add(videoMoreMenu);
 
         // ── Synchronization ───────────────────────────────────────────────────
@@ -293,16 +301,13 @@ public static class InitNativeMacMenu
 
         // ── Options ───────────────────────────────────────────────────────────
         var optionsItems = new NativeMenu();
-        optionsItems.Items.Add(Item(Clean(l.Settings), v => v.CommandShowSettingsCommand));
         optionsItems.Items.Add(Item(Clean(l.Shortcuts), v => v.CommandShowSettingsShortcutsCommand));
         optionsItems.Items.Add(Item(Clean(l.WordLists), v => v.ShowWordListsCommand));
         optionsItems.Items.Add(Item(Clean(l.ChooseLanguage), v => v.CommandShowSettingsLanguageCommand));
 
         // ── Help ──────────────────────────────────────────────────────────────
         var helpItems = new NativeMenu();
-        helpItems.Items.Add(Item(Clean(l.CheckForUpdates), v => v.ShowCheckForUpdatesCommand));
-        helpItems.Items.Add(new NativeMenuItemSeparator());
-        helpItems.Items.Add(Item(Clean(l.Help), v => v.ShowHelpCommand));
+        helpItems.Items.Add(Item($"{Clean(Se.Language.Title)} {Clean(l.HelpTitle)}", v => v.ShowHelpCommand));
         helpItems.Items.Add(Item(Clean(l.About), v => v.ShowAboutCommand));
 
         // ── ASSA Tools ────────────────────────────────────────────────────────
@@ -326,7 +331,7 @@ public static class InitNativeMacMenu
         assaItems.Items.Add(new NativeMenuItemSeparator());
         assaItems.Items.Add(Item(Clean(l.FilterLayersForDisplayDotDotDot), v => v.ShowPickLayerFilterCommand));
         var assaMenu = new NativeMenuItem(Clean(l.AssaTools)) { Menu = assaItems };
-        _conditionals.Add((assaMenu, v => v.IsFormatAssa, [nameof(MainViewModel.IsFormatAssa)]));
+        _visibilities.Add((assaMenu, v => v.IsFormatAssa, [nameof(MainViewModel.IsFormatAssa)]));
 
         // ── Assemble ──────────────────────────────────────────────────────────
         root.Items.Add(new NativeMenuItem(Clean(l.File)) { Menu = fileItems });
@@ -361,8 +366,8 @@ public static class InitNativeMacMenu
         foreach (var (getCmd, item) in _gestureItems)
             item.Gesture = FindGesture(getCmd(vm), shortcuts);
 
-        foreach (var (item, isEnabled, _) in _conditionals)
-            item.IsEnabled = isEnabled(vm);
+        foreach (var (item, isVisible, _) in _visibilities)
+            item.IsVisible = isVisible(vm);
 
         foreach (var (item, isChecked, _) in _toggles)
             item.IsChecked = isChecked(vm);
@@ -377,8 +382,8 @@ public static class InitNativeMacMenu
         {
             if (s is not MainViewModel v2 || e.PropertyName is null)
                 return;
-            foreach (var (item, isEnabled, props) in _conditionals)
-                if (props.Contains(e.PropertyName)) item.IsEnabled = isEnabled(v2);
+            foreach (var (item, isVisible, props) in _visibilities)
+                if (props.Contains(e.PropertyName)) item.IsVisible = isVisible(v2);
             foreach (var (item, isChecked, props) in _toggles)
                 if (props.Contains(e.PropertyName)) item.IsChecked = isChecked(v2);
             foreach (var (item, getHeader, props) in _dynamicHeaders)
@@ -513,10 +518,10 @@ public static class InitNativeMacMenu
     }
 
     private static NativeMenuItem Conditional(string? header, Func<MainViewModel, IRelayCommand> getCmd,
-        Func<MainViewModel, bool> isEnabled, params string[] propertyNames)
+        Func<MainViewModel, bool> isVisible, params string[] propertyNames)
     {
         var item = Item(header, getCmd);
-        _conditionals.Add((item, isEnabled, propertyNames));
+        _visibilities.Add((item, isVisible, propertyNames));
         return item;
     }
 

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -281,7 +281,10 @@ public static class InitNativeMacMenu
         videoMoreList.Add(Toggle(Clean(Se.Language.Options.Shortcuts.ToggleWaveformToolbar), v => v.ToggleIsWaveformToolbarVisibleCommand,
             v => v.IsWaveformToolbarVisible, nameof(MainViewModel.IsWaveformToolbarVisible)));
 
-        var setOffsetItem = new NativeMenuItem(string.Empty);
+        // Seed with the default header (matches MainViewModel.SetVideoOffsetText's initial value)
+        // so the alphabetical sort below places this item with the other "S" entries instead of
+        // floating it to the top while the dynamic-header binding waits for Sync(vm) to run.
+        var setOffsetItem = new NativeMenuItem(Clean(l.SetVideoOffset));
         setOffsetItem.Click += (_, _) => GetVm()?.ShowVideoSetOffsetCommand.Execute(null);
         _dynamicHeaders.Add((setOffsetItem, v => Clean(v.SetVideoOffsetText), [nameof(MainViewModel.SetVideoOffsetText)]));
         videoMoreList.Add(setOffsetItem);

--- a/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
+++ b/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
@@ -89,10 +89,7 @@ public class TextEditorBindingHelper
     private void OnTextAreaLostFocus(object? sender, RoutedEventArgs e)
     {
         _textEditorBorder.BorderBrush = _defaultBorderBrush;
-        if (_isOriginal)
-        {
-            _wrapper.HasFocus = false;
-        }
+        _wrapper.HasFocus = false;
     }
 
     private void OnTextEditorTextChanged(object? sender, System.EventArgs e)

--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -73,6 +73,11 @@ public class MainView : ViewBase
 
         // Menu bar
         InitMenu.Make(_vm);
+        if (OperatingSystem.IsMacOS() && Application.Current is { } macApp)
+        {
+            InitNativeMacMenu.Make(macApp, _vm);
+            _vm.Menu.IsVisible = false;
+        }
         DockPanel.SetDock(_vm.Menu, Dock.Top);
         root.Children.Add(_vm.Menu);
 

--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -73,9 +73,8 @@ public class MainView : ViewBase
 
         // Menu bar
         InitMenu.Make(_vm);
-        if (OperatingSystem.IsMacOS() && Application.Current is { } macApp)
+        if (OperatingSystem.IsMacOS())
         {
-            InitNativeMacMenu.Make(macApp, _vm);
             _vm.Menu.IsVisible = false;
         }
         DockPanel.SetDock(_vm.Menu, Dock.Top);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8218,8 +8218,8 @@ public partial class MainViewModel :
 
         // reload current layout
         InitMenu.Make(this);
-        if (OperatingSystem.IsMacOS() && Avalonia.Application.Current is { } app)
-            Layout.InitNativeMacMenu.Sync(app, this);
+        if (OperatingSystem.IsMacOS())
+            Layout.InitNativeMacMenu.Sync(this);
         SetLayout(Se.Settings.General.LayoutNumber);
 
         if (Toolbar is Border toolbarBorder)
@@ -14589,8 +14589,8 @@ public partial class MainViewModel :
 
     internal void OnLoaded()
     {
-        if (OperatingSystem.IsMacOS() && Avalonia.Application.Current is { } macApp)
-            Layout.InitNativeMacMenu.Sync(macApp, this);
+        if (OperatingSystem.IsMacOS())
+            Layout.InitNativeMacMenu.Sync(this);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && string.IsNullOrEmpty(Se.Settings.General.LibMpvPath))
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9987,6 +9987,19 @@ public partial class MainViewModel :
     [RelayCommand]
     private void SelectAllLines()
     {
+        if (IsTextInputFocused())
+        {
+            var textBoxWrapper = GetFocusedTextBoxWrapper();
+            if (textBoxWrapper != null)
+            {
+                textBoxWrapper.SelectAll();
+            }
+            else
+            {
+                (Window?.FocusManager?.GetFocusedElement() as TextBox)?.SelectAll();
+            }
+            return;
+        }
         SelectAllRows();
         _shortcutManager.ClearKeys();
     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8219,7 +8219,7 @@ public partial class MainViewModel :
         // reload current layout
         InitMenu.Make(this);
         if (OperatingSystem.IsMacOS() && Avalonia.Application.Current is { } app)
-            Layout.InitNativeMacMenu.Make(app, this);
+            Layout.InitNativeMacMenu.Sync(app, this);
         SetLayout(Se.Settings.General.LayoutNumber);
 
         if (Toolbar is Border toolbarBorder)
@@ -14590,7 +14590,7 @@ public partial class MainViewModel :
     internal void OnLoaded()
     {
         if (OperatingSystem.IsMacOS() && Avalonia.Application.Current is { } macApp)
-            Layout.InitNativeMacMenu.Make(macApp, this);
+            Layout.InitNativeMacMenu.Sync(macApp, this);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && string.IsNullOrEmpty(Se.Settings.General.LibMpvPath))
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14589,6 +14589,9 @@ public partial class MainViewModel :
 
     internal void OnLoaded()
     {
+        if (OperatingSystem.IsMacOS() && Avalonia.Application.Current is { } macApp)
+            Layout.InitNativeMacMenu.Make(macApp, this);
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && string.IsNullOrEmpty(Se.Settings.General.LibMpvPath))
         {
             Dispatcher.UIThread.Post(async void () =>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -279,6 +279,9 @@ public partial class MainViewModel :
     public TextBlock StatusTextLeftLabel { get; set; }
     public MenuItem MenuReopen { get; set; }
     public MenuItem MenuPlugins { get; set; }
+    public NativeMenuItem? NativeMenuReopen { get; set; }
+    public NativeMenuItem? NativeMenuPlugins { get; set; }
+    public NativeMenuItem? NativeMenuAudioTracks { get; set; }
     public AudioVisualizer? AudioVisualizer { get; set; }
 
     VideoPlayerUndockedViewModel? _videoPlayerUndockedViewModel;
@@ -1821,6 +1824,8 @@ public partial class MainViewModel :
     {
         Se.Settings.File.RecentFiles.Clear();
         InitMenu.UpdateRecentFiles(this);
+        if (OperatingSystem.IsMacOS())
+            Layout.InitNativeMacMenu.UpdateRecentFiles(this);
         _shortcutManager.ClearKeys();
     }
 
@@ -4805,6 +4810,8 @@ public partial class MainViewModel :
 
         await ShowDialogAsync<PluginManagerWindow, PluginManagerViewModel>(vm => vm.Initialize());
         Layout.InitMenu.UpdatePluginsMenu(this);
+        if (OperatingSystem.IsMacOS())
+            Layout.InitNativeMacMenu.UpdatePluginsMenu(this);
     }
 
     [RelayCommand]
@@ -7774,6 +7781,8 @@ public partial class MainViewModel :
     {
         await ShowDialogAsync<ShortcutsWindow, ShortcutsViewModel>(vm => { vm.LoadShortCuts(this); });
         ReloadShortcuts();
+        if (OperatingSystem.IsMacOS())
+            Layout.InitNativeMacMenu.UpdateShortcuts(this);
     }
 
     [RelayCommand]
@@ -8209,6 +8218,8 @@ public partial class MainViewModel :
 
         // reload current layout
         InitMenu.Make(this);
+        if (OperatingSystem.IsMacOS() && Avalonia.Application.Current is { } app)
+            Layout.InitNativeMacMenu.Make(app, this);
         SetLayout(Se.Settings.General.LayoutNumber);
 
         if (Toolbar is Border toolbarBorder)
@@ -14402,6 +14413,8 @@ public partial class MainViewModel :
         if (updateMenu)
         {
             InitMenu.UpdateRecentFiles(this);
+            if (OperatingSystem.IsMacOS())
+                Layout.InitNativeMacMenu.UpdateRecentFiles(this);
         }
     }
 
@@ -15021,6 +15034,8 @@ public partial class MainViewModel :
                     {
                         IsAudioTracksVisible = false;
                         AudioTraksMenuItem.Items.Clear();
+                        if (OperatingSystem.IsMacOS())
+                            Layout.InitNativeMacMenu.UpdateAudioTracksMenu(this, [], null);
                     });
                     return;
                 }
@@ -15072,6 +15087,8 @@ public partial class MainViewModel :
                     }
 
                     IsAudioTracksVisible = AudioTraksMenuItem.Items.Count > 1;
+                    if (OperatingSystem.IsMacOS())
+                        Layout.InitNativeMacMenu.UpdateAudioTracksMenu(this, audioTracks, _audioTrack);
                 });
             }
         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8219,7 +8219,7 @@ public partial class MainViewModel :
         // reload current layout
         InitMenu.Make(this);
         if (OperatingSystem.IsMacOS())
-            Layout.InitNativeMacMenu.Sync(this);
+            Layout.InitNativeMacMenu.Rebuild(this);
         SetLayout(Se.Settings.General.LayoutNumber);
 
         if (Toolbar is Border toolbarBorder)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9996,7 +9996,23 @@ public partial class MainViewModel :
             }
             else
             {
-                (Window?.FocusManager?.GetFocusedElement() as TextBox)?.SelectAll();
+                // Fallback covers the same control set as IsTextInputFocused so Cmd+A from the
+                // native menu isn't swallowed in non-edit-box text inputs (timecode MaskedTextBox,
+                // source view TextEditor, actor AutoCompleteBox, etc.). MaskedTextBox inherits
+                // from TextBox so the first branch already catches it.
+                var focused = Window?.FocusManager?.GetFocusedElement();
+                if (focused is TextBox tb)
+                {
+                    tb.SelectAll();
+                }
+                else if (focused is TextEditor editor)
+                {
+                    editor.SelectAll();
+                }
+                else if (focused is AutoCompleteBox acb)
+                {
+                    acb.FindDescendantOfType<TextBox>()?.SelectAll();
+                }
             }
             return;
         }

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -133,6 +133,7 @@ public class LanguageMainMenu
     public string FilterLayersForDisplayDotDotDot { get; set; }
     public string ToggleSelectSubtitleWhilePlayingCurrentlyOn { get; set; }
     public string ToggleSelectSubtitleWhilePlayingCurrentlyOff { get; set; }
+    public string SelectSubtitleWhilePlaying { get; set; }
 
     public LanguageMainMenu()
     {
@@ -228,6 +229,7 @@ public class LanguageMainMenu
         DockVideoControls = "_Dock video controls";
         ToggleSelectSubtitleWhilePlayingCurrentlyOff = "Toggle select subtitle while playing (currently: off)";
         ToggleSelectSubtitleWhilePlayingCurrentlyOn = "Toggle select subtitle while playing (currently: on)";
+        SelectSubtitleWhilePlaying = "Select subtitle while playing";
         SetVideoOffset = "Set video offset...";
         UpdateVideoOffsetX = "Update video offset from {0}...";
         SmpteTiming = "SMPTE timing (non-integer frame rate)";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -400,6 +400,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.ZoomLayoutOutCommand), Se.Language.Options.Shortcuts.LayoutZoomOut },
         { nameof(MainViewModel.OpenSecondarySubtitleCommand), Se.Language.Video.OpenSecondarySubtitleOnVideoPlayer },
         { nameof(MainViewModel.ToggleCurrentSubtitleWhilePlayingCommand), Se.Language.Video.ToggleCurrentSubtitleWhilePlaying },
+        { nameof(MainViewModel.ToggleSmpteTimingCommand), Se.Language.Main.Menu.SmpteTiming },
     };
     }
 
@@ -728,6 +729,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ZoomLayoutOutCommand, nameof(vm.ZoomLayoutOutCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.OpenSecondarySubtitleCommand, nameof(vm.OpenSecondarySubtitleCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ToggleCurrentSubtitleWhilePlayingCommand, nameof(vm.ToggleCurrentSubtitleWhilePlayingCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ToggleSmpteTimingCommand, nameof(vm.ToggleSmpteTimingCommand), ShortcutCategory.General);
 
         return shortcuts;
     }

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -90,6 +90,17 @@ namespace Nikse.SubtitleEdit
                 else
                 {
                     SetupMainWindow(lifetime);
+
+                    // Set the full macOS menu bar (File, Edit, Tools, …) on the Window.
+                    // NativeMenu.SetMenu(Application, …) only controls the App menu dropdown;
+                    // NativeMenu.SetMenu(Window, …) calls avnWindow.SetMainMenu and builds
+                    // the full NSMenuBar with separate top-level menus.
+                    if (OperatingSystem.IsMacOS() && lifetime.MainWindow != null)
+                    {
+                        var menuBarRoot = new NativeMenu();
+                        Nikse.SubtitleEdit.Features.Main.Layout.InitNativeMacMenu.MakeStructure(menuBarRoot);
+                        NativeMenu.SetMenu(lifetime.MainWindow, menuBarRoot);
+                    }
                 }
 
 #if DEBUG
@@ -149,15 +160,11 @@ namespace Nikse.SubtitleEdit
 
         private static void SetupNativeMenu(Application app, ClassicDesktopStyleApplicationLifetime lifetime)
         {
-            // Build the full native menu structure during setup, before Avalonia's macOS
-            // backend initializes NSMenuBar. Commands use lazy VM resolution so the
-            // ViewModel is not needed here. Sync() (called from OnLoaded) applies
-            // gestures, initial states, and dynamic submenus once the VM is ready.
+            // Populate the "Subtitle Edit" app menu dropdown (About, Preferences…).
+            // Standard macOS items (Hide, Quit, etc.) are auto-appended by Avalonia.
             if (OperatingSystem.IsMacOS())
             {
-                var root = new NativeMenu();
-                Nikse.SubtitleEdit.Features.Main.Layout.InitNativeMacMenu.MakeStructure(root);
-                NativeMenu.SetMenu(app, root);
+                Nikse.SubtitleEdit.Features.Main.Layout.InitNativeMacMenu.SetupAppMenu(app);
             }
 
             // mac finder "Send to"

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -98,7 +98,7 @@ namespace Nikse.SubtitleEdit
                     if (OperatingSystem.IsMacOS() && lifetime.MainWindow != null)
                     {
                         var menuBarRoot = new NativeMenu();
-                        Nikse.SubtitleEdit.Features.Main.Layout.InitNativeMacMenu.MakeStructure(menuBarRoot);
+                        Nikse.SubtitleEdit.Features.Main.Layout.InitNativeMacMenu.MakeStructure(menuBarRoot, lifetime.MainWindow);
                         NativeMenu.SetMenu(lifetime.MainWindow, menuBarRoot);
                     }
                 }

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -149,6 +149,14 @@ namespace Nikse.SubtitleEdit
 
         private static void SetupNativeMenu(Application app, ClassicDesktopStyleApplicationLifetime lifetime)
         {
+            // Register an empty native menu early so Avalonia's macOS backend doesn't
+            // install its own "About Avalonia" defaults. InitNativeMacMenu.Make will
+            // populate the full menu once the view model is available (OnLoaded).
+            if (OperatingSystem.IsMacOS())
+            {
+                NativeMenu.SetMenu(app, new NativeMenu());
+            }
+
             // mac finder "Send to"
             if (OperatingSystem.IsMacOS())
             {

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -149,12 +149,15 @@ namespace Nikse.SubtitleEdit
 
         private static void SetupNativeMenu(Application app, ClassicDesktopStyleApplicationLifetime lifetime)
         {
-            // Register an empty native menu early so Avalonia's macOS backend doesn't
-            // install its own "About Avalonia" defaults. InitNativeMacMenu.Make will
-            // populate the full menu once the view model is available (OnLoaded).
+            // Build the full native menu structure during setup, before Avalonia's macOS
+            // backend initializes NSMenuBar. Commands use lazy VM resolution so the
+            // ViewModel is not needed here. Sync() (called from OnLoaded) applies
+            // gestures, initial states, and dynamic submenus once the VM is ready.
             if (OperatingSystem.IsMacOS())
             {
-                NativeMenu.SetMenu(app, new NativeMenu());
+                var root = new NativeMenu();
+                Nikse.SubtitleEdit.Features.Main.Layout.InitNativeMacMenu.MakeStructure(root);
+                NativeMenu.SetMenu(app, root);
             }
 
             // mac finder "Send to"

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -6,7 +6,6 @@ using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
 using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
-using Nikse.SubtitleEdit.Features.Help.About;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
 using Nikse.SubtitleEdit.Logic;
@@ -150,21 +149,6 @@ namespace Nikse.SubtitleEdit
 
         private static void SetupNativeMenu(Application app, ClassicDesktopStyleApplicationLifetime lifetime)
         {
-            var nativeMenu = new NativeMenu();
-            var aboutMenu = new NativeMenuItem(Se.Language.Help.AboutSubtitleEdit);
-
-            aboutMenu.Click += async (sender, e) =>
-            {
-                var aboutWindow = new AboutWindow(new AboutViewModel());
-                if (lifetime.MainWindow != null)
-                {
-                    await aboutWindow.ShowDialog(lifetime.MainWindow);
-                }
-            };
-
-            nativeMenu.Items.Add(aboutMenu);
-            NativeMenu.SetMenu(app, nativeMenu);
-
             // mac finder "Send to"
             if (OperatingSystem.IsMacOS())
             {


### PR DESCRIPTION
  Adds a native macOS menu bar using Avalonia's `NativeMenu` API, replacing the in-window menu on macOS.
  
<img width="1022" height="379" alt="Screenshot 2026-05-28 at 10 55 46 PM" src="https://github.com/user-attachments/assets/ad77289c-bf66-4609-a6ea-11baecf6a7a2" />

  #### Why this matters
  
  On macOS, the menu bar lives at the very top of the screen — not inside the application window. This is a foundational part of the Apple Human Interface Guidelines (HIG) and one of the most visible ways an app signals whether it belongs on the platform. Without a native menu bar, Subtitle Edit rendered an in-window toolbar-style menu, which immediately reads as a ported app rather than a Mac-native one.

  Some other reasons I can think of:  

  Full screen mode: macOS full screen hides all window chrome. The native menu bar auto-hides and reappears when the cursor reaches the top of the screen, so full access to all commands is preserved. 
  
  Expected menu locations: Mac users have strong muscle memory for where things live — application-level actions (About, Preferences, Quit) in the leftmost application menu; window and view controls in predictable positions. The native menu bar lets us map to those conventions correctly, including letting macOS automatically place About and Quit in the application menu.
  
  Keyboard shortcut discoverability: The native menu bar is the canonical place macOS surfaces keyboard shortcuts. System features like the Help menu's built-in search ("Search menu items…"), UI automation, and accessibility tools all enumerate shortcuts through the native menu — none of that works with an in-window menu. 
  
  Accessibility: VoiceOver and other assistive technologies expect menu items to be in the native menu bar. This change makes the application's commands fully reachable to users who rely on those tools.
  
  ## Changes
  
  - Add native macOS menu bar with full menu structure mirroring the existing in-window menu
  - Remove About from Help menu and Settings from Options (macOS places these in the application menu). Also move Check for updates to the application menu, and use Subtitle Edit Help as the help menu item name (macOS convention)
  - Toggle gestures and language rebuild on UI language change are supported. Use static label for the select-subtitle toggle item since the status of the menu is clear from the tick in front of the menu item
  - Register `ToggleSmpteTimingCommand` in `ShortcutsMain` so it appears in the shortcuts dialog and its gesture is picked up by the native menu (a related gap I discovered while working in the area)
  - Fix Cmd+A selecting all rows instead of text when the edit box is focused. This is a macOS specific regression caused by the native menu. I brought it back to the correct behavior: Select All selects text in the focus item (edit box, Show box, subtitle list etc.)