### PR TITLE
Fix and improve OCR spell check prompt button behavior

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -2738,7 +2738,7 @@ public partial class OcrViewModel : ObservableObject
                         }
                         else if (result.SkipAllPressed)
                         {
-                            _ocrFixEngine.SkipAll(result.Word);
+                            _ocrFixEngine.SkipAll(unknownWord.Word.FixedWord);
                         }
                         else if (result.AddToNamesListPressed)
                         {
@@ -3118,7 +3118,7 @@ public partial class OcrViewModel : ObservableObject
                         }
                         else if (result.SkipAllPressed)
                         {
-                            _ocrFixEngine.SkipAll(result.Word);
+                            _ocrFixEngine.SkipAll(unknownWord.Word.FixedWord);
                         }
                         else if (result.AddToNamesListPressed)
                         {
@@ -3452,7 +3452,7 @@ public partial class OcrViewModel : ObservableObject
                             }
                             else if (result.SkipAllPressed)
                             {
-                                _ocrFixEngine.SkipAll(result.Word);
+                                _ocrFixEngine.SkipAll(unknownWord.Word.FixedWord);
                             }
                             else if (result.AddToNamesListPressed)
                             {

--- a/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
@@ -21,16 +21,35 @@ public partial class PromptUnknownWordViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _suggestions;
     [ObservableProperty] private string _selectedSuggestion;
     [ObservableProperty] private string? _text;
-    [ObservableProperty] private string _wholeText;
-    [ObservableProperty] private string _word;
-    [ObservableProperty] private bool _doEditWholeText;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ChangeOnceCommand))]
+    private string _wholeText;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ChangeAllCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ChangeOnceCommand))]
+    [NotifyCanExecuteChangedFor(nameof(GoogleItCommand))]
+    [NotifyCanExecuteChangedFor(nameof(AddToNamesListCommand))]
+    [NotifyCanExecuteChangedFor(nameof(AddToUserDictionaryCommand))]
+    private string _word;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ChangeAllCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ChangeOnceCommand))]
+    private bool _doEditWholeText;
+
     [ObservableProperty] private bool _areSuggestionsEnabled;
+    [ObservableProperty] private string _editButtonLabel;
 
     public StackPanel PanelWholeText { get; set; }
     public TextBox TextBoxWholeText { get; set; }
     public TextBox TextBoxWord { get; set; }
     public Bitmap? Bitmap { get; set; }
     public Window? Window { get; set; }
+
+    private string _wordOriginal = string.Empty;
+    private string _wholeTextOriginal = string.Empty;
 
     public bool ChangeAllPressed { get; private set; }
     public bool ChangeOncePressed { get; private set; }
@@ -51,13 +70,17 @@ public partial class PromptUnknownWordViewModel : ObservableObject
         Text = string.Empty;
         WholeText = string.Empty;
         Word = string.Empty;
+        EditButtonLabel = string.Empty;
     }
 
     public void Initialize(Bitmap bitmap, string wholeText, UnknownWordItem word, List<string> suggestions)
     {
         Bitmap = bitmap;
+        _wholeTextOriginal = wholeText;
         WholeText = wholeText;
+        _wordOriginal = word.Word.FixedWord;
         Word = word.Word.FixedWord;
+        EditButtonLabel = Se.Language.Ocr.EditWholeText;
         Suggestions.AddRange(suggestions);
 
         Dispatcher.UIThread.Invoke(() =>
@@ -122,6 +145,19 @@ public partial class PromptUnknownWordViewModel : ObservableObject
         PanelWholeText.Children.Add(textBlock);
     }
 
+    partial void OnDoEditWholeTextChanged(bool value)
+    {
+        EditButtonLabel = value ? Se.Language.Ocr.EditWordOnly : Se.Language.Ocr.EditWholeText;
+    }
+
+    private bool CanChangeAll() => !DoEditWholeText && !string.IsNullOrWhiteSpace(Word) && Word != _wordOriginal;
+
+    private bool CanChangeOnce() => DoEditWholeText
+        ? WholeText != _wholeTextOriginal
+        : !string.IsNullOrWhiteSpace(Word) && Word != _wordOriginal;
+
+    private bool CanActOnWord() => !string.IsNullOrWhiteSpace(Word);
+
     [RelayCommand]
     private void EditWholeText()
     {
@@ -148,18 +184,23 @@ public partial class PromptUnknownWordViewModel : ObservableObject
     [RelayCommand]
     private void SuggestionUseAlways()
     {
+        if (string.IsNullOrEmpty(SelectedSuggestion))
+        {
+            return;
+        }
+
         Word = SelectedSuggestion;
         ChangeAll();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanChangeAll))]
     private void ChangeAll()
     {
         ChangeAllPressed = true;
         Window?.Close();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanChangeOnce))]
     private void ChangeOnce()
     {
         if (DoEditWholeText)
@@ -181,7 +222,7 @@ public partial class PromptUnknownWordViewModel : ObservableObject
         Window?.Close();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanActOnWord))]
     private void GoogleIt()
     {
 
@@ -194,14 +235,14 @@ public partial class PromptUnknownWordViewModel : ObservableObject
         Window?.Close();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanActOnWord))]
     private void AddToNamesList()
     {
         AddToNamesListPressed = true;
         Window?.Close();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanActOnWord))]
     private void AddToUserDictionary()
     {
         AddToUserDictionaryPressed = true;

--- a/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;
 
@@ -223,9 +224,9 @@ public partial class PromptUnknownWordViewModel : ObservableObject
     }
 
     [RelayCommand(CanExecute = nameof(CanActOnWord))]
