### PR TITLE
Add multi-select to checkbox data grids in tool windows

### DIFF
--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
@@ -183,22 +183,8 @@ public class ApplyDurationLimitsWindow : Window
                 },
             },
         };
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is ApplyDurationLimitItem selectedItem)
-            {
-                selectedItem.Apply = !selectedItem.Apply;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<ApplyDurationLimitItem>(dataGrid,
+            item => item.Apply, (item, v) => item.Apply = v);
 
         grid.Add(labelFixesAvailable, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
@@ -8,7 +8,6 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
-using System.Collections;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -114,22 +113,8 @@ public class BatchConvertFixCommonErrorsSettingsWindow : Window
                 },
             },
         };
-        rulesGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && rulesGrid.SelectedItem is FixRuleDisplayItem selectedItem)
-            {
-                selectedItem.IsSelected = !selectedItem.IsSelected;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && rulesGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                rulesGrid.SelectedItem = target;
-                rulesGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        rulesGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => rulesGrid.Focus());
+        new DataGridCheckboxMultiSelect<FixRuleDisplayItem>(rulesGrid,
+            item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         return UiUtil.MakeBorderForControl(rulesGrid);
     }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -403,23 +403,9 @@ public class BatchConvertWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchFunction)) { Source = vm });
-        dataGrid.SelectionChanged += (_, _) => vm.SelectedFunctionChanged();
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is BatchConvertFunction selectedItem)
-            {
-                selectedItem.IsSelected = !selectedItem.IsSelected;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<BatchConvertFunction>(dataGrid,
+            item => item.IsSelected, (item, v) => item.IsSelected = v,
+            onFocusedItemChanged: _ => vm.SelectedFunctionChanged());
         UiUtil.AttachMacContextFlyoutHandler(dataGrid);
 
         return UiUtil.MakeBorderForControl(dataGrid);

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
@@ -7,7 +7,6 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
-using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -145,22 +144,8 @@ public class FixNamesWindow : Window
             IsReadOnly = true,
         });
 
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is FixNameItem selectedItem)
-            {
-                selectedItem.IsChecked = !selectedItem.IsChecked;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<FixNameItem>(dataGrid,
+            item => item.IsChecked, (item, v) => item.IsChecked = v);
 
         var flyout = new MenuFlyout();
         flyout.Items.Add(new MenuItem { Header = Se.Language.General.SelectAll, Command = vm.NamesSelectAllCommand });
@@ -227,22 +212,8 @@ public class FixNamesWindow : Window
             IsReadOnly = true
         });
 
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is FixNameHitItem selectedItem)
-            {
-                selectedItem.IsEnabled = !selectedItem.IsEnabled;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<FixNameHitItem>(dataGrid,
+            item => item.IsEnabled, (item, v) => item.IsEnabled = v);
 
         var flyout = new MenuFlyout();
         flyout.Items.Add(new MenuItem { Header = Se.Language.General.SelectAll, Command = vm.HitsSelectAllCommand });

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -7,7 +7,6 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
-using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -232,22 +231,8 @@ public class ConvertActorsWindow : Window
                 },
             },
         };
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is ConvertActorsDisplayItem selectedItem)
-            {
-                selectedItem.IsChecked = !selectedItem.IsChecked;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<ConvertActorsDisplayItem>(dataGrid,
+            item => item.IsChecked, (item, v) => item.IsChecked = v);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -249,7 +249,6 @@ public class FixCommonErrorsWindow : Window
         var dataGridFixes = new DataGrid
         {
             AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Extended,
             CanUserResizeColumns = true,
             CanUserSortColumns = true,
             HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -333,7 +332,7 @@ public class FixCommonErrorsWindow : Window
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
         new DataGridCheckboxMultiSelect<FixDisplayItem>(dataGridFixes,
             item => item.IsSelected, (item, v) => item.IsSelected = v,
-            onFocusedItemChanged: item => _vm.SelectAndScrollTo(item));
+            onFocusedItemChanged: item => { if (item != null) _vm.SelectAndScrollTo(item); });
 
         var leftButtons = new StackPanel
         {

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -8,7 +8,10 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
+using Avalonia.VisualTree;
+using System;
 using System.Collections;
+using System.Linq;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
@@ -21,7 +24,10 @@ public class FixCommonErrorsWindow : Window
 {
     private readonly FixCommonErrorsViewModel _vm;
     private FixRuleDisplayItem? _lastClickedFixRule;
-    private FixDisplayItem? _lastClickedFix;
+    private DataGrid? _dataGridFixes;
+    private int _fixesShiftAnchorIndex = -1;
+    private int _fixesShiftCurrentIndex = -1;
+    private bool _fixesSelectionChangedSkip;
 
     public FixCommonErrorsWindow(FixCommonErrorsViewModel vm)
     {
@@ -263,7 +269,7 @@ public class FixCommonErrorsWindow : Window
         var dataGridFixes = new DataGrid
         {
             AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
+            SelectionMode = DataGridSelectionMode.Extended,
             CanUserResizeColumns = true,
             CanUserSortColumns = true,
             HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -280,7 +286,7 @@ public class FixCommonErrorsWindow : Window
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     CellTemplate = new FuncDataTemplate<FixDisplayItem>((item, _) =>
                     {
-                        var border = new Border
+                        return new Border
                         {
                             Background = Brushes.Transparent, // Prevents highlighting
                             Padding = new Thickness(4),
@@ -291,11 +297,6 @@ public class FixCommonErrorsWindow : Window
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
                         };
-                        border.AddHandler(
-                            PointerPressedEvent,
-                            (_, e) => OnFixPointerPressed(item, e),
-                            handledEventsToo: true);
-                        return border;
                     }),
                     Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
                 },
@@ -349,21 +350,46 @@ public class FixCommonErrorsWindow : Window
                 },
             },
         };
+        _dataGridFixes = dataGridFixes;
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
         dataGridFixes.SelectionChanged += DataGridFixes_SelectionChanged;
         dataGridFixes.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key == Key.Space && dataGridFixes.SelectedItem is FixDisplayItem selectedItem)
