### PR TITLE
Add SSA Properties and Attachments windows + toolbar/menu items

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -272,6 +272,8 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<AssaStylePickerViewModel>();
         collection.AddTransient<AssaStylesViewModel>();
         collection.AddTransient<SsaStylesViewModel>();
+        collection.AddTransient<SsaPropertiesViewModel>();
+        collection.AddTransient<SsaAttachmentsViewModel>();
         collection.AddTransient<AssaTagHistoryViewModel>();
         collection.AddTransient<SpeechToTextViewModel>();
         collection.AddTransient<SpeechToTextEngineSettingsViewModel>();

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -921,6 +921,28 @@ public static class InitMenu
         });
 
         menu.Items.Add(menuItemAssaTools);
+
+        var menuItemSsaTools = new MenuItem
+        {
+            Header = l.SsaTools,
+            [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.IsFormatSsa)),
+        };
+        menuItemSsaTools.Items.Add(new MenuItem
+        {
+            Header = l.AssaStyles,
+            Command = vm.ShowSsaStylesCommand,
+        });
+        menuItemSsaTools.Items.Add(new MenuItem
+        {
+            Header = l.AssaProperties,
+            Command = vm.ShowSsaPropertiesCommand,
+        });
+        menuItemSsaTools.Items.Add(new MenuItem
+        {
+            Header = l.AssaAttachments,
+            Command = vm.ShowSsaAttachmentsCommand,
+        });
+        menu.Items.Add(menuItemSsaTools);
     }
 
     public static void UpdateRecentFiles(MainViewModel vm)

