### PR TITLE
Add CosyVoice3 and F5-TTS as CrispASR TTS engines

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -147,6 +147,8 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
@@ -242,6 +244,8 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<IQwen3TtsCrispAsrDownloadService, Qwen3TtsCrispAsrDownloadService>();
         collection.AddHttpClient<IVibeVoiceCrispAsrDownloadService, VibeVoiceCrispAsrDownloadService>();
         collection.AddHttpClient<IIndexTtsCrispAsrDownloadService, IndexTtsCrispAsrDownloadService>();
+        collection.AddHttpClient<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
+        collection.AddHttpClient<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
         collection.AddHttpClient<IKokoroTtsCppDownloadService, KokoroTtsCppDownloadService>();
         collection.AddHttpClient<IChatterboxTtsCppDownloadService, ChatterboxTtsCppDownloadService>();
         collection.AddHttpClient<IOmniVoiceDownloadService, OmniVoiceDownloadService>();
@@ -402,6 +406,8 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<Qwen3TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<VibeVoiceCrispAsrSettingsViewModel>();
         collection.AddTransient<IndexTtsCrispAsrSettingsViewModel>();
+        collection.AddTransient<CosyVoice3CrispAsrSettingsViewModel>();
+        collection.AddTransient<F5TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<KokoroTtsSettingsViewModel>();
         collection.AddTransient<ChatterboxTtsSettingsViewModel>();
         collection.AddTransient<OpenFromUrlViewModel>();

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
@@ -1,0 +1,201 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
+
+public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
+{
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+
+    [ObservableProperty] private string _llmQ4KLabel = string.Empty;
+    [ObservableProperty] private IBrush _llmQ4KBrush = Grey();
+
+    [ObservableProperty] private string _llmF16Label = string.Empty;
+    [ObservableProperty] private IBrush _llmF16Brush = Grey();
+
+    [ObservableProperty] private string _presetsLabel = string.Empty;
+
+    [ObservableProperty] private double _speed = 1.0;
+
+    public string SpeedLabel => $"Speed {Speed:0.00}x";
+
+    partial void OnSpeedChanged(double value)
+    {
+        OnPropertyChanged(nameof(SpeedLabel));
+        Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed = Math.Clamp(value, 0.25, 4.0);
+    }
+
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public CosyVoice3CrispAsrSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        ModelsFolder = CosyVoice3CrispAsr.GetSetModelsFolder();
+        Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed, 0.25, 4.0);
+        PresetsLabel = $"{CosyVoice3CrispAsr.Presets.Length} baked presets (zero-shot + FLEURS en/de/zh/ja/fr/es/ko)";
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = CosyVoice3CrispAsr.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = "CrispASR not installed";
+            EngineBrush = Red();
+            EngineDownloadButtonText = "Download CrispASR";
+        }
+        else if (CosyVoice3CrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = "CrispASR - update available";
+            EngineBrush = Amber();
+            EngineDownloadButtonText = "Update CrispASR";
+        }
+        else
+        {
+            EngineLabel = "CrispASR";
+            EngineBrush = Green();
+            EngineDownloadButtonText = "Re-download CrispASR";
+        }
+
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "CosyVoice3CrispAsrSettings: CrispASR version probe failed");
+                }
+            });
+        }
+
+        ApplyModelStatus(
+            CosyVoice3CrispAsr.AreModelsInstalled(CosyVoice3CrispAsr.ModelKeyQ4K),
+            IsEngineInstalled,
+            label => LlmQ4KLabel = label,
+            brush => LlmQ4KBrush = brush);
+
+        ApplyModelStatus(
+            CosyVoice3CrispAsr.AreModelsInstalled(CosyVoice3CrispAsr.ModelKeyF16),
+            IsEngineInstalled,
+            label => LlmF16Label = label,
+            brush => LlmF16Brush = brush);
+    }
+
+    private static void ApplyModelStatus(bool fileInstalled, bool engineInstalled, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        if (fileInstalled)
+        {
+            setLabel("Installed");
+            setBrush(Green());
+            return;
+        }
+
+        if (!engineInstalled)
+        {
+            setLabel("CrispASR required");
+            setBrush(Grey());
+            return;
+        }
+
+        setLabel("Auto-download on first use");
+        setBrush(Grey());
+    }
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await TtsVoiceInstaller.EnsureCrispAsrForCosyVoice3(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
@@ -38,6 +38,7 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
     [ObservableProperty] private IBrush _llmF16Brush = Grey();
 
     [ObservableProperty] private string _presetsLabel = string.Empty;
+    [ObservableProperty] private string _voicesLabel = string.Empty;
 
     [ObservableProperty] private double _speed = 1.0;
 
@@ -50,6 +51,7 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
     }
 
     [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
     [ObservableProperty] private bool _isEngineInstalled;
 
     public Window? Window { get; set; }
@@ -64,6 +66,7 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
     public void Initialize()
     {
         ModelsFolder = CosyVoice3CrispAsr.GetSetModelsFolder();
+        VoicesFolder = CosyVoice3CrispAsr.GetSetVoicesFolder();
         Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed, 0.25, 4.0);
         PresetsLabel = $"{CosyVoice3CrispAsr.Presets.Length} baked presets (zero-shot + FLEURS en/de/zh/ja/fr/es/ko)";
         Refresh();
@@ -131,6 +134,20 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
             IsEngineInstalled,
             label => LlmF16Label = label,
             brush => LlmF16Brush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No cloned voices imported (baked presets always available)"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
     }
 
     private static void ApplyModelStatus(bool fileInstalled, bool engineInstalled, Action<string> setLabel, Action<IBrush> setBrush)
@@ -176,6 +193,24 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
         try
         {
             await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
         }
         catch
         {

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
@@ -31,11 +31,11 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
     [ObservableProperty] private IBrush _engineBrush = Grey();
     [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
 
-    [ObservableProperty] private string _llmQ4KLabel = string.Empty;
-    [ObservableProperty] private IBrush _llmQ4KBrush = Grey();
+    [ObservableProperty] private string _q4KBundleLabel = string.Empty;
+    [ObservableProperty] private IBrush _q4KBundleBrush = Grey();
 
-    [ObservableProperty] private string _llmF16Label = string.Empty;
-    [ObservableProperty] private IBrush _llmF16Brush = Grey();
+    [ObservableProperty] private string _f16BundleLabel = string.Empty;
+    [ObservableProperty] private IBrush _f16BundleBrush = Grey();
 
     [ObservableProperty] private string _presetsLabel = string.Empty;
     [ObservableProperty] private string _voicesLabel = string.Empty;
@@ -123,17 +123,19 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
             });
         }
 
+        // CosyVoice3 needs 6 files per quant — the status row reports the bundle as a whole
+        // (green only when every file is present + correct-sized).
         ApplyModelStatus(
             CosyVoice3CrispAsr.AreModelsInstalled(CosyVoice3CrispAsr.ModelKeyQ4K),
             IsEngineInstalled,
-            label => LlmQ4KLabel = label,
-            brush => LlmQ4KBrush = brush);
+            label => Q4KBundleLabel = label,
+            brush => Q4KBundleBrush = brush);
 
         ApplyModelStatus(
             CosyVoice3CrispAsr.AreModelsInstalled(CosyVoice3CrispAsr.ModelKeyF16),
             IsEngineInstalled,
-            label => LlmF16Label = label,
-            brush => LlmF16Brush = brush);
+            label => F16BundleLabel = label,
+            brush => F16BundleBrush = brush);
 
         try
         {

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
@@ -1,0 +1,259 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
+
+public class CosyVoice3CrispAsrSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly CosyVoice3CrispAsrSettingsViewModel _vm;
+
+    public CosyVoice3CrispAsrSettingsWindow(CosyVoice3CrispAsrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "CosyVoice3 (CrispASR) settings";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 580;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(CosyVoice3CrispAsrSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "CosyVoice3 (CrispASR)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new CosyVoice3CrispAsr().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(CosyVoice3CrispAsrSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel("Engine"), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12);
+        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel("LLM " + CosyVoice3CrispAsr.ModelKeyQ4K), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.LlmQ4KBrush), nameof(vm.LlmQ4KLabel)), 1, 1);
+
+        grid.Add(MakeLabel("LLM " + CosyVoice3CrispAsr.ModelKeyF16), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.LlmF16Brush), nameof(vm.LlmF16Label)), 2, 1);
+
+        grid.Add(MakeLabel("Presets"), 3, 0);
+        var presetsText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.PresetsLabel)),
+        };
+        grid.Add(presetsText, 3, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Speed), 4, 0);
+        grid.Add(MakeSpeedPanel(), 4, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 5, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        };
+        grid.Add(folderText, 5, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static StackPanel MakeSpeedPanel()
+    {
+        var slider = new Slider
+        {
+            Minimum = 0.5,
+            Maximum = 2.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(CosyVoice3CrispAsrSettingsViewModel.Speed)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(CosyVoice3CrispAsrSettingsViewModel.SpeedLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Grid BuildActions(CosyVoice3CrispAsrSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
@@ -104,6 +104,7 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 12,
             RowSpacing = 10,
@@ -133,10 +134,19 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
         };
         grid.Add(presetsText, 3, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.Speed), 4, 0);
-        grid.Add(MakeSpeedPanel(), 4, 1);
+        grid.Add(MakeLabel("Voices"), 4, 0);
+        var voicesText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        };
+        grid.Add(voicesText, 4, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 5, 0);
+        grid.Add(MakeLabel(Se.Language.General.Speed), 5, 0);
+        grid.Add(MakeSpeedPanel(), 5, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 6, 0);
         var folderText = new TextBox
         {
             IsReadOnly = true,
@@ -148,7 +158,7 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
             FontSize = 12,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
-        grid.Add(folderText, 5, 1);
+        grid.Add(folderText, 6, 1);
 
         return new Border
         {
@@ -213,13 +223,14 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
     private static Grid BuildActions(CosyVoice3CrispAsrSettingsViewModel vm)
     {
         var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
         var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
 
         var leftPanel = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 8,
-            Children = { openModelsFolder },
+            Children = { openModelsFolder, openVoicesFolder },
         };
 
         var rightPanel = new StackPanel

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
@@ -119,11 +119,11 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 
-        grid.Add(MakeLabel("LLM " + CosyVoice3CrispAsr.ModelKeyQ4K), 1, 0);
-        grid.Add(MakeStatusPanel(nameof(vm.LlmQ4KBrush), nameof(vm.LlmQ4KLabel)), 1, 1);
+        grid.Add(MakeLabel(CosyVoice3CrispAsr.ModelKeyQ4K), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.Q4KBundleBrush), nameof(vm.Q4KBundleLabel)), 1, 1);
 
-        grid.Add(MakeLabel("LLM " + CosyVoice3CrispAsr.ModelKeyF16), 2, 0);
-        grid.Add(MakeStatusPanel(nameof(vm.LlmF16Brush), nameof(vm.LlmF16Label)), 2, 1);
+        grid.Add(MakeLabel(CosyVoice3CrispAsr.ModelKeyF16), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.F16BundleBrush), nameof(vm.F16BundleLabel)), 2, 1);
 
         grid.Add(MakeLabel("Presets"), 3, 0);
         var presetsText = new TextBlock

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -59,6 +59,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskIndexTtsCrispAsrModels;
     private Task? _downloadTaskIndexTtsCrispAsrVoices;
     private Task? _downloadTaskCosyVoice3CrispAsrModels;
+    private Task? _downloadTaskCosyVoice3CrispAsrVoices;
     private Task? _downloadTaskF5TtsCrispAsrModels;
     private Task? _downloadTaskF5TtsCrispAsrVoices;
     private Task? _downloadTaskOmniVoice;
@@ -88,6 +89,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly MemoryStream _downloadStreamQwen3TtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamVibeVoiceCrispAsrVoices;
     private readonly MemoryStream _downloadStreamIndexTtsCrispAsrVoices;
+    private readonly MemoryStream _downloadStreamCosyVoice3CrispAsrVoices;
     private readonly MemoryStream _downloadStreamF5TtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamOmniVoice;
     private readonly MemoryStream _downloadStreamOmniVoices;
@@ -130,6 +132,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _downloadStreamQwen3TtsCrispAsrVoices = new MemoryStream();
         _downloadStreamVibeVoiceCrispAsrVoices = new MemoryStream();
         _downloadStreamIndexTtsCrispAsrVoices = new MemoryStream();
+        _downloadStreamCosyVoice3CrispAsrVoices = new MemoryStream();
         _downloadStreamF5TtsCrispAsrVoices = new MemoryStream();
         _downloadStreamOmniVoice = new MemoryStream();
         _downloadStreamOmniVoices = new MemoryStream();
@@ -803,15 +806,39 @@ public partial class DownloadTtsViewModel : ObservableObject
                 Close();
             }
 
-            // CosyVoice3 has no separate voices download — the voice bank ships inside
-            // cosyvoice3-voices.gguf (~665 KB) which crispasr --auto-download pulls on first
-            // synth. Once the LLM model finishes, we're done.
+            // CosyVoice3 supports both baked presets (in cosyvoice3-voices.gguf, fetched by
+            // crispasr --auto-download) AND zero-shot cloning from user-supplied WAVs. After
+            // the LLM downloads, chain the qwen3-tts.cpp voice pack ZIP so the user has the
+            // shared reference voices available without a second manual download step. The
+            // baked presets are always usable regardless of this step.
             if (_downloadTaskCosyVoice3CrispAsrModels is { IsCompleted: true })
             {
                 _timer.Stop();
                 _downloadTaskCosyVoice3CrispAsrModels = null;
-                OkPressed = true;
-                Close();
+
+                var voicesFolder = CosyVoice3CrispAsr.GetSetVoicesFolder();
+                var voicesAlreadyInstalled = Directory.Exists(voicesFolder)
+                    && Directory.EnumerateFiles(voicesFolder, "*.wav").Any();
+                if (voicesAlreadyInstalled)
+                {
+                    OkPressed = true;
+                    Close();
+                    return;
+                }
+
+                TitleText = "Downloading CosyVoice3 (CrispASR) voices";
+                ProgressValue = 0;
+                ProgressText = Se.Language.General.StartingDotDotDot;
+                var voicesProgress = new Progress<float>(number =>
+                {
+                    var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+                    var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+                    ProgressValue = percentage;
+                    ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+                });
+                _downloadTaskCosyVoice3CrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
+                    _downloadStreamCosyVoice3CrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
+                _timer.Start();
             }
             else if (_downloadTaskCosyVoice3CrispAsrModels is { IsFaulted: true })
             {
@@ -827,6 +854,42 @@ public partial class DownloadTtsViewModel : ObservableObject
                     ProgressText = "Download failed";
                     Error = ex?.Message ?? "Unknown error";
                 }
+            }
+
+            if (_downloadTaskCosyVoice3CrispAsrVoices is { IsCompleted: true })
+            {
+                _timer.Stop();
+                if (_downloadStreamCosyVoice3CrispAsrVoices.Length > 0)
+                {
+                    var voicesFolder = CosyVoice3CrispAsr.GetSetVoicesFolder();
+                    try
+                    {
+                        _downloadStreamCosyVoice3CrispAsrVoices.Position = 0;
+                        _zipUnpacker.UnpackZipStream(_downloadStreamCosyVoice3CrispAsrVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        ResampleVoicesTo16kHz(voicesFolder);
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex);
+                    }
+                    _downloadStreamCosyVoice3CrispAsrVoices.Dispose();
+                }
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskCosyVoice3CrispAsrVoices is { IsFaulted: true })
+            {
+                _timer.Stop();
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                    return;
+                }
+                var ex = _downloadTaskCosyVoice3CrispAsrVoices.Exception?.InnerException ?? _downloadTaskCosyVoice3CrispAsrVoices.Exception;
+                if (ex != null) Se.LogError(ex);
+                OkPressed = true;
+                Close();
             }
 
             // F5-TTS mirrors IndexTTS: model first, then a voices ZIP from the shared
@@ -1199,6 +1262,49 @@ public partial class DownloadTtsViewModel : ObservableObject
                 // or threw during the rename. Without this an accumulating set of *.24k.wav
                 // temp files would slowly clutter the voices folder and bloat .zip / sync
                 // backups.