+            var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+            if (e.Key == Key.Space)
             {
-                selectedItem.IsSelected = !selectedItem.IsSelected;
+                ToggleFixesCheckboxForSelectedRows();
                 e.Handled = true;
             }
-            else if (e.Key is Key.Home or Key.End && dataGridFixes.ItemsSource is IList items && items.Count > 0)
+            else if (isShift && e.Key is Key.Up or Key.Down or Key.PageUp or Key.PageDown or Key.Home or Key.End)
             {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
+                var direction = e.Key switch
+                {
+                    Key.Up => -1,
+                    Key.Down => 1,
+                    Key.PageUp => -GetFixesGridPageSize(),
+                    Key.PageDown => GetFixesGridPageSize(),
+                    Key.Home => -_vm.Fixes.Count,
+                    Key.End => _vm.Fixes.Count,
+                    _ => 0
+                };
+                HandleFixesShiftArrowSelection(direction);
+                e.Handled = true;
+            }
+            else if (e.Key is Key.Home or Key.End && _vm.Fixes.Count > 0)
+            {
+                _fixesShiftAnchorIndex = -1;
+                _fixesShiftCurrentIndex = -1;
+                var target = e.Key == Key.Home ? _vm.Fixes[0] : _vm.Fixes[^1];
                 dataGridFixes.SelectedItem = target;
                 dataGridFixes.ScrollIntoView(target, null);
                 e.Handled = true;
+            }
+            else if (e.Key is Key.Up or Key.Down)
+            {
+                _fixesShiftAnchorIndex = -1;
+                _fixesShiftCurrentIndex = -1;
             }
         }, RoutingStrategies.Tunnel);
         dataGridFixes.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGridFixes.Focus());
@@ -583,7 +609,15 @@ public class FixCommonErrorsWindow : Window
 
     private void DataGridFixes_SelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (e.AddedItems.Count == 1 && e.AddedItems[0] is FixDisplayItem fixDisplayItem)
+        if (_fixesSelectionChangedSkip)
+        {
+            return;
+        }
+
+        _fixesShiftAnchorIndex = -1;
+        _fixesShiftCurrentIndex = -1;
+
+        if (_dataGridFixes?.SelectedItem is FixDisplayItem fixDisplayItem)
         {
             _vm.SelectAndScrollTo(fixDisplayItem);
         }
@@ -625,32 +659,92 @@ public class FixCommonErrorsWindow : Window
         _lastClickedFixRule = item;
     }
 
-    private void OnFixPointerPressed(FixDisplayItem item, PointerPressedEventArgs e)
+    private void HandleFixesShiftArrowSelection(int direction)
     {
-        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift) &&
-            _lastClickedFix != null &&
-            _lastClickedFix != item)
+        var fixes = _vm.Fixes;
+        if (fixes.Count == 0 || _dataGridFixes == null)
         {
-            var fixes = _vm.Fixes;
-            var lastIdx = fixes.IndexOf(_lastClickedFix);
-            var currIdx = fixes.IndexOf(item);
-            if (lastIdx >= 0 && currIdx >= 0)
-            {
-                var newValue = !item.IsSelected;
-                var min = lastIdx < currIdx ? lastIdx : currIdx;
-                var max = lastIdx > currIdx ? lastIdx : currIdx;
-                for (var i = min; i <= max; i++)
-                {
-                    if (i == currIdx)
-                    {
-                        continue;
-                    }
-
-                    fixes[i].IsSelected = newValue;
-                }
-            }
+            return;
         }
 
