### PR TITLE
Fix two-line limit on merge and move-word shortcuts (#11308)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11540,29 +11540,21 @@ public partial class MainViewModel :
     private void MoveLastWordFromFirstLineDownCurrentSubtitle()
     {
         var s = SelectedSubtitle;
-        if (s == null)
+        if (s == null || string.IsNullOrWhiteSpace(s.Text))
         {
             return;
         }
 
-        var lines = s.Text.SplitToLines();
-        if (!string.IsNullOrWhiteSpace(s.Text) && lines.Count == 1)
-        {
-            lines.Add(string.Empty);
-        }
-
+        var lines = NormalizeToTwoLines(s.Text);
         if (lines.Count != 2)
         {
             return;
         }
 
-        var currentText = lines[0].Trim();
-        var nextText = lines[1].Trim();
-
-        var upDown = new MoveWordUpDown(currentText, nextText);
+        var upDown = new MoveWordUpDown(lines[0].Trim(), lines[1].Trim());
         upDown.MoveWordDown();
 
-        s.Text = upDown.S1 + Environment.NewLine + upDown.S2;
+        s.Text = JoinAndCapAtTwoLines(upDown.S1, upDown.S2);
 
         _updateAudioVisualizer = true;
     }
@@ -11571,31 +11563,50 @@ public partial class MainViewModel :
     private void MoveFirstWordFromNextLineUpCurrentSubtitle()
     {
         var s = SelectedSubtitle;
-        if (s == null)
+        if (s == null || string.IsNullOrWhiteSpace(s.Text))
         {
             return;
         }
 
-        var lines = s.Text.SplitToLines();
-        if (!string.IsNullOrWhiteSpace(s.Text) && lines.Count == 1)
-        {
-            lines.Add(string.Empty);
-        }
-
+        var lines = NormalizeToTwoLines(s.Text);
         if (lines.Count != 2)
         {
             return;
         }
 
-        var currentText = lines[0].Trim();
-        var nextText = lines[1].Trim();
-
-        var upDown = new MoveWordUpDown(currentText, nextText);
+        var upDown = new MoveWordUpDown(lines[0].Trim(), lines[1].Trim());
         upDown.MoveWordUp();
 
-        s.Text = upDown.S1 + Environment.NewLine + upDown.S2;
+        s.Text = JoinAndCapAtTwoLines(upDown.S1, upDown.S2);
 
         _updateAudioVisualizer = true;
+    }
+
+    private static List<string> NormalizeToTwoLines(string text)
+    {
+        var lines = text.SplitToLines();
+        if (lines.Count > 2)
+        {
+            lines = Utilities.AutoBreakLine(Utilities.UnbreakLine(text)).SplitToLines();
+        }
+
+        if (lines.Count == 1)
+        {
+            lines.Add(string.Empty);
+        }
+
+        return lines;
+    }
+
+    private static string JoinAndCapAtTwoLines(string s1, string s2)
+    {
+        var result = s1 + Environment.NewLine + s2;
+        if (result.SplitToLines().Count > 2)
+        {
+            result = Utilities.AutoBreakLine(Utilities.UnbreakLine(result));
+        }
+
+        return result;
     }
 
     [RelayCommand]

--- a/src/ui/Logic/MergeManager.cs
+++ b/src/ui/Logic/MergeManager.cs
@@ -212,7 +212,7 @@ namespace Nikse.SubtitleEdit.Logic
                     .Replace(" " + Environment.NewLine, string.Empty)
                     .Replace(Environment.NewLine, string.Empty);
             }
-            else if (breakMode == BreakMode.KeepBreaks)
+            else if (breakMode != BreakMode.KeepBreaks)
             {
                 text = Utilities.AutoBreakLine(text, inputSubtitle.AutoDetectGoogleLanguage());
             }
@@ -234,7 +234,7 @@ namespace Nikse.SubtitleEdit.Logic
                         .Replace(" " + Environment.NewLine, string.Empty)
                         .Replace(Environment.NewLine, string.Empty);
                 }
-                else if (breakMode == BreakMode.KeepBreaks)
+                else if (breakMode != BreakMode.KeepBreaks)
                 {
                     originalText = Utilities.AutoBreakLine(originalText, inputSubtitle.AutoDetectGoogleLanguage());
                 }

--- a/tests/UI/Logic/MergeManagerTests.cs
+++ b/tests/UI/Logic/MergeManagerTests.cs
@@ -37,8 +37,8 @@ public class MergeManagerTests
 
         // Assert
         Assert.Single(subtitles);
-        Assert.Equal($"Translated one{Environment.NewLine}Translated two", subtitles[0].Text);
-        Assert.Equal($"Original one{Environment.NewLine}Original two", subtitles[0].OriginalText);
+        Assert.Equal("Translated one Translated two", subtitles[0].Text);
+        Assert.Equal("Original one Original two", subtitles[0].OriginalText);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes [#11308](https://github.com/SubtitleEdit/subtitleedit/issues/11308). Two related bugs let SE5 RC1 leave subtitles stuck at 3+ lines despite a 2-line `MaxNumberOfLines` setting:

- **Move last/first word up/down**: `MainViewModel.MoveLastWordFromFirstLineDownCurrentSubtitle` and `MoveFirstWordFromNextLineUpCurrentSubtitle` returned early when `lines.Count != 2`. If `MoveWordUpDown.AutoBreakIfNeeded` had previously broken one side into 2 lines (producing a 3-line subtitle), the shortcuts then refused to operate — the user was stuck. New `NormalizeToTwoLines` / `JoinAndCapAtTwoLines` helpers unbreak + re-auto-break around the move so the result respects `MaxNumberOfLines` (≤ 2). When the combined text doesn't fit within `SubtitleLineMaximumLength × MaxNumberOfLines`, the result stays on 2 lines with one longer line — matching the reporter's clarification.
- **Merge selected lines**: `MergeManager.MergeSelectedLines(ObservableCollection<…>, …)` had the `BreakMode` dispatch inverted relative to the legacy `Subtitle` overload and the caller intent (`MergeLineBefore` → `Normal`, `MergeLineBeforeKeepBreaks` → `KeepBreaks`). The default `Normal` did no auto-break (so merging produced 3+ line output) while `KeepBreaks` did. Swapped so `KeepBreaks` is the no-transform case and every other mode falls through to `AutoBreakLine`, mirroring the legacy overload.

`MergeSelectedLines_ShouldMergeOriginalText` was asserting the buggy behavior (preserved newline for two short merged lines); updated to expect the auto-broken result that `Normal` mode is supposed to produce.

Issue #11308 also reports a third bug — undo jumping the grid to a different position. That one is unrelated to the line-count logic and lives in the undo-snapshot timing in `UndoRedoManager` / `MakeUndoRedoObject`; left for a follow-up PR.

## Test plan

- [x] `dotnet build src/ui/UI.csproj` — clean.
- [x] `dotnet test tests/UI/UITests.csproj` — 306/306 pass (including the 3 `MergeManagerTests`).
- [x] `dotnet test tests/libse/LibSETests.csproj --filter MoveWordUpDown` — 46/46 pass.
- [ ] Manual: with `MaxNumberOfLines=2`, merge a 1-line + 2-line pair → result is 2 lines, not 3.
- [ ] Manual: take a 3-line subtitle, press the move-last-word-down shortcut → subtitle becomes 2 lines (was: no-op).
- [ ] Manual: with `KeepBreaks` merge command (`MergeLineBeforeKeepBreaks` / `MergeLineAfterKeepBreaks`), existing line breaks are preserved (no auto-break applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)