### PR TITLE
seconv: honor --teletext-only in DVB-sub preserve path

### DIFF
--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -429,6 +429,16 @@ internal class SubtitleConverter
 
     private async Task<bool> PassThroughTransportStreamDvbAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex)
     {
+        // --teletext-only means "skip DVB-sub". The regular container path
+        // (ContainerSubtitleLoader.LoadTransportStream) honors this by gating its DVB-sub
+        // load on !options.TeletextOnly; this preserve path has to do the same or the
+        // flag is bypassed whenever the target is an image format.
+        if (options.TeletextOnly)
+        {
+            await Task.CompletedTask;
+            return false;
+        }
+
         var streams = BitmapSubtitleLoader.LoadTransportStreamDvbSub(inputFile);
         if (streams.Count == 0)
         {


### PR DESCRIPTION
## Summary
- `PassThroughTransportStreamDvbAsync` (added in #11302) didn't check `options.TeletextOnly` before loading DVB-sub PIDs, so `seconv movie.ts bdnxml --teletext-only` still emitted DVB-sub output despite the flag.
- The regular container path in `ContainerSubtitleLoader.LoadTransportStream` already gates DVB-sub on `!options.TeletextOnly` (line 240). The new image-to-image preserve path needs the same guard, otherwise it short-circuits before that guard can run.
- Fix is an early return that falls through to the regular container loader, which then emits only teletext tracks (rendered to the chosen image format when the target is image-based).

Found during a fresh format-coverage audit after #11301 and #11302 landed.

## Test plan
- [x] `dotnet test tests/seconv/SeConvTests.csproj` — 151/151 passing.
- [ ] (Reviewer): no regression test added because the existing TS fixture (`container_teletext.ts`) carries no DVB-sub PIDs, so before and after the fix it produces the same output for that file. A meaningful test needs a TS sample with both teletext **and** DVB-sub. Happy to add one if a fixture appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)