### PR TITLE
Read word-level timestamps from OpenAI-compatible STT (Grok) (#11239)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiCompatibleModels.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiCompatibleModels.cs
@@ -11,6 +11,15 @@ public class OpenAiCompatibleSttResponse
     [JsonPropertyName("segments")]
     public List<OpenAiCompatibleSegment>? Segments { get; set; }
 
+    /// <summary>
+    /// Top-level word timings. Some OpenAI-compatible providers (e.g. xAI Grok
+    /// at /v1/stt) return only this array — with per-word start/end and no
+    /// <see cref="Segments"/> — so the timings must be grouped into segments
+    /// instead of being dropped (discussion #11239).
+    /// </summary>
+    [JsonPropertyName("words")]
+    public List<OpenAiCompatibleWord>? Words { get; set; }
+
     [JsonPropertyName("language")]
     public string? Language { get; set; }
 
@@ -53,6 +62,13 @@ public class OpenAiCompatibleWord
     [JsonPropertyName("word")]
     public string Word { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Word text under the "text" key. OpenAI's verbose_json uses "word"; xAI
+    /// Grok uses "text". Whichever the provider sends, the other stays empty.
+    /// </summary>
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = string.Empty;
+
     [JsonPropertyName("start")]
     public double Start { get; set; }
 
@@ -61,4 +77,10 @@ public class OpenAiCompatibleWord
 
     [JsonPropertyName("probability")]
     public double Probability { get; set; }
+
+    /// <summary>
+    /// The word text regardless of which key the provider used ("word" or "text").
+    /// </summary>
+    [JsonIgnore]
+    public string EffectiveText => !string.IsNullOrEmpty(Word) ? Word : Text;
 }

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -368,6 +368,16 @@ public class OpenAiSttService
             var result = JsonSerializer.Deserialize<OpenAiCompatibleSttResponse>(jsonResponse, options);
             if (result != null)
             {
+                // Providers that return only top-level word timings and no
+                // segments (e.g. xAI Grok at /v1/stt, discussion #11239) would
+                // otherwise collapse to a single timestamp-less block. Group the
+                // words into segments so the timings survive.
+                if ((result.Segments == null || result.Segments.Count == 0) &&
+                    result.Words != null && result.Words.Count > 0)
+                {
+                    result.Segments = BuildSegmentsFromWords(result.Words);
+                }
+
                 return result;
             }
         }
@@ -390,6 +400,72 @@ public class OpenAiSttService
                 }
             }
         };
+    }
+
+    /// <summary>
+    /// Group word-level timings into subtitle-sized segments. Used when a
+    /// provider returns only a top-level <c>words</c> array and no
+    /// <c>segments</c> (e.g. xAI Grok at /v1/stt). Starts a new segment on a
+    /// gap larger than 0.5 s or once the line would exceed ~80 characters,
+    /// mirroring the word-grouping used for the Qwen3 ASR engine.
+    /// </summary>
+    internal static List<OpenAiCompatibleSegment> BuildSegmentsFromWords(List<OpenAiCompatibleWord> words)
+    {
+        var segments = new List<OpenAiCompatibleSegment>();
+        var currentText = new StringBuilder();
+        var startTime = 0.0;
+        var endTime = 0.0;
+        var first = true;
+        var id = 0;
+
+        foreach (var word in words)
+        {
+            var text = word.EffectiveText;
+            if (string.IsNullOrEmpty(text))
+            {
+                continue;
+            }
+
+            if (first)
+            {
+                startTime = word.Start;
+                first = false;
+            }
+
+            if (currentText.Length > 0 && (word.Start - endTime > 0.5 || currentText.Length + text.Length > 80))
+            {
+                segments.Add(new OpenAiCompatibleSegment
+                {
+                    Id = id++,
+                    Start = startTime,
+                    End = endTime,
+                    Text = currentText.ToString().Trim(),
+                });
+                currentText.Clear();
+                startTime = word.Start;
+            }
+
+            if (currentText.Length > 0)
+            {
+                currentText.Append(' ');
+            }
+
+            currentText.Append(text);
+            endTime = word.End;
+        }
+
+        if (currentText.Length > 0)
+        {
+            segments.Add(new OpenAiCompatibleSegment
+            {
+                Id = id,
+                Start = startTime,
+                End = endTime,
+                Text = currentText.ToString().Trim(),
+            });
+        }
+
+        return segments;
     }
 
     /// <summary>

--- a/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
@@ -80,6 +80,90 @@ public class OpenAiSttServiceTests
     }
 
     [Fact]
