### PR TITLE
Fix SSA style editor: *Default style recognition and style preview (#11342)

### DIFF
--- a/src/libse/SubtitleFormats/SubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/SubStationAlpha.cs
@@ -555,7 +555,10 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
                             }
                             else if (i == indexStyle)
                             {
-                                style = splitLine[i];
+                                // A leading '*' is the old SSA "marked"/"this is the used style"
+                                // convention (e.g. "*Default"); strip it so the name matches the
+                                // styles defined in [V4 Styles]. (#11342)
+                                style = splitLine[i].Trim().TrimStart('*');
                             }
                             else if (i == indexMarginL)
                             {

--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -745,7 +745,7 @@ public partial class AssaStylesViewModel : ObservableObject
 
         var text = "This is a test";
 
-        var fontSize = (float)style.FontSize;
+        var fontSize = (float)style.FontSize * 0.75f; // render a little smaller in the preview
         var libAssFontName = FontHelper.GetSkiaFontNameFromLibAssaFontName(style.FontName);
         SKBitmap bitmap;
 
@@ -761,7 +761,10 @@ public partial class AssaStylesViewModel : ObservableObject
                 style.ColorOutline.ToSKColor(),
                 style.ColorOutline.ToSKColor(),
                 0,
-                (float)style.ShadowWidth);
+                (float)style.ShadowWidth,
+                isItalic: style.Italic,
+                isUnderline: style.Underline,
+                isStrikeout: style.Strikeout);
 
             if (style.ShadowWidth > 0)
             {
@@ -783,7 +786,10 @@ public partial class AssaStylesViewModel : ObservableObject
                 (float)style.OutlineWidth,
                 0,
                 1.0f,
-                (int)Math.Round(style.ShadowWidth));
+                (int)Math.Round(style.ShadowWidth),
+                isItalic: style.Italic,
+                isUnderline: style.Underline,
+                isStrikeout: style.Strikeout);
         }
         else // FontBoxType.None
         {
@@ -797,10 +803,28 @@ public partial class AssaStylesViewModel : ObservableObject
                 style.ColorShadow.ToSKColor(),
                 SKColors.Transparent,
                 (float)style.OutlineWidth,
-                (float)style.ShadowWidth);
+                (float)style.ShadowWidth,
+                isItalic: style.Italic,
+                isUnderline: style.Underline,
+                isStrikeout: style.Strikeout);
         }
 
-        ImagePreview = bitmap.ToAvaloniaBitmap();
+        var frame = TextToImageGenerator.ComposeOnPreviewFrame(bitmap, GetAlignment(style), style.MarginLeft, style.MarginRight, style.MarginVertical);
+        ImagePreview = frame.ToAvaloniaBitmap();
+    }
+
+    private static int GetAlignment(StyleDisplay style)
+    {
+        if (style.AlignmentAn1) return 1;
+        if (style.AlignmentAn2) return 2;
+        if (style.AlignmentAn3) return 3;
+        if (style.AlignmentAn4) return 4;
+        if (style.AlignmentAn5) return 5;
+        if (style.AlignmentAn6) return 6;
+        if (style.AlignmentAn7) return 7;
+        if (style.AlignmentAn8) return 8;
+        if (style.AlignmentAn9) return 9;
+        return 2;
     }
 
     internal void FileStylesChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -621,9 +621,10 @@ public class AssaStylesWindow : Window
         {
             [!Image.SourceProperty] = new Binding(nameof(vm.ImagePreview)),
             DataContext = vm,
-            HorizontalAlignment = HorizontalAlignment.Left,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Top,
-            Stretch = Stretch.None, // Prevents stretching of the image
+            Stretch = Stretch.Uniform, // Scale the preview frame to fit while keeping aspect ratio
+            MinHeight = 240,
         };
 
         grid.Add(label, 0);

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -706,7 +706,7 @@ public partial class SsaStylesViewModel : ObservableObject
 
         var text = "This is a test";
 
