### PR TITLE
Float undocked video/waveform while SE main is active

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5253,6 +5253,11 @@ public partial class MainViewModel :
             {
                 _videoPlayerUndockedViewModel = vm;
                 vm.Initialize(_videoFileName ?? string.Empty, position, volume, this);
+                // Float above main while main (or this window) is active, but drop behind when
+                // SE loses focus to another app. Mirrors the Find/Replace helper from #11243.
+                // The two undocked windows are still independent in Alt+Tab — KeepTopmost… is
+                // just a Z-order knob, not an ownership change.
+                WindowService.KeepTopmostWhileOwnerActive(window, Window!);
             });
 
             _windowService.ShowIndependentWindow<AudioVisualizerUndockedWindow, AudioVisualizerUndockedViewModel>((window, vm) =>
@@ -5260,6 +5265,7 @@ public partial class MainViewModel :
                 _audioVisualizerUndockedViewModel = vm;
                 vm.Initialize(AudioVisualizer, this);
                 ReloadAudioVisualizer();
+                WindowService.KeepTopmostWhileOwnerActive(window, Window!);
             });
 
             InitLayout.MakeLayout12KeepVideo(MainView!, this);


### PR DESCRIPTION
## Summary
Applies `WindowService.KeepTopmostWhileOwnerActive` — introduced for Find/Replace in #11243 — to the two undocked windows opened from `MainViewModel.VideoUndockControls` (around `MainViewModel.cs:5252` / `:5258`).

Result: the undocked video player and audio visualizer now stay visually above SE main while either SE window is the active app, and drop behind when SE loses focus to another application. Matches what `GrampaWildWilly` asked for in their follow-up on #11229 ("the audio visualizer doesn't stay visible, floating on top of the main window").

Important: this does **not** change Alt+Tab grouping. `KeepTopmost…` is a Z-order knob, not an ownership change. The two undocked windows remain independent top-levels in the Alt+Tab list, which was the whole point of #11229.

## Why it's safe
- Both call sites pass the configure callback to `ShowIndependentWindow`, which runs `configure` *before* `Show()`. The helper just subscribes to `Activated`/`Deactivated` (which fire after Show) and writes one initial Topmost value — both safe on an unshown window.
- The helper unsubscribes on the child's `Closed` event, so the existing redock/cleanup path in `MainViewModel.cs:5230-5263` continues to work unchanged.
- macOS: same fix as #11243 — `Topmost` flips to `false` on Deactivated, so it does not leak across applications.
- Fullscreen video player: when fullscreen takes focus, `main.IsActive` goes to false, so neither helper raises its child above the fullscreen window.

## Test plan
- [ ] **Windows**: undock both. Click main → both undocked windows raise above main. Click Firefox/Notepad → both drop behind.
- [ ] **Windows**: with video player fullscreened on the undocked window, the audio visualizer does not punch through.
- [ ] **macOS**: same behavior; verify undocked windows do not float above other apps.
- [ ] **Linux**: behavior matches today's Find/Replace (depends on WM honoring Topmost).
- [ ] Alt+Tab still treats both undocked windows as independent top-levels (#11229 behavior preserved).
- [ ] Redock controls → both undocked windows close cleanly, no leftover event subscriptions (verified via the helper's `Closed` cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)