### PR TITLE
Fix waveform Alt+drag producing overlapping subtitles on release

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -338,6 +338,7 @@ public class AudioVisualizer : Control
     private double _originalDurationSeconds;
     private double _originalPreviousEndSeconds;
     private double _originalNextStartSeconds;
+    private bool _preventNextTap;
     private long _audioVisualizerLastScroll;
     private SubtitleLineViewModel? _cachedHitParagraph;
     private bool _cachedIsNearLeftEdge;
@@ -499,6 +500,12 @@ public class AudioVisualizer : Control
         if (OperatingSystem.IsMacOS())
         {
             _isCtrlDown = _isMetaDown;
+        }
+
+        if (_preventNextTap)
+        {
+            _preventNextTap = false;
+            return;
         }
 
         var point = e.GetPosition(this);
@@ -799,6 +806,18 @@ public class AudioVisualizer : Control
             return;
         }
 
+        if (_interactionMode is
+            InteractionMode.Moving or
+            InteractionMode.ResizingLeft or
+            InteractionMode.ResizingRight or
+            InteractionMode.ResizingLeftOr or
+            InteractionMode.ResizingRightOr or
+            InteractionMode.ResizeLeftAnd or
+            InteractionMode.ResizeRightAnd)
+        {
+            _preventNextTap = true;
+        }
+
         _interactionMode = InteractionMode.None;
         _activeParagraph = null;
 
@@ -813,6 +832,7 @@ public class AudioVisualizer : Control
         _isMetaDown = e.KeyModifiers.HasFlag(KeyModifiers.Meta);
 
         _lastPointerPressed = Environment.TickCount64;
+        _preventNextTap = false;
         e.Handled = true;
         var point = e.GetPosition(this);
         _startPointerPosition = point;


### PR DESCRIPTION
   ## Summary

   - When holding Option (Alt) and making a very short drag on a subtitle's left edge, Avalonia fires both `PointerReleased` and `Tapped` (movement was below the ~3px tap threshold)
   - The `OnTapped` Alt branch was setting the **grid-selected** subtitle's `StartTime` to the tap position — which could be a different subtitle than the one being dragged, causing it to jump forward and overlap the dragged subtitle
   - Fix: add a `_preventNextTap` flag that is set in `OnPointerReleased` whenever a drag mode was active, and checked at the top of `OnTapped` to bail out early

   ## Details

   The waveform's `ResizeLeftAnd` mode (Option+drag left edge) correctly moves both subtitle N's start and subtitle N-1's end backward, preserving the gap. The bug manifested when the drag was short enough for Avalonia to also raise a `Tapped` event:

   1. `OnPointerReleased` clears drag state — both subtitles correctly positioned
   2. `OnTapped` fires with `_isAltDown = true`
   3. `firstSelected = AllSelectedParagraphs.FirstOrDefault()` — the grid-selected subtitle, potentially N-1
   4. `firstSelected.StartTime = tap_position` (≈ N's left edge) triggers `OnStartTimeChanged`, moving N-1's entire block forward to overlap N

   The bug was intermittent because it only occurred when the drag fell below the tap threshold (~3 logical pixels) and a different subtitle was selected in the grid.

   Alt+tap on empty waveform space (`New` mode) is unaffected by this change.

   ## Testing

I tested the following scenarios:
   - Hold Option and drag a subtitle's left edge backward — confirm the previous subtitle shortens correctly and does **not** jump forward on release
   - Reproduce with the grid-selected subtitle being the one *before* the dragged subtitle — confirm the previous (selected) subtitle shortens correctly and does **not** jump forward on release
   - Alt+click on empty waveform space — confirm the selected subtitle's start time still moves to the clicked position


  ## Video of the bug

There are 3 subtitles on the wave form. I'm Option(Alt)-dragging the left edge of the thirds one and upon mouse release the second subtitle start time gets set to where the pointer is at that time, resulting in the second subtitle moving to the right, on top of the third one.

https://github.com/user-attachments/assets/cc0fd5ef-e54c-4fd9-b472-7d5479c15137


