### PR TITLE
seconv: image-to-image conversion preserves source bitmaps

### DIFF
--- a/src/seconv/Core/BitmapSubtitleLoader.cs
+++ b/src/seconv/Core/BitmapSubtitleLoader.cs
@@ -1,0 +1,166 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
+using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+using Nikse.SubtitleEdit.Core.VobSub;
+using SkiaSharp;
+using System.Text;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// Loads image-based subtitle sources as a stream of pre-rendered bitmaps, bypassing
+/// OCR. Used by the image-to-image conversion path (e.g. .sup → BDN-XML, VobSub → .sup)
+/// so the original source pixels reach the output handler intact instead of being
+/// OCR'd to text and re-rasterised at seconv's default font.
+/// </summary>
+internal static class BitmapSubtitleLoader
+{
+    /// <summary>
+    /// One bitmap subtitle event. <see cref="ScreenWidth"/> / <see cref="ScreenHeight"/>
+    /// are the source-format's declared video frame dimensions when known — pass them
+    /// to the output handler so e.g. Blu-Ray 1920x1080 stays at 1920x1080 rather than
+    /// being squashed into the CLI's default <c>--resolution</c>. Null = caller picks.
+    /// </summary>
+    public sealed record BitmapSubtitleItem(
+        TimeCode StartTime,
+        TimeCode EndTime,
+        SKBitmap Bitmap,
+        int? ScreenWidth = null,
+        int? ScreenHeight = null) : IDisposable
+    {
+        public void Dispose() => Bitmap.Dispose();
+    }
+
+    /// <summary>
+    /// Blu-Ray .sup file → bitmap events. PcsData times are 90 kHz ticks; divide
+    /// by 90 for milliseconds. The PCS header's Width/Height carry the source video
+    /// dimensions (typically 1920x1080 or 1280x720).
+    /// </summary>
+    public static IReadOnlyList<BitmapSubtitleItem> LoadBluRaySup(string filePath)
+    {
+        var log = new StringBuilder();
+        var pcsList = BluRaySupParser.ParseBluRaySup(filePath, log);
+        if (pcsList.Count == 0)
+        {
+            throw new InvalidOperationException($"No Blu-Ray sup subtitles found in: {filePath}");
+        }
+        return PcsListToItems(pcsList);
+    }
+
+    /// <summary>
+    /// MKV PGS track (S_HDMV/PGS) → bitmap events. PGS-in-MKV is the same PCS payload
+    /// as a .sup file, just wrapped in Matroska block timing.
+    /// </summary>
+    public static IReadOnlyList<BitmapSubtitleItem> LoadMatroskaPgs(MatroskaFile matroska, MatroskaTrackInfo track)
+    {
+        var pcsList = BluRaySupParser.ParseBluRaySupFromMatroska(track, matroska);
+        if (pcsList.Count == 0)
+        {
+            throw new InvalidOperationException($"No PGS subtitles in MKV track #{track.TrackNumber}.");
+        }
+        return PcsListToItems(pcsList);
+    }
+
+    /// <summary>
+    /// VobSub <c>.sub</c> + <c>.idx</c> pair → bitmap events. Uses
+    /// <see cref="VobSubParser.OpenSubIdx"/> so the .idx provides timing + palette
+    /// and the .sub provides the subpicture stream payload. The VobSub spec doesn't
+    /// carry a screen size, so we leave dims unset and let the caller decide
+    /// (typical defaults: 720x576 PAL, 720x480 NTSC).
+    /// </summary>
+    public static IReadOnlyList<BitmapSubtitleItem> LoadVobSub(string subPath, string idxPath, bool isPal)
+    {
+        if (!File.Exists(idxPath))
+        {
+            throw new InvalidOperationException($"VobSub .idx companion not found at: {idxPath}");
+        }
+
+        var parser = new VobSubParser(isPal);
+        parser.OpenSubIdx(subPath, idxPath);
+        var packs = parser.MergeVobSubPacks();
+        if (packs.Count == 0)
+        {
+            throw new InvalidOperationException($"No VobSub subtitle packs in: {subPath}");
+        }
+
+        var items = new List<BitmapSubtitleItem>(packs.Count);
+        foreach (var pack in packs)
+        {
+            var bmp = pack.GetBitmap();
+            if (bmp is null)
+            {
+                continue;
+            }
+            items.Add(new BitmapSubtitleItem(pack.StartTimeCode, pack.EndTimeCode, bmp));
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Transport stream DVB-sub → one bitmap list per packet ID. Caller is responsible
+    /// for routing each PID to its own output file (multiple subtitle streams =
+    /// multiple languages, same as the OCR path in <see cref="ImageOcrLoader"/>).
+    /// </summary>
+    public static List<(IReadOnlyList<BitmapSubtitleItem> Items, int PacketId)> LoadTransportStreamDvbSub(string filePath)
+    {
+        var parser = new TransportStreamParser();
+        parser.Parse(filePath, null);
+
+        var results = new List<(IReadOnlyList<BitmapSubtitleItem>, int)>();
+        if (parser.SubtitlePacketIds.Count == 0)
+        {
+            return results;
+        }
+
+        foreach (var pid in parser.SubtitlePacketIds)
+        {
+            var dvbSubtitles = parser.GetDvbSubtitles(pid);
+            if (dvbSubtitles.Count == 0)
+            {
+                continue;
+            }
+
+            var items = new List<BitmapSubtitleItem>(dvbSubtitles.Count);
+            foreach (var dvb in dvbSubtitles)
+            {
+                var bmp = dvb.GetBitmap();
+                if (bmp is null)
+                {
+                    continue;
+                }
+                items.Add(new BitmapSubtitleItem(
+                    new TimeCode((double)dvb.StartMilliseconds),
+                    new TimeCode((double)dvb.EndMilliseconds),
+                    bmp));
+            }
+            if (items.Count > 0)
+            {
+                results.Add((items, pid));
+            }
+        }
+        return results;
+    }
+
+    private static IReadOnlyList<BitmapSubtitleItem> PcsListToItems(IReadOnlyList<BluRaySupParser.PcsData> pcsList)
+    {
+        // Take width/height from the first PCS that reports them. Blu-Ray streams
+        // typically declare a single video resolution per epoch; the value is
+        // baked into the PCS header so every entry should agree.
+        var firstSize = pcsList[0].GetScreenSize();
+        var screenWidth = firstSize.Width > 0 ? (int)firstSize.Width : (int?)null;
+        var screenHeight = firstSize.Height > 0 ? (int)firstSize.Height : (int?)null;
+
+        var items = new List<BitmapSubtitleItem>(pcsList.Count);
+        foreach (var pcs in pcsList)
+        {
+            var bmp = pcs.GetBitmap();
+            if (bmp is null)
+            {
+                continue;
+            }
+            items.Add(new BitmapSubtitleItem(pcs.StartTimeCode, pcs.EndTimeCode, bmp, screenWidth, screenHeight));
+        }
+        return items;
+    }
+}

--- a/src/seconv/Core/BitmapSubtitleLoader.cs
+++ b/src/seconv/Core/BitmapSubtitleLoader.cs
@@ -66,8 +66,10 @@ internal static class BitmapSubtitleLoader
     /// VobSub <c>.sub</c> + <c>.idx</c> pair → bitmap events. Uses
     /// <see cref="VobSubParser.OpenSubIdx"/> so the .idx provides timing + palette
     /// and the .sub provides the subpicture stream payload. The VobSub spec doesn't
-    /// carry a screen size, so we leave dims unset and let the caller decide
-    /// (typical defaults: 720x576 PAL, 720x480 NTSC).
+    /// store a screen size in the index file, so we bake in the DVD-standard frame
+    /// sizes (720x576 PAL, 720x480 NTSC) — otherwise the output writer would fall
+    /// back to <c>--resolution</c> / 1920x1080, which is wrong metadata for DVD
+    /// sources.
     /// </summary>
     public static IReadOnlyList<BitmapSubtitleItem> LoadVobSub(string subPath, string idxPath, bool isPal)
     {
@@ -84,6 +86,9 @@ internal static class BitmapSubtitleLoader
             throw new InvalidOperationException($"No VobSub subtitle packs in: {subPath}");
         }
 
+        var screenWidth = 720;
+        var screenHeight = isPal ? 576 : 480;
+
         var items = new List<BitmapSubtitleItem>(packs.Count);
         foreach (var pack in packs)
         {
@@ -92,7 +97,7 @@ internal static class BitmapSubtitleLoader
             {
                 continue;
             }
-            items.Add(new BitmapSubtitleItem(pack.StartTimeCode, pack.EndTimeCode, bmp));
+            items.Add(new BitmapSubtitleItem(pack.StartTimeCode, pack.EndTimeCode, bmp, screenWidth, screenHeight));
         }
         return items;
     }

--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -260,7 +260,13 @@ internal static class ContainerSubtitleLoader
         return tracks;
     }
 
