### PR TITLE
seconv: extract subtitles from MXF containers

### DIFF
--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
+using Nikse.SubtitleEdit.Core.ContainerFormats.MaterialExchangeFormat;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
 using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
@@ -65,7 +66,87 @@ internal static class ContainerSubtitleLoader
             return LoadTransportStream(filePath, options);
         }
 
+        if (ext == ".mxf")
+        {
+            return LoadMxf(filePath);
+        }
+
         return null;
+    }
+
+    /// <summary>
+    /// MXF (Material Exchange Format) container — broadcast / DCP workflows wrap timed
+    /// text essences (TTML, SRT, etc.) inside KLV-packetised "essence elements". libse's
+    /// <see cref="MxfParser"/> walks the KLV structure and extracts each candidate
+    /// subtitle blob; we hand them to <see cref="Subtitle.ReloadLoadSubtitle"/> to
+    /// auto-detect which SubtitleFormat each one actually is.
+    ///
+    /// Returns one <see cref="LoadedTrack"/> per parseable subtitle essence. Image
+    /// essences (PNG payloads in MxfParser.GetImages) are *not* surfaced here —
+    /// MxfParser collects the bitmaps but doesn't carry per-essence PTS, so there's no
+    /// timing context for image output. Flagged as a warning instead.
+    /// </summary>
+    private static List<LoadedTrack>? LoadMxf(string filePath)
+    {
+        var parser = new MxfParser(filePath);
+        if (!parser.IsValid)
+        {
+            // Not a real MXF (no Header Partition Pack signature). Fall through to the
+            // text loader — the file might just have a misleading extension.
+            return null;
+        }
+
+        var subtitleTexts = parser.GetSubtitles();
+        var images = parser.GetImages();
+
+        if (subtitleTexts.Count == 0)
+        {
+            if (images.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"MXF contains {images.Count} image essence(s) but no text subtitles. "
+                    + "Image-based MXF subtitles (PNG essences) aren't supported yet — "
+                    + "the parser doesn't reconstruct per-essence PTS, so the bitmaps have no timing.");
+            }
+            throw new InvalidOperationException($"No subtitle essences found in MXF: {filePath}");
+        }
+
+        if (images.Count > 0)
+        {
+            AnsiConsole.MarkupLine(
+                $"[yellow]Note: MXF also contains {images.Count} image essence(s) — skipped (no timing context).[/]");
+        }
+
+        var tracks = new List<LoadedTrack>();
+        var trackNumber = 1;
+        foreach (var subtitleText in subtitleTexts)
+        {
+            var subtitle = new Subtitle();
+            var lines = new List<string>(subtitleText.SplitToLines());
+            // ReloadLoadSubtitle scans every SubtitleFormat's IsMine until one claims the text.
+            // Passing null for all three "preferred format" hints means full auto-detect.
+            var format = subtitle.ReloadLoadSubtitle(lines, null, null);
+            if (format == null || subtitle.Paragraphs.Count == 0)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[yellow]Warning: MXF essence #{trackNumber} doesn't parse as a known subtitle format; skipped.[/]");
+                trackNumber++;
+                continue;
+            }
+            subtitle.Renumber();
+            // Use "mxf_track{n}" as the language-suffix slot so multi-track MXFs produce
+            // stably-named outputs (mirrors the teletext_<page> / dvb_pid<n> conventions).
+            tracks.Add(new LoadedTrack(subtitle, format, $"mxf_track{trackNumber}", trackNumber));
+            trackNumber++;
+        }
+
+        if (tracks.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"MXF contained {subtitleTexts.Count} candidate subtitle essence(s) but none parsed as a known format: {filePath}");
+        }
+
+        return tracks;
     }
 
     private static List<LoadedTrack> LoadMatroska(string filePath, ConversionOptions options)

--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -68,7 +68,7 @@ internal static class ContainerSubtitleLoader
 
         if (ext == ".mxf")
         {
-            return LoadMxf(filePath);
+            return LoadMxf(filePath, options);
         }
 
         return null;
@@ -86,9 +86,24 @@ internal static class ContainerSubtitleLoader
     /// MxfParser collects the bitmaps but doesn't carry per-essence PTS, so there's no
     /// timing context for image output. Flagged as a warning instead.
     /// </summary>
