### PR TITLE
Restore /video: CLI argument for opening a video alongside the subtitle

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14876,7 +14876,8 @@ public partial class MainViewModel :
             AudioVisualizer.IsReadOnly = LockTimeCodes;
         }
 
-        if (Program.FileOpenedViaActivation && !string.IsNullOrEmpty(Program.PendingFileToOpen))
+        if (Program.FileOpenedViaActivation &&
+            (!string.IsNullOrEmpty(Program.PendingFileToOpen) || !string.IsNullOrEmpty(Program.PendingVideoToOpen)))
         {
             Dispatcher.UIThread.Post(async void () =>
             {
@@ -14891,8 +14892,19 @@ public partial class MainViewModel :
                 }
 
                 await Task.Delay(100);
-                await SubtitleOpen(Program.PendingFileToOpen);
+                var hasCliVideo = !string.IsNullOrEmpty(Program.PendingVideoToOpen);
+                if (!string.IsNullOrEmpty(Program.PendingFileToOpen))
+                {
+                    // skipLoadVideo when a CLI video is given so SubtitleOpen does not
+                    // auto-guess and load a different one before we open the explicit path.
+                    await SubtitleOpen(Program.PendingFileToOpen, skipLoadVideo: hasCliVideo);
+                }
+                if (hasCliVideo && File.Exists(Program.PendingVideoToOpen!))
+                {
+                    await VideoOpenFile(Program.PendingVideoToOpen!);
+                }
                 Program.PendingFileToOpen = null;
+                Program.PendingVideoToOpen = null;
             });
         }
         else if (Se.Settings.File.OpenLastFileOnStart)

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -24,6 +24,7 @@ namespace Nikse.SubtitleEdit
         private const string AppName = "Subtitle Edit";
 
         public static string? PendingFileToOpen { get; set; }
+        public static string? PendingVideoToOpen { get; set; }
         public static bool FileOpenedViaActivation { get; set; }
 
         [STAThread]
@@ -257,14 +258,50 @@ namespace Nikse.SubtitleEdit
                 UiUtil.RestoreWindowPosition(lifetime.MainWindow);
             }
 
-            lifetime.Startup += (_, e) =>
+            lifetime.Startup += (_, e) => ParseStartupArgs(e.Args);
+        }
+
+        // Accepts the first existing positional path as the subtitle file and any of
+        // /video:<path>, --video:<path>, or --video <path> for the video file.
+        // /video: is the legacy Subtitle Edit syntax kept for backwards compatibility
+        // with existing user scripts (see discussion #11380).
+        private static void ParseStartupArgs(string[] args)
+        {
+            string? subtitle = null;
+            string? video = null;
+
+            for (var i = 0; i < args.Length; i++)
             {
-                if (e.Args.Length > 0 && System.IO.File.Exists(e.Args[0]))
+                var a = args[i];
+                if (a.StartsWith("/video:", StringComparison.OrdinalIgnoreCase))
                 {
-                    PendingFileToOpen = e.Args[0];
-                    FileOpenedViaActivation = true;
+                    video = a.Substring("/video:".Length);
                 }
-            };
+                else if (a.StartsWith("--video:", StringComparison.OrdinalIgnoreCase))
+                {
+                    video = a.Substring("--video:".Length);
+                }
+                else if (a.Equals("--video", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    video = args[++i];
+                }
+                else if (subtitle == null && System.IO.File.Exists(a))
+                {
+                    subtitle = a;
+                }
+            }
+
+            if (subtitle != null)
+            {
+                PendingFileToOpen = subtitle;
+                FileOpenedViaActivation = true;
+            }
+
+            if (!string.IsNullOrEmpty(video) && System.IO.File.Exists(video))
+            {
+                PendingVideoToOpen = video;
+                FileOpenedViaActivation = true;
+            }
         }
 
         private static bool HasBatchConvertUiArg(string[] args)


### PR DESCRIPTION
## Summary
- The v5 Avalonia rewrite only inspected `args[0]` as a subtitle path, silently dropping the legacy `/video:<path>` flag that users' sync pipelines (e.g. alass/ffsubsync wrappers) relied on — reported in discussion #11380.
- `Program.cs` now parses all startup args and accepts `/video:<path>`, `--video:<path>`, and `--video <path>`; the first existing positional path is the subtitle.
- `MainViewModel`'s activation block force-loads the CLI video via `VideoOpenFile` after `SubtitleOpen` (with `skipLoadVideo: true` to suppress the auto-guess), so the explicit flag wins regardless of the `Settings.Video.AutoOpen` setting.

## Test plan
- [ ] `subtitleedit sub.srt /video:vid.mp4` opens both (legacy syntax).
- [ ] `subtitleedit sub.srt --video:vid.mp4` opens both.
- [ ] `subtitleedit sub.srt --video vid.mp4` opens both.
- [ ] `subtitleedit /video:vid.mp4` (video only) opens just the video.
- [ ] `subtitleedit sub.srt` still opens just the subtitle (no regression).
- [ ] Behavior holds with `Settings.Video.AutoOpen` both on and off.

Refs: #11380

🤖 Generated with [Claude Code](https://claude.com/claude-code)