### PR TITLE
Fix three bugs in seconv (image output leak, multiple-replace regex, OCR deadlock)

### DIFF
--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -59,6 +59,7 @@ internal static class ImageOutputWriter
         var firstParam = BuildParameter(subtitle.Paragraphs[0], 0, screenWidth, screenHeight, options);
         firstParam.Bitmap = ImageRenderer.GenerateBitmap(firstParam);
         handler.WriteHeader(filePath, firstParam);
+        firstParam.Bitmap?.Dispose();
 
         for (var i = 0; i < subtitle.Paragraphs.Count; i++)
         {

--- a/src/seconv/Core/MultipleReplaceLoader.cs
+++ b/src/seconv/Core/MultipleReplaceLoader.cs
@@ -94,6 +94,27 @@ public static class MultipleReplaceLoader
             return 0;
         }
 
+        // Pre-compile regex rules once (not per-paragraph). Use RegexOptions.Multiline so
+        // ^/$ anchors match at every line boundary inside a multi-line subtitle, matching
+        // the UI's behaviour (MultipleReplaceViewModel compiles with Compiled | Multiline).
+        // A rule with an invalid pattern is dropped here so it's skipped entirely.
+        var compiledRegex = new Dictionary<Rule, Regex>();
+        foreach (var rule in rules)
+        {
+            if (!string.Equals(rule.SearchType, SearchTypeRegularExpression, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            try
+            {
+                compiledRegex[rule] = new Regex(rule.FindWhat, RegexOptions.Compiled | RegexOptions.Multiline);
+            }
+            catch
+            {
+                // Bad regex — leave it out so it's skipped during replacement.
+            }
+        }
+
         var modified = 0;
         foreach (var paragraph in subtitle.Paragraphs)
         {
@@ -106,14 +127,9 @@ public static class MultipleReplaceLoader
                 }
                 else if (string.Equals(rule.SearchType, SearchTypeRegularExpression, StringComparison.OrdinalIgnoreCase))
                 {
-                    try
+                    if (compiledRegex.TryGetValue(rule, out var regex))
                     {
-                        var regex = new Regex(rule.FindWhat);
                         newText = RegexUtils.ReplaceNewLineSafe(regex, newText, rule.ReplaceWith);
-                    }
-                    catch
-                    {
-                        // Bad regex — skip this rule for this paragraph
                     }
                 }
                 else // Normal — case-insensitive whole-string replace

--- a/src/seconv/Core/PaddleOcrEngine.cs
+++ b/src/seconv/Core/PaddleOcrEngine.cs
@@ -80,11 +80,14 @@ internal sealed class PaddleOcrEngine : IOcrEngine
             };
             using var proc = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start paddleocr process.");
+            // Drain stderr concurrently — paddleocr is chatty on stderr, and reading stdout
+            // to completion while stderr fills the pipe buffer would deadlock.
+            var stderrTask = proc.StandardError.ReadToEndAsync();
             var stdout = proc.StandardOutput.ReadToEnd();
             proc.WaitForExit();
             if (proc.ExitCode != 0)
             {
-                var err = proc.StandardError.ReadToEnd();
+                var err = stderrTask.GetAwaiter().GetResult();
                 throw new InvalidOperationException($"paddleocr exited with code {proc.ExitCode}: {err}");
             }
             return ParseStdout(stdout);

--- a/src/seconv/Core/TesseractOcrEngine.cs
+++ b/src/seconv/Core/TesseractOcrEngine.cs
@@ -87,11 +87,14 @@ internal sealed class TesseractOcrEngine : IOcrEngine
             };
             using var proc = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start tesseract process.");
+            // Drain stderr concurrently — Tesseract emits warnings to stderr, and reading
+            // stdout to completion while stderr fills the pipe buffer would deadlock.
+            var stderrTask = proc.StandardError.ReadToEndAsync();
             var stdout = proc.StandardOutput.ReadToEnd();
             proc.WaitForExit();
             if (proc.ExitCode != 0)
             {
-                var err = proc.StandardError.ReadToEnd();
+                var err = stderrTask.GetAwaiter().GetResult();
                 throw new InvalidOperationException($"Tesseract exited with code {proc.ExitCode}: {err}");
             }
             return stdout.Trim();

--- a/tests/seconv/Core/ContainerLoaderTest.cs
+++ b/tests/seconv/Core/ContainerLoaderTest.cs
@@ -54,6 +54,14 @@ public class ContainerLoaderTest : IDisposable
         // image-subtitle track. Behaviour split:
         //  - PGS: OCR'd via Tesseract to text → one .srt produced
         //  - VobSub: warned-and-skipped (seconv has no VobSub OCR path yet)
+        //
+        // PGS OCR shells out to the Tesseract binary, which seconv does not bundle.
+        // Skip (don't fail) when it isn't installed so the suite stays green on
+        // machines/CI without Tesseract on PATH.
+        Assert.SkipWhen(
+            TesseractOcrEngine.Detect() is null,
+            "Tesseract is not installed on PATH; PGS OCR cannot run.");
+
         var input = Fixtures.Path("container_image.mkv");
         Assert.True(File.Exists(input), $"Fixture missing: {input}");
         var outputFolder = Path.Combine(_tempRoot, "out");


### PR DESCRIPTION
## Summary

Fixes three bugs found during a bug hunt in `seconv` (the command-line subtitle converter), plus a flaky test that depended on an external binary.

### 1. SKBitmap leak in image-format output
`ImageOutputWriter.Write` rendered a "representative" header bitmap, passed it to `WriteHeader`, and never disposed it — while the per-paragraph loop right below correctly disposes each bitmap. One unmanaged `SKBitmap` leaked per file written to any image-based target (Blu-Ray sup, VobSub, BDN-XML, DOST, FCP, D-Cinema, ImagesWithTimeCode, WebVTT thumbnail), accumulating across batch runs.

### 2. MultipleReplace regex dropped `Multiline`
`MultipleReplaceLoader` compiled regex rules with `new Regex(pattern)` and no options, whereas the SubtitleEdit UI compiles the same rules with `RegexOptions.Compiled | RegexOptions.Multiline`. Without `Multiline`, `^`/`$` anchors only match the start/end of the whole paragraph instead of each line — so common rules like `^-\s` applied to only the first line of a multi-line subtitle, silently diverging from the GUI for the same `--multiple-replace` XML. Rules are now compiled once (not per paragraph), and invalid patterns are dropped up front.

### 3. Potential deadlock in Tesseract/Paddle OCR
Both OCR engines read `stdout` to completion and only read `stderr` *after* `WaitForExit()`. If the OCR binary writes more to stderr than the OS pipe buffer holds (Tesseract/Paddle both emit warnings) before stdout finishes, the child blocks on the stderr write while the parent blocks forever in `stdout.ReadToEnd()`. Now stderr is drained concurrently via `ReadToEndAsync()`.

### 4. Test fix: skip PGS-OCR test when Tesseract is missing
`ConvertAsync_MkvWithImageTracks_OcrsPgsAndSkipsVobSub` shells out to the Tesseract binary (not bundled by seconv). On a machine/CI without Tesseract on PATH it failed because 0 files convert. It now uses `Assert.SkipWhen(TesseractOcrEngine.Detect() is null, ...)` to skip rather than fail, while still exercising the real OCR path where Tesseract is installed.

## Testing

- `dotnet build src/seconv/SeConv.csproj` — succeeds, 0 warnings.
- `dotnet test tests/seconv/SeConvTests.csproj` — **159 passed, 1 skipped, 0 failed** (the skip is the Tesseract-dependent test above; it runs fully where Tesseract is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
