### PR TITLE
Fix GitHub product capitalization in About labels

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3085,10 +3085,10 @@
     "licenseText": "Subtitle Edit is free software under the MIT license.",
     "descriptionTextBeta": "Subtitle Edit 5 is a release candidate for our upcoming major release.\nWe are putting the finishing touches on the new tools and appreciate your help in testing.\nPlease share your feedback to help us ensure the best possible final version.\n\nThank you for being part of the Subtitle Edit community! :)",
     "issueTrackingAndSourceCode": "Issue tracking and source code: ",
-    "gitHub": "Github",
+    "gitHub": "GitHub",
     "donate": "Donate: ",
     "payPal": "PayPal",
-    "gitHubSponsor": "Github sponsor",
+    "gitHubSponsor": "GitHub sponsor",
     "or": " or "
   }
 }

--- a/src/ui/Assets/Languages/French.json
+++ b/src/ui/Assets/Languages/French.json
@@ -2048,10 +2048,10 @@
     "LicenseText": "Subtitle Edit est un logiciel libre sous licence MIT.",
     "DescriptionTextBeta": "Subtitle Edit 5 est une version candidate de notre prochaine version majeure.\nNous mettons la dernière main aux nouveaux outils et apprécions votre aide pour les tests.\nN'hésitez pas à partager vos commentaires pour nous aider à garantir la meilleure version finale possible.\n\nMerci de faire partie de la communauté Subtitle Edit ! :)",
     "IssueTrackingAndSourceCode": "Suivi des problèmes et code source : ",
-    "GitHub": "Github",
+    "GitHub": "GitHub",
     "Donate": "Faire un don : ",
     "PayPal": "PayPal",
-    "GitHubSponsor": "Sponsor Github",
+    "GitHubSponsor": "Sponsor GitHub",
     "Or": " ou "
   }
 }

--- a/src/ui/Logic/Config/Language/LanguageAbout.cs
+++ b/src/ui/Logic/Config/Language/LanguageAbout.cs
@@ -21,10 +21,10 @@ public class LanguageAbout
         LicenseText = "Subtitle Edit is free software under the MIT license.";
         DescriptionTextBeta = "Subtitle Edit 5 is a release candidate for our upcoming major release.\nWe are putting the finishing touches on the new tools and appreciate your help in testing.\nPlease share your feedback to help us ensure the best possible final version.\n\nThank you for being part of the Subtitle Edit community! :)";
         IssueTrackingAndSourceCode = "Issue tracking and source code: ";
-        GitHub = "Github";
+        GitHub = "GitHub";
         Donate = "Donate: ";
         PayPal = "PayPal";
-        GitHubSponsor = "Github sponsor";
+        GitHubSponsor = "GitHub sponsor";
         Or = " or ";
     }
 }


### PR DESCRIPTION
Follow-up to #11263 addressing Copilot's review comments.

Copilot flagged the GitHub product capitalization ("Github" → "GitHub") in the French About section added in #11263. Applied the fix to:

- `src/ui/Assets/Languages/French.json` — `GitHub` link label and sponsor label
- `src/ui/Assets/Languages/English.json` — canonical `gitHub` / `gitHubSponsor` values
- `src/ui/Logic/Config/Language/LanguageAbout.cs` — C# default `GitHub` / `GitHubSponsor`

The canonical English + C# defaults were updated too so French isn't left as an outlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)