### PR TITLE
TTS: add Audio export format setting (Wav default, also Mp3/Ogg/Flac/M4a)

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -596,6 +596,16 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptMergeContinuationLines, nameof(_vm.TextToSpeechPromptMergeContinuationLines)),
             MakeCheckboxSetting(Se.Language.Options.Settings.SpeechToTextPromptMergeContinuationLines, nameof(_vm.SpeechToTextPromptMergeContinuationLines)),
+            new SettingsItem(Se.Language.Options.Settings.AudioExportFormat, () => new ComboBox
+            {
+                MinWidth = 200,
+                DataContext = _vm,
+                [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(_vm.AudioExportFormats)),
+                [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(_vm.SelectedAudioExportFormat))
+                {
+                    Mode = BindingMode.TwoWay,
+                }
+            }),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.Appearance,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -144,6 +144,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _saveAsAppendLanguageCode;
     [ObservableProperty] private string _selectedSaveAsAppendLanguageCode;
 
+    [ObservableProperty] private ObservableCollection<string> _audioExportFormats = new();
+    [ObservableProperty] private string _selectedAudioExportFormat = string.Empty;
+
     [ObservableProperty] private bool _allowSingleLetterShortcutsInTextbox;
     [ObservableProperty] private bool _goToLineNumberAlsoSetVideoPosition;
     [ObservableProperty] private bool _adjustAllTimesRememberLineSelectionChoice;
@@ -486,6 +489,19 @@ public partial class SettingsViewModel : ObservableObject
         ];
         SelectedSaveAsBehaviorType = SaveAsBehaviorTypes[0];
 
