### PR TITLE
Fix window overflow with long video file paths (#11327)

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -656,7 +656,7 @@ public class BurnInWindow : Window
 
         var buttonOutputProperties = UiUtil.MakeButton(Se.Language.Video.BurnIn.OutputProperties, vm.OutputPropertiesCommand);
         var labelOutputPropertiesFolder = UiUtil.MakeLink(string.Empty, vm.OpenOutputFolderCommand)
-            .WithBindText(vm, nameof(vm.OutputFolder))
+            .WithFilePathText(vm, nameof(vm.OutputFolder))
             .WithBindVisible(vm, nameof(vm.UseOutputFolderVisible));
         var labelOutputPropertiesUseSourceFolder = UiUtil.MakeLabel(Se.Language.Video.BurnIn.UseSourceFolder)
             .WithBindVisible(vm, nameof(vm.UseSourceFolderVisible));
@@ -754,7 +754,7 @@ public class BurnInWindow : Window
     private static Border MakeVideoInfoView(BurnInViewModel vm)
     {
         var labelVideoFile = UiUtil.MakeLabel(Se.Language.General.VideoFile);
-        var labelVideoFileName = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.VideoFileName));
+        var labelVideoFileName = UiUtil.MakeFilePathLabel(vm, nameof(vm.VideoFileName));
 
         var labelVideoSize = UiUtil.MakeLabel(Se.Language.Video.BurnIn.VideoFileSize);
         var labelVideoSizeValue = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.VideoFileSize));

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -517,7 +517,7 @@ public class TransparentSubtitlesWindow : Window
 
         var buttonOutputProperties = UiUtil.MakeButton(Se.Language.Video.BurnIn.OutputProperties, vm.OutputPropertiesCommand);
         var labelOutputPropertiesFolder = UiUtil.MakeLink(string.Empty, vm.OpenOutputFolderCommand)
-            .WithBindText(vm, nameof(vm.OutputFolder))
+            .WithFilePathText(vm, nameof(vm.OutputFolder))
             .WithBindVisible(vm, nameof(vm.UseOutputFolderVisible));
         var labelOutputPropertiesUseSourceFolder = UiUtil.MakeLabel(Se.Language.Video.BurnIn.UseSourceFolder)
             .WithBindVisible(vm, nameof(vm.UseSourceFolderVisible));
@@ -565,7 +565,7 @@ public class TransparentSubtitlesWindow : Window
     private static Border MakeVideoInfoView(TransparentSubtitlesViewModel vm)
     {
         var labelVideoFile = UiUtil.MakeLabel(Se.Language.General.VideoFile);
-        var labelVideoFileName = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.VideoFileName));
+        var labelVideoFileName = UiUtil.MakeFilePathLabel(vm, nameof(vm.VideoFileName));
 
         var labelVideoSize = UiUtil.MakeLabel(Se.Language.Video.BurnIn.VideoFileSize);
         var labelVideoSizeValue = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.VideoFileSize));

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1855,6 +1855,68 @@ public static class UiUtil
         return label;
     }
 