+                if (!consumed && File.Exists(temp))
+                {
+                    try { File.Delete(temp); } catch { /* leave it; not worth retrying */ }
+                }
+            }
+        }
+    }
+
+    // Same shape as ResampleVoicesTo24kHz but targets 16 kHz — CosyVoice3's s3tok speech
+    // tokenizer expects 16 kHz mono and resamples internally on every synth call otherwise.
+    // Best-effort per file: on ffmpeg failure we leave the original WAV in place.
+    private static void ResampleVoicesTo16kHz(string folder)
+    {
+        if (!Directory.Exists(folder))
+        {
+            return;
+        }
+
+        foreach (var wav in Directory.GetFiles(folder, "*.wav"))
+        {
+            var temp = wav + ".16k.wav";
+            var consumed = false;
+            try
+            {
+                var ffmpeg = FfmpegGenerator.ConvertToMono16kHzWav(wav, temp);
+                if (!ffmpeg.Start())
+                {
+                    continue;
+                }
+                ffmpeg.WaitForExit();
+                if (File.Exists(temp) && new FileInfo(temp).Length > 0)
+                {
+                    File.Delete(wav);
+                    File.Move(temp, wav);
+                    consumed = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Se.LogError(ex, $"Resample voice to 16 kHz failed for '{wav}'; leaving original in place");
+            }
+            finally
+            {
                 if (!consumed && File.Exists(temp))
                 {
                     try { File.Delete(temp); } catch { /* leave it; not worth retrying */ }

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -58,6 +58,9 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskVibeVoiceCrispAsrVoices;
     private Task? _downloadTaskIndexTtsCrispAsrModels;
     private Task? _downloadTaskIndexTtsCrispAsrVoices;
+    private Task? _downloadTaskCosyVoice3CrispAsrModels;
+    private Task? _downloadTaskF5TtsCrispAsrModels;
+    private Task? _downloadTaskF5TtsCrispAsrVoices;
     private Task? _downloadTaskOmniVoice;
     private Task? _downloadTaskOmniVoices;
     private Task? _downloadTaskOmniVoiceModels;
@@ -72,6 +75,8 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly IQwen3TtsCrispAsrDownloadService _qwen3TtsCrispAsrDownloadService;
     private readonly IVibeVoiceCrispAsrDownloadService _vibeVoiceCrispAsrDownloadService;
     private readonly IIndexTtsCrispAsrDownloadService _indexTtsCrispAsrDownloadService;
+    private readonly ICosyVoice3CrispAsrDownloadService _cosyVoice3CrispAsrDownloadService;
+    private readonly IF5TtsCrispAsrDownloadService _f5TtsCrispAsrDownloadService;
     private readonly IOmniVoiceDownloadService _omniVoiceDownloadService;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly MemoryStream _downloadStream;
@@ -83,6 +88,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly MemoryStream _downloadStreamQwen3TtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamVibeVoiceCrispAsrVoices;
     private readonly MemoryStream _downloadStreamIndexTtsCrispAsrVoices;
+    private readonly MemoryStream _downloadStreamF5TtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamOmniVoice;
     private readonly MemoryStream _downloadStreamOmniVoices;
     private readonly IZipUnpacker _zipUnpacker;
@@ -97,6 +103,8 @@ public partial class DownloadTtsViewModel : ObservableObject
         IQwen3TtsCrispAsrDownloadService qwen3TtsCrispAsrDownloadService,
         IVibeVoiceCrispAsrDownloadService vibeVoiceCrispAsrDownloadService,
         IIndexTtsCrispAsrDownloadService indexTtsCrispAsrDownloadService,
+        ICosyVoice3CrispAsrDownloadService cosyVoice3CrispAsrDownloadService,
+        IF5TtsCrispAsrDownloadService f5TtsCrispAsrDownloadService,
         IOmniVoiceDownloadService omniVoiceDownloadService)
     {
         _ttsDownloadService = ttsDownloadService;
@@ -106,6 +114,8 @@ public partial class DownloadTtsViewModel : ObservableObject
         _qwen3TtsCrispAsrDownloadService = qwen3TtsCrispAsrDownloadService;
         _vibeVoiceCrispAsrDownloadService = vibeVoiceCrispAsrDownloadService;
         _indexTtsCrispAsrDownloadService = indexTtsCrispAsrDownloadService;
+        _cosyVoice3CrispAsrDownloadService = cosyVoice3CrispAsrDownloadService;
+        _f5TtsCrispAsrDownloadService = f5TtsCrispAsrDownloadService;
         _omniVoiceDownloadService = omniVoiceDownloadService;
         _zipUnpacker = zipUnpacker;
 
@@ -120,6 +130,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _downloadStreamQwen3TtsCrispAsrVoices = new MemoryStream();
         _downloadStreamVibeVoiceCrispAsrVoices = new MemoryStream();
         _downloadStreamIndexTtsCrispAsrVoices = new MemoryStream();
+        _downloadStreamF5TtsCrispAsrVoices = new MemoryStream();
         _downloadStreamOmniVoice = new MemoryStream();
         _downloadStreamOmniVoices = new MemoryStream();
 
@@ -792,6 +803,115 @@ public partial class DownloadTtsViewModel : ObservableObject
                 Close();
             }
 
+            // CosyVoice3 has no separate voices download — the voice bank ships inside
+            // cosyvoice3-voices.gguf (~665 KB) which crispasr --auto-download pulls on first
+            // synth. Once the LLM model finishes, we're done.
+            if (_downloadTaskCosyVoice3CrispAsrModels is { IsCompleted: true })
+            {
+                _timer.Stop();
+                _downloadTaskCosyVoice3CrispAsrModels = null;
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskCosyVoice3CrispAsrModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskCosyVoice3CrispAsrModels.Exception?.InnerException ?? _downloadTaskCosyVoice3CrispAsrModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
+
+            // F5-TTS mirrors IndexTTS: model first, then a voices ZIP from the shared
+            // qwen3-tts.cpp voice pack (same 24 kHz mono format F5-TTS wants).
+            if (_downloadTaskF5TtsCrispAsrModels is { IsCompleted: true })
+            {
+                _timer.Stop();
+                _downloadTaskF5TtsCrispAsrModels = null;
+
+                var voicesFolder = F5TtsCrispAsr.GetSetVoicesFolder();
+                var voicesAlreadyInstalled = Directory.Exists(voicesFolder)
+                    && Directory.EnumerateFiles(voicesFolder, "*.wav").Any();
+                if (voicesAlreadyInstalled)
+                {
+                    OkPressed = true;
+                    Close();
+                    return;
+                }
+
+                TitleText = "Downloading F5-TTS (CrispASR) voices";
+                ProgressValue = 0;
+                ProgressText = Se.Language.General.StartingDotDotDot;
+                var voicesProgress = new Progress<float>(number =>
+                {
+                    var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+                    var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+                    ProgressValue = percentage;
+                    ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+                });
+                _downloadTaskF5TtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
+                    _downloadStreamF5TtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
+                _timer.Start();
+            }
+            else if (_downloadTaskF5TtsCrispAsrModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskF5TtsCrispAsrModels.Exception?.InnerException ?? _downloadTaskF5TtsCrispAsrModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
+
+            if (_downloadTaskF5TtsCrispAsrVoices is { IsCompleted: true })
+            {
+                _timer.Stop();
+                if (_downloadStreamF5TtsCrispAsrVoices.Length > 0)
+                {
+                    var voicesFolder = F5TtsCrispAsr.GetSetVoicesFolder();
+                    try
+                    {
+                        _downloadStreamF5TtsCrispAsrVoices.Position = 0;
+                        _zipUnpacker.UnpackZipStream(_downloadStreamF5TtsCrispAsrVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        ResampleVoicesTo24kHz(voicesFolder);
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex);
+                    }
+                    _downloadStreamF5TtsCrispAsrVoices.Dispose();
+                }
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskF5TtsCrispAsrVoices is { IsFaulted: true })
+            {
+                _timer.Stop();
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                    return;
+                }
+                var ex = _downloadTaskF5TtsCrispAsrVoices.Exception?.InnerException ?? _downloadTaskF5TtsCrispAsrVoices.Exception;
+                if (ex != null) Se.LogError(ex);
+                OkPressed = true;
+                Close();
+            }
+
             if (_downloadTaskOmniVoice is { IsCompleted: true })
             {
                 _timer.Stop();
@@ -1334,6 +1454,52 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskIndexTtsCrispAsrModels =
             _indexTtsCrispAsrDownloadService.DownloadModels(IndexTtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadCosyVoice3CrispAsrModels(string? modelKey = null)
+    {
+        var resolved = CosyVoice3CrispAsr.ResolveModelKey(modelKey);
+        var llmFileName = CosyVoice3CrispAsr.GetLlmFileName(resolved);
+        TitleText = $"Downloading CosyVoice3 (CrispASR) model ({resolved}): {llmFileName}";
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskCosyVoice3CrispAsrModels =
+            _cosyVoice3CrispAsrDownloadService.DownloadModels(CosyVoice3CrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadF5TtsCrispAsrModels(string? modelKey = null)
+    {
+        var resolved = F5TtsCrispAsr.ResolveModelKey(modelKey);
+        var talkerFileName = F5TtsCrispAsr.GetTalkerFileName(resolved);
+        TitleText = $"Downloading F5-TTS (CrispASR) model ({resolved}): {talkerFileName}";
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskF5TtsCrispAsrModels =
+            _f5TtsCrispAsrDownloadService.DownloadModels(F5TtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadOmniVoice(string windowsVariant = OmniVoiceDownloadService.WindowsVariantVulkan)

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -806,11 +806,11 @@ public partial class DownloadTtsViewModel : ObservableObject
                 Close();
             }
 
-            // CosyVoice3 supports both baked presets (in cosyvoice3-voices.gguf, fetched by
-            // crispasr --auto-download) AND zero-shot cloning from user-supplied WAVs. After
-            // the LLM downloads, chain the qwen3-tts.cpp voice pack ZIP so the user has the
-            // shared reference voices available without a second manual download step. The
-            // baked presets are always usable regardless of this step.
+            // CosyVoice3 supports both baked presets (8 voices in cosyvoice3-voices.gguf, which
+            // CosyVoice3CrispAsrDownloadService stages with the rest of the bundle) AND zero-shot
+            // cloning from user-supplied 16 kHz WAVs. After the model bundle finishes, chain the
+            // qwen3-tts.cpp voice pack ZIP so the user has the shared reference WAVs available
+            // without a second manual download step. Baked presets work regardless of this step.
             if (_downloadTaskCosyVoice3CrispAsrModels is { IsCompleted: true })
             {
                 _timer.Stop();
@@ -1694,6 +1694,8 @@ public partial class DownloadTtsViewModel : ObservableObject
         DisposeQuietly(_downloadStreamQwen3TtsCrispAsrVoices);
         DisposeQuietly(_downloadStreamVibeVoiceCrispAsrVoices);
         DisposeQuietly(_downloadStreamIndexTtsCrispAsrVoices);
+        DisposeQuietly(_downloadStreamCosyVoice3CrispAsrVoices);
+        DisposeQuietly(_downloadStreamF5TtsCrispAsrVoices);
         DisposeQuietly(_downloadStreamOmniVoice);
         DisposeQuietly(_downloadStreamOmniVoices);
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -23,8 +23,13 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// Alibaba CosyVoice3 0.5B (Dec 2025 release) run through the CrispASR runtime. LLM + flow-matching DiT
 /// + HiFT vocoder architecture with 9 languages and 18 Mandarin dialects. Supports BOTH baked-in voice
 /// presets (8 entries in <c>cosyvoice3-voices.gguf</c>) AND zero-shot cloning from a user-supplied 16 kHz
-/// mono reference WAV. The s3tok speech tokenizer and CAMPPlus speaker encoder companion files do the
-/// cloning; crispasr's --auto-download pulls them on first synth alongside the voice bank.
+/// mono reference WAV (the s3tok speech tokenizer + CAMPPlus speaker encoder do the cloning).
+///
+/// The backend needs ALL of LLM + flow + hift + s3tok + campplus + voices co-located. crispasr's
+/// <c>--auto-download</c> only fetches companions when <c>-m auto</c> is also passed, so we stage every
+/// file ourselves in <c>CrispAsr/models/</c> and crispasr finds them as siblings of the LLM. The
+/// per-quant combos pair Q4_K LLM with Q8_0 flow / Q4_K s3tok (HF-recommended "minimum viable" combo,
+/// ~921 MB) or F16 LLM with F16 flow / F16 s3tok (~2.5 GB).
 ///
 /// When the user picks a baked preset, <c>--voice &lt;preset_name&gt;</c> is passed at server startup.
 /// When the user picks an imported WAV, <c>--voice /path/to/ref.wav --ref-text "transcription"</c>
@@ -52,17 +57,49 @@ public class CosyVoice3CrispAsr : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
 
-    // Two LLM quants — Q4_K is the lightweight default (~384 MB), F16 the reference (~1.29 GB).
-    // The flow/hift/s3tok/campplus/voices companion files (~360-665 MB) are fetched by crispasr
-    // --auto-download on first run; we don't stage them ourselves yet.
-    public const string ModelKeyQ4K = "Q4_K (~745 MB total)";
+    // Two LLM quants — Q4_K is the lightweight default (~921 MB total), F16 the reference (~2.5 GB).
+    // The label total covers every required companion (flow / hift / s3tok / campplus / voices).
+    public const string ModelKeyQ4K = "Q4_K (~921 MB total)";
     public const string ModelKeyF16 = "F16 (~2.5 GB total)";
     public const string DefaultModelKey = ModelKeyQ4K;
 
     public const string LlmQ4KFileName = "cosyvoice3-llm-q4_k.gguf";
     public const string LlmF16FileName = "cosyvoice3-llm-f16.gguf";
+    public const string FlowQ8_0FileName = "cosyvoice3-flow-q8_0.gguf";
+    public const string FlowF16FileName = "cosyvoice3-flow-f16.gguf";
+    public const string HiftF16FileName = "cosyvoice3-hift-f16.gguf";
+    public const string S3TokQ4KFileName = "cosyvoice3-s3tok-q4_k.gguf";
+    public const string S3TokF16FileName = "cosyvoice3-s3tok-f16.gguf";
+    public const string CampPlusF16FileName = "cosyvoice3-campplus-f16.gguf";
+    public const string VoicesGgufFileName = "cosyvoice3-voices.gguf";
 
     public const string BackendName = "cosyvoice3-tts";
+
+    /// <summary>
+    /// All filenames that must be present in <see cref="GetSetModelsFolder"/> for the chosen
+    /// quant. Listed in this order so the download dialog progresses through them deterministically.
+    /// </summary>
+    public static string[] GetRequiredFileNames(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyF16 => new[]
+        {
+            LlmF16FileName,
+            FlowF16FileName,
+            HiftF16FileName,
+            S3TokF16FileName,
+            CampPlusF16FileName,
+            VoicesGgufFileName,
+        },
+        _ => new[]
+        {
+            LlmQ4KFileName,
+            FlowQ8_0FileName,
+            HiftF16FileName,
+            S3TokQ4KFileName,
+            CampPlusF16FileName,
+            VoicesGgufFileName,
+        },
+    };
 
     // Preset voice names baked into cosyvoice3-voices.gguf. Reading these dynamically would require
     // either a running server (/v1/voices) or parsing the voices GGUF, neither of which is worth the
@@ -86,6 +123,13 @@ public class CosyVoice3CrispAsr : ITtsEngine
     {
         [LlmQ4KFileName] = 383891200L,
         [LlmF16FileName] = 1289653952L,
+        [FlowQ8_0FileName] = 360751936L,
+        [FlowF16FileName] = 665140992L,
+        [HiftF16FileName] = 41601888L,
+        [S3TokQ4KFileName] = 145258240L,
+        [S3TokF16FileName] = 484406944L,
+        [CampPlusF16FileName] = 14153600L,
+        [VoicesGgufFileName] = 665472L,
     };
 
     public static string ResolveModelKey(string? modelKey)
@@ -322,8 +366,18 @@ public class CosyVoice3CrispAsr : ITtsEngine
         }
     }
 
-    public static bool AreModelsInstalled(string? modelKey = null) =>
-        IsValidLocalModelFile(GetLlmPath(modelKey), GetLlmFileName(modelKey));
+    public static bool AreModelsInstalled(string? modelKey = null)
+    {
+        var modelsFolder = GetSetModelsFolder();
+        foreach (var name in GetRequiredFileNames(modelKey))
+        {
+            if (!IsValidLocalModelFile(Path.Combine(modelsFolder, name), name))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
 
     public Task<Voice[]> GetVoices(string language)
     {
@@ -560,12 +614,15 @@ public class CosyVoice3CrispAsr : ITtsEngine
                     "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
             }
 
-            // LLM is the only file we stage locally. Flow / HiFT / S3 tokenizer / CAMPPlus /
-            // voices.gguf are fetched by crispasr --auto-download into ~/.cache/crispasr/ on
-            // first run. Always pass --auto-download so a missing companion never bricks startup.
+            // crispasr's cosyvoice3-tts backend needs LLM + flow + hift + s3tok + campplus +
+            // voices co-located as siblings of the LLM. We stage every file via SE's download
+            // service into CrispAsr/models/, so when all are present we don't need
+            // --auto-download. If any required file is missing, fall back to -m auto +
+            // --auto-download which makes crispasr fetch the whole bundle into its own cache
+            // (slower, no SE progress bar — happens silently behind the synth call).
             var llmFileName = GetLlmFileName(modelKey);
             var llmPath = GetLlmPath(modelKey);
-            var hasLocalLlm = IsValidLocalModelFile(llmPath, llmFileName);
+            var allLocal = AreModelsInstalled(modelKey);
 
             var port = FindFreeLoopbackPort();
             var psi = new ProcessStartInfo
@@ -581,11 +638,11 @@ public class CosyVoice3CrispAsr : ITtsEngine
             psi.ArgumentList.Add("--backend");
             psi.ArgumentList.Add(BackendName);
             psi.ArgumentList.Add("-m");
-            psi.ArgumentList.Add(hasLocalLlm ? llmPath : "auto");
-            // CosyVoice3 needs ~5 companion files alongside the LLM. We don't stage them, so
-            // --auto-download is always required to pull whichever ones aren't already in the
-            // crispasr cache. Idempotent when everything is present.
-            psi.ArgumentList.Add("--auto-download");
+            psi.ArgumentList.Add(allLocal ? llmPath : "auto");
+            if (!allLocal)
+            {
+                psi.ArgumentList.Add("--auto-download");
+            }
             psi.ArgumentList.Add("--host");
             psi.ArgumentList.Add("127.0.0.1");
             psi.ArgumentList.Add("--port");
@@ -636,8 +693,9 @@ public class CosyVoice3CrispAsr : ITtsEngine
             _serverRefText = refText;
             HookProcessExitOnce();
 
-            // First-run auto-download (~745 MB minimum, ~2.5 GB for F16) needs a generous timeout.
-            var deadline = DateTime.UtcNow.AddMinutes(hasLocalLlm ? 10 : 30);
+            // Local startup is fast; first-run --auto-download (~921 MB minimum, ~2.5 GB for F16)
+            // needs a generous timeout for the silent companion fetch behind -m auto.
+            var deadline = DateTime.UtcNow.AddMinutes(allLocal ? 5 : 30);
             while (DateTime.UtcNow < deadline)
             {
                 ct.ThrowIfCancellationRequested();
@@ -667,7 +725,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
             var timeoutLaunchCommand = _serverLaunchCommand;
             StopServerInternal();
             throw new TimeoutException(
-                $"crispasr (cosyvoice3-tts) did not report healthy within {(hasLocalLlm ? 10 : 30)} minutes. Last output: {lastOutput}"
+                $"crispasr (cosyvoice3-tts) did not report healthy within {(allLocal ? 5 : 30)} minutes. Last output: {lastOutput}"
                 + LaunchCmdSuffix(timeoutLaunchCommand));
         }
         finally

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -27,9 +27,12 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 ///
 /// The backend needs ALL of LLM + flow + hift + s3tok + campplus + voices co-located. crispasr's
 /// <c>--auto-download</c> only fetches companions when <c>-m auto</c> is also passed, so we stage every
-/// file ourselves in <c>CrispAsr/models/</c> and crispasr finds them as siblings of the LLM. The
-/// per-quant combos pair Q4_K LLM with Q8_0 flow / Q4_K s3tok (HF-recommended "minimum viable" combo,
-/// ~921 MB) or F16 LLM with F16 flow / F16 s3tok (~2.5 GB).
+/// file ourselves in <c>CrispAsr/models/</c> and crispasr finds them as siblings of the LLM.
+///
+/// Sibling discovery in CrispASR 0.6.12 looks for the F16 companion filenames specifically
+/// (<c>cosyvoice3-flow-f16.gguf</c>, <c>cosyvoice3-s3tok-f16.gguf</c>) — passing the Q8_0 / Q4_K
+/// variants instead trips a "no flow GGUF found" startup error even with --codec-model. Both quants
+/// therefore share the F16 companions; only the LLM differs (Q4_K ~1.6 GB total, F16 ~2.5 GB).
 ///
 /// When the user picks a baked preset, <c>--voice &lt;preset_name&gt;</c> is passed at server startup.
 /// When the user picks an imported WAV, <c>--voice /path/to/ref.wav --ref-text "transcription"</c>
@@ -57,18 +60,16 @@ public class CosyVoice3CrispAsr : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
 
-    // Two LLM quants — Q4_K is the lightweight default (~921 MB total), F16 the reference (~2.5 GB).
+    // Two LLM quants — Q4_K is the lightweight default (~1.6 GB total), F16 the reference (~2.5 GB).
     // The label total covers every required companion (flow / hift / s3tok / campplus / voices).
-    public const string ModelKeyQ4K = "Q4_K (~921 MB total)";
+    public const string ModelKeyQ4K = "Q4_K (~1.6 GB total)";
     public const string ModelKeyF16 = "F16 (~2.5 GB total)";
     public const string DefaultModelKey = ModelKeyQ4K;
 
     public const string LlmQ4KFileName = "cosyvoice3-llm-q4_k.gguf";
     public const string LlmF16FileName = "cosyvoice3-llm-f16.gguf";
-    public const string FlowQ8_0FileName = "cosyvoice3-flow-q8_0.gguf";
     public const string FlowF16FileName = "cosyvoice3-flow-f16.gguf";
     public const string HiftF16FileName = "cosyvoice3-hift-f16.gguf";
-    public const string S3TokQ4KFileName = "cosyvoice3-s3tok-q4_k.gguf";
     public const string S3TokF16FileName = "cosyvoice3-s3tok-f16.gguf";
     public const string CampPlusF16FileName = "cosyvoice3-campplus-f16.gguf";
     public const string VoicesGgufFileName = "cosyvoice3-voices.gguf";
@@ -77,28 +78,17 @@ public class CosyVoice3CrispAsr : ITtsEngine
 
     /// <summary>
     /// All filenames that must be present in <see cref="GetSetModelsFolder"/> for the chosen
-    /// quant. Listed in this order so the download dialog progresses through them deterministically.
+    /// quant. Both quants share the F16 companion set — only the LLM differs. Listed in this
+    /// order so the download dialog progresses through them deterministically.
     /// </summary>
-    public static string[] GetRequiredFileNames(string? modelKey) => ResolveModelKey(modelKey) switch
+    public static string[] GetRequiredFileNames(string? modelKey) => new[]
     {
-        ModelKeyF16 => new[]
-        {
-            LlmF16FileName,
-            FlowF16FileName,
-            HiftF16FileName,
-            S3TokF16FileName,
-            CampPlusF16FileName,
-            VoicesGgufFileName,
-        },
-        _ => new[]
-        {
-            LlmQ4KFileName,
-            FlowQ8_0FileName,
-            HiftF16FileName,
-            S3TokQ4KFileName,
-            CampPlusF16FileName,
-            VoicesGgufFileName,
-        },
+        ResolveModelKey(modelKey) == ModelKeyF16 ? LlmF16FileName : LlmQ4KFileName,
+        FlowF16FileName,
+        HiftF16FileName,
+        S3TokF16FileName,
+        CampPlusF16FileName,
+        VoicesGgufFileName,
     };
 
     // Preset voice names baked into cosyvoice3-voices.gguf. Reading these dynamically would require
@@ -123,10 +113,8 @@ public class CosyVoice3CrispAsr : ITtsEngine
     {
         [LlmQ4KFileName] = 383891200L,
         [LlmF16FileName] = 1289653952L,
-        [FlowQ8_0FileName] = 360751936L,
         [FlowF16FileName] = 665140992L,
         [HiftF16FileName] = 41601888L,
-        [S3TokQ4KFileName] = 145258240L,
         [S3TokF16FileName] = 484406944L,
         [CampPlusF16FileName] = 14153600L,
         [VoicesGgufFileName] = 665472L,

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -25,9 +25,11 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// presets (8 entries in <c>cosyvoice3-voices.gguf</c>) AND zero-shot cloning from a user-supplied 16 kHz
 /// mono reference WAV (the s3tok speech tokenizer + CAMPPlus speaker encoder do the cloning).
 ///
-/// The backend needs ALL of LLM + flow + hift + s3tok + campplus + voices co-located. crispasr's
-/// <c>--auto-download</c> only fetches companions when <c>-m auto</c> is also passed, so we stage every
-/// file ourselves in <c>CrispAsr/models/</c> and crispasr finds them as siblings of the LLM.
+/// The backend needs ALL of LLM + flow + hift + s3tok + campplus + voices co-located as siblings of
+/// the LLM. <see cref="Nikse.SubtitleEdit.Logic.Download.CosyVoice3CrispAsrDownloadService"/> stages
+/// every required GGUF into <c>CrispAsr/models/</c> with size + SHA-256 verification before first
+/// synth — crispasr's own <c>--auto-download</c> only fires when <c>-m auto</c> is passed, which is
+/// the slower fallback we keep for the case where any required file is missing at startup.
 ///
 /// Sibling discovery in CrispASR 0.6.12 looks for the F16 companion filenames specifically
 /// (<c>cosyvoice3-flow-f16.gguf</c>, <c>cosyvoice3-s3tok-f16.gguf</c>) — passing the Q8_0 / Q4_K

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -769,7 +769,15 @@ public class CosyVoice3CrispAsr : ITtsEngine
         return candidate;
     }
 
-    public bool ImportVoice(string fileName)
+    public bool ImportVoice(string fileName) => ImportVoice(fileName, string.Empty);
+
+    /// <summary>
+    /// Imports <paramref name="fileName"/> as a CosyVoice3 zero-shot reference voice. When
+    /// <paramref name="transcript"/> is non-empty it's written to the destination .txt sidecar
+    /// directly (the s3tok tokenizer requires it). When empty, falls back to copying any .txt
+    /// sidecar that already lives next to the source WAV.
+    /// </summary>
+    public bool ImportVoice(string fileName, string transcript)
     {
         if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
         {
@@ -803,17 +811,20 @@ public class CosyVoice3CrispAsr : ITtsEngine
             return false;
         }
 
-        // Zero-shot cloning requires an accurate transcription. If the source had a .txt
-        // sidecar (same basename), copy it alongside the imported WAV. Best-effort — the WAV
-        // alone is unusable for cloning (Speak surfaces a clear error in that case), but the
-        // import itself succeeds so the user can add the sidecar manually after the fact.
+        // Zero-shot cloning requires an accurate transcription. Caller-supplied transcript
+        // wins; otherwise fall back to a sibling .txt next to the source WAV. Either way the
+        // sidecar gets written to the destination folder so the engine can read it back later.
         try
         {
-            var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
-            if (File.Exists(sourceSidecar))
+            var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+            if (!string.IsNullOrWhiteSpace(transcript))
             {
-                var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
-                if (!File.Exists(destSidecar))
+                File.WriteAllText(destSidecar, transcript.Trim());
+            }
+            else
+            {
+                var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+                if (File.Exists(sourceSidecar) && !File.Exists(destSidecar))
                 {
                     File.Copy(sourceSidecar, destSidecar);
                 }
@@ -821,9 +832,35 @@ public class CosyVoice3CrispAsr : ITtsEngine
         }
         catch (Exception ex)
         {
-            Se.LogError(ex, "CosyVoice3 (CrispASR) voice import: failed to copy .txt sidecar");
+            Se.LogError(ex, "CosyVoice3 (CrispASR) voice import: failed to write .txt sidecar");
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Writes <paramref name="transcript"/> to <c>&lt;voice&gt;.txt</c> next to the supplied
+    /// voice WAV inside the voices folder. Used to retro-fit a transcription onto a voice
+    /// that was already imported (or seeded from the qwen3-tts.cpp pack) without going through
+    /// a full re-import. Returns false on IO failure.
+    /// </summary>
+    public static bool TryWriteRefTextSidecar(string voiceWavPath, string transcript)
+    {
+        if (string.IsNullOrEmpty(voiceWavPath) || string.IsNullOrWhiteSpace(transcript))
+        {
+            return false;
+        }
+
+        try
+        {
+            var sidecar = Path.ChangeExtension(voiceWavPath, ".txt");
+            File.WriteAllText(sidecar, transcript.Trim());
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"CosyVoice3 (CrispASR): failed to write ref-text sidecar for '{voiceWavPath}'");
+            return false;
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -3,10 +3,12 @@ using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
@@ -19,10 +21,14 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
 /// <summary>
 /// Alibaba CosyVoice3 0.5B (Dec 2025 release) run through the CrispASR runtime. LLM + flow-matching DiT
-/// + HiFT vocoder architecture with 9 languages and 18 Mandarin dialects. Unlike VibeVoice/IndexTTS which
-/// clone from a user-supplied reference WAV, CosyVoice3 uses a BAKED-IN voice bank shipped in
-/// <c>cosyvoice3-voices.gguf</c> (~665 KB). The user picks a preset name (e.g. "fleurs-en", "zero_shot");
-/// crispasr loads the voice bank at server startup via the <c>--voice &lt;name&gt;</c> flag.
+/// + HiFT vocoder architecture with 9 languages and 18 Mandarin dialects. Supports BOTH baked-in voice
+/// presets (8 entries in <c>cosyvoice3-voices.gguf</c>) AND zero-shot cloning from a user-supplied 16 kHz
+/// mono reference WAV. The s3tok speech tokenizer and CAMPPlus speaker encoder companion files do the
+/// cloning; crispasr's --auto-download pulls them on first synth alongside the voice bank.
+///
+/// When the user picks a baked preset, <c>--voice &lt;preset_name&gt;</c> is passed at server startup.
+/// When the user picks an imported WAV, <c>--voice /path/to/ref.wav --ref-text "transcription"</c>
+/// is passed — both must be in place for cloning to work (no transcription → noisy output).
 ///
 /// The repo on Hugging Face (cstr/cosyvoice3-0.5b-2512-GGUF) ships ~5 companion files:
 ///   - LLM           : cosyvoice3-llm-{q4_k,f16}.gguf  (we manage this)
@@ -134,9 +140,11 @@ public class CosyVoice3CrispAsr : ITtsEngine
     private static int _serverPort;
     private static string? _serverLaunchCommand;
     private static string? _serverModelKey;
-    // CosyVoice3 takes the active preset via --voice at startup (like IndexTTS), so a preset
-    // change requires teardown + restart. Tracked here so a no-op restart is avoided.
-    private static string? _serverPreset;
+    // CosyVoice3 takes the active voice via --voice at startup (either a preset name or a
+    // reference WAV path). For cloned voices --ref-text is also baked in at startup. Any
+    // change to either triggers a teardown + restart — same trade-off IndexTTS made.
+    private static string? _serverVoiceArg;
+    private static string? _serverRefText;
     private static bool _processExitHooked;
     private static readonly StringBuilder _serverLog = new();
 
@@ -195,6 +203,88 @@ public class CosyVoice3CrispAsr : ITtsEngine
         return modelsFolder;
     }
 
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        return voicesFolder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder.
+    /// CosyVoice3 clones at 16 kHz mono and requires a transcription sidecar, same shape as
+    /// Qwen3 CustomVoice — so we resample to 16 kHz on seed and copy the .txt sidecar too.
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+
+                if (!File.Exists(dest))
+                {
+                    try
+                    {
+                        var ffmpeg = FfmpegGenerator.ConvertToMono16kHzWav(src, dest);
+                        if (!ffmpeg.Start())
+                        {
+                            File.Copy(src, dest);
+                        }
+                        else
+                        {
+                            ffmpeg.WaitForExit();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex, $"CosyVoice3 (CrispASR): resample seed '{src}' failed; falling back to plain copy");
+                        try { if (!File.Exists(dest)) File.Copy(src, dest); } catch { }
+                    }
+                }
+
+                var sidecar = Path.ChangeExtension(src, ".txt");
+                if (File.Exists(sidecar))
+                {
+                    var sidecarDest = Path.ChangeExtension(dest, ".txt");
+                    if (!File.Exists(sidecarDest))
+                    {
+                        try { File.Copy(sidecar, sidecarDest); } catch { }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "CosyVoice3 (CrispASR): voice seeding from qwen3-tts.cpp folder failed");
+        }
+    }
+
     public static string GetLlmPath(string? modelKey = null) =>
         Path.Combine(GetSetModelsFolder(), GetLlmFileName(modelKey));
 
@@ -238,11 +328,40 @@ public class CosyVoice3CrispAsr : ITtsEngine
     public Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
+
+        // Baked-in presets come first so the combo opens on a working default. Imported WAVs
+        // (zero-shot clones) follow — they need a .txt sidecar with the transcription or the
+        // server returns noise.
         foreach (var (display, preset) in Presets)
         {
             result.Add(new Voice(new CosyVoice3Voice(display, preset)));
         }
+
+        var voicesFolder = GetSetVoicesFolder();
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                var refText = TryReadRefText(file);
+                result.Add(new Voice(new CosyVoice3Voice(name, file, refText)));
+            }
+        }
+
         return Task.FromResult(result.ToArray());
+    }
+
+    private static string TryReadRefText(string wavPath)
+    {
+        try
+        {
+            var sidecar = Path.ChangeExtension(wavPath, ".txt");
+            return File.Exists(sidecar) ? File.ReadAllText(sidecar).Trim() : string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
     }
 
     public bool IsVoiceInstalled(Voice voice) => true;
@@ -270,14 +389,28 @@ public class CosyVoice3CrispAsr : ITtsEngine
             throw new ArgumentException("Voice is not a CosyVoice3Voice");
         }
 
-        if (string.IsNullOrEmpty(cosyVoice.Preset))
+        // Either Preset OR FilePath must be set. Preset wins if both are populated (defensive
+        // — shouldn't happen with the constructors but guards against future drift).
+        var voiceArg = !string.IsNullOrEmpty(cosyVoice.Preset) ? cosyVoice.Preset : cosyVoice.FilePath;
+        if (string.IsNullOrEmpty(voiceArg))
         {
             throw new InvalidOperationException(
-                "CosyVoice3 (CrispASR) requires a preset. Pick one of the FLEURS-* voices or zero_shot.");
+                "CosyVoice3 (CrispASR) requires a preset or an imported reference WAV. "
+                + "Pick one of the baked presets (zero_shot / fleurs-*) or import a 16 kHz mono "
+                + "reference WAV with an adjacent .txt transcription sidecar.");
+        }
+
+        var isClone = string.IsNullOrEmpty(cosyVoice.Preset);
+        if (isClone && string.IsNullOrEmpty(cosyVoice.RefText))
+        {
+            throw new InvalidOperationException(
+                $"CosyVoice3 (CrispASR) zero-shot cloning requires a transcription. "
+                + $"Add a .txt sidecar next to '{Path.GetFileName(cosyVoice.FilePath)}' with the "
+                + "spoken text of the reference WAV.");
         }
 
         var modelKey = ResolveModelKey(model);
-        await EnsureServerRunningAsync(modelKey, cosyVoice.Preset, cancellationToken);
+        await EnsureServerRunningAsync(modelKey, voiceArg, cosyVoice.RefText, cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
 
@@ -286,13 +419,21 @@ public class CosyVoice3CrispAsr : ITtsEngine
         {
             ["input"] = text,
             ["response_format"] = "wav",
-            ["voice"] = cosyVoice.Preset,
+            ["voice"] = voiceArg,
             ["speed"] = speed,
         };
+        if (isClone)
+        {
+            // ref_text mirrors the F5-TTS payload guess. CosyVoice3's voice + ref_text are
+            // baked at server startup (see EnsureServerRunningAsync) so this field is mostly
+            // informational, but we send it for logging + future server versions that read it
+            // per-request.
+            payload["ref_text"] = cosyVoice.RefText;
+        }
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"CosyVoice3 (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (preset={cosyVoice.Preset}, textLen={text.Length})");
+        Se.WriteToolsLog($"CosyVoice3 (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={cosyVoice}, clone={isClone}, refTextLen={cosyVoice.RefText.Length}, textLen={text.Length})");
 
         HttpResponseMessage response;
         try
@@ -309,7 +450,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
                 StopServerInternal();
             }
 
-            var failMsg = $"CosyVoice3 (CrispASR) request failed — Preset: {cosyVoice.Preset}, Text: {text}, "
+            var failMsg = $"CosyVoice3 (CrispASR) request failed — Voice: {cosyVoice}, Text: {text}, "
                 + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
                 + LaunchCmdSuffix(launchCommand);
             Se.LogError(ex, failMsg);
@@ -332,7 +473,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
                 var serverLog = SnapshotServerLog();
                 var launchCommand = _serverLaunchCommand;
                 var errMsg = $"CosyVoice3 (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
-                    + $"Preset: {cosyVoice.Preset}, Text: {text}, RequestJson: {body}, "
+                    + $"Voice: {cosyVoice}, Text: {text}, RequestJson: {body}, "
                     + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
                     + LaunchCmdSuffix(launchCommand);
                 Se.LogError(errMsg);
@@ -383,11 +524,18 @@ public class CosyVoice3CrispAsr : ITtsEngine
         }
     }
 
-    private static async Task EnsureServerRunningAsync(string modelKey, string preset, CancellationToken ct)
+    private static async Task EnsureServerRunningAsync(string modelKey, string voiceArg, string refText, CancellationToken ct)
     {
-        if (_serverProcess is { HasExited: false } && _serverPort != 0
+        // Server is keyed by (model, voice, ref-text) since all three are baked in at process
+        // start. A switch from preset → clone, clone → different clone, or refText edit all
+        // require a fresh server.
+        bool MatchesCurrent() =>
+            _serverProcess is { HasExited: false } && _serverPort != 0
             && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(_serverPreset, preset, StringComparison.OrdinalIgnoreCase))
+            && string.Equals(_serverVoiceArg, voiceArg, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverRefText, refText, StringComparison.Ordinal);
+
+        if (MatchesCurrent())
         {
             return;
         }
@@ -395,9 +543,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
         await ServerLock.WaitAsync(ct);
         try
         {
-            if (_serverProcess is { HasExited: false } && _serverPort != 0
-                && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(_serverPreset, preset, StringComparison.OrdinalIgnoreCase))
+            if (MatchesCurrent())
             {
                 return;
             }
@@ -444,10 +590,23 @@ public class CosyVoice3CrispAsr : ITtsEngine
             psi.ArgumentList.Add("127.0.0.1");
             psi.ArgumentList.Add("--port");
             psi.ArgumentList.Add(port.ToString());
-            // Preset is baked in at startup (like IndexTTS's --voice). Changing presets means
-            // teardown + restart of the server — handled by the (modelKey, preset) cache key.
+
+            // --voice-dir lets the server resolve relative WAV filenames against our voices
+            // folder. Doesn't hurt for preset-based voices (the preset name short-circuits the
+            // filesystem lookup).
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+
+            // Voice arg is either a baked preset name ("zero_shot", "fleurs-en", ...) or an
+            // absolute path to an imported reference WAV. For WAV clones --ref-text carries
+            // the spoken transcription; required by the s3tok speech tokenizer.
             psi.ArgumentList.Add("--voice");
-            psi.ArgumentList.Add(preset);
+            psi.ArgumentList.Add(voiceArg);
+            if (!string.IsNullOrEmpty(refText))
+            {
+                psi.ArgumentList.Add("--ref-text");
+                psi.ArgumentList.Add(refText);
+            }
 
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start crispasr (cosyvoice3-tts)");
@@ -473,7 +632,8 @@ public class CosyVoice3CrispAsr : ITtsEngine
             _serverProcess = process;
             _serverPort = port;
             _serverModelKey = modelKey;
-            _serverPreset = preset;
+            _serverVoiceArg = voiceArg;
+            _serverRefText = refText;
             HookProcessExitOnce();
 
             // First-run auto-download (~745 MB minimum, ~2.5 GB for F16) needs a generous timeout.
@@ -490,7 +650,8 @@ public class CosyVoice3CrispAsr : ITtsEngine
                     _serverPort = 0;
                     _serverLaunchCommand = null;
                     _serverModelKey = null;
-                    _serverPreset = null;
+                    _serverVoiceArg = null;
+                    _serverRefText = null;
                     throw new InvalidOperationException(
                         $"crispasr (cosyvoice3-tts) exited during startup (code {exitCode}). Output: {tail}"
                         + LaunchCmdSuffix(exitedLaunchCommand));
@@ -569,7 +730,8 @@ public class CosyVoice3CrispAsr : ITtsEngine
         _serverPort = 0;
         _serverLaunchCommand = null;
         _serverModelKey = null;
-        _serverPreset = null;
+        _serverVoiceArg = null;
+        _serverRefText = null;
         if (p == null) return;
         try
         {
@@ -589,8 +751,79 @@ public class CosyVoice3CrispAsr : ITtsEngine
         }
     }
 
-    // CosyVoice3 uses baked-in voice presets shipped in cosyvoice3-voices.gguf; there's no
-    // user-supplied reference WAV to import. Stay false so the UI hides the "Import voice"
-    // affordance for this engine.
-    public bool ImportVoice(string fileName) => false;
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // CosyVoice3's s3tok speech tokenizer expects 16 kHz mono — resample on import so the
+        // server doesn't have to upsample / convert on every synth call.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono16kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "CosyVoice3 (CrispASR) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        if (!File.Exists(destinationFileName))
+        {
+            return false;
+        }
+
+        // Zero-shot cloning requires an accurate transcription. If the source had a .txt
+        // sidecar (same basename), copy it alongside the imported WAV. Best-effort — the WAV
+        // alone is unusable for cloning (Speak surfaces a clear error in that case), but the
+        // import itself succeeds so the user can add the sidecar manually after the fact.
+        try
+        {
+            var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+            if (File.Exists(sourceSidecar))
+            {
+                var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+                if (!File.Exists(destSidecar))
+                {
+                    File.Copy(sourceSidecar, destSidecar);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "CosyVoice3 (CrispASR) voice import: failed to copy .txt sidecar");
+        }
+
+        return true;
+    }
 }

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -1,0 +1,596 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Alibaba CosyVoice3 0.5B (Dec 2025 release) run through the CrispASR runtime. LLM + flow-matching DiT
+/// + HiFT vocoder architecture with 9 languages and 18 Mandarin dialects. Unlike VibeVoice/IndexTTS which
+/// clone from a user-supplied reference WAV, CosyVoice3 uses a BAKED-IN voice bank shipped in
+/// <c>cosyvoice3-voices.gguf</c> (~665 KB). The user picks a preset name (e.g. "fleurs-en", "zero_shot");
+/// crispasr loads the voice bank at server startup via the <c>--voice &lt;name&gt;</c> flag.
+///
+/// The repo on Hugging Face (cstr/cosyvoice3-0.5b-2512-GGUF) ships ~5 companion files:
+///   - LLM           : cosyvoice3-llm-{q4_k,f16}.gguf  (we manage this)
+///   - Flow          : cosyvoice3-flow-{q8_0,f16}.gguf  (crispasr --auto-download)
+///   - HiFT vocoder  : cosyvoice3-hift-f16.gguf         (crispasr --auto-download)
+///   - S3 tokenizer  : cosyvoice3-s3tok-{q4_k,f16}.gguf (crispasr --auto-download)
+///   - CAMPPlus      : cosyvoice3-campplus-f16.gguf     (crispasr --auto-download)
+///   - Voice bank    : cosyvoice3-voices.gguf           (crispasr --auto-download)
+///
+/// First-pass integration only stages the LLM file in SE's CrispASR/models folder; the rest are
+/// fetched lazily by <c>--auto-download</c> into <c>~/.cache/crispasr/</c> on first synth. Keeping
+/// a single primary file mirrors VibeVoice's layout and avoids a 6-file download-progress UI.
+/// </summary>
+public class CosyVoice3CrispAsr : ITtsEngine
+{
+    public string Name => "CosyVoice3 (CrispASR)";
+    public string Description => "Alibaba CosyVoice3 0.5B with 9 languages + 18 zh dialects, via CrispASR";
+    public bool HasLanguageParameter => false;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+
+    // Two LLM quants — Q4_K is the lightweight default (~384 MB), F16 the reference (~1.29 GB).
+    // The flow/hift/s3tok/campplus/voices companion files (~360-665 MB) are fetched by crispasr
+    // --auto-download on first run; we don't stage them ourselves yet.
+    public const string ModelKeyQ4K = "Q4_K (~745 MB total)";
+    public const string ModelKeyF16 = "F16 (~2.5 GB total)";
+    public const string DefaultModelKey = ModelKeyQ4K;
+
+    public const string LlmQ4KFileName = "cosyvoice3-llm-q4_k.gguf";
+    public const string LlmF16FileName = "cosyvoice3-llm-f16.gguf";
+
+    public const string BackendName = "cosyvoice3-tts";
+
+    // Preset voice names baked into cosyvoice3-voices.gguf. Reading these dynamically would require
+    // either a running server (/v1/voices) or parsing the voices GGUF, neither of which is worth the
+    // complexity for a static list that only changes when cstr re-uploads the voice bank.
+    public static readonly (string Display, string Preset)[] Presets =
+    {
+        ("Zero-shot (Mandarin)",   "zero_shot"),
+        ("FLEURS English",         "fleurs-en"),
+        ("FLEURS German",          "fleurs-de"),
+        ("FLEURS Mandarin",        "fleurs-zh"),
+        ("FLEURS Japanese",        "fleurs-ja"),
+        ("FLEURS French",          "fleurs-fr"),
+        ("FLEURS Spanish",         "fleurs-es"),
+        ("FLEURS Korean",          "fleurs-ko"),
+    };
+
+    // Exact byte sizes from the HF tree API (size field, == on-disk bytes). Same truncation
+    // guard as VibeVoice/IndexTTS — a partial file would otherwise crash the loader at server
+    // startup with an opaque access violation.
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [LlmQ4KFileName] = 383891200L,
+        [LlmF16FileName] = 1289653952L,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return modelKey switch
+        {
+            ModelKeyF16 => ModelKeyF16,
+            _ => ModelKeyQ4K,
+        };
+    }
+
+    public static string GetLlmFileName(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyF16 => LlmF16FileName,
+        _ => LlmQ4KFileName,
+    };
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            return new FileInfo(path).Length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(5),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    private static string? _serverModelKey;
+    // CosyVoice3 takes the active preset via --voice at startup (like IndexTTS), so a preset
+    // change requires teardown + restart. Tracked here so a no-op restart is avoided.
+    private static string? _serverPreset;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "CosyVoice3CrispAsr");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        var modelsFolder = Path.Combine(Se.CrispAsrFolder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetLlmPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetLlmFileName(modelKey));
+
+    public static string GetCrispAsrCacheFolder() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "crispasr");
+
+    public static bool TrySeedModelFromCrispAsrCache(string fileName, string destinationPath)
+    {
+        if (IsValidLocalModelFile(destinationPath, fileName))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (File.Exists(destinationPath))
+            {
+                Se.LogError($"CosyVoice3 (CrispASR): removing wrong-sized local model file {destinationPath}");
+                File.Delete(destinationPath);
+            }
+
+            var cachePath = Path.Combine(GetCrispAsrCacheFolder(), fileName);
+            if (!IsValidLocalModelFile(cachePath, fileName))
+            {
+                return false;
+            }
+
+            File.Copy(cachePath, destinationPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"CosyVoice3 (CrispASR): cache seed copy failed for {fileName}");
+            return false;
+        }
+    }
+
+    public static bool AreModelsInstalled(string? modelKey = null) =>
+        IsValidLocalModelFile(GetLlmPath(modelKey), GetLlmFileName(modelKey));
+
+    public Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>();
+        foreach (var (display, preset) in Presets)
+        {
+            result.Add(new Voice(new CosyVoice3Voice(display, preset)));
+        }
+        return Task.FromResult(result.ToArray());
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyF16 });
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not CosyVoice3Voice cosyVoice)
+        {
+            throw new ArgumentException("Voice is not a CosyVoice3Voice");
+        }
+
+        if (string.IsNullOrEmpty(cosyVoice.Preset))
+        {
+            throw new InvalidOperationException(
+                "CosyVoice3 (CrispASR) requires a preset. Pick one of the FLEURS-* voices or zero_shot.");
+        }
+
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, cosyVoice.Preset, cancellationToken);
+
+        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+
+        var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed, 0.25, 4.0);
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+            ["voice"] = cosyVoice.Preset,
+            ["speed"] = speed,
+        };
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"CosyVoice3 (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (preset={cosyVoice.Preset}, textLen={text.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"CosyVoice3 (CrispASR) request failed — Preset: {cosyVoice.Preset}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "CosyVoice3 (CrispASR) — the crispasr server crashed during synthesis."
+                    : "CosyVoice3 (CrispASR) request failed — the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"CosyVoice3 (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Preset: {cosyVoice.Preset}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"CosyVoice3 (CrispASR) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string preset, CancellationToken ct)
+    {
+        if (_serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverPreset, preset, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0
+                && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(_serverPreset, preset, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            // LLM is the only file we stage locally. Flow / HiFT / S3 tokenizer / CAMPPlus /
+            // voices.gguf are fetched by crispasr --auto-download into ~/.cache/crispasr/ on
+            // first run. Always pass --auto-download so a missing companion never bricks startup.
+            var llmFileName = GetLlmFileName(modelKey);
+            var llmPath = GetLlmPath(modelKey);
+            var hasLocalLlm = IsValidLocalModelFile(llmPath, llmFileName);
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(BackendName);
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(hasLocalLlm ? llmPath : "auto");
+            // CosyVoice3 needs ~5 companion files alongside the LLM. We don't stage them, so
+            // --auto-download is always required to pull whichever ones aren't already in the
+            // crispasr cache. Idempotent when everything is present.
+            psi.ArgumentList.Add("--auto-download");
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString());
+            // Preset is baked in at startup (like IndexTTS's --voice). Changing presets means
+            // teardown + restart of the server — handled by the (modelKey, preset) cache key.
+            psi.ArgumentList.Add("--voice");
+            psi.ArgumentList.Add(preset);
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (cosyvoice3-tts)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog("CosyVoice3 (CrispASR) server starting — "
+                + $"PID: {process.Id}, "
+                + $"Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelKey = modelKey;
+            _serverPreset = preset;
+            HookProcessExitOnce();
+
+            // First-run auto-download (~745 MB minimum, ~2.5 GB for F16) needs a generous timeout.
+            var deadline = DateTime.UtcNow.AddMinutes(hasLocalLlm ? 10 : 30);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverModelKey = null;
+                    _serverPreset = null;
+                    throw new InvalidOperationException(
+                        $"crispasr (cosyvoice3-tts) exited during startup (code {exitCode}). Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (cosyvoice3-tts) did not report healthy within {(hasLocalLlm ? 10 : 30)} minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked) return;
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverModelKey = null;
+        _serverPreset = null;
+        if (p == null) return;
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    // CosyVoice3 uses baked-in voice presets shipped in cosyvoice3-voices.gguf; there's no
+    // user-supplied reference WAV to import. Stay false so the UI hides the "Import voice"
+    // affordance for this engine.
+    public bool ImportVoice(string fileName) => false;
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -55,11 +55,12 @@ public class F5TtsCrispAsr : ITtsEngine
 
     public const string BackendName = "f5-tts";
 
-    // TODO: confirm whether F5-TTS in CrispASR 0.6.12 reads voice/ref-text from the request
-    // payload (like VibeVoice/Qwen3) or only from startup CLI flags (like IndexTTS 0.6.11).
-    // If the per-request approach silently ignores the field, flip this to true and the
-    // server will be (re)started whenever the voice changes — same trade-off IndexTTS made.
-    private static readonly bool UseStartupVoiceFlags = false;
+    // Confirmed against CrispASR 0.6.12: the f5-tts backend ignores the per-request `voice`
+    // field and only reads the reference audio from the startup --voice flag (the server log
+    // shows `ref_T=0 duration=0` and an "empty audio" 500 otherwise). Same upstream behaviour
+    // as IndexTTS 0.6.11 — server gets torn down and restarted when the voice or ref-text
+    // changes, keyed by (model, voice, ref-text) below.
+    private static readonly bool UseStartupVoiceFlags = true;
 
     // Exact byte size from the HF tree API (cstr/f5-tts-GGUF). Same truncation guard as the
     // other CrispASR TTS engines — a partial file would crash the loader on startup.

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -719,7 +719,15 @@ public class F5TtsCrispAsr : ITtsEngine
         return candidate;
     }
 
-    public bool ImportVoice(string fileName)
+    public bool ImportVoice(string fileName) => ImportVoice(fileName, string.Empty);
+
+    /// <summary>
+    /// Imports <paramref name="fileName"/> as an F5-TTS reference voice. When
+    /// <paramref name="transcript"/> is non-empty it's written to the destination .txt sidecar
+    /// directly (improves cloning quality significantly). When empty, falls back to copying
+    /// any .txt sidecar that already lives next to the source WAV.
+    /// </summary>
+    public bool ImportVoice(string fileName, string transcript)
     {
         if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
         {
@@ -752,17 +760,19 @@ public class F5TtsCrispAsr : ITtsEngine
             return false;
         }
 
-        // Voice cloning quality depends on an accurate transcription. If the source had a .txt
-        // sidecar (same basename), copy it alongside the imported WAV under the de-duplicated
-        // destination name. Best-effort — the WAV still loads without a sidecar (cloning quality
-        // is just lower).
+        // Voice cloning quality depends on an accurate transcription. Caller-supplied
+        // transcript wins; otherwise fall back to a sibling .txt next to the source WAV.
         try
         {
-            var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
-            if (File.Exists(sourceSidecar))
+            var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+            if (!string.IsNullOrWhiteSpace(transcript))
             {
-                var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
-                if (!File.Exists(destSidecar))
+                File.WriteAllText(destSidecar, transcript.Trim());
+            }
+            else
+            {
+                var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+                if (File.Exists(sourceSidecar) && !File.Exists(destSidecar))
                 {
                     File.Copy(sourceSidecar, destSidecar);
                 }
@@ -770,9 +780,35 @@ public class F5TtsCrispAsr : ITtsEngine
         }
         catch (Exception ex)
         {
-            Se.LogError(ex, "F5-TTS (CrispASR) voice import: failed to copy .txt sidecar");
+            Se.LogError(ex, "F5-TTS (CrispASR) voice import: failed to write .txt sidecar");
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Writes <paramref name="transcript"/> to <c>&lt;voice&gt;.txt</c> next to the supplied
+    /// voice WAV inside the voices folder. Used to retro-fit a transcription onto a voice
+    /// that was already imported (or seeded from the qwen3-tts.cpp pack) without going through
+    /// a full re-import.
+    /// </summary>
+    public static bool TryWriteRefTextSidecar(string voiceWavPath, string transcript)
+    {
+        if (string.IsNullOrEmpty(voiceWavPath) || string.IsNullOrWhiteSpace(transcript))
+        {
+            return false;
+        }
+
+        try
+        {
+            var sidecar = Path.ChangeExtension(voiceWavPath, ".txt");
+            File.WriteAllText(sidecar, transcript.Trim());
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"F5-TTS (CrispASR): failed to write ref-text sidecar for '{voiceWavPath}'");
+            return false;
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -1,0 +1,777 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// F5-TTS v1 base (E2 TTS / SWivT family) run through the CrispASR runtime. DiT flow-matching
+/// transformer + Vocos vocoder, MIT-licensed, strong zero-shot voice cloning. Single ~953 MB
+/// F16 GGUF (cstr/f5-tts-GGUF on Hugging Face) — no separate codec file. 24 kHz mono reference
+/// WAV; cloning quality is best with 3-10 s of clean speech and an accurate transcription.
+///
+/// CLI usage from the upstream README:
+///   crispasr --backend f5-tts -m auto \
+///       --voice reference.wav \
+///       --ref-text "Transcript of the reference audio" \
+///       --tts "Hello, how are you today?" --tts-output out.wav
+///
+/// Server-mode flag layout is unconfirmed in CrispASR 0.6.12's README. This implementation
+/// assumes the same per-request payload shape Qwen3 CustomVoice uses (voice = WAV path,
+/// ref_text = transcription) and falls back to a startup --voice / --ref-text if needed
+/// (toggle <see cref="UseStartupVoiceFlags"/> below). Verify against an actual 0.6.12 binary.
+/// </summary>
+public class F5TtsCrispAsr : ITtsEngine
+{
+    public string Name => "F5-TTS (CrispASR)";
+    public string Description => "F5-TTS v1 with zero-shot voice cloning, via CrispASR";
+    public bool HasLanguageParameter => false;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+
+    // Only one quant on the HF repo at time of integration. ModelKey is still exposed so the
+    // engine settings dialog can grow new quants without breaking the saved-settings string.
+    public const string ModelKeyF16 = "F16 (~953 MB)";
+    public const string DefaultModelKey = ModelKeyF16;
+
+    public const string TalkerF16FileName = "f5-tts-v1-base-f16.gguf";
+
+    public const string BackendName = "f5-tts";
+
+    // TODO: confirm whether F5-TTS in CrispASR 0.6.12 reads voice/ref-text from the request
+    // payload (like VibeVoice/Qwen3) or only from startup CLI flags (like IndexTTS 0.6.11).
+    // If the per-request approach silently ignores the field, flip this to true and the
+    // server will be (re)started whenever the voice changes — same trade-off IndexTTS made.
+    private static readonly bool UseStartupVoiceFlags = false;
+
+    // Exact byte size from the HF tree API (cstr/f5-tts-GGUF). Same truncation guard as the
+    // other CrispASR TTS engines — a partial file would crash the loader on startup.
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [TalkerF16FileName] = 999097152L,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.F5TtsCrispAsrModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return ModelKeyF16;
+    }
+
+    public static string GetTalkerFileName(string? modelKey) => TalkerF16FileName;
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            return new FileInfo(path).Length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(5),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    private static string? _serverModelKey;
+    // Only used when UseStartupVoiceFlags is true. Matches the IndexTTS layout: changing the
+    // selected reference WAV means tear-down + restart so the new --voice path takes effect.
+    private static string? _serverVoicePath;
+    private static string? _serverRefText;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "F5TtsCrispAsr");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        var modelsFolder = Path.Combine(Se.CrispAsrFolder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        return voicesFolder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder.
+    /// F5-TTS requires a transcription (ref-text) alongside the reference WAV, same as
+    /// Qwen3 CustomVoice — so we copy both the .wav and the .txt sidecar.
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+
+                if (!File.Exists(dest))
+                {
+                    try
+                    {
+                        // qwen3-tts.cpp voice pack ships at 16 kHz; F5-TTS expects 24 kHz.
+                        // Resample on seed via ffmpeg so cloning sees 24 kHz directly.
+                        var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
+                        if (!ffmpeg.Start())
+                        {
+                            File.Copy(src, dest);
+                        }
+                        else
+                        {
+                            ffmpeg.WaitForExit();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex, $"F5-TTS (CrispASR): resample seed '{src}' failed; falling back to plain copy");
+                        try { if (!File.Exists(dest)) File.Copy(src, dest); } catch { }
+                    }
+                }
+
+                var sidecar = Path.ChangeExtension(src, ".txt");
+                if (File.Exists(sidecar))
+                {
+                    var sidecarDest = Path.ChangeExtension(dest, ".txt");
+                    if (!File.Exists(sidecarDest))
+                    {
+                        try { File.Copy(sidecar, sidecarDest); } catch { }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "F5-TTS (CrispASR): voice seeding from qwen3-tts.cpp folder failed");
+        }
+    }
+
+    public static string GetTalkerPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetTalkerFileName(modelKey));
+
+    public static string GetCrispAsrCacheFolder() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "crispasr");
+
+    public static bool TrySeedModelFromCrispAsrCache(string fileName, string destinationPath)
+    {
+        if (IsValidLocalModelFile(destinationPath, fileName))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (File.Exists(destinationPath))
+            {
+                Se.LogError($"F5-TTS (CrispASR): removing wrong-sized local model file {destinationPath}");
+                File.Delete(destinationPath);
+            }
+
+            var cachePath = Path.Combine(GetCrispAsrCacheFolder(), fileName);
+            if (!IsValidLocalModelFile(cachePath, fileName))
+            {
+                return false;
+            }
+
+            File.Copy(cachePath, destinationPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"F5-TTS (CrispASR): cache seed copy failed for {fileName}");
+            return false;
+        }
+    }
+
+    public static bool AreModelsInstalled(string? modelKey = null) =>
+        IsValidLocalModelFile(GetTalkerPath(modelKey), GetTalkerFileName(modelKey));
+
+    public Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>();
+
+        // Voice cloning only — no built-in default voice. The combo is empty until the user
+        // imports a reference WAV (or the qwen3-tts.cpp voice seed runs above).
+        var voicesFolder = GetSetVoicesFolder();
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new F5TtsVoice(name, file)));
+            }
+        }
+
+        return Task.FromResult(result.ToArray());
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyF16 });
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not F5TtsVoice f5Voice)
+        {
+            throw new ArgumentException("Voice is not an F5TtsVoice");
+        }
+
+        if (string.IsNullOrEmpty(f5Voice.FilePath))
+        {
+            throw new InvalidOperationException(
+                "F5-TTS (CrispASR) requires a reference voice WAV. "
+                + "Import one via the voice settings, then pick it in the voice combo. "
+                + "Reference WAV should be 24 kHz mono (3-10 s of clean speech) with an "
+                + "adjacent .txt file holding the spoken transcription.");
+        }
+
+        var refText = TryReadRefText(f5Voice.FilePath);
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, f5Voice.FilePath, refText, cancellationToken);
+
+        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+
+        var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.F5TtsCrispAsrSpeed, 0.25, 4.0);
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+            ["voice"] = f5Voice.FilePath,
+            ["speed"] = speed,
+        };
+        if (!string.IsNullOrEmpty(refText))
+        {
+            // TODO: verify field name. CrispASR's CLI uses `--ref-text`; the OpenAI-compat
+            // server may expose this as `ref_text`, `ref-text`, or `instructions`. Adjust
+            // once a real synth round-trip confirms which key the backend reads.
+            payload["ref_text"] = refText;
+        }
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"F5-TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={f5Voice}, refTextLen={refText.Length}, textLen={text.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"F5-TTS (CrispASR) request failed — Voice: {f5Voice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "F5-TTS (CrispASR) — the crispasr server crashed during synthesis."
+                    : "F5-TTS (CrispASR) request failed — the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"F5-TTS (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {f5Voice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"F5-TTS (CrispASR) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static string TryReadRefText(string wavPath)
+    {
+        try
+        {
+            var sidecar = Path.ChangeExtension(wavPath, ".txt");
+            return File.Exists(sidecar) ? File.ReadAllText(sidecar).Trim() : string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, CancellationToken ct)
+    {
+        // When UseStartupVoiceFlags is true the server is keyed by (model, voice, ref-text) since
+        // those are baked in at process start. When false the server is keyed only by model and
+        // voice/ref-text are sent per-request, so the cache key collapses to (model).
+        bool MatchesCurrent() =>
+            _serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && (!UseStartupVoiceFlags
+                || (string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(_serverRefText, refText, StringComparison.Ordinal)));
+
+        if (MatchesCurrent())
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (MatchesCurrent())
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            var talkerFileName = GetTalkerFileName(modelKey);
+            var talker = GetTalkerPath(modelKey);
+            var hasLocalTalker = IsValidLocalModelFile(talker, talkerFileName);
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(BackendName);
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(hasLocalTalker ? talker : "auto");
+            if (!hasLocalTalker)
+            {
+                psi.ArgumentList.Add("--auto-download");
+            }
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString());
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+
+            if (UseStartupVoiceFlags)
+            {
+                psi.ArgumentList.Add("--voice");
+                psi.ArgumentList.Add(voicePath);
+                if (!string.IsNullOrEmpty(refText))
+                {
+                    psi.ArgumentList.Add("--ref-text");
+                    psi.ArgumentList.Add(refText);
+                }
+            }
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (f5-tts)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog("F5-TTS (CrispASR) server starting — "
+                + $"PID: {process.Id}, "
+                + $"Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelKey = modelKey;
+            _serverVoicePath = voicePath;
+            _serverRefText = refText;
+            HookProcessExitOnce();
+
+            // First-run auto-download (~953 MB talker) needs a generous timeout.
+            var deadline = DateTime.UtcNow.AddMinutes(hasLocalTalker ? 5 : 20);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverModelKey = null;
+                    _serverVoicePath = null;
+                    _serverRefText = null;
+                    throw new InvalidOperationException(
+                        $"crispasr (f5-tts) exited during startup (code {exitCode}). Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (f5-tts) did not report healthy within {(hasLocalTalker ? 5 : 20)} minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked) return;
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverModelKey = null;
+        _serverVoicePath = null;
+        _serverRefText = null;
+        if (p == null) return;
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // F5-TTS expects 24 kHz mono. Resample on import via ffmpeg regardless of source format.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "F5-TTS (CrispASR) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        if (!File.Exists(destinationFileName))
+        {
+            return false;
+        }
+
+        // Voice cloning quality depends on an accurate transcription. If the source had a .txt
+        // sidecar (same basename), copy it alongside the imported WAV under the de-duplicated
+        // destination name. Best-effort — the WAV still loads without a sidecar (cloning quality
+        // is just lower).
+        try
+        {
+            var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+            if (File.Exists(sourceSidecar))
+            {
+                var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+                if (!File.Exists(destSidecar))
+                {
+                    File.Copy(sourceSidecar, destSidecar);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "F5-TTS (CrispASR) voice import: failed to copy .txt sidecar");
+        }
+
+        return true;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -104,9 +104,15 @@ public class F5TtsCrispAsr : ITtsEngine
         }
     }
 
+    // F5-TTS is CPU-only in CrispASR 0.6.12 (no Metal/CUDA backend) and runs a fixed 32-step
+    // Euler ODE through a 22-layer DiT plus the Vocos vocoder — there's no flag to reduce
+    // steps. On Mac CPU one short utterance routinely takes 3-8 minutes, so a 5-minute
+    // HttpClient timeout (the default we use for other CrispASR TTS engines) fires before the
+    // synth completes and looks like a hang. 30 minutes gives generous headroom; users can
+    // always cancel from the GeneratingAudioWindow if they're done waiting.
     private static readonly HttpClient HttpClient = new()
     {
-        Timeout = TimeSpan.FromMinutes(5),
+        Timeout = TimeSpan.FromMinutes(30),
     };
     private static readonly SemaphoreSlim ServerLock = new(1, 1);
     private static Process? _serverProcess;

--- a/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsViewModel.cs
@@ -1,0 +1,225 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
+
+public partial class F5TtsCrispAsrSettingsViewModel : ObservableObject
+{
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+
+    [ObservableProperty] private string _talkerF16Label = string.Empty;
+    [ObservableProperty] private IBrush _talkerF16Brush = Grey();
+
+    [ObservableProperty] private string _voicesLabel = string.Empty;
+
+    [ObservableProperty] private double _speed = 1.0;
+
+    public string SpeedLabel => $"Speed {Speed:0.00}x";
+
+    partial void OnSpeedChanged(double value)
+    {
+        OnPropertyChanged(nameof(SpeedLabel));
+        Se.Settings.Video.TextToSpeech.F5TtsCrispAsrSpeed = Math.Clamp(value, 0.25, 4.0);
+    }
+
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public F5TtsCrispAsrSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        ModelsFolder = F5TtsCrispAsr.GetSetModelsFolder();
+        VoicesFolder = F5TtsCrispAsr.GetSetVoicesFolder();
+        Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.F5TtsCrispAsrSpeed, 0.25, 4.0);
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = F5TtsCrispAsr.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = "CrispASR not installed";
+            EngineBrush = Red();
+            EngineDownloadButtonText = "Download CrispASR";
+        }
+        else if (F5TtsCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = "CrispASR - update available";
+            EngineBrush = Amber();
+            EngineDownloadButtonText = "Update CrispASR";
+        }
+        else
+        {
+            EngineLabel = "CrispASR";
+            EngineBrush = Green();
+            EngineDownloadButtonText = "Re-download CrispASR";
+        }
+
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "F5TtsCrispAsrSettings: CrispASR version probe failed");
+                }
+            });
+        }
+
+        ApplyModelStatus(
+            F5TtsCrispAsr.AreModelsInstalled(F5TtsCrispAsr.ModelKeyF16),
+            IsEngineInstalled,
+            label => TalkerF16Label = label,
+            brush => TalkerF16Brush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No voices imported"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
+    }
+
+    private static void ApplyModelStatus(bool fileInstalled, bool engineInstalled, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        if (fileInstalled)
+        {
+            setLabel("Installed");
+            setBrush(Green());
+            return;
+        }
+
+        if (!engineInstalled)
+        {
+            setLabel("CrispASR required");
+            setBrush(Grey());
+            return;
+        }
+
+        setLabel("Auto-download on first use");
+        setBrush(Grey());
+    }
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await TtsVoiceInstaller.EnsureCrispAsrForF5Tts(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsWindow.cs
@@ -1,0 +1,256 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
+
+public class F5TtsCrispAsrSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly F5TtsCrispAsrSettingsViewModel _vm;
+
+    public F5TtsCrispAsrSettingsWindow(F5TtsCrispAsrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "F5-TTS (CrispASR) settings";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 580;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(F5TtsCrispAsrSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "F5-TTS (CrispASR)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new F5TtsCrispAsr().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(F5TtsCrispAsrSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel("Engine"), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12);
+        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel("Talker " + F5TtsCrispAsr.ModelKeyF16), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.TalkerF16Brush), nameof(vm.TalkerF16Label)), 1, 1);
+
+        grid.Add(MakeLabel("Voices"), 2, 0);
+        var voicesText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        };
+        grid.Add(voicesText, 2, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Speed), 3, 0);
+        grid.Add(MakeSpeedPanel(), 3, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 4, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        };
+        grid.Add(folderText, 4, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static StackPanel MakeSpeedPanel()
+    {
+        var slider = new Slider
+        {
+            Minimum = 0.5,
+            Maximum = 2.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(F5TtsCrispAsrSettingsViewModel.Speed)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(F5TtsCrispAsrSettingsViewModel.SpeedLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Grid BuildActions(F5TtsCrispAsrSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder, openVoicesFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
@@ -479,6 +480,119 @@ public partial class TextToSpeechViewModel : ObservableObject
     partial void OnSelectedVoiceChanged(Voice? value)
     {
         UpdateOmniVoicePickerState();
+        // Fire-and-forget: when the user picks a CosyVoice3 or F5-TTS clone voice that has
+        // no .txt sidecar, immediately prompt for the transcription. Writes the sidecar and
+        // refreshes the voice list so the engine picks up the new RefText on the next synth.
+        // Without this the user only sees the failure at Generate time with a confusing
+        // "add a .txt sidecar" message, which is hard to act on inside the SE UI.
+        _ = EnsureClonedVoiceRefTextAsync(value);
+    }
+
+    private bool _isPromptingForRefText;
+
+    private async Task EnsureClonedVoiceRefTextAsync(Voice? voice)
+    {
+        if (_isPromptingForRefText || Window == null || voice == null)
+        {
+            return;
+        }
+
+        // CosyVoice3 requires ref-text (server fails outright). F5-TTS recommends it strongly
+        // (cloning falls back to a generic voice without it). Both prompt the same way.
+        string? wavPath = null;
+        bool isCosyVoice3 = false;
+        if (voice.EngineVoice is CosyVoice3Voice cosy && !string.IsNullOrEmpty(cosy.FilePath) && string.IsNullOrEmpty(cosy.RefText))
+        {
+            wavPath = cosy.FilePath;
+            isCosyVoice3 = true;
+        }
+        else if (voice.EngineVoice is F5TtsVoice f5 && !string.IsNullOrEmpty(f5.FilePath))
+        {
+            var existing = TryReadRefTextSibling(f5.FilePath);
+            if (string.IsNullOrEmpty(existing))
+            {
+                wavPath = f5.FilePath;
+            }
+        }
+
+        if (string.IsNullOrEmpty(wavPath))
+        {
+            return;
+        }
+
+        _isPromptingForRefText = true;
+        try
+        {
+            var audioFileName = wavPath;
+            var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window, vm =>
+            {
+                vm.Initialize(
+                    Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
+                    string.Empty,
+                    500,
+                    150);
+                vm.ConfigureExtraButton(
+                    Se.Language.Video.TextToSpeech.UseSpeechToTextDotDotDot,
+                    () => RunSpeechToTextForRefTextAsync(audioFileName));
+            });
+
+            if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text))
+            {
+                return;
+            }
+
+            var written = isCosyVoice3
+                ? CosyVoice3CrispAsr.TryWriteRefTextSidecar(wavPath, result.Text)
+                : F5TtsCrispAsr.TryWriteRefTextSidecar(wavPath, result.Text);
+
+            if (!written || SelectedEngine == null)
+            {
+                return;
+            }
+
+            // Re-pull the voice list so the picked entry now carries RefText and the engine's
+            // (model, voice, refText) cache key on the running server picks up the change.
+            await RefreshVoices(SelectedEngine);
+        }
+        finally
+        {
+            _isPromptingForRefText = false;
+        }
+    }
+
+    private static string? TryReadRefTextSibling(string wavPath)
+    {
+        try
+        {
+            var sidecar = Path.ChangeExtension(wavPath, ".txt");
+            return File.Exists(sidecar) ? File.ReadAllText(sidecar).Trim() : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task<string?> RunSpeechToTextForRefTextAsync(string audioFileName)
+    {
+        if (Window == null)
+        {
+            return null;
+        }
+
+        var sttResult = await _windowService.ShowDialogAsync<SpeechToTextWindow, SpeechToTextViewModel>(Window, vm =>
+        {
+            vm.Initialize(audioFileName, -1);
+        });
+
+        if (!sttResult.OkPressed || sttResult.TranscribedSubtitle == null || sttResult.TranscribedSubtitle.Paragraphs.Count == 0)
+        {
+            return null;
+        }
+
+        return string.Join(' ', sttResult.TranscribedSubtitle.Paragraphs
+            .Select(p => p.Text?.Replace('\n', ' ').Replace('\r', ' ').Trim())
+            .Where(t => !string.IsNullOrWhiteSpace(t)));
     }
 
     private static ObservableCollection<string> BuildKeywordOptions(string[] keywords)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1695,8 +1695,8 @@ public partial class TextToSpeechViewModel : ObservableObject
             {
                 var answer = await MessageBox.Show(
                     Window,
-                    "Download CosyVoice3 (CrispASR) model?",
-                    $"{Environment.NewLine}\"CosyVoice3 (CrispASR)\" ({cosyModelKey}) requires a model.{Environment.NewLine}{Environment.NewLine}Companion files (flow/hift/s3tok/campplus/voices, ~360 MB extra) are fetched automatically on first synth.{Environment.NewLine}{Environment.NewLine}Download model?",
+                    "Download CosyVoice3 (CrispASR) models?",
+                    $"{Environment.NewLine}\"CosyVoice3 (CrispASR)\" ({cosyModelKey}) requires LLM + flow + hift + s3tok + campplus + voice-bank GGUFs (all sized into the total above).{Environment.NewLine}{Environment.NewLine}Download models?",
                     MessageBoxButtons.YesNoCancel,
                     MessageBoxIcon.Question);
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -337,6 +337,14 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrModel = SelectedModel ?? IndexTtsCrispAsr.DefaultModelKey;
         }
+        else if (SelectedEngine is CosyVoice3CrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrModel = SelectedModel ?? CosyVoice3CrispAsr.DefaultModelKey;
+        }
+        else if (SelectedEngine is F5TtsCrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.F5TtsCrispAsrModel = SelectedModel ?? F5TtsCrispAsr.DefaultModelKey;
+        }
         else if (SelectedEngine is OmniVoiceTtsCpp)
         {
             Se.Settings.Video.TextToSpeech.OmniVoiceTtsCppInstruction = (Instruction ?? string.Empty).Trim();
@@ -2719,6 +2727,24 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (SelectedEngine is IndexTtsCrispAsr)
             {
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+            }
+            else if (SelectedEngine is CosyVoice3CrispAsr)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+            }
+            else if (SelectedEngine is F5TtsCrispAsr)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.F5TtsCrispAsrModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -24,6 +24,8 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceSettings;
@@ -199,6 +201,8 @@ public partial class TextToSpeechViewModel : ObservableObject
             // CrispASR's VibeVoice backend ships a higher-quality build.
             // new VibeVoiceCrispAsr(),
             new IndexTtsCrispAsr(),
+            new CosyVoice3CrispAsr(),
+            new F5TtsCrispAsr(),
             new ChatterboxTtsCpp(),
         ];
 
@@ -860,6 +864,14 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             await _windowService.ShowDialogAsync<IndexTtsCrispAsrSettingsWindow, IndexTtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
         }
+        else if (SelectedEngine is CosyVoice3CrispAsr)
+        {
+            await _windowService.ShowDialogAsync<CosyVoice3CrispAsrSettingsWindow, CosyVoice3CrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
+        }
+        else if (SelectedEngine is F5TtsCrispAsr)
+        {
+            await _windowService.ShowDialogAsync<F5TtsCrispAsrSettingsWindow, F5TtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
+        }
         else if (SelectedEngine is KokoroTtsCpp)
         {
             await _windowService.ShowDialogAsync<KokoroTtsSettingsWindow, KokoroTtsSettingsViewModel>(Window!, vm => vm.Initialize());
@@ -1503,6 +1515,82 @@ public partial class TextToSpeechViewModel : ObservableObject
 
                 var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadIndexTtsCrispAsrModels(indexModelKey));
                 if (!dlResult.OkPressed || !IndexTtsCrispAsr.AreModelsInstalled(indexModelKey))
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await RefreshVoices(engine);
+                });
+                return true;
+            }
+
+            return true;
+        }
+
+        if (engine is CosyVoice3CrispAsr)
+        {
+            if (!await TtsVoiceInstaller.EnsureCrispAsrForCosyVoice3(Window, _windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var cosyModelKey = CosyVoice3CrispAsr.ResolveModelKey(SelectedModel);
+            if (!CosyVoice3CrispAsr.AreModelsInstalled(cosyModelKey))
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download CosyVoice3 (CrispASR) model?",
+                    $"{Environment.NewLine}\"CosyVoice3 (CrispASR)\" ({cosyModelKey}) requires a model.{Environment.NewLine}{Environment.NewLine}Companion files (flow/hift/s3tok/campplus/voices, ~360 MB extra) are fetched automatically on first synth.{Environment.NewLine}{Environment.NewLine}Download model?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadCosyVoice3CrispAsrModels(cosyModelKey));
+                if (!dlResult.OkPressed || !CosyVoice3CrispAsr.AreModelsInstalled(cosyModelKey))
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await RefreshVoices(engine);
+                });
+                return true;
+            }
+
+            return true;
+        }
+
+        if (engine is F5TtsCrispAsr)
+        {
+            if (!await TtsVoiceInstaller.EnsureCrispAsrForF5Tts(Window, _windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var f5ModelKey = F5TtsCrispAsr.ResolveModelKey(SelectedModel);
+            if (!F5TtsCrispAsr.AreModelsInstalled(f5ModelKey))
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download F5-TTS (CrispASR) model?",
+                    $"{Environment.NewLine}\"F5-TTS (CrispASR)\" ({f5ModelKey}) requires a model.{Environment.NewLine}{Environment.NewLine}Download model?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadF5TtsCrispAsrModels(f5ModelKey));
+                if (!dlResult.OkPressed || !F5TtsCrispAsr.AreModelsInstalled(f5ModelKey))
                 {
                     return false;
                 }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -202,10 +202,42 @@ public partial class TextToSpeechViewModel : ObservableObject
             // CrispASR's VibeVoice backend ships a higher-quality build.
             // new VibeVoiceCrispAsr(),
             new IndexTtsCrispAsr(),
-            new CosyVoice3CrispAsr(),
-            new F5TtsCrispAsr(),
+            // F5-TTS (CrispASR) hidden: CrispASR 0.6.12 has no GPU backend for f5-tts, so
+            // synthesis runs the fixed 32-step Euler ODE through a 22-layer DiT + Vocos on
+            // CPU only. That's 3-8 minutes per short utterance on Mac CPU — unusable for the
+            // typical TTS-from-subtitles workflow. Engine + download service + settings dialog
+            // are kept so this is a one-line re-enable when upstream CrispASR adds Metal/CUDA
+            // support or exposes an --ode-steps flag.
+            // new F5TtsCrispAsr(),
             new ChatterboxTtsCpp(),
         ];
+
+        // CosyVoice3 (CrispASR) is gated on platforms where CrispASR has a runtime: the
+        // upstream v0.6.12 release ships Windows + macOS builds but no Linux build (see commit
+        // 53a739e6f "Update to CrispASR v0.6.12 (no linux)"). Hiding the engine on Linux
+        // avoids a confusing "Download CrispASR" prompt that can't actually succeed there.
+        if (!OperatingSystem.IsLinux())
+        {
+            // Insert immediately after IndexTtsCrispAsr to keep the CrispASR engines grouped
+            // visually in the engine combo.
+            var indexTtsIndex = -1;
+            for (var i = 0; i < Engines.Count; i++)
+            {
+                if (Engines[i] is IndexTtsCrispAsr)
+                {
+                    indexTtsIndex = i;
+                    break;
+                }
+            }
+            if (indexTtsIndex >= 0)
+            {
+                Engines.Insert(indexTtsIndex + 1, new CosyVoice3CrispAsr());
+            }
+            else
+            {
+                Engines.Add(new CosyVoice3CrispAsr());
+            }
+        }
 
         if (!OperatingSystem.IsMacOS())
         {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -126,6 +126,10 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, VibeVoiceCrispAsr.GetEngineUpdateStatus());
             case IndexTtsCrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, IndexTtsCrispAsr.GetEngineUpdateStatus());
+            case CosyVoice3CrispAsr:
+                return StatusDots.From(engine.IsInstalled(null).Result, CosyVoice3CrispAsr.GetEngineUpdateStatus());
+            case F5TtsCrispAsr:
+                return StatusDots.From(engine.IsInstalled(null).Result, F5TtsCrispAsr.GetEngineUpdateStatus());
             case OmniVoiceTtsCpp:
                 return StatusDots.From(engine.IsInstalled(null).Result, OmniVoiceTtsCpp.GetEngineUpdateStatus());
             case ChatterboxTtsCpp:
@@ -161,6 +165,12 @@ public class TextToSpeechWindow : Window
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             IndexTtsCrispAsr => IndexTtsCrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            CosyVoice3CrispAsr => CosyVoice3CrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            F5TtsCrispAsr => F5TtsCrispAsr.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             ChatterboxTtsCpp => ChatterboxTtsCpp.AreModelsInstalled(modelKey)

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -95,8 +95,10 @@ public static class TtsVoiceInstaller
 
     /// <summary>
     /// Ensures the CrispASR runtime that CosyVoice3 (CrispASR) runs on is installed.
-    /// The cosyvoice3-tts backend ships in CrispASR v0.6.12+; companion GGUFs (flow / hift /
-    /// s3tok / campplus / voices) are auto-downloaded by crispasr on first run.
+    /// The cosyvoice3-tts backend ships in CrispASR v0.6.12+; every required GGUF (LLM + flow
+    /// + hift + s3tok + campplus + voice-bank) is staged into SE's CrispAsr/models folder by
+    /// <see cref="Nikse.SubtitleEdit.Logic.Download.CosyVoice3CrispAsrDownloadService"/> with
+    /// hash verification before first synth.
     /// </summary>
     public static Task<bool> EnsureCrispAsrForCosyVoice3(Window? window, IWindowService windowService, bool forceRedownload)
         => EnsureCrispAsrAsync(window, windowService, forceRedownload,

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -94,6 +94,27 @@ public static class TtsVoiceInstaller
             minVersionNote: null);
 
     /// <summary>
+    /// Ensures the CrispASR runtime that CosyVoice3 (CrispASR) runs on is installed.
+    /// The cosyvoice3-tts backend ships in CrispASR v0.6.12+; companion GGUFs (flow / hift /
+    /// s3tok / campplus / voices) are auto-downloaded by crispasr on first run.
+    /// </summary>
+    public static Task<bool> EnsureCrispAsrForCosyVoice3(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "CosyVoice3 (CrispASR)",
+            extraCapabilityCheck: null,
+            minVersionNote: "v0.6.12 or newer");
+
+    /// <summary>
+    /// Ensures the CrispASR runtime that F5-TTS (CrispASR) runs on is installed.
+    /// The f5-tts backend ships in CrispASR v0.6.12+.
+    /// </summary>
+    public static Task<bool> EnsureCrispAsrForF5Tts(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "F5-TTS (CrispASR)",
+            extraCapabilityCheck: null,
+            minVersionNote: "v0.6.12 or newer");
+
+    /// <summary>
     /// Shared CrispASR install/update flow used by all TTS engines that sit on the
     /// CrispASR runtime. Prompts refer to <paramref name="engineDisplayName"/> so users
     /// see the right engine name. <paramref name="extraCapabilityCheck"/> lets the caller

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -107,6 +107,58 @@ public partial class VoiceSettingsViewModel : ObservableObject
 
             ok = omniEngine.ImportVoice(fileName, transcript);
         }
