### PR TITLE
Fix split-line gap and proportional duration (#11245)

### DIFF
--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -27,16 +27,13 @@ public class SplitManager : ISplitManager
         }
 
         var newSubtitle = new SubtitleLineViewModel(subtitle, true);
-        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 2.0;
+        var originalStartMs = subtitle.StartTime.TotalMilliseconds;
+        var originalDurationMs = subtitle.Duration.TotalMilliseconds;
+        var originalEndMs = subtitle.EndTime.TotalMilliseconds;
 
-        var dividePositionMs = subtitle.StartTime.TotalMilliseconds + subtitle.Duration.TotalMilliseconds / 2.0 + gap;
-        if (videoPositionSeconds > 0 && videoPositionSeconds > subtitle.StartTime.TotalSeconds && videoPositionSeconds < subtitle.EndTime.TotalSeconds)
-        {
-            dividePositionMs = videoPositionSeconds * 1000.0;
-        }
-
-        newSubtitle.SetStartTimeOnly(TimeSpan.FromMilliseconds(dividePositionMs));
-        subtitle.EndTime = TimeSpan.FromMilliseconds(newSubtitle.StartTime.TotalMilliseconds - gap);
+        var hasUserVideoPosition = videoPositionSeconds > 0
+            && videoPositionSeconds > subtitle.StartTime.TotalSeconds
+            && videoPositionSeconds < subtitle.EndTime.TotalSeconds;
 
         var text = subtitle.Text;
         var lines = text.SplitToLines();
@@ -128,7 +125,78 @@ public class SplitManager : ISplitManager
         subtitle.Text = s1;
         newSubtitle.Text = s2;
 
+        // Time split — done AFTER the text split so we can weight the divide point
+        // by the resulting text-length ratio when no user video position was given.
+        //
+        // The gap between the two halves is the full MinimumBetweenLines (SE 4 parity).
+        // Before #11247 follow-up, SE 5 inserted only half the configured gap because
+        // `gap` was divided by 2 and applied only on the leading edge.
+        var minGapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        var halfGapMs = minGapMs / 2.0;
+
+        double subtitleEndMs;
+        double newSubtitleStartMs;
+
+        if (hasUserVideoPosition)
+        {
+            // User picked a video frame — that frame becomes the start of the new
+            // line; the old line ends one full MinGap earlier. Mirrors SE 4's
+            // SplitBehavior == 0 path in SetSplitTime.
+            var divideMs = videoPositionSeconds * 1000.0;
+            newSubtitleStartMs = divideMs;
+            subtitleEndMs = divideMs - minGapMs;
+        }
+        else
+        {
+            // Auto-split — divide at the midpoint, weighted by the text-length
+            // ratio of the two halves when they differ by more than a couple of
+            // characters. Clamp to [0.25, 0.75] so a very lopsided split still
+            // produces two viable durations. SE 4 Main.cs:12808 SetSplitTime.
+            var firstTextLen = StripForLengthMeasure(subtitle.Text).Length;
+            var secondTextLen = StripForLengthMeasure(newSubtitle.Text).Length;
+
+            var startFactor = 0.5;
+            if (Math.Abs(firstTextLen - secondTextLen) > 2)
+            {
+                var total = firstTextLen + secondTextLen;
+                if (total > 0)
+                {
+                    startFactor = (double)firstTextLen / total;
+                    if (startFactor < 0.25) startFactor = 0.25;
+                    if (startFactor > 0.75) startFactor = 0.75;
+                }
+            }
+
+            var middleMs = originalStartMs + originalDurationMs * startFactor;
+            subtitleEndMs = middleMs - halfGapMs;
+            newSubtitleStartMs = middleMs + halfGapMs;
+        }
+
+        // Don't let either half collapse to zero / negative duration when MinGap is
+        // larger than the available headroom on a short subtitle. Clamp to the
+        // line's original boundaries; a sub-minimum half is better than a negative one.
+        if (subtitleEndMs <= originalStartMs)
+        {
+            subtitleEndMs = originalStartMs + 1;
+        }
+        if (newSubtitleStartMs >= originalEndMs)
+        {
+            newSubtitleStartMs = originalEndMs - 1;
+        }
+        if (newSubtitleStartMs < subtitleEndMs)
+        {
+            newSubtitleStartMs = subtitleEndMs;
+        }
+
+        subtitle.EndTime = TimeSpan.FromMilliseconds(subtitleEndMs);
+        newSubtitle.SetStartTimeOnly(TimeSpan.FromMilliseconds(newSubtitleStartMs));
+
         subtitles.Insert(idx + 1, newSubtitle);