-    private void GoogleIt()
+    private async Task GoogleIt()
     {
-
+        await Window!.Launcher.LaunchUriAsync(new Uri("https://www.google.com/search?q=" + HttpUtility.UrlEncode(Word)));
     }
 
     [RelayCommand]

--- a/src/ui/Features/Ocr/PromptUnknownWordWindow.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordWindow.cs
@@ -124,8 +124,8 @@ public class PromptUnknownWordWindow : Window
 
         var buttonEditWholeText = new ToggleButton
         {
-            Content = Se.Language.Ocr.EditWholeText,
             DataContext = vm,
+            [!ContentControl.ContentProperty] = new Binding(nameof(vm.EditButtonLabel)),
             [!ToggleButton.IsCheckedProperty] = new Binding(nameof(vm.DoEditWholeText)) { Mode = BindingMode.TwoWay },
             VerticalAlignment = VerticalAlignment.Center,
             Margin = new Thickness(3, 0, 0, 0),
@@ -147,12 +147,12 @@ public class PromptUnknownWordWindow : Window
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -174,24 +174,23 @@ public class PromptUnknownWordWindow : Window
             vm.TextBoxWord.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         var buttonChangeAll = UiUtil.MakeButton(Se.Language.General.ChangeAll, vm.ChangeAllCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindEnabled(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
         var buttonChangeOnce = UiUtil.MakeButton(Se.Language.General.ChangeOnce, vm.ChangeOnceCommand)
             .WithHorizontalAlignmentStretch();
         var buttonSkipOne = UiUtil.MakeButton(Se.Language.General.SkipOnce, vm.SkipOnceCommand)
-            .WithHorizontalAlignmentStretch()
-            .WithBindEnabled(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithHorizontalAlignmentStretch();
         var buttonGoogleIt = UiUtil.MakeButton(Se.Language.General.GoogleIt, vm.GoogleItCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindEnabled(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
         var buttonSkipAll = UiUtil.MakeButton(Se.Language.General.SkipAll, vm.SkipAllCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindEnabled(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
         var buttonAddToNameList = UiUtil.MakeButton(Se.Language.General.AddToNamesListCaseSensitive, vm.AddToNamesListCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindEnabled(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
         var buttonAddToUserDictionary = UiUtil.MakeButton(Se.Language.General.AddToUserDictionary, vm.AddToUserDictionaryCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindEnabled(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
 
         grid.Add(vm.TextBoxWord, 0, 0, 1, 2);
         grid.Add(buttonChangeAll, 1, 0, 1, 2);


### PR DESCRIPTION
  ## Summary

  Several correctness and usability improvements to the OCR spell check prompt (the dialog shown during OCR when an unknown word is encountered).

  **Button enable/disable logic**
  - Change and Change all are disabled when the word textbox still shows the original flagged word — there is nothing to change yet. They enable once the user edits the text and re-disable if the edit is reverted.
  - Change and Change all are disabled when the word textbox is empty.
  - Google it, Add to names list, and Add to user dictionary are also disabled when the word textbox is empty.
  - Skip once and Skip all remain enabled at all times.

  **Edit whole text mode**
  - The toggle button label switches between "Edit whole text" and "Edit word only" to reflect the current state.
  - Change once is disabled until the whole-text textbox differs from the original; re-disables if reverted.
  - Change all, Google it, Skip all, Add to names list, and Add to user dictionary are hidden (not just disabled) in this mode to reduce clutter. Only Change once and Skip once remain visible.
  - Grid rows are Auto-sized so hidden rows collapse cleanly.

  **Bug fixes**
  - Skip all was passing the current textbox content to the engine instead of the original flagged word. If the user had edited or cleared the textbox, the wrong word (or an empty string) would be skipped. Fixed to always use the original flagged word.
  - `SuggestionUseAlways()` was missing the null/empty guard that `SuggestionUse()` already had; if triggered with no suggestion selected it would submit an empty Change all.

  **Google it**
  - The button was a no-op stub. Now opens a Google search for the word in the default browser using Avalonia's Launcher API.


https://github.com/user-attachments/assets/da41ed5c-8aca-4d2b-881a-f613be1637d7

