### PR TITLE
SE5: add "Text to speech..." to grid context menu (#10941)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -875,6 +875,12 @@ public static partial class InitListViewAndEditBox
                 },
                 new MenuItem
                 {
+                    Header = Se.Language.Main.Menu.TextToSpeech,
+                    Command = vm.ShowVideoTextToSpeechCommand,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
                     Header = Se.Language.Main.Menu.AutoTranslate,
                     Command = vm.AutoTranslateSelectedLinesCommand,
                     DataContext = vm,


### PR DESCRIPTION
## Summary

Adds a **"Text to speech..."** item to the subtitle grid context menu, right after **"Speech to text..."**, as requested in [#10941](https://github.com/SubtitleEdit/subtitleedit/issues/10941#issuecomment-4593612239).

The item lives in the **"Selected lines"** submenu of the grid context flyout (where "Speech to text..." already appears) and reuses the existing `ShowVideoTextToSpeechCommand` and `Se.Language.Main.Menu.TextToSpeech` string — no new ViewModel plumbing or language entries needed.

## Notes

- The TTS window itself handles voice/line selection, which aligns with the broader "select and voice" request in the issue.
- `ShowVideoTextToSpeechCommand` currently operates on the whole subtitle rather than only the selected lines; a selected-lines-scoped TTS variant could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
