### PR TITLE
Remove five dead private methods

### DIFF
--- a/src/libse/Forms/MoveWordUpDown.cs
+++ b/src/libse/Forms/MoveWordUpDown.cs
@@ -394,23 +394,6 @@ namespace Nikse.SubtitleEdit.Core.Forms
             S2 = AutoBreakIfNeeded(S2);
         }
 
-        private static bool IsPartOfFontTag(string s, int i)
-        {
-            var indexOfFontTag = s.Substring(0, i).LastIndexOf("<font ", StringComparison.OrdinalIgnoreCase);
-            if (indexOfFontTag < 0)
-            {
-                return false;
-            }
-
-            var indexOfEndFontTag = s.IndexOf(">", indexOfFontTag, StringComparison.Ordinal);
-            if (indexOfEndFontTag < 0)
-            {
-                return false;
-            }
-
-            return i >= indexOfFontTag && i <= indexOfEndFontTag;
-        }
-
         private static string RemoveEmptyTags(string s)
         {
             var noTags = HtmlUtil.RemoveHtmlTags(s, true);
@@ -423,61 +406,6 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 .Replace("<i></i>", string.Empty)
                 .Replace("<u></u>", string.Empty)
                 .Replace("<b></b>", string.Empty);
-        }
-
-        private static string AddWordBefore(string word, string input)
-        {
-            var pre = string.Empty;
-            var s = input;
-            if (s.StartsWith("{\\") && s.Contains("}"))
-            {
-                var idx = s.IndexOf('}');
-                pre = s.Substring(0, idx + 1);
-                s = s.Remove(0, idx + 1);
-            }
-            var arr = s.SplitToLines();
-            if (s.StartsWith("<i>", StringComparison.OrdinalIgnoreCase) && (s.EndsWith("</i>", StringComparison.OrdinalIgnoreCase) || arr[0].EndsWith("</i>", StringComparison.OrdinalIgnoreCase)))
-            {
-                return pre + s.Insert(3, word.Trim() + " ").Trim();
-            }
-            if (s.StartsWith("<b>", StringComparison.OrdinalIgnoreCase) && (s.EndsWith("</b>", StringComparison.OrdinalIgnoreCase) || arr[0].EndsWith("</b>", StringComparison.OrdinalIgnoreCase)))
-            {
-                return pre + s.Insert(3, word.Trim() + " ").Trim();
-            }
-            if (s.StartsWith("<u>", StringComparison.OrdinalIgnoreCase) && (s.EndsWith("</u>", StringComparison.OrdinalIgnoreCase) || arr[0].EndsWith("</u>", StringComparison.OrdinalIgnoreCase)))
-            {
-                return pre + s.Insert(3, word.Trim() + " ").Trim();
-            }
-            if (s.StartsWith("<font", StringComparison.OrdinalIgnoreCase) && s.Contains(">") && s.Contains("</font>", StringComparison.OrdinalIgnoreCase))
-            {
-                var endIdx = s.IndexOf('>');
-                return pre + s.Insert(endIdx + 1, word.Trim() + " ").Trim();
-            }
-
-            return pre + (word.Trim() + " " + s.Trim()).Trim();
-        }
-
-        private static string AddWordAfter(string word, string s)
-        {
-            var arr = s.SplitToLines();
-            if (s.EndsWith("</i>", StringComparison.OrdinalIgnoreCase) && (s.StartsWith("<i>", StringComparison.OrdinalIgnoreCase) || arr[arr.Count - 1].StartsWith("<i>", StringComparison.OrdinalIgnoreCase)))
-            {
-                return s.Insert(s.Length - 4, " " + word.Trim()).Trim();
-            }
-            if (s.EndsWith("</b>", StringComparison.OrdinalIgnoreCase) && (s.StartsWith("<b>", StringComparison.OrdinalIgnoreCase) || arr[arr.Count - 1].StartsWith("<b>", StringComparison.OrdinalIgnoreCase)))
-            {
-                return s.Insert(s.Length - 4, " " + word.Trim()).Trim();
-            }
-            if (s.EndsWith("</u>", StringComparison.OrdinalIgnoreCase) && (s.StartsWith("<u>", StringComparison.OrdinalIgnoreCase) || arr[arr.Count - 1].StartsWith("<u>", StringComparison.OrdinalIgnoreCase)))
-            {
-                return s.Insert(s.Length - 4, " " + word.Trim()).Trim();
-            }
-            if (s.EndsWith("</font>", StringComparison.OrdinalIgnoreCase) && s.Contains("<font", StringComparison.OrdinalIgnoreCase))
-            {
-                return s.Insert(s.Length - 7, " " + word.Trim()).Trim();
-            }
-
-            return (s.Trim() + " " + word.Trim()).Trim();
         }
 
         private static string AutoBreakIfNeeded(string s)

