### PR TITLE
Bug hunt: GoogleSpeech voice parse, waveform space info, plugin cancel

### DIFF
--- a/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Plugins;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
@@ -27,6 +28,13 @@ public partial class GetPluginsViewModel : ObservableObject
     private readonly IPluginDownloadService _downloadService;
     private readonly IPluginCatalog _pluginCatalog;
     private CancellationTokenSource? _cancellationTokenSource;
+    // Per-install CTSs so concurrent Install clicks each keep their own cancel
+    // handle. The single _cancellationTokenSource pattern below was overwritten
+    // by every new Install, orphaning the previous one — clicking Cancel could
+    // then only cancel the most recent install. CancelDownload / Close iterate
+    // both this list and _cancellationTokenSource so a single "Cancel" stops
+    // everything in flight.
+    private readonly List<CancellationTokenSource> _activeInstalls = new();
 
     public GetPluginsViewModel(IPluginDownloadService downloadService, IPluginCatalog pluginCatalog)
     {
@@ -90,9 +98,10 @@ public partial class GetPluginsViewModel : ObservableObject
             return;
         }
 
-        // Create the cancellation source BEFORE flipping IsBusy so the cancel button
+        // Create a per-install CTS BEFORE flipping IsBusy so the cancel button
         // always has a token to cancel from the moment it becomes visible.
-        _cancellationTokenSource = new CancellationTokenSource();
+        var cts = new CancellationTokenSource();
+        _activeInstalls.Add(cts);
         item.DownloadProgress = 0;
         var previousStatus = item.StatusText;
         item.IsBusy = true;
@@ -104,7 +113,7 @@ public partial class GetPluginsViewModel : ObservableObject
 
         try
         {
-            await _downloadService.InstallAsync(item.Entry, progress, _cancellationTokenSource.Token);
+            await _downloadService.InstallAsync(item.Entry, progress, cts.Token);
             InstalledAnything = true;
 
             var match = _pluginCatalog.GetPlugins().FirstOrDefault(p =>
@@ -125,6 +134,8 @@ public partial class GetPluginsViewModel : ObservableObject
         }
         finally
         {
+            _activeInstalls.Remove(cts);
+            cts.Dispose();
             item.IsBusy = false;
         }
     }
@@ -132,14 +143,31 @@ public partial class GetPluginsViewModel : ObservableObject
     [RelayCommand]
     private void CancelDownload()
     {
-        _cancellationTokenSource?.Cancel();
+        CancelAllInFlight();
     }
 
     [RelayCommand]
     private void Close()
     {
-        _cancellationTokenSource?.Cancel();
+        CancelAllInFlight();
         Window?.Close();
+    }
+
+    private void CancelAllInFlight()
+    {
+        _cancellationTokenSource?.Cancel();
+        foreach (var cts in _activeInstalls.ToList())
+        {
+            try
+            {
+                cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The install finished and disposed its CTS between our snapshot
+                // and the Cancel call — nothing to cancel, just move on.
+            }
+        }
     }
 
     internal void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -2018,8 +2018,15 @@ public partial class SettingsViewModel : ObservableObject
 
     private static List<string> GetWaveformAndSpecgtrogramFiles()
     {
-        var files = Directory.GetFiles(Se.WaveformsFolder, "*.wav").ToList();
-        files.AddRange(Directory.GetFiles(Se.SpectrogramsFolder, "*.spectrogram", SearchOption.AllDirectories));
+        var files = new List<string>();
+        if (Directory.Exists(Se.WaveformsFolder))
+        {
+            files.AddRange(Directory.GetFiles(Se.WaveformsFolder, "*.wav"));
+        }
+        if (Directory.Exists(Se.SpectrogramsFolder))
+        {
+            files.AddRange(Directory.GetFiles(Se.SpectrogramsFolder, "*.spectrogram", SearchOption.AllDirectories));
+        }
         return files;
     }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
@@ -70,7 +70,11 @@ public class GoogleSpeech : ITtsEngine
         foreach (var item in arr)
         {
             var name = parser.GetFirstObject(item, "name");
-            var languageCode = name.Substring(0,5);
+            if (string.IsNullOrEmpty(name) || name.Length < 5)
+            {
+                continue;
+            }
+            var languageCode = name.Substring(0, 5);
             var ssmlGender = parser.GetFirstObject(item, "ssmlGender");
             var naturalSampleRateHertz = parser.GetFirstObject(item, "naturalSampleRateHertz");
 


### PR DESCRIPTION
## Summary

Three small defensive fixes uncovered while bug-hunting the UI project. All independent, bundled for review velocity.

### 1. `GoogleSpeech.Map` — crash on short / missing voice name

`src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs:73`

The voice listing called \`name.Substring(0, 5)\` without checking length. \`SeJsonParser.GetFirstObject\` returns \`string.Empty\` (or \`null\` on empty input) when a field is missing, so one malformed voice would throw \`ArgumentOutOfRangeException\` inside the \`foreach\` and wipe the entire returned voice list. Now skips such entries via \`if (string.IsNullOrEmpty(name) || name.Length < 5) continue;\`.

Today Google ships 5+ char names like \`\"en-US-Wavenet-A\"\`, so this is a latent crash, not an active one — but the cost of the guard is one line.

### 2. `SettingsViewModel.GetWaveformAndSpecgtrogramFiles` — fresh-install crash

`src/ui/Features/Options/Settings/SettingsViewModel.cs:2019`

Called \`Directory.GetFiles(Se.WaveformsFolder, …)\` and \`Directory.GetFiles(Se.SpectrogramsFolder, …)\` with no \`Directory.Exists\` guard. Those folders are derived paths (\`Se.cs:116-117\`) and are **not** auto-created — only \`DataFolder\` is (\`Se.cs:88\`). On a fresh install, the first call threw \`DirectoryNotFoundException\`.

Both callers are fire-and-forget (\`_ = UpdateWaveformSpaceInfoAsync()\`), so the throw propagated to \`TaskScheduler.UnobservedTaskException\` and the Settings window's waveform-space-info row silently stayed blank for new users, with no error signal. \`DeleteWaveformAndSpectrogramFiles\` on the same file (\`:1988\`, \`:2003\`) already uses the \`Directory.Exists\` guard — matched that pattern.

### 3. `GetPluginsViewModel` — concurrent Install orphans the cancel button

`src/ui/Features/Options/Plugins/GetPluginsViewModel.cs`

\`Install\` was gated on per-item \`item.IsBusy\`, not a global flag, so plugin A and plugin B could be installed concurrently. Each call overwrote the single \`_cancellationTokenSource\` field. Clicking Cancel then only cancelled B; A's CTS was orphaned, the user had no way to stop A, and even \`Close()\` couldn't cancel it (it called \`Cancel()\` on the same overwritten field).

Switched to a per-install CTS tracked in \`_activeInstalls\`. \`CancelDownload\` / \`Close\` now iterate that list (plus the load CTS) so a single Cancel stops everything currently in flight. The list is mutated only on the UI thread, so no locking needed.

## Test plan

- [x] \`dotnet build src/ui/UI.csproj\` — clean.
- [x] \`dotnet test tests/UI/UITests.csproj\` — 306/306 pass.
- [ ] Manual: fresh install (clean SE data folder) → open Settings → waveform-space-info row populates without exception (was: silently blank).
- [ ] Manual: open Plugins → start downloading plugin A → start downloading plugin B → click Cancel → both stop.
- [ ] Manual: open Plugins → start downloading plugin A → close window → A is cancelled (was: kept running until process exit).
- [ ] Manual (cannot easily reproduce): Google TTS voice picker still lists voices normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)