+    }
+
+    private static string StripForLengthMeasure(string text)
+    {
+        return HtmlUtil.RemoveHtmlTags(text ?? string.Empty, true).Replace(Environment.NewLine, string.Empty);
     }
 
     private static readonly (string Open, string Close)[] SimpleHtmlTags =

--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -51,6 +51,12 @@ public class SplitManager : ISplitManager
                     newSubtitle.Text = DialogSplitMerge.RemoveStartDash(newSubtitle.Text);
                 }
             }
+
+            // SE 4 parity (#11245 follow-up): if either half ends up with a single line
+            // longer than the configured max, auto-break it. Cursor-split at the middle
+            // of a long single-line subtitle would otherwise leave a too-wide line.
+            subtitle.Text = AutoBreakIfTooLong(subtitle.Text, languageCode);
+            newSubtitle.Text = AutoBreakIfTooLong(newSubtitle.Text, languageCode);
         }
         else if (lines.Count == 2)
         {
@@ -197,6 +203,30 @@ public class SplitManager : ISplitManager
     private static string StripForLengthMeasure(string text)
     {
         return HtmlUtil.RemoveHtmlTags(text ?? string.Empty, true).Replace(Environment.NewLine, string.Empty);
+    }
+
+    // Mirrors SE 4's per-half guard in SplitSelectedParagraph: if any line in `text`
+    // (after stripping HTML/ASSA tags for measurement) is over the configured
+    // single-line max length, fold it via Utilities.AutoBreakLine. Otherwise the user
+    // keeps the line breaks they intentionally chose.
+    private static string AutoBreakIfTooLong(string text, string languageCode)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var maxLen = Configuration.Settings.General.SubtitleLineMaximumLength;
+        if (maxLen <= 0)
+        {
+            return text;
+        }
+
+        var anyLineTooLong = HtmlUtil.RemoveHtmlTags(text, true)
+            .SplitToLines()
+            .Any(line => line.Length > maxLen);
+
+        return anyLineTooLong ? Utilities.AutoBreakLine(text, languageCode) : text;
     }
 
     private static readonly (string Open, string Close)[] SimpleHtmlTags =

--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -179,19 +179,26 @@ public class SplitManager : ISplitManager
         }
 
         // Don't let either half collapse to zero / negative duration when MinGap is
-        // larger than the available headroom on a short subtitle. Clamp to the
-        // line's original boundaries; a sub-minimum half is better than a negative one.
-        if (subtitleEndMs <= originalStartMs)
+        // larger than the available headroom on a short subtitle. Each half needs
+        // strictly positive duration; we give up the configured gap before we give
+        // up a positive duration on either side.
+        if (subtitleEndMs < originalStartMs + 1)
         {
             subtitleEndMs = originalStartMs + 1;
         }
-        if (newSubtitleStartMs >= originalEndMs)
+        if (newSubtitleStartMs > originalEndMs - 1)
         {
             newSubtitleStartMs = originalEndMs - 1;
         }
-        if (newSubtitleStartMs < subtitleEndMs)
+        if (subtitleEndMs > newSubtitleStartMs)
         {
-            newSubtitleStartMs = subtitleEndMs;
+            // No room left for the requested gap — collapse to the midpoint of the
+            // available window so both halves still end up with positive duration
+            // (originalEnd > newSubtitleStart > originalStart, and
+            //  originalStart < subtitleEnd < originalEnd).
+            var midpoint = (subtitleEndMs + newSubtitleStartMs) / 2.0;
+            subtitleEndMs = midpoint;
+            newSubtitleStartMs = midpoint;
         }
 
         subtitle.EndTime = TimeSpan.FromMilliseconds(subtitleEndMs);
@@ -200,9 +207,29 @@ public class SplitManager : ISplitManager
         subtitles.Insert(idx + 1, newSubtitle);
     }
 
+    // Strip HTML/ASSA tags and ALL line-break variants for length measurement.
+    // Subtitle text may contain CRLF, LF, CR, or Unicode line separator (U+2028)
+    // regardless of platform — these are all recognised by SplitToLines — and
+    // counting them as characters would skew the proportional-duration weighting.
     private static string StripForLengthMeasure(string text)
     {
-        return HtmlUtil.RemoveHtmlTags(text ?? string.Empty, true).Replace(Environment.NewLine, string.Empty);
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var stripped = HtmlUtil.RemoveHtmlTags(text, true);
+        var sb = new System.Text.StringBuilder(stripped.Length);
+        foreach (var c in stripped)
+        {
+            // CR, LF, NEL (U+0085), line separator (U+2028), paragraph separator (U+2029).
+            if (c == '\r' || c == '\n' || c == '\u0085' || c == '\u2028' || c == '\u2029')
+            {
+                continue;
+            }
+            sb.Append(c);
+        }
+        return sb.ToString();
     }
 
     // Mirrors SE 4's per-half guard in SplitSelectedParagraph: if any line in `text`

