### PR TITLE
Make Find/Replace topmost only while main window has focus

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9288,7 +9288,7 @@ public partial class MainViewModel :
         var subs = Subtitles.Select(p => p.Text).ToList();
         var result = _windowService.ShowWindow<FindWindow, FindViewModel>(Window!, (window, vm) =>
         {
-            window.Topmost = true;
+            WindowService.KeepTopmostWhileOwnerActive(window, Window!);
             _findViewModel = vm;
 
             var selectedText = string.Empty;
@@ -9575,17 +9575,9 @@ public partial class MainViewModel :
         var replaceWin = _replaceViewModel?.Window;
         var dialogWindow = (findWin?.IsVisible == true ? findWin : null)
                         ?? (replaceWin?.IsVisible == true ? replaceWin : null);
-        if (dialogWindow != null) dialogWindow.Topmost = false;
-        try
-        {
-            var parentWindow = dialogWindow ?? Window!;
-            return await MessageBox.Show(parentWindow, Se.Language.General.ContinueFindTitle,
-                message, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-        }
-        finally
-        {
-            if (dialogWindow != null) dialogWindow.Topmost = true;
-        }
+        var parentWindow = dialogWindow ?? Window!;
+        return await MessageBox.Show(parentWindow, Se.Language.General.ContinueFindTitle,
+            message, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
     }
 
     [RelayCommand]
@@ -9615,7 +9607,7 @@ public partial class MainViewModel :
         var subs = Subtitles.Select(p => p.Text).ToList();
         var result = _windowService.ShowWindow<ReplaceWindow, ReplaceViewModel>(Window!, (window, vm) =>
         {
-            window.Topmost = true;
+            WindowService.KeepTopmostWhileOwnerActive(window, Window!);
             _replaceViewModel = vm;
 
             var selectedText = string.Empty;

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -188,6 +189,45 @@ namespace Nikse.SubtitleEdit.Logic
             await window.ShowDialog(owner);
             
             return viewModel;
+        }
+
+        /// <summary>
+        /// Keeps <paramref name="child"/> on top of other windows only while <paramref name="owner"/>
+        /// or the child itself has focus. Use this instead of a blanket Topmost=true for
+        /// non-modal tool windows (Find, Replace, etc.) so they don't float above other
+        /// applications on macOS, where Avalonia maps Topmost to NSWindowLevel.Floating
+        /// process-wide.
+        /// </summary>
+        public static void KeepTopmostWhileOwnerActive(Window child, Window owner)
+        {
+            void OnFocusChanged(object? sender, EventArgs e)
+            {
+                // Defer so the new active window's IsActive has settled before we read it
+                // (Deactivated of the old window can fire before Activated of the new one).
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (!child.IsLoaded)
+                    {
+                        return;
+                    }
+
+                    child.Topmost = owner.IsActive || child.IsActive;
+                });
+            }
+
+            owner.Activated += OnFocusChanged;
+            owner.Deactivated += OnFocusChanged;
+            child.Activated += OnFocusChanged;
+            child.Deactivated += OnFocusChanged;
+            child.Closed += (_, _) =>
+            {
+                owner.Activated -= OnFocusChanged;
+                owner.Deactivated -= OnFocusChanged;
+                child.Activated -= OnFocusChanged;
+                child.Deactivated -= OnFocusChanged;
+            };
+
+            child.Topmost = owner.IsActive || child.IsActive;
         }
 
         /// <summary>

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+using Nikse.SubtitleEdit.Features.Options.Settings;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Logic
@@ -206,7 +207,7 @@ namespace Nikse.SubtitleEdit.Logic
                 // (Deactivated of the old window can fire before Activated of the new one).
                 Dispatcher.UIThread.Post(() =>
                 {
-                    if (!child.IsLoaded)
+                    if (child.IsClosing() || owner.IsClosing())
                     {
                         return;
                     }


### PR DESCRIPTION
## Summary
- Find/Replace dialogs now toggle `Topmost` dynamically based on owner/child window activation instead of being unconditionally topmost.
- Avoids the dialogs floating above other applications on macOS (where Avalonia maps `Topmost` to `NSWindowLevel.Floating` process-wide), without needing an `OperatingSystem.IsMacOS()` branch.
- Alternative to #11234.

## Implementation
- New `WindowService.KeepTopmostWhileOwnerActive(child, owner)` helper subscribes to `Activated`/`Deactivated` on both windows and recomputes `child.Topmost = owner.IsActive || child.IsActive`. Handlers are removed on `child.Closed`.
- `ShowFind` and `ShowReplace` in `MainViewModel` call the helper instead of setting `window.Topmost = true`.
- `ShowWrapAroundDialog` no longer needs to manually flip `Topmost` around `MessageBox.Show` — the message box stealing focus already triggers the helper to drop the dialog out of topmost.

## Test plan
- [ ] macOS: open Find, switch to another app — Find no longer floats above it.
- [ ] macOS: switch back to Subtitle Edit — Find pops back above the main window.
- [ ] macOS: click the Find window, switch to another app — Find drops behind.
- [ ] macOS: trigger wrap-around search so the MessageBox appears over the Find dialog — message box appears in front, Find dialog returns to topmost after closing.
- [x] Windows: existing behavior unchanged (Find on top while main active, drops when main loses focus).
- [ ] Linux: existing behavior unchanged.
- [ ] Same checks for Replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)