### PR TITLE
Fix image-export alignment and override-position bugs

### DIFF
--- a/src/libuilogic/Export/ExportHandlerBdnXml.cs
+++ b/src/libuilogic/Export/ExportHandlerBdnXml.cs
@@ -68,7 +68,7 @@ public class ExportHandlerBdnXml : IExportHandler
                 y = _height - (param.Bitmap.Height + param.BottomTopMargin);
                 break;
             case ExportAlignment.BottomRight:
-                x = _height - param.Bitmap.Width - border;
+                x = _width - param.Bitmap.Width - border;
                 y = _height - (param.Bitmap.Height + param.BottomTopMargin);
                 break;
             case ExportAlignment.MiddleCenter:
@@ -97,9 +97,14 @@ public class ExportHandlerBdnXml : IExportHandler
                 break;
         }
 
+        // OverridePosition is the bitmap's top-left in screen coordinates (e.g. taken
+        // from a DVD/Blu-Ray PCS object's display area). Validate against the screen
+        // dimensions, not the bitmap's own — checking against the bitmap's W/H rejects
+        // any sensible screen-coord placement (a 200×40 cue at x=500 on a 1920-wide
+        // frame would fail X < 200), silently dropping the override.
         if (param.OverridePosition.HasValue &&
-            param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < param.Bitmap.Width &&
-            param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < param.Bitmap.Height)
+            param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < _width &&
+            param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < _height)
         {
             x = param.OverridePosition.Value.X;
             y = param.OverridePosition.Value.Y;

--- a/src/libuilogic/Export/ExportHandlerDost.cs
+++ b/src/libuilogic/Export/ExportHandlerDost.cs
@@ -59,12 +59,16 @@ public class ExportHandlerDost : IExportHandler
 
         if (param.Alignment == ExportAlignment.MiddleLeft || param.Alignment == ExportAlignment.MiddleCenter || param.Alignment == ExportAlignment.MiddleRight)
         {
-            top = param.ScreenHeight - (param.Bitmap.Height / 2);
+            top = (param.ScreenHeight - param.Bitmap.Height) / 2;
         }
 
+        // OverridePosition carries screen coordinates (typically from a source-format's
+        // declared display area, e.g. DVD PCS); validate against screen dims, not the
+        // bitmap's own. The prior check against Bitmap.W/H rejected almost every
+        // realistic override since subtitle bitmaps are smaller than the screen.
         if (param.OverridePosition.HasValue &&
-            param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < param.Bitmap.Width &&
-            param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < param.Bitmap.Height)
+            param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < param.ScreenWidth &&
+            param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < param.ScreenHeight)
         {
             left = param.OverridePosition.Value.X;
             top = param.OverridePosition.Value.Y;


### PR DESCRIPTION
## Summary
Three correctness bugs in the image-export handlers found during a follow-up bug hunt after #11319. All are visible when seconv's image output and the new image-to-image preserve path (#11302) exercise these handlers with non-default alignments / real source positions.

### 1. `ExportHandlerBdnXml.cs:71` — `BottomRight` uses the wrong dimension
```csharp
case ExportAlignment.BottomRight:
    x = _height - param.Bitmap.Width - border;  // ← _height, should be _width
    y = _height - (param.Bitmap.Height + param.BottomTopMargin);
    break;
```
Copy-paste typo — the **same file's** `MiddleRight` (line 83) and `TopRight` (line 95) both correctly use `_width - param.Bitmap.Width - border`, and `ExportHandlerDost.cs:52` uses `param.ScreenWidth - ... - param.LeftRightMargin`. On 1920×1080 video, "BottomRight" placed the bitmap ~840 px too far left.

### 2. `ExportHandlerDost.cs:62` — middle vertical alignment formula
```csharp
top = param.ScreenHeight - (param.Bitmap.Height / 2);
```
Off by a factor. The bitmap's TOP edge ends up near the bottom of the screen — for a 100×100 bitmap on a 1080-tall frame this gives `top = 1030`, so the bitmap extends down to y=1130 (off-screen). The correct centered formula is `(ScreenHeight - Bitmap.Height) / 2`.

### 3. `OverridePosition` validation in both files — wrong dimensions
Both `BdnXml.cs:100-102` and `Dost.cs:65-67` validate the override X/Y against `param.Bitmap.Width / Height`:
```csharp
param.OverridePosition.Value.X < param.Bitmap.Width &&
param.OverridePosition.Value.Y < param.Bitmap.Height
```
But the override carries **screen coordinates** (e.g. a DVD/Blu-Ray PCS object's `Origin`), so a perfectly sensible `x=500` for a 200-px-wide cue on a 1920-wide frame fails `X<200` and the override is silently discarded. Validate against screen dims instead (`_width`/`_height` in BdnXml, `param.ScreenWidth`/`ScreenHeight` in Dost — to match each file's existing idiom).

**Latent today**: nothing in the codebase currently sets `ImageParameter.OverridePosition`, so this bug doesn't trip. Included here because it blocks the natural follow-up of threading source-format positions (`pcs.GetPosition()`, `pack.GetPosition()`) through the preserve path added in #11302.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` — 0 warnings, 0 errors (covers libuilogic + libse via project refs).
- [x] `dotnet test tests/seconv/SeConvTests.csproj` — 160/160 passing.
- [ ] (Reviewer): on a real subtitle, set alignment to `BottomRight` in BDN-XML export. Without this fix the cue lands near the left edge; with it, it should hug the right edge with the configured margin.
- [ ] (Reviewer): set alignment to `MiddleCenter` (or any Middle-*) in DOST export. Without this fix the bitmap is below the frame; with it, it should be vertically centered.

No tests added — `libuilogic/Export` has no unit-test surface in this repo and the bugs are pixel-position arithmetic that's awkward to assert without a rendering fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)