-        _lastClickedFix = item;
+        if (_fixesShiftAnchorIndex < 0)
+        {
+            var anchor = _dataGridFixes.SelectedItems.Count > 0
+                ? fixes.IndexOf((FixDisplayItem)_dataGridFixes.SelectedItems[0]!)
+                : -1;
+            if (anchor < 0)
+            {
+                return;
+            }
+
+            _fixesShiftAnchorIndex = anchor;
+            _fixesShiftCurrentIndex = anchor;
+        }
+
+        var newCurrent = Math.Clamp(_fixesShiftCurrentIndex + direction, 0, fixes.Count - 1);
+        if (newCurrent == _fixesShiftCurrentIndex)
+        {
+            return;
+        }
+
+        _fixesShiftCurrentIndex = newCurrent;
+
+        var startIdx = Math.Min(_fixesShiftAnchorIndex, _fixesShiftCurrentIndex);
+        var endIdx = Math.Max(_fixesShiftAnchorIndex, _fixesShiftCurrentIndex);
+
+        _fixesSelectionChangedSkip = true;
+        _dataGridFixes.SelectedItems.Clear();
+        for (var i = startIdx; i <= endIdx; i++)
+        {
+            _dataGridFixes.SelectedItems.Add(fixes[i]);
+        }
+
+        _fixesSelectionChangedSkip = false;
+
+        _dataGridFixes.ScrollIntoView(fixes[_fixesShiftCurrentIndex], null);
+        _vm.SelectAndScrollTo(fixes[_fixesShiftCurrentIndex]);
+    }
+
+    private void ToggleFixesCheckboxForSelectedRows()
+    {
+        if (_dataGridFixes == null)
+        {
+            return;
+        }
+
+        var selected = _dataGridFixes.SelectedItems.OfType<FixDisplayItem>().ToList();
+        if (selected.Count == 0)
+        {
+            return;
+        }
+
+        var allChecked = selected.All(f => f.IsSelected);
+        var newValue = !allChecked;
+        foreach (var fix in selected)
+        {
+            fix.IsSelected = newValue;
+        }
+    }
+
+    private int GetFixesGridPageSize()
+    {
+        if (_dataGridFixes == null)
+        {
+            return 10;
+        }
+
+        var rowsPresenter = _dataGridFixes.GetVisualDescendants()
+            .OfType<DataGridRowsPresenter>()
+            .FirstOrDefault();
+        var rowHeight = _dataGridFixes.RowHeight;
+        if (rowsPresenter != null && rowsPresenter.Bounds.Height > 0 && !double.IsNaN(rowHeight) && rowHeight > 0)
+        {
+            return Math.Max(1, (int)Math.Ceiling(rowsPresenter.Bounds.Height / rowHeight) - 1);
+        }
+
+        var visibleRows = _dataGridFixes.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .Count(r => r.IsVisible && r.Bounds.Height > 0);
+        return Math.Max(1, visibleRows - 1);
     }
 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -21,7 +21,6 @@ namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 public class FixCommonErrorsWindow : Window
 {
     private readonly FixCommonErrorsViewModel _vm;
-    private FixRuleDisplayItem? _lastClickedFixRule;
 
     public FixCommonErrorsWindow(FixCommonErrorsViewModel vm)
     {
@@ -87,7 +86,7 @@ public class FixCommonErrorsWindow : Window
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     CellTemplate = new FuncDataTemplate<FixRuleDisplayItem>((item, _) =>
                     {
-                        var border = new Border
+                        return new Border
                         {
                             Background = Brushes.Transparent, // Prevents highlighting
                             Padding = new Thickness(4),
@@ -98,11 +97,6 @@ public class FixCommonErrorsWindow : Window
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
                         };
-                        border.AddHandler(
-                            PointerPressedEvent,
-                            (_, e) => OnFixRulePointerPressed(item, e),
-                            handledEventsToo: true);
-                        return border;
                     }),
                     Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
                 },
@@ -551,36 +545,6 @@ public class FixCommonErrorsWindow : Window
     {
         base.OnKeyDown(e);
         _vm.OnKeyDown(e);
-    }
-
-    private void OnFixRulePointerPressed(FixRuleDisplayItem item, PointerPressedEventArgs e)
-    {
-        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift) &&
-            _lastClickedFixRule != null &&
-            _lastClickedFixRule != item &&
-            _vm.SelectedProfile is { } profile)
-        {
-            var rules = profile.FixRules;
-            var lastIdx = rules.IndexOf(_lastClickedFixRule);
-            var currIdx = rules.IndexOf(item);
-            if (lastIdx >= 0 && currIdx >= 0)
-            {
-                var newValue = !item.IsSelected; // CheckBox will toggle the current item to this on release
-                var min = lastIdx < currIdx ? lastIdx : currIdx;
-                var max = lastIdx > currIdx ? lastIdx : currIdx;
-                for (var i = min; i <= max; i++)
-                {
-                    if (i == currIdx)
-                    {
-                        continue;
-                    }
-
-                    rules[i].IsSelected = newValue;
-                }
-            }
-        }
-
-        _lastClickedFixRule = item;
     }
 
 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -704,7 +704,6 @@ public class FixCommonErrorsWindow : Window
             _dataGridFixes.SelectedItems.Add(fixes[i]);
         }
 