-    private static List<LoadedTrack>? LoadMxf(string filePath)
+    private static List<LoadedTrack>? LoadMxf(string filePath, ConversionOptions options)
     {
-        var parser = new MxfParser(filePath);
+        // MxfParser walks the KLV structure inside its constructor, so any malformed
+        // packet (zero-length essence, truncated BER length, etc.) surfaces here as a
+        // low-level exception like IndexOutOfRangeException. Wrap it so the user sees
+        // an MXF-contextual error instead of a stack-traceless "Index was outside the
+        // bounds of the array".
+        MxfParser parser;
+        try
+        {
+            parser = new MxfParser(filePath);
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                $"Failed to parse MXF file '{filePath}': {ex.Message}", ex);
+        }
+
         if (!parser.IsValid)
         {
             // Not a real MXF (no Header Partition Pack signature). Fall through to the
@@ -121,6 +136,14 @@ internal static class ContainerSubtitleLoader
         var trackNumber = 1;
         foreach (var subtitleText in subtitleTexts)
         {
+            // Honour --track-number against the 1-based essence index — mirrors how
+            // LoadMatroska / LoadMp4 filter their multi-track inputs (line ~96).
+            if (options.TrackNumbers.Count > 0 && !options.TrackNumbers.Contains(trackNumber))
+            {
+                trackNumber++;
+                continue;
+            }
+
             var subtitle = new Subtitle();
             var lines = new List<string>(subtitleText.SplitToLines());
             // ReloadLoadSubtitle scans every SubtitleFormat's IsMine until one claims the text.
@@ -142,6 +165,11 @@ internal static class ContainerSubtitleLoader
 
         if (tracks.Count == 0)
         {
+            if (options.TrackNumbers.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"MXF contained {subtitleTexts.Count} essence(s) but none matched --track-number ({string.Join(",", options.TrackNumbers)}): {filePath}");
+            }
             throw new InvalidOperationException(
                 $"MXF contained {subtitleTexts.Count} candidate subtitle essence(s) but none parsed as a known format: {filePath}");
         }

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -7,7 +7,7 @@ operations, and OCR engines as the desktop UI — without an Avalonia / GUI depe
 ## Features
 
 - 380+ subtitle formats (text, binary, image-based)
-- Container input: Matroska (.mkv/.mks), MP4, MCC, transport stream teletext
+- Container input: Matroska (.mkv/.mks), MP4, MCC, MXF, transport stream teletext
 - OCR pipelines for image-based sources (Blu-Ray .sup, MKV PGS, DVB-sub)
 - Five OCR engines: Tesseract subprocess, nOCR (built-in), BinaryOCR (built-in), Ollama (HTTP), PaddleOCR subprocess
 - Image-based output: Blu-Ray sup, BDN-XML, DOST, FCP, D-Cinema interop / SMPTE 2014, images-with-time-code, WebVTT thumbnails

--- a/tests/seconv/Core/MxfInputTest.cs
+++ b/tests/seconv/Core/MxfInputTest.cs
@@ -1,0 +1,135 @@
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Verifies ContainerSubtitleLoader's new MXF branch. There's no real-world MXF fixture
+/// in the repo, so each test builds a minimal valid MXF byte stream from scratch: a
+/// Header Partition Pack signature + a single Essence Element KLV whose payload is SRT
+/// text. The libse MxfParser only needs the header signature + KLV walking to succeed —
+/// any extra MXF structural metadata is optional.
+/// </summary>
+public class MxfInputTest : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public MxfInputTest()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "Mxf_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ConvertAsync_MxfWithSrtEssence_ProducesSrtOutput()
+    {
+        var mxfPath = Path.Combine(_tempRoot, "movie.mxf");
+        var srt =
+            "1\n00:00:01,000 --> 00:00:04,000\nHello from MXF!\n\n"
+            + "2\n00:00:05,000 --> 00:00:08,000\nSecond subtitle.\n\n";
+        File.WriteAllBytes(mxfPath, BuildSyntheticMxf(srt));
+
+        var outputFolder = Path.Combine(_tempRoot, "out");
+        Directory.CreateDirectory(outputFolder);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [mxfPath],
+            Format = "SubRip",
+            OutputFolder = outputFolder,
+            Overwrite = true,
+        });
+
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+        var srts = Directory.GetFiles(outputFolder, "*.srt");
+        Assert.Single(srts);
+        // The MXF loader tags the essence with a "mxf_track{n}" suffix so multi-essence
+        // files don't collide on output. Verify the suffix made it into the filename.
+        Assert.Contains(srts, p => Path.GetFileName(p).Contains("mxf_track1"));
+
+        var content = await File.ReadAllTextAsync(srts[0], TestContext.Current.CancellationToken);
+        Assert.Contains("Hello from MXF!", content);
+        Assert.Contains("Second subtitle.", content);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_MxfWithoutValidHeader_FallsThrough()
+    {
+        // A .mxf file without the Header Partition Pack signature should be treated as
+        // a regular file (MxfParser.IsValid = false → LoadMxf returns null → caller
+        // falls back to LibSEIntegration.LoadSubtitleWithFormat). With non-MXF bytes in
+        // the .mxf file, that fallback will fail with a parse error — but we only need
+        // to verify the MXF path didn't claim the file.
+        var mxfPath = Path.Combine(_tempRoot, "fake.mxf");
+        File.WriteAllText(mxfPath, "Not really an MXF file, just text with a .mxf extension.");
+        var outputFolder = Path.Combine(_tempRoot, "out");
+        Directory.CreateDirectory(outputFolder);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [mxfPath],
+            Format = "SubRip",
+            OutputFolder = outputFolder,
+            Overwrite = true,
+        });
+
+        // Fallback should fail because the file isn't a parseable subtitle either — but
+        // the error must come from the text loader, not from MXF assertions.
+        Assert.False(result.Success);
+        Assert.Single(result.Errors);
+        // The error message shouldn't mention MXF — it should be the generic format
+        // detection failure.
+        Assert.DoesNotContain("MXF", result.Errors[0]);
+    }
+
+    /// <summary>
+    /// Builds a minimal valid MXF byte stream: 16-byte Header Partition Pack key with
+    /// no payload, followed by a 16-byte Essence Element key carrying <paramref name="payload"/>
+    /// as UTF-8 bytes. This is the smallest structure MxfParser will walk successfully
+    /// (header signature at offset 0, single KLV essence containing the subtitle text).
+    /// </summary>
+    private static byte[] BuildSyntheticMxf(string payload)
+    {
+        // Header Partition Pack: only bytes 0..10 are checked by ReadHeaderPartitionPack;
+        // the remaining 5 bytes can be anything per the spec's wildcard convention.
+        byte[] headerKey = [0x06, 0x0E, 0x2B, 0x34, 0x02, 0x05, 0x01, 0x01, 0x0D, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00];
+        // Essence Element key: last 4 bytes wildcarded in KlvPacket.IsKey, so any 0xff
+        // placeholder works.
+        byte[] essenceKey = [0x06, 0x0E, 0x2B, 0x34, 0x01, 0x02, 0x01, 0x01, 0x0D, 0x01, 0x03, 0x01, 0xFF, 0xFF, 0xFF, 0xFF];
+
+        var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payload);
+
+        using var ms = new MemoryStream();
+        // First KLV: header partition pack with zero-length payload (BER 0x00).
+        ms.Write(headerKey);
+        ms.WriteByte(0x00);
+        // Second KLV: essence element with the SRT text. BER long-form length: 0x84
+        // means "4-byte big-endian length follows", which handles payloads up to 4 GB
+        // and avoids the short-form 0..127 boundary case.
+        ms.Write(essenceKey);
+        ms.WriteByte(0x84);
+        ms.WriteByte((byte)((payloadBytes.Length >> 24) & 0xFF));
+        ms.WriteByte((byte)((payloadBytes.Length >> 16) & 0xFF));
+        ms.WriteByte((byte)((payloadBytes.Length >> 8) & 0xFF));
+        ms.WriteByte((byte)(payloadBytes.Length & 0xFF));
+        ms.Write(payloadBytes);
+        // ReadHeaderPartitionPack requires the file to be >= 100 bytes; pad if smaller.
+        // (With a typical multi-cue SRT payload, we're already well past 100 bytes, but
+        // the guard keeps short single-cue tests honest.)
+        while (ms.Length < 100)
+        {
+            ms.WriteByte(0x00);
+        }
+        return ms.ToArray();
+    }
+}

