### PR TITLE
Add keyboard navigation (Space, Home, End) to tool window data grids

### DIFF
--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitItem.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitItem.cs
@@ -1,10 +1,11 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Features.Main;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ApplyDurationLimits;
 
-public class ApplyDurationLimitItem
+public partial class ApplyDurationLimitItem : ObservableObject
 {
-    public bool Apply { get; set; }
+    [ObservableProperty] private bool _apply;
     public string Name { get; set; }
     public int Number { get; set; }
     public string Fix { get; set; }

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
@@ -3,7 +3,10 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Threading;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
@@ -155,6 +158,7 @@ public class ApplyDurationLimitsWindow : Window
                             Padding = new Thickness(4),
                             Child = new CheckBox
                             {
+                                Focusable = false,
                                 [!ToggleButton.IsCheckedProperty] = new Binding(nameof(ApplyDurationLimitItem.Apply)),
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
@@ -178,6 +182,15 @@ public class ApplyDurationLimitsWindow : Window
                 },
             },
         };
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is ApplyDurationLimitItem selectedItem)
+            {
+                selectedItem.Apply = !selectedItem.Apply;
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         grid.Add(labelFixesAvailable, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -189,6 +190,13 @@ public class ApplyDurationLimitsWindow : Window
                 selectedItem.Apply = !selectedItem.Apply;
                 e.Handled = true;
             }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
         }, RoutingStrategies.Tunnel);
         dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
@@ -271,6 +279,17 @@ public class ApplyDurationLimitsWindow : Window
                 },
             },
         };
+
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         grid.Add(labelFixesAvailable, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapWindow.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapWindow.cs
@@ -1,9 +1,12 @@
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Collections;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ApplyMinGap;
 
@@ -122,6 +125,17 @@ public class ApplyMinGapWindow : Window
                 },
             },
         };
+
+        dataGridSubtitle.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGridSubtitle.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGridSubtitle.SelectedItem = target;
+                dataGridSubtitle.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGridSubtitle);
     }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
@@ -3,7 +3,10 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Threading;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Logic;
@@ -56,7 +59,7 @@ public class BatchConvertFixCommonErrorsSettingsWindow : Window
         Content = grid;
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
-        KeyDown += (s, e) => vm.OnKeyDown(e);
+        KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 
     private static Border MakeRulesView(BatchConvertFixCommonErrorsSettingsViewModel vm)
@@ -86,6 +89,7 @@ public class BatchConvertFixCommonErrorsSettingsWindow : Window
                             Padding = new Thickness(4),
                             Child = new CheckBox
                             {
+                                Focusable = false,
                                 [!ToggleButton.IsCheckedProperty] = new Binding(nameof(FixRuleDisplayItem.IsSelected)),
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
@@ -109,14 +113,16 @@ public class BatchConvertFixCommonErrorsSettingsWindow : Window
                 },
             },
         };
-        rulesGrid.CellPointerPressed += (sender, e) =>
+        rulesGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Column is DataGridCheckBoxColumn column && e.Row.DataContext is FixRuleDisplayItem item)
+            if (e.Key == Key.Space && rulesGrid.SelectedItem is FixRuleDisplayItem selectedItem)
             {
-                item.IsSelected = !item.IsSelected;
+                selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
             }
-        };
-        
+        }, RoutingStrategies.Tunnel);
+        rulesGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => rulesGrid.Focus());
+
         return UiUtil.MakeBorderForControl(rulesGrid);
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -118,6 +119,13 @@ public class BatchConvertFixCommonErrorsSettingsWindow : Window
             if (e.Key == Key.Space && rulesGrid.SelectedItem is FixRuleDisplayItem selectedItem)
             {
                 selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && rulesGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                rulesGrid.SelectedItem = target;
+                rulesGrid.ScrollIntoView(target, null);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -188,6 +189,16 @@ public class BatchConvertWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchItem)) { Source = vm });
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         var comboBoxSubtitleFormat = UiUtil.MakeComboBox(vm.TargetFormats, vm, nameof(vm.SelectedTargetFormat));
         comboBoxSubtitleFormat.SelectionChanged += (_, _) => vm.ComboBoxSubtitleFormatChanged();
