### PR TITLE
Fix UI scale not applied at startup and freeze on scale change

### DIFF
--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -119,6 +119,18 @@ public static class UiTheme
     public const double MinScale = 0.5;
     public const double MaxScale = 2.0;
 
+    /// <summary>
+    /// Returns the logical content of a window, unwrapping the
+    /// <see cref="LayoutTransformControl"/> that <see cref="ApplyScaleToWindow"/>
+    /// uses to host scaled content.
+    /// </summary>
+    public static Control? GetUnscaledContent(Window window)
+    {
+        return window.Content is LayoutTransformControl ltc
+            ? ltc.Child as Control
+            : window.Content as Control;
+    }
+
     public static void ApplyScaleToWindow(Window window)
     {
         var factor = Se.Settings.Appearance.LayoutScale;

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -244,7 +244,7 @@ namespace Nikse.SubtitleEdit
             lifetime.MainWindow.Content = new LayoutTransformControl { Child = mainView };
             UiTheme.ApplyScaleToWindow(lifetime.MainWindow);
 
-            // Restore window position BEFORE setting content and showing
+            // Restore window position before showing
             if (Se.Settings.General.RememberPositionAndSize)
             {
                 UiUtil.RestoreWindowPosition(lifetime.MainWindow);

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -194,7 +194,10 @@ namespace Nikse.SubtitleEdit
                         if (System.IO.File.Exists(filePath))
                         {
                             FileOpenedViaActivation = true;
-                            if (lifetime.MainWindow?.Content is MainView mainView)
+                            var mainView = lifetime.MainWindow == null
+                                ? null
+                                : UiTheme.GetUnscaledContent(lifetime.MainWindow) as MainView;
+                            if (mainView != null)
                             {
                                 Dispatcher.UIThread.Post(async () =>
                                 {
@@ -232,7 +235,14 @@ namespace Nikse.SubtitleEdit
             };
 
             var mainView = new MainView();
-            lifetime.MainWindow.Content = mainView;
+
+            // Always host MainView inside a LayoutTransformControl, even at scale 1.0.
+            // SetCurrentTheme() runs before this window exists, so the saved UI scale is
+            // applied here at creation. Pre-wrapping also means later scale changes only
+            // update the transform instead of swapping window.Content, which would
+            // reparent the video player's native HWND and freeze the UI.
+            lifetime.MainWindow.Content = new LayoutTransformControl { Child = mainView };
+            UiTheme.ApplyScaleToWindow(lifetime.MainWindow);
 
             // Restore window position BEFORE setting content and showing
             if (Se.Settings.General.RememberPositionAndSize)


### PR DESCRIPTION
## Problems

Two issues with the **Settings → UI scale** option (`Appearance.LayoutScale`):

1. **Not remembered at startup.** `UiTheme.SetCurrentTheme()` applies the scale to all open windows, but at startup it runs *before* the main window is created, so the main window never received the saved scale. (`SetupBatchConvertOnlyWindow` already applies it; `SetupMainWindow` did not.)

2. **UI freezes when changing the scale.** `ApplyScaleToWindow` swapped `window.Content` into a new `LayoutTransformControl` at runtime. On the main window that reparents the video player's native HWND (mpv-wid/VLC on Windows), which freezes the UI — the same class of native-handle hazard as #10815.

## Fix

- `SetupMainWindow` now hosts `MainView` inside a `LayoutTransformControl` from creation and calls `ApplyScaleToWindow`, so the saved scale is applied at startup.
- Because the content is pre-wrapped, later scale changes only update the transform (the early-return path in `ApplyScaleToWindow`) instead of swapping `window.Content` — no native-HWND reparenting, no freeze. This covers both the OK and Apply paths.
- Added `UiTheme.GetUnscaledContent` to unwrap the `LayoutTransformControl`, used by the macOS file-activation handler that previously read `MainWindow.Content` directly as `MainView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)