### PR TITLE
Add format & sample-rate settings for waveform Extract audio (#11235, #11237)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3004,8 +3004,13 @@ public partial class MainViewModel :
         }
 
         var line = selectedItems[0];
-        var suggestedName = $"{Path.GetFileNameWithoutExtension(_videoFileName)}_{line.Number}.wav";
-        var outputFileName = await _fileHelper.PickSaveFile(Window, ".wav", suggestedName, Se.Language.Waveform.ExtractAudioDotDotDot);
+
+        // Offer the configured format first in the Save dialog, then the rest; the
+        // user can still switch the type there (issues #11235 / #11237).
+        var configuredFormat = NormalizeExtractAudioFormat(Se.Settings.Waveform.ExtractAudioFormat);
+        var fileTypes = ExtractAudioFileTypes(configuredFormat);
+        var suggestedName = $"{Path.GetFileNameWithoutExtension(_videoFileName)}_{line.Number}.{configuredFormat}";
+        var outputFileName = await _fileHelper.PickSaveFile(Window, fileTypes, suggestedName, Se.Language.Waveform.ExtractAudioDotDotDot);
         if (string.IsNullOrEmpty(outputFileName))
         {
             return;
@@ -3013,13 +3018,22 @@ public partial class MainViewModel :
 
         try
         {
+            // The actual output format is whatever extension the file ended up with
+            // (the user may have changed the type in the dialog). ffmpeg picks the
+            // codec from the extension; bitrate only applies to lossy formats.
+            var chosenFormat = NormalizeExtractAudioFormat(Path.GetExtension(outputFileName).TrimStart('.'));
+            var sampleRate = Se.Settings.Waveform.ExtractAudioSampleRate;
+            var bitRate = IsLossyAudioFormat(chosenFormat) ? Se.Settings.Waveform.ExtractAudioBitRate : string.Empty;
+
             var arguments = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
                 _videoFileName,
                 line.StartTime.TotalSeconds,
                 line.Duration.TotalSeconds,
                 false,
                 outputFileName,
-                _audioTrack?.FfIndex ?? -1);
+                _audioTrack?.FfIndex ?? -1,
+                sampleRate,
+                bitRate);
 
             using var process = FfmpegGenerator.GetProcess(arguments, (_, _) => { });
             process.Start();
@@ -3047,6 +3061,35 @@ public partial class MainViewModel :
         {
             await MessageBox.Show(Window, Se.Language.General.Error, exception.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
+    }
+
+    // Output formats offered by the waveform "Extract audio..." action. Order here is the
+    // fallback order; the user's configured format is always moved to the front.
+    private static readonly string[] ExtractAudioFormats = { "wav", "mp3", "m4a", "flac" };
+
+    private static string NormalizeExtractAudioFormat(string? format)
+    {
+        var f = format?.Trim().ToLowerInvariant();
+        return !string.IsNullOrEmpty(f) && ExtractAudioFormats.Contains(f) ? f! : "wav";
+    }
+
+    private static bool IsLossyAudioFormat(string format) => format is "mp3" or "m4a";
+
+    private static IReadOnlyList<(string Name, string Extension)> ExtractAudioFileTypes(string preferredFormat)
+    {
+        string DisplayName(string f) => f switch
+        {
+            "wav" => "WAV",
+            "mp3" => "MP3",
+            "m4a" => "M4A (AAC)",
+            "flac" => "FLAC",
+            _ => f.ToUpperInvariant(),
+        };
+
+        // Preferred format first so it's the dialog's default selection.
+        var ordered = new List<string> { preferredFormat };
+        ordered.AddRange(ExtractAudioFormats.Where(f => f != preferredFormat));
+        return ordered.Select(f => (DisplayName(f), "." + f)).ToList();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -478,6 +478,13 @@ public class SettingsPage : UserControl
                 }
             }),
 
