### PR TITLE
Bump WhisperCPP to v1.8.5

### DIFF
--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -663,45 +663,55 @@ public static class DownloadHashManager
             // whatever URL WhisperDownloadService.cs is pinned to.
             [WhisperCpp.WindowsBlas] = new[]
             {
-                "5f8d6b1bcdf86edf898d21379468ae8329bb783803dab9c5dbc1fa65e7f2da6c", // whispercpp-184 / v1.8.4 (current download URL)
+                "4a8a07e14c035bd6c1bcd55dedba5925f982f122d6bc05034f9bbe7e55f5c4b0", // whispercpp-185 / v1.8.5 (current download URL)
+                "5f8d6b1bcdf86edf898d21379468ae8329bb783803dab9c5dbc1fa65e7f2da6c", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.WindowsCuBlas] = new[]
             {
-                "b07cff4e59831b227896018facbb6334907bf324a342c84597c44f087823d252", // v1.8.4 (current download URL — fetched directly from ggml-org/whisper.cpp)
+                "ff50101f85a6026d39053771c25b42f5752ac05d5be9ee2e5d2632541adef231", // v1.8.5 (current download URL — fetched directly from ggml-org/whisper.cpp)
+                "b07cff4e59831b227896018facbb6334907bf324a342c84597c44f087823d252", // v1.8.4
             },
             [WhisperCpp.WindowsVulkan] = new[]
             {
-                "42f90548f551f525666b96bd734f4ee23e58f82dcc2a1b68c4eba5e453ba7080", // whispercpp-184 / v1.8.4 (current download URL)
+                "8a993d86fbad6cfacf3123be615a692f17e9a19957ddfa6e071c751deaf8df42", // whispercpp-185 / v1.8.5 (current download URL)
+                "42f90548f551f525666b96bd734f4ee23e58f82dcc2a1b68c4eba5e453ba7080", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.MacOs] = new[]
             {
-                "81dbd530f21a6daf10b1c9cece61d7e56d774e3bcb3d21af4d17299caa532a4d", // whispercpp-184 / v1.8.4 (current download URL)
+                "49ef4acfaef0b4989885c258f22eb1355592c5f343897508899a2b598cd683bf", // whispercpp-185 / v1.8.5 (current download URL)
+                "81dbd530f21a6daf10b1c9cece61d7e56d774e3bcb3d21af4d17299caa532a4d", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.LinuxVulkan] = new[]
             {
-                "7a7d131b5fbb605fef6a8d39b6f2480480d8a26ec8a1dbec3b3740485023158d", // whispercpp-184 / v1.8.4 (current download URL)
+                "c385a01228f85764cfd9b6072e078d03e44f151d71ab145e912425e5cc9a7c8e", // whispercpp-185 / v1.8.5 (current download URL)
+                "7a7d131b5fbb605fef6a8d39b6f2480480d8a26ec8a1dbec3b3740485023158d", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.LinuxCuda] = new[]
             {
-                "708ea1c502ac5082d4eb9afc86c8adb9d67d76da25e70fd81cb6fae2cfcf00ce", // whispercpp-184 / v1.8.4 (current download URL)
+                "1aee5fddee30f8486275d3b2bd1d568e92615e7b1b063d46c635cb9f44d7d13b", // whispercpp-185 / v1.8.5 (current download URL)
+                "708ea1c502ac5082d4eb9afc86c8adb9d67d76da25e70fd81cb6fae2cfcf00ce", // whispercpp-184 / v1.8.4
             },
 
             // SHA-256 of whisper-cli / whisper-cli.exe extracted from each archive above.
             [WhisperCpp.WindowsBlasExecutable] = new[]
             {
-                "80865086479dfedb0ce8d0c03f061629dd83e9d1e86b14343e5cf9fd01927098", // whispercpp-184 / v1.8.4 (current download URL)
+                "6a2e5cbd090c1dacc43461d1fac543e4b13881210f181c6d1e95267ec8c64c64", // whispercpp-185 / v1.8.5 (current download URL)
+                "80865086479dfedb0ce8d0c03f061629dd83e9d1e86b14343e5cf9fd01927098", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.WindowsCuBlasExecutable] = new[]
             {
-                "03947f51efb42abc82a0208cb0ead74822eff8e88a41df4c1f4536f6b78188ae", // v1.8.4 (current download URL)
+                "304eef3b9fc30b0b0d74f4ab756b6e5efe7b2f6f88813f79205631d1ebba448d", // v1.8.5 (current download URL)
+                "03947f51efb42abc82a0208cb0ead74822eff8e88a41df4c1f4536f6b78188ae", // v1.8.4
             },
             [WhisperCpp.WindowsVulkanExecutable] = new[]
             {
-                "69a270fb42b98fc4927e6e9a79bda16ec7bf152825e2af68df09ff99f43479e6", // whispercpp-184 / v1.8.4 (current download URL)
+                "3d43e45f7b575dcc127d5a1c30bdb9f9f1650576007a31d955917027794672bd", // whispercpp-185 / v1.8.5 (current download URL)
+                "69a270fb42b98fc4927e6e9a79bda16ec7bf152825e2af68df09ff99f43479e6", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.MacOsExecutable] = new[]
             {
-                "11d902af004d1e79538f8f801b4a42ac3a21094370c9063f67d885d04dccdd96", // whispercpp-184 / v1.8.4 (current download URL)
+                "0fd752e0384484eb3a72ce644135f20963879e80624b23f7f739eda187a23359", // whispercpp-185 / v1.8.5 (current download URL)
+                "11d902af004d1e79538f8f801b4a42ac3a21094370c9063f67d885d04dccdd96", // whispercpp-184 / v1.8.4
             },
         };
 

