### PR TITLE
Fix SCC import: italics and byte-misaligned musical notes (#9803)

### DIFF
--- a/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
+++ b/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
@@ -969,11 +969,36 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             // Row-code first byte: low 7 bits in 0x10-0x17 (parity-stripped 10-17), plus the
             // odd-parity forms that differ (11->91, 12->92, 14->94, 17->97).
             var firstByte = code.Substring(0, 2);
-            var isRowCode = firstByte == "10" || firstByte == "11" || firstByte == "12" || firstByte == "13" ||
-                            firstByte == "14" || firstByte == "15" || firstByte == "16" || firstByte == "17" ||
-                            firstByte == "91" || firstByte == "92" || firstByte == "94" || firstByte == "97";
-            var isPositionByte = "4567cdef".IndexOf(code[2]) >= 0;
-            return isRowCode && isPositionByte;
+            return IsPreambleAddressRowCode(firstByte) && "4567cdef".IndexOf(code[2]) >= 0;
+        }
+
+        private static bool IsPreambleAddressRowCode(string firstByte)
+        {
+            // Row-code first byte: low 7 bits in 0x10-0x17 (parity-stripped 10-17), plus the
+            // odd-parity forms that differ (11->91, 12->92, 14->94, 17->97).
+            return firstByte == "10" || firstByte == "11" || firstByte == "12" || firstByte == "13" ||
+                   firstByte == "14" || firstByte == "15" || firstByte == "16" || firstByte == "17" ||
+                   firstByte == "91" || firstByte == "92" || firstByte == "94" || firstByte == "97";
+        }
+
+        // A PAC also carries the row's style. White italic (optionally underlined) is encoded in the
+        // second byte; parity-stripped that byte is 0x4e/0x4f/0x6e/0x6f (#9803). Many real files use
+        // the parity-applied row codes (916e, 92ce, ...) that are not in SccPositionAndStyleTable.
+        private static bool IsItalicPreambleAddressCode(string code)
+        {
+            if (!IsPreambleAddressCode(code))
+            {
+                return false;
+            }
+
+            var secondByte = Convert.ToInt32(code.Substring(2, 2), 16) & 0x7f;
+            return secondByte == 0x4e || secondByte == 0x4f || secondByte == 0x6e || secondByte == 0x6f;
+        }
+
+        // First byte of a two-byte CEA-608 control code (PAC, mid-row, special char): high nibble 1 or 9.
+        private static bool IsControlCodeFirstByte(string twoHex)
+        {
+            return twoHex.Length == 2 && (twoHex[0] == '1' || twoHex[0] == '9');
         }
 
         public static string GetSccText(string s, ref int errorCount)
@@ -1207,7 +1232,35 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                             sb.AppendLine();
                                         }
 
+                                        // The PAC also sets the row's style; honour white italic. (#9803)
+                                        if (IsItalicPreambleAddressCode(part) && !italicOn)
+                                        {
+                                            sb.Append("<i>");
+                                            italicOn = true;
+                                        }
+                                        else if (!IsItalicPreambleAddressCode(part) && italicOn)
+                                        {
+                                            sb.Append("</i>");
+                                            italicOn = false;
+                                        }
+
                                         break;
+                                    }
+
+                                    // A two-byte control code can straddle the SCC word boundary, e.g.
+                                    // " ♪" arrives as "2091 3780" = char(20) + control(9137) + pad(80)
+                                    // instead of the aligned "2080 9137". Re-join it. (#9803)
+                                    if (k < parts.Length - 1 && IsControlCodeFirstByte(part.Substring(2, 2)) &&
+                                        parts[k + 1].EndsWith("80", StringComparison.Ordinal))
+                                    {
+                                        var joined = GetLetterFromCode(part.Substring(2, 2) + parts[k + 1].Substring(0, 2));
+                                        if (joined != null)
+                                        {
+                                            sb.Append(GetLetterFromCode(part.Substring(0, 2)));
+                                            sb.Append(joined);
+                                            k += 2;
+                                            continue;
+                                        }
                                     }
 
                                     var result = GetLetterFromCode(part);

--- a/tests/libse/SubtitleFormats/ScenaristClosedCaptionsTest.cs
+++ b/tests/libse/SubtitleFormats/ScenaristClosedCaptionsTest.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -96,5 +97,45 @@ public class ScenaristClosedCaptionsTest
 
         Assert.Single(subtitle.Paragraphs);
         Assert.Equal(new string('A', 40), HtmlUtil.RemoveHtmlTags(subtitle.Paragraphs[0].Text, true));
