### PR TITLE
Perf: cache Regex and html-stripping in three hot paths

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixCommas.cs
+++ b/src/libse/Forms/FixCommonErrors/FixCommas.cs
@@ -12,13 +12,24 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixCommas { get; set; } = "Fix commas";
         }
 
+        // Hoisted out of Fix() so each Fix() call reuses the same compiled NFA instead of
+        // recompiling per-call. The Arabic variants below used to be re-allocated *per
+        // paragraph* — for a 1000-line Arabic subtitle that's ~5000 unnecessary Regex+compile
+        // cycles per FCE run.
+        private static readonly Regex CommaDouble = new Regex(@"([\p{L}\d\s]),,([\p{L}\d\s])", RegexOptions.Compiled);
+        private static readonly Regex CommaTriple = new Regex(@"([\p{L}\d\s]) *, *, *,([\p{L}\d\s])", RegexOptions.Compiled);
+        private static readonly Regex CommaTripleEndOfLine = new Regex(@"([\p{L}\d\s]), *, *,$", RegexOptions.Compiled);
+        private static readonly Regex CommaWhiteSpaceBetween = new Regex(@"([\p{L}\d\s]),\s+,([\p{L}\d\s])", RegexOptions.Compiled);
+        private static readonly Regex CommaFollowedByLetter = new Regex(@",(\p{L})", RegexOptions.Compiled);
+
+        private static readonly Regex CommaDoubleAr = new Regex(@"([\p{L}\d\s]) *،،([\p{L}\d\s])", RegexOptions.Compiled);
+        private static readonly Regex CommaTripleAr = new Regex(@"([\p{L}\d\s]) *، *، *،([\p{L}\d\s])", RegexOptions.Compiled);
+        private static readonly Regex CommaTripleEndOfLineAr = new Regex(@"([\p{L}\d\s]) *، *، *،$", RegexOptions.Compiled);
+        private static readonly Regex CommaWhiteSpaceBetweenAr = new Regex(@"([\p{L}\d\s]) *،\s+،([\p{L}\d\s])", RegexOptions.Compiled);
+        private static readonly Regex CommaFollowedByLetterAr = new Regex(@"،(\p{L})", RegexOptions.Compiled);
+
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
-            var commaDouble = new Regex(@"([\p{L}\d\s]),,([\p{L}\d\s])");
-            var commaTriple = new Regex(@"([\p{L}\d\s]) *, *, *,([\p{L}\d\s])");
-            var commaTripleEndOfLine = new Regex(@"([\p{L}\d\s]), *, *,$");
-            var commaWhiteSpaceBetween = new Regex(@"([\p{L}\d\s]),\s+,([\p{L}\d\s])");
-            var commaFollowedByLetter = new Regex(@",(\p{L})");
 
             var fixAction = Language.FixCommas;
             var fixCount = 0;
