### PR TITLE
Waveform: add "Set video position when moving start/end" (SE 4 parity)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2403,6 +2403,7 @@
       "waveformParagraphBackgroundColor": "Waveform subtitle background color",
       "waveformParagraphSelectedBackgroundColor": "Waveform selected subtitle background color",
       "waveformAllowOverlap": "Allow overlap (when moving/resizing)",
+      "waveformSetVideoPositionOnMoveStartEnd": "Set video position when moving start/end",
       "saveAsBehaviorUseSubtitleVideoFilename": "Use subtitle/video file name",
       "saveAsBehaviorUseVideoSubtitleFilename": "Use video/subtitle file name",
       "saveAsBehaviorUseVideoFileName": "Use video file name",

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1231,6 +1231,23 @@ public class AudioVisualizer : Control
                 break;
         }
 
+        // SE 4 parity: scrub the video to the edge being dragged so the user sees the
+        // exact frame at the new start/end while resizing (whole-paragraph moves are excluded).
+        if (Se.Settings.Waveform.SetVideoPositionOnMoveStartEnd && OnVideoPositionChanged != null && _activeParagraph != null)
+        {
+            switch (_interactionMode)
+            {
+                case InteractionMode.ResizingLeft:
+                case InteractionMode.ResizeLeftAnd:
+                    OnVideoPositionChanged.Invoke(this, new PositionEventArgs { PositionInSeconds = _activeParagraph.StartTime.TotalSeconds });
+                    break;
+                case InteractionMode.ResizingRight:
+                case InteractionMode.ResizeRightAnd:
+                    OnVideoPositionChanged.Invoke(this, new PositionEventArgs { PositionInSeconds = _activeParagraph.EndTime.TotalSeconds });
+                    break;
+            }
+        }
+
         InvalidateVisual();
     }
 

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -480,6 +480,7 @@ public class SettingsPage : UserControl
 
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformRightClickSelectsSubtitle, nameof(_vm.WaveformRightClickSelectsSubtitle)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformAllowOverlap, nameof(_vm.WaveformAllowOverlap)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.WaveformSetVideoPositionOnMoveStartEnd, nameof(_vm.WaveformSetVideoPositionOnMoveStartEnd)),
             new SettingsItem(Se.Language.Options.Settings.WaveformSnapToShotChanges, () =>
                 UiUtil.MakeHorizontalPanel(
                     new CheckBox

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -253,6 +253,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _waveformSnapToFrames;
     [ObservableProperty] private bool _waveformShotChangesAutoGenerate;
     [ObservableProperty] private bool _waveformAllowOverlap;
+    [ObservableProperty] private bool _waveformSetVideoPositionOnMoveStartEnd;
 
     [ObservableProperty] private ObservableCollection<string> _waveformSingleClickActionTypes;
     [ObservableProperty] private string _selectedWaveformSingleClickActionType;
@@ -796,6 +797,7 @@ public partial class SettingsViewModel : ObservableObject
         WaveformSnapToFrames = Se.Settings.Waveform.SnapToFrames;
         WaveformShotChangesAutoGenerate = Se.Settings.Waveform.ShotChangesAutoGenerate;
         WaveformAllowOverlap = Se.Settings.Waveform.AllowOverlap;
+        WaveformSetVideoPositionOnMoveStartEnd = Se.Settings.Waveform.SetVideoPositionOnMoveStartEnd;
 
         SelectedWaveformSingleClickActionType = MapWaveformSingleClickToTranslation(Se.Settings.Waveform.SingleClickAction);
         SelectedWaveformDoubleClickActionType = MapWaveformDoubleClickToTranslation(Se.Settings.Waveform.DoubleClickAction);
@@ -1425,6 +1427,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Waveform.SnapToFrames = WaveformSnapToFrames;
         Se.Settings.Waveform.ShotChangesAutoGenerate = WaveformShotChangesAutoGenerate;
         Se.Settings.Waveform.AllowOverlap = WaveformAllowOverlap;
+        Se.Settings.Waveform.SetVideoPositionOnMoveStartEnd = WaveformSetVideoPositionOnMoveStartEnd;
 
         Se.Settings.Waveform.SingleClickAction = MapWaveformSingleClickFromTranslation(SelectedWaveformSingleClickActionType);
         Se.Settings.Waveform.DoubleClickAction = MapWaveformDoubleClickFromTranslation(SelectedWaveformDoubleClickActionType);

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -258,6 +258,7 @@ public class LanguageSettings
     public string WaveformParagraphBackgroundColor { get; set; }
     public string WaveformParagraphSelectedBackgroundColor { get; set; }
     public string WaveformAllowOverlap { get; set; }
+    public string WaveformSetVideoPositionOnMoveStartEnd { get; set; }
     public string SaveAsBehaviorUseSubtitleVideoFilename { get; set; }
     public string SaveAsBehaviorUseVideoSubtitleFilename { get; set; }
     public string SaveAsBehaviorUseVideoFileName { get; set; }
@@ -555,6 +556,7 @@ public class LanguageSettings
         WaveformParagraphBackgroundColor = "Waveform subtitle background color";
         WaveformParagraphSelectedBackgroundColor = "Waveform selected subtitle background color";
         WaveformAllowOverlap = "Allow overlap (when moving/resizing)";
+        WaveformSetVideoPositionOnMoveStartEnd = "Set video position when moving start/end";
         SaveAsBehaviorUseSubtitleVideoFilename = "Use subtitle/video file name";
         SaveAsBehaviorUseVideoSubtitleFilename = "Use video/subtitle file name";
         SaveAsBehaviorUseVideoFileName = "Use video file name";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -49,6 +49,7 @@ public class SeWaveform
     public string LastDisplayMode { get; set; }
     public bool RightClickSelectsSubtitle { get; set; }
     public bool AllowOverlap { get; set; }
+    public bool SetVideoPositionOnMoveStartEnd { get; set; }
     public string SingleClickAction { get; set; }
     public string DoubleClickAction { get; set; }
     public bool WaveformUnwrapText { get; set; }


### PR DESCRIPTION
## Summary

Ports the SE 4 waveform option **"Set video position when moving start/end"** to the Avalonia rewrite. When enabled, dragging a subtitle's start or end edge in the waveform scrubs the video to that edge, so you see the exact frame as you adjust the cue. Whole-paragraph moves are intentionally excluded, matching SE 4 which only triggered on start/end resize.

Defaults to **off** (matching SE 4's actual constructor default).

## Changes

- **`SeWaveform.cs`** — new `SetVideoPositionOnMoveStartEnd` setting.
- **`AudioVisualizer.cs`** — after the resize switch in the pointer-move handler, fires the existing `OnVideoPositionChanged` event with the new start (`ResizingLeft`/`ResizeLeftAnd`) or end (`ResizingRight`/`ResizeRightAnd`) when the setting is on. Reuses `MainViewModel.AudioVisualizerOnVideoPositionChanged`, which already clamps and applies the position.
- **`SettingsViewModel.cs`** — observable property plus load/save next to `WaveformAllowOverlap`.
- **`SettingsPage.cs`** — checkbox in the Waveform settings section, right after "Allow overlap".
- **`LanguageSettings.cs`** + **`English.json`** — label "Set video position when moving start/end" (same wording as SE 4). Other languages fall back to English until translated.

## Notes

SE 4 set the position to the raw mouse `e.Seconds`; this uses the paragraph's clamped/frame-snapped start/end after the drag resolves, which lands on where the cue actually ends up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