-        _vm.SelectedFix = fixes[_fixesShiftCurrentIndex];
         _fixesSelectionChangedSkip = false;
 
         _dataGridFixes.ScrollIntoView(fixes[_fixesShiftCurrentIndex], null);

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -286,7 +286,7 @@ public class FixCommonErrorsWindow : Window
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     CellTemplate = new FuncDataTemplate<FixDisplayItem>((item, _) =>
                     {
-                        return new Border
+                        var border = new Border
                         {
                             Background = Brushes.Transparent, // Prevents highlighting
                             Padding = new Thickness(4),
@@ -297,6 +297,11 @@ public class FixCommonErrorsWindow : Window
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
                         };
+                        border.AddHandler(
+                            PointerPressedEvent,
+                            (_, _) => { if (_dataGridFixes != null) _dataGridFixes.SelectedItem = item; },
+                            handledEventsToo: true);
+                        return border;
                     }),
                     Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
                 },
@@ -617,7 +622,7 @@ public class FixCommonErrorsWindow : Window
         _fixesShiftAnchorIndex = -1;
         _fixesShiftCurrentIndex = -1;
 
-        if (_dataGridFixes?.SelectedItem is FixDisplayItem fixDisplayItem)
+        if (e.AddedItems.Count > 0 && _dataGridFixes?.SelectedItem is FixDisplayItem fixDisplayItem)
         {
             _vm.SelectAndScrollTo(fixDisplayItem);
         }
@@ -699,6 +704,7 @@ public class FixCommonErrorsWindow : Window
             _dataGridFixes.SelectedItems.Add(fixes[i]);
         }
 
+        _vm.SelectedFix = fixes[_fixesShiftCurrentIndex];
         _fixesSelectionChangedSkip = false;
 
         _dataGridFixes.ScrollIntoView(fixes[_fixesShiftCurrentIndex], null);

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -8,10 +8,8 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
-using Avalonia.VisualTree;
 using System;
 using System.Collections;
-using System.Linq;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
@@ -24,10 +22,6 @@ public class FixCommonErrorsWindow : Window
 {
     private readonly FixCommonErrorsViewModel _vm;
     private FixRuleDisplayItem? _lastClickedFixRule;
-    private DataGrid? _dataGridFixes;
-    private int _fixesShiftAnchorIndex = -1;
-    private int _fixesShiftCurrentIndex = -1;
-    private bool _fixesSelectionChangedSkip;
 
     public FixCommonErrorsWindow(FixCommonErrorsViewModel vm)
     {
@@ -130,22 +124,8 @@ public class FixCommonErrorsWindow : Window
             },
         };
         rulesGrid.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
-        rulesGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && rulesGrid.SelectedItem is FixRuleDisplayItem selectedItem)
-            {
-                selectedItem.IsSelected = !selectedItem.IsSelected;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && rulesGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                rulesGrid.SelectedItem = target;
-                rulesGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        rulesGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => rulesGrid.Focus());
+        new DataGridCheckboxMultiSelect<FixRuleDisplayItem>(rulesGrid,
+            item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         var step2Grid = MakeStep2Grid();
         step2Grid.Bind(IsVisibleProperty, new Binding(nameof(_vm.Step2IsVisible)));
@@ -350,49 +330,10 @@ public class FixCommonErrorsWindow : Window
                 },
             },
         };
-        _dataGridFixes = dataGridFixes;
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
-        dataGridFixes.SelectionChanged += DataGridFixes_SelectionChanged;
-        dataGridFixes.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
-
-            if (e.Key == Key.Space)
-            {
-                ToggleFixesCheckboxForSelectedRows();
-                e.Handled = true;
-            }
-            else if (isShift && e.Key is Key.Up or Key.Down or Key.PageUp or Key.PageDown or Key.Home or Key.End)
-            {
-                var direction = e.Key switch
-                {
-                    Key.Up => -1,
-                    Key.Down => 1,
-                    Key.PageUp => -GetFixesGridPageSize(),
-                    Key.PageDown => GetFixesGridPageSize(),
-                    Key.Home => -_vm.Fixes.Count,
-                    Key.End => _vm.Fixes.Count,
-                    _ => 0
-                };
-                HandleFixesShiftArrowSelection(direction);
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && _vm.Fixes.Count > 0)
-            {
-                _fixesShiftAnchorIndex = -1;
-                _fixesShiftCurrentIndex = -1;
-                var target = e.Key == Key.Home ? _vm.Fixes[0] : _vm.Fixes[^1];
-                dataGridFixes.SelectedItem = target;
-                dataGridFixes.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Up or Key.Down)
-            {
-                _fixesShiftAnchorIndex = -1;
-                _fixesShiftCurrentIndex = -1;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGridFixes.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGridFixes.Focus());
+        new DataGridCheckboxMultiSelect<FixDisplayItem>(dataGridFixes,
+            item => item.IsSelected, (item, v) => item.IsSelected = v,
+            onFocusedItemChanged: item => _vm.SelectAndScrollTo(item));
 
         var leftButtons = new StackPanel
         {
@@ -607,22 +548,6 @@ public class FixCommonErrorsWindow : Window
         return grid;
     }
 
