### PR TITLE
Remove unused ReplaceNext from IFindService

### DIFF
--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -175,65 +175,6 @@ public partial class FindService : IFindService
         return results;
     }
 
-    public int ReplaceNext(string searchText, string replaceText, List<string> textLines, int startLineIndex, int startTextIndex)
-    {
-        if (string.IsNullOrEmpty(searchText) || textLines == null || textLines.Count == 0)
-        {
-            ResetSearchState();
-            return -1;
-        }
-
-        SearchText = RegexUtils.EscapeNewLines(searchText);
-        _textLines = textLines;
-        AddToSearchHistory(searchText);
-
-        if (startLineIndex < 0)
-        {
-            startLineIndex = 0;
-            startTextIndex = 0;
-        }
-        else
-        {
-            if (startLineIndex >= _textLines.Count)
-            {
-                return NotFound();
-            }
-
-            // If we've reached the end of current line, move to next line
-            if (startTextIndex >= _textLines[startLineIndex].Length)
-            {
-                startLineIndex++;
-                startTextIndex = 0;
-            }
-
-            if (startLineIndex >= _textLines.Count)
-            {
-                return NotFound();
-            }
-        }
-
-        var result = FindInList(searchText, startLineIndex, startTextIndex);
-        if (result.lineIndex == -1)
-        {
-            return NotFound();
-        }
-
-        // Perform the replacement
-        var replacedText = ReplaceInLine(_textLines[result.lineIndex], searchText, replaceText, result.textIndex, 1);
-        if (replacedText.replaced)
-        {
-            _textLines[result.lineIndex] = replacedText.newText;
-            CurrentLineNumber = result.lineIndex;
-            CurrentTextIndex = result.textIndex;
-            CurrentTextFound = CurrentFindMode == FindMode.RegularExpression
-                ? RegexUtils.FixNewLine(replaceText ?? string.Empty)
-                : replaceText ?? string.Empty;
-            return result.lineIndex;
-        }
-
-        return NotFound();
-    }
-
     public int ReplaceAll(string searchText, string replaceText)
     {
         if (string.IsNullOrEmpty(searchText) || _textLines.Count == 0)

--- a/src/ui/Logic/IFindService.cs
+++ b/src/ui/Logic/IFindService.cs
@@ -16,7 +16,6 @@ public interface IFindService
     void Initialize(List<string> textLines, int currentLineIndex, bool wholeWord, FindMode findMode);
     int FindNext(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex);
     int FindPrevious(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex);
-    int ReplaceNext(string searchText, string replaceText, List<string> textLines, int startLineIndex, int startTextIndex);
     int ReplaceAll(string searchText, string replaceText);
     int Count(string searchText);
     List<(int LineIndex, int TextIndex, string FoundText)> FindAll(string searchText);


### PR DESCRIPTION
I came across this while working on #11356 earlier today - I ended up refactoring dead code. I postponed its removal until after the mentioned PR was merged to keep concerns separate.

  `FindService.ReplaceNext` was introduced in the initial SE5 commit as a convenience wrapper intended to encapsulate the "replace current match, then find next" operation. It was never wired up: the Replace & Find Next feature is implemented inline in `MainViewModel.HandleReplaceResult`, which calls `_findService.Initialize()` and `_findService.FindNext()` directly and handles the substitution itself. No caller existed anywhere in the codebase.

The method also did not exist in v4 — this is SE5-only dead code, not a port from the old WinForms codebase.

  Removes:
  - the interface declaration in `IFindService`
  - the full implementation in `FindService` (~58 lines)

  `ReplaceAll`, `ReplaceWithRegex`, and all Find* members are untouched.