--- a/tests/UI/Logic/SplitManagerTests.cs
+++ b/tests/UI/Logic/SplitManagerTests.cs
@@ -469,6 +469,60 @@ public class SplitManagerTests
     }
 
     [Fact]
+    public void Split_MinGapLargerThanLineDuration_GivesBothHalvesPositiveDuration()
+    {
+        // Edge case (Copilot review on #11248): when MinimumBetweenLines is larger than
+        // the subtitle's own duration, the clamp must still produce two halves with
+        // strictly positive duration. We give up the configured gap before we collapse
+        // either half to zero.
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 500;
+        var manager = new SplitManager();
+        // 100 ms line — far shorter than the 500 ms configured gap.
+        var subtitle = MakeSubtitle("Hi there", 1.000, 1.100);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, languageCode: "en");
+
+        Assert.Equal(2, subtitles.Count);
+        Assert.True(subtitles[0].Duration.TotalMilliseconds > 0,
+            $"first half duration must be positive, was {subtitles[0].Duration.TotalMilliseconds}");
+        Assert.True(subtitles[1].Duration.TotalMilliseconds > 0,
+            $"second half duration must be positive, was {subtitles[1].Duration.TotalMilliseconds}");
+        Assert.True(subtitles[1].StartTime >= subtitles[0].EndTime);
+        Assert.True(subtitles[0].StartTime.TotalMilliseconds >= 1000);
+        Assert.True(subtitles[1].EndTime.TotalMilliseconds <= 1100);
+    }
+
+    [Fact]
+    public void Split_NonNewLineLineBreaks_StillProportionalByVisibleText()
+    {
+        // Copilot review on #11248: StripForLengthMeasure must collapse all line-break
+        // variants (\n, \r, U+2028, etc.), not just Environment.NewLine, so that the
+        // proportional-duration weighting reflects the visible text length consistently
+        // regardless of which line-break characters happened to be in the input.
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        // First half embeds a bare LF (no CR); makes it ~47 visible chars regardless of
+        // host OS. Without the broader strip these embedded line-break chars would
+        // either be counted or not depending on the platform, skewing the ratio.
+        var first = "AAAAAA\nBBBBBB CCCCCC DDDDDD EEEEEE FFFFFF GGGGGG";
+        var second = "Tiny. end.";
+        var subtitle = MakeSubtitle($"{first}{Environment.NewLine}{second}", 1, 5);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, languageCode: "en");
+
+        Assert.Equal(2, subtitles.Count);
+        var firstDurationMs = subtitles[0].Duration.TotalMilliseconds;
+        var secondDurationMs = subtitles[1].Duration.TotalMilliseconds;
+        // Same expectation as the proportional test: the longer (visible) first half
+        // gets the clamped maximum 75% share of the 4 s window, ~3 s.
+        Assert.True(firstDurationMs > secondDurationMs,
+            $"expected first > second; got {firstDurationMs}ms vs {secondDurationMs}ms");
+        Assert.InRange(firstDurationMs, 2900, 3100);
+    }
+
+    [Fact]
     public void Split_WithVideoPosition_LeavesFullMinimumBetweenLinesGap()
     {
         // User-chosen video frame becomes the new line's start; the old line ends

--- a/tests/UI/Logic/SplitManagerTests.cs
+++ b/tests/UI/Logic/SplitManagerTests.cs
@@ -422,6 +422,53 @@ public class SplitManagerTests
     }
 
     [Fact]