+        else if (_engine is CosyVoice3CrispAsr cosyEngine)
+        {
+            // CosyVoice3's s3tok speech tokenizer REQUIRES a transcript at synth time — without
+            // it the server fails outright. Always prompt (matching OmniVoice's flow), with the
+            // sibling-text autofill so existing .txt sidecars don't force a re-type.
+            var transcript = TryReadSiblingTranscript(fileName) ?? string.Empty;
+            var audioFileName = fileName;
+            var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window!, vm =>
+            {
+                vm.Initialize(
+                    Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
+                    transcript,
+                    500,
+                    150);
+                vm.ConfigureExtraButton(
+                    Se.Language.Video.TextToSpeech.UseSpeechToTextDotDotDot,
+                    () => RunSpeechToTextAsync(audioFileName));
+            });
+
+            if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text))
+            {
+                return;
+            }
+
+            ok = cosyEngine.ImportVoice(fileName, result.Text.Trim());
+        }
+        else if (_engine is F5TtsCrispAsr f5Engine)
+        {
+            // F5-TTS cloning quality depends sharply on an accurate transcription. Not strictly
+            // required by the server, but synthesis with no ref-text falls back to a generic
+            // voice, so prompt the same way as CosyVoice3.
+            var transcript = TryReadSiblingTranscript(fileName) ?? string.Empty;
+            var audioFileName = fileName;
+            var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window!, vm =>
+            {
+                vm.Initialize(
+                    Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
+                    transcript,
+                    500,
+                    150);
+                vm.ConfigureExtraButton(
+                    Se.Language.Video.TextToSpeech.UseSpeechToTextDotDotDot,
+                    () => RunSpeechToTextAsync(audioFileName));
+            });
+
+            if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text))
+            {
+                return;
+            }
+
+            ok = f5Engine.ImportVoice(fileName, result.Text.Trim());
+        }
         else
         {
             ok = _engine.ImportVoice(fileName);
@@ -259,6 +311,8 @@ public partial class VoiceSettingsViewModel : ObservableObject
                                || engine.GetType() == typeof(Qwen3TtsCrispAsr)
                                || engine.GetType() == typeof(VibeVoiceCrispAsr)
                                || engine.GetType() == typeof(IndexTtsCrispAsr)
+                               || engine.GetType() == typeof(CosyVoice3CrispAsr)
+                               || engine.GetType() == typeof(F5TtsCrispAsr)
                                || engine.GetType() == typeof(ChatterboxTtsCpp)
                                || engine.GetType() == typeof(OmniVoiceTtsCpp);
     }