--- a/tests/seconv/Core/MxfInputTest.cs
+++ b/tests/seconv/Core/MxfInputTest.cs
@@ -35,7 +35,7 @@ public class MxfInputTest : IDisposable
         var srt =
             "1\n00:00:01,000 --> 00:00:04,000\nHello from MXF!\n\n"
             + "2\n00:00:05,000 --> 00:00:08,000\nSecond subtitle.\n\n";
-        File.WriteAllBytes(mxfPath, BuildSyntheticMxf(srt));
+        File.WriteAllBytes(mxfPath, BuildSyntheticMxf([srt]));
 
         var outputFolder = Path.Combine(_tempRoot, "out");
         Directory.CreateDirectory(outputFolder);
@@ -59,6 +59,63 @@ public class MxfInputTest : IDisposable
         var content = await File.ReadAllTextAsync(srts[0], TestContext.Current.CancellationToken);
         Assert.Contains("Hello from MXF!", content);
         Assert.Contains("Second subtitle.", content);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_MxfWithTrackNumberFilter_PicksOneEssence()
+    {
+        // Two-essence MXF, request only essence #2 via --track-number. The first
+        // essence's text must not appear in the output.
+        var mxfPath = Path.Combine(_tempRoot, "movie.mxf");
+        var srt1 = "1\n00:00:01,000 --> 00:00:02,000\nFirst essence.\n\n";
+        var srt2 = "1\n00:00:03,000 --> 00:00:04,000\nSecond essence.\n\n";
+        File.WriteAllBytes(mxfPath, BuildSyntheticMxf([srt1, srt2]));
+
+        var outputFolder = Path.Combine(_tempRoot, "out");
+        Directory.CreateDirectory(outputFolder);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [mxfPath],
+            Format = "SubRip",
+            OutputFolder = outputFolder,
+            Overwrite = true,
+            TrackNumbers = [2],
+        });
+
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+        var srts = Directory.GetFiles(outputFolder, "*.srt");
+        Assert.Single(srts);
+        Assert.Contains(srts, p => Path.GetFileName(p).Contains("mxf_track2"));
+        var content = await File.ReadAllTextAsync(srts[0], TestContext.Current.CancellationToken);
+        Assert.Contains("Second essence.", content);
+        Assert.DoesNotContain("First essence.", content);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_MxfWithCorruptKlv_ProducesMxfContextualError()
+    {
+        // A file with a valid Header Partition Pack signature but a truncated KLV
+        // packet should surface a "Failed to parse MXF" error, not a raw
+        // IndexOutOfRangeException leaked from libse's KLV reader.
+        var mxfPath = Path.Combine(_tempRoot, "corrupt.mxf");
+        File.WriteAllBytes(mxfPath, BuildCorruptMxf());
+        var outputFolder = Path.Combine(_tempRoot, "out");
+        Directory.CreateDirectory(outputFolder);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [mxfPath],
+            Format = "SubRip",
+            OutputFolder = outputFolder,
+            Overwrite = true,
+        });
+
+        Assert.False(result.Success);
+        Assert.Single(result.Errors);
+        Assert.Contains("MXF", result.Errors[0]);
     }
 
     [Fact]