@@ -398,6 +409,13 @@ public class BatchConvertWindow : Window
             if (e.Key == Key.Space && dataGrid.SelectedItem is BatchConvertFunction selectedItem)
             {
                 selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Threading;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -392,6 +393,15 @@ public class BatchConvertWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchFunction)) { Source = vm });
         dataGrid.SelectionChanged += (_, _) => vm.SelectedFunctionChanged();
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is BatchConvertFunction selectedItem)
+            {
+                selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
         UiUtil.AttachMacContextFlyoutHandler(dataGrid);
 
         return UiUtil.MakeBorderForControl(dataGrid);
@@ -401,6 +411,7 @@ public class BatchConvertWindow : Window
     {
         var checkBox = new CheckBox
         {
+            Focusable = false,
             [!ToggleButton.IsCheckedProperty] = new Binding(nameof(BatchConvertFunction.IsSelected)),
             HorizontalAlignment = HorizontalAlignment.Center,
             Margin = new Thickness(5, 0, 0, 0),

--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListWindow.cs
@@ -1,7 +1,10 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
+using System.Collections;
 using Nikse.SubtitleEdit.Features.Tools.BatchConvert.BatchErrorList;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -107,6 +110,16 @@ public class BatchErrorListWindow : Window
             Mode = BindingMode.TwoWay
         });
         dataGrid.SelectionChanged += vm.GridSelectionChanged;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }

--- a/src/ui/Features/Tools/BridgeGaps/BridgeGapsWindow.cs
+++ b/src/ui/Features/Tools/BridgeGaps/BridgeGapsWindow.cs
@@ -1,9 +1,12 @@
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Collections;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BridgeGaps;
 
@@ -136,6 +139,17 @@ public class BridgeGapsWindow : Window
                 },
             },
         };
+
+        dataGridSubtitle.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGridSubtitle.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGridSubtitle.SelectedItem = target;
+                dataGridSubtitle.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGridSubtitle);
     }

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
@@ -3,8 +3,11 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Threading;
+using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -125,6 +128,7 @@ public class FixNamesWindow : Window
                 Padding = new Thickness(4),
                 Child = new CheckBox
                 {
+                    Focusable = false,
                     [!ToggleButton.IsCheckedProperty] = new Binding(nameof(FixNameItem.IsChecked)),
                     HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
                 }
@@ -140,6 +144,23 @@ public class FixNamesWindow : Window
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
             IsReadOnly = true,
         });
+
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is FixNameItem selectedItem)
+            {
+                selectedItem.IsChecked = !selectedItem.IsChecked;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         var flyout = new MenuFlyout();
         flyout.Items.Add(new MenuItem { Header = Se.Language.General.SelectAll, Command = vm.NamesSelectAllCommand });
@@ -174,6 +195,7 @@ public class FixNamesWindow : Window
                 Padding = new Thickness(4),
                 Child = new CheckBox
                 {
+                    Focusable = false,
                     [!ToggleButton.IsCheckedProperty] = new Binding(nameof(FixNameHitItem.IsEnabled)),
                     HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
                 }
@@ -204,6 +226,23 @@ public class FixNamesWindow : Window
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
             IsReadOnly = true
         });
+
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is FixNameHitItem selectedItem)
+            {
+                selectedItem.IsEnabled = !selectedItem.IsEnabled;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         var flyout = new MenuFlyout();
         flyout.Items.Add(new MenuItem { Header = Se.Language.General.SelectAll, Command = vm.HitsSelectAllCommand });

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -2,7 +2,10 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Threading;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -160,6 +163,7 @@ public class ConvertActorsWindow : Window
                     CellTemplate = new FuncDataTemplate<ConvertActorsDisplayItem>((_, _) =>
                         new CheckBox
                         {
+                            Focusable = false,
                             HorizontalAlignment = HorizontalAlignment.Center,
                             VerticalAlignment = VerticalAlignment.Center,
                             [!CheckBox.IsCheckedProperty] = new Binding(nameof(ConvertActorsDisplayItem.IsChecked)) { Mode = BindingMode.TwoWay },
@@ -227,6 +231,15 @@ public class ConvertActorsWindow : Window
                 },
             },
         };
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is ConvertActorsDisplayItem selectedItem)
+            {
+                selectedItem.IsChecked = !selectedItem.IsChecked;
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -7,6 +7,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -236,6 +237,13 @@ public class ConvertActorsWindow : Window
             if (e.Key == Key.Space && dataGrid.SelectedItem is ConvertActorsDisplayItem selectedItem)
             {
                 selectedItem.IsChecked = !selectedItem.IsChecked;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
@@ -128,6 +129,13 @@ public class FixCommonErrorsWindow : Window
             if (e.Key == Key.Space && rulesGrid.SelectedItem is FixRuleDisplayItem selectedItem)
             {
                 selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && rulesGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                rulesGrid.SelectedItem = target;
+                rulesGrid.ScrollIntoView(target, null);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);
@@ -341,6 +349,13 @@ public class FixCommonErrorsWindow : Window
                 selectedItem.IsSelected = !selectedItem.IsSelected;
                 e.Handled = true;
             }
+            else if (e.Key is Key.Home or Key.End && dataGridFixes.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGridFixes.SelectedItem = target;
+                dataGridFixes.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
         }, RoutingStrategies.Tunnel);
         dataGridFixes.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGridFixes.Focus());
 