-        var fontSize = (float)style.FontSize;
+        var fontSize = (float)style.FontSize * 0.75f; // render a little smaller in the preview
         var libAssFontName = FontHelper.GetSkiaFontNameFromLibAssaFontName(style.FontName);
         SKBitmap bitmap;
 
@@ -722,7 +722,10 @@ public partial class SsaStylesViewModel : ObservableObject
                 style.ColorOutline.ToSKColor(),
                 style.ColorOutline.ToSKColor(),
                 0,
-                (float)style.ShadowWidth);
+                (float)style.ShadowWidth,
+                isItalic: style.Italic,
+                isUnderline: style.Underline,
+                isStrikeout: style.Strikeout);
 
             if (style.ShadowWidth > 0)
             {
@@ -744,7 +747,10 @@ public partial class SsaStylesViewModel : ObservableObject
                 (float)style.OutlineWidth,
                 0,
                 1.0f,
-                (int)Math.Round(style.ShadowWidth));
+                (int)Math.Round(style.ShadowWidth),
+                isItalic: style.Italic,
+                isUnderline: style.Underline,
+                isStrikeout: style.Strikeout);
         }
         else // FontBoxType.None
         {
@@ -758,10 +764,28 @@ public partial class SsaStylesViewModel : ObservableObject
                 style.ColorShadow.ToSKColor(),
                 SKColors.Transparent,
                 (float)style.OutlineWidth,
-                (float)style.ShadowWidth);
+                (float)style.ShadowWidth,
+                isItalic: style.Italic,
+                isUnderline: style.Underline,
+                isStrikeout: style.Strikeout);
         }
 
-        ImagePreview = bitmap.ToAvaloniaBitmap();
+        var frame = TextToImageGenerator.ComposeOnPreviewFrame(bitmap, GetAlignment(style), style.MarginLeft, style.MarginRight, style.MarginVertical);
+        ImagePreview = frame.ToAvaloniaBitmap();
+    }
+
+    private static int GetAlignment(StyleDisplay style)
+    {
+        if (style.AlignmentAn1) return 1;
+        if (style.AlignmentAn2) return 2;
+        if (style.AlignmentAn3) return 3;
+        if (style.AlignmentAn4) return 4;
+        if (style.AlignmentAn5) return 5;
+        if (style.AlignmentAn6) return 6;
+        if (style.AlignmentAn7) return 7;
+        if (style.AlignmentAn8) return 8;
+        if (style.AlignmentAn9) return 9;
+        return 2;
     }
 
     internal void FileStylesChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Ssa/SsaStylesWindow.cs
+++ b/src/ui/Features/Ssa/SsaStylesWindow.cs
@@ -621,9 +621,10 @@ public class SsaStylesWindow : Window
         {
             [!Image.SourceProperty] = new Binding(nameof(vm.ImagePreview)),
             DataContext = vm,
-            HorizontalAlignment = HorizontalAlignment.Left,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Top,
-            Stretch = Stretch.None, // Prevents stretching of the image
+            Stretch = Stretch.Uniform, // Scale the preview frame to fit while keeping aspect ratio
+            MinHeight = 240,
         };
 
         grid.Add(label, 0);

--- a/src/ui/Logic/Media/TextToImageGenerator.cs
+++ b/src/ui/Logic/Media/TextToImageGenerator.cs
@@ -1,4 +1,5 @@
 using SkiaSharp;
+using System;
 
 namespace Nikse.SubtitleEdit.Logic.Media;
 
@@ -103,18 +104,26 @@ public static class TextToImageGenerator
      float outlineWidth,
      float shadowWidth,
      float cornerRadius = 1.0f, // Parameter for rounded corners