+    }
+
+    [Fact]
+    public void ItalicPreambleAddressCodeProducesItalic()
+    {
+        // Issue #9803: italics are carried by italic-style PACs (916e, 92ce, ...), not by mid-row
+        // codes. "NARRADOR:" (regular PAC 91d0) stays regular; the next rows (916e/92ce) are italic.
+        var subtitle = LoadScc(
+            "00:00:25:00\t9420 9420 91d0 91d0 cec1 5252 c1c4 4f52 ba80 916e 916e c173 6820 7920 7375 7320 616d e967 ef73 92ce 92ce e3ef 6ef4 e96e e061 6e20 7375 2076 e961 eae5 942c 942c 942f 942f",
+            "00:45:36:04\t942c 942c");
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("{\\an7}NARRADOR:" + Environment.NewLine + "<i>Ash y sus amigos" + Environment.NewLine + "continúan su viaje</i>",
+            subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void DecodesMusicNoteSplitAcrossWordBoundary()
+    {
+        // Issue #9803: a trailing " ♪" can arrive byte-misaligned as "2091 3780" (space + the note
+        // code 9137 split over two words + 80 padding). It must decode to ♪, not "7".
+        var subtitle = LoadScc(
+            "00:00:25:00\t9420 9420 946e 946e 9137 9137 2045 ec20 6d75 6e64 ef20 f175 e9e5 f2ef 2076 e5f2 2091 3780 942c 942c 942f 942f",
+            "00:45:36:04\t942c 942c");
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("<i>♪ El mundo quiero ver ♪</i>", subtitle.Paragraphs[0].Text);
+        Assert.DoesNotContain("7", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void DecodesAlignedMusicNotes()
+    {
+        // The common case: both notes byte-aligned as full 9137 words must keep working.
+        var subtitle = LoadScc(
+            "00:00:25:00\t9420 9420 946e 946e 9137 9137 20c4 e520 d075 e562 ecef 20d0 61ec e5f4 6120 73ef 7920 9137 9137 942c 942c 942f 942f",
+            "00:45:36:04\t942c 942c");
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("<i>♪ De Pueblo Paleta soy ♪</i>", subtitle.Paragraphs[0].Text);
     }
 }


### PR DESCRIPTION
## Summary

Two more Scenarist SCC (`.scc`) decode problems from #9803, on top of the line-break fixes already merged in #11343.

### 1. Italics were almost entirely lost
Italics are carried by **italic-style Preamble Address Codes** (e.g. `916e`, `92ce`, `946e`), not by mid-row codes. The parity-applied forms aren't in `SccPositionAndStyleTable`, so the style was dropped. Italic is now detected directly from the PAC's second byte (parity-stripped `4e/4f/6e/6f`) and emitted as `<i>…</i>`, toggling off at a regular PAC or caption end.

### 2. Musical note `♪` decoded as `7`
A two-byte control code can straddle the SCC word boundary: a trailing `" ♪"` arrives as `2091 3780` = `char(20)` + the note code `9137` split over two words + `80` padding (instead of the aligned `2080 9137`). It decoded to `7`. The decoder now re-joins such a split control code.

**Before / After on the #9803 sample (`Original.scc`):**
```
[27] {\an7}NARRADOR:nAsh y sus amigosNcontinúan su viaje     ->  {\an7}NARRADOR:
                                                                  <i>Ash y sus amigos
                                                                  continúan su viaje</i>
[32] ♪ El mundo quiero ver 7                                  ->  <i>♪ El mundo quiero ver ♪</i>
```
Italic cues go from ~2 to **61** (matching the reference tool), and the bogus `7` artifacts are gone.

## Validation
Decoded the full SCC corpus: every file keeps the **same cue count** with **no** over-long lines, blank lines, or unbalanced italic tags — no regressions.

## Tests
Adds three unit tests (using real lines from the sample files): italic PAC styling, the split-note `2091 3780` → `♪` case, and aligned `9137` notes (regression). All SCC tests and the full libse suite (366) pass.

## Not addressed (still open)
- Round-trip / export timing & formatting fidelity (#10577).
- Fine-grained region positioning (SE uses coarse `{\an}` alignment).
- Sustained byte-misalignment without `80` re-padding (the decoder is still word-based; only the common split-control pattern is handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)