--- a/src/ui/Features/Video/TextToSpeech/Voices/CosyVoice3Voice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/CosyVoice3Voice.cs
@@ -1,0 +1,24 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+public class CosyVoice3Voice
+{
+    public string Voice { get; set; }
+    public string Preset { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public CosyVoice3Voice()
+    {
+        Voice = string.Empty;
+        Preset = string.Empty;
+    }
+
+    public CosyVoice3Voice(string voice, string preset)
+    {
+        Voice = voice;
+        Preset = preset;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Voices/CosyVoice3Voice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/CosyVoice3Voice.cs
@@ -1,9 +1,17 @@
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 
+/// <summary>
+/// Either a baked-in CosyVoice3 preset (<see cref="Preset"/> set, <see cref="FilePath"/> empty)
+/// or a user-imported reference WAV for zero-shot cloning (<see cref="FilePath"/> set,
+/// <see cref="Preset"/> empty). The CosyVoice3CrispAsr engine picks which value to forward
+/// to crispasr's <c>--voice</c> flag based on whether FilePath is populated.
+/// </summary>
 public class CosyVoice3Voice
 {
     public string Voice { get; set; }
     public string Preset { get; set; }
+    public string FilePath { get; set; }
+    public string RefText { get; set; }
 
     public override string ToString()
     {
@@ -14,11 +22,23 @@ public class CosyVoice3Voice
     {
         Voice = string.Empty;
         Preset = string.Empty;
+        FilePath = string.Empty;
+        RefText = string.Empty;
     }
 
     public CosyVoice3Voice(string voice, string preset)
     {
         Voice = voice;
         Preset = preset;
+        FilePath = string.Empty;
+        RefText = string.Empty;
+    }
+
+    public CosyVoice3Voice(string voice, string filePath, string refText)
+    {
+        Voice = voice;
+        Preset = string.Empty;
+        FilePath = filePath;
+        RefText = refText;
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Voices/F5TtsVoice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/F5TtsVoice.cs
@@ -1,0 +1,24 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+public class F5TtsVoice
+{
+    public string Voice { get; set; }
+    public string FilePath { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public F5TtsVoice()
+    {
+        Voice = string.Empty;
+        FilePath = string.Empty;
+    }
+
+    public F5TtsVoice(string voice, string filePath)
+    {
+        Voice = voice;
+        FilePath = filePath;
+    }
+}

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -36,6 +36,10 @@ public class SeVideoTextToSpeech
     public double VibeVoiceCrispAsrSpeed { get; set; }
     public string IndexTtsCrispAsrModel { get; set; }
     public double IndexTtsCrispAsrSpeed { get; set; }
+    public string CosyVoice3CrispAsrModel { get; set; }
+    public double CosyVoice3CrispAsrSpeed { get; set; }
+    public string F5TtsCrispAsrModel { get; set; }
+    public double F5TtsCrispAsrSpeed { get; set; }
     public string OmniVoiceTtsCppVulkanPath { get; set; }
     public string OmniVoiceTtsCppInstruction { get; set; }
     public string ChatterboxModel { get; set; }
@@ -109,6 +113,10 @@ public class SeVideoTextToSpeech
         VibeVoiceCrispAsrSpeed = 1.1;
         IndexTtsCrispAsrModel = "Q8_0 (~870 MB)";
         IndexTtsCrispAsrSpeed = 1.0;
+        CosyVoice3CrispAsrModel = "Q4_K (~745 MB total)";
+        CosyVoice3CrispAsrSpeed = 1.0;
+        F5TtsCrispAsrModel = "F16 (~953 MB)";
+        F5TtsCrispAsrSpeed = 1.0;
         OmniVoiceTtsCppVulkanPath = string.Empty;
         OmniVoiceTtsCppInstruction = string.Empty;
         ChatterboxModel = "Base";

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -113,7 +113,7 @@ public class SeVideoTextToSpeech
         VibeVoiceCrispAsrSpeed = 1.1;
         IndexTtsCrispAsrModel = "Q8_0 (~870 MB)";
         IndexTtsCrispAsrSpeed = 1.0;
-        CosyVoice3CrispAsrModel = "Q4_K (~745 MB total)";
+        CosyVoice3CrispAsrModel = "Q4_K (~1.6 GB total)";
         CosyVoice3CrispAsrSpeed = 1.0;
         F5TtsCrispAsrModel = "F16 (~953 MB)";
         F5TtsCrispAsrSpeed = 1.0;

--- a/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
@@ -14,22 +14,29 @@ public interface ICosyVoice3CrispAsrDownloadService
 }
 
 /// <summary>
-/// Downloads the CosyVoice3 LLM GGUF (Q4_K ~384 MB or F16 ~1.29 GB) into SE's CrispASR/models
-/// folder. Companion files (flow / hift / s3tok / campplus / voices, ~360-665 MB combined) are
-/// left to crispasr's --auto-download — see <see cref="CosyVoice3CrispAsr"/> for why we don't
-/// stage them ourselves. Same .part + size-check pattern as VibeVoice/IndexTTS download services
-/// so an interrupted download can't leave a truncated file at the real path.
+/// Downloads every GGUF the cosyvoice3-tts backend needs (LLM + flow + hift + s3tok + campplus
+/// + voices) into SE's CrispASR/models folder. crispasr looks for the companions as siblings of
+/// the LLM at server startup; staging them ourselves means the user gets a single SE progress
+/// dialog instead of crispasr's silent --auto-download. Same .part + size-check + optional
+/// SHA-256 verify pattern as VibeVoice/IndexTTS.
 /// </summary>
 public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadService
 {
+    private const string RepoBase = "https://huggingface.co/cstr/cosyvoice3-0.5b-2512-GGUF/resolve/main/";
+
     private readonly HttpClient _httpClient;
 
     private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
     {
-        [CosyVoice3CrispAsr.LlmQ4KFileName] =
-            "https://huggingface.co/cstr/cosyvoice3-0.5b-2512-GGUF/resolve/main/cosyvoice3-llm-q4_k.gguf",
-        [CosyVoice3CrispAsr.LlmF16FileName] =
-            "https://huggingface.co/cstr/cosyvoice3-0.5b-2512-GGUF/resolve/main/cosyvoice3-llm-f16.gguf",
+        [CosyVoice3CrispAsr.LlmQ4KFileName] = RepoBase + CosyVoice3CrispAsr.LlmQ4KFileName,
+        [CosyVoice3CrispAsr.LlmF16FileName] = RepoBase + CosyVoice3CrispAsr.LlmF16FileName,
+        [CosyVoice3CrispAsr.FlowQ8_0FileName] = RepoBase + CosyVoice3CrispAsr.FlowQ8_0FileName,
+        [CosyVoice3CrispAsr.FlowF16FileName] = RepoBase + CosyVoice3CrispAsr.FlowF16FileName,
+        [CosyVoice3CrispAsr.HiftF16FileName] = RepoBase + CosyVoice3CrispAsr.HiftF16FileName,
+        [CosyVoice3CrispAsr.S3TokQ4KFileName] = RepoBase + CosyVoice3CrispAsr.S3TokQ4KFileName,
+        [CosyVoice3CrispAsr.S3TokF16FileName] = RepoBase + CosyVoice3CrispAsr.S3TokF16FileName,
+        [CosyVoice3CrispAsr.CampPlusF16FileName] = RepoBase + CosyVoice3CrispAsr.CampPlusF16FileName,
+        [CosyVoice3CrispAsr.VoicesGgufFileName] = RepoBase + CosyVoice3CrispAsr.VoicesGgufFileName,
     };
 
     public CosyVoice3CrispAsrDownloadService(HttpClient httpClient)
@@ -39,22 +46,41 @@ public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadServ
 
     public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
     {
-        var llmFileName = CosyVoice3CrispAsr.GetLlmFileName(modelKey);
-        var llmPath = CosyVoice3CrispAsr.GetLlmPath(modelKey);
+        var required = CosyVoice3CrispAsr.GetRequiredFileNames(modelKey);
 
+        // Seed any matching files already in crispasr's --auto-download cache before deciding
+        // what to fetch — saves a re-download for users who tried CosyVoice3 via raw crispasr
+        // before the SE integration.
         await Task.Run(() =>
         {
-            CosyVoice3CrispAsr.TrySeedModelFromCrispAsrCache(llmFileName, llmPath);
-            EnsureRemovedIfInvalid(llmPath, llmFileName);
+            foreach (var fileName in required)
+            {
+                var dest = Path.Combine(modelsFolder, fileName);
+                CosyVoice3CrispAsr.TrySeedModelFromCrispAsrCache(fileName, dest);
+                EnsureRemovedIfInvalid(dest, fileName);
+            }
         }, cancellationToken);
 
-        if (CosyVoice3CrispAsr.IsValidLocalModelFile(llmPath, llmFileName))
+        // Count missing files for the "(n/total)" title prefix. Doing this after the seed pass
+        // so the user doesn't see "1/6" right before the seeder turns 5 of them into hits.
+        var missing = new List<string>();
+        foreach (var fileName in required)
         {
-            return;
+            var dest = Path.Combine(modelsFolder, fileName);
+            if (!CosyVoice3CrispAsr.IsValidLocalModelFile(dest, fileName))
+            {
+                missing.Add(fileName);
+            }
         }
 
-        titleProgress?.Invoke($"Downloading CosyVoice3 (CrispASR) model: {llmFileName}");
-        await DownloadAndVerify(llmPath, llmFileName, progress, cancellationToken);
+        var step = 0;
+        foreach (var fileName in missing)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading CosyVoice3 (CrispASR) models ({step}/{missing.Count}): {fileName}");
+            var dest = Path.Combine(modelsFolder, fileName);
+            await DownloadAndVerify(dest, fileName, progress, cancellationToken);
+        }
     }
 
     private async Task DownloadAndVerify(string finalPath, string fileName, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -76,13 +102,23 @@ public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadServ
     private static string? GetHashKey(string fileName)
     {
         if (string.Equals(fileName, CosyVoice3CrispAsr.LlmQ4KFileName, StringComparison.OrdinalIgnoreCase))
-        {
             return DownloadHashManager.CosyVoice3CrispAsr.LlmQ4K;
-        }
         if (string.Equals(fileName, CosyVoice3CrispAsr.LlmF16FileName, StringComparison.OrdinalIgnoreCase))
-        {
             return DownloadHashManager.CosyVoice3CrispAsr.LlmF16;
-        }
+        if (string.Equals(fileName, CosyVoice3CrispAsr.FlowQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+            return DownloadHashManager.CosyVoice3CrispAsr.FlowQ8_0;
+        if (string.Equals(fileName, CosyVoice3CrispAsr.FlowF16FileName, StringComparison.OrdinalIgnoreCase))
+            return DownloadHashManager.CosyVoice3CrispAsr.FlowF16;
+        if (string.Equals(fileName, CosyVoice3CrispAsr.HiftF16FileName, StringComparison.OrdinalIgnoreCase))
+            return DownloadHashManager.CosyVoice3CrispAsr.HiftF16;
+        if (string.Equals(fileName, CosyVoice3CrispAsr.S3TokQ4KFileName, StringComparison.OrdinalIgnoreCase))
+            return DownloadHashManager.CosyVoice3CrispAsr.S3TokQ4K;
+        if (string.Equals(fileName, CosyVoice3CrispAsr.S3TokF16FileName, StringComparison.OrdinalIgnoreCase))
+            return DownloadHashManager.CosyVoice3CrispAsr.S3TokF16;
+        if (string.Equals(fileName, CosyVoice3CrispAsr.CampPlusF16FileName, StringComparison.OrdinalIgnoreCase))
+            return DownloadHashManager.CosyVoice3CrispAsr.CampPlusF16;
+        if (string.Equals(fileName, CosyVoice3CrispAsr.VoicesGgufFileName, StringComparison.OrdinalIgnoreCase))
+            return DownloadHashManager.CosyVoice3CrispAsr.VoicesGguf;
         return null;
     }
 

--- a/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
@@ -1,0 +1,137 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface ICosyVoice3CrispAsrDownloadService
+{
+    Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Downloads the CosyVoice3 LLM GGUF (Q4_K ~384 MB or F16 ~1.29 GB) into SE's CrispASR/models
+/// folder. Companion files (flow / hift / s3tok / campplus / voices, ~360-665 MB combined) are
+/// left to crispasr's --auto-download — see <see cref="CosyVoice3CrispAsr"/> for why we don't
+/// stage them ourselves. Same .part + size-check pattern as VibeVoice/IndexTTS download services
+/// so an interrupted download can't leave a truncated file at the real path.
+/// </summary>
+public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [CosyVoice3CrispAsr.LlmQ4KFileName] =
+            "https://huggingface.co/cstr/cosyvoice3-0.5b-2512-GGUF/resolve/main/cosyvoice3-llm-q4_k.gguf",
+        [CosyVoice3CrispAsr.LlmF16FileName] =
+            "https://huggingface.co/cstr/cosyvoice3-0.5b-2512-GGUF/resolve/main/cosyvoice3-llm-f16.gguf",
+    };
+
+    public CosyVoice3CrispAsrDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var llmFileName = CosyVoice3CrispAsr.GetLlmFileName(modelKey);
+        var llmPath = CosyVoice3CrispAsr.GetLlmPath(modelKey);
+
+        await Task.Run(() =>
+        {
+            CosyVoice3CrispAsr.TrySeedModelFromCrispAsrCache(llmFileName, llmPath);
+            EnsureRemovedIfInvalid(llmPath, llmFileName);
+        }, cancellationToken);
+
+        if (CosyVoice3CrispAsr.IsValidLocalModelFile(llmPath, llmFileName))
+        {
+            return;
+        }
+
+        titleProgress?.Invoke($"Downloading CosyVoice3 (CrispASR) model: {llmFileName}");
+        await DownloadAndVerify(llmPath, llmFileName, progress, cancellationToken);
+    }
+
+    private async Task DownloadAndVerify(string finalPath, string fileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, CosyVoice3CrispAsr.LlmQ4KFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.CosyVoice3CrispAsr.LlmQ4K;
+        }
+        if (string.Equals(fileName, CosyVoice3CrispAsr.LlmF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.CosyVoice3CrispAsr.LlmF16;
+        }
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await DownloadHashManager.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"CosyVoice3 (CrispASR) model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static string GetUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown CosyVoice3 (CrispASR) model: {fileName}", nameof(fileName));
+        }
+        return url;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || CosyVoice3CrispAsr.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+        TryDelete(path);
+    }
+}

--- a/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
@@ -44,6 +44,12 @@ public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadServ
 
     public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
     {
+        // modelsFolder is intentionally ignored — destinations are derived from
+        // CosyVoice3CrispAsr.GetSetModelsFolder() so cache-seed adoption and SE-managed downloads
+        // converge on the same canonical location. The parameter stays on the interface for
+        // symmetry with the other CrispASR TTS download services.
+        _ = modelsFolder;
+
         var required = CosyVoice3CrispAsr.GetRequiredFileNames(modelKey);
 
         // Seed any matching files already in crispasr's --auto-download cache before deciding

--- a/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
@@ -30,10 +30,8 @@ public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadServ
     {
         [CosyVoice3CrispAsr.LlmQ4KFileName] = RepoBase + CosyVoice3CrispAsr.LlmQ4KFileName,
         [CosyVoice3CrispAsr.LlmF16FileName] = RepoBase + CosyVoice3CrispAsr.LlmF16FileName,
-        [CosyVoice3CrispAsr.FlowQ8_0FileName] = RepoBase + CosyVoice3CrispAsr.FlowQ8_0FileName,
         [CosyVoice3CrispAsr.FlowF16FileName] = RepoBase + CosyVoice3CrispAsr.FlowF16FileName,
         [CosyVoice3CrispAsr.HiftF16FileName] = RepoBase + CosyVoice3CrispAsr.HiftF16FileName,
-        [CosyVoice3CrispAsr.S3TokQ4KFileName] = RepoBase + CosyVoice3CrispAsr.S3TokQ4KFileName,
         [CosyVoice3CrispAsr.S3TokF16FileName] = RepoBase + CosyVoice3CrispAsr.S3TokF16FileName,
         [CosyVoice3CrispAsr.CampPlusF16FileName] = RepoBase + CosyVoice3CrispAsr.CampPlusF16FileName,
         [CosyVoice3CrispAsr.VoicesGgufFileName] = RepoBase + CosyVoice3CrispAsr.VoicesGgufFileName,
@@ -105,14 +103,10 @@ public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadServ
             return DownloadHashManager.CosyVoice3CrispAsr.LlmQ4K;
         if (string.Equals(fileName, CosyVoice3CrispAsr.LlmF16FileName, StringComparison.OrdinalIgnoreCase))
             return DownloadHashManager.CosyVoice3CrispAsr.LlmF16;
-        if (string.Equals(fileName, CosyVoice3CrispAsr.FlowQ8_0FileName, StringComparison.OrdinalIgnoreCase))
-            return DownloadHashManager.CosyVoice3CrispAsr.FlowQ8_0;
         if (string.Equals(fileName, CosyVoice3CrispAsr.FlowF16FileName, StringComparison.OrdinalIgnoreCase))
             return DownloadHashManager.CosyVoice3CrispAsr.FlowF16;
         if (string.Equals(fileName, CosyVoice3CrispAsr.HiftF16FileName, StringComparison.OrdinalIgnoreCase))
             return DownloadHashManager.CosyVoice3CrispAsr.HiftF16;
-        if (string.Equals(fileName, CosyVoice3CrispAsr.S3TokQ4KFileName, StringComparison.OrdinalIgnoreCase))
-            return DownloadHashManager.CosyVoice3CrispAsr.S3TokQ4K;
         if (string.Equals(fileName, CosyVoice3CrispAsr.S3TokF16FileName, StringComparison.OrdinalIgnoreCase))
             return DownloadHashManager.CosyVoice3CrispAsr.S3TokF16;
         if (string.Equals(fileName, CosyVoice3CrispAsr.CampPlusF16FileName, StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -145,13 +145,12 @@ public static class DownloadHashManager
     {
         // SHA-256 of every GGUF the cosyvoice3-tts backend needs. We stage all of them in
         // CrispAsr/models/ rather than letting crispasr --auto-download them, so each has a
-        // verified hash. Hashes are HF LFS oid from the tree API.
+        // verified hash. Hashes are HF LFS oid from the tree API. Companions are F16-only —
+        // crispasr 0.6.12's sibling discovery is hardcoded to those filenames.
         public const string LlmQ4K = "CosyVoice3CrispAsr.LlmQ4K";
         public const string LlmF16 = "CosyVoice3CrispAsr.LlmF16";
-        public const string FlowQ8_0 = "CosyVoice3CrispAsr.FlowQ8_0";
         public const string FlowF16 = "CosyVoice3CrispAsr.FlowF16";
         public const string HiftF16 = "CosyVoice3CrispAsr.HiftF16";
-        public const string S3TokQ4K = "CosyVoice3CrispAsr.S3TokQ4K";
         public const string S3TokF16 = "CosyVoice3CrispAsr.S3TokF16";
         public const string CampPlusF16 = "CosyVoice3CrispAsr.CampPlusF16";
         public const string VoicesGguf = "CosyVoice3CrispAsr.VoicesGguf";
@@ -662,10 +661,6 @@ public static class DownloadHashManager
             {
                 "f13149e1f695d79dcc707de45b3df58ccaf2ab7eba1dad4168ae2c778efe4e67", // cosyvoice3-llm-f16.gguf
             },
-            [CosyVoice3CrispAsr.FlowQ8_0] = new[]
-            {
-                "ab264405ca243baf9aa2f2f26959d213d3e3ca9fb204db2a0b582ed2ca243d86", // cosyvoice3-flow-q8_0.gguf
-            },
             [CosyVoice3CrispAsr.FlowF16] = new[]
             {
                 "689566f06437567f764bfb50d3c06461c79bab97914ab8889b735e35498bd5f6", // cosyvoice3-flow-f16.gguf
@@ -673,10 +668,6 @@ public static class DownloadHashManager
             [CosyVoice3CrispAsr.HiftF16] = new[]
             {
                 "6df249e52901714f30f9bb163ff47cedfa56f6df3385567b657610eeb8b8cfd3", // cosyvoice3-hift-f16.gguf
-            },
-            [CosyVoice3CrispAsr.S3TokQ4K] = new[]
-            {
-                "0fb0b43516487dff1b52623e7fcbe44b5d27b2df68a5a61d7f4f05012d0a36ca", // cosyvoice3-s3tok-q4_k.gguf
             },
             [CosyVoice3CrispAsr.S3TokF16] = new[]
             {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -141,6 +141,20 @@ public static class DownloadHashManager
         public const string Codec = "IndexTtsCrispAsr.Codec";
     }
 
+    public static class CosyVoice3CrispAsr
+    {
+        // SHA-256 of the LLM GGUF (two quants). Companion files (flow/hift/s3tok/campplus/voices)
+        // are not staged by SE — they're fetched by crispasr --auto-download and not verified here.
+        public const string LlmQ4K = "CosyVoice3CrispAsr.LlmQ4K";
+        public const string LlmF16 = "CosyVoice3CrispAsr.LlmF16";
+    }
+
+    public static class F5TtsCrispAsr
+    {
+        // SHA-256 of the F16 talker (single GGUF — Vocos vocoder is bundled in).
+        public const string TalkerF16 = "F5TtsCrispAsr.TalkerF16";
+    }
+
     public static class KokoroTtsCpp
     {
         // Hashes of the release archive (.zip) - same role as OmniVoice's set. Index 0 must match
@@ -627,6 +641,23 @@ public static class DownloadHashManager
             [IndexTtsCrispAsr.Codec] = new[]
             {
                 "fcba9a322d80ef318da8a17c01e8a5e7f299ccdf881c62a43abf62cb3c104268", // indextts-bigvgan.gguf
+            },
+
+            // CosyVoice3 (CrispASR) — cstr/cosyvoice3-0.5b-2512-GGUF on HuggingFace.
+            // Hashes are HF LFS oid (= SHA-256) pulled from the tree API.
+            [CosyVoice3CrispAsr.LlmQ4K] = new[]
+            {
+                "33d899490108bce896c3448bca40ebd994daa125ce0b118e6267f6b84fc09530", // cosyvoice3-llm-q4_k.gguf
+            },
+            [CosyVoice3CrispAsr.LlmF16] = new[]
+            {
+                "f13149e1f695d79dcc707de45b3df58ccaf2ab7eba1dad4168ae2c778efe4e67", // cosyvoice3-llm-f16.gguf
+            },
+
+            // F5-TTS (CrispASR) — cstr/f5-tts-GGUF on HuggingFace.
+            [F5TtsCrispAsr.TalkerF16] = new[]
+            {
+                "25a4d273048dad072774ff139cf19b96fe442bebda8392c08009d73256cf1e81", // f5-tts-v1-base-f16.gguf
             },
 
             // Kokoro TTS — https://github.com/niksedk/kokoro.cpp/releases

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -143,10 +143,18 @@ public static class DownloadHashManager
 
     public static class CosyVoice3CrispAsr
     {
-        // SHA-256 of the LLM GGUF (two quants). Companion files (flow/hift/s3tok/campplus/voices)
-        // are not staged by SE — they're fetched by crispasr --auto-download and not verified here.
+        // SHA-256 of every GGUF the cosyvoice3-tts backend needs. We stage all of them in
+        // CrispAsr/models/ rather than letting crispasr --auto-download them, so each has a
+        // verified hash. Hashes are HF LFS oid from the tree API.
         public const string LlmQ4K = "CosyVoice3CrispAsr.LlmQ4K";
         public const string LlmF16 = "CosyVoice3CrispAsr.LlmF16";
+        public const string FlowQ8_0 = "CosyVoice3CrispAsr.FlowQ8_0";
+        public const string FlowF16 = "CosyVoice3CrispAsr.FlowF16";
+        public const string HiftF16 = "CosyVoice3CrispAsr.HiftF16";
+        public const string S3TokQ4K = "CosyVoice3CrispAsr.S3TokQ4K";
+        public const string S3TokF16 = "CosyVoice3CrispAsr.S3TokF16";
+        public const string CampPlusF16 = "CosyVoice3CrispAsr.CampPlusF16";
+        public const string VoicesGguf = "CosyVoice3CrispAsr.VoicesGguf";
     }
 
     public static class F5TtsCrispAsr
@@ -644,7 +652,8 @@ public static class DownloadHashManager
             },
 
             // CosyVoice3 (CrispASR) — cstr/cosyvoice3-0.5b-2512-GGUF on HuggingFace.
-            // Hashes are HF LFS oid (= SHA-256) pulled from the tree API.
+            // Hashes are HF LFS oid (= SHA-256) pulled from the tree API. Every file is staged
+            // by SE, so each gets an integrity check.
             [CosyVoice3CrispAsr.LlmQ4K] = new[]
             {
                 "33d899490108bce896c3448bca40ebd994daa125ce0b118e6267f6b84fc09530", // cosyvoice3-llm-q4_k.gguf
@@ -652,6 +661,34 @@ public static class DownloadHashManager
             [CosyVoice3CrispAsr.LlmF16] = new[]
             {
                 "f13149e1f695d79dcc707de45b3df58ccaf2ab7eba1dad4168ae2c778efe4e67", // cosyvoice3-llm-f16.gguf
+            },
+            [CosyVoice3CrispAsr.FlowQ8_0] = new[]
+            {
+                "ab264405ca243baf9aa2f2f26959d213d3e3ca9fb204db2a0b582ed2ca243d86", // cosyvoice3-flow-q8_0.gguf
+            },
+            [CosyVoice3CrispAsr.FlowF16] = new[]
+            {
+                "689566f06437567f764bfb50d3c06461c79bab97914ab8889b735e35498bd5f6", // cosyvoice3-flow-f16.gguf
+            },
+            [CosyVoice3CrispAsr.HiftF16] = new[]
+            {
+                "6df249e52901714f30f9bb163ff47cedfa56f6df3385567b657610eeb8b8cfd3", // cosyvoice3-hift-f16.gguf
+            },
+            [CosyVoice3CrispAsr.S3TokQ4K] = new[]
+            {
+                "0fb0b43516487dff1b52623e7fcbe44b5d27b2df68a5a61d7f4f05012d0a36ca", // cosyvoice3-s3tok-q4_k.gguf
+            },
+            [CosyVoice3CrispAsr.S3TokF16] = new[]
+            {
+                "12d6b5761e9d2efbc905f8b5ddecc6dc34371c928fbbe30cf52d900c0fb27f7e", // cosyvoice3-s3tok-f16.gguf
+            },
+            [CosyVoice3CrispAsr.CampPlusF16] = new[]
+            {
+                "f3243551ace3dd0cc73844e2edfd94feea89d2668dad79bcfc9f5800b376c334", // cosyvoice3-campplus-f16.gguf
+            },
+            [CosyVoice3CrispAsr.VoicesGguf] = new[]
+            {
+                "73b5cac894d8e715d418d0228d2878ad6e836a809ccb85799ff08ae5f63ac6a2", // cosyvoice3-voices.gguf
             },
 
             // F5-TTS (CrispASR) — cstr/f5-tts-GGUF on HuggingFace.

--- a/src/ui/Logic/Download/F5TtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/F5TtsCrispAsrDownloadService.cs
@@ -36,6 +36,12 @@ public class F5TtsCrispAsrDownloadService : IF5TtsCrispAsrDownloadService
 
     public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
     {
+        // modelsFolder is intentionally ignored — the destination path is derived from
+        // F5TtsCrispAsr.GetTalkerPath so SE-managed callers and crispasr's own --auto-download
+        // cache adoption end up at the same canonical location. The parameter stays on the
+        // interface for symmetry with the other CrispASR TTS download services.
+        _ = modelsFolder;
+
         var talkerFileName = F5TtsCrispAsr.GetTalkerFileName(modelKey);
         var talkerPath = F5TtsCrispAsr.GetTalkerPath(modelKey);
 

--- a/src/ui/Logic/Download/F5TtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/F5TtsCrispAsrDownloadService.cs
@@ -1,0 +1,130 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IF5TtsCrispAsrDownloadService
+{
+    Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Downloads the F5-TTS v1 base GGUF (~953 MB F16) into SE's CrispASR/models folder. Same
+/// .part + size-check + optional SHA-256 verify pattern as VibeVoice/IndexTTS so an interrupted
+/// download can't leave a truncated file at the real path. There is no separate codec/vocoder
+/// file — F5-TTS bundles the Vocos vocoder into the talker GGUF.
+/// </summary>
+public class F5TtsCrispAsrDownloadService : IF5TtsCrispAsrDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [F5TtsCrispAsr.TalkerF16FileName] =
+            "https://huggingface.co/cstr/f5-tts-GGUF/resolve/main/f5-tts-v1-base-f16.gguf",
+    };
+
+    public F5TtsCrispAsrDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var talkerFileName = F5TtsCrispAsr.GetTalkerFileName(modelKey);
+        var talkerPath = F5TtsCrispAsr.GetTalkerPath(modelKey);
+
+        await Task.Run(() =>
+        {
+            F5TtsCrispAsr.TrySeedModelFromCrispAsrCache(talkerFileName, talkerPath);
+            EnsureRemovedIfInvalid(talkerPath, talkerFileName);
+        }, cancellationToken);
+
+        if (F5TtsCrispAsr.IsValidLocalModelFile(talkerPath, talkerFileName))
+        {
+            return;
+        }
+
+        titleProgress?.Invoke($"Downloading F5-TTS (CrispASR) model: {talkerFileName}");
+        await DownloadAndVerify(talkerPath, talkerFileName, progress, cancellationToken);
+    }
+
+    private async Task DownloadAndVerify(string finalPath, string fileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, F5TtsCrispAsr.TalkerF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.F5TtsCrispAsr.TalkerF16;
+        }
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await DownloadHashManager.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"F5-TTS (CrispASR) model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static string GetUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown F5-TTS (CrispASR) model: {fileName}", nameof(fileName));
+        }
+        return url;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || F5TtsCrispAsr.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+        TryDelete(path);
+    }
+}

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -757,6 +757,29 @@ public class FfmpegGenerator
         return process;
     }
 
+    /// <summary>
+    /// Resamples / mixes the input to mono PCM16 WAV at 16 kHz. Used by CosyVoice3 (CrispASR)
+    /// for its zero-shot voice-cloning reference WAV — the s3tok speech tokenizer expects
+    /// 16 kHz mono. Higher rates work but cause a lossy resample on every synth call.
+    /// </summary>
+    public static Process ConvertToMono16kHzWav(string inputFileName, string outputFileName, DataReceivedEventHandler? dataReceivedHandler = null)
+    {
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = GetFfmpegLocation(),
+                Arguments = $"-y -i \"{inputFileName}\" -ar 16000 -ac 1 -c:a pcm_s16le \"{outputFileName}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            }
+        };
+
+        SetupDataReceiveHandler(dataReceivedHandler, process);
+
+        return process;
+    }
+
     public static string GenerateTransparentVideoFile(string assaSubtitleFileName, string outputVideoFileName, int width, int height, string frameRate, string timeCode)
     {
         if (width % 2 == 1)


### PR DESCRIPTION
## Summary
- Adds **CosyVoice3 (CrispASR)** — Alibaba 0.5B, 9 languages + 18 zh dialects, 8 baked-in voice presets (zero_shot + FLEURS en/de/zh/ja/fr/es/ko). Q4_K (~745 MB total) or F16 (~2.5 GB total). Companion files (flow / hift / s3tok / campplus / voices, ~360 MB) fetched by crispasr `--auto-download` on first synth.
- Adds **F5-TTS (CrispASR)** — F5-TTS v1 base (MIT), DiT flow-matching + Vocos vocoder, zero-shot voice cloning from a 24 kHz mono reference WAV plus optional `.txt` transcription sidecar. Single 953 MB F16 GGUF.
- Both require CrispASR v0.6.12 or newer.

## Implementation
Each engine ships with the same supporting pieces as the existing CrispASR-backed engines (Qwen3 / VibeVoice / IndexTTS):

- `Engines/*CrispAsr.cs` — server lifecycle, OpenAI-compat `/v1/audio/speech` client, model-key resolution, truncation guard with exact byte sizes from the HF tree API.
- `Voices/*.cs` — engine-specific voice POCO (preset name for CosyVoice3; WAV path for F5-TTS).
- `Logic/Download/*CrispAsrDownloadService.cs` — `.part` + size-check + SHA-256 verify against `DownloadHashManager` entries (HF LFS oid).
- `*CrispAsrSettings/` — settings dialog ViewModel + Window with engine/model status dots, speed slider (CosyVoice3 0.25–4.0, F5-TTS 0.25–4.0), and re-download buttons.
- Wired into `TextToSpeechViewModel` (engine list + `ShowEngineSettings` + `EnsureEngineIsInstalled`), `DownloadTtsViewModel` (download orchestration + voices ZIP chain for F5-TTS), `TtsVoiceInstaller` (CrispASR install/update prompts), `DependencyInjectionExtensions`, and `SeVideoTextToSpeech` (persisted Model + Speed settings).

CosyVoice3 has no `ImportVoice` flow — the voice bank is baked into `cosyvoice3-voices.gguf`. F5-TTS reuses the qwen3-tts.cpp voice pack via the same seed-into-voices-folder pattern as IndexTTS, with ffmpeg resampling to 24 kHz.

## Known caveats
- F5-TTS server-mode payload schema is unconfirmed in the CrispASR 0.6.12 README. This PR sends `voice` + `ref_text` per-request (mirroring VibeVoice / Qwen3 CustomVoice). If first synth comes back as noise, flip the `UseStartupVoiceFlags` toggle in `F5TtsCrispAsr.cs` — that switches to baking the reference WAV into the `--voice` startup flag (IndexTTS pattern) at the cost of one server restart per voice change.

## Test plan
- [ ] CosyVoice3: install crispasr 0.6.12, pick the engine, pick FLEURS English preset, synth a short subtitle → output WAV plays back as English speech.
- [ ] CosyVoice3: switch preset to `zero_shot` or `fleurs-ja` → server restarts cleanly, new output matches the new preset.
- [ ] CosyVoice3: switch quant Q4_K ↔ F16 → server restarts, model status dot reflects which quant is installed.
- [ ] CosyVoice3: open engine settings dialog → all status rows render (engine, LLM Q4_K, LLM F16, Presets count, Speed slider, Install folder).
- [ ] F5-TTS: install crispasr 0.6.12, pick the engine, no voices imported → voice combo is empty, synth surfaces the "requires a reference voice WAV" error.
- [ ] F5-TTS: import a 5–10 s WAV (with adjacent .txt sidecar), synth a subtitle → output WAV clones the voice.
- [ ] F5-TTS: open engine settings dialog → all status rows render, voice count reflects the imported WAVs.
- [ ] First-synth download path: with no local models, picking either engine triggers the download dialog and crispasr `--auto-download` pulls companion files into `~/.cache/crispasr/`.
- [ ] Restart SE → saved model/speed/preset settings persist across launches.