--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -334,6 +334,32 @@ public static class InitToolbar
         stackPanelLeft.Children.Add(new Button
         {
             Content = MakeImage("AssaProperties"),
+            Command = vm.ShowSsaPropertiesCommand,
+            Background = Brushes.Transparent,
+            [AutomationProperties.NameProperty] = languageHints.AssaPropertiesHint,
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.AssaPropertiesHint, shortcuts, nameof(vm.ShowSsaPropertiesCommand)),
+            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsFormatSsa))
+            {
+                Source = vm,
+            },
+        });
+
+        stackPanelLeft.Children.Add(new Button
+        {
+            Content = MakeImage("AssaAttachments"),
+            Command = vm.ShowSsaAttachmentsCommand,
+            Background = Brushes.Transparent,
+            [AutomationProperties.NameProperty] = languageHints.AssaAttachmentsHint,
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.AssaAttachmentsHint, shortcuts, nameof(vm.ShowSsaAttachmentsCommand)),
+            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsFormatSsa))
+            {
+                Source = vm,
+            },
+        });
+
+        stackPanelLeft.Children.Add(new Button
+        {
+            Content = MakeImage("AssaProperties"),
             Command = vm.ShowAssaPropertiesCommand,
             Background = Brushes.Transparent,
             [AutomationProperties.NameProperty] = languageHints.AssaPropertiesHint,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1118,6 +1118,48 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task ShowSsaProperties()
+    {
+        if (Window == null || !IsFormatSsa)
+        {
+            return;
+        }
+
+        var result = await ShowDialogAsync<SsaPropertiesWindow, SsaPropertiesViewModel>(vm =>
+        {
+            vm.Initialize(_subtitle, SelectedSubtitleFormat, _subtitleFileName ?? string.Empty,
+                _videoFileName ?? string.Empty);
+        });
+
+        if (result.OkPressed)
+        {
+            _subtitle.Header = result.Header;
+            RefreshSubtitlePreview();
+        }
+    }
+
+    [RelayCommand]
+    private async Task ShowSsaAttachments()
+    {
+        if (Window == null || !IsFormatSsa)
+        {
+            return;
+        }
+
+        var result = await ShowDialogAsync<SsaAttachmentsWindow, SsaAttachmentsViewModel>(vm =>
+        {
+            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat, _subtitleFileName ?? string.Empty);
+        });
+
+        if (result.OkPressed)
+        {
+            _subtitle.Header = result.Header;
+            _subtitle.Footer = result.Footer;
+            RefreshSubtitlePreview();
+        }
+    }
+
+    [RelayCommand]
     private async Task ShowAssaDraw()
     {
         if (Window == null || !IsFormatAssa)

--- a/src/ui/Features/Ssa/SsaAttachmentItem.cs
+++ b/src/ui/Features/Ssa/SsaAttachmentItem.cs
@@ -1,0 +1,44 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Ssa;
+
+public class SsaAttachmentItem
+{
+    public string FileName { get; set; }
+    public string Category { get; set; }
+    public string Content { get; set; }
+    public byte[] Bytes { get; set; }
+
+    public string Size { get; set; }
+    public string FontName { get; set; }
+
+    public SsaAttachmentItem()
+    {
+        FileName = string.Empty;
+        Category = string.Empty;
+        Content = string.Empty;
+        Bytes = Array.Empty<byte>();
+        Size = string.Empty;
+        FontName = string.Empty;
+    }
+
+    public SsaAttachmentItem(string fileName)
+    {
+        FileName = fileName;
+        FontName = string.Empty;
+        if (fileName.EndsWith(".ttf", StringComparison.OrdinalIgnoreCase))
+        {
+            Category = Se.Language.General.Fonts;
+        }
+        else
+        {
+            Category = Se.Language.Assa.Graphics;
+        }
+
+        Bytes = FileUtil.ReadAllBytesShared(fileName);
+        Content = UUEncoding.UUEncode(Bytes);
+        Size = Utilities.FormatBytesToDisplayFileSize(Bytes.Length);
+    }
+}

--- a/src/ui/Features/Ssa/SsaAttachmentsViewModel.cs
+++ b/src/ui/Features/Ssa/SsaAttachmentsViewModel.cs
@@ -1,0 +1,509 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Ssa;
+
+public partial class SsaAttachmentsViewModel : ObservableObject
+{
+    [ObservableProperty] private string _title;
+    [ObservableProperty] private ObservableCollection<SsaAttachmentItem> _attachments;
+    [ObservableProperty] private SsaAttachmentItem? _selectedAttachment;
+    [ObservableProperty] private string _previewTitle;
+    [ObservableProperty] private Bitmap? _previewImage;
+    [ObservableProperty] private bool _isCopyFontnameToClipboardVisible;
+    [ObservableProperty] private bool _isDeleteVisible;
+    [ObservableProperty] private bool _isDeleteAllVisible;
+
+    public Window? Window { get; internal set; }
+    public bool OkPressed { get; private set; }
+    public string Header { get; set; }
+    public string Footer { get; set; }
+
+    private readonly IFileHelper _fileHelper;
+    private string _fileName;
+    private Subtitle _subtitle;
+    private readonly List<string> _imageExtensions = new List<string>
+    {
+        "*.png",
+        "*.jpg" ,
+        "*.gif" ,
+        "*.bmp" ,
+        "*.ico"
+    };
+
+    public SsaAttachmentsViewModel(IFileHelper fileHelper)
+    {
+        _fileHelper = fileHelper;
+
+        Title = string.Empty;
+        Attachments = new ObservableCollection<SsaAttachmentItem>();
+        PreviewTitle = string.Empty;
+        _fileName = string.Empty;
+        Header = string.Empty;
+        Footer = string.Empty;
+        _subtitle = new Subtitle();
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Footer = GetUpdatedFooter();
+        Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    [RelayCommand]
+    private async Task CopyFontNameToClipboard()
+    {
+        if (Window?.Clipboard != null && SelectedAttachment != null && !string.IsNullOrEmpty(SelectedAttachment.FontName))
+        {
+            await ClipboardHelper.SetTextAsync(Window, SelectedAttachment.FontName);
+        }
+    }
+
+    [RelayCommand]
+    private async Task FileAttach()
+    {
+        var fileNames = await _fileHelper.PickOpenFiles(Window!, "Select attachment", "True type font", ["*.ttf"], Se.Language.Assa.Graphics, _imageExtensions);
+
+        foreach (var fileName in fileNames)
+        {
+            var attachmentFileName = Path.GetFileName(fileName);
+            var attachment = new SsaAttachmentItem(fileName);
+            var ext = Path.GetExtension(attachmentFileName)?.ToLowerInvariant();
+            Attachments.Add(attachment);
+            SelectedAttachment = attachment;
+        }
+    }
+
+    [RelayCommand]
+    private async Task FileImport()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenFile(Window, "Select import file", "Sub Station Alpha files", "*.ssa");
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var subtitle = Subtitle.Parse(fileName, new SubStationAlpha());
+        var attachments = ListAttachments(subtitle.Footer.SplitToLines() ?? []);
+        if (attachments.Count == 0)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.Assa.NoAttachmentsFound, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        Attachments.AddRange(attachments);
+        if (Attachments.Count > 0 && SelectedAttachment == null)
+        {
+            SelectedAttachment = Attachments.First();
+        }
+    }
+
+    [RelayCommand]
+    private async Task FileExport()
+    {
+        var selected = SelectedAttachment;
+        if (Window == null || selected == null)
+        {
+            return;
+        }
+
+        var ext = Path.GetExtension(selected.FileName);
+        var suggestedFileName = Path.GetFileName(selected.FileName);
+        var fileName = await _fileHelper.PickSaveFile(Window, ext, suggestedFileName, "Export attachment");
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var bytes = selected.Bytes;
+        try
+        {
+            File.WriteAllBytes(fileName, bytes);
+        }
+        catch (Exception exception)
+        {
+            await MessageBox.Show(Window, exception.Message, Se.Language.General.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    [RelayCommand]
+    private void AttachmentRemove()
+    {
+        var selectedStyle = SelectedAttachment;
+        if (selectedStyle == null)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(async void () =>
+        {
+            var answer = await MessageBox.Show(
+            Window!,
+            "Delete attachment?",
+            $"Do you want to delete {selectedStyle.FileName}?",
+            MessageBoxButtons.YesNoCancel,
+            MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            if (selectedStyle != null)
+            {
+                var idx = Attachments.IndexOf(selectedStyle);
+                Attachments.Remove(selectedStyle);
+                SelectedAttachment = null;
+                if (Attachments.Count > 0)
+                {
+                    if (idx >= Attachments.Count)
+                    {
+                        idx = Attachments.Count - 1;
+                    }
+                    SelectedAttachment = Attachments[idx];
+                }
+            }
+        });
+    }
+
+    [RelayCommand]
+    private void AttachemntsRemoveAll()
+    {
+        Attachments.Clear();
+    }
+
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            Window?.Close();
+        });
+    }
+
+    public void Initialize(Subtitle subtitle, SubtitleFormat format, string fileName)
+    {
+        Title = string.Format(Se.Language.Assa.AttachmentsTitleX, fileName);
+        Header = subtitle.Header;
+        Footer = subtitle.Footer ?? string.Empty;
+        _subtitle = subtitle;
+
+        if (Header != null && Header.Contains("http://www.w3.org/ns/ttml"))
+        {
+            var s = new Subtitle { Header = Header };
+            AdvancedSubStationAlpha.LoadStylesFromTimedText10(s, string.Empty, Header, AdvancedSubStationAlpha.HeaderNoStyles, new StringBuilder());
+            Header = s.Header;
+        }
+        else if (Header != null && Header.StartsWith("WEBVTT", StringComparison.Ordinal))
+        {
+            _subtitle = WebVttToAssa.Convert(subtitle, new SsaStyle(), 0, 0);
+            Header = _subtitle.Header;
+        }
+
+        if (Header == null || !Header.Contains("style:", StringComparison.OrdinalIgnoreCase))
+        {
+            ResetHeader();
+        }
+
+        Attachments.AddRange(ListAttachments(Footer.SplitToLines() ?? []));
+
+        if (Attachments.Count > 0)
+        {
+            SelectedAttachment = Attachments[0];
+        }
+
+        UpdatePreview();
+    }
+
+    private List<SsaAttachmentItem> ListAttachments(List<string> lines)
+    {
+        var attachments = new List<SsaAttachmentItem>();
+        bool attachmentOn = false;
+        var attachmentContent = new StringBuilder();
+        var attachmentFileName = string.Empty;
+        var category = string.Empty;
+        foreach (var line in lines)
+        {
+            var s = line.Trim();
+            if (attachmentOn)
+            {
+                if (s == "[V4+ Styles]" || s == "[V4 Styles]" || s == "[Events]")
+                {
+                    AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
+                    attachmentOn = false;
+                    attachmentContent = new StringBuilder();
+                    attachmentFileName = string.Empty;
+                }
+                else if (s == string.Empty)
+                {
+                    AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
+                    attachmentContent = new StringBuilder();
+                    attachmentFileName = string.Empty;
+                }
+                else if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
+                    attachmentContent = new StringBuilder();
+                    attachmentFileName = string.Empty;
+                    category = Se.Language.General.Fonts;
+                }
+                else if (s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
+                    attachmentContent = new StringBuilder();
+                    attachmentFileName = string.Empty;
+                    category = Se.Language.Assa.Graphics;
+                }
+                else if (s.StartsWith("filename:") || s.StartsWith("fontname:"))
+                {
+                    AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
+                    attachmentContent = new StringBuilder();
+                    attachmentFileName = s.Remove(0, 9).Trim();
+                }
+                else
+                {
+                    attachmentContent.AppendLine(s);
+                }
+            }
+            else if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
+            {
+                category = Se.Language.General.Fonts;
+                attachmentOn = true;
+                attachmentContent = new StringBuilder();
+                attachmentFileName = string.Empty;
+            }
+            else if (s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase))
+            {
+                category = Se.Language.Assa.Graphics;
+                attachmentOn = true;
+                attachmentContent = new StringBuilder();
+                attachmentFileName = string.Empty;
+            }
+        }
+
+        AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
+        return attachments;
+    }
+
+    private string GetUpdatedFooter()
+    {
+        var sb = new StringBuilder();
+
+        var fonts = Attachments.Where(p => p.Category == Se.Language.General.Fonts).ToList();
+        if (fonts.Count > 0)
+        {
+            sb.AppendLine("[Fonts]");
+            foreach (var font in fonts)
+            {
+                sb.AppendLine("fontname: " + Path.GetFileName(font.FileName));
+                sb.AppendLine(font.Content.Trim());
+            }
+            sb.AppendLine();
+        }
+
+        var graphics = Attachments.Where(p => p.Category == Se.Language.Assa.Graphics).ToList();
+        if (graphics.Count > 0)
+        {
+            sb = new StringBuilder(sb.ToString().Trim());
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("[Graphics]");
+            foreach (var g in graphics)
+            {
+                sb.AppendLine("filename: " + Path.GetFileName(g.FileName));
+                sb.AppendLine(g.Content.Trim());
+            }
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimStart();
+    }
+
+    private void AddToListIfNotEmpty(List<SsaAttachmentItem> attachments, string attachmentContent, string attachmentFileName, string category)
+    {
+        var content = attachmentContent.Trim();
+        if (!string.IsNullOrWhiteSpace(attachmentFileName) && !string.IsNullOrEmpty(content))
+        {
+            var bytes = UUEncoding.UUDecode(content);
+            var attachment = new SsaAttachmentItem
+            {
+                FileName = Path.GetFileName(attachmentFileName),
+                Bytes = bytes,
+                Category = category,
+                Content = content,
+                Size = Utilities.FormatBytesToDisplayFileSize(bytes.Length),
+            };
+            attachments.Add(attachment);
+        }
+    }
+
+    private void ResetHeader()
+    {
+        var format = new SubStationAlpha();
+        var sub = new Subtitle();
+        var text = format.ToText(sub, string.Empty);
+        var lines = text.SplitToLines();
+        format.LoadSubtitle(sub, lines, string.Empty);
+        Header = sub.Header;
+    }
+
+    private void UpdatePreview()
+    {
+        var selectedItem = SelectedAttachment;
+        if (selectedItem == null)
+        {
+            PreviewImage = new SKBitmap(1, 1, true).ToAvaloniaBitmap();
+            IsCopyFontnameToClipboardVisible = false;
+            return;
+        }
+
+        if (selectedItem.Category == Se.Language.General.Fonts)
+        {
+            selectedItem.FontName = ShowFont(selectedItem.Bytes);
+        }
+        else if (selectedItem.Category == Se.Language.Assa.Graphics)
+        {
+            ShowImage(selectedItem.Bytes);
+        }
+        else
+        {
+            PreviewImage = new SKBitmap(1, 1, true).ToAvaloniaBitmap();
+        }
+    }
+
+    private void ShowImage(byte[] bytes)
+    {
+        using var skBitmap = SKBitmap.Decode(bytes);
+        PreviewTitle = $"{Se.Language.General.Image}: {SelectedAttachment?.FileName ?? "untitled"}, {skBitmap.Width}x{skBitmap.Height}";
+        PreviewImage?.Dispose();
+        PreviewImage = skBitmap.ToAvaloniaBitmap();
+        IsCopyFontnameToClipboardVisible = false;
+    }
+
+    public string ShowFont(byte[] fontBytes)
+    {
+        var previewWidth = 400; // Replace with actual width from your control
+        var previewHeight = 300; // Replace with actual height from your control
+        if (previewWidth <= 1 || previewHeight <= 1)
+        {
+            return string.Empty;
+        }
+        using var skTypeface = SKTypeface.FromData(SKData.CreateCopy(fontBytes));
+        if (skTypeface == null)
+        {
+            return string.Empty;
+        }
+        var fontName = FontHelper.GetLibAssaFontName(skTypeface);
+
+        PreviewTitle = $"{Se.Language.General.FontName}: {fontName}";
+        PreviewImage?.Dispose();
+
+        // Create Skia surface and canvas
+        var imageInfo = new SKImageInfo(previewWidth, previewHeight, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using var surface = SKSurface.Create(imageInfo);
+        var canvas = surface.Canvas;
+
+        // Clear background
+        canvas.Clear(SKColors.Transparent);
+
+        // Create SKFont and SKPaint (modern approach)
+        using var font = new SKFont(skTypeface, 25);
+        using var paint = new SKPaint
+        {
+            Color = SKColors.Orange,
+            IsAntialias = true
+        };
+
+        // Draw the text
+        var previewText =
+                "Hello World!" + Environment.NewLine +
+                "æøåäöüß (Latin)" + Environment.NewLine +
+                "你好世界 (Chinese simplified)" + Environment.NewLine +
+                "こんにちは世界。 (Japanese)" + Environment.NewLine +
+                "مرحبا بالعالم (Arabic)" + Environment.NewLine +
+                "1234567890 (Numbers)";
+        var text = $"{skTypeface.FamilyName}\n\n{previewText}";
+        var lines = text.SplitToLines() ?? [];
+        float y = 23;
+        foreach (var line in lines)
+        {
+            if (!string.IsNullOrEmpty(line))
+            {
+                canvas.DrawText(line, 12, y, font, paint);
+            }
+            y += font.Size + 5; // Line spacing using font.Size instead of paint.TextSize
+        }
+
+        // Convert to Avalonia bitmap
+        using var skImage = surface.Snapshot();
+        using var skData = skImage.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = new MemoryStream(skData.ToArray());
+        PreviewImage = new Bitmap(stream);
+        IsCopyFontnameToClipboardVisible = true;
+        return fontName;
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assa-attachments");
+        }
+    }
+
+    internal void DataGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        UpdatePreview();
+    }
+
+    internal void AttachmentsContextMenuOpening(object? sender, EventArgs e)
+    {
+        IsDeleteAllVisible = Attachments.Count > 0;
+        IsDeleteVisible = SelectedAttachment != null;
+    }
+
+    internal void AttachmentsDataGridKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Delete && SelectedAttachment != null)
+        {
+            AttachmentRemove();
+            e.Handled = true;
+        }
+    }
+}