@@ -460,6 +475,16 @@ public class FixCommonErrorsWindow : Window
         };
         dataGridSubtitles.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedParagraph)));
         _vm.GridSubtitles = dataGridSubtitles;
+        dataGridSubtitles.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGridSubtitles.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGridSubtitles.SelectedItem = target;
+                dataGridSubtitles.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         var gridCurrentSubtbtitle = MakeStep2EditPanel();
 

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -4,7 +4,9 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Threading;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using Nikse.SubtitleEdit.Features.Main;
@@ -90,6 +92,7 @@ public class FixCommonErrorsWindow : Window
                             Padding = new Thickness(4),
                             Child = new CheckBox
                             {
+                                Focusable = false,
                                 [!ToggleButton.IsCheckedProperty] = new Binding(nameof(FixRuleDisplayItem.IsSelected)),
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
@@ -120,13 +123,15 @@ public class FixCommonErrorsWindow : Window
             },
         };
         rulesGrid.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
-        rulesGrid.CellPointerPressed += (sender, e) =>
+        rulesGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Column is DataGridCheckBoxColumn column && e.Row.DataContext is FixRuleDisplayItem item)
+            if (e.Key == Key.Space && rulesGrid.SelectedItem is FixRuleDisplayItem selectedItem)
             {
-                item.IsSelected = !item.IsSelected;
+                selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
             }
-        };
+        }, RoutingStrategies.Tunnel);
+        rulesGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => rulesGrid.Focus());
 
         var step2Grid = MakeStep2Grid();
         step2Grid.Bind(IsVisibleProperty, new Binding(nameof(_vm.Step2IsVisible)));
@@ -264,6 +269,7 @@ public class FixCommonErrorsWindow : Window
                             Padding = new Thickness(4),
                             Child = new CheckBox
                             {
+                                Focusable = false,
                                 [!ToggleButton.IsCheckedProperty] = new Binding(nameof(FixDisplayItem.IsSelected)),
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
@@ -328,6 +334,15 @@ public class FixCommonErrorsWindow : Window
         };
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
         dataGridFixes.SelectionChanged += DataGridFixes_SelectionChanged;
+        dataGridFixes.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGridFixes.SelectedItem is FixDisplayItem selectedItem)
+            {
+                selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGridFixes.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGridFixes.Focus());
 
         var leftButtons = new StackPanel
         {

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsItem.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsItem.cs
@@ -1,11 +1,12 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.NetflixQualityCheck;
 
 namespace Nikse.SubtitleEdit.Features.Tools.FixNetflixErrors;
 
-public class FixNetflixErrorsItem
+public partial class FixNetflixErrorsItem : ObservableObject
 {
-    public bool Apply { get; set; }
+    [ObservableProperty] private bool _apply;
     public int Index { get; set; }
     public int IndexDisplay { get; set; }
     public string Before { get; set; }

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -143,6 +144,13 @@ public class FixNetflixErrorsWindow : Window
                 selectedItem.IsSelected = !selectedItem.IsSelected;
                 e.Handled = true;
             }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
         }, RoutingStrategies.Tunnel);
         dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
