### PR TITLE
Fix four OCR bugs: Use once loop, alignment tag, fix engine interaction, pre-processing

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3212,8 +3212,9 @@ public partial class OcrViewModel : ObservableObject
             _ocrFixEngine.IsLoaded() && DoFixOcrErrors)
         {
             result.OcrFixLineResult = _ocrFixEngine.FixOcrErrors(i, item, DoTryToGuessUnknownWords);
-            var alignment = GetAlignment(item);
-            result.ResultText = alignment.AlignmentAdded ? alignment.Text : result.OcrFixLineResult.GetText();
+            var correctedText = result.OcrFixLineResult.GetText();
+            var alignment = GetAlignment(item, correctedText);
+            result.ResultText = alignment.AlignmentAdded ? alignment.Text : correctedText;
 
             if (!string.IsNullOrEmpty(result.OcrFixLineResult.ReplacementUsed.From))
             {
@@ -3245,12 +3246,11 @@ public partial class OcrViewModel : ObservableObject
 
     private void SetText(int i, OcrSubtitleItem item, OcrFixLineResultTemp resultTemp)
     {
-        var alignment = GetAlignment(item);
-
         if (SelectedDictionary != null &&
             SelectedDictionary.Name != GetDictionaryNameNone() &&
             _ocrFixEngine.IsLoaded() && DoFixOcrErrors)
         {
+            var alignment = GetAlignment(item, resultTemp.ResultText);
             var text = alignment.AlignmentAdded ? alignment.Text : resultTemp.ResultText;
 
             Dispatcher.UIThread.Post(() =>
@@ -3262,6 +3262,7 @@ public partial class OcrViewModel : ObservableObject
         }
         else
         {
+            var alignment = GetAlignment(item);
             var text = alignment.Text;
 
             Dispatcher.UIThread.Post(() =>
@@ -3305,8 +3306,9 @@ public partial class OcrViewModel : ObservableObject
             _ocrFixEngine.IsLoaded() && DoFixOcrErrors)
         {
             var result = _ocrFixEngine.FixOcrErrors(i, item, DoTryToGuessUnknownWords);
-            var alignment = GetAlignment(item);
-            var resultText = alignment.AlignmentAdded ? alignment.Text : result.GetText();
+            var correctedText = result.GetText();
+            var alignment = GetAlignment(item, correctedText);
+            var resultText = alignment.AlignmentAdded ? alignment.Text : correctedText;
 
             Dispatcher.UIThread.Post(() =>
             {
@@ -4403,12 +4405,14 @@ public partial class OcrViewModel : ObservableObject
         }
     }
 
-    private (string Text, bool AlignmentAdded) GetAlignment(OcrSubtitleItem item)
+    private (string Text, bool AlignmentAdded) GetAlignment(OcrSubtitleItem item, string? correctedText = null)
     {
         if (!HasCaptureAlignment) // Repurposed for ASSA position capture
         {
             return (item.Text, false);
         }
+
+        var textToUse = correctedText ?? item.Text;
 
         try
         {
@@ -4427,8 +4431,8 @@ public partial class OcrViewModel : ObservableObject
             if (imageHeightRatio > 0.33)
             {
                 // Try to split lines and set alignment for each line
-                var lines = item.Text.Trim().SplitToLines();
-                if (lines.Count > 1 && item.Text.Length < 40)
+                var lines = textToUse.Trim().SplitToLines();
+                if (lines.Count > 1 && textToUse.Length < 40)
                 {
                     // Similar logic to RunGoogleLensOcr method
                     var nbmp = new NikseBitmap2(bitmap);
@@ -4472,7 +4476,7 @@ public partial class OcrViewModel : ObservableObject
 
             // Map to ASSA alignment positions (An1-An9)
             var assaPosition = GetAssaPositionFromScreen(relativeX, relativeY);
-            return ($"{{\\{assaPosition}}}{item.Text}", true);
+            return ($"{{\\{assaPosition}}}{textToUse}", true);
         }
         catch
         {

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1572,7 +1572,8 @@ public partial class OcrViewModel : ObservableObject
                 _preProcessingSettings.CropTransparentColors ||
                 _preProcessingSettings.InverseColors ||
                 _preProcessingSettings.Binarize ||
-                _preProcessingSettings.RemoveBorders;
+                _preProcessingSettings.RemoveBorders ||
+                _preProcessingSettings.ToOneColor;
         });
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -2581,7 +2581,6 @@ public partial class OcrViewModel : ObservableObject
                         if (runOnceChar != null)
                         {
                             matches.Add(new NOcrChar { Text = runOnceChar.Text, ImageSplitterItem = splitterItem });
-                            _runOnceChars.Clear();
                             index++;
                             continue;
                         }
@@ -2996,7 +2995,6 @@ public partial class OcrViewModel : ObservableObject
                         if (runOnceChar != null)
                         {
                             matches.Add(new BinaryOcrMatcher.CompareMatch(runOnceChar.Text, false, 0, null));
-                            _runOnceChars.Clear();
                             index++;
                             continue;
                         }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3250,8 +3250,7 @@ public partial class OcrViewModel : ObservableObject
             SelectedDictionary.Name != GetDictionaryNameNone() &&
             _ocrFixEngine.IsLoaded() && DoFixOcrErrors)
         {
-            var alignment = GetAlignment(item, resultTemp.ResultText);
-            var text = alignment.AlignmentAdded ? alignment.Text : resultTemp.ResultText;
+            var text = resultTemp.ResultText;
 
             Dispatcher.UIThread.Post(() =>
             {

--- a/src/ui/Features/Ocr/PreProcessingSettings.cs
+++ b/src/ui/Features/Ocr/PreProcessingSettings.cs
@@ -146,23 +146,18 @@ public class PreProcessingSettings
         {
             var pixel = srcPixels[i];
 
-            // Extract RGB components
+            var a = (pixel >> 24) & 0xFF;
+            if (a == 0)
+            {
+                dstPixels[i] = 0x00000000;
+                continue;
+            }
+
             var r = (pixel >> 16) & 0xFF;
             var g = (pixel >> 8) & 0xFF;
             var b = pixel & 0xFF;
-
-            // Calculate brightness (same formula as grayscale conversion)
             var brightness = (byte)(0.299 * r + 0.587 * g + 0.114 * b);
-
-            // If brightness is above threshold, make it white; otherwise transparent
-            if (brightness > threshold)
-            {
-                dstPixels[i] = 0xFFFFFFFF; // White with full alpha
-            }
-            else
-            {
-                dstPixels[i] = 0x00000000; // Transparent
-            }
+            dstPixels[i] = brightness > threshold ? 0xFFFFFFFF : 0x00000000;
         }
 
         return result;


### PR DESCRIPTION
  ## Summary

  Fixes four bugs in the OCR window.

  - **"Use once" loops back to first unknown character** — the run-once entry was cleared too early (immediately on first match), so when the OCR loop restarted from the same subtitle the entry was gone and the dialog appeared again. The clear now happens only at end-of-subtitle, where it always did for the normal path.

  - **OCR fixes and guesses silently discarded when ASSA alignment capture is enabled** — See screenshot below. `GetAlignment()` was always tagging `item.Text` (raw OCR output), so when it returned `AlignmentAdded=true` the corrected text from the fix engine was thrown away. It now receives the corrected text and tags that instead.

  - **Pre-processing pipeline bugs**
    - `ConvertToOneColor` ran the brightness calculation on fully-transparent pixels (alpha == 0), incorrectly promoting them to opaque white in non-premultiplied bitmaps. The bug would only bite with straight (unpremultiplied) alpha bitmaps where a transparent pixel (alpha=0) carries non-zero RGB values. In premultiplied bitmaps — which is SkiaSharp's default — transparent pixels always have RGB=0 by definition, so the old brightness calculation would yield 0, not exceed the threshold, and write 0x00000000 anyway. Same result as the new code. The fix is defensively correct but doesn't change observable behavior for any current input.
    - Separately, `HasPreProcessingSettings` was missing the `ToOneColor` flag, so the pre-processing active indicator stayed dark when "One color (white)" was the only enabled option.

---

<img width="1199" height="723" alt="Guesses not applied" src="https://github.com/user-attachments/assets/d5b5cc75-c823-4b22-9dca-6876bf497207" />