--- a/src/ui/Features/Ssa/SsaAttachmentsWindow.cs
+++ b/src/ui/Features/Ssa/SsaAttachmentsWindow.cs
@@ -1,0 +1,190 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Ssa;
+
+public class SsaAttachmentsWindow : Window
+{
+    public SsaAttachmentsWindow(SsaAttachmentsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Bind(Window.TitleProperty, new Binding(nameof(vm.Title))
+        {
+            Source = vm,
+            Mode = BindingMode.TwoWay,
+        });
+        CanResize = true;
+        Width = 1200;
+        Height = 850;
+        MinWidth = 1100;
+        MinHeight = 600;
+
+        vm.Window = this;
+        DataContext = vm;
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(2, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 5,
+            RowSpacing = 5,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var labelFontsAndImages = UiUtil.MakeLabel(Se.Language.Assa.FontsAndGraphics);
+        var labelPreview = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.PreviewTitle));
+        var buttonCopyToClipboard = UiUtil.MakeButton(Se.Language.General.CopyToClipboard, vm.CopyFontNameToClipboardCommand)
+            .WithBindIsVisible(nameof(vm.IsCopyFontnameToClipboardVisible));
+        var previewLine = UiUtil.MakeHorizontalPanel(labelPreview, buttonCopyToClipboard);
+
+        var buttonAttach = UiUtil.MakeButton(Se.Language.General.AttachDotDotDot, vm.FileAttachCommand);
+        var buttonImport = UiUtil.MakeButton(Se.Language.General.ImportDotDotDot, vm.FileImportCommand);
+        var buttonExport = UiUtil.MakeButton(Se.Language.General.ExportDotDotDot, vm.FileExportCommand);
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonAttach, buttonImport, buttonExport, buttonOk, buttonCancel);
+
+        grid.Add(labelFontsAndImages, 0);
+        grid.Add(previewLine, 0, 1);
+        grid.Add(MakeLeftView(vm), 1);
+        grid.Add(MakeRightView(vm), 1, 1);
+        grid.Add(panelButtons, 3, 0, 1, 2);
+
+        Content = grid;
+
+        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        KeyDown += vm.KeyDown;
+    }
+
+    private static Border MakeLeftView(SsaAttachmentsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var dataGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = vm.Attachments,
+            Columns =
+            {
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.FileName,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(SsaAttachmentItem.FileName)),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Type,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(SsaAttachmentItem.Category)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Size,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(SsaAttachmentItem.Size)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+            },
+        };
+        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedAttachment)) { Source = vm });
+        dataGrid.SelectionChanged += vm.DataGridSelectionChanged;
+        dataGrid.KeyDown += vm.AttachmentsDataGridKeyDown;
+
+        var flyout = new MenuFlyout();
+        flyout.Opening += vm.AttachmentsContextMenuOpening;
+        dataGrid.ContextFlyout = flyout;
+        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
+
+        var menuItemDelete = new MenuItem
+        {
+            Header = Se.Language.General.Delete,
+            DataContext = vm,
+            Command = vm.AttachmentRemoveCommand,
+        };
+        menuItemDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)) { Source = vm });
+        flyout.Items.Add(menuItemDelete);
+
+        var menuItemClear = new MenuItem
+        {
+            Header = Se.Language.General.Clear,
+            DataContext = vm,
+            Command = vm.AttachemntsRemoveAllCommand,
+        };
+        menuItemClear.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteAllVisible)) { Source = vm });
+        flyout.Items.Add(menuItemClear);
+
+        grid.Add(dataGrid, 0);
+
+        return UiUtil.MakeBorderForControlNoPadding(grid);
+    }
+
+    private static Border MakeRightView(SsaAttachmentsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var image = new Image
+        {
+            [!Image.SourceProperty] = new Binding(nameof(vm.PreviewImage)),
+            DataContext = vm,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Stretch = Stretch.Uniform,
+        };
+
+        grid.Add(image, 0);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+}

