### PR TITLE
seconv: gate Spanish FCE rule on language + clarify --settings / --apply-min-gap docs (#11037)

### DIFF
--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -322,13 +322,18 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
 
             // Resolve FCE rule selection. Passing --FixCommonErrorsRules implicitly
             // enables --FixCommonErrors so users don't have to specify both.
+            // We also parse out which rules the user named by hand — that's a separate
+            // signal from the resolved set so language-conditional rules can bypass
+            // their gate when explicitly requested (see FixCommonErrorsRunner.Run).
             IReadOnlyList<string> fceRules = [];
+            IReadOnlyList<string> fceExplicitlyNamed = [];
             var fceRequested = settings.FixCommonErrors || !string.IsNullOrWhiteSpace(settings.FixCommonErrorsRules);
             if (fceRequested)
             {
                 try
                 {
                     fceRules = FixCommonErrorsRunner.ResolveRuleIds(settings.FixCommonErrorsRules);
+                    fceExplicitlyNamed = FixCommonErrorsRunner.ParseExplicitlyNamedRules(settings.FixCommonErrorsRules);
                 }
                 catch (ArgumentException ex)
                 {
@@ -423,6 +428,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 Overwrite = settings.Overwrite,
                 Operations = operations,
                 FixCommonErrorsRules = fceRules,
+                FixCommonErrorsExplicitlyNamedRules = fceExplicitlyNamed,
                 DeleteFirst = settings.DeleteFirst,
                 DeleteLast = settings.DeleteLast,
                 DeleteContains = settings.DeleteContains,

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -60,6 +60,17 @@ internal static class FixCommonErrorsRunner
                 continue;
             }
 
+            // Language-conditional rules mirror what the GUI's Fix Common Errors
+            // window does: it only surfaces FixSpanishInvertedQuestionAndExclamationMarks
+            // when the detected language is "es" (FixCommonErrorsViewModel.cs:377).
+            // Running it on non-Spanish content would insert ¿ / ¡ on questions and
+            // exclamations in any language, which surprises users (issue #11037 item 3).
+            // The user can still opt in explicitly via --FixCommonErrorsRules.
+            if (wanted == null && IsLanguageOnlyRule(id, language))
+            {
+                continue;
+            }
+
             try
             {
                 factory().Fix(subtitle, callbacks);
@@ -69,6 +80,22 @@ internal static class FixCommonErrorsRunner
                 // A rogue rule shouldn't kill the conversion. Skip and continue.
             }
         }
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="ruleId"/> is a language-conditional rule
+    /// that should not run in the default ("all rules") pass because the detected
+    /// language doesn't match. Skipped here, included by name in an explicit
+    /// <c>--FixCommonErrorsRules</c> list.
+    /// </summary>
+    private static bool IsLanguageOnlyRule(string ruleId, string language)
+    {
+        return ruleId switch
+        {
+            "FixSpanishInvertedQuestionAndExclamationMarks"
+                => !"es".Equals(language, StringComparison.OrdinalIgnoreCase),
+            _ => false,
+        };
     }
 
     /// <summary>

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -30,11 +30,30 @@ internal static class FixCommonErrorsRunner
     public static void RunAll(Subtitle subtitle) => Run(subtitle, null);
 
     /// <summary>
-    /// Runs the specified rules. Pass <c>null</c> or an empty collection to run all rules.
-    /// Rules execute in canonical order, not caller order, to keep behaviour stable
-    /// across invocations.
+    /// Back-compat overload. Pass <c>null</c> or an empty collection to run all rules
+    /// (gates language-conditional rules to their language). When a non-empty list is
+    /// passed, every entry is treated as both <em>wanted</em> and <em>explicitly named</em> —
+    /// language gates are bypassed for those rules. Rules execute in canonical order,
+    /// not caller order, to keep behaviour stable across invocations.
     /// </summary>
     public static void Run(Subtitle subtitle, IReadOnlyCollection<string>? ruleIds)
+        => Run(subtitle, ruleIds, explicitlyNamedRules: ruleIds);
+
+    /// <summary>
+    /// Runs the specified rules.
+    /// <para><paramref name="ruleIds"/> selects which rules execute (<c>null</c>/empty = all).</para>
+    /// <para><paramref name="explicitlyNamedRules"/> lists rules the user named by hand —
+    /// these bypass language gating. <c>null</c> means "no signal, treat <paramref name="ruleIds"/>
+    /// as explicit" (back-compat); an empty collection means "no rule was explicitly named"
+    /// (the CLI's implicit <c>--FixCommonErrors</c> path), which keeps language gates active.</para>
+    /// The split matters because the CLI pre-resolves a bare <c>--FixCommonErrors</c> to
+    /// the full rule list, so a <c>wanted == null</c> check alone would never fire for the
+    /// default path — see <see cref="ParseExplicitlyNamedRules"/>.
+    /// </summary>
+    public static void Run(
+        Subtitle subtitle,
+        IReadOnlyCollection<string>? ruleIds,
+        IReadOnlyCollection<string>? explicitlyNamedRules)
     {
         if (subtitle == null || subtitle.Paragraphs.Count == 0)
         {
@@ -45,6 +64,23 @@ internal static class FixCommonErrorsRunner
         if (ruleIds != null && ruleIds.Count > 0)
         {
             wanted = new HashSet<string>(ruleIds, StringComparer.OrdinalIgnoreCase);
+        }
+
+        // null = treat wanted as explicit (back-compat path used by direct callers / tests).
+        // empty = "user named nothing" — keeps language gates fully active.
+        // non-empty = exact set of rules the user typed by hand.
+        HashSet<string>? explicitlyNamed;
+        if (explicitlyNamedRules == null)
+        {
+            explicitlyNamed = wanted;
+        }
+        else if (explicitlyNamedRules.Count == 0)
+        {
+            explicitlyNamed = null;
+        }
+        else
+        {
+            explicitlyNamed = new HashSet<string>(explicitlyNamedRules, StringComparer.OrdinalIgnoreCase);
         }
 
         var language = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle) ?? "en";
@@ -60,13 +96,13 @@ internal static class FixCommonErrorsRunner
                 continue;
             }
 
-            // Language-conditional rules mirror what the GUI's Fix Common Errors
-            // window does: it only surfaces FixSpanishInvertedQuestionAndExclamationMarks
-            // when the detected language is "es" (FixCommonErrorsViewModel.cs:377).
-            // Running it on non-Spanish content would insert ¿ / ¡ on questions and
-            // exclamations in any language, which surprises users (issue #11037 item 3).
-            // The user can still opt in explicitly via --FixCommonErrorsRules.
-            if (wanted == null && IsLanguageOnlyRule(id, language))
+            // Language-conditional rules mirror the GUI's Fix Common Errors window
+            // (FixCommonErrorsViewModel.cs:359-377), which only surfaces these rules
+            // when the detected language matches. Running e.g. the Spanish inverted-mark
+            // fix on French content would insert ¿ / ¡ on every question — issue #11037.
+            // The user can still opt in explicitly by naming the rule in --FixCommonErrorsRules.
+            if (IsLanguageOnlyRule(id, language)
+                && (explicitlyNamed == null || !explicitlyNamed.Contains(id)))
             {
                 continue;
             }
@@ -83,17 +119,42 @@ internal static class FixCommonErrorsRunner
     }
 
     /// <summary>