+            new SettingsItem(Se.Language.Options.Settings.WaveformExtractAudioFormat,
+                () => UiUtil.MakeComboBox(_vm.WaveformExtractAudioFormats, _vm, nameof(_vm.SelectedWaveformExtractAudioFormat))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformExtractAudioSampleRate,
+                () => UiUtil.MakeComboBox(_vm.WaveformExtractAudioSampleRates, _vm, nameof(_vm.SelectedWaveformExtractAudioSampleRate))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformExtractAudioBitRate,
+                () => UiUtil.MakeComboBox(_vm.WaveformExtractAudioBitRates, _vm, nameof(_vm.SelectedWaveformExtractAudioBitRate))),
+
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformRightClickSelectsSubtitle, nameof(_vm.WaveformRightClickSelectsSubtitle)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformAllowOverlap, nameof(_vm.WaveformAllowOverlap)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformSetVideoPositionOnMoveStartEnd, nameof(_vm.WaveformSetVideoPositionOnMoveStartEnd)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -433,7 +433,8 @@ public partial class SettingsViewModel : ObservableObject
         ];
         SelectedWaveformDoubleClickActionType = WaveformDoubleClickActionTypes[0];
 
-        WaveformExtractAudioFormats = new ObservableCollection<string>(ExtractAudioFormatLabels.Values);
+        WaveformExtractAudioFormats = new ObservableCollection<string>(
+            ExtractAudioFormatOrder.Select(ExtractAudioFormatToLabel));
         SelectedWaveformExtractAudioFormat = WaveformExtractAudioFormats[0];
         WaveformExtractAudioSampleRates = new ObservableCollection<string>
         {
@@ -904,6 +905,10 @@ public partial class SettingsViewModel : ObservableObject
     }
 
     // Display label <-> stored extension for the waveform "Extract audio" format.
+    // ExtractAudioFormatOrder fixes the dropdown order (and thus the default at index 0);
+    // a Dictionary's enumeration order is not contractually guaranteed.
+    private static readonly string[] ExtractAudioFormatOrder = { "wav", "mp3", "m4a", "flac" };
+
     private static readonly Dictionary<string, string> ExtractAudioFormatLabels = new()
     {
         { "wav", "WAV" },

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -260,6 +260,13 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _waveformDoubleClickActionTypes;
     [ObservableProperty] private string _selectedWaveformDoubleClickActionType;
 
+    [ObservableProperty] private ObservableCollection<string> _waveformExtractAudioFormats;
+    [ObservableProperty] private string _selectedWaveformExtractAudioFormat;
+    [ObservableProperty] private ObservableCollection<string> _waveformExtractAudioSampleRates;
+    [ObservableProperty] private string _selectedWaveformExtractAudioSampleRate;
+    [ObservableProperty] private ObservableCollection<string> _waveformExtractAudioBitRates;
+    [ObservableProperty] private string _selectedWaveformExtractAudioBitRate;
+
     [ObservableProperty] private bool _waveformRightClickSelectsSubtitle;
     [ObservableProperty] private ObservableCollection<string> _themes;
     [ObservableProperty] private string _selectedTheme;
@@ -425,6 +432,20 @@ public partial class SettingsViewModel : ObservableObject
             Se.Language.General.Play,
         ];
         SelectedWaveformDoubleClickActionType = WaveformDoubleClickActionTypes[0];
+
+        WaveformExtractAudioFormats = new ObservableCollection<string>(ExtractAudioFormatLabels.Values);
+        SelectedWaveformExtractAudioFormat = WaveformExtractAudioFormats[0];
+        WaveformExtractAudioSampleRates = new ObservableCollection<string>
+        {
+            Se.Language.Options.Settings.WaveformExtractAudioSampleRateOriginal,
+            "48000",
+            "44100",
+            "32000",
+            "16000",
+        };
+        SelectedWaveformExtractAudioSampleRate = WaveformExtractAudioSampleRates[0];
+        WaveformExtractAudioBitRates = new ObservableCollection<string> { "96k", "128k", "192k", "256k", "320k" };
+        SelectedWaveformExtractAudioBitRate = "192k";
 
         var subtitleFormats = SubtitleFormat.AllSubtitleFormats;
         var defaultSubtitleFormats = new List<string>();
@@ -800,6 +821,14 @@ public partial class SettingsViewModel : ObservableObject
         SelectedWaveformSingleClickActionType = MapWaveformSingleClickToTranslation(Se.Settings.Waveform.SingleClickAction);
         SelectedWaveformDoubleClickActionType = MapWaveformDoubleClickToTranslation(Se.Settings.Waveform.DoubleClickAction);
 