@@ -32,15 +43,15 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                     if (p.Text.IndexOf(',') >= 0)
                     {
-                        s = commaDouble.Replace(s, "$1,$2");
-                        s = commaTriple.Replace(s, "$1...$2");
-                        s = commaTripleEndOfLine.Replace(s, "$1...");
-                        s = commaWhiteSpaceBetween.Replace(s, "$1,$2");
+                        s = CommaDouble.Replace(s, "$1,$2");
+                        s = CommaTriple.Replace(s, "$1...$2");
+                        s = CommaTripleEndOfLine.Replace(s, "$1...");
+                        s = CommaWhiteSpaceBetween.Replace(s, "$1,$2");
 
-                        var match = commaFollowedByLetter.Match(s);
+                        var match = CommaFollowedByLetter.Match(s);
                         if (match.Success && (!(match.Index > 0 && s[match.Index-1] == 'ό' && s.Substring(match.Index).StartsWith(",τι", StringComparison.OrdinalIgnoreCase)) || callbacks.Language != "el"))
                         {
-                            s = commaFollowedByLetter.Replace(s, ", $1");
+                            s = CommaFollowedByLetter.Replace(s, ", $1");
                         }
 
                         s = RemoveCommaBeforeSentenceEndingChar(s, ',');
@@ -48,16 +59,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                     if (p.Text.IndexOf('،') >= 0)
                     {
-                        var commaDoubleAr = new Regex(@"([\p{L}\d\s]) *،،([\p{L}\d\s])");
-                        var commaTripleAr = new Regex(@"([\p{L}\d\s]) *، *، *،([\p{L}\d\s])");
-                        var commaTripleEndOfLineAr = new Regex(@"([\p{L}\d\s]) *، *، *،$");
-                        var commaWhiteSpaceBetweenAr = new Regex(@"([\p{L}\d\s]) *،\s+،([\p{L}\d\s])");
-                        var commaFollowedByLetterAr = new Regex(@"،(\p{L})");
-                        s = commaDoubleAr.Replace(s, "$1،$2");
-                        s = commaTripleAr.Replace(s, "$1...$2");
-                        s = commaTripleEndOfLineAr.Replace(s, "$1...");
-                        s = commaWhiteSpaceBetweenAr.Replace(s, "$1،$2");
-                        s = commaFollowedByLetterAr.Replace(s, "، $1");
+                        s = CommaDoubleAr.Replace(s, "$1،$2");
+                        s = CommaTripleAr.Replace(s, "$1...$2");
+                        s = CommaTripleEndOfLineAr.Replace(s, "$1...");
+                        s = CommaWhiteSpaceBetweenAr.Replace(s, "$1،$2");
+                        s = CommaFollowedByLetterAr.Replace(s, "، $1");
 
                         s = RemoveCommaBeforeSentenceEndingChar(s, '،');
                     }

--- a/src/libse/Forms/RemoveInterjection.cs
+++ b/src/libse/Forms/RemoveInterjection.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -29,6 +30,18 @@ namespace Nikse.SubtitleEdit.Core.Forms
     {
         // https://github.com/SubtitleEdit/subtitleedit/issues/1421 + https://github.com/SubtitleEdit/subtitleedit/issues/7563
 
+        // Cache compiled `\bWORD\b` regexes keyed by interjection. Invoke() is called once per
+        // paragraph during HI removal; the inner foreach iterates over ~100+ interjections, and
+        // each match used to allocate-and-compile a fresh Regex. For a 1000-paragraph HI subtitle
+        // that's tens of thousands of redundant Regex constructions per "Remove text for HI" run.
+        // The interjection set is small and stable across a run, so a process-wide cache is safe.
+        private static readonly ConcurrentDictionary<string, Regex> InterjectionRegexCache = new ConcurrentDictionary<string, Regex>();
+
+        private static Regex GetWordBoundaryRegex(string word)
+        {
+            return InterjectionRegexCache.GetOrAdd(word, w => new Regex("\\b" + Regex.Escape(w) + "\\b", RegexOptions.Compiled));
+        }
+
         public string Invoke(InterjectionRemoveContext context)
         {
             if (string.IsNullOrWhiteSpace(context.Text))
@@ -46,7 +59,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 {
                     if (text.Contains(s))
                     {
-                        var regex = new Regex("\\b" + Regex.Escape(s) + "\\b");
+                        var regex = GetWordBoundaryRegex(s);
                         var match = regex.Match(text);
                         if (match.Success)
                         {

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -254,17 +254,32 @@ public partial class SubtitleLineViewModel : ObservableObject
             // Avalonia re-evaluates this getter on every cell repaint (scroll, selection,
             // edit, focus). Previously the getter could call HtmlUtil.RemoveHtmlTags(Text)
             // up to three times per repaint — once inside CharactersPerSecond and once per
-            // settings-enabled branch below. Strip once and reuse across all branches.
+            // settings-enabled branch below. Strip once and reuse across all branches —
+            // including a local CPS calculation so we don't re-strip via CharactersPerSecond.
             string? stripped = null;
 
             if (Se.Settings.General.ColorTextTooLong)
             {
-                if (CharactersPerSecond > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                stripped = HtmlUtil.RemoveHtmlTags(Text, true);
+
+                // Compute CPS from the just-stripped text instead of calling the
+                // CharactersPerSecond property (which would strip again). Mirrors the
+                // logic in that property; kept in sync with it.
+                double cps;
+                if (Duration.TotalMilliseconds <= 1.0)
+                {
+                    cps = 999.0;
+                }
+                else
+                {
+                    cps = (double)stripped.CountCharacters(forCps: true) / Duration.TotalSeconds;
+                }
+
+                if (cps > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
                 {
                     return _errorBrush;
                 }
 
-                stripped = HtmlUtil.RemoveHtmlTags(Text, true);
                 foreach (var line in stripped.SplitToLines())
                 {
                     if (line.Length > Se.Settings.General.SubtitleLineMaximumLength)

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -246,16 +246,26 @@ public partial class SubtitleLineViewModel : ObservableObject
     {
         get
         {
-            if (Se.Settings.General.ColorTextTooLong && !string.IsNullOrEmpty(Text))
+            if (string.IsNullOrEmpty(Text))
+            {
+                return _transparentBrush;
+            }
+
+            // Avalonia re-evaluates this getter on every cell repaint (scroll, selection,
+            // edit, focus). Previously the getter could call HtmlUtil.RemoveHtmlTags(Text)
+            // up to three times per repaint — once inside CharactersPerSecond and once per
+            // settings-enabled branch below. Strip once and reuse across all branches.
+            string? stripped = null;
+
+            if (Se.Settings.General.ColorTextTooLong)
             {
                 if (CharactersPerSecond > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
                 {
                     return _errorBrush;
                 }
 
-                var text = HtmlUtil.RemoveHtmlTags(Text, true);
-                var lines = text.SplitToLines();
-                foreach (var line in lines)
+                stripped = HtmlUtil.RemoveHtmlTags(Text, true);
+                foreach (var line in stripped.SplitToLines())
                 {
                     if (line.Length > Se.Settings.General.SubtitleLineMaximumLength)
                     {
@@ -264,10 +274,10 @@ public partial class SubtitleLineViewModel : ObservableObject
                 }
             }
 
-            if (Se.Settings.General.ColorTextTooWide && !string.IsNullOrEmpty(Text))
+            if (Se.Settings.General.ColorTextTooWide)
             {
-                var text = HtmlUtil.RemoveHtmlTags(Text, true);
-                foreach (var line in text.SplitToLines())
+                stripped ??= HtmlUtil.RemoveHtmlTags(Text, true);
+                foreach (var line in stripped.SplitToLines())
                 {
                     if (CalculatePixelWidth(line) > Se.Settings.General.ColorTextTooWidePixels)
                     {


### PR DESCRIPTION
## Summary
Three targeted perf fixes — no behaviour changes, all avoid redundant work that scales badly with paragraph count and repaint frequency.

### 1. `FixCommas.cs` — Regex objects allocated per Fix() call (and per Arabic paragraph)
The 5 outer regex objects were `new`'d on every `Fix()` invocation. Worse, the 5 Arabic-comma variants lived **inside** the per-paragraph loop, so for a 1000-line Arabic subtitle ~5000 Regex+compile cycles happened in that block alone per FCE run.

Hoisted all 10 to `static readonly Regex` fields with `RegexOptions.Compiled`. Each pattern compiles once per process.

### 2. `RemoveInterjection.cs:49` — Regex per (paragraph × matching interjection × repeat)
The inner `\bWORD\b` regex was allocated and compiled on every match inside a `while (doRepeat) × foreach (Interjections)` loop in `Invoke()`. With ~100+ interjections and 1000 paragraphs that's tens of thousands of Regex constructions per "Remove text for HI" run.

Added a `ConcurrentDictionary<string, Regex>` keyed by the interjection string, populated lazily via `GetOrAdd`:
```csharp
private static Regex GetWordBoundaryRegex(string word)
{
    return InterjectionRegexCache.GetOrAdd(word, w => new Regex("\\b" + Regex.Escape(w) + "\\b", RegexOptions.Compiled));
}
```
Process-wide cache is safe because the regex shape only depends on the input word.

### 3. `SubtitleLineViewModel.TextBackgroundBrush` — `RemoveHtmlTags` called 3× per cell repaint
Avalonia re-evaluates this getter on every cell repaint (scroll, selection, edit, focus). With both `ColorTextTooLong` and `ColorTextTooWide` enabled, the getter called `HtmlUtil.RemoveHtmlTags(Text, true)` up to three times — once inside `CharactersPerSecond` and once per settings branch.

Strip once into a local and reuse across both branches. Moved the null/empty Text check to the top so the common (empty-text) case fast-paths without touching settings.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` — 0 warnings, 0 errors.
- [x] `dotnet test tests/seconv/SeConvTests.csproj` — 160/160 passing.
- [ ] (Reviewer): try FCE on a large Arabic subtitle (e.g. 2000+ lines with `،` commas); should feel snappier. The behaviour should be identical — same regex patterns, same replacements.
- [ ] (Reviewer): scroll fast through a 1000-line subtitle with `ColorTextTooLong` + `ColorTextTooWide` enabled in settings. Frame times should drop because each visible row's `TextBackgroundBrush` evaluates fewer string operations per repaint.
- [ ] (Reviewer): run "Remove text for HI" on a long HI-rich subtitle; the regex cache means subsequent runs in the same SE process are even faster (first run pays the compile cost, later runs hit the cache).

No new tests — the behaviour is byte-identical to before, and there's no existing unit-test surface for these helpers in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)