### PR TITLE
Fix SHIFT+arrow selection and DataGridRow hover highlight

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12306,6 +12306,9 @@ public partial class MainViewModel :
             return;
         }
 
+        _shiftSelectAnchorIndex = -1;
+        _shiftSelectCurrentIndex = -1;
+
         lock (_scrollLock)
         {
             _pendingScrollIndex = index;
@@ -16358,7 +16361,24 @@ public partial class MainViewModel :
 
             if (IsSubtitleGridFocused())
             {
-                if (keyEventArgs.Key == Key.Home && keyEventArgs.KeyModifiers == KeyModifiers.None && Subtitles.Count > 0)
+                if (keyEventArgs.Key == Key.Down && keyEventArgs.KeyModifiers == KeyModifiers.Shift && Subtitles.Count > 0)
+                {
+                    keyEventArgs.Handled = true;
+                    HandleShiftArrowSelection(1);
+                    return;
+                }
+                else if (keyEventArgs.Key == Key.Up && keyEventArgs.KeyModifiers == KeyModifiers.Shift && Subtitles.Count > 0)
+                {
+                    keyEventArgs.Handled = true;
+                    HandleShiftArrowSelection(-1);
+                    return;
+                }
+                else if ((keyEventArgs.Key == Key.Down || keyEventArgs.Key == Key.Up) && keyEventArgs.KeyModifiers == KeyModifiers.None)
+                {
+                    _shiftSelectAnchorIndex = -1;
+                    _shiftSelectCurrentIndex = -1;
+                }
+                else if (keyEventArgs.Key == Key.Home && keyEventArgs.KeyModifiers == KeyModifiers.None && Subtitles.Count > 0)
                 {
                     keyEventArgs.Handled = true;
                     SelectAndScrollToRow(0);
@@ -16461,6 +16481,8 @@ public partial class MainViewModel :
     private bool _subtitleGridIsControlPressed = false;
     private int _dragSelectStartIndex = -1;
     private int _dragSelectLastIndex = -1;
+    private int _shiftSelectAnchorIndex = -1;
+    private int _shiftSelectCurrentIndex = -1;
     private int _dragSelectAutoScrollDirection;
     private int _dragSelectAutoScrollStep = 1;
     private bool _dragSelectHasMoved;
@@ -16478,6 +16500,8 @@ public partial class MainViewModel :
         _dragSelectStartIndex = -1;
         _dragSelectLastIndex = -1;
         _dragSelectHasMoved = false;
+        _shiftSelectAnchorIndex = -1;
+        _shiftSelectCurrentIndex = -1;
         IsSubtitleGridFlyoutHeaderVisible = false;
 
         if (sender is Control { ContextFlyout: not null } control)
@@ -16615,6 +16639,51 @@ public partial class MainViewModel :
 
         _subtitleGridSelectionChangedSkip = false;
 
+        SubtitleGridSelectionChanged();
+    }
+
+    private void HandleShiftArrowSelection(int direction)
+    {
+        if (Subtitles.Count == 0)
+        {
+            return;
+        }
+
+        if (_shiftSelectAnchorIndex < 0)
+        {
+            var anchor = SelectedSubtitleIndex ?? (SubtitleGrid.SelectedItems.Count > 0
+                ? Subtitles.IndexOf((SubtitleLineViewModel)SubtitleGrid.SelectedItems[0]!)
+                : -1);
+            if (anchor < 0)
+            {
+                return;
+            }
+
+            _shiftSelectAnchorIndex = anchor;
+            _shiftSelectCurrentIndex = anchor;
+        }
+
+        var newCurrent = _shiftSelectCurrentIndex + direction;
+        if (newCurrent < 0 || newCurrent >= Subtitles.Count)
+        {
+            return;
+        }
+
+        _shiftSelectCurrentIndex = newCurrent;
+
+        var startIdx = Math.Min(_shiftSelectAnchorIndex, _shiftSelectCurrentIndex);
+        var endIdx = Math.Max(_shiftSelectAnchorIndex, _shiftSelectCurrentIndex);
+
+        _subtitleGridSelectionChangedSkip = true;
+        SubtitleGrid.SelectedItems.Clear();
+        for (var i = startIdx; i <= endIdx; i++)
+        {
+            SubtitleGrid.SelectedItems.Add(Subtitles[i]);
+        }
+
+        _subtitleGridSelectionChangedSkip = false;
+
+        SubtitleGrid.ScrollIntoView(Subtitles[_shiftSelectCurrentIndex], null);
         SubtitleGridSelectionChanged();
     }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16812,6 +16812,15 @@ public partial class MainViewModel :
             return;
         }
 
+        // Any user-driven selection change that isn't our own shift-arrow manipulation
+        // (HandleShiftArrowSelection sets _subtitleGridSelectionChangedSkip and short-circuits
+        // above) obsoletes the shift-select anchor. Plain Up/Down already clear it in the
+        // key handler, but PageUp/PageDown, mouse clicks, Home/End, programmatic jumps,
+        // etc. all land here and must reset the anchor so the next Shift+Down starts from
+        // the current row instead of resuming an old range.
+        _shiftSelectAnchorIndex = -1;
+        _shiftSelectCurrentIndex = -1;
+
         var selectedItems = SubtitleGrid.SelectedItems;
 
         // If user is trying to deselect the last selected item

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -126,6 +126,12 @@ namespace Nikse.SubtitleEdit
                     Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml")
                 });
 
