### PR TITLE
Fix: ColorTextTooLong should not trigger on CPS violations

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -251,34 +251,13 @@ public partial class SubtitleLineViewModel : ObservableObject
                 return _transparentBrush;
             }
 
-            // Avalonia re-evaluates this getter on every cell repaint (scroll, selection,
-            // edit, focus). Previously the getter could call HtmlUtil.RemoveHtmlTags(Text)
-            // up to three times per repaint — once inside CharactersPerSecond and once per
-            // settings-enabled branch below. Strip once and reuse across all branches —
-            // including a local CPS calculation so we don't re-strip via CharactersPerSecond.
+            // Avalonia re-evaluates this getter on every cell repaint; strip HTML once
+            // and reuse across all settings-enabled branches below.
             string? stripped = null;
 
             if (Se.Settings.General.ColorTextTooLong)
             {
                 stripped = HtmlUtil.RemoveHtmlTags(Text, true);
-
-                // Compute CPS from the just-stripped text instead of calling the
-                // CharactersPerSecond property (which would strip again). Mirrors the
-                // logic in that property; kept in sync with it.
-                double cps;
-                if (Duration.TotalMilliseconds <= 1.0)
-                {
-                    cps = 999.0;
-                }
-                else
-                {
-                    cps = (double)stripped.CountCharacters(forCps: true) / Duration.TotalSeconds;
-                }
-
-                if (cps > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
-                {
-                    return _errorBrush;
-                }
 
                 foreach (var line in stripped.SplitToLines())
                 {


### PR DESCRIPTION
  The text cell background was turning red for CPS violations when "Color text if too long" was enabled. This disrupted my workflow when I migrated from Subtitle Edit 4. In that version, I could easily identify lines that were too long by noticing the text cell turning red, and I could spot lines with excessive CPS by seeing the CPS cell in red. In Subtitle Edit 5, the text cell turned red for both CPS violations and line length violations. I consider this incorrect for two reasons:
  
  1. **Inconsistent with Subtitle Edit 4**: `ListViewSyntaxColorLongLines` in Subtitle Edit 4 checks only line length (and line count). CPS violations have always been indicated via the Duration/CPS columns, not the text cell.
     
  2. **Redundant**: CPS violations already have a dedicated visual indicator — the CPS column is highlighted via `CpsBackgroundBrush` (and the Duration column too), both gated by `ColorDurationTooLong`. Lighting up the text cell as well conflates two unrelated conditions under one setting, making it impossible to tell from the text background alone whether a subtitle is too long or just too fast.
     
  The fix removes the CPS check from `TextBackgroundBrush`. The `ColorTextTooLong` setting now correctly reflects only what its name says: lines that exceed the maximum character length.