+    public void Split_WithTextIndex_AutoBreaksHalvesThatExceedMaxLineLength()
+    {
+        // SE 4 parity (#11245 follow-up): cursor-splitting a long single-line
+        // subtitle should auto-break either half if it's still over the configured
+        // single-line max. Each half here is 39 chars (above MergeLinesShorterThan=33,
+        // so AutoBreakLine will actually fold them) and over the configured max of 20.
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        Configuration.Settings.General.SubtitleLineMaximumLength = 20;
+        Configuration.Settings.General.MergeLinesShorterThan = 33;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle(
+            "AAAAAAAAA BBBBBBBBB CCCCCCCCC DDDDDDDDD EEEEEEEEE FFFFFFFFF GGGGGGGGG HHHHHHHHH",
+            1, 5);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        // Cursor at the space between DDDDDDDDD and EEEEEEEEE (index 40).
+        manager.Split(subtitles, subtitle, textIndex: 40, languageCode: "en");
+
+        Assert.Equal(2, subtitles.Count);
+        Assert.Contains(Environment.NewLine, subtitles[0].Text);
+        Assert.Contains(Environment.NewLine, subtitles[1].Text);
+        // No individual line on either side exceeds the configured max.
+        Assert.All(subtitles[0].Text.Split(Environment.NewLine),
+            line => Assert.True(line.Length <= 20, $"'{line}' exceeds 20 chars"));
+        Assert.All(subtitles[1].Text.Split(Environment.NewLine),
+            line => Assert.True(line.Length <= 20, $"'{line}' exceeds 20 chars"));
+    }
+
+    [Fact]
+    public void Split_WithTextIndex_ShortHalves_NoAutoBreak()
+    {
+        // Counter-test: when both halves fit on a single line, the existing line
+        // breaks (here: none) are preserved.
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        Configuration.Settings.General.SubtitleLineMaximumLength = 40;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle("Hello world", 1, 3);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, textIndex: 5, languageCode: "en");
+
+        Assert.Equal(2, subtitles.Count);
+        Assert.Equal("Hello", subtitles[0].Text);
+        Assert.Equal("world", subtitles[1].Text);
+    }
+
+    [Fact]
     public void Split_WithVideoPosition_LeavesFullMinimumBetweenLinesGap()
     {
         // User-chosen video frame becomes the new line's start; the old line ends

--- a/tests/UI/Logic/SplitManagerTests.cs
+++ b/tests/UI/Logic/SplitManagerTests.cs
@@ -333,4 +333,110 @@ public class SplitManagerTests
         Assert.Contains("<b>", subtitles[1].Text, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("<i>", subtitles[1].Text, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void Split_AutoSplit_LeavesFullMinimumBetweenLinesGap()
+    {
+        // Bug repro for #11245: with MinimumBetweenLines > 0, the gap between the two
+        // halves was previously MinimumBetweenLines / 2. Auto-split (no video position)
+        // must leave the full configured gap.
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 100;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle($"First line{Environment.NewLine}Second line", 1, 3);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, languageCode: "en");
+
+        Assert.Equal(2, subtitles.Count);
+        var gapMs = subtitles[1].StartTime.TotalMilliseconds - subtitles[0].EndTime.TotalMilliseconds;
+        Assert.Equal(100.0, gapMs, 1);
+    }
+
+    [Fact]
+    public void Split_AutoSplit_EqualLengthHalves_DivideAtMidpoint()
+    {
+        // Balanced halves should still split at the literal midpoint, with the gap
+        // straddling it (halfGap before, halfGap after).
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 80;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle($"Same len.{Environment.NewLine}Same len.", 1, 3);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, languageCode: "en");
+
+        // Midpoint = 2000 ms; with 80 ms gap symmetric around it:
+        //   first.End  = 1960 ms
+        //   second.Start = 2040 ms
+        Assert.Equal(2, subtitles.Count);
+        Assert.Equal(1960.0, subtitles[0].EndTime.TotalMilliseconds, 1);
+        Assert.Equal(2040.0, subtitles[1].StartTime.TotalMilliseconds, 1);
+    }
+
+    [Fact]
+    public void Split_AutoSplit_LongerFirstHalf_GetsProportionallyMoreDuration()
+    {
+        // SE 4 parity (#11245): when one half has materially more text, it should
+        // get a proportionally larger share of the original duration, clamped to
+        // [0.25, 0.75] so the smaller half never drops below a quarter.
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        // ~70 chars vs ~10 chars — startFactor before clamp would be ~0.875, clamped
+        // to 0.75. Original duration is 4 s, so middle ≈ start + 3.0 s.
+        var first = "This is the much longer first half of the subtitle text content.";
+        var second = "Tiny end.";
+        var subtitle = MakeSubtitle($"{first}{Environment.NewLine}{second}", 1, 5);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, languageCode: "en");
+
+        Assert.Equal(2, subtitles.Count);
+        var firstDurationMs = subtitles[0].Duration.TotalMilliseconds;
+        var secondDurationMs = subtitles[1].Duration.TotalMilliseconds;
+        Assert.True(firstDurationMs > secondDurationMs,
+            $"Expected first half > second half; got {firstDurationMs}ms vs {secondDurationMs}ms");
+        // Clamped startFactor of 0.75 means first half is ~3 s out of 4 s.
+        Assert.InRange(firstDurationMs, 2900, 3100);
+    }
+
+    [Fact]
+    public void Split_AutoSplit_LongerSecondHalf_GetsProportionallyMoreDuration()
+    {
+        // Mirror of the previous test: longer text on the second half gets the
+        // proportionally larger duration.
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        var first = "Tiny start.";
+        var second = "This is the much longer second half of the subtitle text content.";
+        var subtitle = MakeSubtitle($"{first}{Environment.NewLine}{second}", 1, 5);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, languageCode: "en");
+
+        Assert.Equal(2, subtitles.Count);
+        var firstDurationMs = subtitles[0].Duration.TotalMilliseconds;
+        var secondDurationMs = subtitles[1].Duration.TotalMilliseconds;
+        Assert.True(secondDurationMs > firstDurationMs,
+            $"Expected second half > first half; got {secondDurationMs}ms vs {firstDurationMs}ms");
+        // Clamped startFactor of 0.25 means first half is ~1 s out of 4 s.
+        Assert.InRange(firstDurationMs, 900, 1100);
+    }
+
+    [Fact]
+    public void Split_WithVideoPosition_LeavesFullMinimumBetweenLinesGap()
+    {
+        // User-chosen video frame becomes the new line's start; the old line ends
+        // one full MinGap earlier (mirrors SE 4 SplitBehavior == 0).
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 100;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle("Hello world", 1, 3);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, videoPositionSeconds: 2.0, languageCode: "en");
+
+        Assert.Equal(2, subtitles.Count);
+        Assert.Equal(2000.0, subtitles[1].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(1900.0, subtitles[0].EndTime.TotalMilliseconds, 1);
+        var gapMs = subtitles[1].StartTime.TotalMilliseconds - subtitles[0].EndTime.TotalMilliseconds;
+        Assert.Equal(100.0, gapMs, 1);
+    }
 }


