### PR TITLE
Remember auto-translate line-merge strategy per engine

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/DoAutoTranslate.cs
+++ b/src/ui/Features/Tools/BatchConvert/DoAutoTranslate.cs
@@ -20,8 +20,7 @@ public class DoAutoTranslate
         {
             translator.Initialize();
             var start = 0;
-            var forceSingleLineMode = Configuration.Settings.Tools.AutoTranslateStrategy ==
-                                      nameof(TranslateStrategy.TranslateEachLineSeparately) ||
+            var forceSingleLineMode = Se.Settings.AutoTranslate.IsTranslateEachLineSeparately(translator.Name) ||
                                       translator.Name ==
                                       NoLanguageLeftBehindApi.StaticName || // NLLB seems to miss some text...
                                       translator.Name == NoLanguageLeftBehindServe.StaticName ||

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1216,8 +1216,7 @@ public partial class AutoTranslateViewModel : ObservableObject
                 start = Rows.IndexOf(selectedItem);
             }
 
-            var forceSingleLineMode = Configuration.Settings.Tools.AutoTranslateStrategy ==
-                                      TranslateStrategy.TranslateEachLineSeparately.ToString() ||
+            var forceSingleLineMode = Se.Settings.AutoTranslate.IsTranslateEachLineSeparately(translator.Name) ||
                                       translator.Name ==
                                       NoLanguageLeftBehindApi.StaticName || // NLLB seems to miss some text...
                                       translator.Name == NoLanguageLeftBehindServe.StaticName ||

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -97,6 +97,10 @@ public partial class TranslateSettingsViewModel : ObservableObject
 
         Se.Settings.AutoTranslate.RequestDelaySeconds = ServerDelaySeconds ?? 0;
         Se.Settings.AutoTranslate.RequestMaxBytes = MaxBytesRequest ?? 0;
+        Se.Settings.AutoTranslate.EngineStrategies[AutoTranslator.Name] =
+            SelectedMergeOptions == Se.Language.Translate.TranslateEachLineSeparately
+                ? nameof(TranslateStrategy.TranslateEachLineSeparately)
+                : nameof(TranslateStrategy.Default);
         var translate = AutoTranslator as IAutoTranslator;
         if (translate != null)
         {
@@ -171,7 +175,9 @@ public partial class TranslateSettingsViewModel : ObservableObject
             Se.Language.General.Default,
             Se.Language.Translate.TranslateEachLineSeparately,
         };
-        SelectedMergeOptions = MergeOptions[0];
+        SelectedMergeOptions = Se.Settings.AutoTranslate.IsTranslateEachLineSeparately(AutoTranslator.Name)
+            ? MergeOptions[1]
+            : MergeOptions[0];
 
         ServerDelaySeconds = Se.Settings.AutoTranslate.RequestDelaySeconds;
         MaxBytesRequest = Se.Settings.AutoTranslate.RequestMaxBytes;

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.AutoTranslate;
+using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -32,6 +33,12 @@ public class SeAutoTranslate
     public string MicrosoftTranslatorCategory { get; set; }
     public decimal RequestMaxBytes { get; set; }
     public decimal RequestDelaySeconds { get; set; }
+
+    /// <summary>
+    /// Line-merge strategy per translation engine, keyed by engine name.
+    /// A missing entry means <see cref="TranslateStrategy.Default"/>.
+    /// </summary>
+    public Dictionary<string, string> EngineStrategies { get; set; } = new();
     public int CopyPasteMaxBlockSize { get; set; }
     public string CopyPasteLineSeparator { get; set; }
     public string OpenRouterUrl { get; set; }
@@ -182,5 +189,12 @@ public class SeAutoTranslate
         CrispAsrModel = string.Empty;
         LaraApiId = string.Empty;
         LaraApiSecret = string.Empty;
+    }
+
+    public bool IsTranslateEachLineSeparately(string engineName)
+    {
+        return !string.IsNullOrEmpty(engineName) &&
+               EngineStrategies.TryGetValue(engineName, out var strategy) &&
+               strategy == nameof(TranslateStrategy.TranslateEachLineSeparately);
     }
 }


### PR DESCRIPTION
## Problem

In the auto-translate settings dialog, the line-merge strategy (`Default` vs `Translate each line separately`) was not remembered between sessions.

## Cause

`TranslateSettingsViewModel` never persisted the combo box:
- `LoadValues` always hard-coded `SelectedMergeOptions = MergeOptions[0]`, ignoring any saved value.
- `SaveValues` never wrote the selection anywhere.

The persisted settings model (`SeAutoTranslate`) also had no field to hold it.

## Fix

The strategy is now remembered **per translation engine**, so e.g. ChatGPT and a local NLLB can each keep their own choice:

- Add `EngineStrategies` (a `Dictionary<string,string>` keyed by engine name) to `SeAutoTranslate`, plus an `IsTranslateEachLineSeparately(engineName)` helper.
- `LoadValues` restores the selected option for the active engine; `SaveValues` writes it back under that engine's name.
- The read sites (`AutoTranslateViewModel`, batch-convert `DoAutoTranslate`) now look up the strategy for the engine being used instead of a single global value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)