### PR TITLE
Fix Merge Continuation Lines on mixed-script (CJK+Latin) files (#11267)

### DIFF
--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelper.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelper.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
 using Nikse.SubtitleEdit.Features.Main;
 using System;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ public static class MergeContinuationLinesHelper
         int maxTotalLength)
     {
         var result = new List<MergeContinuationLinesCandidate>();
-        if (subtitles == null || subtitles.Count < 2 || IsLanguageSkipped(language))
+        if (subtitles == null || subtitles.Count < 2)
         {
             return result;
         }
@@ -41,6 +42,16 @@ public static class MergeContinuationLinesHelper
             var nextP = next.ToParagraph();
 
             if (!Utilities.QualifiesForMerge(p, nextP, maxGapMs, maxTotalLength, onlyContinuationLines: true))
+            {
+                continue;
+            }
+
+            // Detect CJK per line rather than skipping the whole file by its overall
+            // detected language (issue #11267): a file can mix scripts (e.g. a few
+            // Japanese lines over an English body). In CJK the absence of sentence-final
+            // punctuation makes QualifiesForMerge treat almost every line as a
+            // continuation, so skip only those lines that actually end in CJK.
+            if (EndsWithCjk(current.Text))
             {
                 continue;
             }
@@ -102,6 +113,19 @@ public static class MergeContinuationLinesHelper
         }
 
         return result;
+    }
+
+    // Mirrors the CJK check inside Utilities.QualifiesForMerge: sanitize tags/whitespace
+    // the same way and test the last visible character.
+    private static bool EndsWithCjk(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var sanitized = HtmlUtil.RemoveHtmlTags(text!.Trim(), true);
+        return sanitized.Length > 0 && CalcCjk.IsCjk(sanitized[sanitized.Length - 1]);
     }
 
     private static bool StartsWithDashSpeaker(string? text)

--- a/tests/UI/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelperTests.cs
+++ b/tests/UI/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelperTests.cs
@@ -1,0 +1,72 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
+using System.Collections.Generic;
+
+namespace UITests.Features.Tools.MergeContinuationLines;
+
+public class MergeContinuationLinesHelperTests
+{
+    private static SubtitleLineViewModel MakeSubtitle(string text, double startSec, double endSec) =>
+        new()
+        {
+            Text = text,
+            StartTime = TimeSpan.FromSeconds(startSec),
+            EndTime = TimeSpan.FromSeconds(endSec),
+        };
+
+    [Fact]
+    public void Detect_EnglishContinuationLines_FindsCandidates()
+    {
+        var subtitles = new List<SubtitleLineViewModel>
+        {
+            MakeSubtitle("an", 1.00, 1.10),
+            MakeSubtitle("illusion,", 1.12, 1.30),
+            MakeSubtitle("an", 1.32, 1.40),
+            MakeSubtitle("echo", 1.42, 1.60),
+        };
+
+        var candidates = MergeContinuationLinesHelper.Detect(subtitles, "en", maxGapMs: 500, maxTotalLength: 200);
+
+        Assert.NotEmpty(candidates);
+    }
+
+    [Fact]
+    public void Detect_MixedScriptFileDetectedAsJapanese_StillMergesEnglishBody()
+    {
+        // Regression for issue #11267: a few Japanese lines at the top make the
+        // whole-file language detection return "ja", which previously suppressed
+        // the entire feature ("No continuation candidates found"). CJK must be
+        // skipped per line so the English continuation lines still merge.
+        var subtitles = new List<SubtitleLineViewModel>
+        {
+            MakeSubtitle("はよう", 0.62, 0.70),
+            MakeSubtitle("はな", 0.81, 0.98),
+            MakeSubtitle("an", 1.02, 1.13),
+            MakeSubtitle("illusion,", 1.16, 1.74),
+            MakeSubtitle("an", 1.80, 1.90),
+            MakeSubtitle("echo", 1.92, 2.10),
+        };
+
+        var candidates = MergeContinuationLinesHelper.Detect(subtitles, "ja", maxGapMs: 500, maxTotalLength: 200);
+
+        Assert.NotEmpty(candidates);
+        // None of the produced candidates should start from a CJK (Japanese) line.
+        Assert.DoesNotContain(candidates, c => c.Text1.Contains("はよう") || c.Text1.Contains("はな"));
+    }
+
+    [Fact]
+    public void Detect_CjkLines_AreSkipped()
+    {
+        // Pure CJK continuation lines remain noise-free: ending in a CJK character
+        // is not treated as an English-style "unfinished sentence".
+        var subtitles = new List<SubtitleLineViewModel>
+        {
+            MakeSubtitle("はよう", 0.62, 0.70),
+            MakeSubtitle("はな", 0.81, 0.98),
+        };
+
+        var candidates = MergeContinuationLinesHelper.Detect(subtitles, "ja", maxGapMs: 500, maxTotalLength: 200);
+
+        Assert.Empty(candidates);
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #11267 — **Merge Continuation Lines** returns "No continuation candidates found" and merges nothing on certain files. This is a regression from 4.0.x.

The cause: `MergeContinuationLinesHelper.Detect` skips the **entire file** when the whole-file auto-detected language is CJK (`zh/ja/th/lo/my/km/ko/bo`). The reported file opens with a handful of Japanese lines over an otherwise English body, so `AutoDetectGoogleLanguage` returns `ja` and the whole feature bails out — none of the English continuation lines merge.

## Fix

Detect CJK **per line** instead of per file. The guard now runs on each candidate's current line, mirroring the exact CJK check already inside `Utilities.QualifiesForMerge` (`CalcCjk.IsCjk` on the last visible character). This keeps CJK lines noise-free (a CJK ending isn't an English-style unfinished sentence) while letting the non-CJK body merge normally.

- Pure-CJK files behave exactly as before (every pair is skipped → no candidates).
- Mixed-script files now merge their non-CJK continuation lines.

`IsLanguageSkipped` is retained (still used by the Text-to-Speech merge prompt).

## Tests

Added `MergeContinuationLinesHelperTests` (3 cases, all passing):
- English continuation lines produce candidates.
- Mixed file detected as `ja` still merges the English body, and no candidate starts from a Japanese line.
- Pure-CJK lines produce no candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
