### PR TITLE
Update Japanese translation (v5.0.0 RC1)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -2,7 +2,7 @@
 Subtitle Edit Changelog
 
 
-v5.0.0-rc2 (31st May 2026)
+v5.0.0-rc2 (TBD)
 
 * Update Japanese translation - thx hisui3393
 

--- a/change-log.txt
+++ b/change-log.txt
@@ -2,6 +2,12 @@
 Subtitle Edit Changelog
 
 
+v5.0.0-rc2 (31st May 2026)
+
+* Update Japanese translation - thx hisui3393
+
+-----------------------------------------------------------------------------------------------------
+
 v5.0.0-rc1 (30th May 2026)
 
 * Update docs for RC1

--- a/src/ui/Assets/Languages/Japanese.json
+++ b/src/ui/Assets/Languages/Japanese.json
@@ -2421,7 +2421,7 @@
       "splitOddLineActionWeightBottom": "下行を多めに配分する",
       "splitOddLinesAction": "字幕行 分割時の動作",
       "ocrUseWordSplitList": "OCR:単語を誤分割しない為に 単語分割リストを使う",
-      "speechToTextSelectedLinesPromptFistTimeOnly": "音声認識：言語/エンジンの選択は 初回のみ",
+      "speechToTextSelectedLinesPromptFirstTimeOnly": "音声認識：言語/エンジンの選択は 初回のみ",
       "multipleReplaceShowDotDotDotButtons": "複数置換：コンテキストメニューボタンを表示",
       "gridFocusTextboxAfterInsertNew": "グリッド：新しい字幕を挿入した後 テキスト欄をアクティブに",
       "textToSpeechPromptMergeContinuationLines": "音声合成: 継続行結合を確認",


### PR DESCRIPTION
Applies the corrected Japanese translation file submitted by the community translator in [discussion #10742](https://github.com/SubtitleEdit/subtitleedit/discussions/10742#discussioncomment-17122041) ("Complete Japanese translation file (japanese.json) AGAIN!").

## Change
The only difference from the current file is a translation-key typo fix:

```diff
-"speechToTextSelectedLinesPromptFistTimeOnly": "音声認識：言語/エンジンの選択は 初回のみ",
+"speechToTextSelectedLinesPromptFirstTimeOnly": "音声認識：言語/エンジンの選択は 初回のみ",
```

The key was misspelled as `...Fist...` instead of `...First...`, so it did not match the key in `English.json` (line 2424) and the string was therefore not picked up. After the fix the key matches and the Japanese string is used correctly.

File encoding/format unchanged (UTF-8 no BOM, CRLF, 3097 lines), and the JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)