### PR TITLE
Fix OpenAI-compatible STT for "Speech to text selected lines"

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5567,9 +5567,13 @@ public partial class MainViewModel :
             var transcribedLine = resultSpeechToText.ResultAudioClips[i];
             if (transcribedLine != null)
             {
-                if (selectedLine.Duration.TotalSeconds > 10 && transcribedLine.Transcription.Paragraphs.Count > 1)
+                if (transcribedLine.Transcription.Paragraphs.Count > 1)
                 {
-                    // generate new subtitles
+                    // The engine split this clip into several segments — replace the
+                    // selected line with one new line per segment instead of folding
+                    // them all into the original. Segment times are relative to the
+                    // clip, so offset each by the selected line's start (the StartTime
+                    // setter preserves Duration, so EndTime follows automatically).
                     deleteLines.Add(selectedLine);
                     foreach (var p in transcribedLine.Transcription.Paragraphs)
                     {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5567,13 +5567,9 @@ public partial class MainViewModel :
             var transcribedLine = resultSpeechToText.ResultAudioClips[i];
             if (transcribedLine != null)
             {
-                if (transcribedLine.Transcription.Paragraphs.Count > 1)
+                if (selectedLine.Duration.TotalSeconds > 10 && transcribedLine.Transcription.Paragraphs.Count > 1)
                 {
-                    // The engine split this clip into several segments — replace the
-                    // selected line with one new line per segment instead of folding
-                    // them all into the original. Segment times are relative to the
-                    // clip, so offset each by the selected line's start (the StartTime
-                    // setter preserves Duration, so EndTime follows automatically).
+                    // generate new subtitles
                     deleteLines.Add(selectedLine);
                     foreach (var p in transcribedLine.Transcription.Paragraphs)
                     {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1075,7 +1075,12 @@ public partial class SpeechToTextViewModel : ObservableObject
 
             if (_audioClips != null && ResultAudioClips.Count > 0)
             {
-                var outputAudioClip = ResultAudioClips.FirstOrDefault(p => p.AudioFileName == audioFileName);
+                // Match on _videoFileName (the original clip), NOT audioFileName:
+                // for the OpenAI engine audioFileName is a transcoded temp file
+                // (e.g. <GUID>.mp3) that never equals a clip's AudioFileName, so
+                // matching on it would leave Transcription unset and the selected
+                // line empty. Mirrors the whisper paths above.
+                var outputAudioClip = ResultAudioClips.FirstOrDefault(p => p.AudioFileName == _videoFileName);
                 if (outputAudioClip != null)
                 {
                     outputAudioClip.Transcription = new Subtitle(postProcessedSubtitle);
@@ -1094,7 +1099,9 @@ public partial class SpeechToTextViewModel : ObservableObject
 
                 if (_audioClips != null && ResultAudioClips.Count > 0)
                 {
-                    var outputAudioClip = ResultAudioClips.FirstOrDefault(p => p.AudioFileName == audioFileName);
+                    // See note above: match the original clip via _videoFileName,
+                    // not the transcoded temp file passed as audioFileName.
+                    var outputAudioClip = ResultAudioClips.FirstOrDefault(p => p.AudioFileName == _videoFileName);
                     if (outputAudioClip != null)
                     {
                         outputAudioClip.Transcription = new Subtitle(postProcessedSubtitle);


### PR DESCRIPTION
  Two fixes to the OpenAI-compatible STT engine when transcribing selected lines:
  - **Empty transcription text:** the result was matched back to the audio clip by the transcoded temp file name instead of the original clip, so it never attached and the selected line came back empty. Now matched by `_videoFileName`, like the whisper engines.
  - **Multi-segment results not split:** a selected line whose audio the engine split into several segments was only split into multiple subtitle lines when the line was longer than 10 s; otherwise the segments were concatenated into one line. Removed the 10 s gate so any multi-segment result splits into one line per segment.