### PR TITLE
Fix #11355: startup crash on Debian 13 (no system fonts)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12444,11 +12444,12 @@ public partial class MainViewModel :
         }
         catch (Exception ex)
         {
-            // Font resolution can throw on minimal Linux installs that ship without fontconfig
-            // -discoverable fonts (Avalonia's `Could not create glyphTypeface` — see issue #11355).
-            // Program.cs registers Inter as the default to make this nearly unreachable, but
-            // surviving any future font edge case is cheap insurance — falling back to an
-            // approximate width keeps startup alive instead of taking the whole app down.
+            // Font resolution can throw on minimal Linux installs that ship without
+            // fontconfig-discoverable fonts (Avalonia's `Could not create glyphTypeface` —
+            // see issue #11355). Program.cs registers Inter as the default to make this
+            // nearly unreachable, but surviving any future font edge case is cheap
+            // insurance — falling back to an approximate width keeps startup alive
+            // instead of taking the whole app down.
             Se.LogError(ex, "MeasureShowHideColumnWidth: font measurement failed; using approximate width");
             return Math.Ceiling(sample.Length * fontSize * 0.6) + cellPadding + textBlockMargin + safetyBuffer;
         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12421,23 +12421,37 @@ public partial class MainViewModel :
             sample = "-" + sample;
         }
 
-        var fontFamily = SubtitleGrid.FontFamily ?? FontFamily.Default;
-        var typeface = new Typeface(fontFamily);
         var fontSize = SubtitleGrid.FontSize > 0 ? SubtitleGrid.FontSize : Se.Settings.Appearance.SubtitleGridFontSize;
-
-        var formattedText = new FormattedText(
-            sample,
-            CultureInfo.CurrentCulture,
-            FlowDirection.LeftToRight,
-            typeface,
-            fontSize,
-            Brushes.Black);
-
         var cellPadding = Se.Settings.Appearance.GridCompactMode ? 0 : 8; // cell theme: 4 left + 4 right
         const int textBlockMargin = 8; // Avalonia DataGridTextColumn wraps text in TextBlock with Margin=Thickness(4)
         // Scale safety buffer with font size: gridline + sort indicator chrome + sub-pixel rounding grows with size.
         var safetyBuffer = Math.Max(10.0, fontSize);
-        return Math.Ceiling(formattedText.Width) + cellPadding + textBlockMargin + safetyBuffer;
+
+        try
+        {
+            var fontFamily = SubtitleGrid.FontFamily ?? FontFamily.Default;
+            var typeface = new Typeface(fontFamily);
+
+            var formattedText = new FormattedText(
+                sample,
+                CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight,
+                typeface,
+                fontSize,
+                Brushes.Black);
+
+            return Math.Ceiling(formattedText.Width) + cellPadding + textBlockMargin + safetyBuffer;
+        }
+        catch (Exception ex)
+        {
+            // Font resolution can throw on minimal Linux installs that ship without fontconfig
+            // -discoverable fonts (Avalonia's `Could not create glyphTypeface` — see issue #11355).
+            // Program.cs registers Inter as the default to make this nearly unreachable, but
+            // surviving any future font edge case is cheap insurance — falling back to an
+            // approximate width keeps startup alive instead of taking the whole app down.
+            Se.LogError(ex, "MeasureShowHideColumnWidth: font measurement failed; using approximate width");
+            return Math.Ceiling(sample.Length * fontSize * 0.6) + cellPadding + textBlockMargin + safetyBuffer;
+        }
     }
 
     private void SelectAllRows()

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -56,6 +56,13 @@ namespace Nikse.SubtitleEdit
                 // Build and configure the app
                 var appBuilder = AppBuilder.Configure<Application>()
                     .UsePlatformDetect()
+                    // Register the embedded Inter font as the default. Avalonia v12's font manager
+                    // throws "Could not create glyphTypeface. Font family: $Default" at startup on
+                    // minimal Linux installs that ship without fontconfig-discoverable fonts
+                    // (e.g. Debian 13 trixie base — issue #11355). With Inter registered, FontFamily.Default
+                    // resolves to the embedded font when no system font is available; healthy systems
+                    // still pick up their own fonts for explicit family names.
+                    .WithInterFont()
                     .With(new X11PlatformOptions
                     {
                         RenderingMode = new[] { X11RenderingMode.Glx, X11RenderingMode.Egl }


### PR DESCRIPTION
## Summary

Fixes [#11355](https://github.com/SubtitleEdit/subtitleedit/issues/11355). SE crashes at startup on Debian 13 (and other minimal Linux installs that ship without fontconfig-discoverable fonts in the base repo). The stack trace ends at \`Avalonia.Media.Typeface.get_GlyphTypeface()\` with "Could not create glyphTypeface. Font family: \$Default" — Avalonia v12's font manager can't resolve the symbolic default and nothing is registered as a fallback.

The trigger in our code is in \`MainViewModel.OnLoaded()\` → \`ComboBoxSubtitleFormatChanged()\` → \`AutoFitColumns()\` → \`MeasureShowHideColumnWidth()\`, where we build a \`FormattedText\` against \`FontFamily.Default\` and ask for its \`Width\`. The exception is hit on the first column measurement.

### Root cause

\`UI.csproj:29\` already pulls in \`Avalonia.Fonts.Inter\` v12.0.4, but \`Program.cs\` never calls \`.WithInterFont()\` on the \`AppBuilder\`. The package sits on disk and contributes nothing. With nothing registered, the font manager's \`\$Default\` lookup returns no glyph typeface on a font-less system, and \`get_GlyphTypeface()\` throws.

### Fix (two changes)

1. **\`Program.cs\`** — add \`.WithInterFont()\` to the \`AppBuilder\` chain. This registers the embedded Inter font as the resolution target for \`FontFamily.Default\`. Healthy systems still use their own fonts for explicit family names; broken Linux installs no longer crash because \`\$Default\` now always resolves to Inter.

2. **\`MainViewModel.MeasureShowHideColumnWidth\`** — wrap the \`FormattedText\` measurement in try/catch with an approximate-width fallback (\`sample.Length × fontSize × 0.6\` plus the same padding/margin/buffer the happy path adds). The Inter registration makes this nearly unreachable, but surviving any future font edge case is cheap insurance — startup stays alive instead of taking the whole app down for a column-width measurement.

### Test plan

- [x] \`dotnet build src/ui/UI.csproj\` — clean.
- [x] \`dotnet test tests/UI/UITests.csproj\` — 306/306 pass.
- [ ] Manual: launch SE on Debian 13 trixie with no font packages installed → no crash, UI renders in Inter.
- [ ] Manual: launch SE on Debian 13 with \`fonts-dejavu\` installed → no regression, Inter is still the fallback but explicit family names work normally.
- [ ] Manual: launch SE on Windows / macOS → no visual change; default UI font is unchanged for the locale.

Changelog left for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)