--- a/src/ui/Features/Ssa/SsaPropertiesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaPropertiesViewModel.cs
@@ -1,0 +1,313 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Video.BurnIn;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Ssa;
+
+public partial class SsaPropertiesViewModel : ObservableObject
+{
+    [ObservableProperty] private string _title;
+    [ObservableProperty] private string _scriptTitle;
+    [ObservableProperty] private string _originalScript;
+    [ObservableProperty] private string _translation;
+    [ObservableProperty] private string _editing;
+    [ObservableProperty] private string _timing;
+    [ObservableProperty] private string _syncPoint;
+    [ObservableProperty] private string _updatedBy;
+    [ObservableProperty] private string _updateDetails;
+    [ObservableProperty] private int _videoWidth;
+    [ObservableProperty] private int _videoHeight;
+    [ObservableProperty] private bool _showGetResolutionFromCurrentVideo;
+    [ObservableProperty] private ObservableCollection<string> _collisions;
+    [ObservableProperty] private string _selectedCollision;
+    [ObservableProperty] private int _playDepth;
+    [ObservableProperty] private string _timer;
+
+    public Window? Window { get; internal set; }
+    public bool OkPressed { get; private set; }
+    public string Header { get; set; }
+
+    private readonly IFileHelper _fileHelper;
+    private readonly IWindowService _windowService;
+    private string _videoFileName;
+
+    public SsaPropertiesViewModel(IFileHelper fileHelper, IWindowService windowService)
+    {
+        _fileHelper = fileHelper;
+        _windowService = windowService;
+
+        Title = string.Empty;
+        ScriptTitle = string.Empty;
+        OriginalScript = string.Empty;
+        Translation = string.Empty;
+        Editing = string.Empty;
+        Timing = string.Empty;
+        SyncPoint = string.Empty;
+        UpdatedBy = string.Empty;
+        UpdateDetails = string.Empty;
+        Collisions = new ObservableCollection<string> { "Normal", "Reverse" };
+        SelectedCollision = Collisions[0];
+        PlayDepth = 0;
+        Timer = "100.0000";
+
+        _videoFileName = string.Empty;
+        Header = string.Empty;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        UpdateHeader();
+        Close();
+    }
+
+    private void UpdateHeader()
+    {
+        UpdateTag("Title", ScriptTitle, string.IsNullOrWhiteSpace(ScriptTitle));
+        UpdateTag("Original Script", OriginalScript, string.IsNullOrWhiteSpace(OriginalScript));
+        UpdateTag("Original Translation", Translation, string.IsNullOrWhiteSpace(Translation));
+        UpdateTag("Original Editing", Editing, string.IsNullOrWhiteSpace(Editing));
+        UpdateTag("Original Timing", Timing, string.IsNullOrWhiteSpace(Timing));
+        UpdateTag("Synch Point", SyncPoint, string.IsNullOrWhiteSpace(SyncPoint));
+        UpdateTag("Script Updated By", UpdatedBy, string.IsNullOrWhiteSpace(UpdatedBy));
+        UpdateTag("Update Details", UpdateDetails, string.IsNullOrWhiteSpace(UpdateDetails));
+        UpdateTag("PlayResX", VideoWidth.ToString(CultureInfo.InvariantCulture), VideoWidth == 0);
+        UpdateTag("PlayResY", VideoHeight.ToString(CultureInfo.InvariantCulture), VideoHeight == 0);
+        UpdateTag("PlayDepth", PlayDepth.ToString(CultureInfo.InvariantCulture), false);
+        UpdateTag("Collisions", SelectedCollision, string.IsNullOrWhiteSpace(SelectedCollision));
+        UpdateTag("Timer", Timer, string.IsNullOrWhiteSpace(Timer));
+    }
+
+    private void UpdateTag(string tag, string text, bool remove)
+    {
+        var scriptInfoOn = false;
+        var sb = new StringBuilder();
+        var found = false;
+        foreach (var line in Header.SplitToLines())
+        {
+            if (line.StartsWith("[script info]", StringComparison.OrdinalIgnoreCase))
+            {
+                scriptInfoOn = true;
+            }
+            else if (line.StartsWith('['))
+            {
+                if (!found && scriptInfoOn && !remove)
+                {
+                    sb = new StringBuilder(sb.ToString().Trim() + Environment.NewLine);
+                    sb.AppendLine(tag + ": " + text);
+                }
+                sb = new StringBuilder(sb.ToString().TrimEnd());
+                sb.AppendLine();
+                sb.AppendLine();
+                scriptInfoOn = false;
+            }
+
+            var s = line.ToLowerInvariant();
+            if (s.StartsWith(tag.ToLowerInvariant() + ":", StringComparison.Ordinal))
+            {
+                if (!remove)
+                {
+                    sb.AppendLine(line.Substring(0, tag.Length) + ": " + text);
+                }
+
+                found = true;
+            }
+            else
+            {
+                sb.AppendLine(line);
+            }
+        }
+
+        Header = sb.ToString().Trim();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    [RelayCommand]
+    private async Task BrowseResolution()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<BurnInResolutionPickerWindow, BurnInResolutionPickerViewModel>(Window, vm =>
+        {
+            vm.RemoveUseSourceResolution();
+        });
+
+        if (!result.OkPressed || result.SelectedResolution == null)
+        {
+            return;
+        }
+
+        if (result.SelectedResolution.ItemType == ResolutionItemType.PickResolution)
+        {
+            var videoFileName = await _fileHelper.PickOpenVideoFile(Window!, Se.Language.General.OpenVideoFileTitle);
+            if (string.IsNullOrWhiteSpace(videoFileName))
+            {
+                return;
+            }
+
+            var mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
+            VideoWidth = mediaInfo.Dimension.Width;
+            VideoHeight = mediaInfo.Dimension.Height;
+        }
+        else if (result.SelectedResolution.ItemType == ResolutionItemType.Resolution)
+        {
+            VideoWidth = result.SelectedResolution.Width;
+            VideoHeight = result.SelectedResolution.Height;
+        }
+    }
+
+    [RelayCommand]
+    private void GetResolutionFromCurrentVideo()
+    {
+        _ = Task.Run(() =>
+        {
+            var mediaInfo = FfmpegMediaInfo2.Parse(_videoFileName);
+            if (mediaInfo?.Dimension is { Width: > 0, Height: > 0 })
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    VideoWidth = mediaInfo.Dimension.Width;
+                    VideoHeight = mediaInfo.Dimension.Height;
+                });
+            }
+        });
+    }
+
+    public void Initialize(Subtitle subtitle, SubtitleFormat format, string fileName, string videoFileName)
+    {
+        Title = string.Format(Se.Language.Assa.PropertiesTitleX, fileName);
+        Header = subtitle.Header;
+        _videoFileName = videoFileName;
+        ShowGetResolutionFromCurrentVideo = !string.IsNullOrWhiteSpace(videoFileName) && System.IO.File.Exists(videoFileName);
+
+        if (Header == null || !Header.Contains("style:", StringComparison.OrdinalIgnoreCase))
+        {
+            ResetHeader();
+        }
+
+        LoadFromHeader();
+    }
+
+    private void LoadFromHeader()
+    {
+        foreach (var line in Header.SplitToLines())
+        {
+            var s = line.ToLowerInvariant().Trim();
+            if (s.StartsWith("title:", StringComparison.Ordinal))
+            {
+                ScriptTitle = line.Trim().Remove(0, 6).Trim();
+            }
+            else if (s.StartsWith("original script:", StringComparison.Ordinal))
+            {
+                OriginalScript = line.Trim().Remove(0, 16).Trim();
+            }
+            else if (s.StartsWith("original translation:", StringComparison.Ordinal))
+            {
+                Translation = line.Trim().Remove(0, 21).Trim();
+            }
+            else if (s.StartsWith("original editing:", StringComparison.Ordinal))
+            {
+                Editing = line.Trim().Remove(0, 17).Trim();
+            }
+            else if (s.StartsWith("original timing:", StringComparison.Ordinal))
+            {
+                Timing = line.Trim().Remove(0, 16).Trim();
+            }
+            else if (s.StartsWith("synch point:", StringComparison.Ordinal))
+            {
+                SyncPoint = line.Trim().Remove(0, 12).Trim();
+            }
+            else if (s.StartsWith("script updated by:", StringComparison.Ordinal))
+            {
+                UpdatedBy = line.Trim().Remove(0, 18).Trim();
+            }
+            else if (s.StartsWith("update details:", StringComparison.Ordinal))
+            {
+                UpdateDetails = line.Trim().Remove(0, 15).Trim();
+            }
+            else if (s.StartsWith("playresx:", StringComparison.Ordinal))
+            {
+                if (int.TryParse(line.Trim().Remove(0, 9).Trim(), out var number))
+                {
+                    VideoWidth = number;
+                }
+            }
+            else if (s.StartsWith("playresy:", StringComparison.Ordinal))
+            {
+                if (int.TryParse(line.Trim().Remove(0, 9).Trim(), out var number))
+                {
+                    VideoHeight = number;
+                }
+            }
+            else if (s.StartsWith("playdepth:", StringComparison.Ordinal))
+            {
+                if (int.TryParse(line.Trim().Remove(0, 10).Trim(), out var number))
+                {
+                    PlayDepth = number;
+                }
+            }
+            else if (s.StartsWith("collisions:", StringComparison.Ordinal))
+            {
+                var collision = line.Trim().Remove(0, 11).Trim();
+                SelectedCollision = collision.Equals("Reverse", StringComparison.OrdinalIgnoreCase) ? "Reverse" : "Normal";
+            }
+            else if (s.StartsWith("timer:", StringComparison.Ordinal))
+            {
+                Timer = line.Trim().Remove(0, 6).Trim();
+            }
+        }
+    }
+
+    private void ResetHeader()
+    {
+        var format = new SubStationAlpha();
+        var sub = new Subtitle();
+        var text = format.ToText(sub, string.Empty);
+        var lines = text.SplitToLines();
+        format.LoadSubtitle(sub, lines, string.Empty);
+        Header = sub.Header;
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            Window?.Close();
+        });
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assa-properties");
+        }
+    }
+}