+        // Format names are not localized — these strings are also the persisted enum
+        // names (AudioExportFormatType), so the dropdown value can be written to
+        // Se.Settings.General.AudioExportFormat without a separate mapper.
+        AudioExportFormats =
+        [
+            nameof(AudioExportFormatType.Wav),
+            nameof(AudioExportFormatType.Mp3),
+            nameof(AudioExportFormatType.Ogg),
+            nameof(AudioExportFormatType.Flac),
+            nameof(AudioExportFormatType.M4a),
+        ];
+        SelectedAudioExportFormat = AudioExportFormats[0];
+
         SaveAsAppendLanguageCode =
         [
             Se.Language.General.None,
@@ -624,6 +640,11 @@ public partial class SettingsViewModel : ObservableObject
         SubtitleGridCenterSelectedRow = Se.Settings.General.SubtitleGridCenterSelectedRow;
         SelectedSaveAsBehaviorType = MapFromSelectedSaveAsBehavior(Se.Settings.General.SaveAsBehavior);
         SelectedSaveAsAppendLanguageCode = MapFromSelectedSaveAsAppendLanguageCode(Se.Settings.General.SaveAsAppendLanguageCode);
+        // Audio export format is round-tripped through the AudioExportFormatType enum
+        // names; unknown / legacy values fall back to Wav.
+        SelectedAudioExportFormat = AudioExportFormats.Contains(Se.Settings.General.AudioExportFormat)
+            ? Se.Settings.General.AudioExportFormat
+            : nameof(AudioExportFormatType.Wav);
         AutoConvertToUtf8 = general.AutoConvertToUtf8;
         ForceCrLfOnSave = general.ForceCrLfOnSave;
         AutoTrimWhiteSpace = general.AutoTrimWhiteSpace;
@@ -1278,6 +1299,7 @@ public partial class SettingsViewModel : ObservableObject
         general.SubtitleGridCenterSelectedRow = SubtitleGridCenterSelectedRow;
         general.SaveAsBehavior = MapToSaveAsBehavior(SelectedSaveAsBehaviorType);
         general.SaveAsAppendLanguageCode = MapToSaveAsAppendLanguageCode(SelectedSaveAsAppendLanguageCode);
+        general.AudioExportFormat = SelectedAudioExportFormat;
         general.AutoConvertToUtf8 = AutoConvertToUtf8;
         general.ForceCrLfOnSave = ForceCrLfOnSave;
         general.AutoTrimWhiteSpace = AutoTrimWhiteSpace;

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1814,9 +1814,37 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
         var outputFolder = result;
-        var audioFileName = Path.Combine(outputFolder, GetBestFileName(outputFolder, ".wav"));
+        var exportExt = GetAudioExportExtension();
+        var audioFileName = Path.Combine(outputFolder, GetBestFileName(outputFolder, exportExt));
 
-        File.Move(mergedAudioFileName, audioFileName);
+        if (exportExt == ".wav")
+        {
+            File.Move(mergedAudioFileName, audioFileName);
+        }
+        else
+        {
+            // Transcode the pipeline's WAV output to the user's chosen audio format
+            // (Settings → Tools → Audio export format). ffmpeg infers the codec from
+            // the output extension. Drop the intermediate WAV after a successful
+            // convert; on failure we keep the WAV alongside so the user doesn't lose
+            // a long synthesis run.
+            var transcode = FfmpegGenerator.ConvertFormat(mergedAudioFileName, audioFileName);
+            await transcode.StartAndWaitAsync(_cancellationToken);
+            if (File.Exists(audioFileName))
+            {
+                try { File.Delete(mergedAudioFileName); } catch { /* best effort */ }
+            }
+            else
+            {
+                // ffmpeg didn't produce the target file — fall back to keeping the
+                // WAV so the user has *something*. Surface the transcode failure path
+                // by moving the WAV under its original temp name into the output
+                // folder with a .wav extension.
+                var fallback = Path.Combine(outputFolder, GetBestFileName(outputFolder, ".wav"));
+                File.Move(mergedAudioFileName, fallback);
+                audioFileName = fallback;
+            }
+        }
 
         await HandleAddToVideo(audioFileName, outputFolder, _cancellationToken);
 
@@ -1974,6 +2002,23 @@ public partial class TextToSpeechViewModel : ObservableObject
         var silenceProcess = FfmpegGenerator.GenerateEmptyAudio(silenceFileName, durationInSeconds);
         await silenceProcess.StartAndWaitAsync(cancellationToken);
         return silenceFileName;
+    }
+
+    // Maps the Settings → Tools → "Audio export format" selection (an AudioExportFormatType
+    // enum name) to its corresponding ffmpeg-friendly file extension. ffmpeg uses the output
+    // extension to pick the encoder, so e.g. ".mp3" -> libmp3lame is automatic. Unknown
+    // values fall back to ".wav" so a malformed Settings.json never silently produces a
+    // wrongly-named file.
+    private static string GetAudioExportExtension()
+    {
+        return Se.Settings.General.AudioExportFormat switch
+        {
+            nameof(AudioExportFormatType.Mp3) => ".mp3",
+            nameof(AudioExportFormatType.Ogg) => ".ogg",
+            nameof(AudioExportFormatType.Flac) => ".flac",
+            nameof(AudioExportFormatType.M4a) => ".m4a",
+            _ => ".wav",
+        };
     }
 
     private string GetBestFileName(string folder, string extension)

--- a/src/ui/Logic/Config/AudioExportFormatType.cs
+++ b/src/ui/Logic/Config/AudioExportFormatType.cs
@@ -1,0 +1,13 @@
+namespace Nikse.SubtitleEdit.Logic.Config;
+
+// Format used when writing a standalone audio file (e.g. the TTS export step).
+// Default is Wav. Non-Wav values trigger a post-pipeline ffmpeg transcode — the
+// codec is inferred from the output file extension.
+public enum AudioExportFormatType
+{
+    Wav,
+    Mp3,
+    Ogg,
+    Flac,
+    M4a,
+}

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -246,6 +246,7 @@ public class LanguageSettings
     public string SubtitleGridCenterSelectedRow { get; set; }
     public string SaveAsBehavior { get; set; }
     public string SaveAsAppendLanguageCode { get; set; }
+    public string AudioExportFormat { get; set; }
     public string GridGoToSubtitleAndSetVideoPosition { get; set; }
     public string GridGoToNextLine { get; set; }
     public string GridGoToSubtitleOnlyWaveformOnly { get; set; }
