### PR TITLE
Fix OCR window progress bar and status text overlap

### DIFF
--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -919,10 +919,11 @@ public class OcrWindow : Window
         var progressBar = UiUtil.MakeProgressBar();
         progressBar.Width = double.NaN;
         progressBar.HorizontalAlignment = HorizontalAlignment.Stretch;
+        progressBar.VerticalAlignment = VerticalAlignment.Top;
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
         progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm });
 
-        var statusText = new TextBlock().WithMarginTop(22);
+        var statusText = new TextBlock().WithMarginTop(14).WithAlignmentTop();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
         statusText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm });
 


### PR DESCRIPTION
## Summary
- Anchor both the progress bar and the status text to the top of the bottom-bar grid cell in `OcrWindow`
- Reduce the status text's top margin from 22 → 14 so there is a 4px gap between the 10px-tall progress bar and the text, instead of the previous overlap/center-aligned mess

## Test plan
- [ ] Open OCR window and start an OCR run; verify the progress bar and the status text are stacked with a small (4px) gap, not overlapping or far apart

🤖 Generated with [Claude Code](https://claude.com/claude-code)