+        SelectedWaveformExtractAudioFormat = ExtractAudioFormatToLabel(Se.Settings.Waveform.ExtractAudioFormat);
+        SelectedWaveformExtractAudioSampleRate = Se.Settings.Waveform.ExtractAudioSampleRate <= 0
+            ? WaveformExtractAudioSampleRates[0]
+            : Se.Settings.Waveform.ExtractAudioSampleRate.ToString(CultureInfo.InvariantCulture);
+        SelectedWaveformExtractAudioBitRate = string.IsNullOrEmpty(Se.Settings.Waveform.ExtractAudioBitRate)
+            ? "192k"
+            : Se.Settings.Waveform.ExtractAudioBitRate;
+
         WaveformRightClickSelectsSubtitle = Se.Settings.Waveform.RightClickSelectsSubtitle;
 
         ColorDurationTooLong = general.ColorDurationTooLong;
@@ -872,6 +901,35 @@ public partial class SettingsViewModel : ObservableObject
         return Se.Settings.Waveform.ToolbarItems
             .First(p => p.Type == type)
             .IsVisible;
+    }
+
+    // Display label <-> stored extension for the waveform "Extract audio" format.
+    private static readonly Dictionary<string, string> ExtractAudioFormatLabels = new()
+    {
+        { "wav", "WAV" },
+        { "mp3", "MP3" },
+        { "m4a", "M4A (AAC)" },
+        { "flac", "FLAC" },
+    };
+
+    private string ExtractAudioFormatToLabel(string format)
+    {
+        return ExtractAudioFormatLabels.TryGetValue(format.Trim().ToLowerInvariant(), out var label)
+            ? label
+            : ExtractAudioFormatLabels["wav"];
+    }
+
+    private string ExtractAudioLabelToFormat(string label)
+    {
+        foreach (var kvp in ExtractAudioFormatLabels)
+        {
+            if (kvp.Value == label)
+            {
+                return kvp.Key;
+            }
+        }
+
+        return "wav";
     }
 
     private static readonly Dictionary<string, string> _waveformSingleClickActionToTextMap = BuildWaveformSingleClickActionToTextMap();
@@ -1428,6 +1486,13 @@ public partial class SettingsViewModel : ObservableObject
 
         Se.Settings.Waveform.SingleClickAction = MapWaveformSingleClickFromTranslation(SelectedWaveformSingleClickActionType);
         Se.Settings.Waveform.DoubleClickAction = MapWaveformDoubleClickFromTranslation(SelectedWaveformDoubleClickActionType);
+
+        Se.Settings.Waveform.ExtractAudioFormat = ExtractAudioLabelToFormat(SelectedWaveformExtractAudioFormat);
+        Se.Settings.Waveform.ExtractAudioSampleRate =
+            int.TryParse(SelectedWaveformExtractAudioSampleRate, NumberStyles.Integer, CultureInfo.InvariantCulture, out var extractRate)
+                ? extractRate
+                : 0; // "Original" (non-numeric) keeps the source sample rate
+        Se.Settings.Waveform.ExtractAudioBitRate = SelectedWaveformExtractAudioBitRate;
 
         Se.Settings.Waveform.RightClickSelectsSubtitle = WaveformRightClickSelectsSubtitle;
 

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -239,6 +239,10 @@ public class LanguageSettings
     public string WaveformRightClickSelectsSubtitle { get; set; }
     public string WaveformPauseOnSingleClick { get; set; }
     public string WaveformDrawStyle { get; set; }
+    public string WaveformExtractAudioFormat { get; set; }
+    public string WaveformExtractAudioSampleRate { get; set; }
+    public string WaveformExtractAudioSampleRateOriginal { get; set; }
+    public string WaveformExtractAudioBitRate { get; set; }
     public string VlcWidRendering { get; set; }
     public string SubtitleGridEnterKeyAction { get; set; }
     public string SubtitleSingleClickAction { get; set; }
@@ -537,6 +541,10 @@ public class LanguageSettings
         WaveformRightClickSelectsSubtitle = "Select subtitle on right click";
         WaveformPauseOnSingleClick = "Pause on single click";
         WaveformDrawStyle = "Waveform draw style";