@@ -243,6 +251,13 @@ public class FixNetflixErrorsWindow : Window
             if (e.Key == Key.Space && dataGrid.SelectedItem is FixNetflixErrorsItem selectedItem && selectedItem.CanBeFixed)
             {
                 selectedItem.Apply = !selectedItem.Apply;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Threading;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -112,6 +113,7 @@ public class FixNetflixErrorsWindow : Window
             {
                 var cb = new CheckBox
                 {
+                    Focusable = false,
                     [!ToggleButton.IsCheckedProperty] = new Binding(nameof(NetflixCheckDisplayItem.IsSelected)) { Mode = BindingMode.TwoWay },
                     HorizontalAlignment = HorizontalAlignment.Center,
                 };
@@ -134,6 +136,15 @@ public class FixNetflixErrorsWindow : Window
             IsReadOnly = true,
             Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
         });
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is NetflixCheckDisplayItem selectedItem)
+            {
+                selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         var grid = new Grid
         {
@@ -178,6 +189,7 @@ public class FixNetflixErrorsWindow : Window
                     {
                         var cb = new CheckBox
                         {
+                            Focusable = false,
                             [!ToggleButton.IsCheckedProperty] = new Binding(nameof(FixNetflixErrorsItem.Apply)) { Mode = BindingMode.TwoWay },
                             HorizontalAlignment = HorizontalAlignment.Center,
                         };
@@ -226,6 +238,15 @@ public class FixNetflixErrorsWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is FixNetflixErrorsItem selectedItem && selectedItem.CanBeFixed)
+            {
+                selectedItem.Apply = !selectedItem.Apply;
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }

--- a/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesWindow.cs
+++ b/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesWindow.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -126,6 +127,16 @@ public class JoinSubtitlesWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedJoinItem)) { Source = vm });
         dataGrid.KeyDown += vm.DataGridKeyDown;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         var flyout = new MenuFlyout();
         flyout.Opening += vm.ItemsContextMenuOpening;

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -199,6 +200,13 @@ public class MergeContinuationLinesWindow : Window
             if (e.Key == Key.Space && dataGrid.SelectedItem is MergeContinuationLinesCandidate selectedItem)
             {
                 selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -3,7 +3,10 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Threading;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -147,6 +150,7 @@ public class MergeContinuationLinesWindow : Window
                             Padding = new Thickness(4),
                             Child = new CheckBox
                             {
+                                Focusable = false,
                                 [!ToggleButton.IsCheckedProperty] = new Binding(nameof(MergeContinuationLinesCandidate.IsSelected))
                                 {
                                     Mode = BindingMode.TwoWay,
@@ -190,6 +194,15 @@ public class MergeContinuationLinesWindow : Window
                 },
             },
         };
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is MergeContinuationLinesCandidate selectedItem)
+            {
+                selectedItem.IsSelected = !selectedItem.IsSelected;
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         grid.Add(labelInfo, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
@@ -1,8 +1,11 @@
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 
@@ -150,6 +153,17 @@ public class MergeShortLinesWindow : Window
                 },
             },
         };
+
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         grid.Add(labelFixesAvailable, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
@@ -3,8 +3,11 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -132,6 +135,16 @@ public class MergeSameTextWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedMergeItem)) { Source = vm });
         dataGrid.SelectionChanged += vm.DataGridMergeItemChanged;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }
@@ -196,6 +209,16 @@ public class MergeSameTextWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedMergeSubtitle)) { Source = vm });
         vm.SubtitleGrid = dataGrid;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
@@ -3,8 +3,11 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -138,6 +141,16 @@ public class MergeSameTimeCodesWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedMergeItem)) { Source = vm });
         dataGrid.SelectionChanged += vm.DataGridMergeItemChanged;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }
@@ -202,6 +215,16 @@ public class MergeSameTimeCodesWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedMergeSubtitle)) { Source = vm });
         vm.SubtitleGrid = dataGrid;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