### PR DESCRIPTION
## Summary
Two SE 4 → SE 5 regressions reported in #11245 around **Split line at cursor position**:

1. **Gap was half the configured value.** `SplitManager` (`ISplitManager.cs:30`) divided `MinimumBetweenLines` by 2 and applied it only on the leading edge of the divide point, so the actual gap between the two halves was `MinimumBetweenLines / 2`. With the user's setting of e.g. 100 ms, the resulting gap was 50 ms.
2. **Durations were always 50/50.** SE 5 always divided at the literal duration midpoint. SE 4 (`Forms/Main.cs:12808` `SetSplitTime`) weights the divide point by the text-length ratio (`startFactor = firstLen / totalLen`, clamped to `[0.25, 0.75]`), so a cursor-split at the 75% text mark gives the first half ~75% of the duration.

## Implementation
Restructures `SplitManager.Split` so the **time split runs after the text split** — we then have the post-tag-fixup halves' lengths available to weight the divide point.

- **Auto-split** (no `videoPositionSeconds`): compute `startFactor` from `firstText.Length / (firstText.Length + secondText.Length)`, clamped to `[0.25, 0.75]`. Apply only when the two halves differ by more than 2 characters; otherwise stay at the literal midpoint. Place the gap symmetrically around the divide: `firstEnd = middle - halfGap`, `secondStart = middle + halfGap`. Final gap = `MinimumBetweenLines`.
- **Video-position split**: the user's chosen frame becomes the **start of the new line**, and the old line ends one full `MinimumBetweenLines` earlier. Matches SE 4 `SplitBehavior == 0`.
- A floor clamp prevents either half from collapsing to zero / negative duration when `MinGap` is larger than the line's headroom.

`HtmlUtil.RemoveHtmlTags(text, true).Replace(Environment.NewLine, "")` is used for length measurement so HTML markup and line breaks don't skew the ratio (same as SE 4).

## Tests
5 new cases in `SplitManagerTests.cs`. All 24 SplitManager tests pass.

- `Split_AutoSplit_LeavesFullMinimumBetweenLinesGap` — `MinGap=100` → gap is 100 ms (not 50).
- `Split_AutoSplit_EqualLengthHalves_DivideAtMidpoint` — equal halves stay at the midpoint with the gap straddling it.
- `Split_AutoSplit_LongerFirstHalf_GetsProportionallyMoreDuration` — first half ~75 % of duration when its text is much longer.
- `Split_AutoSplit_LongerSecondHalf_GetsProportionallyMoreDuration` — symmetric reverse.
- `Split_WithVideoPosition_LeavesFullMinimumBetweenLinesGap` — `MinGap=100` + videoPosition 2 s → `new.Start=2000`, `first.End=1900`, gap 100 ms.

The pre-existing 19 tests all set `MinimumBetweenLines = 0` and so weren't affected by either bug; they still pass with the new code.

Refs #11245 (split-line follow-up to #11247).

🤖 Generated with [Claude Code](https://claude.com/claude-code)