@@ -94,11 +151,12 @@ public class MxfInputTest : IDisposable
 
     /// <summary>
     /// Builds a minimal valid MXF byte stream: 16-byte Header Partition Pack key with
-    /// no payload, followed by a 16-byte Essence Element key carrying <paramref name="payload"/>
-    /// as UTF-8 bytes. This is the smallest structure MxfParser will walk successfully
-    /// (header signature at offset 0, single KLV essence containing the subtitle text).
+    /// no payload, followed by one Essence Element KLV per entry in <paramref name="payloads"/>
+    /// carrying the entry as UTF-8 bytes. This is the smallest structure MxfParser will
+    /// walk successfully — header signature at offset 0, then N KLV essences containing
+    /// the subtitle text(s).
     /// </summary>
-    private static byte[] BuildSyntheticMxf(string payload)
+    private static byte[] BuildSyntheticMxf(IReadOnlyList<string> payloads)
     {
         // Header Partition Pack: only bytes 0..10 are checked by ReadHeaderPartitionPack;
         // the remaining 5 bytes can be anything per the spec's wildcard convention.
@@ -107,25 +165,53 @@ public class MxfInputTest : IDisposable
         // placeholder works.
         byte[] essenceKey = [0x06, 0x0E, 0x2B, 0x34, 0x01, 0x02, 0x01, 0x01, 0x0D, 0x01, 0x03, 0x01, 0xFF, 0xFF, 0xFF, 0xFF];
 
-        var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payload);
-
         using var ms = new MemoryStream();
         // First KLV: header partition pack with zero-length payload (BER 0x00).
         ms.Write(headerKey);
         ms.WriteByte(0x00);