--- a/src/ui/Logic/Download/WhisperDownloadService.cs
+++ b/src/ui/Logic/Download/WhisperDownloadService.cs
@@ -22,14 +22,14 @@ public interface IWhisperDownloadService
 public class WhisperDownloadService : IWhisperDownloadService
 {
     private readonly HttpClient _httpClient;
-    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-184/whisper-blas-bin-x64.zip";
-    private const string MacArmUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-184/whisper-mac.zip";
-    private const string MacX64Url = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-184/whisper-mac.zip";
-    private const string LinuxUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-184/whisper-vulkan-linux64.zip";
+    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-185/whisper-blas-bin-x64.zip";
+    private const string MacArmUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-185/whisper-mac.zip";
+    private const string MacX64Url = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-185/whisper-mac.zip";
+    private const string LinuxUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-185/whisper-vulkan-linux64.zip";
 
-    private const string WindowsUrlCuBlass = "https://github.com/ggml-org/whisper.cpp/releases/download/v1.8.4/whisper-cublas-12.4.0-bin-x64.zip";
-    private const string WindowsUrlCppVulkan = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-184/whisper-vulkan-x64.zip";
-    private const string LinuxUrlCuBlass = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-184/whisper-cuda-linux64.zip";
+    private const string WindowsUrlCuBlass = "https://github.com/ggml-org/whisper.cpp/releases/download/v1.8.5/whisper-cublas-12.4.0-bin-x64.zip";
+    private const string WindowsUrlCppVulkan = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-185/whisper-vulkan-x64.zip";
+    private const string LinuxUrlCuBlass = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-185/whisper-cuda-linux64.zip";
     
     private const string DownloadUrlConstMe = "https://github.com/Const-me/Whisper/releases/download/1.12.0/cli.zip";
     private const string SileroVadUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-184/ggml-silero-v6.2.0.zip";


### PR DESCRIPTION
## Summary
Bumps the pinned whisper.cpp version from v1.8.4 → v1.8.5. Two files touched:

- `WhisperDownloadService.cs` — 6 SE-repackaged URLs flip from `whispercpp-184` to [`whispercpp-185`](https://github.com/SubtitleEdit/support-files/releases/tag/whispercpp-185), plus the upstream Windows CUDA URL bumps from `v1.8.4` to `v1.8.5`. `SileroVadUrl` is **unchanged** — the v185 support-files release only ships whisper.cpp build archives, not the VAD model (it's still the same `ggml-silero-v6.2.0` file).
- `DownloadHashManager.cs` — 10 v1.8.5 SHA-256 hashes prepended (6 archive keys + 4 executable keys). Older v1.8.4 hashes are preserved so installs from earlier SE builds still recognise their files as "outdated, update available" instead of "unknown".

Archive sizes vs v184:

| Archive | v184 | v185 |
|---|---|---|
| `whisper-blas-bin-x64.zip` | 14 MB | 17 MB |
| `whisper-vulkan-x64.zip` | 17 MB | 15 MB |
| `whisper-vulkan-linux64.zip` | 19 MB | 24 MB |
| `whisper-cuda-linux64.zip` | 119 MB | 256 MB |
| `whisper-mac.zip` | 3 MB | 3 MB |
| `whisper-cublas-12.4.0-bin-x64.zip` (upstream) | n/a | 440 MB |

The CUDA Linux jump (119 → 256 MB) is from upstream's default-now-larger CUDA target set in v1.8.5; nothing changed in our build flags.

Linux Vulkan + Linux CUDA executable hashes are intentionally still missing — the comment in DownloadHashManager spells out why (the two Linux backends produce identical `whisper-cli`; the backend lives in `libggml-*.so`, so executable-hash fallback is Windows + Mac only).

## How the v185 archives were produced
The new SE-repackaged builds came from `SubtitleEdit/support-files`'s new `Build whisper.cpp release zips` workflow ([PR #4](https://github.com/SubtitleEdit/support-files/pull/4) and follow-up fix PRs #5–#7) — a workflow that builds the SE-specific configurations (Windows Vulkan, Linux Vulkan, Linux CUDA, macOS Universal) from upstream source and repackages the Windows BLAS one. Future bumps will be a one-line workflow dispatch followed by a PR like this.

## Test plan
- [ ] Fresh install: whisper.cpp download lands the v185 zip and verifies against the prepended hash.
- [ ] Existing v184 install: SE reports "update available" instead of "unknown".
- [ ] `whisper-cli` runs end-to-end on a short clip per platform (Windows BLAS / Vulkan / CUDA, Linux Vulkan / CUDA, macOS Universal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)