### PR TITLE
Fix missing Renumber() after subtitle inserts

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5645,6 +5645,11 @@ public partial class MainViewModel :
             _insertService.InsertInCorrectPosition(Subtitles, line);
         }
 
+        if (newLines.Count > 0 || deleteLines.Count > 0)
+        {
+            Renumber();
+        }
+
         _updateAudioVisualizer = true;
         return true;
     }
@@ -8374,6 +8379,11 @@ public partial class MainViewModel :
             _insertService.InsertInCorrectPosition(Subtitles, newSubtitle);
         }
 
+        if (newSubtitles.Count > 0)
+        {
+            Renumber();
+        }
+
         _shortcutManager.ClearKeys();
     }
 
@@ -10915,6 +10925,7 @@ public partial class MainViewModel :
         _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
         AudioVisualizer.NewSelectionParagraph = null;
         SelectAndScrollToSubtitle(newParagraph);
+        Renumber();
         FocusEditTextBox();
         _updateAudioVisualizer = true;
     }
@@ -10935,6 +10946,7 @@ public partial class MainViewModel :
         AudioVisualizer.NewSelectionParagraph = null;
         SubtitleGrid.SelectedItem = newParagraph;
         SubtitleGrid.ScrollIntoView(newParagraph, null);
+        Renumber();
         _updateAudioVisualizer = true;
 
         await SpeechToTextSelectedLines();
@@ -11039,6 +11051,7 @@ public partial class MainViewModel :
 
         AudioVisualizer.NewSelectionParagraph = null;
         SelectAndScrollToSubtitle(newParagraph);
+        Renumber();
         FocusEditTextBox();
         _updateAudioVisualizer = true;
     }
@@ -11080,6 +11093,7 @@ public partial class MainViewModel :
 
         AudioVisualizer.NewSelectionParagraph = null;
         SelectAndScrollToSubtitle(newParagraph);
+        Renumber();
         _updateAudioVisualizer = true;
     }
 


### PR DESCRIPTION
## Summary
- Several `MainViewModel` insert paths inserted a paragraph without calling `Renumber()`, leaving the new row with `Number = 0` until the grid refreshed. This is the root cause reported in #11382 ("subtitle added in timeline gets entry numbered 0 until refresh").
- Added `Renumber()` to: `WaveformInsertNewSelection`, `WaveformSpeechToTextNewSelection`, `WaveformInsertAtPositionAndFocusTextBox`, `WaveformInsertAtPositionNoFocusTextBox`, `DuplicateSelectedLines`, and `SpeechToTextSelectedLines` (when a long line is split into multiple segments).
- Other insert call sites in `MainViewModel` were reviewed and already either call `Renumber()` or pull numbers from a trusted source (undo/redo, sorts, file load, OCR window, etc.).

Fixes part of #11382 — the numbering bug. The other two requests in that issue (Enter key behaviour on selection, snapping selection to neighbouring subtitles + min-gap) are separate features and are not addressed here.

## Test plan
- [ ] Open SE, select an audio area in the waveform/timeline, press Enter to insert — the new row shows its correct number immediately (not 0).
- [ ] Right-click waveform → Insert new selection — number is correct immediately.
- [ ] Right-click waveform → Insert at position — number is correct immediately.
- [ ] Right-click waveform → Speech-to-text for new selection — number is correct immediately.
- [ ] Duplicate selected lines — all new rows have correct numbers.
- [ ] Speech-to-text on a >10s selected line that splits into multiple lines — inserted lines have correct numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)