-    private void DataGridFixes_SelectionChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        if (_fixesSelectionChangedSkip)
-        {
-            return;
-        }
-
-        _fixesShiftAnchorIndex = -1;
-        _fixesShiftCurrentIndex = -1;
-
-        if (e.AddedItems.Count > 0 && _dataGridFixes?.SelectedItem is FixDisplayItem fixDisplayItem)
-        {
-            _vm.SelectAndScrollTo(fixDisplayItem);
-        }
-    }
-
     protected override void OnKeyDown(KeyEventArgs e)
     {
         base.OnKeyDown(e);
@@ -659,92 +584,4 @@ public class FixCommonErrorsWindow : Window
         _lastClickedFixRule = item;
     }
 
-    private void HandleFixesShiftArrowSelection(int direction)
-    {
-        var fixes = _vm.Fixes;
-        if (fixes.Count == 0 || _dataGridFixes == null)
-        {
-            return;
-        }
-
-        if (_fixesShiftAnchorIndex < 0)
-        {
-            var anchor = _dataGridFixes.SelectedItems.Count > 0
-                ? fixes.IndexOf((FixDisplayItem)_dataGridFixes.SelectedItems[0]!)
-                : -1;
-            if (anchor < 0)
-            {
-                return;
-            }
-
-            _fixesShiftAnchorIndex = anchor;
-            _fixesShiftCurrentIndex = anchor;
-        }
-
-        var newCurrent = Math.Clamp(_fixesShiftCurrentIndex + direction, 0, fixes.Count - 1);
-        if (newCurrent == _fixesShiftCurrentIndex)
-        {
-            return;
-        }
-
-        _fixesShiftCurrentIndex = newCurrent;
-
-        var startIdx = Math.Min(_fixesShiftAnchorIndex, _fixesShiftCurrentIndex);
-        var endIdx = Math.Max(_fixesShiftAnchorIndex, _fixesShiftCurrentIndex);
-
-        _fixesSelectionChangedSkip = true;
-        _dataGridFixes.SelectedItems.Clear();
-        for (var i = startIdx; i <= endIdx; i++)
-        {
-            _dataGridFixes.SelectedItems.Add(fixes[i]);
-        }
-
-        _fixesSelectionChangedSkip = false;
-
-        _dataGridFixes.ScrollIntoView(fixes[_fixesShiftCurrentIndex], null);
-        _vm.SelectAndScrollTo(fixes[_fixesShiftCurrentIndex]);
-    }
-
-    private void ToggleFixesCheckboxForSelectedRows()
-    {
-        if (_dataGridFixes == null)
-        {
-            return;
-        }
-
-        var selected = _dataGridFixes.SelectedItems.OfType<FixDisplayItem>().ToList();
-        if (selected.Count == 0)
-        {
-            return;
-        }
-
-        var allChecked = selected.All(f => f.IsSelected);
-        var newValue = !allChecked;
-        foreach (var fix in selected)
-        {
-            fix.IsSelected = newValue;
-        }
-    }
-
-    private int GetFixesGridPageSize()
-    {
-        if (_dataGridFixes == null)
-        {
-            return 10;
-        }
-
-        var rowsPresenter = _dataGridFixes.GetVisualDescendants()
-            .OfType<DataGridRowsPresenter>()
-            .FirstOrDefault();
-        var rowHeight = _dataGridFixes.RowHeight;
-        if (rowsPresenter != null && rowsPresenter.Bounds.Height > 0 && !double.IsNaN(rowHeight) && rowHeight > 0)
-        {
-            return Math.Max(1, (int)Math.Ceiling(rowsPresenter.Bounds.Height / rowHeight) - 1);
-        }
-
-        var visibleRows = _dataGridFixes.GetVisualDescendants()
-            .OfType<DataGridRow>()
-            .Count(r => r.IsVisible && r.Bounds.Height > 0);
-        return Math.Max(1, visibleRows - 1);
-    }
 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -286,7 +286,7 @@ public class FixCommonErrorsWindow : Window
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     CellTemplate = new FuncDataTemplate<FixDisplayItem>((item, _) =>
                     {
-                        var border = new Border
+                        return new Border
                         {
                             Background = Brushes.Transparent, // Prevents highlighting
                             Padding = new Thickness(4),
@@ -297,11 +297,6 @@ public class FixCommonErrorsWindow : Window
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
                         };
-                        border.AddHandler(
-                            PointerPressedEvent,
-                            (_, _) => { if (_dataGridFixes != null) _dataGridFixes.SelectedItem = item; },
-                            handledEventsToo: true);
-                        return border;
                     }),
                     Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
                 },

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
@@ -8,7 +8,6 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
-using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -137,22 +136,8 @@ public class FixNetflixErrorsWindow : Window
             IsReadOnly = true,
             Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
         });
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is NetflixCheckDisplayItem selectedItem)
-            {
-                selectedItem.IsSelected = !selectedItem.IsSelected;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<NetflixCheckDisplayItem>(dataGrid,
+            item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         var grid = new Grid
         {
@@ -246,22 +231,9 @@ public class FixNetflixErrorsWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is FixNetflixErrorsItem selectedItem && selectedItem.CanBeFixed)
-            {
-                selectedItem.Apply = !selectedItem.Apply;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<FixNetflixErrorsItem>(dataGrid,
+            item => item.Apply, (item, v) => item.Apply = v,
+            canToggle: item => item.CanBeFixed);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -8,7 +8,6 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.Media;
-using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -195,22 +194,8 @@ public class MergeContinuationLinesWindow : Window
                 },
             },
         };
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is MergeContinuationLinesCandidate selectedItem)
-            {
-                selectedItem.IsSelected = !selectedItem.IsSelected;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<MergeContinuationLinesCandidate>(dataGrid,
+            item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         grid.Add(labelInfo, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -10,7 +10,6 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Logic.Config;
-using System.Collections;
 
 namespace Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 
@@ -327,22 +326,8 @@ public class RemoveTextForHearingImpairedWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key == Key.Space && dataGrid.SelectedItem is RemoveItem selectedItem)
-            {
-                selectedItem.Apply = !selectedItem.Apply;
-                e.Handled = true;
-            }
-            else if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
-        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+        new DataGridCheckboxMultiSelect<RemoveItem>(dataGrid,
+            item => item.Apply, (item, v) => item.Apply = v);
 
         return UiUtil.MakeBorderForControl(dataGrid);
     }

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -16,6 +16,7 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
     private readonly Func<TItem, bool> _getChecked;
     private readonly Action<TItem, bool> _setChecked;
     private readonly Func<TItem, bool>? _canToggle;
+    private readonly Action<TItem?>? _onFocusedItemChanged;
     private int _shiftAnchorIndex = -1;
     private int _shiftCurrentIndex = -1;
     private bool _selectionChangedSkip;
@@ -33,6 +34,7 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
         _getChecked = getChecked;
         _setChecked = setChecked;
         _canToggle = canToggle;
+        _onFocusedItemChanged = onFocusedItemChanged;
 
         dataGrid.SelectionMode = DataGridSelectionMode.Extended;
 
@@ -49,7 +51,7 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             _shiftAnchorIndex = -1;
             _shiftCurrentIndex = -1;
 
-            onFocusedItemChanged?.Invoke(dataGrid.SelectedItem as TItem);
+            _onFocusedItemChanged?.Invoke(dataGrid.SelectedItem as TItem);
         };
     }
 
