### PR TITLE
Fix incorrect double-click description in main window help

### DIFF
--- a/docs/features/main-window.md
+++ b/docs/features/main-window.md
@@ -77,7 +77,7 @@ The subtitle grid shows all subtitle lines in a table format. Each row represent
 - **Click** a row to select it and load its text into the text editor
 - **Ctrl+Click** to add/remove rows from a multi-selection
 - **Shift+Click** to select a range
-- **Double-click** a cell to edit inline
+- **Double-click** a row to go to that subtitle's video position (behavior configurable in Options → Settings)
 - **Right-click** for a context menu
 
 **Keyboard:**


### PR DESCRIPTION
The help file stated that double-clicking a subtitle grid cell opens inline editing. This is incorrect — the grid is read-only by design (IsReadOnly = true, all bindings OneWay). The actual double-click behavior seeks the video to the subtitle's start position (configurable in Options → Settings).

Updated the description to match what the feature actually does, consistent with the existing docs/reference/mouse-controls.md entry.