### PR TITLE
Common Errors: wire up SkipStep1 setting and fix several edge cases

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -603,6 +603,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.MultipleReplaceShowDotDotDotButtons, nameof(_vm.MultipleReplaceShowDotDotDotButtons)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptMergeContinuationLines, nameof(_vm.TextToSpeechPromptMergeContinuationLines)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.FixCommonErrorsSkipStep1, nameof(_vm.FixCommonErrorsSkipStep1)),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.Appearance,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -177,6 +177,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _showToolbarVisualSync;
     [ObservableProperty] private bool _showToolbarBeautifyTimeCodes;
     [ObservableProperty] private bool _showToolbarBurnIn;
+    [ObservableProperty] private bool _fixCommonErrorsSkipStep1;
     [ObservableProperty] private bool _showToolbarSettings;
     [ObservableProperty] private bool _showToolbarLayout;
     [ObservableProperty] private bool _showToolbarHelp;
@@ -686,6 +687,7 @@ public partial class SettingsViewModel : ObservableObject
         GridFocusTextboxAfterInsertNew = Se.Settings.Tools.GridFocusTextboxAfterInsertNew;
         TextToSpeechPromptMergeContinuationLines = Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines;
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
+        FixCommonErrorsSkipStep1 = Se.Settings.Tools.FixCommonErrors.SkipStep1;
 
         SelectedTheme = MapThemeToTranslation(appearance.Theme);
         SelectedIconTheme = IconThemes.FirstOrDefault(p => p == appearance.IconTheme) ?? IconThemes.First();
@@ -1365,6 +1367,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons = MultipleReplaceShowDotDotDotButtons;
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;
         Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines = TextToSpeechPromptMergeContinuationLines;
+        Se.Settings.Tools.FixCommonErrors.SkipStep1 = FixCommonErrorsSkipStep1;
         Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
         Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
 

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -113,6 +113,11 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         InitStep1(languageCode, subtitle);
         LoadProfiles();
         SelectedProfile = Profiles.FirstOrDefault(p => p.Name == Se.Settings.Tools.FixCommonErrors.LastProfileName) ?? Profiles.FirstOrDefault() ?? Profiles.FirstOrDefault();
+
+        if (Se.Settings.Tools.FixCommonErrors.SkipStep1)
+        {
+            ToApplyFixes();
+        }
     }
 
     private void SaveProfiles()

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -112,7 +112,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
         InitStep1(languageCode, subtitle);
         LoadProfiles();
-        SelectedProfile = Profiles.FirstOrDefault(p => p.Name == Se.Settings.Tools.FixCommonErrors.LastProfileName) ?? Profiles.FirstOrDefault() ?? Profiles.FirstOrDefault();
+        SelectedProfile = Profiles.FirstOrDefault(p => p.Name == Se.Settings.Tools.FixCommonErrors.LastProfileName) ?? Profiles.FirstOrDefault();
 
         if (Se.Settings.Tools.FixCommonErrors.SkipStep1 && SelectedProfile != null)
         {

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -116,7 +116,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
         if (Se.Settings.Tools.FixCommonErrors.SkipStep1)
         {
-            ToApplyFixes();
+            ShowStep2();
         }
     }
 
@@ -203,18 +203,21 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         Step1IsVisible = true;
     }
 
