### PR TITLE
Fix Compare dialog: placeholder rows and previous/next navigation

### DIFF
--- a/src/ui/Features/Files/Compare/CompareItem.cs
+++ b/src/ui/Features/Files/Compare/CompareItem.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using System;
@@ -9,9 +10,9 @@ namespace Nikse.SubtitleEdit.Features.Files.Compare;
 
 public partial class CompareItem : ObservableObject
 {
-    [ObservableProperty] private int _number;
-    [ObservableProperty] private TimeSpan _startTime;
-    [ObservableProperty] private TimeSpan _endTime;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(NumberDisplay))] private int _number;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(StartTimeDisplay))] private TimeSpan _startTime;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(EndTimeDisplay))] private TimeSpan _endTime;
     [ObservableProperty] private TimeSpan _duration;
     [ObservableProperty] private string _text;
     [ObservableProperty] private StackPanel _textPanel;
@@ -23,6 +24,9 @@ public partial class CompareItem : ObservableObject
     [ObservableProperty] private IBrush _textBackgroundBrush;
     public bool HasDifference { get; set; }
     public bool IsDefault => Text == string.Empty && Number == 0 && Duration == TimeSpan.Zero && StartTime == TimeSpan.Zero;
+    public string NumberDisplay => IsDefault ? string.Empty : Number.ToString();
+    public string StartTimeDisplay => IsDefault ? string.Empty : new TimeCode(StartTime).ToDisplayString();
+    public string EndTimeDisplay => IsDefault ? string.Empty : new TimeCode(EndTime).ToDisplayString();
 
     public CompareItem()
     {

--- a/src/ui/Features/Files/Compare/CompareItem.cs
+++ b/src/ui/Features/Files/Compare/CompareItem.cs
@@ -1,10 +1,11 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Features.Files.Compare;
 
@@ -25,8 +26,11 @@ public partial class CompareItem : ObservableObject
     public bool HasDifference { get; set; }
     public bool IsDefault => Text == string.Empty && Number == 0 && Duration == TimeSpan.Zero && StartTime == TimeSpan.Zero;
     public string NumberDisplay => IsDefault ? string.Empty : Number.ToString();
-    public string StartTimeDisplay => IsDefault ? string.Empty : new TimeCode(StartTime).ToDisplayString();
-    public string EndTimeDisplay => IsDefault ? string.Empty : new TimeCode(EndTime).ToDisplayString();
+    public string StartTimeDisplay => IsDefault ? string.Empty : FormatTime(StartTime);
+    public string EndTimeDisplay => IsDefault ? string.Empty : FormatTime(EndTime);
+
+    private static string FormatTime(TimeSpan ts) =>
+        (string)TimeSpanToDisplayFullConverter.Instance.Convert(ts, typeof(string), null, CultureInfo.CurrentCulture);
 
     public CompareItem()
     {

--- a/src/ui/Features/Files/Compare/CompareWindow.cs
+++ b/src/ui/Features/Files/Compare/CompareWindow.cs
@@ -135,8 +135,8 @@ public class CompareWindow : Window
         Activated += delegate { Dispatcher.UIThread.Post(() => buttonOk.Focus()); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
 
-        vm.LeftDataGrid = leftView.Child as DataGrid;
-        vm.RightDataGrid = rightView.Child as DataGrid;
+        vm.LeftDataGrid = (leftView.Child as Border)?.Child as DataGrid;
+        vm.RightDataGrid = (rightView.Child as Border)?.Child as DataGrid;
         if (vm.LeftDataGrid != null && vm.RightDataGrid != null)
         {
             vm.LeftDataGrid.SelectionChanged += vm.LeftDataGridSelectionChanged;

--- a/src/ui/Features/Files/Compare/CompareWindow.cs
+++ b/src/ui/Features/Files/Compare/CompareWindow.cs
@@ -10,7 +10,6 @@ using Avalonia.Threading;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System;
 using System.Collections.ObjectModel;
 
@@ -178,15 +177,13 @@ public class CompareWindow : Window
                 var textBlock = new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Center,
-                    [!TextBlock.TextProperty] = new Binding(nameof(CompareItem.Number))
+                    [!TextBlock.TextProperty] = new Binding(nameof(CompareItem.NumberDisplay))
                 };
 
                 border.Child = textBlock;
                 return border;
             })
         });
-
-        var fullTimeConverter = new TimeSpanToDisplayFullConverter();
 
         // StartTime column
         dg.Columns.Add(new DataGridTemplateColumn
@@ -205,7 +202,7 @@ public class CompareWindow : Window
                 var textBlock = new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Center,
-                    [!TextBlock.TextProperty] = new Binding(nameof(CompareItem.StartTime)) { Converter = fullTimeConverter },
+                    [!TextBlock.TextProperty] = new Binding(nameof(CompareItem.StartTimeDisplay)),
                 };
 
                 border.Child = textBlock;
@@ -230,7 +227,7 @@ public class CompareWindow : Window
                 var textBlock = new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Center,
-                    [!TextBlock.TextProperty] = new Binding(nameof(CompareItem.EndTime)) { Converter = fullTimeConverter },
+                    [!TextBlock.TextProperty] = new Binding(nameof(CompareItem.EndTimeDisplay)),
                 };
 
                 border.Child = textBlock;


### PR DESCRIPTION
Two bug fixes for the Compare dialog.
  
  **Placeholder rows showing 0 and 00:00:00.000**
  
  When comparing two subtitle files of different lengths, the shorter side is padded with placeholder (empty) rows. These were binding directly to `Number`, `StartTime`, and `EndTime`, which default to `0` and `TimeSpan.Zero` — rendering as `0` and `00:00:00.000` instead of blank.
  
  Fixed by adding `NumberDisplay`, `StartTimeDisplay`, and `EndTimeDisplay` display properties to `CompareItem` that return an empty string when the item `IsDefault`, and updating the column bindings to use them. Also removes the now-unused `TimeSpanToDisplayFullConverter` from the column setup.
  
##### Before
Note the placeholder line on the right with 0 and 00:00:00.000

<img width="1179" height="56" alt="before" src="https://github.com/user-attachments/assets/3119fce7-0c40-49bb-976e-f728352107ec" />

##### After:
<img width="1172" height="96" alt="after" src="https://github.com/user-attachments/assets/b53e32b8-7887-43e9-a977-5b55eb9c13fa" />

  **Previous/next difference buttons and selection sync not working**
  
  `LeftDataGrid` and `RightDataGrid` were resolved as direct children of their container views, but the actual `DataGrid` is wrapped in a `Border`. The null-safe cast through the `Border` layer now correctly retrieves the `DataGrid`, restoring previous/next navigation and selection sync between the two grids.