### PR TITLE
Fix Shift+Page Up/Down and Shift+Home/End selection in subtitle grid

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16425,6 +16425,30 @@ public partial class MainViewModel :
                     _shiftSelectAnchorIndex = -1;
                     _shiftSelectCurrentIndex = -1;
                 }
+                else if (keyEventArgs.Key == Key.PageDown && keyEventArgs.KeyModifiers == KeyModifiers.Shift && Subtitles.Count > 0)
+                {
+                    keyEventArgs.Handled = true;
+                    HandleShiftArrowSelection(GetSubtitleGridPageSize());
+                    return;
+                }
+                else if (keyEventArgs.Key == Key.PageUp && keyEventArgs.KeyModifiers == KeyModifiers.Shift && Subtitles.Count > 0)
+                {
+                    keyEventArgs.Handled = true;
+                    HandleShiftArrowSelection(-GetSubtitleGridPageSize());
+                    return;
+                }
+                else if (keyEventArgs.Key == Key.Home && keyEventArgs.KeyModifiers == KeyModifiers.Shift && Subtitles.Count > 0)
+                {
+                    keyEventArgs.Handled = true;
+                    HandleShiftArrowSelection(-Subtitles.Count); // clamps to 0
+                    return;
+                }
+                else if (keyEventArgs.Key == Key.End && keyEventArgs.KeyModifiers == KeyModifiers.Shift && Subtitles.Count > 0)
+                {
+                    keyEventArgs.Handled = true;
+                    HandleShiftArrowSelection(Subtitles.Count); // clamps to Count - 1
+                    return;
+                }
                 else if (keyEventArgs.Key == Key.Home && keyEventArgs.KeyModifiers == KeyModifiers.None && Subtitles.Count > 0)
                 {
                     keyEventArgs.Handled = true;
@@ -16710,8 +16734,8 @@ public partial class MainViewModel :
             _shiftSelectCurrentIndex = anchor;
         }
 
-        var newCurrent = _shiftSelectCurrentIndex + direction;
-        if (newCurrent < 0 || newCurrent >= Subtitles.Count)
+        var newCurrent = Math.Clamp(_shiftSelectCurrentIndex + direction, 0, Subtitles.Count - 1);
+        if (newCurrent == _shiftSelectCurrentIndex)
         {
             return;
         }
@@ -16732,6 +16756,22 @@ public partial class MainViewModel :
 
         SubtitleGrid.ScrollIntoView(Subtitles[_shiftSelectCurrentIndex], null);
         SubtitleGridSelectionChanged();
+    }
+
+    private int GetSubtitleGridPageSize()
+    {
+        var scrollBar = SubtitleGrid.GetVisualDescendants()
+            .OfType<ScrollBar>()
+            .FirstOrDefault(sb => sb.Orientation == Orientation.Vertical);
+        if (scrollBar != null && scrollBar.LargeChange > 0)
+        {
+            return Math.Max(1, (int)scrollBar.LargeChange - 1);
+        }
+
+        var visibleRowCount = SubtitleGrid.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .Count(r => r.IsVisible && r.Bounds.Height > 0);
+        return Math.Max(1, visibleRowCount - 1);
     }
 
     private void UpdateSubtitleGridDragSelectAutoScroll(Avalonia.Point position)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16760,14 +16760,19 @@ public partial class MainViewModel :
 
     private int GetSubtitleGridPageSize()
     {
-        var scrollBar = SubtitleGrid.GetVisualDescendants()
-            .OfType<ScrollBar>()
-            .FirstOrDefault(sb => sb.Orientation == Orientation.Vertical);
-        if (scrollBar != null && scrollBar.LargeChange > 0)
+        var rowsPresenter = SubtitleGrid.GetVisualDescendants()
+            .OfType<DataGridRowsPresenter>()
+            .FirstOrDefault();
+        if (rowsPresenter != null && rowsPresenter.Bounds.Height > 0)
         {
-            return Math.Max(1, (int)scrollBar.LargeChange - 1);
+            var rowHeight = SubtitleGrid.RowHeight;
+            if (!double.IsNaN(rowHeight) && rowHeight > 0)
+            {
+                return Math.Max(1, (int)(rowsPresenter.Bounds.Height / rowHeight) - 1);
+            }
         }
 
+        // Fallback for variable row heights: count rendered rows in the visual tree
         var visibleRowCount = SubtitleGrid.GetVisualDescendants()
             .OfType<DataGridRow>()
             .Count(r => r.IsVisible && r.Bounds.Height > 0);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16768,7 +16768,7 @@ public partial class MainViewModel :
             var rowHeight = SubtitleGrid.RowHeight;
             if (!double.IsNaN(rowHeight) && rowHeight > 0)
             {
-                return Math.Max(1, (int)(rowsPresenter.Bounds.Height / rowHeight) - 1);
+                return Math.Max(1, (int)Math.Ceiling(rowsPresenter.Bounds.Height / rowHeight) - 1);
             }
         }
 


### PR DESCRIPTION
This PR is the continuation of DataGrid selection usability improvements I started in #11242

Avalonia's DataGrid does not handle Shift+PageDown/PageUp/Home/End correctly — it uses its own broken range selection logic that bypasses the anchor-based tracking introduced for Shift+Arrow. The result was that Shift+PageDown added rows incorrectly and Shift+PageUp failed to deselect them.

  ## Changes

  - Intercept Shift+PageDown, Shift+PageUp, Shift+Home, and Shift+End in the grid's key handler and route them through the existing `HandleShiftArrowSelection` machinery, which correctly manages the anchor index and rebuilds `SelectedItems` as a contiguous range.
  - `HandleShiftArrowSelection` now clamps the target index instead of bailing at boundaries, so it can handle page-sized and full-extent jumps in addition to single-row steps.
  - Add `GetSubtitleGridPageSize()` which computes the visible row count from `DataGridRowsPresenter.Bounds.Height / DataGrid.RowHeight` (with `Math.Ceiling` so a partially-visible bottom row is included). Falls back to counting rendered `DataGridRow` instances for variable-height grids.

  ## Behaviour

  - **Shift+PageDown**: extends selection by one page (last visible row included), with one row of overlap on the next press.
  - **Shift+PageUp**: correctly shrinks the selection back.
  - **Shift+Home / Shift+End**: extends selection to the first / last row.
  - Plain PageDown/PageUp/Home/End: unaffected — anchor resets via the existing `SelectionChanged` handler.

  ## A Note on Variable Row Height in DataGrid

Avalonia DataGrid's row virtualizer requires uniform row heights to correctly estimate the scroll extent. When rows have different heights (e.g. 1-line vs 2-line subtitle text rendered via LineBreak inlines), the virtualizer's position estimates drift on every layout pass, causing a visible oscillation between scroll-to-top and scroll-to-bottom on each trackpad gesture. References I found point in the direction that this is a known issue and not going to be fixed in Avalonia.

https://github.com/user-attachments/assets/0e8a2a89-322b-4c19-b9d2-875266b4a62a

Options are using fixed row height, or replacing DataGrid. The latter being very involved, I've been using Subtitle Edit with fixed row height for a while and I like the spacious layout. With all rows having the same height, the virtualizer gets a stable, accurate scroll extent.

 I am still thinking about the best ui design choice here. In this PR, I'm handling both variable and fixed row height. Should we switch to fixed row height to work around the Avalonia DataGrid issue, this PR could be slightly simplified.


https://github.com/user-attachments/assets/cb5eb440-09d8-44e9-8bc0-c28b3bb1a632


