### PR TITLE
SE5: align waveform window with restored video position (fixes #11305)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14829,6 +14829,13 @@ public partial class MainViewModel :
                             {
                                 vp.Position = s.StartTime.TotalSeconds;
                                 Dispatcher.UIThread.Post(() => { vp.Position = SelectedSubtitle.StartTime.TotalSeconds; });
+                                // If wave peaks were already cached and loaded by this point,
+                                // the waveform load fired before vp.Position was set and so
+                                // is anchored at 0:00. Center it now (issue #11305). If peaks
+                                // haven't finished loading yet, the load-completion paths in
+                                // LoadWaveformAndSpectrogram / ExtractWaveformAndSpectrogram
+                                // AndShotChanges will do the centering instead.
+                                CenterAudioVisualizerOnCurrentVideoPosition();
                             }
                         }
 
@@ -15078,6 +15085,12 @@ public partial class MainViewModel :
                     {
                         ExtractShotChanges(videoFileName, trackNumber);
                     }
+
+                    // Session-restore on startup sets the video position to the last-edited
+                    // cue *before* wave peaks are loaded from disk, so the waveform window
+                    // would otherwise stay at 0:00 (issue #11305). Center now that peaks
+                    // are available.
+                    CenterAudioVisualizerOnCurrentVideoPosition();
 
                     _updateAudioVisualizer = true;
                 });
@@ -15344,6 +15357,12 @@ public partial class MainViewModel :
                         }
 
                         InitializeWaveformDisplayMode();
+
+                        // Same rationale as the cached-peaks path in LoadWaveformAndSpectrogram:
+                        // by the time FFmpeg has produced the peak data, the video position
+                        // may already be set (session-restore / user click). Bring the
+                        // waveform window in line.
+                        CenterAudioVisualizerOnCurrentVideoPosition();
                     }
 
                     _updateAudioVisualizer = true;
@@ -17968,6 +17987,24 @@ public partial class MainViewModel :
                 _updateAudioVisualizer = true;
             }
         }
+    }
+
+    /// <summary>
+    /// Re-centers the waveform on the video player's current position if it falls
+    /// outside the currently visible waveform window. Used after wave peaks finish
+    /// loading and after session-restore sets the video position — without this,
+    /// the waveform stays anchored at 0:00 even though the grid and video are
+    /// pointed at the last-edited cue (issue #11305).
+    /// </summary>
+    private void CenterAudioVisualizerOnCurrentVideoPosition()
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp == null || vp.Position <= 0)
+        {
+            // No video / fresh open at zero — keep the default 0:00 view.
+            return;
+        }
+        AudioVisualizerCenterOnPositionIfNeeded(vp.Position);
     }
 
     private CancellationTokenSource? _singleTapCancellationTokenSource;


### PR DESCRIPTION
## Summary
Fixes #11305. On startup with **Open last file on start** enabled, the subtitle grid scrolls to the last-selected cue and the video position is set to that cue's start time — but the waveform stays anchored at 0:00. Users have to click the video to jog the waveform before it follows.

**Root cause: a race.** `SubtitleOpen` kicks off wave-peak loading early (either reading cached peaks from disk or spawning an FFmpeg extraction). The `OnLoaded` handler then sets `vp.Position` much later (after `WaitForPlayersReadyAsync` + a 200 ms settle). Whichever side wins, neither one nudges the waveform window afterwards.

**Fix.** New `CenterAudioVisualizerOnCurrentVideoPosition()` helper that re-uses the existing `AudioVisualizerCenterOnPositionIfNeeded` (idempotent — only scrolls when the position falls outside the visible window). Called at every load-or-position-set crossing:

1. After `AudioVisualizer.WavePeaks = wavePeaks;` in the cached-peaks branch of `LoadWaveformAndSpectrogram`.
2. After `AudioVisualizer.WavePeaks = wavePeaks;` in `ExtractWaveformAndSpectrogramAndShotChanges` (the FFmpeg extraction completion path).
3. In `OnLoaded`, right after `vp.Position = s.StartTime.TotalSeconds;` during session restore — in case wave peaks had already finished loading earlier inside `SubtitleOpen`.

Guarded on `vp.Position > 0` so a fresh video open at 0:00 is unaffected, and the underlying helper only scrolls when the position is *outside* the current window — so users who haven't moved the video don't see the waveform jump.

## Test plan
- [x] Clean Debug build of `src/ui/UI.csproj`.
- [ ] (Reviewer): with **Open last file on start** enabled and a recent file whose last-selected cue is mid-video (e.g. 5+ minutes in), close and reopen Subtitle Edit. The waveform should land showing the selected cue's region, not 0:00. Confirm the same for the case where the wave-peak cache file already exists vs. where it has to be re-extracted.
- [ ] (Reviewer): with a fresh video open (no last-selected cue), confirm the waveform still defaults to 0:00 — no unwanted auto-scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)