@@ -543,6 +544,7 @@ public class LanguageSettings
         SubtitleGridCenterSelectedRow = "Subtitle grid, center when selecting prev/next row";
         SaveAsBehavior = "\"Save as\" behavior";
         SaveAsAppendLanguageCode = "\"Save as\" append language code";
+        AudioExportFormat = "Audio export format";
         GridGoToSubtitleAndSetVideoPosition = "Go to subtitle and set video position";
         GridGoToNextLine = "Go to next line";
         GridGoToSubtitleOnlyWaveformOnly = "Go to subtitle only (waveform only)";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -62,6 +62,12 @@ public class SeGeneral
     public bool SubtitleGridCenterSelectedRow { get; set; }
     public string SaveAsBehavior { get; set; }
     public string SaveAsAppendLanguageCode { get; set; }
+
+    // Generic audio-file output format, read by features that write standalone audio
+    // (currently: TTS export). Defaults to Wav for backwards compatibility; non-Wav
+    // values trigger a post-pipeline ffmpeg transcode at the export step.
+    // Values are AudioExportFormatType enum names ("Wav", "Mp3", "Ogg", "Flac", "M4a").
+    public string AudioExportFormat { get; set; }
     public bool AutoConvertToUtf8 { get; set; }
     public bool AutoGuessAnsiEncoding { get; set; }
     public int MaxNumberOfLinesPlusAbort { get; set; }
@@ -181,6 +187,7 @@ public class SeGeneral
         SubtitleGridCenterSelectedRow = false;
         SaveAsBehavior = nameof(SaveAsBehaviourType.UseVideoFileNameThenSubtitleFileName);
         SaveAsAppendLanguageCode = nameof(SaveAsLanguageAppendType.None);
+        AudioExportFormat = nameof(AudioExportFormatType.Wav);
         AutoConvertToUtf8 = false;
         AutoGuessAnsiEncoding = true;
         NewEmptyDefaultMs = 2000;


### PR DESCRIPTION
## Summary
Discussion [#11237](https://github.com/SubtitleEdit/subtitleedit/discussions/11237) — a user asked how to export the TTS output as MP3 instead of WAV. SE 5 had no knob for this.

Adds a **generic** "Audio export format" setting under **Options → Settings → Tools**:

- New enum `AudioExportFormatType` with `Wav` (default), `Mp3`, `Ogg`, `Flac`, `M4a`.
- New `Se.Settings.General.AudioExportFormat` (string, default `"Wav"`). Lives on `SeGeneral` rather than `SeVideoTextToSpeech` because the same setting can be reused by other audio-output features later (extract audio, export selection as audio, etc.).
- UI: ComboBox in the existing Tools section of `SettingsPage`, plumbed through `SettingsViewModel.AudioExportFormats` / `SelectedAudioExportFormat`. Unknown / legacy values in `Settings.json` round-trip back to `Wav`.

TTS export flow (`TextToSpeechViewModel.MergeAndAddToVideo`) now consults the setting:
- `Wav`: same as today — move the merged WAV into the user's output folder.
- Non-Wav: transcode the merged WAV via the existing `FfmpegGenerator.ConvertFormat` (ffmpeg infers codec from output extension), then drop the intermediate WAV. On transcode failure the original WAV is preserved in the output folder so a long synthesis run isn't lost.

## Test plan
- [ ] Fresh install → Options → Settings → Tools shows "Audio export format" defaulting to **Wav**.
- [ ] Run TTS with default → `.wav` file appears in output folder, same content as today.
- [ ] Switch to **Mp3** → run TTS → `.mp3` file appears, no leftover `.wav`.
- [ ] Same with **Ogg**, **Flac**, **M4a**.
- [ ] With "Generate video file" enabled and **Mp3** selected → final MKV/MP4 has audio (ffmpeg reads MP3 just fine as input).
- [ ] Force a transcode failure (e.g. break ffmpeg path) → fallback `.wav` appears in output folder, no silent data loss.
- [ ] Reset Settings.json → field defaults back to `"Wav"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)