### PR TITLE
Remove merge-continuation-lines prompt after speech to text

### DIFF
--- a/src/ui/Assets/Languages/Italian.json
+++ b/src/ui/Assets/Languages/Italian.json
@@ -2419,7 +2419,6 @@
       "MultipleReplaceShowDotDotDotButtons": "Sostituzione multipla: visualizza pulsanti menu contestuale",
       "GridFocusTextboxAfterInsertNew": "Griglia: attiva la casella di testo dopo aver inserito un nuovo sottotitolo",
       "TextToSpeechPromptMergeContinuationLines": "Sintesi vocale: richiedi di unire le righe di continuazione",
-      "SpeechToTextPromptMergeContinuationLines": "Lettura testo: richiedi di unire le righe di continuazione",
       "UseFocusedButtonBackgroundColor": "Usa colore di sfondo pulsante evidenziato",
       "FocusedButtonBackgroundColor": "Colore di sfondo pulsante in evidenza",
       "ForceCrLfOnSave": "Forza CR+LF al salvataggio (file sottotitoli testo)",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4950,50 +4950,6 @@ public partial class MainViewModel :
         }
     }
 
-    private async Task<Subtitle> PromptMergeContinuationLinesAsync(Subtitle subtitle)
-    {
-        if (Window == null || subtitle.Paragraphs.Count < 2)
-        {
-            return subtitle;
-        }
-
-        var language = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle);
-        if (MergeContinuationLinesHelper.IsLanguageSkipped(language))
-        {
-            return subtitle;
-        }
-
-        var format = subtitle.OriginalFormat ?? SelectedSubtitleFormat ?? new SubRip();
-        var viewModels = subtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, format)).ToList();
-
-        const int maxGapMs = 500;
-        const int maxCharacters = 500;
-        var candidates = MergeContinuationLinesHelper.Detect(viewModels, language, maxGapMs, maxCharacters);
-        if (candidates.Count == 0)
-        {
-            return subtitle;
-        }
-
-        var result = await _windowService
-            .ShowDialogAsync<MergeContinuationLinesWindow, MergeContinuationLinesViewModel>(
-                Window!, vm => vm.Initialize(viewModels, language, maxGapMs, maxCharacters));
-
-        if (!result.OkPressed || result.AllSubtitlesFixed.Count == subtitle.Paragraphs.Count)
-        {
-            return subtitle;
-        }
-
-        // Clone via copy constructor to preserve Header/Footer/OriginalEncoding, then replace
-        // Paragraphs with the merged set.
-        var merged = new Subtitle(subtitle);
-        merged.Paragraphs.Clear();
-        foreach (var line in result.AllSubtitlesFixed)
-        {
-            merged.Paragraphs.Add(line.ToParagraph(subtitle.OriginalFormat));
-        }
-        return merged;
-    }
-
     [RelayCommand]
     private void SnapAllTimesToFrames()
     {
@@ -5465,11 +5421,6 @@ public partial class MainViewModel :
             ResetSubtitle();
 
             _subtitle = result.TranscribedSubtitle;
-
-            if (Se.Settings.Tools.SpeechToTextPromptMergeContinuationLines)
-            {
-                _subtitle = await PromptMergeContinuationLinesAsync(_subtitle);
-            }
 
             if (SelectedSubtitleFormat is AdvancedSubStationAlpha)
             {

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -595,7 +595,6 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.MultipleReplaceShowDotDotDotButtons, nameof(_vm.MultipleReplaceShowDotDotDotButtons)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptMergeContinuationLines, nameof(_vm.TextToSpeechPromptMergeContinuationLines)),
-            MakeCheckboxSetting(Se.Language.Options.Settings.SpeechToTextPromptMergeContinuationLines, nameof(_vm.SpeechToTextPromptMergeContinuationLines)),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.Appearance,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -154,7 +154,6 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _multipleReplaceShowDotDotDotButtons;
     [ObservableProperty] private bool _gridFocusTextboxAfterInsertNew;
     [ObservableProperty] private bool _textToSpeechPromptMergeContinuationLines;
-    [ObservableProperty] private bool _speechToTextPromptMergeContinuationLines;
     [ObservableProperty] private bool _openAiCompatibleSttAutoTranscribeOnAudioSelection;
 
     [ObservableProperty] private ObservableCollection<string> _spellCheckEngines;
@@ -663,7 +662,6 @@ public partial class SettingsViewModel : ObservableObject
         MultipleReplaceShowDotDotDotButtons = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
         GridFocusTextboxAfterInsertNew = Se.Settings.Tools.GridFocusTextboxAfterInsertNew;
         TextToSpeechPromptMergeContinuationLines = Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines;
-        SpeechToTextPromptMergeContinuationLines = Se.Settings.Tools.SpeechToTextPromptMergeContinuationLines;
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 
         SelectedTheme = MapThemeToTranslation(appearance.Theme);
@@ -1302,7 +1300,6 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons = MultipleReplaceShowDotDotDotButtons;
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;
         Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines = TextToSpeechPromptMergeContinuationLines;
-        Se.Settings.Tools.SpeechToTextPromptMergeContinuationLines = SpeechToTextPromptMergeContinuationLines;
         Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
         Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -274,7 +274,6 @@ public class LanguageSettings
     public string MultipleReplaceShowDotDotDotButtons { get; set; }
     public string GridFocusTextboxAfterInsertNew { get; set; }
     public string TextToSpeechPromptMergeContinuationLines { get; set; }
-    public string SpeechToTextPromptMergeContinuationLines { get; set; }
     public string UseFocusedButtonBackgroundColor { get; set; }
     public string FocusedButtonBackgroundColor { get; set; }
     public string ForceCrLfOnSave { get; set; }
@@ -571,7 +570,6 @@ public class LanguageSettings
         MultipleReplaceShowDotDotDotButtons = "Multiple replace: show context menu buttons";
         GridFocusTextboxAfterInsertNew = "Grid: focus text box after insert new subtitle";
         TextToSpeechPromptMergeContinuationLines = "Text to speech: prompt to merge continuation lines";
-        SpeechToTextPromptMergeContinuationLines = "Speech to text: prompt to merge continuation lines";
         UseFocusedButtonBackgroundColor = "Use focused button background color";
         FocusedButtonBackgroundColor = "Focused button background color";
         ForceCrLfOnSave = "Force CR+LF on save (text subtitle files)";

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -105,7 +105,6 @@ public class SeTools
     public bool MultipleReplaceShowDotDotDotButtons { get; set; }
     public bool GridFocusTextboxAfterInsertNew { get; set; }
     public bool TextToSpeechPromptMergeContinuationLines { get; set; }
-    public bool SpeechToTextPromptMergeContinuationLines { get; set; }
 
     // OpenAI Compatible STT settings
     public string OpenAiCompatibleSttUrl { get; set; } = "http://localhost:8000/v1/audio/transcriptions";
@@ -196,7 +195,6 @@ public class SeTools
         AllowSingleLetterShortcutsInTextbox = false;
         WriteToolsLog = true;
         TextToSpeechPromptMergeContinuationLines = true;
-        SpeechToTextPromptMergeContinuationLines = true;
 
         LastColorPickerColor = Colors.Yellow.FromColorToHex();
         LastColorPickerColor1 = Colors.Red.FromColorToHex();


### PR DESCRIPTION
@
## Change

After transcribing with **speech to text**, Subtitle Edit prompted to merge continuation lines. This removes that automatic prompt so transcription results are shown as-is. **Merge continuation lines** remains available on demand from the Tools menu.

## What was removed

- The call in `ShowSpeechToTextWhisper` (`MainViewModel`).
- The now-unused `PromptMergeContinuationLinesAsync` helper.
- The `SpeechToTextPromptMergeContinuationLines` setting (declaration + default) and its load/save in settings.
- The settings-page checkbox.
- The related language strings (English defaults + orphaned Italian translation key).

The separate **text-to-speech** prompt (`TextToSpeechPromptMergeContinuationLines`) is intentionally left untouched.

## Testing

- No remaining references to the removed symbols.
- UI project builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@