### PR TITLE
seconv docs: document all output format aliases

### DIFF
--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -262,16 +262,19 @@ and OCR engine setup that seconv doesn't carry.
 
 ## Output format aliases
 
+All aliases below are case-insensitive and accepted by `--format` / the positional
+argument. Both kebab-case and run-together spellings work for the multi-word ones.
+
 ```
-srt / subrip                      ass / assa                      ssa
-vtt / webvtt                      smi / sami                      sbv
-pac                               unipac / pacunicode             ebu / ebustl / stl
-cavena / cavena890                cheetahcaption                  capmakerplus
-ayato
-bluraysup / sup                   vobsub                          bdnxml / bdn-xml
-dost                              fcpimage                        dcinemainterop
-dcinemasmpte2014                  imageswithtimecode              webvttthumbnail / webvtt-thumbnail / vttthumb
-plaintext / text / txt            customtext / customtextformat
+srt / subrip                       ass / assa                       ssa
+vtt / webvtt                       smi / sami                       sbv
+pac                                unipac / pacunicode              ebu / ebustl / stl
+cavena / cavena890                 cheetah / cheetahcaption         capmaker / capmakerplus
+ayato                              vobsub                           bluraysup / sup
+bdnxml / bdn-xml                   dost / dostimage                 fcp / fcpimage
+dcinemainterop / dcinema-interop   dcinemasmpte2014 / dcinema-smpte
+imageswithtimecode / imagesintc    webvttthumbnail / webvtt-thumbnail / vttthumb
+plaintext / text / txt             customtext / customtextformat
 ```
 
 ## Exit codes

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -263,7 +263,8 @@ and OCR engine setup that seconv doesn't carry.
 ## Output format aliases
 
 All aliases below are case-insensitive and accepted by `--format` / the positional
-argument. Both kebab-case and run-together spellings work for the multi-word ones.
+argument. Only the spellings shown in the table are recognised — variants that
+aren't listed (e.g. `plain-text`, `custom-text`) won't resolve.
 
 ```
 srt / subrip                       ass / assa                       ssa


### PR DESCRIPTION
## Summary
`NormalizeFormatName` accepts kebab-case and short-form aliases for most multi-word formats, but the README's aliases table only listed the canonical / longer spellings. Copilot flagged the same mismatch on #11301 (`webvtt-thumbnail` wasn't documented); doing the rest in one sweep.

Aliases newly listed in the table:

| Already documented | Now also documented |
|---|---|
| `cheetahcaption` | `cheetah` |
| `capmakerplus` | `capmaker` |
| `dost` | `dostimage` |
| `fcpimage` | `fcp` |
| `dcinemainterop` | `dcinema-interop` |
| `dcinemasmpte2014` | `dcinema-smpte` |
| `imageswithtimecode` | `imagesintc` |

Also added a one-line preamble noting case-insensitive matching.

The `blurayup` alias (almost certainly a typo for `bluraysup` that's been in the code since day one) is intentionally left undocumented — putting it in user-facing docs would entrench the typo.

No code changes; pure docs.

## Test plan
- [x] Diffed `NormalizeFormatName` against the new table — every alias in the code now appears in the README (modulo the intentional `blurayup` exclusion).
- [ ] (Reviewer): glance over the table layout; the 3-column grid is preserved but a few rows now wrap because the alias strings got longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)