@@ -141,15 +143,22 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
         var endIdx = Math.Max(_shiftAnchorIndex, _shiftCurrentIndex);
 
         _selectionChangedSkip = true;
-        _grid.SelectedItems.Clear();
-        for (var i = startIdx; i <= endIdx; i++)
+        try
         {
-            _grid.SelectedItems.Add(items[i]);
+            _grid.SelectedItems.Clear();
+            for (var i = startIdx; i <= endIdx; i++)
+            {
+                _grid.SelectedItems.Add(items[i]);
+            }
+            _grid.SelectedItem = items[_shiftCurrentIndex];
+        }
+        finally
+        {
+            _selectionChangedSkip = false;
         }
 
-        _selectionChangedSkip = false;
-
-        _grid.ScrollIntoView(items[_shiftCurrentIndex], null);
+        _onFocusedItemChanged?.Invoke(_grid.SelectedItem as TItem);
+        _grid.ScrollIntoView(_grid.SelectedItem, null);
     }
 
     private void ToggleCheckboxForSelectedRows()

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -1,0 +1,194 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+public class DataGridCheckboxMultiSelect<TItem> where TItem : class
+{
+    private readonly DataGrid _grid;
+    private readonly Func<TItem, bool> _getChecked;
+    private readonly Action<TItem, bool> _setChecked;
+    private readonly Func<TItem, bool>? _canToggle;
+    private int _shiftAnchorIndex = -1;
+    private int _shiftCurrentIndex = -1;
+    private bool _selectionChangedSkip;
+
+    public DataGridCheckboxMultiSelect(
+        DataGrid dataGrid,
+        Func<TItem, bool> getChecked,
+        Action<TItem, bool> setChecked,
+        Func<TItem, bool>? canToggle = null,
+        Action<TItem>? onFocusedItemChanged = null)
+    {
+        _grid = dataGrid;
+        _getChecked = getChecked;
+        _setChecked = setChecked;
+        _canToggle = canToggle;
+
+        dataGrid.SelectionMode = DataGridSelectionMode.Extended;
+
+        dataGrid.AddHandler(InputElement.KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel);
+        dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
+
+        dataGrid.SelectionChanged += (_, e) =>
+        {
+            if (_selectionChangedSkip)
+            {
+                return;
+            }
+
+            _shiftAnchorIndex = -1;
+            _shiftCurrentIndex = -1;
+
+            if (onFocusedItemChanged != null && e.AddedItems.Count > 0 && dataGrid.SelectedItem is TItem item)
+            {
+                onFocusedItemChanged(item);
+            }
+        };
+    }
+
+    private IList? GetItems() => _grid.ItemsSource as IList;
+
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+        if (e.Key == Key.Space)
+        {
+            ToggleCheckboxForSelectedRows();
+            e.Handled = true;
+        }
+        else if (isShift && e.Key is Key.Up or Key.Down or Key.PageUp or Key.PageDown or Key.Home or Key.End)
+        {
+            var items = GetItems();
+            if (items == null)
+            {
+                return;
+            }
+
+            var direction = e.Key switch
+            {
+                Key.Up => -1,
+                Key.Down => 1,
+                Key.PageUp => -GetPageSize(),
+                Key.PageDown => GetPageSize(),
+                Key.Home => -items.Count,
+                Key.End => items.Count,
+                _ => 0
+            };
+            HandleShiftArrowSelection(direction);
+            e.Handled = true;
+        }
+        else if (e.Key is Key.Home or Key.End)
+        {
+            var items = GetItems();
+            if (items == null || items.Count == 0)
+            {
+                return;
+            }
+
+            _shiftAnchorIndex = -1;
+            _shiftCurrentIndex = -1;
+            var target = e.Key == Key.Home ? items[0] : items[^1];
+            _grid.SelectedItem = target;
+            _grid.ScrollIntoView(target, null);
+            e.Handled = true;
+        }
+        else if (e.Key is Key.Up or Key.Down)
+        {
+            _shiftAnchorIndex = -1;
+            _shiftCurrentIndex = -1;
+        }
+    }
+
+    private void HandleShiftArrowSelection(int direction)
+    {
+        var items = GetItems();
+        if (items == null || items.Count == 0)
+        {
+            return;
+        }
+
+        if (_shiftAnchorIndex < 0)
+        {
+            var anchor = _grid.SelectedItems.Count > 0
+                ? items.IndexOf(_grid.SelectedItems[0])
+                : -1;
+            if (anchor < 0)
+            {
+                return;
+            }
+
+            _shiftAnchorIndex = anchor;
+            _shiftCurrentIndex = anchor;
+        }
+
+        var newCurrent = Math.Clamp(_shiftCurrentIndex + direction, 0, items.Count - 1);
+        if (newCurrent == _shiftCurrentIndex)
+        {
+            return;
+        }
+
+        _shiftCurrentIndex = newCurrent;
+
+        var startIdx = Math.Min(_shiftAnchorIndex, _shiftCurrentIndex);
+        var endIdx = Math.Max(_shiftAnchorIndex, _shiftCurrentIndex);
+
+        _selectionChangedSkip = true;
+        _grid.SelectedItems.Clear();
+        for (var i = startIdx; i <= endIdx; i++)
+        {
+            _grid.SelectedItems.Add(items[i]);
+        }
+
+        _selectionChangedSkip = false;
+
+        _grid.ScrollIntoView(items[_shiftCurrentIndex], null);
+    }
+
+    private void ToggleCheckboxForSelectedRows()
+    {
+        var selected = _grid.SelectedItems.OfType<TItem>().ToList();
+        if (selected.Count == 0)
+        {
+            return;
+        }
+
+        var toggleable = _canToggle != null ? selected.Where(_canToggle).ToList() : selected;
+        if (toggleable.Count == 0)
+        {
+            return;
+        }
+
+        var allChecked = toggleable.All(_getChecked);
+        var newValue = !allChecked;
+        foreach (var item in toggleable)
+        {
+            _setChecked(item, newValue);
+        }
+    }
+
+    private int GetPageSize()
+    {
+        var rowsPresenter = _grid.GetVisualDescendants()
+            .OfType<DataGridRowsPresenter>()
+            .FirstOrDefault();
+        var rowHeight = _grid.RowHeight;
+        if (rowsPresenter != null && rowsPresenter.Bounds.Height > 0 && !double.IsNaN(rowHeight) && rowHeight > 0)
+        {
+            return Math.Max(1, (int)Math.Ceiling(rowsPresenter.Bounds.Height / rowHeight) - 1);
+        }
+
+        var visibleRows = _grid.GetVisualDescendants()
+            .OfType<DataGridRow>()
+            .Count(r => r.IsVisible && r.Bounds.Height > 0);
+        return Math.Max(1, visibleRows - 1);
+    }
+}

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -146,9 +146,11 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
         try
         {
             _grid.SelectedItems.Clear();
+            _grid.SelectedItems.Add(items[_shiftCurrentIndex]);
             for (var i = startIdx; i <= endIdx; i++)
             {
-                _grid.SelectedItems.Add(items[i]);
+                if (i != _shiftCurrentIndex)
+                    _grid.SelectedItems.Add(items[i]);
             }
         }
         finally

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -20,12 +20,14 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
     private int _shiftCurrentIndex = -1;
     private bool _selectionChangedSkip;
 
