### PR TITLE
fix: TextSplitResult crash on headless Linux (#11314)

### DIFF
--- a/src/libse/Common/TextSplitResult.cs
+++ b/src/libse/Common/TextSplitResult.cs
@@ -15,24 +15,51 @@ namespace Nikse.SubtitleEdit.Core.Common
         public double TotalLength => Lines.Sum(p => p.Length);
         public double TotalLengthPixels => LengthPixels.Sum(p => p) - SpaceLengthPixels;
 
-        private static readonly SKFont Font = new SKFont
-        {
-            Size = 12f // Adjust this size to match your original DefaultFont size
-        };
+        // SkiaSharp resolves a default typeface the first time SKFont's object
+        // initializer runs; on headless Linux setups without fontconfig (e.g. the
+        // eclipse-temurin:21-jre-noble container reported in issue #11314) that
+        // discovery throws. The fields used to have inline `= new SKFont {...}`
+        // initializers, so a single failure broke the entire class's .cctor and
+        // every subsequent line-wrap call hit a TypeInitializationException.
+        //
+        // Moving construction into an explicit static constructor lets us catch the
+        // failure and leave _font / _paint as null. GetWidth then falls back to the
+        // same length × 5 heuristic the >128 char branch already uses — pixel-
+        // precise wrapping isn't possible, but the resulting layout is still a
+        // valid two-line split, so AutoBreak / SCC line-wrap keep working.
+        private static readonly SKFont _font;
+        private static readonly SKPaint _paint;
+        private static readonly bool _fontInitialized;
 
-        private static readonly SKPaint Paint = new SKPaint
+        static TextSplitResult()
         {
-            IsAntialias = false
-        };
+            try
+            {
+                _font = new SKFont { Size = 12f };
+                _paint = new SKPaint { IsAntialias = false };
+                _fontInitialized = true;
+            }
+            catch
+            {
+                _fontInitialized = false;
+            }
+        }
 
         public static float GetWidth(string text)
         {
-            if (text.Length > 128)
+            if (text.Length > 128 || !_fontInitialized)
             {
                 return text.Length * 5;
             }
 
-            return Font.MeasureText(text, Paint);
+            try
+            {
+                return _font.MeasureText(text, _paint);
+            }
+            catch
+            {
+                return text.Length * 5;
+            }
         }
 
         public TextSplitResult(List<string> lines)


### PR DESCRIPTION
## Summary
Fixes #11314. The static `SKFont` / `SKPaint` field initializers in `TextSplitResult` triggered SkiaSharp's default-typeface lookup the first time the class was touched. On headless Linux setups without fontconfig (the issue reporter's `eclipse-temurin:21-jre-noble` container is one example — any minimal Docker image / CI runner that ships SkiaSharp's native libs without a font configuration is at risk), that lookup throws. Because these were field initializers, the failure broke the class's `.cctor`, so every subsequent line-wrap call surfaced as `TypeInitializationException`.

Repro from the issue: any SRT with a line > 32 chars that's auto-wrappable, converted to `ScenaristClosedCaptions`, crashed seconv on the Noble container with:
```
The type initializer for 'Nikse.SubtitleEdit.Core.Common.TextSplitResult' threw an exception.
```

## Approach
Move `SKFont` / `SKPaint` construction into an explicit static constructor guarded by try/catch and an `_fontInitialized` flag. `GetWidth` falls back to the same `text.Length * 5` heuristic that already exists for strings > 128 chars, so callers (`AutoBreak`, SCC line-wrap, anything else hitting `GetWidth`) keep working when SkiaSharp can't find a typeface. A second try/catch wraps the `MeasureText` call itself, so a mid-run native failure can't take down the batch.

Pixel-accurate wrapping when SkiaSharp has a typeface; character-count wrapping when it doesn't.

## Follow-up
The issue also calls out a diagnostics gap — seconv only surfaces `TypeInitializationException.Message`, hiding the real `InnerException` that explains *why* the .cctor threw. I'd suggest a separate, focused PR that adds an InnerException-chain unwrap (recursive `ex.InnerException.Message`) at seconv's catch sites in `SubtitleConverter.cs`, gated on `--verbose` for stack traces. Happy to do that as a follow-up if there's interest.

## Test plan
- [x] Clean build of `src/libse/LibSE.csproj` (0 warnings, 0 errors).
- [ ] (Reviewer): repro the original case from the issue on a minimal Linux container without fontconfig and confirm the SRT → SCC conversion now succeeds (it should produce a valid two-row split, just using character-count instead of pixel-width for break decisions).
- [ ] (Reviewer): on a normal dev machine with fontconfig available, confirm conversion still uses pixel-width wrapping (no regression to the existing wrapping quality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)