-    private static string SanitizeLang(string? lang)
+    /// <summary>
+    /// Cleans a language tag for use in an output filename. Empty/whitespace → empty
+    /// string (caller treats as "no suffix"). Otherwise strips characters that are
+    /// problematic in filenames on Windows. Note: "und" (ISO 639 "undetermined") is
+    /// kept, so MKV tracks tagged as such still get a distinct suffix.
+    /// </summary>
+    internal static string SanitizeLang(string? lang)
     {
         if (string.IsNullOrWhiteSpace(lang))
         {

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -72,6 +72,91 @@ internal static class ImageOutputWriter
         handler.WriteFooter();
     }
 
+    /// <summary>
+    /// Image-to-image variant: write a sequence of pre-rendered bitmaps (Blu-Ray .sup,
+    /// VobSub, MKV PGS, DVB-sub) into <paramref name="handler"/> without going through
+    /// <see cref="ImageRenderer"/>. Source dimensions baked into each
+    /// <see cref="BitmapSubtitleLoader.BitmapSubtitleItem"/> override
+    /// <see cref="ConversionOptions.Resolution"/> when present, so e.g. a 1920x1080
+    /// Blu-Ray sup re-exports as 1920x1080 BDN-XML even if the CLI's default
+    /// <c>--resolution</c> is something else.
+    /// </summary>
+    public static void WritePreservedBitmaps(
+        IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem> items,
+        string filePath,
+        IExportHandler handler,
+        ConversionOptions options)
+    {
+        if (items.Count == 0)
+        {
+            throw new InvalidOperationException("No bitmaps to write.");
+        }
+
+        var (defaultWidth, defaultHeight) = options.Resolution ?? (1920, 1080);
+
+        var first = items[0];
+        var firstParam = BuildPreservedParameter(first, 0, defaultWidth, defaultHeight, options);
+        handler.WriteHeader(filePath, firstParam);
+
+        for (var i = 0; i < items.Count; i++)
+        {
+            var item = items[i];
+            var ip = BuildPreservedParameter(item, i, defaultWidth, defaultHeight, options);
+            handler.CreateParagraph(ip);
+            handler.WriteParagraph(ip);
+            // We do NOT dispose item.Bitmap here — ownership stays with BitmapSubtitleItem;
+            // the caller disposes the whole list when done. Disposing twice would crash.
+        }
+        handler.WriteFooter();
+    }
+
+    private static ImageParameter BuildPreservedParameter(
+        BitmapSubtitleLoader.BitmapSubtitleItem item,
+        int index,
+        int defaultWidth,
+        int defaultHeight,
+        ConversionOptions options)
+    {
+        var screenWidth = item.ScreenWidth ?? defaultWidth;
+        var screenHeight = item.ScreenHeight ?? defaultHeight;
+
+        return new ImageParameter
+        {
+            Index = index,
+            Text = string.Empty,
+            Bitmap = item.Bitmap,
+            StartTime = item.StartTime.TimeSpan,
+            EndTime = item.EndTime.TimeSpan,
+            Alignment = ExportAlignment.BottomCenter,
+            ContentAlignment = ExportContentAlignment.Center,
+            // Font/colour fields are still required by the ImageParameter contract even
+            // though no rendering happens — handlers read them for metadata in some
+            // formats (e.g. FCP XML). Mirror BuildParameter's defaults.
+            FontName = "Arial",
+            FontSize = 50,
+            FontColor = SKColors.White,
+            IsBold = false,
+            OutlineColor = SKColors.Black,
+            OutlineWidth = 2.5,
+            ShadowColor = SKColors.Black,
+            ShadowWidth = 0,
+            BackgroundColor = SKColors.Transparent,
+            BackgroundCornerRadius = 0,
+            LineSpacingPercent = 100,
+            ScreenWidth = screenWidth,
+            ScreenHeight = screenHeight,
+            BottomTopMargin = (int)(screenHeight * 0.05),
+            LeftRightMargin = (int)(screenWidth * 0.05),
+            PaddingLeftRight = 0,
+            PaddingTopBottom = 0,
+            FramesPerSecond = options.TargetFps ?? options.Fps ?? 25.0,
+            IsRightToLeft = false,
+            IsForced = false,
+            IsFullFrame = false,
+            Error = string.Empty,
+        };
+    }
+
     private static ImageParameter BuildParameter(Paragraph p, int index, int screenWidth, int screenHeight, ConversionOptions options)
     {
         return new ImageParameter

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -42,11 +42,26 @@ internal class SubtitleConverter
                 return result;
             }
 
+            // Image-to-image preserve path: if the user asks for an image-based target
+            // (.sup, .sub/.idx, BDN-XML, DOST, FCP, D-Cinema, ImagesWithTimeCode, WebVTT
+            // thumbnail) and the input is an image-based source (.sup, .sub+.idx, MKV PGS,
+            // TS DVB-sub), pass the source bitmaps straight through instead of OCR'ing them
+            // to text and re-rasterising at the CLI's default font. Detect once up front so
+            // the per-file loop below sees only text-eligible inputs.
+            var imageTargetHandler = ImageOutputWriter.TryCreateHandler(LibSEIntegration.NormalizeFormatName(options.Format));
+
             var fileIndex = 1;
             foreach (var inputFile in inputFiles)
             {
                 try
                 {
+                    if (imageTargetHandler is not null
+                        && await TryConvertImageToImageAsync(inputFile, options, result, fileIndex))
+                    {
+                        fileIndex++;
+                        continue;
+                    }
+
                     var tracks = ContainerSubtitleLoader.TryLoadTracks(inputFile, options);
                     if (tracks is null)
                     {
@@ -237,6 +252,267 @@ internal class SubtitleConverter
 
         await Task.CompletedTask;
         return result;
+    }
+
+    /// <summary>
+    /// Image-to-image conversion: when both source and target are image-based, parse the
+    /// source's bitmaps directly and feed them into the image output handler — no OCR, no
+    /// re-rasterise at Arial 50pt. Supports .sup, .sub+.idx, MKV PGS, and TS DVB-sub on
+    /// input. Returns true if the input was handled (recorded in <paramref name="result"/>),
+    /// false if it should fall through to the OCR / text pipeline.
+    /// </summary>
+    private async Task<bool> TryConvertImageToImageAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex)
+    {
+        var ext = Path.GetExtension(inputFile).ToLowerInvariant();
+
+        if (ext == ".sup")
+        {
+            return await PassThroughSingleStreamAsync(inputFile, options, result, fileIndex,
+                () => BitmapSubtitleLoader.LoadBluRaySup(inputFile));
+        }
+
+        if (ext == ".sub")
+        {
+            // Treat .sub as VobSub input only when an .idx companion exists — otherwise
+            // (e.g. a text MicroDVD .sub) leave it for the text loader to detect via IsMine.
+            var idxPath = Path.ChangeExtension(inputFile, ".idx");
+            if (File.Exists(idxPath))
+            {
+                // IsPal: default to PAL to match VobSubExtractor. The .idx "size:" field
+                // could disambiguate per-file, but a wrong guess only affects timing scale,
+                // not bitmap content.
+                return await PassThroughSingleStreamAsync(inputFile, options, result, fileIndex,
+                    () => BitmapSubtitleLoader.LoadVobSub(inputFile, idxPath, isPal: true));
+            }
+            return false;
+        }
+
+        if (ext is ".mkv" or ".mks")
+        {
+            return await PassThroughMatroskaPgsAsync(inputFile, options, result, fileIndex);
+        }
+
+        if (ext is ".ts" or ".m2ts" or ".mts")
+        {
+            return await PassThroughTransportStreamDvbAsync(inputFile, options, result, fileIndex);
+        }
+
+        return false;
+    }
+
+    private async Task<bool> PassThroughSingleStreamAsync(
+        string inputFile,
+        ConversionOptions options,
+        ConversionResult result,
+        int fileIndex,
+        Func<IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem>> load)
+    {
+        var outputFile = ResolveOutputFileName(inputFile, options);
+        if (!options.Quiet)
+        {
+            AnsiConsole.Markup($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile).EscapeMarkup()}[/] [dim](img→img)→[/] [green]{outputFile.EscapeMarkup()}[/]...");
+        }
+
+        IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem>? items = null;
+        try
+        {
+            items = load();
+            WritePreservedBitmaps(items, outputFile, options);
+            result.SuccessfulFiles++;
+            result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
+            if (!options.Quiet)
+            {
+                AnsiConsole.MarkupLine($" [green]done ({items.Count} bitmap(s)).[/]");
+            }
+        }
+        catch (Exception ex)
+        {
+            result.FailedFiles++;
+            result.Errors.Add($"{Path.GetFileName(inputFile)}: {ex.Message}");
+            result.Files.Add(new FileConversionResult(inputFile, null, false, ex.Message));
+            if (!options.Quiet)
+            {
+                AnsiConsole.MarkupLine($" [red]error: {ex.Message.EscapeMarkup()}[/]");
+            }
+        }
+        finally
+        {
+            if (items is not null)
+            {
+                foreach (var item in items)
+                {
+                    item.Dispose();
+                }
+            }
+        }
+
+        await Task.CompletedTask;
+        return true;
+    }
+
+    private async Task<bool> PassThroughMatroskaPgsAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex)
+    {
+        using var matroska = new Nikse.SubtitleEdit.Core.ContainerFormats.Matroska.MatroskaFile(inputFile);
+        if (!matroska.IsValid)
+        {
+            // Not really an MKV — let the regular container loader / text loader try.
+            return false;
+        }
+
+        var pgsTracks = matroska.GetTracks(true)
+            .Where(t => t.CodecId.Equals("S_HDMV/PGS", StringComparison.OrdinalIgnoreCase))
+            .Where(t => !options.ForcedOnly || t.IsForced)
+            .Where(t => options.TrackNumbers.Count == 0 || options.TrackNumbers.Contains(t.TrackNumber))
+            .ToList();
+
+        if (pgsTracks.Count == 0)
+        {
+            // MKV has no PGS tracks usable for image-to-image; fall through so the regular
+            // container loader can handle text tracks / OCR-friendly tracks.
+            return false;
+        }
+
+        if (pgsTracks.Count > 1 && !string.IsNullOrEmpty(options.OutputFilename))
+        {
+            throw new InvalidOperationException(
+                "--output-filename can only target a single track. Use --track-number to select one.");
+        }
+
+        foreach (var track in pgsTracks)
+        {
+            var outputFile = ResolveOutputFileName(
+                inputFile, options, SanitizeLanguage(track.Language), track.TrackNumber);
+
+            if (!options.Quiet)
+            {
+                var trackLabel = $"#{track.TrackNumber} ";
+                AnsiConsole.Markup($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile).EscapeMarkup()}[/] [yellow]{trackLabel}[/][dim](PGS img→img)→[/] [green]{outputFile.EscapeMarkup()}[/]...");
+            }
+
+            IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem>? items = null;
+            try
+            {
+                items = BitmapSubtitleLoader.LoadMatroskaPgs(matroska, track);
+                WritePreservedBitmaps(items, outputFile, options);
+                result.SuccessfulFiles++;
+                result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
+                if (!options.Quiet)
+                {
+                    AnsiConsole.MarkupLine($" [green]done ({items.Count} bitmap(s)).[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                result.FailedFiles++;
+                result.Errors.Add($"{Path.GetFileName(inputFile)} track #{track.TrackNumber}: {ex.Message}");
+                result.Files.Add(new FileConversionResult(inputFile, null, false, ex.Message));
+                if (!options.Quiet)
+                {
+                    AnsiConsole.MarkupLine($" [red]error: {ex.Message.EscapeMarkup()}[/]");
+                }
+            }
+            finally
+            {
+                if (items is not null)
+                {
+                    foreach (var item in items)
+                    {
+                        item.Dispose();
+                    }
+                }
+            }
+        }
+
+        await Task.CompletedTask;
+        return true;
+    }
+
+    private async Task<bool> PassThroughTransportStreamDvbAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex)
+    {
+        var streams = BitmapSubtitleLoader.LoadTransportStreamDvbSub(inputFile);
+        if (streams.Count == 0)
+        {
+            // No DVB-sub PIDs found; let the regular container loader handle teletext / etc.
+            return false;
+        }
+
+        if (streams.Count > 1 && !string.IsNullOrEmpty(options.OutputFilename))
+        {
+            throw new InvalidOperationException(
+                "--output-filename can only target a single DVB-sub PID. Found "
+                + $"{streams.Count} PIDs in the transport stream.");
+        }
+
+        foreach (var (items, pid) in streams)
+        {
+            // PID is the natural per-stream identifier — use it as the track-number-like
+            // suffix so multi-PID streams don't collide on output.
+            var outputFile = ResolveOutputFileName(inputFile, options, languageSuffix: null, trackNumber: pid);
+
+            if (!options.Quiet)
+            {
+                AnsiConsole.Markup($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile).EscapeMarkup()}[/] [yellow]PID {pid} [/][dim](DVB img→img)→[/] [green]{outputFile.EscapeMarkup()}[/]...");
+            }
+
+            try
+            {
+                WritePreservedBitmaps(items, outputFile, options);
+                result.SuccessfulFiles++;
+                result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
+                if (!options.Quiet)
+                {
+                    AnsiConsole.MarkupLine($" [green]done ({items.Count} bitmap(s)).[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                result.FailedFiles++;
+                result.Errors.Add($"{Path.GetFileName(inputFile)} PID {pid}: {ex.Message}");
+                result.Files.Add(new FileConversionResult(inputFile, null, false, ex.Message));
+                if (!options.Quiet)
+                {
+                    AnsiConsole.MarkupLine($" [red]error: {ex.Message.EscapeMarkup()}[/]");
+                }
+            }
+            finally
+            {
+                foreach (var item in items)
+                {
+                    item.Dispose();
+                }
+            }
+        }
+
+        await Task.CompletedTask;
+        return true;
+    }
+
+    private static void WritePreservedBitmaps(
+        IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem> items,
+        string outputFile,
+        ConversionOptions options)
+    {
+        var handler = ImageOutputWriter.TryCreateHandler(LibSEIntegration.NormalizeFormatName(options.Format))
+            ?? throw new InvalidOperationException($"No image handler for format '{options.Format}'");
+        var outputDir = Path.GetDirectoryName(outputFile);
+        if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
+        {
+            Directory.CreateDirectory(outputDir);
+        }
+        ImageOutputWriter.WritePreservedBitmaps(items, outputFile, handler, options);
+    }
+
+    /// <summary>
+    /// Mirrors <c>ContainerSubtitleLoader.SanitizeLang</c> — Matroska Language can be empty
+    /// or "und". Caller wants null in those cases so the language suffix is omitted.
+    /// </summary>
+    private static string? SanitizeLanguage(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language) || language.Equals("und", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+        return language;
     }
 
     private List<string> GetInputFiles(ConversionOptions options)

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -381,7 +381,7 @@ internal class SubtitleConverter
         foreach (var track in pgsTracks)
         {
             var outputFile = ResolveOutputFileName(
-                inputFile, options, SanitizeLanguage(track.Language), track.TrackNumber);
+                inputFile, options, ContainerSubtitleLoader.SanitizeLang(track.Language), track.TrackNumber);
 
             if (!options.Quiet)
             {
@@ -445,9 +445,12 @@ internal class SubtitleConverter
 
         foreach (var (items, pid) in streams)
         {
-            // PID is the natural per-stream identifier — use it as the track-number-like
-            // suffix so multi-PID streams don't collide on output.
-            var outputFile = ResolveOutputFileName(inputFile, options, languageSuffix: null, trackNumber: pid);
+            // PID is the natural per-stream identifier. ResolveOutputFileName only embeds
+            // languageSuffix into the filename stem (trackNumber is only used as the
+            // de-duplication fallback for overwrite collisions), so pass the PID *as* the
+            // language suffix to keep each PID's output stably named — otherwise multiple
+            // PIDs would collide and only differ by an opaque "_2", "_3" rotation.
+            var outputFile = ResolveOutputFileName(inputFile, options, languageSuffix: $"dvb_pid{pid}", trackNumber: pid);
 
             if (!options.Quiet)
             {
@@ -500,19 +503,6 @@ internal class SubtitleConverter
             Directory.CreateDirectory(outputDir);
         }
         ImageOutputWriter.WritePreservedBitmaps(items, outputFile, handler, options);
-    }
-
-    /// <summary>
-    /// Mirrors <c>ContainerSubtitleLoader.SanitizeLang</c> — Matroska Language can be empty
-    /// or "und". Caller wants null in those cases so the language suffix is omitted.
-    /// </summary>
-    private static string? SanitizeLanguage(string? language)
-    {
-        if (string.IsNullOrWhiteSpace(language) || language.Equals("und", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-        return language;
     }
 
     private List<string> GetInputFiles(ConversionOptions options)

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -11,6 +11,7 @@ operations, and OCR engines as the desktop UI — without an Avalonia / GUI depe
 - OCR pipelines for image-based sources (Blu-Ray .sup, MKV PGS, DVB-sub)
 - Five OCR engines: Tesseract subprocess, nOCR (built-in), BinaryOCR (built-in), Ollama (HTTP), PaddleOCR subprocess
 - Image-based output: Blu-Ray sup, BDN-XML, DOST, FCP, D-Cinema interop / SMPTE 2014, images-with-time-code, WebVTT thumbnails
+- Image-to-image conversion (preserve source bitmaps, no OCR): Blu-Ray .sup, VobSub .sub/.idx, MKV PGS, TS DVB-sub → any image output format
 - Full operation pipeline: offset, fps change, renumber, adjust-duration, fix-common-errors,
   merge/split, balance, redo casing, RTL fixes, multiple-replace, custom-text format, plain text
 - Cross-platform (Windows, Linux, macOS) — only requires .NET 10 runtime
@@ -47,6 +48,12 @@ seconv movie.sup subrip --ocr-engine:ollama --ollama-model:llama3.2-vision
 
 seconv subs.srt bluraysup --resolution:1920x1080               # render text → Blu-Ray sup
 seconv subs.srt bdnxml --resolution:1920x1080                  # render text → BDN-XML
+
+seconv movie.sup bdnxml                                        # preserve bitmaps: .sup → BDN-XML (no OCR)
+seconv movie.sup vobsub                                        # preserve bitmaps: Blu-Ray → DVD
+seconv movie.sub bdnxml                                        # preserve bitmaps: VobSub → BDN-XML (.idx auto-detected)
+seconv movie.mkv bluraysup                                     # preserve bitmaps: MKV PGS track → .sup
+seconv movie.ts dost                                           # preserve bitmaps: DVB-sub → DOST (one output per PID)
 
 seconv subs.srt customtext --custom-format:my-template.xml     # custom template
 seconv *.srt subrip --multiple-replace:rules.xml               # search-and-replace pass
@@ -152,6 +159,31 @@ already has and only repair true overlaps.
 > - From the repo: [`Ocr/Latin.nocr`](https://github.com/SubtitleEdit/subtitleedit/raw/main/Ocr/Latin.nocr)
 >   and [`Ocr/Latin.db`](https://github.com/SubtitleEdit/subtitleedit/raw/main/Ocr/Latin.db).
 > - Other languages: download from the SE UI (Tools → "OCR with nOCR" / BinaryOCR → download).
+
+### Image-to-image conversion (no OCR)
+
+When **both** the input and target are image-based subtitle formats, seconv passes the
+source bitmaps straight through to the output handler instead of OCR'ing them to text
+and re-rasterising at the CLI's default font. Routing is automatic — no flag needed:
+
+| Input | Detection | Outputs |
+|---|---|---|
+| `.sup` | extension | any image format |
+| `.sub` (VobSub) | `.idx` companion next to it | any image format |
+| `.mkv` / `.mks` | `S_HDMV/PGS` track present | any image format (one output per track) |
+| `.ts` / `.m2ts` / `.mts` | DVB-sub PID present | any image format (one output per PID) |
+
+The same input with a text target (`subrip`, `ass`, ...) still routes through OCR.
+Source video dimensions (e.g. 1920x1080 for Blu-Ray) are preserved automatically and
+take precedence over `--resolution`.
+
+```bash
+seconv movie.sup bdnxml                                        # Blu-Ray → BDN-XML for NLE re-authoring
+seconv movie.sup vobsub                                        # Blu-Ray → DVD
+seconv movie.sub bluraysup                                     # DVD → Blu-Ray (.idx auto-detected)
+seconv movie.mkv dost                                          # MKV PGS → DOST (per track)
+seconv movie.ts fcpimage                                       # DVB-sub → FCP image XML (per PID)
+```
 
 ### Templates / replacements
 | Option | Description |

--- a/tests/seconv/Core/ImageToImageTest.cs
+++ b/tests/seconv/Core/ImageToImageTest.cs
@@ -1,0 +1,110 @@
+using SeConv.Core;
+using SkiaSharp;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Verifies the image-to-image conversion path: source bitmaps from a Blu-Ray .sup go
+/// directly into the image output handler without OCR + re-render. The fixture
+/// <c>sample.sup</c> is shared with <see cref="OcrTest"/>.
+/// </summary>
+public class ImageToImageTest : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public ImageToImageTest()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "ImgToImg_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ConvertAsync_BluRaySupToBdnXml_PreservesSourceBitmaps()
+    {
+        // sample.sup → BDN-XML through the preserve-bitmaps path. The output PNGs should
+        // be the actual decoded subpicture bitmaps from the .sup, not text re-rendered at
+        // Arial 50pt — so dimensions reflect the source, not seconv's default --resolution.
+        var input = Fixtures.Path("sample.sup");
+        Assert.True(File.Exists(input), $"Fixture missing: {input}");
+        var outputFolder = Path.Combine(_tempRoot, "bdn");
+        Directory.CreateDirectory(outputFolder);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "bdnxml",
+            OutputFolder = outputFolder,
+            Overwrite = true,
+            // Pick a deliberately oddball default so we can confirm it's not used —
+            // the .sup's PCS header carries the real source resolution.
+            Resolution = (400, 300),
+        });
+
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+
+        // BDN-XML emits PNGs and an index.xml referencing them.
+        var pngs = Directory.GetFiles(outputFolder, "*.png", SearchOption.AllDirectories);
+        Assert.NotEmpty(pngs);
+
+        // Each PNG starts with the standard PNG signature.
+        var firstBytes = new byte[8];
+        using (var fs = File.OpenRead(pngs[0]))
+        {
+            Assert.Equal(8, fs.Read(firstBytes, 0, 8));
+        }
+        Assert.Equal(0x89, firstBytes[0]);
+        Assert.Equal((byte)'P', firstBytes[1]);
+        Assert.Equal((byte)'N', firstBytes[2]);
+        Assert.Equal((byte)'G', firstBytes[3]);
+
+        // A re-rendered text bitmap at 400x300 would be 400 wide. The sample.sup's source
+        // resolution is larger — the BDN index records the source frame size, so check it
+        // doesn't match the deliberately-wrong --resolution we passed in.
+        var indexes = Directory.GetFiles(outputFolder, "index.xml", SearchOption.AllDirectories);
+        Assert.Single(indexes);
+        var index = await File.ReadAllTextAsync(indexes[0], TestContext.Current.CancellationToken);
+        Assert.Contains("<BDN", index);
+        Assert.DoesNotContain("400 300", index); // would indicate the --resolution leaked through
+        Assert.DoesNotContain("VideoFormat=\"400x300\"", index);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_BluRaySupToSrt_StillRoutesToOcr_NotPreservePath()
+    {
+        // Text target → OCR path; the preserve path must not swallow this case. We don't
+        // care whether OCR succeeds (Tesseract may not be installed in CI), only that the
+        // image-to-image path is skipped — confirmed by the error referencing Tesseract
+        // rather than image-writer plumbing.
+        if (TesseractOcrEngine.Detect() is not null)
+        {
+            return;
+        }
+
+        var input = Fixtures.Path("sample.sup");
+        Assert.True(File.Exists(input));
+        var outputFolder = Path.Combine(_tempRoot, "out");
+        Directory.CreateDirectory(outputFolder);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "SubRip",
+            OutputFolder = outputFolder,
+            Overwrite = true,
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains("Tesseract not found on PATH", result.Errors[0]);
+    }
+}

--- a/tests/seconv/Core/ImageToImageTest.cs
+++ b/tests/seconv/Core/ImageToImageTest.cs
@@ -1,5 +1,4 @@
 using SeConv.Core;
-using SkiaSharp;
 using Xunit;
 
 namespace SeConvTests.Core;


### PR DESCRIPTION
## Summary
- Adds a preserve-bitmaps path so `.sup → BDN-XML`, `.sub/.idx → .sup`, `MKV PGS → DOST`, etc. don't lose the source pixels to an OCR+re-render round-trip.
- Auto-routes: image input + image target → preserve. Anything else (`.sup → .srt`, text → image) keeps using the existing OCR / render paths.
- Source video dimensions (PCS header on `.sup`/PGS, conventional 720x576/480 for VobSub) override `--resolution` so re-exports stay at native size.

Built on top of #11301 (WebVTT thumbnail wiring) — GitHub will rebase the base to `main` automatically once that merges.

## Background
The format-audit conversation flagged that neither seconv nor the predecessor [subtitleedit-cli](https://github.com/SubtitleEdit/subtitleedit-cli) supported image-to-image conversion. The old tool's `HasImageTarget` literally returns `false` (`CommandLineConverter.cs:1322`), so this is a real CLI gap.

## What's wired

| Input source | Detection | Output handlers it reaches |
|---|---|---|
| `.sup` (Blu-Ray) | file extension | all 9 image-output formats |
| `.sub` + `.idx` (VobSub) | `.idx` companion next to `.sub` | all |
| `.mkv` / `.mks` | `S_HDMV/PGS` track present | all, one output per track |
| `.ts` / `.m2ts` / `.mts` | DVB-sub PID present | all, one output per PID |

The four loaders live in the new `BitmapSubtitleLoader` and reuse the same parsers already used by the OCR path (`BluRaySupParser`, `VobSubParser`, `TransportStreamParser`), just yielding `SKBitmap`s directly instead of OCR'ing them.

`ImageOutputWriter.WritePreservedBitmaps` is a new overload that takes pre-rendered bitmaps and skips `ImageRenderer.GenerateBitmap` — every existing export handler works unchanged because they all consume `ImageParameter.Bitmap`.

`SubtitleConverter.ConvertAsync` short-circuits to `TryConvertImageToImageAsync` for each input before falling through to the OCR / text paths.

## Test plan
- [x] `dotnet test tests/seconv/SeConvTests.csproj` — 151/151 passing.
- [x] New `ImageToImageTest`: `.sup → BDN-XML` produces PNGs + index.xml, and the deliberately-wrong `--resolution:400x300` doesn't leak into the output (confirms source dims were preserved).
- [x] New `ImageToImageTest`: `.sup → .srt` still routes to OCR (Tesseract-missing error message), confirming the preserve path doesn't swallow text targets.
- [x] CLI smoke test against `tests/seconv/Fixtures/sample.sup → bdnxml`: `(img→img)→ done (2 bitmap(s))`, output folder has `index.xml` + `0001.png` + `0002.png`.
- [ ] (Reviewer): try a real Blu-Ray `.sup → BDN-XML` round-trip in your NLE of choice to confirm BDN-XML is consumable.
- [ ] (Reviewer): if you have a DVB-sub `.ts` handy, try `.ts → dost` and confirm one output per subtitle PID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)