+                // Apply app-level style overrides (must come after DataGrid theme)
+                b.Instance.Styles.Add(new StyleInclude(new Uri("avares://SubtitleEdit/Styles.axaml", UriKind.Absolute))
+                {
+                    Source = new Uri("avares://SubtitleEdit/Styles.axaml")
+                });
+
                 b.Instance.Styles.Add(new StyleInclude(new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml", UriKind.Absolute))
                 {
                     Source = new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml")

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -10,8 +10,10 @@
     </Style>
     <Style Selector="DataGridRow:selected:pointerover /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundBrush}"/>
+        <Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundOpacity}"/>
     </Style>
     <Style Selector="DataGridRow:selected:pointerover:focus /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedBackgroundBrush}"/>
+        <Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedBackgroundOpacity}"/>
     </Style>
 </Styles>

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -5,7 +5,7 @@
     <Style Selector="DataGridCell:current /template/ #CurrencyVisual">
         <Setter Property="IsVisible" Value="False"/>
     </Style>
-    <Style Selector="DataGridRow:pointerover">
-        <Setter Property="Background" Value="Transparent"/>
+    <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
+        <Setter Property="Fill" Value="Transparent"/>
     </Style>
 </Styles>

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -1,8 +1,8 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui">
-    <Style Selector="DataGridCell:focus /template/ #FocusVisual">
+    <Style Selector="DataGridCell:focus /template/ Grid#FocusVisual">
         <Setter Property="IsVisible" Value="False"/>
     </Style>
-    <Style Selector="DataGridCell:current /template/ #CurrencyVisual">
+    <Style Selector="DataGridCell:current /template/ Rectangle#CurrencyVisual">
         <Setter Property="IsVisible" Value="False"/>
     </Style>
     <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -5,4 +5,7 @@
     <Style Selector="DataGridCell:current /template/ #CurrencyVisual">
         <Setter Property="IsVisible" Value="False"/>
     </Style>
+    <Style Selector="DataGridRow:pointerover">
+        <Setter Property="Background" Value="Transparent"/>
+    </Style>
 </Styles>

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -5,7 +5,7 @@
     <Style Selector="DataGridCell:current /template/ Rectangle#CurrencyVisual">
         <Setter Property="IsVisible" Value="False"/>
     </Style>
-    <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
+    <Style Selector="DataGridRow:not(:selected):pointerover /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="Transparent"/>
     </Style>
 </Styles>

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -8,4 +8,10 @@
     <Style Selector="DataGridRow:not(:selected):pointerover /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="Transparent"/>
     </Style>
+    <Style Selector="DataGridRow:selected:pointerover /template/ Rectangle#BackgroundRectangle">
+        <Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundBrush}"/>
+    </Style>
+    <Style Selector="DataGridRow:selected:pointerover:focus /template/ Rectangle#BackgroundRectangle">
+        <Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedBackgroundBrush}"/>
+    </Style>
 </Styles>

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -18,9 +18,6 @@
 	  <EmbeddedResource Remove="Assets\Themes\**" />
 	  <None Remove="Assets\Themes\**" />
 	</ItemGroup>
-	<ItemGroup>
-		<AvaloniaXaml Remove="Styles.axaml" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Avalonia" Version="12.0.3" />


### PR DESCRIPTION
This PR brings the behavior in line with SE 4.

  Two related fixes to the subtitle grid: keyboard selection with SHIFT+arrow and the hover highlight on rows.
  
  ## SHIFT+arrow selection
  
  Avalonia's DataGrid does not properly clear the `:selected` visual state when reversing SHIFT+arrow direction — rows that should be deselected remain highlighted. Fixed by intercepting SHIFT+Down/Up in the key handler and manually managing the selection range, mirroring the existing `DragSelectSubtitleGridToIndex` pattern.

  The scenario is as follows:
  1. Open a subtitle file with several rows.
  2. Click row 3 to set it as the selection anchor.
  3. Hold SHIFT and press Down four times — rows 3–7 are now selected and highlighted.
  4. Still holding SHIFT, press Up three times to shrink the selection back toward the anchor.
  5. Expected: rows 5, 6, 7 are deselected and their highlight clears as you arrow back up.
  6. Actual (before fix): rows 5, 6, 7 stay visually highlighted.
  
  ## DataGridRow hover highlight
  
  Suppressing the Fluent theme's default gray hover background turned out to require several iterations. This applies to all DataGrids in the app.

  Hover highlight on unselected rows
  1. Open a subtitle file.
  2. Without clicking, move the mouse over any row.
  3. Expected: no visual change — the row background stays neutral.
  4. Actual (before fix): the row gets a gray hover background from the Fluent theme.
  
  Selected row changing color on hover
  1. Click a row to select it — it turns blue.
  2. Move the mouse away, then hover back over the same selected row.
  3. Expected: the row stays the same blue.
  4. Actual (before fix): the row darkens noticeably on hover as Avalonia increases the background opacity from 0.6 to 0.8 on top of the selection color.
  
  Some implementation details:
  - **Styles.axaml was never loaded.** The file was excluded from AXAML compilation in `UI.csproj` and never referenced, making all overrides dead code. Fixed by removing the exclusion and adding a `StyleInclude` in `Program.cs` after the DataGrid theme so our rules take precedence. Also corrected the `FocusVisual`/`CurrencyVisual` selectors to use the element types required by the AXAML compiler.
  - **`DataGridRow.Background` is ignored by Avalonia** for individual pointer states. The hover color is painted via `Fill` on `Rectangle#BackgroundRectangle` inside the row template, so the override targets that element directly.
  - **The `:pointerover` override was too broad**, making selected rows go transparent on hover and preventing the selection color from appearing immediately on click. Narrowed the selector to `:not(:selected)` so it only suppresses the hover background on unselected rows.
  - **Selected rows still darkened on hover** because the Avalonia theme sets `Opacity` separately from `Fill`. Fixed by also resetting `Opacity` to the non-hovered value for both focused and unfocused selected states.