-    [RelayCommand]
-    private void ToApplyFixes()
+    private void ShowStep2()
     {
         Step1IsVisible = false;
         Step2IsVisible = true;
-
-        SaveProfiles();
         _oldSelectedLanguage = SelectedLanguage!;
-
         _totalFixes = 0;
         FixesAppliedText = string.Empty;
         RefreshFixes();
+    }
+
+    [RelayCommand]
+    private void ToApplyFixes()
+    {
+        SaveProfiles();
+        ShowStep2();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -114,7 +114,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         LoadProfiles();
         SelectedProfile = Profiles.FirstOrDefault(p => p.Name == Se.Settings.Tools.FixCommonErrors.LastProfileName) ?? Profiles.FirstOrDefault() ?? Profiles.FirstOrDefault();
 
-        if (Se.Settings.Tools.FixCommonErrors.SkipStep1)
+        if (Se.Settings.Tools.FixCommonErrors.SkipStep1 && SelectedProfile != null)
         {
             ShowStep2();
         }

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -148,6 +148,7 @@ public class LanguageSettings
     public string WaveformBackgroundColor { get; set; }
     public string WaveformSelectedColor { get; set; }
     public string DownloadFfmpeg { get; set; }
+    public string FixCommonErrorsSkipStep1 { get; set; }
 
     // Toolbar
     public string ShowToolbarNew { get; set; }
@@ -163,7 +164,6 @@ public class LanguageSettings
     public string ShowToolbarVisualSync { get; set; }
     public string ShowToolbarBeautifyTimeCodes { get; set; }
     public string ShowToolbarBurnIn { get; set; }
-    public string FixCommonErrorsSkipStep1 { get; set; }
     public string ShowToolbarSettings { get; set; }
     public string ShowToolbarLayout { get; set; }
     public string ShowToolbarHelp { get; set; }
@@ -452,6 +452,7 @@ public class LanguageSettings
         WaveformBackgroundColor = "Waveform background color";
         WaveformSelectedColor = "Waveform selected color";
         DownloadFfmpeg = "Download ffmpeg";
+        FixCommonErrorsSkipStep1 = "Fix common errors: skip step 1 (choose fixes)";
 
         // Toolbar
         ShowToolbarNew = "Show new icon";
@@ -467,7 +468,6 @@ public class LanguageSettings
         ShowToolbarVisualSync = "Show visual sync icon";
         ShowToolbarBeautifyTimeCodes = "Show beautify time codes icon";
         ShowToolbarBurnIn = "Show burn-in icon";
-        FixCommonErrorsSkipStep1 = "Fix common errors: skip step 1 (choose fixes)";
         ShowToolbarSettings = "Show settings icon";
         ShowToolbarLayout = "Show layout icon";
         ShowToolbarHelp = "Show help icon";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -163,6 +163,7 @@ public class LanguageSettings
     public string ShowToolbarVisualSync { get; set; }
     public string ShowToolbarBeautifyTimeCodes { get; set; }
     public string ShowToolbarBurnIn { get; set; }
+    public string FixCommonErrorsSkipStep1 { get; set; }
     public string ShowToolbarSettings { get; set; }
     public string ShowToolbarLayout { get; set; }
     public string ShowToolbarHelp { get; set; }
@@ -466,6 +467,7 @@ public class LanguageSettings
         ShowToolbarVisualSync = "Show visual sync icon";
         ShowToolbarBeautifyTimeCodes = "Show beautify time codes icon";
         ShowToolbarBurnIn = "Show burn-in icon";
+        FixCommonErrorsSkipStep1 = "Fix common errors: skip step 1 (choose fixes)";
         ShowToolbarSettings = "Show settings icon";
         ShowToolbarLayout = "Show layout icon";
         ShowToolbarHelp = "Show help icon";


### PR DESCRIPTION
If you often use "Fix common errors" and always use the same fix rules, then enable "Skip step one" to save time. It worked in Subtitle Edit 4. I've missed it greatly, so I rewired it for version 5, assuming it was not intentionally removed.

<img width="1050" height="853" alt="Screenshot 2026-06-03 at 9 08 28 PM" src="https://github.com/user-attachments/assets/37eed610-ada4-4fbd-b5dc-e03fa058126e" />

  ## Changes

  - Wire up the Fix Common Errors "skip step 1" setting in SettingsViewModel and SettingsPage so it is exposed in the Settings UI and persisted correctly.
  - Extract `ShowStep2()` from `ToApplyFixes()` so the auto-skip path navigates to step 2 without calling `SaveProfiles()`. Otherwise, opening the dialog with SkipStep1 enabled and pressing Cancel would silently overwrite persisted profile settings.
  - Guard the SkipStep1 auto-advance on `SelectedProfile != null`: on first run with no saved profiles the dialog now falls back to step 1 instead of showing a blank, unrecoverable step-2 panel.
  - Remove a redundant third `?? Profiles.FirstOrDefault()` in the profile selection expression (dead code — the collection is not mutated between the two identical calls).
  - Move `FixCommonErrorsSkipStep1` language string out of the `// Toolbar` section in `LanguageSettings.cs` where it was incorrectly grouped, to just before that block.