+    public async Task TranscribeAsync_TopLevelWords_GroupsIntoSegmentsWithTimeCodes()
+    {
+        // Discussion #11239: xAI Grok (/v1/stt) returns only a top-level "words"
+        // array (with "text"/start/end) and no "segments". Those timings must be
+        // grouped into segments instead of collapsing to one timestamp-less block.
+        const string json = """
+            {
+              "text": "The balance is fine. Thanks a lot.",
+              "language": "English",
+              "duration": 3.45,
+              "words": [
+                { "text": "The", "start": 0.24, "end": 0.48 },
+                { "text": "balance", "start": 0.48, "end": 0.96 },
+                { "text": "is", "start": 0.96, "end": 1.12 },
+                { "text": "fine.", "start": 1.12, "end": 1.60 },
+                { "text": "Thanks", "start": 2.40, "end": 2.80 },
+                { "text": "a", "start": 2.80, "end": 2.90 },
+                { "text": "lot.", "start": 2.90, "end": 3.20 }
+              ]
+            }
+            """;
+
+        using var handler = new StubHandler((req, ct) => Task.FromResult(JsonResponse(json)));
+        using var client = new HttpClient(handler);
+        var service = new OpenAiSttService(client, MakeSettings());
+
+        var ct = TestContext.Current.CancellationToken;
+        var wav = MakeTinyWav();
+        try
+        {
+            var response = await service.TranscribeAsync(wav, cancellationToken: ct);
+
+            Assert.NotNull(response.Segments);
+            // A >0.5 s gap between "fine." (ends 1.60) and "Thanks" (starts 2.40)
+            // splits the words into two segments.
+            Assert.Equal(2, response.Segments!.Count);
+            Assert.Equal("The balance is fine.", response.Segments[0].Text);
+            Assert.Equal(0.24, response.Segments[0].Start);
+            Assert.Equal(1.60, response.Segments[0].End);
+            Assert.Equal("Thanks a lot.", response.Segments[1].Text);
+            Assert.Equal(2.40, response.Segments[1].Start);
+            Assert.Equal(3.20, response.Segments[1].End);
+        }
+        finally
+        {
+            File.Delete(wav);
+        }
+    }
+
+    [Fact]
+    public void BuildSegmentsFromWords_SplitsOnLongLineLength()
+    {
+        // With no large gaps, grouping must still break once a line would exceed
+        // ~80 characters so we don't emit one giant subtitle line.
+        var words = new List<OpenAiCompatibleWord>();
+        for (var i = 0; i < 30; i++)
+        {
+            words.Add(new OpenAiCompatibleWord { Text = "word", Start = i * 0.2, End = i * 0.2 + 0.1 });
+        }
+
+        var segments = OpenAiSttService.BuildSegmentsFromWords(words);
+
+        Assert.True(segments.Count > 1, "Expected long word run to split into multiple segments.");
+        Assert.All(segments, s => Assert.True(s.Text.Length <= 80, $"Segment too long: '{s.Text}'"));
+    }
+
+    [Fact]
+    public void BuildSegmentsFromWords_PrefersWordKeyWhenBothPresent()
+    {
+        // OpenAI verbose_json uses "word"; Grok uses "text". EffectiveText must
+        // resolve either, preferring the OpenAI "word" key when set.
+        var words = new List<OpenAiCompatibleWord>
+        {
+            new() { Word = "Hello", Start = 0.0, End = 0.5 },
+            new() { Text = "world", Start = 0.5, End = 1.0 },
+        };
+
+        var segments = OpenAiSttService.BuildSegmentsFromWords(words);
+
+        Assert.Single(segments);
+        Assert.Equal("Hello world", segments[0].Text);
+    }
+
+    [Fact]
     public async Task TranscribeAsync_PlainTextBody_FallsBackToSingleSegment()
     {
         // Body that JsonSerializer cannot deserialize into OpenAiCompatibleSttResponse


### PR DESCRIPTION
## Problem

Re: discussion #11239 — the **Generic OpenAI-compatible STT** engine works against xAI **Grok** (`https://api.x.ai/v1/stt`), but the transcript comes back "merged into one big chunk without any timestamps," even though Grok returns word-level timings.

**Root cause:** Grok's response shape differs from OpenAI Whisper's `verbose_json`:

```json
{
  "text": "The balance is $167,983.15.",
  "language": "English",
  "duration": 3.45,
  "words": [
    { "text": "The", "start": 0.24, "end": 0.48 },
    { "text": "balance", "start": 0.48, "end": 0.96 }
  ]
}
```

It returns a **top-level `words`** array (and word text under `"text"`), with **no `segments`**. `OpenAiCompatibleSttResponse` only modeled `segments` (and `words` *nested inside* segments), so the timings were dropped — `Segments` came back `null`, and `IngestTranscriptionResponse` fell through to the "no segment timings — span the whole slice" branch, yielding one timestamp-less block.

## Fix

- Add a top-level `Words` property to `OpenAiCompatibleSttResponse`.
- Add a `"text"` key to `OpenAiCompatibleWord` (Grok uses `text`, OpenAI uses `word`) with an `EffectiveText` accessor.
- In `ParseJsonResponse`, when a response has `words` but no `segments`, group the words into subtitle-sized segments — splitting on a >0.5 s gap or ~80-char line — mirroring the existing Qwen3 ASR word grouping. The OpenAI/Whisper path (which already returns `segments`) is unchanged.

## Tests

Added to `OpenAiSttServiceTests` (all 31 in the file pass):
- Grok-style top-level `words` → grouped into segments with correct time codes (gap split verified).
- Long word run still splits on the ~80-char line limit.
- `EffectiveText` resolves both `word` and `text` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