-     int padding = 20 
+     int padding = 20,
+     bool isItalic = false,
+     bool isUnderline = false,
+     bool isStrikeout = false
  )
     {
         outlineWidth *= 1.7f; // factor to match ASSA
 
-        using var typeface = SKTypeface.FromFamilyName(fontName, isBold ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+        using var typeface = SKTypeface.FromFamilyName(fontName, isBold ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal, SKFontStyleWidth.Normal, isItalic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright);
         using var paint = new SKPaint
         {
             IsAntialias = true
         };
 
         using var font = new SKFont(typeface, fontSize);
+        if (isItalic)
+        {
+            font.SkewX = -0.25f; // synthetic slant so italic shows even when the font has no italic face
+        }
+
         font.MeasureText(text, out var textBounds, paint);
 
         var width = (int)(textBounds.Width + padding * 2 + outlineWidth * 2 + shadowWidth);
@@ -139,7 +148,92 @@ public static class TextToImageGenerator
         // Draw main text with rounded outline
         DrawTextWithRoundedOutline(x, y, textColor, outlineColor, textPath, x, y, cornerRadius, outlineWidth, paint, canvas);
 
+        DrawUnderlineAndStrikeout(canvas, font, textColor, x, y, textBounds.Width, fontSize, isUnderline, isStrikeout);
+
         return bitmap;
+    }
+
+    private static void DrawUnderlineAndStrikeout(SKCanvas canvas, SKFont font, SKColor color, float x, float baselineY, float textWidth, float fontSize, bool isUnderline, bool isStrikeout)
+    {
+        if (!isUnderline && !isStrikeout)
+        {
+            return;
+        }
+
+        var metrics = font.Metrics;
+        using var linePaint = new SKPaint { Color = color, Style = SKPaintStyle.Fill, IsAntialias = true };
+
+        if (isUnderline)
+        {
+            var thickness = metrics.UnderlineThickness ?? Math.Max(1f, fontSize / 14f);
+            var position = metrics.UnderlinePosition ?? fontSize * 0.1f;
+            canvas.DrawRect(x, baselineY + position, textWidth, thickness, linePaint);
+        }
+
+        if (isStrikeout)
+        {
+            var thickness = metrics.StrikeoutThickness ?? Math.Max(1f, fontSize / 14f);
+            var position = metrics.StrikeoutPosition ?? -fontSize * 0.3f;
+            canvas.DrawRect(x, baselineY + position, textWidth, thickness, linePaint);
+        }
+    }
+
+    /// <summary>
+    /// Places a generated text bitmap onto a video-frame-proportioned canvas, positioned by the
+    /// CEA/ASSA numpad alignment (1-9) and the margins, so the preview reflects the style layout.
+    /// </summary>
+    public static SKBitmap ComposeOnPreviewFrame(SKBitmap textBitmap, int alignment, int marginLeft, int marginRight, int marginVertical)
+    {
+        var frameWidth = Math.Max(640, textBitmap.Width + 160);
+        var frameHeight = Math.Max((int)Math.Round(frameWidth * 9.0 / 16.0), textBitmap.Height + 60);
+
+        var frame = new SKBitmap(frameWidth, frameHeight);
+        using var canvas = new SKCanvas(frame);
+        canvas.Clear(new SKColor(40, 40, 40)); // represent the video frame
+        using (var border = new SKPaint { Color = new SKColor(90, 90, 90), Style = SKPaintStyle.Stroke, StrokeWidth = 2 })
+        {
+            canvas.DrawRect(1, 1, frameWidth - 2, frameHeight - 2, border);
+        }
+
+        // numpad alignment: 1/4/7 left, 2/5/8 center, 3/6/9 right; 1/2/3 bottom, 4/5/6 middle, 7/8/9 top
+        var isLeft = alignment == 1 || alignment == 4 || alignment == 7;
+        var isRight = alignment == 3 || alignment == 6 || alignment == 9;
+        var isTop = alignment >= 7;
+        var isMiddle = alignment >= 4 && alignment <= 6;
+
+        float x;
+        if (isLeft)
+        {
+            x = marginLeft;
+        }
+        else if (isRight)
+        {
+            x = frameWidth - textBitmap.Width - marginRight;
+        }
+        else
+        {
+            x = (frameWidth - textBitmap.Width) / 2f;
+        }
+
+        float yy;
+        if (isTop)
+        {
+            yy = marginVertical;
+        }
+        else if (isMiddle)
+        {
+            yy = (frameHeight - textBitmap.Height) / 2f;
+        }
+        else
+        {
+            yy = frameHeight - textBitmap.Height - marginVertical;
+        }
+
+        x = Math.Max(0, Math.Min(x, frameWidth - textBitmap.Width));
+        yy = Math.Max(0, Math.Min(yy, frameHeight - textBitmap.Height));
+
+        canvas.DrawBitmap(textBitmap, x, yy);
+        return frame;
     }
 
     private static void DrawTextWithRoundedOutline(float xPos, float yPos, SKColor fillColor, SKColor strokeColor, SKPath textPath, float x, float y, float cornerRadius, float outlineWidth, SKPaint paint, SKCanvas canvas)

--- a/tests/libse/SubtitleFormats/SubStationAlphaTest.cs
+++ b/tests/libse/SubtitleFormats/SubStationAlphaTest.cs
@@ -1,0 +1,32 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Collections.Generic;
+
+namespace LibSETests.SubtitleFormats;
+
+public class SubStationAlphaTest
+{
+    private const string SsaWithMarkedDefault = @"[Script Info]
+ScriptType: v4.00
+
+[V4 Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding
+Style: Default,Arial,20,16777215,65535,0,0,0,0,1,1,1,2,10,10,10,0,1
+
+[Events]
+Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: Marked=0,0:20:19.02,0:20:23.82,*Default,NTP,0000,0000,0000,,Wir freuen uns sehr,
+Dialogue: Marked=0,0:20:24.01,0:20:26.44,*Default,NTP,0000,0000,0000,,Du wirst sehr reich werden.";
+
+    [Fact]
+    public void LeadingAsteriskOnStyleNameIsStripped()
+    {
+        // Issue #11342: "*Default" (old SSA "marked" convention) must resolve to the "Default"
+        // style defined in [V4 Styles], otherwise the style column shows up empty.
+        var subtitle = new Subtitle();
+        new SubStationAlpha().LoadSubtitle(subtitle, new List<string>(SsaWithMarkedDefault.SplitToLines()), "test.ssa");
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.All(subtitle.Paragraphs, p => Assert.Equal("Default", p.Extra));
+    }
+}


### PR DESCRIPTION
## Summary

Addresses the issues in #11342 with the SE5 SSA/ASSA style editor.

### 1. "Default" style not recognized
A `.ssa` file references its style as `*Default` (the old SSA "marked" convention — a leading `*`). The reader stored the name verbatim, so it never matched the `Default` style defined in `[V4 Styles]` and the style column showed up empty. The leading `*` is now stripped on read.

### 2. Style preview didn't reflect the style
The preview always drew plain text in the top-left corner. It now:
- honours **italic, underline and strikeout** (previously only **bold** was applied — italic/underline/strikeout were ignored);
- positions the text on a **video-frame-proportioned canvas** by the numpad **alignment** (1–9) and the **margins**, instead of pinning it top-left;
- uses a **wider preview frame**, with the text rendered a little smaller so the layout is easier to read.

Both the ASSA and SSA style editors share the rendering, so both are fixed.

## Changes
- `libse/SubtitleFormats/SubStationAlpha.cs` — strip leading `*` from the dialogue style name.
- `ui/Logic/Media/TextToImageGenerator.cs` — italic/underline/strikeout support + `ComposeOnPreviewFrame` (alignment/margin placement).
- `ui/Features/Assa/AssaStylesViewModel.cs`, `ui/Features/Ssa/SsaStylesViewModel.cs` — pass the style flags, compose onto the frame.
- `ui/Features/Assa/AssaStylesWindow.cs`, `ui/Features/Ssa/SsaStylesWindow.cs` — preview image stretches to fill width with a min height.

## Validation
- New unit test `LeadingAsteriskOnStyleNameIsStripped`; full libse suite (364) passes.
- UI project builds clean.
- The preview rendering was verified visually in the running app (alignment, italic, wider frame, smaller text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)