--- a/src/ui/Features/Ssa/SsaPropertiesWindow.cs
+++ b/src/ui/Features/Ssa/SsaPropertiesWindow.cs
@@ -1,0 +1,219 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Ssa;
+
+public class SsaPropertiesWindow : Window
+{
+    public SsaPropertiesWindow(SsaPropertiesViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Bind(Window.TitleProperty, new Binding(nameof(vm.Title))
+        {
+            Source = vm,
+            Mode = BindingMode.TwoWay,
+        });
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+
+        vm.Window = this;
+        DataContext = vm;
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 5,
+            RowSpacing = 5,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        grid.Add(MakeScriptView(vm), 0);
+        grid.Add(MakeResolutionView(vm), 1);
+        grid.Add(MakeOptionsView(vm), 2);
+        grid.Add(panelButtons, 3);
+
+        Content = grid;
+
+        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        KeyDown += vm.KeyDown;
+    }
+
+    private static Border MakeScriptView(SsaPropertiesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            RowSpacing = 5,
+        };
+
+        var label = UiUtil.MakeLabel(Se.Language.General.Script).WithBold().WithMarginBottom(10);
+
+        var labelTitle = UiUtil.MakeLabel(Se.Language.General.Title);
+        var textBoxTitle = UiUtil.MakeTextBox(200, vm, nameof(vm.ScriptTitle));
+
+        var labelOriginalScript = UiUtil.MakeLabel(Se.Language.Assa.OriginalScript);
+        var textBoxOriginalScript = UiUtil.MakeTextBox(200, vm, nameof(vm.OriginalScript));
+
+        var labelTranslation = UiUtil.MakeLabel(Se.Language.General.Translation);
+        var textBoxTranslation = UiUtil.MakeTextBox(200, vm, nameof(vm.Translation));
+
+        var labelEditing = UiUtil.MakeLabel(Se.Language.General.Editing);
+        var textBoxEditing = UiUtil.MakeTextBox(200, vm, nameof(vm.Editing));
+
+        var labelTiming = UiUtil.MakeLabel(Se.Language.General.Timing);
+        var textBoxTiming = UiUtil.MakeTextBox(200, vm, nameof(vm.Timing));
+
+        var labelSyncPoint = UiUtil.MakeLabel(Se.Language.General.Sync);
+        var textBoxSyncPoint = UiUtil.MakeTextBox(200, vm, nameof(vm.SyncPoint));
+
+        var labelUpdatedBy = UiUtil.MakeLabel(Se.Language.General.UpdatedBy);
+        var textBoxUpdatedBy = UiUtil.MakeTextBox(200, vm, nameof(vm.UpdatedBy));
+
+        var labelUpdateDetails = UiUtil.MakeLabel(Se.Language.General.UpdateDetails);
+        var textBoxUpdateDetails = UiUtil.MakeTextBox(200, vm, nameof(vm.UpdateDetails));
+
+        grid.Add(label, 0, 0, 1, 2);
+        grid.Add(labelTitle, 1, 0);
+        grid.Add(textBoxTitle, 1, 1);
+        grid.Add(labelOriginalScript, 2, 0);
+        grid.Add(textBoxOriginalScript, 2, 1);
+        grid.Add(labelTranslation, 3, 0);
+        grid.Add(textBoxTranslation, 3, 1);
+        grid.Add(labelEditing, 4, 0);
+        grid.Add(textBoxEditing, 4, 1);
+        grid.Add(labelTiming, 5, 0);
+        grid.Add(textBoxTiming, 5, 1);
+        grid.Add(labelSyncPoint, 6, 0);
+        grid.Add(textBoxSyncPoint, 6, 1);
+        grid.Add(labelUpdatedBy, 7, 0);
+        grid.Add(textBoxUpdatedBy, 7, 1);
+        grid.Add(labelUpdateDetails, 8, 0);
+        grid.Add(textBoxUpdateDetails, 8, 1);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+
+    private static Border MakeResolutionView(SsaPropertiesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            ColumnSpacing = 5,
+            RowSpacing = 5,
+        };
+
+        var label = UiUtil.MakeLabel(Se.Language.General.Resolution).WithBold().WithMarginBottom(10);
+
+        var labelVideoResolution = UiUtil.MakeLabel(Se.Language.General.VideoResolution);
+        var numericUpDownWidth = UiUtil.MakeNumericUpDownInt(0, 10000, 1920, 120, vm, nameof(vm.VideoWidth));
+        var labelX = UiUtil.MakeLabel("x");
+        var numericUpDownHeight = UiUtil.MakeNumericUpDownInt(0, 10000, 1080, 120, vm, nameof(vm.VideoHeight));
+        var buttonBrowseResolution = UiUtil.MakeButtonBrowse(vm.BrowseResolutionCommand);
+        var buttonFromCurrentVideo = UiUtil.MakeButton(Se.Language.General.PickResolutionFromCurrentVideo, vm.GetResolutionFromCurrentVideoCommand);
+
+        grid.Add(label, 0, 0, 1, 6);
+        grid.Add(labelVideoResolution, 1, 0);
+        grid.Add(numericUpDownWidth, 1, 1);
+        grid.Add(labelX, 1, 2);
+        grid.Add(numericUpDownHeight, 1, 3);
+        grid.Add(buttonBrowseResolution, 1, 4);
+        grid.Add(buttonFromCurrentVideo, 1, 5);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+
+    private static Border MakeOptionsView(SsaPropertiesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            RowSpacing = 5,
+        };
+
+        var label = UiUtil.MakeLabel(Se.Language.General.Options).WithBold().WithMarginBottom(10);
+
+        var labelCollisions = UiUtil.MakeLabel(Se.Language.Assa.Collisions);
+        var comboBoxCollisions = UiUtil.MakeComboBox(vm.Collisions, vm, nameof(vm.SelectedCollision));
+
+        var labelPlayDepth = UiUtil.MakeLabel(Se.Language.Assa.PlayDepth);
+        var numericUpDownPlayDepth = UiUtil.MakeNumericUpDownInt(0, 32, 0, 120, vm, nameof(vm.PlayDepth));
+
+        var labelTimer = UiUtil.MakeLabel(Se.Language.Assa.Timer);
+        var textBoxTimer = UiUtil.MakeTextBox(120, vm, nameof(vm.Timer));
+
+        grid.Add(label, 0, 0, 1, 2);
+        grid.Add(labelCollisions, 1, 0);
+        grid.Add(comboBoxCollisions, 1, 1);
+        grid.Add(labelPlayDepth, 2, 0);
+        grid.Add(numericUpDownPlayDepth, 2, 1);
+        grid.Add(labelTimer, 3, 0);
+        grid.Add(textBoxTimer, 3, 1);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+}

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -88,6 +88,9 @@ public class LanguageAssa
     public string FontsAndGraphics { get; set; }
     public string WrapStyle { get; set; }
     public string BorderAndShadowScaling { get; set; }
