### PR TITLE
Color picker: hex is 6 chars (RRGGBB) when there is no alpha channel

### DIFF
--- a/src/ui/Features/Shared/ColorPicker/ColorPickerViewModel.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorPickerViewModel.cs
@@ -152,8 +152,16 @@ public partial class ColorPickerViewModel : ObservableObject
 
     private void UpdateHexColor()
     {
-        HexColor = SelectedColor.FromColorToHex(true).TrimStart('#');
+        // Only include the alpha byte (AARRGGBB) when an alpha/opacity channel is shown;
+        // otherwise the hex is a plain 6-char RRGGBB value. (#11342 follow-up)
+        HexColor = SelectedColor.FromColorToHex(ShowAlpha).TrimStart('#');
         OnPropertyChanged(nameof(HexColor));
+    }
+
+    partial void OnShowAlphaChanged(bool value)
+    {
+        // ShowAlpha is set after Initialize(), so refresh the hex to match the channel count.
+        UpdateHexColor();
     }
 
     private void LoadSettings()

--- a/src/ui/Features/Shared/ColorPicker/ColorPickerWindow.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorPickerWindow.cs
@@ -231,7 +231,11 @@ public class ColorPickerWindow : Window
         var hexTextBox = new TextBox
         {
             Margin = new Thickness(0, 10, 0, 0),
-            MinWidth = 150,
+            // 8 chars (AARRGGBB) when an alpha channel is shown, otherwise 6 chars (RRGGBB)
+            MaxLength = vm.ShowAlpha ? 8 : 6,
+            MinWidth = vm.ShowAlpha ? 95 : 75,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Left,
         };
         hexTextBox.Bind(TextBox.TextProperty, new Binding
         {


### PR DESCRIPTION
## Summary

In the color picker, the hex text box always showed an 8-character `AARRGGBB` value and used a fixed width, even when the picker was opened **without** an alpha/opacity channel (`ShowAlpha = false`, e.g. from the SSA style editor). It should be a plain 6-character `RRGGBB` in that case.

Now:
- `UpdateHexColor` honours `ShowAlpha` — **6 chars (RRGGBB)** without alpha, **8 chars (AARRGGBB)** with it.
- `OnShowAlphaChanged` refreshes the hex, because `ShowAlpha` is assigned after `Initialize()`.
- The hex text box `MaxLength` and width size to the channel count (6 vs 8 chars) instead of a fixed 150px min width.

## Files
- `ui/Features/Shared/ColorPicker/ColorPickerViewModel.cs`
- `ui/Features/Shared/ColorPicker/ColorPickerWindow.cs`

## Validation
UI project builds clean. Input parsing already accepts both 6- and 8-char hex (`FromHexToColor`), and a 6-char value resolves to a fully opaque color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)