### PR TITLE
Fix progress bar / status text overlap in video generation windows

### DIFF
--- a/src/ui/Features/Video/BlankVideo/BlankVideoWindow.cs
+++ b/src/ui/Features/Video/BlankVideo/BlankVideoWindow.cs
@@ -206,12 +206,15 @@ public class BlankVideoWindow : Window
     private static Grid MakeProgressView(BlankVideoViewModel vm)
     {
         var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Margin = new Thickness(0, 4, 0, 0);
+        progressBar.VerticalAlignment = VerticalAlignment.Top;
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
         progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
-            Margin = new Thickness(5, 20, 0, 0),
+            Margin = new Thickness(5, 18, 0, 0),
+            VerticalAlignment = VerticalAlignment.Top,
         };
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
         statusText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -789,13 +789,15 @@ public class BurnInWindow : Window
     private static Grid MakeProgressView(BurnInViewModel vm)
     {
         var progressBar = UiUtil.MakeProgressBar();
-        progressBar.Margin = new Thickness(0, 0, 5, 0);
+        progressBar.Margin = new Thickness(0, 4, 5, 0);
+        progressBar.VerticalAlignment = VerticalAlignment.Top;
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
         progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
-            Margin = new Thickness(5, 20, 0, 0),
+            Margin = new Thickness(5, 18, 0, 0),
+            VerticalAlignment = VerticalAlignment.Top,
         };
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
         statusText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -600,12 +600,15 @@ public class TransparentSubtitlesWindow : Window
     private static Grid MakeProgressView(TransparentSubtitlesViewModel vm)
     {
         var progressBar = UiUtil.MakeProgressBar();
+        progressBar.Margin = new Thickness(0, 4, 0, 0);
+        progressBar.VerticalAlignment = VerticalAlignment.Top;
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
         progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
 
         var statusText = new TextBlock
         {
-            Margin = new Thickness(5, 20, 0, 0),
+            Margin = new Thickness(5, 18, 0, 0),
+            VerticalAlignment = VerticalAlignment.Top,
         };
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
         statusText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));


### PR DESCRIPTION
## Summary
- Burn-in, transparent-subtitles and blank-video windows all stacked the progress bar and status text in the same grid cell without anchoring either to the top, so the ProgressBar (height 10) defaulted to center-aligned and ended up overlapping the status text
- Top-align both controls in all three windows
- Give the progress bar a 4px top margin and the status text an 18px top margin so the bar sits 4px below the cell top with a 4px gap before the text

Same shape as #11336, which fixed the equivalent bug in the OCR window.

## Test plan
- [ ] Open *Generate video with burned-in subtitles* and start a render; verify the progress bar and status text are stacked with a small gap, not overlapping
- [ ] Open *Generate transparent subtitles* and start a render; same check
- [ ] Open *Generate blank video* and start a render; same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)