+        WaveformExtractAudioFormat = "Extract audio format";
+        WaveformExtractAudioSampleRate = "Extract audio sample rate";
+        WaveformExtractAudioSampleRateOriginal = "Original (keep source)";
+        WaveformExtractAudioBitRate = "Extract audio bitrate (MP3/M4A)";
         SubtitleGridEnterKeyAction = "Subtitle grid Enter-key action";
         SubtitleSingleClickAction = "Subtitle grid single-click action";
         SubtitleDoubleClickAction = "Subtitle grid double-click action";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -55,6 +55,16 @@ public class SeWaveform
     public bool WaveformUnwrapText { get; set; }
     public int WaveformMinimumSampleRate { get; set; }
 
+    // Defaults for the waveform "Extract audio..." context-menu action. The STT
+    // audio-clip path stays at 16 kHz mono regardless of these; these only apply
+    // to the user-initiated extract (issues #11235 / #11237).
+    // ExtractAudioFormat: container/extension without the dot ("wav", "mp3", "m4a", "flac").
+    // ExtractAudioSampleRate: 0 = keep the source sample rate; otherwise e.g. 48000.
+    // ExtractAudioBitRate: bitrate for lossy formats (mp3/m4a), e.g. "192k"; ignored for wav/flac.
+    public string ExtractAudioFormat { get; set; }
+    public int ExtractAudioSampleRate { get; set; }
+    public string ExtractAudioBitRate { get; set; }
+
     // SE 4 parity: small footer at the bottom-left of each paragraph rectangle showing
     // the subtitle number, duration, and characters-per-second. Defaults on so SE 5
     // matches the SE 4 out-of-box look; users can hide them via Settings.json.
@@ -104,6 +114,10 @@ public class SeWaveform
         SeekSilenceMinDurationSeconds = 0.3;
         SeekSilenceMaxVolume = 0.1;
         WaveformMinimumSampleRate = 126;
+
+        ExtractAudioFormat = "wav";
+        ExtractAudioSampleRate = 0; // keep source sample rate
+        ExtractAudioBitRate = "192k";
 
         WaveformShowNumberAndDuration = true;
         WaveformShowCps = true;

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -1144,13 +1144,27 @@ public class FfmpegGenerator
         return arguments.Trim();
     }
 
+    /// <summary>
+    /// Build ffmpeg parameters for extracting an audio clip from a video/audio file.
+    /// The output codec is inferred from <paramref name="outputFileName"/>'s extension
+    /// (wav→pcm, mp3→libmp3lame, m4a→aac, flac→flac).
+    /// </summary>
+    /// <param name="sampleRate">Output sample rate in Hz, or 0 to keep the source rate (no -ar).</param>
+    /// <param name="audioBitRate">Bitrate for lossy outputs (e.g. "192k"); empty to omit -b:a.</param>
+    /// <remarks>
+    /// The defaults (16 kHz, 32k) reproduce the historical command used for the
+    /// speech-to-text audio clips; only the user-initiated waveform "Extract audio..."
+    /// passes different values (issues #11235 / #11237).
+    /// </remarks>
     internal static string ExtractAudioClipFromVideoParameters(
        string videoFileName,
        double startSeconds,
        double durationSeconds,
        bool useCenterChannelOnly,
        string outputFileName,
-       int audioTrackFfIndex = -1)
+       int audioTrackFfIndex = -1,
+       int sampleRate = 16000,
+       string audioBitRate = "32k")
     {
         var start = $"{startSeconds:0.000}".Replace(",", ".");
         var duration = $"{durationSeconds:0.000}".Replace(",", ".");
@@ -1164,7 +1178,19 @@ public class FfmpegGenerator
             args += $" -map 0:{audioTrackFfIndex}";
         }
 
-        args += " -vn -ar 16000 -b:a 32k";
+        args += " -vn";
+
+        // sampleRate <= 0 means "keep the source sample rate" — omit -ar entirely.
+        if (sampleRate > 0)
+        {
+            args += $" -ar {sampleRate}";
+        }
+
+        // -b:a only matters for lossy encoders; it's harmlessly ignored by pcm/flac.
+        if (!string.IsNullOrEmpty(audioBitRate))
+        {
+            args += $" -b:a {audioBitRate}";
+        }
 
         // Optional center-channel only
         if (useCenterChannelOnly)

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -1146,8 +1146,8 @@ public class FfmpegGenerator
 
     /// <summary>
     /// Build ffmpeg parameters for extracting an audio clip from a video/audio file.
