### PR TITLE
Preserve grid position when closing Fix Common Errors and Fix Netflix Errors dialogs

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4505,19 +4505,13 @@ public partial class MainViewModel :
             return;
         }
 
+        var idx = SelectedSubtitleIndex ?? 0;
         var result =
             await ShowDialogAsync<ChangeFormattingWindow, ChangeFormattingViewModel>(vm => { vm.Initialize(Subtitles.ToList(), SelectedSubtitleFormat); });
 
-        if (!result.OkPressed)
-        {
-            return;
-        }
-
-        var idx = SelectedSubtitleIndex ?? 0;
         if (result.OkPressed)
         {
-            SetSubtitles(result.FixedSubtitle);
-            SelectAndScrollToRow(idx);
+            ApplyFixedSubtitle(result.FixedSubtitle, idx);
         }
     }
 
@@ -4552,19 +4546,13 @@ public partial class MainViewModel :
             return;
         }
 
+        var idx = SelectedSubtitleIndex ?? 0;
         var result =
             await ShowDialogAsync<ConvertActorsWindow, ConvertActorsViewModel>(vm => { vm.Initialize(Subtitles.ToList(), SelectedSubtitleFormat); });
 
-        if (!result.OkPressed)
-        {
-            return;
-        }
-
-        var idx = SelectedSubtitleIndex ?? 0;
         if (result.OkPressed)
         {
-            SetSubtitles(result.FixedSubtitle);
-            SelectAndScrollToRow(idx);
+            ApplyFixedSubtitle(result.FixedSubtitle, idx);
         }
     }
 
@@ -4831,12 +4819,12 @@ public partial class MainViewModel :
             return;
         }
 
+        var idx = SelectedSubtitleIndex ?? 0;
         var viewModel = await ShowDialogAsync<FixCommonErrorsWindow, FixCommonErrorsViewModel>(vm => { vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat); });
 
         if (viewModel.OkPressed)
         {
-            SetSubtitles(viewModel.FixedSubtitle);
-            SelectAndScrollToRow(0);
+            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx);
             ShowStatus(string.Format(Se.Language.Main.FixedXLines, viewModel.FixedSubtitle.Paragraphs.Count));
         }
     }
@@ -4855,12 +4843,12 @@ public partial class MainViewModel :
             return;
         }
 
+        var idx = SelectedSubtitleIndex ?? 0;
         var viewModel = await ShowDialogAsync<FixNetflixErrorsWindow, FixNetflixErrorsViewModel>(vm => { vm.Initialize(GetUpdateSubtitle(), _videoFileName ?? string.Empty); });
 
         if (viewModel.OkPressed)
         {
-            SetSubtitles(viewModel.FixedSubtitle);
-            SelectAndScrollToRow(0);
+            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx);
             ShowStatus(string.Format(Se.Language.Main.FixedXLines, viewModel.FixedSubtitle.Paragraphs.Count));
         }
     }
@@ -12457,6 +12445,56 @@ public partial class MainViewModel :
                 BindingFlags.NonPublic | BindingFlags.Instance);
             processVerticalScroll?.Invoke(SubtitleGrid, new object[] { ScrollEventType.EndScroll });
         }, DispatcherPriority.Loaded);
+    }
+
+    /// <summary>
+    /// Applies the fixed subtitle returned by Fix Common Errors / Fix Netflix Errors.
+    /// When the paragraph count is unchanged (the common case), updates each
+    /// SubtitleLineViewModel in-place so the grid keeps its current scroll position
+    /// and selection without any manipulation.
+    /// Falls back to a full SetSubtitles reset only when rows were added or removed.
+    /// </summary>
+    /// <summary>
+    /// Applies the fixed subtitle returned by Fix Common Errors / Fix Netflix Errors.
+    /// When the paragraph count is unchanged (the common case), updates each
+    /// SubtitleLineViewModel in-place so the grid keeps its current scroll position
+    /// and selection without any manipulation.
+    /// Falls back to a full SetSubtitles reset only when rows were added or removed.
+    /// </summary>
+    private void ApplyFixedSubtitle(Subtitle fixedSubtitle, int selectedIndex)
+    {
+        if (fixedSubtitle.Paragraphs.Count == Subtitles.Count)
+        {
+            for (var i = 0; i < Subtitles.Count; i++)
+                Subtitles[i].UpdateFrom(fixedSubtitle.Paragraphs[i]);
+            Renumber();
+            UpdateGaps();
+        }
+        else
+        {
+            SetSubtitles(fixedSubtitle);
+            SelectAndScrollToRow(selectedIndex);
+        }
+    }
+
+    /// <summary>
+    /// Overload for dialogs (ChangeFormatting, ConvertActors) that return a
+    /// pre-built List&lt;SubtitleLineViewModel&gt; rather than a raw Subtitle.
+    /// </summary>
+    private void ApplyFixedSubtitle(List<SubtitleLineViewModel> fixedSubtitles, int selectedIndex)
+    {
+        if (fixedSubtitles.Count == Subtitles.Count)
+        {
+            for (var i = 0; i < Subtitles.Count; i++)
+                Subtitles[i].UpdateFrom(fixedSubtitles[i]);
+            Renumber();
+            UpdateGaps();
+        }
+        else
+        {
+            SetSubtitles(fixedSubtitles);
+            SelectAndScrollToRow(selectedIndex);
+        }
     }
 
     public void SelectAndScrollToSubtitle(SubtitleLineViewModel subtitle)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4824,7 +4824,7 @@ public partial class MainViewModel :
 
         if (viewModel.OkPressed)
         {
-            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx);
+            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx, SelectedSubtitleFormat);
             ShowStatus(string.Format(Se.Language.Main.FixedXLines, viewModel.FixedSubtitle.Paragraphs.Count));
         }
     }
