### PR TITLE
Disable spell check Change/Change all until word is edited

### DIFF
--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -24,8 +24,16 @@ public partial class SpellCheckViewModel : ObservableObject
 {
     [ObservableProperty] private string _lineText;
     [ObservableProperty] private string _wholeText;
-    [ObservableProperty] private string _currentWord;
-    [ObservableProperty] private string _wordNotFoundOriginal;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ChangeWordCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ChangeWordAllCommand))]
+    private string _currentWord;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ChangeWordCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ChangeWordAllCommand))]
+    private string _wordNotFoundOriginal;
     [ObservableProperty] private string _statusText;
     [ObservableProperty] private ObservableCollection<SpellCheckDictionaryDisplay> _dictionaries;
     [ObservableProperty] private SpellCheckDictionaryDisplay? _selectedDictionary;
@@ -290,10 +298,12 @@ public partial class SpellCheckViewModel : ObservableObject
         DoSpellCheck();
     }
 
-    [RelayCommand]
+    private bool CanChangeWord() => !string.IsNullOrWhiteSpace(CurrentWord) && WordNotFoundOriginal != CurrentWord;
+
+    [RelayCommand(CanExecute = nameof(CanChangeWord))]
     private void ChangeWord()
     {
-        if (string.IsNullOrWhiteSpace(CurrentWord) || WordNotFoundOriginal == CurrentWord || SelectedParagraph == null)
+        if (SelectedParagraph == null)
         {
             Dispatcher.UIThread.Invoke(() => { TextBoxWordNotFound.Focus(); });
             return;
@@ -304,11 +314,11 @@ public partial class SpellCheckViewModel : ObservableObject
         DoSpellCheck();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanChangeWord))]
     private void ChangeWordAll()
     {
         var selectedParagraph = SelectedParagraph;
-        if (string.IsNullOrWhiteSpace(CurrentWord) || WordNotFoundOriginal == CurrentWord || selectedParagraph == null)
+        if (selectedParagraph == null)
         {
             Dispatcher.UIThread.Invoke(() => { TextBoxWordNotFound.Focus(); });
             return;


### PR DESCRIPTION
## Summary

In the spell check window, the **Change** and **Change all** buttons stayed enabled even when the "Word not found" field was left unchanged. Clicking them in that state did nothing (the commands already no-op when the current word equals the original).

This wires the two buttons' `CanExecute` to a `CanChangeWord` guard, so they are disabled until the user actually edits the word, and re-evaluate as the field (or the next misspelled word) changes.

## Changes

- Added `CanChangeWord()` — `true` only when `CurrentWord` is non-blank and differs from `WordNotFoundOriginal`.
- Decorated `ChangeWordCommand` / `ChangeWordAllCommand` with `[RelayCommand(CanExecute = nameof(CanChangeWord))]`.
- Added `[NotifyCanExecuteChangedFor(...)]` on `CurrentWord` and `WordNotFoundOriginal` so button state updates live.
- Removed the now-redundant value-equality checks inside the command bodies (kept the `SelectedParagraph == null` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)