### PR TITLE
seconv: surface InnerException chain at catch sites (follow-up to #11314)

### DIFF
--- a/src/seconv/Core/ErrorMessageFormatter.cs
+++ b/src/seconv/Core/ErrorMessageFormatter.cs
@@ -1,0 +1,52 @@
+using System.Text;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// Renders an <see cref="Exception"/> as a user-facing error message. Wrapper
+/// exceptions like <see cref="TypeInitializationException"/> have <c>.Message</c>
+/// values that hide the real cause ("The type initializer for 'X' threw an exception."),
+/// so by default we walk the <see cref="Exception.InnerException"/> chain and join
+/// the messages. With <c>--verbose</c> the full <see cref="Exception.ToString()"/>
+/// — including stack traces — is emitted.
+///
+/// Issue #11314 was the trigger: a static field initializer in libse threw and
+/// users only saw the outer message, hiding the actual SkiaSharp font-discovery
+/// failure that was the root cause. This formatter makes those failures actionable.
+/// </summary>
+internal static class ErrorMessageFormatter
+{
+    /// <summary>
+    /// Formats <paramref name="ex"/> for surfacing to the user. When
+    /// <paramref name="verbose"/> is true returns the full <c>ToString()</c>
+    /// (stack traces and all); otherwise returns the message chain joined with
+    /// " → ".
+    /// </summary>
+    public static string FormatForUser(Exception ex, bool verbose)
+    {
+        if (verbose)
+        {
+            return ex.ToString();
+        }
+
+        var sb = new StringBuilder();
+        var current = ex;
+        var depth = 0;
+        // Hard cap on chain depth — pathological exception chains (cyclical
+        // wrappers etc.) shouldn't make us spin or produce kilobyte-long messages.
+        while (current != null && depth < 8)
+        {
+            if (sb.Length > 0)
+            {
+                sb.Append(" → ");
+            }
+            // Trim trailing periods so the joined chain reads cleanly when each
+            // wrapper's Message ends in one ("The type initializer for X threw an
+            // exception." → "Unable to load font.").
+            sb.Append(current.Message.TrimEnd('.'));
+            current = current.InnerException;
+            depth++;
+        }
+        return sb.ToString();
+    }
+}

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -109,13 +109,14 @@ internal class SubtitleConverter
                 }
                 catch (Exception ex)
                 {
+                    var msg = ErrorMessageFormatter.FormatForUser(ex, options.Verbose);
                     result.FailedFiles++;
-                    result.Errors.Add($"{Path.GetFileName(inputFile)}: {ex.Message}");
-                    result.Files.Add(new FileConversionResult(inputFile, null, false, ex.Message));
+                    result.Errors.Add($"{Path.GetFileName(inputFile)}: {msg}");
+                    result.Files.Add(new FileConversionResult(inputFile, null, false, msg));
 
                     if (!options.Quiet)
                     {
-                        AnsiConsole.MarkupLine($" [red]error: {ex.Message.EscapeMarkup()}[/]");
+                        AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
                     }
                 }
 
@@ -124,7 +125,7 @@ internal class SubtitleConverter
         }
         catch (Exception ex)
         {
-            result.Errors.Add($"Conversion failed: {ex.Message}");
+            result.Errors.Add($"Conversion failed: {ErrorMessageFormatter.FormatForUser(ex, options.Verbose)}");
         }
 
         return result;
@@ -238,15 +239,16 @@ internal class SubtitleConverter
         }
         catch (Exception ex)
         {
+            var msg = ErrorMessageFormatter.FormatForUser(ex, options.Verbose);
             result.FailedFiles = vobFiles.Count;
-            result.Errors.Add($"VOB extraction failed: {ex.Message}");
+            result.Errors.Add($"VOB extraction failed: {msg}");
             foreach (var f in vobFiles)
             {
-                result.Files.Add(new FileConversionResult(f, null, false, ex.Message));
+                result.Files.Add(new FileConversionResult(f, null, false, msg));
             }
             if (!options.Quiet)
             {
-                AnsiConsole.MarkupLine($" [red]error: {ex.Message.EscapeMarkup()}[/]");
+                AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
             }
         }
 
