### PR TITLE
SE5: highlight Duration column on CPS-too-high (fixes #11307)

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -324,7 +324,12 @@ public partial class SubtitleLineViewModel : ObservableObject
         {
             if ((Se.Settings.General.ColorDurationTooShort && Duration.TotalMilliseconds < Se.Settings.General.SubtitleMinimumDisplayMilliseconds) ||
                 (Se.Settings.General.ColorDurationTooLong && Duration.TotalMilliseconds > Se.Settings.General.SubtitleMaximumDisplayMilliseconds) ||
-                (Se.Settings.General.ColorTimeCodeOverlap && Gap < 0))
+                (Se.Settings.General.ColorTimeCodeOverlap && Gap < 0) ||
+                // CPS too high == the duration is too short for this much text. SE4 lit up
+                // the Duration column for this case and users (issue #11307) rely on it
+                // being visible there, not just in the CPS column. Reuse the same gate
+                // setting so users who turn duration colouring off get a uniform behaviour.
+                (Se.Settings.General.ColorDurationTooLong && CharactersPerSecond > Se.Settings.General.SubtitleMaximumCharactersPerSeconds))
             {
                 return _errorBrush;
             }
@@ -482,6 +487,9 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(CharactersPerSecond));
         OnPropertyChanged(nameof(TextBackgroundBrush));
         OnPropertyChanged(nameof(CpsBackgroundBrush));
+        // DurationBackgroundBrush now also reacts to CPS-too-high, and text edits change
+        // CPS (numerator), so the Duration cell must repaint on text changes too.
+        OnPropertyChanged(nameof(DurationBackgroundBrush));
         OnPropertyChanged(nameof(WordsPerMinute));
         OnPropertyChanged(nameof(WpmBackgroundBrush));
         OnPropertyChanged(nameof(PixelWidth));


### PR DESCRIPTION
## Summary
Fixes #11307. SE5's subtitle grid stopped highlighting the Duration column when a row's CPS exceeded `General.SubtitleMaximumCharactersPerSeconds` — only the CPS column (and the Text column, via the line-length highlight gate) lit up. SE4 highlighted Duration too, and users rely on that signal because "CPS too high" is conceptually "duration too short for this much text."

This patch extends `DurationBackgroundBrush` (`src/ui/Features/Main/SubtitleLineViewModel.cs:321`) with one extra predicate: `ColorDurationTooLong` gate + `CharactersPerSecond > Max`. Re-using the existing gate keeps user-facing behaviour consistent — turning off duration colouring still disables the new branch.

Also notifies `DurationBackgroundBrush` in `OnTextChanged`. Text edits change CPS, and since the Duration cell now reacts to CPS-too-high, it has to repaint on text changes too. The other notification points (`OnEndTimeChanged`, `OnDurationChanged`, `UpdateDuration`) already fired the Duration brush, so nothing else needed updating.

Behaviour table now:

| Column | Highlights on CPS-too-high? |
|---|---|
| CPS | yes (unchanged) |
| Text | yes, when `ColorTextTooLong` is on (unchanged) |
| **Duration** | **yes, when `ColorDurationTooLong` is on** (new) |
| WPM | no (CPS-independent) |

Doesn't touch the separate concerns the issue mentions ("incoherent CPS counting vs v4" and "distinguishable from line-length errors"). Those are bigger and want their own discussion; this PR just restores the v4 Duration-column behaviour, which the issue author called out as the most useful immediate fix.

## Test plan
- [x] Clean Debug build of `src/ui/UI.csproj`.
- [ ] (Reviewer): in the running app, load a subtitle with a too-high-CPS row; confirm the Duration cell goes red and updates live when the text is edited up or down through the threshold.
- [ ] (Reviewer): turn off **Color duration too long** in settings; confirm the Duration cell stops highlighting on too-high CPS (the gate is shared).

No unit test added — `SubtitleLineViewModel` has no existing unit-test surface and adding one would pull in Avalonia ApplicationHost infrastructure just to assert a brush colour. Happy to add a focused test if there's an established pattern I missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)