### PR TITLE
Fix last inconsistent toggle label in native macOS menu bar

### DIFF
--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -278,7 +278,7 @@ public static class InitNativeMacMenu
             Item(Clean(lVideo.ReEncodeVideoForBetterSubtitlingDotDotDot), v => v.VideoReEncodeCommand),
             Item(Clean(lVideo.CutVideoDotDotDot), v => v.VideoCutCommand),
         };
-        videoMoreList.Add(Toggle(Clean(Se.Language.Options.Shortcuts.ToggleWaveformToolbar), v => v.ToggleIsWaveformToolbarVisibleCommand,
+        videoMoreList.Add(Toggle(Clean(l.WaveformToolbar), v => v.ToggleIsWaveformToolbarVisibleCommand,
             v => v.IsWaveformToolbarVisible, nameof(MainViewModel.IsWaveformToolbarVisible)));
 
         // Seed with the default header (matches MainViewModel.SetVideoOffsetText's initial value)

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -96,6 +96,7 @@ public class LanguageMainMenu
     public string SetVideoOffset { get; set; }
     public string UpdateVideoOffsetX { get; set; }
     public string SmpteTiming { get; set; }
+    public string WaveformToolbar { get; set; }
     public string GenerateBurnIn { get; set; }
     public string GenerateTransparent { get; set; }
     public string GenerateImportShotChanges { get; set; }
@@ -235,6 +236,7 @@ public class LanguageMainMenu
         SetVideoOffset = "Set video offset...";
         UpdateVideoOffsetX = "Update video offset from {0}...";
         SmpteTiming = "SMPTE timing (non-integer frame rate)";
+        WaveformToolbar = "Waveform toolbar";
         GenerateBurnIn = "Generate video with _burned-in subtitles...";
         GenerateTransparent = "_Generate transparent video with subtitles...";
 


### PR DESCRIPTION
   ## Summary

   The native macOS menu bar uses checkmark ticks to convey on/off state for toggle items, so labels don't need to say "Toggle" — the tick already communicates that. The four toggle items in the native Mac menu are:

   | Menu | Item | Label |
   |---|---|---|
   | Edit | Right-to-left mode | ✅ No "Toggle" prefix |
   | Video | Select subtitle while playing | ✅ Fixed in #11240 |
   | Video > More | SMPTE timing (non-integer frame rate) | ✅ No "Toggle" prefix |
   | Video > More | ~~Toggle waveform toolbar~~ → **Waveform toolbar** | ✅ Fixed here |

   "Toggle waveform toolbar" was the last item still using the "Toggle" prefix, making it inconsistent with the other three. This PR applies the same fix: add a plain `WaveformToolbar` language string to `LanguageMainMenu` and use it in `InitNativeMacMenu`. The cross-platform Avalonia menu is unaffected and continues to use the existing `ToggleWaveformToolbar` shortcut string.