@@ -327,12 +329,13 @@ internal class SubtitleConverter
         }
         catch (Exception ex)
         {
+            var msg = ErrorMessageFormatter.FormatForUser(ex, options.Verbose);
             result.FailedFiles++;
-            result.Errors.Add($"{Path.GetFileName(inputFile)}: {ex.Message}");
-            result.Files.Add(new FileConversionResult(inputFile, null, false, ex.Message));
+            result.Errors.Add($"{Path.GetFileName(inputFile)}: {msg}");
+            result.Files.Add(new FileConversionResult(inputFile, null, false, msg));
             if (!options.Quiet)
             {
-                AnsiConsole.MarkupLine($" [red]error: {ex.Message.EscapeMarkup()}[/]");
+                AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
             }
         }
         finally
@@ -403,12 +406,13 @@ internal class SubtitleConverter
             }
             catch (Exception ex)
             {
+                var msg = ErrorMessageFormatter.FormatForUser(ex, options.Verbose);
                 result.FailedFiles++;
-                result.Errors.Add($"{Path.GetFileName(inputFile)} track #{track.TrackNumber}: {ex.Message}");
-                result.Files.Add(new FileConversionResult(inputFile, null, false, ex.Message));
+                result.Errors.Add($"{Path.GetFileName(inputFile)} track #{track.TrackNumber}: {msg}");
+                result.Files.Add(new FileConversionResult(inputFile, null, false, msg));
                 if (!options.Quiet)
                 {
-                    AnsiConsole.MarkupLine($" [red]error: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
                 }
             }
             finally
@@ -479,12 +483,13 @@ internal class SubtitleConverter
             }
             catch (Exception ex)
             {
+                var msg = ErrorMessageFormatter.FormatForUser(ex, options.Verbose);
                 result.FailedFiles++;
-                result.Errors.Add($"{Path.GetFileName(inputFile)} PID {pid}: {ex.Message}");
-                result.Files.Add(new FileConversionResult(inputFile, null, false, ex.Message));
+                result.Errors.Add($"{Path.GetFileName(inputFile)} PID {pid}: {msg}");
+                result.Files.Add(new FileConversionResult(inputFile, null, false, msg));
                 if (!options.Quiet)
                 {
-                    AnsiConsole.MarkupLine($" [red]error: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
                 }
             }
             finally

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -220,7 +220,7 @@ seconv movie.ts fcpimage                                       # DVB-sub → FCP
 | Option | Description |
 |---|---|
 | `--quiet` / `-q` | Suppress per-file progress; only print the final summary |
-| `--verbose` / `-v` | Print extra diagnostic information |
+| `--verbose` / `-v` | Print extra diagnostic information (incl. full `Exception.ToString()` with stack traces on errors; without it, the message chain is still walked so wrapper exceptions like `TypeInitializationException` surface their root cause) |
 | `--json` | Emit per-file results as JSON to stdout (suppresses Spectre output) |
 
 ## Operations (boolean flags)

--- a/tests/seconv/Core/ErrorMessageFormatterTest.cs
+++ b/tests/seconv/Core/ErrorMessageFormatterTest.cs
@@ -1,0 +1,110 @@
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Tests for ErrorMessageFormatter — added alongside the seconv catch-site enrichment
+/// so the InnerException-chain unwrapping (issue #11314 follow-up) is locked in.
+/// </summary>
+public class ErrorMessageFormatterTest
+{
+    [Fact]
+    public void FormatForUser_NoInnerException_ReturnsBareMessage()
+    {
+        var ex = new InvalidOperationException("Boom");
+
+        var formatted = ErrorMessageFormatter.FormatForUser(ex, verbose: false);
+
+        // Trailing period would have been stripped if present; raw message has none, so
+        // the output is unchanged.
+        Assert.Equal("Boom", formatted);
+    }
+
+    [Fact]
+    public void FormatForUser_TypeInitializerWithInner_SurfacesRootCause()
+    {
+        // Mirrors the issue #11314 shape: outer TypeInitializationException whose
+        // .Message is opaque ("The type initializer for 'X' threw an exception."), with
+        // the actual root cause one level deeper. The formatter must surface that root.
+        var inner = new InvalidOperationException("Unable to load default typeface.");
+        var outer = new TypeInitializationException(
+            "Nikse.SubtitleEdit.Core.Common.TextSplitResult",
+            inner);
+
+        var formatted = ErrorMessageFormatter.FormatForUser(outer, verbose: false);
+
+        Assert.Contains("The type initializer", formatted);
+        Assert.Contains("Unable to load default typeface", formatted);
+        Assert.Contains(" → ", formatted);
+    }
+
+    [Fact]
+    public void FormatForUser_NestedChain_IncludesAllLayers()
+    {
+        var innermost = new ArgumentNullException("path");
+        var middle = new InvalidOperationException("Wrapper", innermost);
+        var outer = new TypeInitializationException("Some.Type", middle);
+
+        var formatted = ErrorMessageFormatter.FormatForUser(outer, verbose: false);
+
+        // All three layers' messages should appear, separated by the arrow.
+        Assert.Contains("The type initializer", formatted);
+        Assert.Contains("Wrapper", formatted);
+        Assert.Contains("path", formatted);
+        // Exactly two separators for a three-level chain.
+        Assert.Equal(2, CountOccurrences(formatted, " → "));
+    }
+
+    [Fact]
+    public void FormatForUser_Verbose_IncludesStackTrace()
+    {
+        Exception caught;
+        try
+        {
+            throw new InvalidOperationException("Verbose test");
+        }
+        catch (Exception ex)
+        {
+            caught = ex;
+        }
+
+        var formatted = ErrorMessageFormatter.FormatForUser(caught, verbose: true);
+
+        // Verbose mode delegates to ex.ToString() which prefixes the type and includes
+        // a stack frame from this test method.
+        Assert.Contains("InvalidOperationException", formatted);
+        Assert.Contains("Verbose test", formatted);
+        Assert.Contains(nameof(FormatForUser_Verbose_IncludesStackTrace), formatted);
+    }
+
+    [Fact]
+    public void FormatForUser_TrimsTrailingPeriodsInChain()
+    {
+        // Real-world wrapper exceptions (TypeInitializationException's own message ends
+        // with ".") would otherwise produce "...threw an exception. → cause", which is
+        // visually clunky. The formatter trims the dot before joining.
+        var inner = new InvalidOperationException("cause text");
+        var outer = new InvalidOperationException("first layer.", inner);
+
+        var formatted = ErrorMessageFormatter.FormatForUser(outer, verbose: false);
+
+        Assert.Equal("first layer → cause text", formatted);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        if (string.IsNullOrEmpty(needle))
+        {
+            return 0;
+        }
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #11315. The original issue #11314 had two requests — the libse crash (fixed in #11315) and a diagnostics improvement: surface the `InnerException` chain so wrapper exceptions like `TypeInitializationException` don't hide the real cause.

Today seconv only emits `ex.Message`. For a `TypeInitializationException` that message reads literally `"The type initializer for 'X' threw an exception."` — opaque. The user reporting #11314 had to recompile a debug build to discover that the real problem was SkiaSharp's font discovery throwing one level deeper.

## Approach
New `ErrorMessageFormatter.FormatForUser(ex, verbose)`:
- **Default**: walks `.InnerException` (capped at 8 levels — pathological wrapper chains shouldn't blow up the message), trims trailing periods, joins with ` → `. So users now see e.g.
  ```
  The type initializer for 'X' threw an exception → Unable to load default typeface
  ```
  instead of just the outer wrapper.
- **`--verbose`**: delegates to `ex.ToString()` so stack traces are included for full debugging.

All six catch sites in `SubtitleConverter.cs` updated (per-file, outer, VOB batch, single-stream image-to-image, PGS, DVB-sub) to compute the formatted message once and use it consistently for `result.Errors`, the per-file `FileConversionResult`, and the `AnsiConsole` output. Markup escaping preserved.

README's `--verbose` row now mentions the chain unwrapping behaviour so users discover it without trial and error.

## Test plan
- [x] `dotnet test tests/seconv/SeConvTests.csproj` — 160/160 pass (5 new).
- [x] `ErrorMessageFormatterTest` covers: bare message (no inner), `TypeInitializationException` wrapping the real cause (mirrors the #11314 shape), three-level nested chain, verbose `ToString` with stack frames, and trailing-period trimming for clean joins.
- [ ] (Reviewer): on a normal failure (e.g. unknown input format), confirm the error message reads the same as before — single-layer exceptions should be unaffected.
- [ ] (Reviewer): repro the #11314 scenario before that fix lands; confirm seconv now reports the SkiaSharp inner cause instead of just `TypeInitializationException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)