### PR TITLE
Fix #10940: sync FixCommonErrors language dropdown to Language field

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -294,6 +294,17 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         }
     }
 
+    partial void OnSelectedLanguageChanged(LanguageDisplayItem? value)
+    {
+        // Language drives which OCR-fix list, names list, and per-language rules are loaded;
+        // without this sync a user picking e.g. Croatian after auto-detect chose English would
+        // still get the English replacements (GH #10940).
+        if (value != null)
+        {
+            Language = value.Code.TwoLetterISOLanguageName;
+        }
+    }
+
     private void SelectedParagraph_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(SubtitleLineViewModel.Text) &&


### PR DESCRIPTION
## Summary
- In `FixCommonErrorsViewModel`, `SelectedLanguage` (UI dropdown, `[ObservableProperty]`) was not propagated to `Language`, the plain string consumed by every `IFixCallbacks` rule (including `FixCommonOcrErrors`).
- Result: opening *Fix common errors* on a subtitle that auto-detects as English, then manually picking **Croatian** in the dropdown, leaves `Language = "en"` — so `FixCommonOcrErrors` loads `eng_OCRFixReplaceList.xml` instead of `hrv_OCRFixReplaceList.xml` and reports 0 fixes (matches diomed's description in #10940 and #10320).
- Added a `partial void OnSelectedLanguageChanged` that mirrors `SelectedLanguage.Code.TwoLetterISOLanguageName` into `Language`.

The engine + bundled list themselves are fine — verified that `OcrFixReplaceList2.FromLanguageId("hrv")` loads `hrv_OCRFixReplaceList.xml` and applies entries (e.g. `bašta → vrt`). Same wiring bug also affects other per-language rules (Turkish, French, Bulgarian, Arabic, Greek…) that key off `callbacks.Language`.

## Test plan
- [ ] Open *Fix common errors* on an English-auto-detected SRT
- [ ] Switch dropdown to **Croatian**, enable *Fix common OCR errors*, click *Go to apply fixes*
- [ ] Verify Croatian replacements (e.g. `bašta → vrt`) are reported
- [ ] Spot-check at least one other rule that branches on `callbacks.Language` (Turkish ANSI, French missing-spaces) still behaves correctly after dropdown changes

Fixes #10940.

🤖 Generated with [Claude Code](https://claude.com/claude-code)