@@ -4848,7 +4848,7 @@ public partial class MainViewModel :
 
         if (viewModel.OkPressed)
         {
-            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx);
+            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx, SelectedSubtitleFormat);
             ShowStatus(string.Format(Se.Language.Main.FixedXLines, viewModel.FixedSubtitle.Paragraphs.Count));
         }
     }
@@ -12454,26 +12454,19 @@ public partial class MainViewModel :
     /// and selection without any manipulation.
     /// Falls back to a full SetSubtitles reset only when rows were added or removed.
     /// </summary>
-    /// <summary>
-    /// Applies the fixed subtitle returned by Fix Common Errors / Fix Netflix Errors.
-    /// When the paragraph count is unchanged (the common case), updates each
-    /// SubtitleLineViewModel in-place so the grid keeps its current scroll position
-    /// and selection without any manipulation.
-    /// Falls back to a full SetSubtitles reset only when rows were added or removed.
-    /// </summary>
-    private void ApplyFixedSubtitle(Subtitle fixedSubtitle, int selectedIndex)
+    private void ApplyFixedSubtitle(Subtitle fixedSubtitle, int selectedIndex, SubtitleFormat? subtitleFormat)
     {
         if (fixedSubtitle.Paragraphs.Count == Subtitles.Count)
         {
             for (var i = 0; i < Subtitles.Count; i++)
-                Subtitles[i].UpdateFrom(fixedSubtitle.Paragraphs[i]);
+                Subtitles[i].UpdateFrom(fixedSubtitle.Paragraphs[i], subtitleFormat);
             Renumber();
             UpdateGaps();
         }
         else
         {
             SetSubtitles(fixedSubtitle);
-            SelectAndScrollToRow(selectedIndex);
+            SelectAndScrollToRow(Math.Min(selectedIndex, Subtitles.Count - 1));
         }
     }
 
@@ -12493,7 +12486,7 @@ public partial class MainViewModel :
         else
         {
             SetSubtitles(fixedSubtitles);
-            SelectAndScrollToRow(selectedIndex);
+            SelectAndScrollToRow(Math.Min(selectedIndex, Subtitles.Count - 1));
         }
     }
 

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -492,6 +492,39 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(Text));
     }
 
+    /// <summary>Updates all display properties from a fixed <see cref="Paragraph"/> in-place.</summary>
+    internal void UpdateFrom(Paragraph p)
+    {
+        Paragraph = p;
+        Text = p.Text;
+        Actor = p.Actor;
+        Style = p.Style;
+        Layer = p.Layer;
+        Extra = p.Extra;
+        _skipUpdate = true;
+        StartTime = TimeSpan.FromMilliseconds(p.StartTime.TotalMilliseconds);
+        EndTime = TimeSpan.FromMilliseconds(p.EndTime.TotalMilliseconds);
+        _skipUpdate = false;
+        UpdateDuration();
+    }
+
+    /// <summary>Updates all display properties from another <see cref="SubtitleLineViewModel"/> in-place.</summary>
+    internal void UpdateFrom(SubtitleLineViewModel src)
+    {
+        if (src.Paragraph != null)
+            Paragraph = src.Paragraph;
+        Text = src.Text;
+        Actor = src.Actor;
+        Style = src.Style;
+        Layer = src.Layer;
+        Extra = src.Extra;
+        _skipUpdate = true;
+        StartTime = src.StartTime;
+        EndTime = src.EndTime;
+        _skipUpdate = false;
+        UpdateDuration();
+    }
+
     internal void SetStartTimeOnly(TimeSpan timeSpan)
     {
         _skipUpdate = true;

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -493,7 +493,7 @@ public partial class SubtitleLineViewModel : ObservableObject
     }
 
     /// <summary>Updates all display properties from a fixed <see cref="Paragraph"/> in-place.</summary>
-    internal void UpdateFrom(Paragraph p)
+    internal void UpdateFrom(Paragraph p, SubtitleFormat? subtitleFormat)
     {
         Paragraph = p;
         Text = p.Text;
@@ -501,6 +501,10 @@ public partial class SubtitleLineViewModel : ObservableObject
         Style = p.Style;
         Layer = p.Layer;
         Extra = p.Extra;
+        if (subtitleFormat is AdvancedSubStationAlpha)
+        {
+            Style = p.Extra;
+        }
         _skipUpdate = true;
         StartTime = TimeSpan.FromMilliseconds(p.StartTime.TotalMilliseconds);
         EndTime = TimeSpan.FromMilliseconds(p.EndTime.TotalMilliseconds);


### PR DESCRIPTION
Both dialogs were unconditionally calling `SelectAndScrollToRow(0)` after applying fixes, which scrolled the subtitle grid back to the top regardless of where the user was working.
  
This PR captures the selected row index before opening each dialog and restores it afterward, matching the existing pattern used by the Change Formatting and Convert Actors dialogs.