+    public string Collisions { get; set; }
+    public string PlayDepth { get; set; }
+    public string Timer { get; set; }
     public string OriginalScript { get; set; }
     public string Graphics { get; set; }
     public string CopyToStorageStyles { get; set; }
@@ -288,6 +291,9 @@ public class LanguageAssa
         FontsAndGraphics = "Fonts and graphics";
         WrapStyle = "Wrap style";
         BorderAndShadowScaling = "Border and shadow scaling";
+        Collisions = "Collisions";
+        PlayDepth = "Play depth";
+        Timer = "Timer";
         OriginalScript = "Original script";
         Graphics = "Graphics";
         CopyToStorageStyles = "Copy to storage styles";

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -65,6 +65,7 @@ public class LanguageMainMenu
     public string MergeTwoSubtitles { get; set; }
 
     public string AssaTools { get; set; }
+    public string SsaTools { get; set; }
     public string AssaProgressBar { get; set; }
     public string AssaChangeResolution { get; set; }
     public string AssaGenerateBackground { get; set; }
@@ -197,6 +198,7 @@ public class LanguageMainMenu
         MergeTwoSubtitles = "Merge two subtitles...";
 
         AssaTools = "_ASSA tools";
+        SsaTools = "_SSA tools";
         AssaChangeResolution = "Change _resolution...";
         AssaGenerateBackground = "Generate background _boxes...";
         AssaProgressBar = "Generate _progress bar...";


