### PR TITLE
Add engine update button to auto-translate window

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -87,6 +87,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<SpeechToTextModelDisplay> _crispAsrModels = new();
     [ObservableProperty] private SpeechToTextModelDisplay? _selectedCrispAsrModel;
     [ObservableProperty] private bool _crispAsrModelComboIsVisible;
+    [ObservableProperty] private bool _engineUpdateButtonIsVisible;
     [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels = new();
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
     [ObservableProperty] private bool _llamaCppModelComboIsVisible;
@@ -735,6 +736,51 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         RefreshDownloadDots?.Invoke();
+        RefreshEngineUpdateButton();
+    }
+
+    [RelayCommand]
+    private async Task UpdateEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (SelectedAutoTranslator is CrispAsrMadladTranslate)
+        {
+            await UpdateCrispAsrEngineAsync();
+        }
+        else if (SelectedAutoTranslator is LlamaCppTranslate && GetLlamaCppEngineUpdate() is var (key, _))
+        {
+            await UpdateLlamaCppEngineAsync(key);
+        }
+    }
+
+    private async Task UpdateCrispAsrEngineAsync()
+    {
+        var updated = await CrispAsrTranslateDownloadHelper.UpdateEngineAsync(Window!, _windowService);
+        if (updated)
+        {
+            PopulateCrispAsrModels(SelectedCrispAsrModel?.Model.Name);
+            SaveSettings();
+        }
+
+        RefreshDownloadDots?.Invoke();
+        RefreshEngineUpdateButton();
+    }
+
+    // Shows the "Update" button next to the engine combo only when the selected SE-managed engine is
+    // installed but outdated (the amber status dot): CrispASR/MADLAD or llama.cpp. Cloud/API translators
+    // have no local binary to update, so the button stays hidden for them.
+    private void RefreshEngineUpdateButton()
+    {
+        EngineUpdateButtonIsVisible = SelectedAutoTranslator switch
+        {
+            CrispAsrMadladTranslate => CrispAsrTranslateDownloadHelper.IsEngineUpdateAvailable(),
+            LlamaCppTranslate => GetLlamaCppEngineUpdate() != null,
+            _ => false,
+        };
     }
 
     private void PopulateCrispAsrModels(string? selectModelName)
@@ -777,6 +823,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         RefreshDownloadDots?.Invoke();
+        RefreshEngineUpdateButton();
         return ready;
     }
 
@@ -928,19 +975,12 @@ public partial class AutoTranslateViewModel : ObservableObject
     /// </summary>
     private async Task CheckLlamaCppForUpdateAsync()
     {
-        if (_llamaCppUpdatePromptShown || Window == null || !LlamaCppServerManager.IsEngineInstalled())
+        if (_llamaCppUpdatePromptShown || Window == null)
         {
             return;
         }
 
-        var folder = LlamaCppServerManager.GetAndCreateFolder();
-        var lookup = TryReadLlamaCppSidecarHash(folder) ?? TryHashInstalledLlamaCppExecutable();
-        if (lookup is not var (key, hash))
-        {
-            return;
-        }
-
-        if (DownloadHashManager.GetStatus(key, hash) != DownloadHashManager.UpdateStatus.UpdateAvailable)
+        if (GetLlamaCppEngineUpdate() is not var (key, _))
         {
             return;
         }
@@ -959,12 +999,48 @@ public partial class AutoTranslateViewModel : ObservableObject
             return;
         }
 
-        // The running server holds the binary open (and a stale build would keep serving), so
-        // stop it before overwriting the install.
+        await UpdateLlamaCppEngineAsync(key);
+    }
+
+    /// <summary>
+    /// Returns the install key/hash of the installed llama-server when a newer build than the one
+    /// SE ships is available (sidecar hash, falling back to hashing the executable), otherwise null.
+    /// </summary>
+    private (string key, string hash)? GetLlamaCppEngineUpdate()
+    {
+        if (!LlamaCppServerManager.IsEngineInstalled())
+        {
+            return null;
+        }
+
+        var folder = LlamaCppServerManager.GetAndCreateFolder();
+        var lookup = TryReadLlamaCppSidecarHash(folder) ?? TryHashInstalledLlamaCppExecutable();
+        if (lookup is not var (key, hash))
+        {
+            return null;
+        }
+
+        return DownloadHashManager.GetStatus(key, hash) == DownloadHashManager.UpdateStatus.UpdateAvailable
+            ? (key, hash)
+            : null;
+    }
+
+    /// <summary>
+    /// Stops the running llama-server (it holds the binary open and would keep serving a stale build),
+    /// re-downloads the matching llama.cpp build, and refreshes the model list and status indicators.
+    /// </summary>
+    private async Task UpdateLlamaCppEngineAsync(string installedKey)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
         LlamaCppServerManager.StopServer();
         UpdateLlamaCppServerButtonText();
 
-        var variant = DownloadHashManager.GetLlamaCppWindowsVariant(key)
+        var folder = LlamaCppServerManager.GetAndCreateFolder();
+        var variant = DownloadHashManager.GetLlamaCppWindowsVariant(installedKey)
                       ?? (OperatingSystem.IsWindows() ? DownloadHashManager.DetectLlamaCppWindowsVariant(folder) : null);
 
         var model = SelectedLlamaCppModel?.Model;
@@ -977,6 +1053,7 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         RefreshDownloadDots?.Invoke();
         UpdateLlamaCppServerButtonText();
+        RefreshEngineUpdateButton();
     }
 
     private static (string key, string hash)? TryReadLlamaCppSidecarHash(string folder)
@@ -1375,6 +1452,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         ButtonModelIsVisible = false;
         ButtonDownloadIsVisible = false;
         CrispAsrModelComboIsVisible = false;