+    /// <summary>
+    /// Creates a label bound to a (possibly long) file name or path. The displayed text
+    /// is truncated in the middle with an ellipsis so the start and the file name stay
+    /// visible, the width is capped so a long path can't force a fixed-size window to grow,
+    /// and the full value is shown as a tooltip.
+    /// </summary>
+    internal static Label MakeFilePathLabel(object viewModel, string fullPathPropertyPath, int maxLength = 50, int maxWidth = 400)
+    {
+        var label = new Label
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            MaxWidth = maxWidth,
+            DataContext = viewModel,
+        };
+
+        label.Bind(Label.ContentProperty, new Binding
+        {
+            Path = fullPathPropertyPath,
+            Mode = BindingMode.OneWay,
+            Converter = new MiddleEllipsisConverter(),
+            ConverterParameter = maxLength,
+        });
+
+        label.Bind(ToolTip.TipProperty, new Binding
+        {
+            Path = fullPathPropertyPath,
+            Mode = BindingMode.OneWay,
+            Converter = new NullOrEmptyToNullConverter(),
+        });
+
+        return label;
+    }
+
+    /// <summary>
+    /// Binds a text block (e.g. a link) to a (possibly long) file name or path. The displayed
+    /// text is truncated in the middle with an ellipsis so the start and the file name stay
+    /// visible, the width is capped so a long path can't force a fixed-size window to grow,
+    /// and the full value is shown as a tooltip.
+    /// </summary>
+    internal static TextBlock WithFilePathText(this TextBlock control, object viewModel, string fullPathPropertyPath, int maxLength = 50, int maxWidth = 400)
+    {
+        control.MaxWidth = maxWidth;
+        control.DataContext = viewModel;
+
+        control.Bind(TextBlock.TextProperty, new Binding
+        {
+            Path = fullPathPropertyPath,
+            Mode = BindingMode.OneWay,
+            Converter = new MiddleEllipsisConverter(),
+            ConverterParameter = maxLength,
+        });
+
+        control.Bind(ToolTip.TipProperty, new Binding
+        {
+            Path = fullPathPropertyPath,
+            Mode = BindingMode.OneWay,
+            Converter = new NullOrEmptyToNullConverter(),
+        });
+
+        return control;
+    }
+
     internal static RadioButton MakeRadioButton(string text, object viewModel, string isCheckedPropertyPath)
     {
         return MakeRadioButton(text, viewModel, isCheckedPropertyPath, null);

--- a/src/ui/Logic/ValueConverters/MiddleEllipsisConverter.cs
+++ b/src/ui/Logic/ValueConverters/MiddleEllipsisConverter.cs
@@ -1,0 +1,49 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Logic.ValueConverters;
+
+/// <summary>
+/// Shortens a long string (typically a file name or path) by replacing the middle
+/// with an ellipsis, keeping the start and the end visible - e.g.
+/// "C:\videos\...\my-movie.mp4". The max length can be set via the binding parameter.
+/// </summary>
+public class MiddleEllipsisConverter : IValueConverter
+{
+    private const string Ellipsis = "...";
+    private const int DefaultMaxLength = 50;
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not string s || string.IsNullOrEmpty(s))
+        {
+            return string.Empty;
+        }
+
+        var maxLength = DefaultMaxLength;
+        if (parameter is int i)
+        {
+            maxLength = i;
+        }
+        else if (parameter is string p && int.TryParse(p, out var len))
+        {
+            maxLength = len;
+        }
+
+        if (s.Length <= maxLength || maxLength <= Ellipsis.Length + 1)
+        {
+            return s;
+        }
+
+        var keep = maxLength - Ellipsis.Length;
+        var front = (keep + 1) / 2;
+        var back = keep - front;
+        return s[..front] + Ellipsis + s[^back..];
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/ui/Logic/ValueConverters/NullOrEmptyToNullConverter.cs
+++ b/src/ui/Logic/ValueConverters/NullOrEmptyToNullConverter.cs
@@ -1,0 +1,22 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Logic.ValueConverters;
+
+/// <summary>
+/// Returns null for null/empty/whitespace strings, otherwise the string itself.
+/// Useful for tooltips, so no empty tooltip box is shown when there is no value.
+/// </summary>
+public class NullOrEmptyToNullConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is string s && !string.IsNullOrWhiteSpace(s) ? s : null;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Fixes #11327

## Problem

The **Generate video → Burn-in** (`BurnInWindow`) and **Transparent subtitles** (`TransparentSubtitlesWindow`) windows use `SizeToContent.WidthAndHeight` with `CanResize = false`. Their "Video info" view bound a `Label` directly to the full video-file **path**, and the batch-mode "output folder" link bound to the full folder path. A very long path stretched the control, which grew the whole window horizontally and pushed the bottom button bar off-screen — with no way to resize back (notably on Wayland, where the window can't be resized at all).

## Fix

Two reusable helpers in `UiUtil` instead of per-window patching:

- **`UiUtil.MakeFilePathLabel(viewModel, pathProperty, maxLength = 50, maxWidth = 400)`** — a `Label` that middle-truncates the path (so both the start and the file name stay visible, e.g. `C:\Users\nik\...\my-movie.mp4`), caps `MaxWidth` as a hard backstop, and shows the full path as a tooltip.
- **`TextBlock.WithFilePathText(...)`** — same treatment for link-style `TextBlock`s (used for the output-folder link).

Backed by two small value converters:
- `MiddleEllipsisConverter` — middle-ellipsis truncation by character count (follows the existing `GetShortFileName` convention already in the codebase).
- `NullOrEmptyToNullConverter` — returns `null` for empty strings so no empty tooltip box shows when no file is loaded.

Applied to the video-file-name label and the output-folder link in **both** windows.

## Testing

- `dotnet build UI.csproj` succeeds with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