-        // Second KLV: essence element with the SRT text. BER long-form length: 0x84
-        // means "4-byte big-endian length follows", which handles payloads up to 4 GB
-        // and avoids the short-form 0..127 boundary case.
-        ms.Write(essenceKey);
-        ms.WriteByte(0x84);
-        ms.WriteByte((byte)((payloadBytes.Length >> 24) & 0xFF));
-        ms.WriteByte((byte)((payloadBytes.Length >> 16) & 0xFF));
-        ms.WriteByte((byte)((payloadBytes.Length >> 8) & 0xFF));
-        ms.WriteByte((byte)(payloadBytes.Length & 0xFF));
-        ms.Write(payloadBytes);
+        // Each payload becomes its own essence-element KLV. BER long-form length:
+        // 0x84 means "4-byte big-endian length follows", which handles payloads up to
+        // 4 GB and avoids the short-form 0..127 boundary case.
+        foreach (var payload in payloads)
+        {
+            var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payload);
+            ms.Write(essenceKey);
+            ms.WriteByte(0x84);
+            ms.WriteByte((byte)((payloadBytes.Length >> 24) & 0xFF));
+            ms.WriteByte((byte)((payloadBytes.Length >> 16) & 0xFF));
+            ms.WriteByte((byte)((payloadBytes.Length >> 8) & 0xFF));
+            ms.WriteByte((byte)(payloadBytes.Length & 0xFF));
+            ms.Write(payloadBytes);
+        }
         // ReadHeaderPartitionPack requires the file to be >= 100 bytes; pad if smaller.
-        // (With a typical multi-cue SRT payload, we're already well past 100 bytes, but
+        // (With typical multi-cue SRT payload, we're already well past 100 bytes, but
         // the guard keeps short single-cue tests honest.)
+        while (ms.Length < 100)
+        {
+            ms.WriteByte(0x00);
+        }
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Builds a byte stream with a valid Header Partition Pack signature followed by
+    /// a KLV that announces a huge payload but is truncated before the data — exercises
+    /// the error path where the libse KLV reader runs off the end of the file.
+    /// </summary>
+    private static byte[] BuildCorruptMxf()
+    {
+        byte[] headerKey = [0x06, 0x0E, 0x2B, 0x34, 0x02, 0x05, 0x01, 0x01, 0x0D, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00];
+        byte[] essenceKey = [0x06, 0x0E, 0x2B, 0x34, 0x01, 0x02, 0x01, 0x01, 0x0D, 0x01, 0x03, 0x01, 0xFF, 0xFF, 0xFF, 0xFF];
+
+        using var ms = new MemoryStream();
+        ms.Write(headerKey);
+        ms.WriteByte(0x00);
+        ms.Write(essenceKey);
+        // Claim a 1 MB payload but write only a few bytes — the parser's stream.Read
+        // will return a short count and downstream parsing trips up.
+        ms.WriteByte(0x83);
+        ms.WriteByte(0x0F); ms.WriteByte(0xFF); ms.WriteByte(0xFF);
+        ms.Write([0x01, 0x02, 0x03]);
         while (ms.Length < 100)
         {
             ms.WriteByte(0x00);


### PR DESCRIPTION
## Summary
- libse's `MxfParser` had been sitting unused (no callers in the repo). Wire it into `ContainerSubtitleLoader` so `seconv movie.mxf srt` works for broadcast / DCP workflows where the timed-text track (TTML, SRT, etc.) is wrapped inside a Material Exchange Format container's KLV essence elements.
- Each text essence becomes a `LoadedTrack` tagged `mxf_track<n>`, mirroring the existing `teletext_<page>` / `dvb_pid<n>` conventions for multi-stream containers so outputs stay stably named.
- Format detection per essence is delegated to `Subtitle.ReloadLoadSubtitle` — TTML / SRT / SSA / whatever's actually wrapped gets recognised automatically.
- Image essences (PNG payloads in `MxfParser.GetImages`) are not surfaced. `MxfParser` collects the bitmaps but doesn't reconstruct per-essence PTS, so they have no timing for image-output handlers. They produce a warning when text essences are also present, or a clear error when they're the only essences in the file.

Found during a fresh format-coverage audit after #11301 / #11302 / #11303.

## Test plan
- [x] `dotnet test tests/seconv/SeConvTests.csproj` — 153/153 passing.
- [x] New `MxfInputTest`: builds a synthetic MXF byte stream directly from the KLV spec (Header Partition Pack signature at offset 0 + Essence Element KLV with an SRT payload). Verifies the SRT round-trips through `seconv movie.mxf SubRip` and lands in `out/movie.mxf_track1.srt` with both cues intact.
- [x] New `MxfInputTest`: a file with a `.mxf` extension but no Header Partition Pack signature falls through to the regular text loader (which then errors with a generic format-detection failure — confirming the MXF branch correctly returned `null`).
- [ ] (Reviewer): try a real-world MXF from your broadcast / DCP toolchain — none ship in the repo so I couldn't exercise the wild variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)