### PR TITLE
Fix CPS strategy not updating grid until restart (#11379)

### DIFF
--- a/src/libse/Common/TextLengthCalculator/CalcFactory.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcFactory.cs
@@ -16,6 +16,8 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
             new CalcIncludeCompositionCharactersNotSpace(),
             new CalcNoSpaceOrPunctuation(),
             new CalcNoSpaceOrPunctuationCpsOnly(),
+            new CalcIgnoreArabicDiacritics(),
+            new CalcIgnoreArabicDiacriticsNoSpace(),
         };
 
         public static ICalcLength MakeCalculator(string strategy)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7781,6 +7781,17 @@ public partial class MainViewModel :
         SetLibSeSettings();
         SubtitleLineViewModel.ErrorColor = Se.Settings.General.ErrorColor.FromHexToColor();
 
+        // Settings that feed into CPS / line-length / colour calculations
+        // (CpsLineLengthStrategy, SubtitleLineMaximumLength, the various
+        // Color* toggles, ErrorColor, etc.) just changed. The grid binds to
+        // computed properties on each row, but nothing on the rows themselves
+        // changed, so without an explicit notification the cells keep showing
+        // the previous values until the user edits a row (issue #11379).
+        foreach (var row in Subtitles)
+        {
+            row.RefreshAfterSettingsChanged();
+        }
+
         var selectedSubtitleFormatName = SelectedSubtitleFormat.Name;
         SubtitleFormats.Clear();
         foreach (var format in SubtitleFormatHelper.GetSubtitleFormatsWithFavoritesAtTop())
@@ -17327,7 +17338,7 @@ public partial class MainViewModel :
                     .WithPadding(2));
             }
 
-            var lineLength = lines[i].Length;
+            var lineLength = (int)lines[i].CountCharacters(false);
             var tb = UiUtil.MakeTextBlock(lineLength.ToString(CultureInfo.InvariantCulture))
                 .WithFontSize(12)
                 .WithPadding(2);

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -261,7 +261,7 @@ public partial class SubtitleLineViewModel : ObservableObject
 
                 foreach (var line in stripped.SplitToLines())
                 {
-                    if (line.Length > Se.Settings.General.SubtitleLineMaximumLength)
+                    if (line.CountCharacters(false) > Se.Settings.General.SubtitleLineMaximumLength)
                     {
                         return _errorBrush;
                     }
@@ -502,6 +502,26 @@ public partial class SubtitleLineViewModel : ObservableObject
     public void RefreshText()
     {
         OnPropertyChanged(nameof(Text));
+    }
+
+    /// <summary>
+    /// Raises change notifications for properties whose values depend on
+    /// <see cref="Se.Settings"/> (CPS strategy, line-length limit, colour
+    /// toggles, error colour, etc.). The grid's per-cell bindings cache the
+    /// last value, so when a setting changes mid-session the rows keep
+    /// showing stale CPS numbers and stale error highlights until something
+    /// on the row itself changes. Call this once per row after
+    /// <see cref="Se.Settings"/> is updated.
+    /// </summary>
+    public void RefreshAfterSettingsChanged()
+    {
+        OnPropertyChanged(nameof(CharactersPerSecond));
+        OnPropertyChanged(nameof(WordsPerMinute));
+        OnPropertyChanged(nameof(TextBackgroundBrush));
+        OnPropertyChanged(nameof(DurationBackgroundBrush));
+        OnPropertyChanged(nameof(CpsBackgroundBrush));
+        OnPropertyChanged(nameof(WpmBackgroundBrush));
+        OnPropertyChanged(nameof(GapBackgroundBrush));
     }
 
     /// <summary>Updates all display properties from a fixed <see cref="Paragraph"/> in-place.</summary>

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -522,6 +522,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(CpsBackgroundBrush));
         OnPropertyChanged(nameof(WpmBackgroundBrush));
         OnPropertyChanged(nameof(GapBackgroundBrush));
+        OnPropertyChanged(nameof(PixelWidth));
     }
 
     /// <summary>Updates all display properties from a fixed <see cref="Paragraph"/> in-place.</summary>


### PR DESCRIPTION
## Summary

Fixes #11379. Three related issues in the CPS/line-length pipeline:

- **CPS strategy change didn't repaint the grid.** Changing the CPS strategy (or any other setting that feeds into CPS/length/colour calculations) and clicking OK updated `Se.Settings` and was synced into `Configuration.Settings` by `ApplySettings`/`SetLibSeSettings`, but the rows themselves never received `PropertyChanged` for the computed properties (`CharactersPerSecond`, the five `*BackgroundBrush`es, `WordsPerMinute`). Cells kept the previously-computed numbers until the user edited a row or restarted. `ApplySettings` now walks `Subtitles` and calls a small `RefreshAfterSettingsChanged()` helper on each row.

- **Two strategies in the dropdown silently fell back to `CalcAll`.** `CpsLineLengthStrategyDisplay.List()` offered `CalcIgnoreArabicDiacritics` and `CalcIgnoreArabicDiacriticsNoSpace`, but `CalcFactory.Calculators` didn't include them, so the name lookup in `MakeCalculator` returned `null` and fell through to the `?? new CalcAll()` default. Added both to the list.

- **Per-line length didn't agree with the total.** The textbox info panel showed per-line lengths as raw `line.Length` and the total as `cleanText.CountCharacters(false)` (strategy-aware), so with any "no spaces" / "no punctuation" strategy the per-line sum didn't equal the displayed total. Same raw-`.Length` mismatch in the grid's `TextBackgroundBrush` for the row text-too-long check. Both now use `line.CountCharacters(false)`, matching libse's other per-line length checks (`SplitLongLinesHelper`, `FixLongLines`, `MoveWordUpDown`, `Helper.cs` in FixCommonErrors).

## Test plan

- [ ] Open a subtitle, change CPS strategy in Options → CPS column repaints immediately (no restart needed).
- [ ] Pick "CalcIgnoreArabicDiacritics" or "...NoSpace" — verify counts change (previously identical to CalcAll).
- [ ] With a strategy that excludes spaces/punctuation, the per-line numbers under the textbox now sum to the displayed total.
- [ ] With the same strategy, a line that is over `SubtitleLineMaximumLength` in raw chars but under it after stripping spaces no longer gets a red row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)