-    /// The output codec is inferred from <paramref name="outputFileName"/>'s extension
-    /// (wav→pcm, mp3→libmp3lame, m4a→aac, flac→flac).
+    /// No <c>-c:a</c> is set, so ffmpeg picks the default encoder for the output
+    /// extension (typically pcm for .wav, libmp3lame for .mp3, aac for .m4a, flac for .flac).
     /// </summary>
     /// <param name="sampleRate">Output sample rate in Hz, or 0 to keep the source rate (no -ar).</param>
     /// <param name="audioBitRate">Bitrate for lossy outputs (e.g. "192k"); empty to omit -b:a.</param>

--- a/src/ui/Logic/Media/FileHelper.cs
+++ b/src/ui/Logic/Media/FileHelper.cs
@@ -413,19 +413,29 @@ namespace Nikse.SubtitleEdit.Logic.Media
             return string.Empty;
         }
 
-        public async Task<string> PickSaveFile(
+        public Task<string> PickSaveFile(
             Visual sender,
             string extension,
             string suggestedFileName,
             string title)
         {
+            return PickSaveFile(sender, new[] { (extension, extension) }, suggestedFileName, title);
+        }
+
+        public async Task<string> PickSaveFile(
+            Visual sender,
+            IReadOnlyList<(string Name, string Extension)> fileTypes,
+            string suggestedFileName,
+            string title)
+        {
             var topLevel = TopLevel.GetTopLevel(sender)!;
+            var defaultExtension = fileTypes.Count > 0 ? fileTypes[0].Extension : string.Empty;
             var options = new FilePickerSaveOptions
             {
                 Title = title,
                 SuggestedFileName = System.IO.Path.GetFileName(suggestedFileName),
-                FileTypeChoices = MakeSaveFilePickerFileTypes(extension, extension),
-                DefaultExtension = extension.TrimStart('.'),
+                FileTypeChoices = MakeSaveFilePickerFileTypes(fileTypes),
+                DefaultExtension = defaultExtension.TrimStart('.'),
             };
 
             var suggestedStartLocationPath = Path.GetDirectoryName(suggestedFileName);
@@ -452,6 +462,20 @@ namespace Nikse.SubtitleEdit.Logic.Media
             }
 
             return string.Empty;
+        }
+
+        private static List<FilePickerFileType> MakeSaveFilePickerFileTypes(IReadOnlyList<(string Name, string Extension)> fileTypes)
+        {
+            var result = new List<FilePickerFileType>();
+            foreach (var (name, extension) in fileTypes)
+            {
+                result.Add(new FilePickerFileType(name)
+                {
+                    Patterns = new List<string> { "*" + extension },
+                });
+            }
+
+            return result;
         }
 
         private static List<FilePickerFileType> MakeSaveFilePickerFileTypes(SubtitleFormat currentFormat)

--- a/src/ui/Logic/Media/IFileHelper.cs
+++ b/src/ui/Logic/Media/IFileHelper.cs
@@ -35,6 +35,18 @@ public interface IFileHelper
         string extension,
         string suggestedFileName,
         string title);
+
+    /// <summary>
+    /// Save-file picker that offers several file types. The first entry is the
+    /// default selection / default extension. Each tuple is (display name, extension
+    /// including the leading dot), e.g. ("WAV", ".wav").
+    /// </summary>
+    Task<string> PickSaveFile(
+        Visual sender,
+        IReadOnlyList<(string Name, string Extension)> fileTypes,
+        string suggestedFileName,
+        string title);
+
     Task<string> PickOpenVideoFile(Visual sender, string title);
     Task<string[]> PickOpenVideoFiles(Visual sender, string title);
     Task<string> PickOpenImageFile(Visual sender, string title);