+    // The caller does not need to store the returned instance.
+    // Event subscriptions on dataGrid keep it alive for the lifetime of the grid.
     public DataGridCheckboxMultiSelect(
         DataGrid dataGrid,
         Func<TItem, bool> getChecked,
         Action<TItem, bool> setChecked,
         Func<TItem, bool>? canToggle = null,
-        Action<TItem>? onFocusedItemChanged = null)
+        Action<TItem?>? onFocusedItemChanged = null)
     {
         _grid = dataGrid;
         _getChecked = getChecked;
@@ -47,10 +49,7 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             _shiftAnchorIndex = -1;
             _shiftCurrentIndex = -1;
 
-            if (onFocusedItemChanged != null && e.AddedItems.Count > 0 && dataGrid.SelectedItem is TItem item)
-            {
-                onFocusedItemChanged(item);
-            }
+            onFocusedItemChanged?.Invoke(dataGrid.SelectedItem as TItem);
         };
     }
 
@@ -118,8 +117,8 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
 
         if (_shiftAnchorIndex < 0)
         {
-            var anchor = _grid.SelectedItems.Count > 0
-                ? items.IndexOf(_grid.SelectedItems[0])
+            var anchor = _grid.SelectedItem != null
+                ? items.IndexOf(_grid.SelectedItem)
                 : -1;
             if (anchor < 0)
             {

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -150,15 +150,14 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             {
                 _grid.SelectedItems.Add(items[i]);
             }
-            _grid.SelectedItem = items[_shiftCurrentIndex];
         }
         finally
         {
             _selectionChangedSkip = false;
         }
 
-        _onFocusedItemChanged?.Invoke(_grid.SelectedItem as TItem);
-        _grid.ScrollIntoView(_grid.SelectedItem, null);
+        _onFocusedItemChanged?.Invoke(items[_shiftCurrentIndex] as TItem);
+        _grid.ScrollIntoView(items[_shiftCurrentIndex], null);
     }
 
     private void ToggleCheckboxForSelectedRows()


