### PR TITLE
Fix Common Errors: tweak Step 2 button flow and add fixes-applied counter

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -37,6 +37,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [ObservableProperty] private bool _step1IsVisible;
     [ObservableProperty] private bool _step2IsVisible;
     [ObservableProperty] private string _step2Title;
+    [ObservableProperty] private string _fixesAppliedText = string.Empty;
 
     public Window? Window { get; set; }
 
@@ -187,6 +188,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         ApplyFixes();
 
         RefreshFixes();
+        FixesAppliedText = string.Format(_language.XFixesApplied, _totalFixes);
     }
 
     [RelayCommand]
@@ -205,6 +207,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         SaveProfiles();
         _oldSelectedLanguage = SelectedLanguage!;
 
+        _totalFixes = 0;
+        FixesAppliedText = string.Empty;
         RefreshFixes();
     }
 
@@ -217,8 +221,6 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [RelayCommand]
     private void Ok()
     {
-        _previewMode = false;
-        ApplyFixes();
         OkPressed = true;
         Se.SaveSettings();
         Window?.Close();

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -148,14 +148,14 @@ public class FixCommonErrorsWindow : Window
             .WithIconLeft("fa-solid fa-arrow-left")
             .BindIsVisible(vm, nameof(vm.Step2IsVisible));
 
-        var buttonApplyFixes = UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.ApplyFixesAndClose, vm.OkCommand)
+        var buttonDone = UiUtil.MakeButton(Se.Language.General.Done, vm.OkCommand)
             .BindIsVisible(vm, nameof(vm.Step2IsVisible));
-        buttonApplyFixes.IsDefault = true;
+        buttonDone.IsDefault = true;
 
         var buttonPanelRight = UiUtil.MakeButtonBar(
             buttonBackToFixList,
             buttonToApplyFixes,
-            buttonApplyFixes,
+            buttonDone,
             UiUtil.MakeButtonCancel(vm.CancelCommand)
         );
 
@@ -204,6 +204,15 @@ public class FixCommonErrorsWindow : Window
         grid.Children.Add(buttonPanelRules);
         Grid.SetRow(buttonPanelRules, 2);
         Grid.SetColumn(buttonPanelRules, 0);
+
+        var labelFixesApplied = UiUtil.MakeTextBlock(string.Empty);
+        labelFixesApplied.Bind(TextBlock.TextProperty, new Binding(nameof(vm.FixesAppliedText)));
+        labelFixesApplied.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
+        labelFixesApplied.HorizontalAlignment = HorizontalAlignment.Left;
+        labelFixesApplied.VerticalAlignment = VerticalAlignment.Center;
+        grid.Children.Add(labelFixesApplied);
+        Grid.SetRow(labelFixesApplied, 2);
+        Grid.SetColumn(labelFixesApplied, 0);
 
         grid.Children.Add(buttonPanelRight);
         Grid.SetRow(buttonPanelRight, 2);


### PR DESCRIPTION
  ## Problem
  
  Step 2 of the Fix Common Errors dialog had two UX issues:
  
  **Confusing and redundant buttons**
  The "Apply fixes & close" button was misleading in two ways: its name implied it would apply *all* fixes, when it actually only applied *selected* ones — the same as clicking "Apply selected fixes" and then closing. Having both buttons side by side created confusion about which one to use and what each one committed.
  
  The adjacent "Cancel" button added to the confusion: it wasn't clear whether it would discard manually typed edits in the text box, or only the pending (unapplied) fixes in the grid.
  
  **No feedback on applied fixes**
  `_totalFixes` was already being accumulated in the view model but was never surfaced in the UI, so users had no indication of how many fixes had been applied across multiple "Apply selected fixes" clicks.
  
  ## Changes
  
  - Replaced "Apply fixes & close" with a **"Done"** button that simply commits the current state of the subtitle (already-applied fixes + any manual text edits) and closes — no implicit extra apply pass on close. This is how the Subtitle Edit 4 "OK" button behaved.
  - "Done" is the intended exit after iterating with "Apply selected fixes". "Cancel" remains as the silent discard path, matching the Subtitle Edit 4 behavior.
  - "Done" was chosen over "OK" because the goal was to use descriptive labels that state what happens rather than abstract confirmations. "Apply" was ruled out because it clashes with the "Apply selected fixes" button already in the dialog — it would imply a second apply action is happening on close, which it isn't. "Done" signals "I'm finished with this workflow, close and keep my work" without suggesting any additional processing.
  - I kept the lack of warning on Cancel, similar to Subtitle Edit 4 because "Done" is an explicit, deliberate commit action — if the user didn't press it, they haven't committed anything. Cancel's behavior (discard and close) is already implied by the absence of "Done". A warning on Cancel would be noise, not safety.
  - Added a **"Fixes applied: X"** label in the bottom-left corner (using the existing `XFixesApplied` language string and the existing `_totalFixes` accumulator). The label appears after the first apply and resets when re-entering Step 2. 
  - Renamed the `buttonApplyFixes` local variable to `buttonDone` to match its new purpose.

<img width="1281" height="838" alt="Screenshot 2026-06-01 at 8 39 45 PM" src="https://github.com/user-attachments/assets/ce9858b8-5f14-457c-95ce-b0e066b4959f" />