@@ -1,8 +1,11 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -169,6 +172,16 @@ public class MergeTwoSubtitlesWindow : Window
         };
         dataGrid.Bind(DataGrid.ItemsSourceProperty, new Binding(itemsPath) { Source = vm });
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(selectedItemPath) { Source = vm });
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         var headerPanel = new StackPanel
         {

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveItem.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveItem.cs
@@ -1,9 +1,11 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
-public class RemoveItem 
+
+public partial class RemoveItem : ObservableObject
 {
-    public bool Apply { get; set; }
+    [ObservableProperty] private bool _apply;
     public int Index { get; set; }
     public int IndexDisplay { get; set; }
     public string Before { get; set; }

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -8,7 +8,9 @@ using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections;
 
 namespace Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 
@@ -293,6 +295,7 @@ public class RemoveTextForHearingImpairedWindow : Window
                             Padding = new Thickness(4),
                             Child = new CheckBox
                             {
+                                Focusable = false,
                                 [!ToggleButton.IsCheckedProperty] = new Binding(nameof(RemoveItem.Apply)),
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
@@ -324,7 +327,22 @@ public class RemoveTextForHearingImpairedWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
-        //dataGridTracks.SelectionChanged += vm.DataGridTracksSelectionChanged;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key == Key.Space && dataGrid.SelectedItem is RemoveItem selectedItem)
+            {
+                selectedItem.Apply = !selectedItem.Apply;
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         return UiUtil.MakeBorderForControl(dataGrid);
     }

--- a/src/ui/Features/Tools/SortBy/SortByWindow.cs
+++ b/src/ui/Features/Tools/SortBy/SortByWindow.cs
@@ -2,7 +2,10 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
+using System.Collections;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Tools.BridgeGaps;
 using Nikse.SubtitleEdit.Logic;
@@ -220,7 +223,16 @@ public class SortByWindow : Window
 
         dataGridSubtitle.Bind(DataGrid.ItemsSourceProperty, new Binding(nameof(SortByViewModel.Subtitles)) { Mode = BindingMode.TwoWay });
         dataGridSubtitle.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(SortByViewModel.SelectedSubtitle)) { Mode = BindingMode.TwoWay });
-
+        dataGridSubtitle.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGridSubtitle.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGridSubtitle.SelectedItem = target;
+                dataGridSubtitle.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGridSubtitle);
     }

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -1,8 +1,11 @@
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 
@@ -156,6 +159,17 @@ public class SplitBreakLongLinesWindow : Window
                 },
             },
         };
+
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         grid.Add(labelFixesAvailable, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleWindow.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleWindow.cs
@@ -1,8 +1,11 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -230,6 +233,16 @@ public class SplitSubtitleWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSpiltItem)) { Source = vm });
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            {
+                var target = e.Key == Key.Home ? items[0] : items[^1];
+                dataGrid.SelectedItem = target;
+                dataGrid.ScrollIntoView(target, null);
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }


### PR DESCRIPTION
  Adds keyboard navigation to all tool window data grids:
- Space toggles checkboxes on the selected row
- Home/End jump to the first/last row (Fn+Left / Fn+Right on Mac).

Page Up/Down already worked via Avalonia's built-in handling; Home/End require an explicit tunnel handler because Avalonia navigates columns by default.
  
  ## Affected windows
  - Fix Common Errors (rules grid and fixes grid)
  - Fix Netflix Errors (checks grid and fixes grid)
  - Change Casing – Fix Names dialog (names grid and hits grid)
  - Remove Text for Hearing Impaired
  - Convert Actors
  - Batch Convert (functions list, fix settings, file list, error list)
  - Apply Duration Limits
  - Apply Min Gap
  - Merge Continuation Lines
  - Merge Short Lines / Same Text / Same Time Codes
  - Merge Two Subtitles / Join Subtitles 
  - Split Subtitle / Split & Break Long Lines
  - Bridge Gaps
  - Sort By
  
  ## Implementation notes
  - `AddHandler` with `RoutingStrategies.Tunnel` intercepts Space/Home/End before child elements see it
  - CheckBoxes in template columns have `Focusable = false` to prevent their built-in Space handler from causing a double-toggle
  - `PointerReleased` calls `Dispatcher.UIThread.Post` to defer `Focus()` until after all pointer handling completes, so the DataGrid reliably gets keyboard focus even in windows where `Activated` sets focus to a default button
  - `Apply` on `ApplyDurationLimitItem`, `FixNetflixErrorsItem`, and `RemoveItem` converted to `[ObservableProperty]` so Space-key toggles propagate to the bound CheckBox via INPC

  ## Out of Scope
  I kept multi-row selection out of scope. It is something that is useful and worked in Subtitle Edit 4 (e.g. selecting a group of fixes in the Fix common errors dialog and pressing Space to select/unselect them all) but it's a separate iteration and PR.

  I also excluded mouse handling improvements from the scope, both for single and multi row selection.