### PR DESCRIPTION
  This PR is a continuation of #11335: it adds keyboard multi-select to the fix list in Fix Common Errors, and also generalizes the behavior to all tool windows that have a checkbox DataGrid.

  While the change list looks large it's net removal (223 additions and 281 deletions) since we're extracting common behavior from many classes, bringing consistent selection and navigation behavior to all tool windows that have a checkbox DataGrid.

  ## Fix Common Errors — fix list
  - Shift+Up/Down extends the row selection
  - Shift+PageUp/Down and Shift+Home/End extend selection by page or to the boundary
  - Space toggles the checkbox for all selected rows at once (unchecks all if all are checked, otherwise checks all)
  - Clicking a checkbox row does not change the DataGrid row selection

  ## All other tool windows
  The same multi-select behaviour is now available in every tool window that has a checkbox DataGrid: Fix Netflix Errors, Fix Names, Remove Text for HI, Apply Duration Limits, Merge Continuation Lines, Convert Actors, Batch Convert (functions list), and Batch Convert Fix Common Errors Settings.

  ## Implementation
  Introduced `DataGridCheckboxMultiSelect<TItem>` in `src/ui/Logic/` — a generic helper that encapsulates shift-range selection, Space batch-toggle, `SelectionMode = Extended`, and focus management. Each window instantiates it with typed getter/setter delegates instead of maintaining its own inline keyboard handler.

https://github.com/user-attachments/assets/3a8f73b3-7a50-4e40-8934-61d9a182d4ce

