### PR TITLE
Apply subtitle font to OCR character text boxes

### DIFF
--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddWindow.cs
@@ -105,6 +105,8 @@ public class BinaryOcrCharacterAddWindow : Window
         };
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText));
+        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+            vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         var image = new Image
         {
             Margin = new Thickness(5),

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterHistoryWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterHistoryWindow.cs
@@ -95,6 +95,8 @@ public class BinaryOcrCharacterHistoryWindow : Window
         };
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText));
+        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+            vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         var image = new Image
         {
             Margin = new Thickness(5),

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -118,6 +119,8 @@ public class BinaryOcrDbEditWindow : Window
         };
 
         vm.TextBoxItem = UiUtil.MakeTextBox(100, vm, nameof(vm.ItemText));
+        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+            vm.TextBoxItem.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         vm.TextBoxItem.Bind(TextBox.FontStyleProperty, new Binding(nameof(vm.IsItemItalic)) { Converter = new BoolToFontStyleConverter() });
 
         var image = new Image

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterAddWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterAddWindow.cs
@@ -104,6 +104,8 @@ public class NOcrCharacterAddWindow : Window
         };
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText));
+        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+            vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         vm.TextBoxNew.FontStyle = vm.IsNewTextItalic ? FontStyle.Italic : FontStyle.Normal;
 
         var image = new Image

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterHistoryWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterHistoryWindow.cs
@@ -97,6 +97,8 @@ public class NOcrCharacterHistoryWindow : Window
         };
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText));
+        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+            vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         var image = new Image
         {
             Margin = new Thickness(5),

--- a/src/ui/Features/Ocr/NOcr/NOcrDbEditWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrDbEditWindow.cs
@@ -122,6 +122,8 @@ public class NOcrDbEditWindow : Window
         };
 
         vm.TextBoxItem = UiUtil.MakeTextBox(100, vm, nameof(vm.ItemText));
+        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+            vm.TextBoxItem.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
 
         var panelCurrent = new StackPanel
         {

--- a/src/ui/Features/Ocr/NOcr/NOcrInspectWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrInspectWindow.cs
@@ -128,6 +128,8 @@ public class NOcrInspectWindow : Window
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText))
             .WithBindEnabled(nameof(vm.IsEditControlsEnabled));
+        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+            vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
 
         var image = new Image
         {


### PR DESCRIPTION
  The subtitle font setting (`Appearance → Subtitle font`) was already applied to the main OCR window and a few secondary windows, but seven OCR dialogs were missed in #11368. This extends the same pattern to the remaining ones:

  - BinaryOcrCharacterAddWindow
  - BinaryOcrCharacterHistoryWindow
  - BinaryOcrDbEditWindow
  - NOcrCharacterAddWindow
  - NOcrCharacterHistoryWindow
  - NOcrDbEditWindow
  - NOcrInspectWindow

  Each gets the same guard applied immediately after `MakeTextBox`, consistent with the existing pattern in `BinaryOcrInspectWindow` and `PromptUnknownWordWindow`.