### PR TITLE
Keep grid position on undo/redo (#11308)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12231,11 +12231,14 @@ public partial class MainViewModel :
 
         RunWithoutChangeDetection(() =>
         {
+            var preIndex = SelectedSubtitleIndex ?? 0;
+
             var undoRedoObject = _undoRedoManager.Undo()!;
             if (undoRedoObject?.Subtitles == null)
                 return;
 
             RestoreUndoRedoState(undoRedoObject);
+            RestoreSelectionToPreviousIndex(preIndex);
             ShowUndoStatus();
         });
     }
@@ -12273,6 +12276,8 @@ public partial class MainViewModel :
 
         RunWithoutChangeDetection(() =>
         {
+            var preIndex = SelectedSubtitleIndex ?? 0;
+
             var undoRedoObject = _undoRedoManager.Redo();
             if (undoRedoObject?.Subtitles == null)
             {
@@ -12280,8 +12285,19 @@ public partial class MainViewModel :
             }
 
             RestoreUndoRedoState(undoRedoObject);
+            RestoreSelectionToPreviousIndex(preIndex);
             ShowRedoStatus();
         });
+    }
+
+    private void RestoreSelectionToPreviousIndex(int preIndex)
+    {
+        if (Subtitles.Count == 0)
+        {
+            return;
+        }
+
+        SelectAndScrollToRow(Math.Clamp(preIndex, 0, Subtitles.Count - 1));
     }
 
     public UndoRedoItem MakeUndoRedoObject(string description)


### PR DESCRIPTION
## Summary

Fixes the third half of [#11308](https://github.com/SubtitleEdit/subtitleedit/issues/11308) — "the grid has the same erratic behavior with the undo: it jumps away to a completely different position." Independent of #11350 (move-word and merge fixes).

### Root cause

`MakeUndoRedoObject` (`MainViewModel.cs:12287`) captures `SelectedSubtitleIndex` at the moment a snapshot is taken. Snapshots are produced by a 250 ms polling timer in `UndoRedoManager.CheckForChanges`, which only fires when content changes — selection-only navigation never produces a snapshot (see `HasChanges`, which compares text/timing/bookmark only).

So each snapshot's `SelectedLines` is "where the cursor was the last time content changed." `RestoreUndoRedoState` calls `SelectAndScrollToRow(undoRedoObject.SelectedLines.First())`, so on Ctrl+Z the grid lands at that stale index — typically far from where the user actually is.

### Fix

In `PerformUndo` / `PerformRedo`, capture the current `SelectedSubtitleIndex` *before* calling `Undo()` / `Redo()`, and after `RestoreUndoRedoState` override the scroll to that pre-undo index, clamped to the new line count. Helper `RestoreSelectionToPreviousIndex` handles the clamp and the empty-grid case.

`ShowHistory` (`MainViewModel.cs:9376`) is left untouched — it deliberately navigates to the user-picked history entry's recorded position.

### Trade-off flagged

If the user deletes lines *before* the cursor and then undoes, the cursor stays at its current numeric index, so the paragraph under the cursor shifts down by however many lines were re-inserted. Reasonable, but not perfect — proper paragraph-identity tracking across undo would need IDs on `SubtitleLineViewModel`, which is a much larger change. Worth doing only if users push back on the simple fix.

## Test plan

- [x] `dotnet build src/ui/UI.csproj` — clean.
- [x] `dotnet test tests/UI/UITests.csproj` — 306/306 pass.
- [ ] Manual: edit at row 5; scroll to row 500; press Ctrl+Z → cursor stays at row 500 (was: jumped to row 5).
- [ ] Manual: merge at row 100; press Ctrl+Z → cursor stays at row 100, both merged lines reappear.
- [ ] Manual: import a new file, delete half of it, Ctrl+Z → cursor lands on a valid row (clamp works).
- [ ] Manual: open Show History, pick a past entry → still navigates to that entry's recorded position (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)