### PR TITLE
Fix Merge two subtitles: keep ASSA styles and split tracks by layer

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4132,9 +4132,12 @@ public partial class MainViewModel :
         }
 
         ResetSubtitle();
-        SetSubtitles(result.ResultSubtitle);
+        // Set the format before building the rows so SubtitleLineViewModel copies the ASSA style (Extra) into Style
         SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == result.ResultFormat.Name) ??
                           SubtitleFormats[0]);
+        SetSubtitles(result.ResultSubtitle);
+        // Carry over the header so the merged styles (Style1/Style2) are kept
+        _subtitle.Header = result.ResultSubtitle.Header;
         SelectAndScrollToRow(0);
     }
 

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesViewModel.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesViewModel.cs
@@ -411,13 +411,14 @@ public partial class MergeTwoSubtitlesViewModel : ObservableObject
         var result = new Subtitle { Header = header };
         foreach (var p in sub1.Paragraphs)
         {
-            var copy = new Paragraph(p) { Extra = "Style1" };
+            // Different layer per track so the two streams don't collide/stack against each other when shown at the same time
+            var copy = new Paragraph(p) { Extra = "Style1", Layer = 0 };
             result.Paragraphs.Add(copy);
         }
 
         foreach (var p in sub2.Paragraphs)
         {
-            var copy = new Paragraph(p) { Extra = "Style2" };
+            var copy = new Paragraph(p) { Extra = "Style2", Layer = 1 };
             result.Paragraphs.Add(copy);
         }
 


### PR DESCRIPTION
@
## Problem

When using **Tools → Merge two subtitles** with the **Advanced SubStation Alpha** output, the merged result lost its styling after being loaded into the main grid: only a single style appeared and **no paragraph carried a style**, so top/bottom positioning could not work.

## Root cause

In `MainViewModel.ShowToolsMergeTwoSubtitles`:

1. **Styles dropped from paragraphs** — the ASSA format was selected *after* `SetSubtitles` built the row view models. `SubtitleLineViewModel` only copies the style (`Extra`) into its `Style` property when the active format is `AdvancedSubStationAlpha`, so the rows ended up with an empty `Style` and `ToParagraph` wrote no style on save.
2. **Header dropped** — the merged header (containing `Style1`/`Style2`) was never transferred to `_subtitle`, so only the default header style survived. The other merge tools already do `_subtitle.Header = result.ResultSubtitle.Header`; this one did not.

The merge logic itself (`MergeTwoSubtitlesViewModel.BuildAssaMerge`) was verified to produce correct output (two styles with `an8`/`an2` alignment, events referencing the right style) — the loss happened only on consumption.

## Fix

- Select the output format **before** building the rows, so the style is copied into each row.
- Carry the merged header over to `_subtitle`.
- Put each merged track on its **own layer** (`0` and `1`) so the two streams do not collide/stack against each other when shown at the same time. Vertical placement still comes from the per-style alignment (`an8` top / `an2` bottom).

## Testing

- Verified the libse serialization produces both styles with correct alignment and per-event layers.
- UI project builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@