### PR TITLE
Show hovered video position in video player slider tooltip

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -368,6 +368,27 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             if (Se.Settings.Appearance.ShowHints)
             {
                 ToolTip.SetTip(sliderPosition, Se.Language.General.VideoPosition);
+
+                // Show the hovered timestamp in the tooltip (frame/HH:MM:SS:FF vs ms format is
+                // already handled by ToShortDisplayString via UseTimeFormatHHMMSSFF).
+                // Avalonia's Slider centers the thumb on the value point, so the effective
+                // value-range track is narrower than the slider by one thumb width — we have
+                // to match that mapping or the hint reads later than the actual click target.
+                const double thumbWidth = 14.0;
+                sliderPosition.AddHandler(PointerMovedEvent, (_, e) =>
+                {
+                    var available = sliderPosition.Bounds.Width - thumbWidth;
+                    if (available <= 0 || Duration <= 0)
+                    {
+                        return;
+                    }
+
+                    var x = e.GetPosition(sliderPosition).X - thumbWidth / 2;
+                    var ratio = Math.Clamp(x / available, 0.0, 1.0);
+                    var hovered = sliderPosition.Minimum + ratio * (sliderPosition.Maximum - sliderPosition.Minimum);
+                    var offsetSec = Se.Settings.General.CurrentVideoOffsetInMs / 1000.0;
+                    ToolTip.SetTip(sliderPosition, TimeCode.FromSeconds(hovered + offsetSec).ToShortDisplayString());
+                });
             }
             sliderPosition.TemplateApplied += (s, e) =>
             {


### PR DESCRIPTION
## Summary
- YouTube-style hint: as the pointer moves over the video player position slider, the tooltip shows the timestamp at that point.
- Frame vs ms formatting falls out of `TimeCode.ToShortDisplayString()` via `Configuration.Settings.General.UseTimeFormatHHMMSSFF`, so in frame mode the hint reads e.g. `00:01:23:12` and in ms mode `00:01:23,500`.
- Mapping subtracts `thumbWidth / 2` from each end of the track to match Avalonia's click-to-value mapping (which centers the thumb on the value point), so the hint and the actual seek position line up.
- Honors the existing video offset (`CurrentVideoOffsetInMs`) and the existing `Appearance.ShowHints` gate.

## Test plan
- [ ] Open a video, hover the position slider, verify tooltip updates with the timestamp at the pointer
- [ ] Click on the slider — the position the video seeks to should match the tooltip reading immediately before the click
- [ ] Toggle *Options → Settings → Use frame format (HH:MM:SS:FF)* and verify the hint switches between `00:01:23:12` and `00:01:23,500`
- [ ] Set a non-zero video offset; verify the hint reflects the offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)