+    /// Extracts the rule IDs a user named by hand in a <c>--FixCommonErrorsRules</c> spec.
+    /// Returns an empty list for null / empty / whitespace / <c>all</c> specs (= no rule
+    /// was explicitly named). Negative tokens (<c>-FixCommas</c>) and the literal <c>all</c>
+    /// are excluded — only positive, named rules count as "explicit". Unknown rule names
+    /// are kept as-is here; <see cref="ResolveRuleIds"/> is responsible for validation.
+    /// </summary>
+    public static IReadOnlyList<string> ParseExplicitlyNamedRules(string? spec)
+    {
+        if (string.IsNullOrWhiteSpace(spec))
+        {
+            return [];
+        }
+
+        return spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(t => !t.StartsWith('-') && !"all".Equals(t, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+    }
+
+    /// <summary>
     /// Returns true when <paramref name="ruleId"/> is a language-conditional rule
-    /// that should not run in the default ("all rules") pass because the detected
-    /// language doesn't match. Skipped here, included by name in an explicit
-    /// <c>--FixCommonErrorsRules</c> list.
+    /// that should not run because the detected language doesn't match. Mirrors
+    /// the GUI's per-language rule additions in <c>FixCommonErrorsViewModel</c>.
+    /// Bypassable via explicit <c>--FixCommonErrorsRules</c>.
     /// </summary>
     private static bool IsLanguageOnlyRule(string ruleId, string language)
     {
         return ruleId switch
         {
+            "FixAloneLowercaseIToUppercaseI"
+                => !"en".Equals(language, StringComparison.OrdinalIgnoreCase),
+            "FixDanishLetterI"
+                => !"da".Equals(language, StringComparison.OrdinalIgnoreCase),
             "FixSpanishInvertedQuestionAndExclamationMarks"
                 => !"es".Equals(language, StringComparison.OrdinalIgnoreCase),
+            "FixTurkishAnsiToUnicode"
+                => !"tr".Equals(language, StringComparison.OrdinalIgnoreCase),
             _ => false,
         };
     }

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -458,12 +458,15 @@ internal static class LibSEIntegration
     /// <summary>
     /// Applies subtitle operations/transformations. <paramref name="fixCommonErrorsRules"/>
     /// is consulted only when <c>fixcommonerrors</c> is in the operation list — pass
-    /// <c>null</c> or empty to run all FCE rules.
+    /// <c>null</c> or empty to run all FCE rules. <paramref name="fixCommonErrorsExplicitlyNamedRules"/>
+    /// is the set of rules the user named by hand (used to bypass FCE language gating);
+    /// pass empty for "no explicit selection" (implicit-all CLI path).
     /// </summary>
     public static void ApplyOperations(
         Subtitle subtitle,
         List<string> operations,
-        IReadOnlyList<string>? fixCommonErrorsRules = null)
+        IReadOnlyList<string>? fixCommonErrorsRules = null,
+        IReadOnlyList<string>? fixCommonErrorsExplicitlyNamedRules = null)
     {
         if (subtitle == null || operations == null || operations.Count == 0)
         {
@@ -472,19 +475,20 @@ internal static class LibSEIntegration
 
         foreach (var operation in operations)
         {
-            ApplyOperation(subtitle, operation, fixCommonErrorsRules);
+            ApplyOperation(subtitle, operation, fixCommonErrorsRules, fixCommonErrorsExplicitlyNamedRules);
         }
     }
 
     private static void ApplyOperation(
         Subtitle subtitle,
         string operation,
-        IReadOnlyList<string>? fixCommonErrorsRules)
+        IReadOnlyList<string>? fixCommonErrorsRules,
+        IReadOnlyList<string>? fixCommonErrorsExplicitlyNamedRules)
     {
         switch (operation.ToLowerInvariant())
         {
             case "fixcommonerrors":
-                FixCommonErrorsRunner.Run(subtitle, fixCommonErrorsRules);
+                FixCommonErrorsRunner.Run(subtitle, fixCommonErrorsRules, fixCommonErrorsExplicitlyNamedRules);
                 break;
 
             case "removetextforhi":

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -253,7 +253,11 @@ internal class SubtitleConverter
 
         if (options.Operations.Count > 0)
         {
-            LibSEIntegration.ApplyOperations(subtitle, options.Operations, options.FixCommonErrorsRules);
+            LibSEIntegration.ApplyOperations(
+                subtitle,
+                options.Operations,
+                options.FixCommonErrorsRules,
+                options.FixCommonErrorsExplicitlyNamedRules);
         }
 
         if (options.BridgeGapsMaxMs.HasValue && options.BridgeGapsMaxMs.Value > 0)
@@ -375,6 +379,14 @@ internal record class ConversionOptions
     /// Resolve via <see cref="FixCommonErrorsRunner.ResolveRuleIds"/>.
     /// </summary>
     public IReadOnlyList<string> FixCommonErrorsRules { get; init; } = [];
+
+    /// <summary>
+    /// Rules the user named by hand in <c>--FixCommonErrorsRules</c>. Used to bypass
+    /// language gating for explicitly-requested rules. Populate via
+    /// <see cref="FixCommonErrorsRunner.ParseExplicitlyNamedRules"/>. Empty means
+    /// "implicit all-rules pass" (gates stay active).
+    /// </summary>
+    public IReadOnlyList<string> FixCommonErrorsExplicitlyNamedRules { get; init; } = [];
     public int? DeleteFirst { get; init; }
     public int? DeleteLast { get; init; }
     public string? DeleteContains { get; init; }

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -97,7 +97,24 @@ seconv lint *.srt --json                    # CI-friendly: exit 1 on any issue
 | `--target-fps:<rate>` | Target frame rate (with `--fps`) |
 | `--adjust-duration:<ms>` | Add/subtract milliseconds to each duration |
 | `--change-speed:<percent>` | Scale all times by 100/percent (e.g. `125` = 1.25x faster) |
+| `--apply-min-gap:<ms>` | Enforce a minimum gap between paragraphs; pull the next start back / push the previous end back so the gap holds. See note below. |
 | `--renumber:<n>` | Renumber paragraphs starting at `n` |
+
+#### `--apply-min-gap` vs `--FixCommonErrorsRules:FixOverlappingDisplayTimes`
+
+Both touch boundary timings but solve different problems:
+
+- `--apply-min-gap:<ms>` is a **hard**, absolute pass over every pair of adjacent
+  paragraphs and guarantees at least the supplied gap. Use this when you want
+  consistent gaps for a delivery spec (e.g. broadcast standards that demand
+  2 frames between cues).
+- `FixOverlappingDisplayTimes` is one rule inside Fix Common Errors and only
+  resolves cases where paragraph end > next paragraph start (true overlap).
+  It does *not* enforce a non-zero minimum gap once overlaps are gone.
+
+In most batch pipelines `--apply-min-gap:<ms>` is the better choice; reach for
+the FCE rule when you specifically want to keep tight 1 ms gaps the source
+already has and only repair true overlaps.
 
 ### Format-specific
 | Option | Description |
@@ -137,8 +154,31 @@ seconv lint *.srt --json                    # CI-friendly: exit 1 on any issue
 |---|---|
 | `--multiple-replace:<path.xml>` | SE MultipleSearchAndReplaceGroups XML |
 | `--custom-format:<path.xml>` | SE CustomFormatItem XML (with `--format customtext`) |
-| `--settings:<path.json>` | JSON settings file overriding libse defaults |
+| `--settings:<path.json>` | JSON settings file overriding libse defaults (seconv-specific schema — **not** the SE 5 GUI's `Settings.json`) |
 | `--profile:<name>` | Named overlay from settings file's `profiles` map |
+
+> ⚠️ **`--settings:` is not the SE 5 GUI's `Settings.json`.** seconv accepts a
+> small, libse-shaped schema with three top-level keys: `general`, `tools`, and
+> `removeTextForHearingImpaired`. Property names follow the **libse** spelling,
+> e.g. `RemoveIfAllUppercase` — *not* the GUI's `IsRemoveTextUppercaseLineOn`.
+> The GUI's `Settings.json` is a much larger, GUI-specific dump and can't be
+> consumed directly.
+>
+> Minimal example: removing speaker labels on all-uppercase lines.
+>
+> ```json
+> {
+>   "removeTextForHearingImpaired": {
+>     "RemoveIfAllUppercase": true
+>   }
+> }
+> ```
+>
+> ```bash
+> seconv movie.srt subrip --settings:./hi.json --remove-text-for-hi
+> ```
+>
+> The full list of supported keys lives in `src/seconv/Core/SeConvSettings.cs`.
 
 ### Verbosity
 | Option | Description |
@@ -161,6 +201,13 @@ Applied in a fixed, sensible order regardless of CLI order:
 
 `--FixCommonErrors` (no value) runs all 38 rules. Pass `--FixCommonErrorsRules:<list>`
 to pick a subset — supplying the option implies `--FixCommonErrors`.
+
+A handful of rules are **language-conditional** and only run in the default
+"all rules" pass when the auto-detected language matches:
+
+- `FixSpanishInvertedQuestionAndExclamationMarks` — only runs on `es`. The
+  GUI's Fix Common Errors window has the same gating. You can still opt in on
+  non-Spanish content by naming the rule explicitly in `--FixCommonErrorsRules`.
 
 ```bash
 seconv movie.srt subrip --FixCommonErrors                              # all rules

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -97,17 +97,21 @@ seconv lint *.srt --json                    # CI-friendly: exit 1 on any issue
 | `--target-fps:<rate>` | Target frame rate (with `--fps`) |
 | `--adjust-duration:<ms>` | Add/subtract milliseconds to each duration |
 | `--change-speed:<percent>` | Scale all times by 100/percent (e.g. `125` = 1.25x faster) |
-| `--apply-min-gap:<ms>` | Enforce a minimum gap between paragraphs; pull the next start back / push the previous end back so the gap holds. See note below. |
+| `--apply-min-gap:<ms>` | Best-effort enforcement of a minimum gap between paragraphs by shortening the previous cue's end time. See note below. |
 | `--renumber:<n>` | Renumber paragraphs starting at `n` |
 
 #### `--apply-min-gap` vs `--FixCommonErrorsRules:FixOverlappingDisplayTimes`
 
 Both touch boundary timings but solve different problems:
 
-- `--apply-min-gap:<ms>` is a **hard**, absolute pass over every pair of adjacent
-  paragraphs and guarantees at least the supplied gap. Use this when you want
-  consistent gaps for a delivery spec (e.g. broadcast standards that demand
-  2 frames between cues).
+- `--apply-min-gap:<ms>` walks every pair of adjacent paragraphs and, when the
+  gap is shorter than `<ms>`, **shortens the previous cue's end time** to open
+  it up. It does **not** move the next cue's start. Pairs are also **skipped**
+  when shortening would drop the previous cue below
+  `General.SubtitleMinimumDisplayMilliseconds` — so this is best-effort, not a
+  hard guarantee. Use it for delivery specs (e.g. broadcast standards that ask
+  for 2 frames between cues) while accepting that minimum-display-duration
+  collisions are left alone.
 - `FixOverlappingDisplayTimes` is one rule inside Fix Common Errors and only
   resolves cases where paragraph end > next paragraph start (true overlap).
   It does *not* enforce a non-zero minimum gap once overlaps are gone.
@@ -203,11 +207,16 @@ Applied in a fixed, sensible order regardless of CLI order:
 to pick a subset — supplying the option implies `--FixCommonErrors`.
 
 A handful of rules are **language-conditional** and only run in the default
-"all rules" pass when the auto-detected language matches:
+"all rules" pass when the auto-detected language matches. The GUI's Fix Common
+Errors window has the same gating:
 
-- `FixSpanishInvertedQuestionAndExclamationMarks` — only runs on `es`. The
-  GUI's Fix Common Errors window has the same gating. You can still opt in on
-  non-Spanish content by naming the rule explicitly in `--FixCommonErrorsRules`.
+- `FixAloneLowercaseIToUppercaseI` — only on `en`
+- `FixDanishLetterI` — only on `da`
+- `FixSpanishInvertedQuestionAndExclamationMarks` — only on `es`
+- `FixTurkishAnsiToUnicode` — only on `tr`
+
+You can still opt in on any content by naming the rule explicitly in
+`--FixCommonErrorsRules` (e.g. `--FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks`).
 
 ```bash
 seconv movie.srt subrip --FixCommonErrors                              # all rules

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -155,4 +155,55 @@ public class FixCommonErrorsRunnerTest
 
         Assert.Contains("NotARealRule", ex.Message);
     }
+
+    // -------------------------------------------------------------------------
+    // Issue #11037 item 3: language-conditional rules should mirror the GUI's
+    // Fix Common Errors window — Spanish-only rules don't run on non-Spanish
+    // content in the default "all rules" pass, but the user can still opt in
+    // via an explicit --FixCommonErrorsRules list.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void RunAll_OnEnglish_SkipsSpanishInvertedMarks()
+    {
+        // English line that ends with '?' should NOT get a leading '¿'.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.RunAll(sub);
+
+        Assert.DoesNotContain('¿', sub.Paragraphs[0].Text);
+        Assert.DoesNotContain('¡', sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void RunAll_OnSpanish_AppliesSpanishInvertedMarks()
+    {
+        // Spanish-language paragraphs should get the inverted-mark fix as the
+        // GUI does for "es" content. Use enough text for LanguageAutoDetect.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Cuántos años tienes?", 0, 3000));
+        sub.Paragraphs.Add(new Paragraph("Dónde está la biblioteca?", 4000, 7000));
+        sub.Paragraphs.Add(new Paragraph("Qué hora es?", 8000, 11000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.RunAll(sub);
+
+        Assert.Contains('¿', sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void Run_WithExplicitSpanishRule_AppliesEvenOnNonSpanishText()
+    {
+        // Opt-in path: --FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks
+        // runs the rule regardless of detected language.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.Run(sub, new[] { "FixSpanishInvertedQuestionAndExclamationMarks" });
+
+        Assert.Contains('¿', sub.Paragraphs[0].Text);
+    }
 }

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -206,4 +206,62 @@ public class FixCommonErrorsRunnerTest
 
         Assert.Contains('¿', sub.Paragraphs[0].Text);
     }
+
+    [Fact]
+    public void Run_CliImplicitPath_GatesSpanishOnNonSpanish()
+    {
+        // Regression for Copilot review on #11300: ConvertCommand pre-resolves a bare
+        // --FixCommonErrors to the full rule list via ResolveRuleIds(null), then passes
+        // that into Run. With the old single-arg overload, wanted was non-null so the
+        // gate never fired and Spanish marks landed on English content.
+        // The new explicitlyNamedRules=[] signal restores the gate for that path.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
+        sub.Renumber();
+
+        var allRules = FixCommonErrorsRunner.AvailableRuleIds;
+        FixCommonErrorsRunner.Run(sub, allRules, explicitlyNamedRules: []);
+
+        Assert.DoesNotContain('¿', sub.Paragraphs[0].Text);
+        Assert.DoesNotContain('¡', sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void Run_CliExplicitPath_ApplySpanishEvenOnNonSpanish()
+    {
+        // CLI path with --FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks
+        // forwards the named rule as both wanted and explicitly-named, so the gate is
+        // bypassed and the rule fires on English content.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
+        sub.Renumber();
+
+        var rules = new[] { "FixSpanishInvertedQuestionAndExclamationMarks" };
+        FixCommonErrorsRunner.Run(sub, rules, explicitlyNamedRules: rules);
+
+        Assert.Contains('¿', sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void ParseExplicitlyNamedRules_NullOrAllOrNegations_ReturnsEmpty()
+    {
+        // "implicit-all" spec forms — nothing the user named by hand.
+        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules(null));
+        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules(""));
+        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules("   "));
+        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules("all"));
+        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules("all,-FixDanishLetterI"));
+        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules("-FixCommas,-FixDanishLetterI"));
+    }
+
+    [Fact]
+    public void ParseExplicitlyNamedRules_PositiveTokens_AreCapturedExactly()
+    {
+        var named = FixCommonErrorsRunner.ParseExplicitlyNamedRules(
+            "FixSpanishInvertedQuestionAndExclamationMarks,-FixDanishLetterI,FixCommas");
+
+        Assert.Equal(
+            new[] { "FixSpanishInvertedQuestionAndExclamationMarks", "FixCommas" },
+            named);
+    }
 }


### PR DESCRIPTION
## Summary
Addresses three actionable items from #11037 in one PR. Items 1, 2, 4, 5 are either already fixed in the new seconv or out-of-scope (UTF-8 detection); items 3, 6, 7, 8 are handled here.

### Item 3 — code: `FixSpanishInvertedQuestionAndExclamationMarks` was applying to non-Spanish content
The GUI's *Fix Common Errors* window only adds this rule to the rule list when the selected language is `es` ([`FixCommonErrorsViewModel.cs:377`](../blob/main/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs#L377)). seconv was running it unconditionally in the default *all rules* pass, so e.g.

```
"Are you coming home tonight?" → "¿Are you coming home tonight?"
```

`FixCommonErrorsRunner.Run` now skips language-conditional rules in the implicit-all pass when the auto-detected language doesn't match. Explicit opt-in via `--FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks` still applies the rule regardless of detection (this matches what the user expects when they name a rule).

Three new tests cover all three branches: skip on English, apply on Spanish, opt-in restores on non-Spanish.

### Item 6 — docs: `--apply-min-gap` vs `FixOverlappingDisplayTimes`
`--apply-min-gap` wasn't even in the README's Time/Frame table. Added the row + a short explainer of when to use which.

### Items 7 & 8 — docs: `--settings:<path.json>` ≠ SE 5 GUI's `Settings.json`
The user tried to feed seconv the GUI's `Settings.json` with the GUI's key names (`IsRemoveTextUppercaseLineOn`). seconv expects its own small libse-shaped schema (`RemoveIfAllUppercase`). Added an explicit callout under the `--settings` row in the README with a minimal working example.

## What's not in this PR
- **Item 1 (UTF-8 misdetection)** — real libse bug, but isolating the trigger needs more digging. User has `--input-encoding-fallback` as a workaround.
- **Items 2, 4, 5** — already fixed in the current seconv (`--encoding:NONSENSE` errors out, `--encoding:source` works).

## Test plan
- [x] 16/16 `FixCommonErrorsRunnerTest` pass (including the 3 new ones for the language gate)
- [x] Build clean; only the pre-existing unrelated `MkvWithImageTracks` failure (fixed separately in #11299) remains in the full suite
- [ ] Manually verify on issue reporter's `test.srt.txt`: defaults no longer add `¿` / `¡` to English content; `--FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks` still applies them

Refs #11037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)