### PR TITLE
Fix \n handling and Replace & Find Next correctness in Find/Replace

### DIFF
--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -213,6 +213,13 @@ namespace Nikse.SubtitleEdit.Core.Common
             return pattern.Replace("\\r\\n", Environment.NewLine).Replace("\\n", Environment.NewLine);
         }
 
+        public static string EscapeNewLines(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+            return text.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
+        }
+
         /// <summary>
         /// Performs replace on regular expression. Line breaks are converted to just "\n" during the replace
         /// and line breaks are returned as Environment.NewLine.

--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -152,7 +152,7 @@ public partial class FindViewModel : ObservableObject
         _subs = subs;
         if (string.IsNullOrEmpty(SearchText))
         {
-            SearchText = selectedText.Trim();
+            SearchText = RegexUtils.EscapeNewLines(selectedText.Trim());
         }
         _findResult = findResult;
 

--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
@@ -158,7 +159,7 @@ public partial class FindViewModel : ObservableObject
         SearchHistory.Clear();
         foreach (var item in findService.SearchHistory)
         {
-            SearchHistory.Add(item.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n"));
+            SearchHistory.Add(RegexUtils.EscapeNewLines(item));
         }
     }
 }

--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -158,7 +158,7 @@ public partial class FindViewModel : ObservableObject
         SearchHistory.Clear();
         foreach (var item in findService.SearchHistory)
         {
-            SearchHistory.Add(item);
+            SearchHistory.Add(item.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n"));
         }
     }
 }

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -1188,8 +1188,9 @@ public partial class MultipleReplaceViewModel : ObservableObject
                 var findWhat = rule.Find;
                 if (!string.IsNullOrEmpty(findWhat)) // allow space or spaces
                 {
-                    var replaceWith = RegexUtils.FixNewLine(rule.ReplaceWith);
-                    findWhat = RegexUtils.FixNewLine(findWhat);
+                    var isRegex = rule.SearchType == ReplaceExpression.SearchTypeRegularExpression;
+                    var replaceWith = isRegex ? RegexUtils.FixNewLine(rule.ReplaceWith) : rule.ReplaceWith;
+                    findWhat = isRegex ? RegexUtils.FixNewLine(findWhat) : findWhat;
                     if (group.SubNodes != null)
                     {
                         var ruleInfo = string.IsNullOrEmpty(rule.Description)

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -164,7 +164,7 @@ public partial class ReplaceViewModel : ObservableObject
         SearchHistory.Clear();
         foreach (var item in findService.SearchHistory)
         {
-            SearchHistory.Add(item);
+            SearchHistory.Add(item.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n"));
         }
     }
 

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -159,7 +159,7 @@ public partial class ReplaceViewModel : ObservableObject
         _findResult = mainViewModel;
         if (!string.IsNullOrEmpty(selectedText))
         {
-            SearchText = selectedText;
+            SearchText = RegexUtils.EscapeNewLines(selectedText);
         }
 
         SearchHistory.Clear();

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Edit.Find;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
@@ -164,7 +165,7 @@ public partial class ReplaceViewModel : ObservableObject
         SearchHistory.Clear();
         foreach (var item in findService.SearchHistory)
         {
-            SearchHistory.Add(item.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n"));
+            SearchHistory.Add(RegexUtils.EscapeNewLines(item));
         }
     }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9816,8 +9816,20 @@ public partial class MainViewModel :
                 {
                     if (result.FindMode == FindMode.RegularExpression)
                     {
-                        var fixedReplaceText = RegexUtils.FixNewLine(result.ReplaceText);
-                        EditTextBox.SelectedText = new Regex(result.SearchText).Replace(savedCurrentTextFound, fixedReplaceText);
+                        try
+                        {
+                            var fixedReplaceText = RegexUtils.FixNewLine(result.ReplaceText);
+                            var regex = new Regex(result.SearchText);
+                            var match = regex.Match(EditTextBox.Text, EditTextBox.SelectionStart);
+                            if (match.Success && match.Index == EditTextBox.SelectionStart)
+                            {
+                                EditTextBox.Text = regex.Replace(EditTextBox.Text, fixedReplaceText, 1, EditTextBox.SelectionStart);
+                            }
+                        }
+                        catch (ArgumentException)
+                        {
+                            // Invalid regex pattern - skip replacement
+                        }
                     }
                     else
                     {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9421,7 +9421,7 @@ public partial class MainViewModel :
                 selectedText = EditTextBox.SelectedText;
             }
 
-            if ((string.IsNullOrEmpty(selectedText) || selectedText == _findService.CurrentTextFound)
+            if ((string.IsNullOrEmpty(selectedText) || string.Equals(selectedText, _findService.CurrentTextFound, _findService.CurrentFindMode == FindMode.CaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                 && !string.IsNullOrEmpty(_findService.SearchText))
             {
                 selectedText = _findService.SearchText;
@@ -9741,7 +9741,7 @@ public partial class MainViewModel :
                 selectedText = EditTextBox.SelectedText;
             }
 
-            if ((string.IsNullOrEmpty(selectedText) || selectedText == _findService.CurrentTextFound)
+            if ((string.IsNullOrEmpty(selectedText) || string.Equals(selectedText, _findService.CurrentTextFound, _findService.CurrentFindMode == FindMode.CaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                 && !string.IsNullOrEmpty(_findService.SearchText))
             {
                 selectedText = _findService.SearchText;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9814,9 +9814,15 @@ public partial class MainViewModel :
                 var selectedText = EditTextBox.SelectedText;
                 if (!string.IsNullOrEmpty(savedCurrentTextFound) && selectedText == savedCurrentTextFound)
                 {
-                    EditTextBox.SelectedText = result.FindMode == FindMode.RegularExpression
-                        ? RegexUtils.FixNewLine(result.ReplaceText)
-                        : result.ReplaceText;
+                    if (result.FindMode == FindMode.RegularExpression)
+                    {
+                        var fixedReplaceText = RegexUtils.FixNewLine(result.ReplaceText);
+                        EditTextBox.SelectedText = new Regex(result.SearchText).Replace(savedCurrentTextFound, fixedReplaceText);
+                    }
+                    else
+                    {
+                        EditTextBox.SelectedText = result.ReplaceText;
+                    }
                     subs[currentLineIndex] = EditTextBox.Text; // reflect replacement so FindNext won't re-match here
                 }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9420,7 +9420,8 @@ public partial class MainViewModel :
                 selectedText = EditTextBox.SelectedText;
             }
 
-            if (string.IsNullOrEmpty(selectedText) && !string.IsNullOrEmpty(_findService.SearchText))
+            if ((string.IsNullOrEmpty(selectedText) || selectedText == _findService.CurrentTextFound)
+                && !string.IsNullOrEmpty(_findService.SearchText))
             {
                 selectedText = _findService.SearchText;
             }
@@ -9739,7 +9740,8 @@ public partial class MainViewModel :
                 selectedText = EditTextBox.SelectedText;
             }
 
-            if (string.IsNullOrEmpty(selectedText) && !string.IsNullOrEmpty(_findService.SearchText))
+            if ((string.IsNullOrEmpty(selectedText) || selectedText == _findService.CurrentTextFound)
+                && !string.IsNullOrEmpty(_findService.SearchText))
             {
                 selectedText = _findService.SearchText;
             }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9784,6 +9784,7 @@ public partial class MainViewModel :
         {
             var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
             var subs = Subtitles.Select(p => p.Text).ToList();
+            var savedCurrentTextFound = _findService.CurrentTextFound;
             _findService.Initialize(subs, SelectedSubtitleIndex ?? 0, result.WholeWord, result.FindMode);
 
             var idx = -1;
@@ -9811,7 +9812,7 @@ public partial class MainViewModel :
             else // replace requested
             {
                 var selectedText = EditTextBox.SelectedText;
-                if (selectedText == _findService.CurrentTextFound)
+                if (selectedText == savedCurrentTextFound)
                 {
                     EditTextBox.SelectedText = result.FindMode == FindMode.RegularExpression
                         ? RegexUtils.FixNewLine(result.ReplaceText)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -146,6 +146,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TransparentSubtitles;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using static Nikse.SubtitleEdit.Logic.FindService;
 using Nikse.SubtitleEdit.Logic.Config.Language;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Initializers;
@@ -9810,9 +9811,11 @@ public partial class MainViewModel :
             else // replace requested
             {
                 var selectedText = EditTextBox.SelectedText;
-                if (selectedText == result.SearchText)
+                if (selectedText == _findService.CurrentTextFound)
                 {
-                    EditTextBox.SelectedText = result.ReplaceText;
+                    EditTextBox.SelectedText = result.FindMode == FindMode.RegularExpression
+                        ? RegexUtils.FixNewLine(result.ReplaceText)
+                        : result.ReplaceText;
                     subs[currentLineIndex] = EditTextBox.Text; // reflect replacement so FindNext won't re-match here
                 }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9812,7 +9812,7 @@ public partial class MainViewModel :
             else // replace requested
             {
                 var selectedText = EditTextBox.SelectedText;
-                if (selectedText == savedCurrentTextFound)
+                if (!string.IsNullOrEmpty(savedCurrentTextFound) && selectedText == savedCurrentTextFound)
                 {
                     EditTextBox.SelectedText = result.FindMode == FindMode.RegularExpression
                         ? RegexUtils.FixNewLine(result.ReplaceText)

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1609,8 +1609,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         {
             foreach (var rule in category.Rules.Where(p => p.Active && !string.IsNullOrEmpty(p.Find)))
             {
-                var findWhat = RegexUtils.FixNewLine(rule.Find);
-                var replaceWith = RegexUtils.FixNewLine(rule.ReplaceWith);
+                var isRegex = rule.Type.ToString() == ReplaceExpression.SearchTypeRegularExpression;
+                var findWhat = isRegex ? RegexUtils.FixNewLine(rule.Find) : rule.Find;
+                var replaceWith = isRegex ? RegexUtils.FixNewLine(rule.ReplaceWith) : rule.ReplaceWith;
 
                 var mpi = new ReplaceExpression(findWhat, replaceWith, rule.Type.ToString(), category.Name + ": " + rule.Description);
                 replaceExpressions.Add(mpi);

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -284,6 +284,8 @@ public partial class FindService : IFindService
             return;
         }
 
+        searchText = searchText.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
+
         // Remove if already exists to move it to top
         _searchHistory.Remove(searchText);
 

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -47,7 +47,7 @@ public partial class FindService : IFindService
             return -1;
         }
 
-        SearchText = searchText;
+        SearchText = searchText.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
         _textLines = textLines;
         AddToSearchHistory(searchText);
 
@@ -98,7 +98,7 @@ public partial class FindService : IFindService
             return -1;
         }
 
-        SearchText = searchText;
+        SearchText = searchText.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
         _textLines = textLines;
         AddToSearchHistory(searchText);
 
@@ -183,7 +183,7 @@ public partial class FindService : IFindService
             return -1;
         }
 
-        SearchText = searchText;
+        SearchText = searchText.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
         _textLines = textLines;
         AddToSearchHistory(searchText);
 

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -1,4 +1,5 @@
-﻿using Nikse.SubtitleEdit.Logic.Config;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -402,6 +403,7 @@ public partial class FindService : IFindService
 
     private (bool replaced, string newText, int replacementCount) ReplaceWithRegex(string line, string searchText, string replaceText, int startIndex, int maxReplacements)
     {
+        replaceText = RegexUtils.FixNewLine(replaceText);
         try
         {
             var regex = new Regex(searchText);

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -47,7 +47,7 @@ public partial class FindService : IFindService
             return -1;
         }
 
-        SearchText = searchText.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
+        SearchText = RegexUtils.EscapeNewLines(searchText);
         _textLines = textLines;
         AddToSearchHistory(searchText);
 
@@ -98,7 +98,7 @@ public partial class FindService : IFindService
             return -1;
         }
 
-        SearchText = searchText.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
+        SearchText = RegexUtils.EscapeNewLines(searchText);
         _textLines = textLines;
         AddToSearchHistory(searchText);
 
@@ -183,7 +183,7 @@ public partial class FindService : IFindService
             return -1;
         }
 
-        SearchText = searchText.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
+        SearchText = RegexUtils.EscapeNewLines(searchText);
         _textLines = textLines;
         AddToSearchHistory(searchText);
 
@@ -286,7 +286,7 @@ public partial class FindService : IFindService
             return;
         }
 
-        searchText = searchText.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
+        searchText = RegexUtils.EscapeNewLines(searchText);
 
         // Remove if already exists to move it to top
         _searchHistory.Remove(searchText);

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -225,7 +225,9 @@ public partial class FindService : IFindService
             _textLines[result.lineIndex] = replacedText.newText;
             CurrentLineNumber = result.lineIndex;
             CurrentTextIndex = result.textIndex;
-            CurrentTextFound = replaceText ?? string.Empty;
+            CurrentTextFound = CurrentFindMode == FindMode.RegularExpression
+                ? RegexUtils.FixNewLine(replaceText ?? string.Empty)
+                : replaceText ?? string.Empty;
             return result.lineIndex;
         }
 


### PR DESCRIPTION
  ## Summary

  Fixes a cluster of related bugs in the Find/Replace pipeline around `\n` escape handling and the Replace & Find Next workflow.

  ## Bugs fixed

  ### `\n` in regex replacement not converted to newline
  - **Replace All (regex):** typing `\n` in the replacement field had no effect — the literal characters `\n` were written into the subtitle instead of a newline.
  - **Multiple Replace / Batch Convert (regex):** same issue; replacement `\n` was not expanded.

  ### `\n` incorrectly expanded in non-regex mode
  - **Multiple Replace / Batch Convert (normal/case-sensitive mode):** `\n` in a plain-text rule was being converted to an actual newline, corrupting searches for literal backslash-n strings. `FixNewLine` is now only applied in regex mode.

  ### Search history and dialog pre-population with `\n` terms
  - After finding text that contained a real newline, reopening Find or Replace showed a blank/garbled search field because the raw newline character was injected into the text box.
  - The search history dropdown rendered actual newlines, producing blank entries.
  - Reopening the dialog after a match overwrote the search pattern with the found text. The dialog now restores the previous search term instead.

  ### Replace & Find Next correctness
  - **Skipped replacement on reopened dialog:** closing and reopening Replace then clicking Replace & Find Next skipped the replacement, because `Initialize()` reset the service state before the replacement check could run. Fixed by capturing `CurrentTextFound` before the reset.
  - **Spurious replacement at position 0:** Replace & Find Next applied a replacement at position 0 even without a prior match.
  - **Backreferences not expanded:** regex replacements using `$1`, `$2`, etc. wrote the literal strings `$1`, `$2` into the subtitle. The replacement now runs through `Regex.Replace` to expand captures correctly.

  ## Example scenarios

  | Scenario | Before | After |
  |---|---|---|
  | Regex replace `(.+)` → `$1\nfoo`, Replace All | Writes literal `$1\nfoo` | Expands to captured text + newline + `foo` |
  | Regex replace `hello` → `hi\nthere`, Replace All | Writes `hi\nthere` | Writes `hi` + newline + `there` |
  | Plain-text Multiple Replace rule: find `\n` literally | Searches for newline character | Searches for literal `\n` |
  | Open Replace after a regex match is highlighted | Search field shows garbled text / blank | Search field shows the pattern |
  | Search history after a `\n` term | Dropdown shows blank entry | Dropdown shows `\n` |
  | Replace & Find Next after closing/reopening Replace dialog | Replacement skipped | Replacement applied correctly |
  | Replace & Find Next with `(.+)` → `[$1]` | Writes `[$1]` | Writes `[matched text]` |


Example: Missing first hyphen

```
Lorem Ipsum
-Dolor Sit
```

`^([^-].*\n)-` -> `-$1-`

```
-Lorem Ipsum
-Dolor Sit
```

Example:  Missing second hyphen

```
-Lorem Ipsum
Dolor Sit
```

`^(-.*\n)([^-])` -> `$1-$2`

```
-Lorem Ipsum
- Dolor Sit
```

Example:  First dialog line spills over to the second line

```
-How long have you
been reading it?
-Six years.
```

`^(-.*)\n([^-].*\n)` -> `$1 $2`

```
-How long have you been reading it?
-Six years.
```

Example:  Second dialog line spills over to the third line

```
-Okay. Oh?
-I write books.
Do you read books?
```

`^(-.*\n)(-.*)\n([^-].*)` -> `$1$2 $3`

```
-Okay. Oh?
-I write books. Do you read books?
```

Example:  Three-line dialogue, first two lines to merge

```
I mean,
not the hardest, hardest,
but the hardest one…
```

`^([^-].*)\n([^-].*)\n([^-].*)` -> `$1 $2\n$3`

```
I mean, not the hardest, hardest,
but the hardest one…
```
