### PR TITLE
Fix "Adjust timings" always re-checked in STT post-processing

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2302,6 +2302,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         if (vm.OkPressed)
         {
+            DoAdjustTimings = vm.AdjustTimings;
             Se.Settings.Tools.AudioToText.WhisperAutoAdjustTimings = vm.AdjustTimings;
             Se.Settings.Tools.AudioToText.WhisperPostProcessingFixShortDuration = vm.FixShortDuration;
             Se.Settings.Tools.AudioToText.WhisperPostProcessingFixCasing = vm.FixCasing;


### PR DESCRIPTION
@
Fixes #11275

## Problem
In the Speech-to-text post-processing dialog, every option remembers its last state on reopen except **Adjust timings**, which is always checked.

## Root cause
The "Adjust timings" setting (`WhisperAutoAdjustTimings`) is mirrored by an in-memory property `DoAdjustTimings` on the main `SpeechToTextViewModel`:
- `LoadSettings()` loads it from the setting when the window opens.
- `SaveSettings()` writes it back to the setting on close.

Unlike the other post-processing options, `DoAdjustTimings` has **no checkbox on the main window** — the only place to toggle it is the post-processing dialog, which writes the setting *directly* and never updates `DoAdjustTimings`. So after the user unchecks it in the dialog, the main windows stale `DoAdjustTimings` (default `true`) overwrites the setting again on the next `SaveSettings()`, and the box reappears checked.

## Fix
When the post-processing dialog is accepted, also sync the in-memory mirror so it cant clobber the user choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@