### PR DESCRIPTION
## Summary

The SSA (SubStation Alpha) format now has its own **Properties** and **Attachments** windows, plus toolbar buttons and menu items — matching what ASSA already offers. SSA previously only had a Styles button.

### SSA Properties (`SsaPropertiesWindow` / `SsaPropertiesViewModel`)
A simpler `[Script Info]` editor than ASSA's:
- Metadata: Title, Original Script, Translation, Editing, Timing, Sync Point, Updated By, Update Details
- Resolution: PlayResX / PlayResY (with browse / from-current-video)
- SSA-specific options: **Collisions** (Normal/Reverse), **PlayDepth**, **Timer**

Per the SSA v4 spec, **WrapStyle** and **ScaledBorderAndShadow** are intentionally omitted (those are ASS-only).

### SSA Attachments (`SsaAttachmentsWindow` / `SsaAttachmentsViewModel` / `SsaAttachmentItem`)
A dedicated SSA fonts/graphics attachment manager. The `[Fonts]`/`[Graphics]` UU-encoded format is the same as ASSA, so this mirrors the ASSA attachments window (attach/import/export/delete + font/image preview).

### Wiring
- `ShowSsaProperties` / `ShowSsaAttachments` commands in `MainViewModel`, gated on `IsFormatSsa`.
- Toolbar buttons (visible for SSA) next to the existing SSA Styles button.
- New **"SSA tools"** menu (Styles, Properties, Attachments), visible for SSA.
- DI registrations and language strings (`Collisions`, `PlayDepth`, `Timer`, `SsaTools`).

## Validation
UI project builds clean (0 errors). The new windows reuse the established ASSA patterns/helpers.

## Note
This is UI; worth a quick visual check (open an `.ssa` file → the SSA toolbar buttons / "SSA tools" menu → Properties and Attachments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)