--- a/src/libuilogic/Ocr/BinaryOcrMatcher.cs
+++ b/src/libuilogic/Ocr/BinaryOcrMatcher.cs
@@ -398,17 +398,6 @@ public class BinaryOcrMatcher : IBinaryOcrMatcher
         return lowercaseHeight;
     }
 
-    private int GetLastBinOcrUppercaseHeight()
-    {
-        var uppercaseHeight = 35;
-        if (_ocrUppercaseHeightsTotalCount > 5)
-        {
-            uppercaseHeight = (int)Math.Round((double)_ocrUppercaseHeightsTotal / _ocrUppercaseHeightsTotalCount);
-        }
-
-        return uppercaseHeight;
-    }
-
     private static void FindBestMatch(ref int index, ref int smallestDifference, out BinaryOcrBitmap? hit, NikseBitmap2 target, BinaryOcrDb binOcrDb, BinaryOcrBitmap bob, double maxDiff)
     {
         hit = null;

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -899,13 +899,6 @@ public partial class SettingsViewModel : ObservableObject
         WriteToolsLog = Se.Settings.Tools.WriteToolsLog;
     }
 
-    private bool GetToolbarVisible(SeWaveformToolbarItemType type)
-    {
-        return Se.Settings.Waveform.ToolbarItems
-            .First(p => p.Type == type)
-            .IsVisible;
-    }
-
     // Display label <-> stored extension for the waveform "Extract audio" format.
     // ExtractAudioFormatOrder fixes the dropdown order (and thus the default at index 0);
     // a Dictionary's enumeration order is not contractually guaranteed.


### PR DESCRIPTION
## Summary
Removes five private methods that have no callers anywhere in `src/` or `tests/` (verified by `grep -rn` — each symbol had exactly one occurrence, its own definition).

## What was removed
- **`MoveWordUpDown.IsPartOfFontTag`** — orphaned `<font ...>` tag check; the rest of the file routes through `HtmlUtil.RemoveHtmlTags` for tag-aware logic.
- **`MoveWordUpDown.AddWordBefore` / `AddWordAfter`** — paired helpers from an earlier tag-preserving word-move path.
- **`BinaryOcrMatcher.GetLastBinOcrUppercaseHeight`** — symmetric counterpart to `GetLastBinOcrLowercaseHeight` (which IS called, at lines 273 + 293). The matcher's uppercase logic reads the `_ocrUppercaseHeights*` accumulators inline instead. The accumulator fields stay because they're still read at line 207.
- **`SettingsViewModel.GetToolbarVisible`** — toolbar-visibility helper from before per-item `IsVisible` observables existed. No callers in code or XAML.

## Net effect
- 3 files changed, 90 deletions
- Solution builds clean (UI + libse + libuilogic + seconv + all 4 test projects)
- No behavior change — these were unreachable

## What was NOT touched (intentionally)
- The `_ocrUppercaseHeightsTotal` / `_ocrUppercaseHeightsTotalCount` accumulator fields in `BinaryOcrMatcher` — still read by the inline matching logic on line 207, only the unused helper that wrapped them is removed.
- Cleared all `[RelayCommand]`-decorated methods and XAML-bound handlers from candidate consideration via a follow-up grep pass.

## Test plan
- [x] `dotnet build SubtitleEdit.sln` succeeds with 0 warnings, 0 errors.
- [ ] Smoke-test "Move word up/down" in the main subtitle window with italic/bold/underline/font-tagged lines (the file these helpers lived in).
- [ ] Smoke-test Binary OCR auto-detect period-at-top heuristic (the lowercase variant that remains is still used).
- [ ] Open Options → Settings, verify the page still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)