--- a/tests/UI/Logic/Media/FfmpegGeneratorExtractAudioTests.cs
+++ b/tests/UI/Logic/Media/FfmpegGeneratorExtractAudioTests.cs
@@ -1,0 +1,56 @@
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic.Media;
+
+public class FfmpegGeneratorExtractAudioTests
+{
+    [Fact]
+    public void ExtractAudio_Defaults_ReproduceSttClipCommand()
+    {
+        // The STT audio-clip callers rely on the historical 16 kHz / 32k behavior;
+        // the defaults must keep producing exactly that so transcription is unaffected.
+        var args = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
+            "video.mp4", 1.0, 2.0, useCenterChannelOnly: false, "clip.wav");
+
+        Assert.Contains("-vn -ar 16000 -b:a 32k", args);
+        Assert.Contains("\"clip.wav\"", args);
+    }
+
+    [Fact]
+    public void ExtractAudio_SampleRateZero_OmitsArSoSourceRateIsKept()
+    {
+        // Issue #11235: passing 0 must NOT force a sample rate (no -ar), so ffmpeg
+        // keeps the source rate instead of downsampling to 16 kHz.
+        var args = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
+            "video.mp4", 0.0, 1.5, useCenterChannelOnly: false, "clip.wav",
+            audioTrackFfIndex: -1, sampleRate: 0, audioBitRate: "");
+
+        Assert.DoesNotContain("-ar", args);
+        Assert.DoesNotContain("-b:a", args);
+        Assert.Contains("-vn", args);
+    }
+
+    [Fact]
+    public void ExtractAudio_Mp3WithBitrate_KeepsSourceRateAndSetsBitrate()
+    {
+        // MP3 export at source sample rate with a chosen bitrate (issue #11237).
+        var args = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
+            "video.mp4", 0.0, 1.5, useCenterChannelOnly: false, "clip.mp3",
+            audioTrackFfIndex: -1, sampleRate: 0, audioBitRate: "192k");
+
+        Assert.DoesNotContain("-ar", args);
+        Assert.Contains("-b:a 192k", args);
+        Assert.Contains("\"clip.mp3\"", args);
+    }
+
+    [Fact]
+    public void ExtractAudio_ExplicitSampleRate_EmitsAr()
+    {
+        var args = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
+            "video.mp4", 0.0, 1.5, useCenterChannelOnly: false, "clip.flac",
+            audioTrackFfIndex: -1, sampleRate: 48000, audioBitRate: "");
+
+        Assert.Contains("-ar 48000", args);
+        Assert.DoesNotContain("-b:a", args);
+    }
+}


### PR DESCRIPTION
## Problem

The waveform right-click **"Extract audio…"** always produced **16 kHz mono WAV**, because it reused the ffmpeg helper tuned for speech-to-text clips — `ExtractAudioClipFromVideoParameters` hardcoded `-ar 16000 -b:a 32k`. That 16 kHz is correct for the STT/Whisper temp clips, but wrong for a clip the user extracts to keep:

- **#11235** — extraction from a 44.1 kHz source is silently downsampled to 16 kHz.
- **#11237** — no way to pick a smaller format like MP3.

## Fix

- **`ExtractAudioClipFromVideoParameters`** now takes `sampleRate` (0 = keep source, omit `-ar`) and `audioBitRate` (lossy only). The two STT callers keep the previous `16000` / `32k` via defaults, so transcription is byte-for-byte unchanged.
- **New Waveform settings** (Options ▸ Waveform): **Extract audio format** (WAV / MP3 / M4A (AAC) / FLAC), **sample rate** (Original / 48000 / 44100 / 32000 / 16000), and **bitrate** (MP3/M4A). Default is **WAV at the source sample rate** — so the default behavior now preserves quality instead of downsampling.
- **Save dialog** offers the four formats as file-type choices (the configured format first). The codec follows the chosen extension (`wav→pcm`, `mp3→libmp3lame`, `m4a→aac`, `flac→flac`); bitrate is applied only for lossy formats.

### Format choice

WAV / MP3 / M4A / FLAC is the standard set for a clip the user keeps (lossless + universal lossy). WebM/Opus — offered in the STT dialog — is intentionally **not** included here: that list is about what gets *uploaded* to the transcription API, whereas an extracted clip is opened in desktop players/editors where WebM/Opus is poorly supported.

## Tests

`FfmpegGeneratorExtractAudioTests` (4 cases, all passing):
- Defaults reproduce the exact STT clip command (`-vn -ar 16000 -b:a 32k`) — guards the STT path.
- `sampleRate: 0` omits `-ar` (keeps source rate) — the #11235 fix.
- MP3 with bitrate → `-b:a 192k`, no `-ar`.
- Explicit sample rate → `-ar 48000`.

Note: **#11237** also touched the Text-to-Speech export format, which is a separate code path with its own existing setting; this PR is scoped to the waveform extract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
