### PR TITLE
Fix F shortcut not working after exiting fullscreen video

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10556,6 +10556,7 @@ public partial class MainViewModel :
             control!.Position = _fullScreenVideoPlayerControl.Position;
             control!.Volume = _fullScreenVideoPlayerControl.Volume;
             _fullScreenVideoPlayerControl = null;
+            Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
         }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy);
         fullScreenWindow.Show(Window!);
         _shortcutManager.ClearKeys();


### PR DESCRIPTION
## Summary
- After exiting the fullscreen video window, no element inside `MainView` held focus, so key events never reached the MainView `KeyDown` handler. Shortcuts like `F` (toggle fullscreen) silently stopped working until the user clicked back into the waveform / subtitle grid.
- Fix: in the `onClose` callback passed to `FullScreenVideoWindow` (`MainViewModel.cs:VideoFullScreen`), post a `SubtitleGrid.Focus()` to the UI dispatcher so focus is restored once the fullscreen window has finished closing.

This mirrors the existing pattern used at app startup (`MainView.cs:109`).

Fixes #11393

## Test plan
- [ ] Open a video.
- [ ] Press `F` to go fullscreen.
- [ ] Press `F` again to exit fullscreen.
- [ ] Press `F` once more — it should go fullscreen again without needing to click on the waveform/subtitle grid first.
- [ ] Repeat several times to confirm the shortcut keeps working.
- [ ] Verify other general shortcuts (e.g. play/pause) also work immediately after exiting fullscreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)