+        EngineUpdateButtonIsVisible = false;
         CrispAsrModels.Clear();
         SelectedCrispAsrModel = null;
         LlamaCppModelComboIsVisible = false;
@@ -1557,6 +1635,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
             SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), savedModelName);
             UpdateLlamaCppServerButtonText();
+            RefreshEngineUpdateButton();
 
             if (!_llamaCppUpdatePromptShown)
             {
@@ -1746,6 +1825,7 @@ public partial class AutoTranslateViewModel : ObservableObject
 
             CrispAsrModelComboIsVisible = true;
             ButtonDownloadIsVisible = true;
+            RefreshEngineUpdateButton();
 
             return;
         }

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -128,6 +128,15 @@ public class AutoTranslateWindow : Window
         // the simplest way to refresh. The model combos already rebuild via PopulateModels.
         vm.RefreshDownloadDots = () => engineCombo.ItemTemplate = BuildTranslatorItemTemplate();
 
+        // Appears only when the selected SE-managed engine (CrispASR/MADLAD or llama.cpp) is installed
+        // but outdated - i.e. it shows the amber "update available" dot - giving the user a way to act on it.
+        var updateEngineButton = UiUtil.MakeButton(Se.Language.General.Update, vm.UpdateEngineCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(8);
+        updateEngineButton.VerticalAlignment = VerticalAlignment.Center;
+        updateEngineButton.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.EngineUpdateButtonIsVisible)));
+        ToolTip.SetTip(updateEngineButton, Se.Language.General.UpdateAvailable);
+
         var fromLabel = UiUtil.MakeTextBlock(Se.Language.General.From);
         fromLabel.VerticalAlignment = VerticalAlignment.Center;
         fromLabel.Margin = new Thickness(16, 0, 8, 0);
@@ -154,6 +163,7 @@ public class AutoTranslateWindow : Window
             {
                 engineLabel,
                 engineCombo,
+                updateEngineButton,
                 fromLabel,
                 sourceCombo,
                 swapButton,

--- a/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
+++ b/src/ui/Features/Translate/CrispAsrTranslateDownloadHelper.cs
@@ -6,6 +6,7 @@ using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -38,6 +39,18 @@ public static class CrispAsrTranslateDownloadHelper
         }
 
         return GetInstalledModelPath() != null;
+    }
+
+    /// <summary>
+    /// True when the CrispASR engine binary is installed but an updated build is available - the
+    /// install sidecar hash no longer matches the latest known build. Mirrors the amber status dot
+    /// shown next to the engine in the auto-translate combo.
+    /// </summary>
+    public static bool IsEngineUpdateAvailable()
+    {
+        var engine = new CrispAsrMadlad();
+        return engine.IsEngineInstalled()
+            && DownloadHashManager.GetSidecarStatus(engine.GetAndCreateWhisperFolder()) == DownloadHashManager.UpdateStatus.UpdateAvailable;
     }
 
     /// <summary>
@@ -152,6 +165,36 @@ public static class CrispAsrTranslateDownloadHelper
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Forces a re-download of the CrispASR engine binary to apply an available update. The MADLAD
+    /// models are left untouched - only the engine executable (and its sidecar hash) is refreshed.
+    /// </summary>
+    /// <returns>True if the engine was re-installed.</returns>
+    public static async Task<bool> UpdateEngineAsync(Window owner, IWindowService windowService)
+    {
+        var engine = new CrispAsrMadlad();
+
+        // Same small CPU build the regular CrispASR/MADLAD flow installs - this is a CPU-bound
+        // translation model, so there is no GPU variant to choose between.
+        var engineVm = await windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
+            owner, vm =>
+            {
+                vm.Engine = engine;
+                vm.CrispAsrWindowsVariant = "cpu";
+                vm.StartDownload();
+            });
+
+        if (!engineVm.OkPressed || !engine.IsEngineInstalled())
+        {
+            return false;
+        }
+
+        Se.Settings.AutoTranslate.CrispAsrExe = engine.GetExecutable();
+        Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
+        Se.SaveSettings();
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

The auto-translate engine combo shows an amber **"update available"** status dot for SE-managed engines (CrispASR/MADLAD and llama.cpp) when the installed binary is outdated — but there was previously no way to act on it. CrispASR had no engine-update path at all (`DownloadAsync` only fetched the binary when it was missing), and llama.cpp only offered a one-time Yes/No prompt when the engine was selected.

This adds an **"Update" button right after the engine combobox** that appears only when the selected engine is installed but outdated, and re-downloads the engine binary.

## Changes

- **`CrispAsrTranslateDownloadHelper`** — `IsEngineUpdateAvailable()` (mirrors the amber dot via `DownloadHashManager.GetSidecarStatus`) and `UpdateEngineAsync()` which force-redownloads just the engine binary, leaving MADLAD models untouched.
- **`AutoTranslateViewModel`** — generalized `UpdateEngine` command + `RefreshEngineUpdateButton()` covering both engines; extracted `GetLlamaCppEngineUpdate()` / `UpdateLlamaCppEngineAsync()` so the new button and the existing llama.cpp on-select prompt share a single code path (no behavior change to that prompt).
- **`AutoTranslateWindow`** — "Update" button (download icon, "Update available" tooltip) bound to `EngineUpdateButtonIsVisible`, placed after the engine combobox.

The button stays **hidden** for cloud/API translators (Google, DeepL, ChatGPT, …) and for engines that are not installed.

## Verification

- Builds clean (0 warnings/errors).
- Ran the app and opened the auto-translate window: with CrispASR/MADLAD installed and **up to date** (green dot), the Update button is correctly hidden — confirming the visibility gating. The amber/button-visible path was confirmed manually.

Uses existing translated strings `General.Update` / `General.UpdateAvailable` — no new language keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)