### PR TITLE
Tighten SSA / ASSA style window preview box and fix font scaling

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -15,6 +15,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -745,7 +746,9 @@ public partial class AssaStylesViewModel : ObservableObject
 
         var text = "This is a test";
 
-        var fontSize = (float)style.FontSize * 0.75f; // render a little smaller in the preview
+        // Scale the rendered font size to the preview canvas height (~360px) the same way
+        // libass scales fonts against PlayResY. Default to 288 (libass default) when missing.
+        var fontSize = (float)style.FontSize * 360f / GetPlayResY(_subtitle.Header);
         var libAssFontName = FontHelper.GetSkiaFontNameFromLibAssaFontName(style.FontName);
         SKBitmap bitmap;
 
@@ -811,6 +814,22 @@ public partial class AssaStylesViewModel : ObservableObject
 
         var frame = TextToImageGenerator.ComposeOnPreviewFrame(bitmap, GetAlignment(style), style.MarginLeft, style.MarginRight, style.MarginVertical);
         ImagePreview = frame.ToAvaloniaBitmap();
+    }
+
+    private static int GetPlayResY(string? header)
+    {
+        if (string.IsNullOrEmpty(header))
+        {
+            return 288;
+        }
+
+        var value = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResY", "[Script Info]", header);
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var y) && y > 0)
+        {
+            return y;
+        }
+
+        return 288;
     }
 
     private static int GetAlignment(StyleDisplay style)

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -624,7 +624,8 @@ public class AssaStylesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Top,
             Stretch = Stretch.Uniform, // Scale the preview frame to fit while keeping aspect ratio
-            MinHeight = 240,
+            MinHeight = 150,
+            MaxHeight = 220,
         };
 
         grid.Add(label, 0);

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -17,6 +17,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -706,7 +707,9 @@ public partial class SsaStylesViewModel : ObservableObject
 
         var text = "This is a test";
 
-        var fontSize = (float)style.FontSize * 0.75f; // render a little smaller in the preview
+        // Scale the rendered font size to the preview canvas height (~360px) the same way
+        // libass scales fonts against PlayResY. Default to 288 (libass default) when missing.
+        var fontSize = (float)style.FontSize * 360f / GetPlayResY(_subtitle.Header);
         var libAssFontName = FontHelper.GetSkiaFontNameFromLibAssaFontName(style.FontName);
         SKBitmap bitmap;
 
@@ -772,6 +775,22 @@ public partial class SsaStylesViewModel : ObservableObject
 
         var frame = TextToImageGenerator.ComposeOnPreviewFrame(bitmap, GetAlignment(style), style.MarginLeft, style.MarginRight, style.MarginVertical);
         ImagePreview = frame.ToAvaloniaBitmap();
+    }
+
+    private static int GetPlayResY(string? header)
+    {
+        if (string.IsNullOrEmpty(header))
+        {
+            return 288;
+        }
+
+        var value = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResY", "[Script Info]", header);
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var y) && y > 0)
+        {
+            return y;
+        }
+
+        return 288;
     }
 
     private static int GetAlignment(StyleDisplay style)

--- a/src/ui/Features/Ssa/SsaStylesWindow.cs
+++ b/src/ui/Features/Ssa/SsaStylesWindow.cs
@@ -624,7 +624,8 @@ public class SsaStylesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Top,
             Stretch = Stretch.Uniform, // Scale the preview frame to fit while keeping aspect ratio
-            MinHeight = 240,
+            MinHeight = 150,
+            MaxHeight = 220,
         };
 
         grid.Add(label, 0);


### PR DESCRIPTION
## Summary
- The preview Image in both ASSA and SSA style windows used `Stretch.Uniform` with only a `MinHeight = 240`, so on wider windows the 16:9 frame stretched much taller than intended. Lower `MinHeight` to 150 and add `MaxHeight = 220` to cap it.
- Replace the fixed `* 0.75f` multiplier on the preview font size (added in #11342) with PlayResY-based scaling — the rendered size is now `FontSize * 360 / PlayResY`, defaulting `PlayResY` to 288 (libass default) when the header has no value. This matches how libass actually renders fonts and is proportional to the script's target resolution instead of always 75% of the literal style size.

## Test plan
- [ ] Open ASSA styles window on a script with `PlayResY: 720` (or unset) and a typical style (e.g. FontSize 40) — preview text should look like a reasonable size, not 75% smaller
- [ ] Open ASSA styles window on a script with `PlayResY: 1080` and a large FontSize (e.g. 80) — preview should look proportional, not blown up
- [ ] Open SSA styles window — same check
- [ ] Resize both windows wider — preview box should not grow taller than ~220px

🤖 Generated with [Claude Code](https://claude.com/claude-code)