### PR TITLE
Include LICENSE in release packages (#11278)

### DIFF
--- a/.github/workflows/build-seconv.yml
+++ b/.github/workflows/build-seconv.yml
@@ -93,6 +93,9 @@ jobs:
 
       - name: Create Windows ZIP packages
         run: |
+          # Stage the repo LICENSE so the SeConv zip carries the MIT terms too (issue #11278).
+          Copy-Item "./LICENSE" "./publish/windows-x64/LICENSE"
+          Copy-Item "./LICENSE" "./publish/windows-arm64/LICENSE"
           Compress-Archive -Path "./publish/windows-x64/*" -DestinationPath "./SeConv-Windows-x64.zip"
           Compress-Archive -Path "./publish/windows-arm64/*" -DestinationPath "./SeConv-Windows-ARM64.zip"
 
@@ -161,6 +164,9 @@ jobs:
 
       - name: Create macOS ZIP packages
         run: |
+          # Stage the repo LICENSE so the SeConv zip carries the MIT terms too (issue #11278).
+          cp ./LICENSE ./publish/macos-x64/LICENSE
+          cp ./LICENSE ./publish/macos-arm64/LICENSE
           cd ./publish/macos-x64 && zip -r ../../SeConv-macOS-x64.zip . && cd ../..
           cd ./publish/macos-arm64 && zip -r ../../SeConv-macOS-ARM64.zip . && cd ../..
 
@@ -237,6 +243,9 @@ jobs:
 
       - name: Create Linux TAR packages
         run: |
+          # Stage the repo LICENSE so the SeConv tarball carries the MIT terms too (issue #11278).
+          cp ./LICENSE ./publish/linux-x64/LICENSE
+          cp ./LICENSE ./publish/linux-arm64/LICENSE
           cd ./publish/linux-x64 && tar -czf ../../SeConv-Linux-x64.tar.gz . && cd ../..
           cd ./publish/linux-arm64 && tar -czf ../../SeConv-Linux-ARM64.tar.gz . && cd ../..
 

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -267,6 +267,10 @@ jobs:
 
       - name: Create Windows ZIP packages
         run: |
+          # Stage the repo LICENSE alongside the binaries so distributors and end users
+          # have the MIT terms readily available in the zip (issue #11278).
+          Copy-Item "./LICENSE" "./publish/windows-x64/LICENSE"
+          Copy-Item "./LICENSE" "./publish/windows-arm64/LICENSE"
           Compress-Archive -Path "./publish/windows-x64/*" -DestinationPath "./SubtitleEdit-Windows-x64.zip"
           Compress-Archive -Path "./publish/windows-arm64/*" -DestinationPath "./SubtitleEdit-Windows-ARM64.zip"
 
@@ -510,6 +514,9 @@ jobs:
           cp -R "$app" "$dmg_dir/Subtitle Edit.app"
           rm -rf "$app"
 
+          # Ship the project's own MIT terms next to the existing third-party bundle so
+          # the DMG carries both (issue #11278).
+          cp "./LICENSE" "$dmg_dir/LICENSE"
           cp "./installer/macBundle/THIRD_PARTY_LICENSES.txt" "$dmg_dir/THIRD_PARTY_LICENSES.txt"
 
           if [ "$SIGNING_AVAILABLE" != "true" ]; then
@@ -631,6 +638,10 @@ jobs:
 
       - name: Create Linux TAR packages
         run: |
+          # Stage the repo LICENSE alongside the binaries so the tarball carries the MIT
+          # terms — important for downstream Linux distributors (issue #11278).
+          cp ./LICENSE ./publish/linux-x64/LICENSE
+          cp ./LICENSE ./publish/linux-arm64/LICENSE
           cd ./publish/linux-x64 && tar -czf ../../SubtitleEdit-Linux-x64.tar.gz . && cd ../..
           cd ./publish/linux-arm64 && tar -czf ../../SubtitleEdit-Linux-ARM64.tar.gz . && cd ../..
 

--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -305,6 +305,9 @@ modules:
       # Icon (256x256 PNG from the source tree)
       - install -Dm644 src/ui/Assets/SE.png /app/share/icons/hicolor/256x256/apps/dk.nikse.subtitleedit.png
 
+      # MIT license — distribute the project's terms alongside the app (issue #11278).
+      - install -Dm644 LICENSE /app/share/licenses/dk.nikse.subtitleedit/LICENSE
+
     sources:
       # Full repo checkout (path relative to this manifest: installer/flatpak/ -> ../../)
       - type: dir


### PR DESCRIPTION
## Summary
Closes #11278 — the release tarballs, zips, and DMG currently ship only the binaries and required runtime/native libraries; the MIT `LICENSE` itself isn't included, which makes redistribution (especially on Linux) awkward.

This PR stages `LICENSE` alongside the binaries before each archive step.

| Package | Workflow | Step |
|---|---|---|
| Windows zip (UI) | `build-ui.yml` | `Copy-Item ./LICENSE ./publish/windows-*/` before `Compress-Archive` |
| Linux tarball (UI) | `build-ui.yml` | `cp ./LICENSE ./publish/linux-*/` before `tar -czf` |
| macOS DMG (UI) | `build-ui.yml` | `cp ./LICENSE "$dmg_dir/LICENSE"` next to the existing `THIRD_PARTY_LICENSES.txt` copy |
| Windows zip (SeConv) | `build-seconv.yml` | same as the UI Windows path |
| macOS zip (SeConv) | `build-seconv.yml` | `cp ./LICENSE ./publish/macos-*/` before `zip -r` |
| Linux tarball (SeConv) | `build-seconv.yml` | same as the UI Linux path |
| Flatpak | `installer/flatpak/dk.nikse.subtitleedit.yaml` | `install -Dm644 LICENSE /app/share/licenses/dk.nikse.subtitleedit/LICENSE` — standard Flatpak licenses directory |

The Windows **Inno Setup installer** already ships `LICENSE.rtf` via `Subtitle_Edit_Installer.iss` (`LicenseFile=..\LICENSE.rtf` + a `Source: ..\LICENSE.rtf … DestDir: {app}` line), so that path is unchanged.

Pure CI / packaging change — no source touched.

## Test plan
Verifies once these workflows next run:
- [ ] `SubtitleEdit-Windows-x64.zip` and `-ARM64.zip` contain a top-level `LICENSE`.
- [ ] `SubtitleEdit-Linux-x64.tar.gz` and `-ARM64.tar.gz` contain a top-level `LICENSE`.
- [ ] `SubtitleEdit-macOS-*.dmg` shows `LICENSE` alongside `THIRD_PARTY_LICENSES.txt` (and the `Subtitle Edit.app` + `Applications` symlink).
- [ ] `SeConv-Windows-*.zip` / `SeConv-macOS-*.zip` / `SeConv-Linux-*.tar.gz` each contain a top-level `LICENSE`.
- [ ] Built Flatpak has `LICENSE` under `/app/share/licenses/dk.nikse.subtitleedit/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)