### PR TITLE
Visual layout tweaks: toolbar, dialogs, data grids, and Convert Actors two-column layout

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -965,7 +965,7 @@ public static partial class InitListViewAndEditBox
         // Left panel for time controls
         var timeControlsPanel = new StackPanel
         {
-            Spacing = 0,
+            Spacing = 6,
             Margin = new Thickness(0, 0, 0, 0),
             VerticalAlignment = VerticalAlignment.Top,
         };

--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -374,9 +374,9 @@ public static class InitToolbar
         {
             Orientation = Orientation.Horizontal,
             Spacing = 1,
-            Margin = new Thickness(2, 2, 8, 2),
+            Margin = new Thickness(2, 6, 8, 6),
             HorizontalAlignment = HorizontalAlignment.Right,
-            VerticalAlignment = VerticalAlignment.Top,
+            VerticalAlignment = VerticalAlignment.Center,
         };
 
         // subtitle formats

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -50,9 +50,48 @@ public class ConvertActorsWindow : Window
 
         var checkBoxOnlyNames = UiUtil.MakeCheckBox(Se.Language.Tools.ConvertActors.OnlyNames, vm, nameof(vm.OnlyNames));
 
-        var panelRow1 = UiUtil.MakeHorizontalPanel(labelFrom, comboBoxFrom, labelTo, comboBoxTo);
-        var panelRow2 = UiUtil.MakeHorizontalPanel(checkBoxSetColor, colorPicker, checkBoxChangeCasing, comboBoxCasing, checkBoxOnlyNames);
-        var panelControls = UiUtil.MakeVerticalPanel(panelRow1, panelRow2);
+        var panelConversion = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = GridLength.Auto },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+            },
+            ColumnSpacing = 5,
+            RowSpacing = 5,
+        };
+        panelConversion.Add(labelFrom, 0, 0);
+        panelConversion.Add(comboBoxFrom, 0, 1);
+        panelConversion.Add(labelTo, 1, 0);
+        panelConversion.Add(comboBoxTo, 1, 1);
+
+        var panelOptions = UiUtil.MakeVerticalPanel(
+            UiUtil.MakeHorizontalPanel(checkBoxSetColor, colorPicker),
+            UiUtil.MakeHorizontalPanel(checkBoxChangeCasing, comboBoxCasing),
+            checkBoxOnlyNames);
+
+        var panelControls = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 24,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        panelControls.Add(panelConversion, 0, 0);
+        panelControls.Add(panelOptions, 0, 1);
 
         var subtitleView = MakeSubtitleView(vm);
 

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -150,6 +150,7 @@ public class FixCommonErrorsWindow : Window
 
         var buttonApplyFixes = UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.ApplyFixesAndClose, vm.OkCommand)
             .BindIsVisible(vm, nameof(vm.Step2IsVisible));
+        buttonApplyFixes.IsDefault = true;
 
         var buttonPanelRight = UiUtil.MakeButtonBar(
             buttonBackToFixList,
@@ -328,13 +329,37 @@ public class FixCommonErrorsWindow : Window
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
         dataGridFixes.SelectionChanged += DataGridFixes_SelectionChanged;
 
-        var buttonBarFixes = UiUtil.MakeButtonBar(
-            UiUtil.MakeButton(Se.Language.General.SelectAll, _vm.FixesSelectAllCommand),
-            UiUtil.MakeButton(Se.Language.General.InvertSelection, _vm.FixesInverseSelectedCommand),
-            UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.RefreshFixes, _vm.DoRefreshFixesCommand),
-            UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.ApplySelectedFixes, _vm.DoApplyFixesCommand)
-        );
-        buttonBarFixes.WithMarginTop(2);
+        var leftButtons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 0,
+        };
+        leftButtons.Children.Add(UiUtil.MakeButton(Se.Language.General.SelectAll, _vm.FixesSelectAllCommand));
+        leftButtons.Children.Add(UiUtil.MakeButton(Se.Language.General.InvertSelection, _vm.FixesInverseSelectedCommand));
+
+        var rightButtons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 0,
+        };
+        rightButtons.Children.Add(UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.RefreshFixes, _vm.DoRefreshFixesCommand));
+        rightButtons.Children.Add(UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.ApplySelectedFixes, _vm.DoApplyFixesCommand));
+
+        var buttonBarFixes = new Grid
+        {
+            Margin = new Thickness(10, 10, 10, 10),
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+        };
+        buttonBarFixes.Add(leftButtons, 0, 0);
+        buttonBarFixes.Add(rightButtons, 0, 1);
 
         gridFixes.Children.Add(dataGridFixes);
         Grid.SetRow(dataGridFixes, 0);
@@ -414,6 +439,7 @@ public class FixCommonErrorsWindow : Window
                     Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
                     IsReadOnly = true,
                     CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
                 },
             },
         };

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -5,6 +5,9 @@
     <Style Selector="DataGridCell:current /template/ Rectangle#CurrencyVisual">
         <Setter Property="IsVisible" Value="False"/>
     </Style>
+    <Style Selector="DataGridColumnHeader:pointerover /template/ Grid#PART_ColumnHeaderRoot">
+        <Setter Property="Background" Value="Transparent"/>
+    </Style>
     <Style Selector="DataGridRow:not(:selected):pointerover /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="Transparent"/>
     </Style>


### PR DESCRIPTION
## Changes
  
  ### Convert Actors dialog – two-column layout (similar to SE 4)
  Replace the two flat horizontal rows with a side-by-side grid: From/To dropdowns in a two-column inner grid on the left (so labels and dropdowns align vertically), options (Set color, Change casing, Only names) stacked on the right with each checkbox directly adjacent to its sub-control.
  
<img width="993" height="238" alt="Screenshot 2026-05-29 at 9 40 13 PM" src="https://github.com/user-attachments/assets/5a2dda57-2f2d-4a1c-97fe-72c5efd2ec31" />

  ### Fix Common Errors dialog – Button grouping (similar to SE 4)
  Split the fixes button bar into left/right groups and set Apply as the default button. Make the Text column star-width so it fills available space.

<img width="1167" height="430" alt="Screenshot 2026-05-29 at 9 38 21 PM" src="https://github.com/user-attachments/assets/176ff549-5aba-47b0-9843-2772d0f33b1c" />

  ### Toolbar & main edit panel – Breathing room for the format dropdown & time control spacing
  Center the format dropdown vertically and add vertical margin. Add spacing between time control rows in the main edit panel.
  
<img width="287" height="104" alt="Screenshot 2026-05-29 at 9 33 53 PM" src="https://github.com/user-attachments/assets/40561697-d43a-435d-a393-58b4a176227b" />

<img width="318" height="134" alt="Screenshot 2026-05-29 at 9 34 50 PM" src="https://github.com/user-attachments/assets/47f50e99-b088-4e64-942c-a284be28e20f" />

  ### DataGrid – Column header gray hover removal
  Suppress column header hover highlight via Styles.axaml.

<img width="744" height="172" alt="Screenshot 2026-05-29 at 9 36 32 PM" src="https://github.com/user-attachments/assets/97068652-e37b-4f2b-b600-d2fa3e35d84d" />
