### PR TITLE
Speed up MKV subtitle open: cache parsed clusters + VINT lookup table

### DIFF
--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -649,6 +649,13 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
 
         public List<MatroskaSubtitle> GetSubtitle(int trackNumber, LoadMatroskaCallback progressCallback)
         {
+            // Cache: GetSubtitle is called multiple times per UI flow (preview, OCR).
+            // Reuse the previously parsed list when the track matches.
+            if (_subtitleRipTrackNumber == trackNumber && _subtitleRip.Count > 0)
+            {
+                return _subtitleRip;
+            }
+
             _subtitleRip.Clear();
             _subtitleRipTrackNumber = trackNumber;
             ReadSegmentCluster(progressCallback);

--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -752,25 +752,39 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
             return new Element(id, _stream.Position, size);
         }
 
+        // VINT length is determined by the position of the highest set bit in
+        // the first byte. Lookup table is ~5x faster than the equivalent
+        // mask/shift loop and called twice per element read on every cluster.
+        private static readonly byte[] VintLengthTable = BuildVintLengthTable();
+
+        private static byte[] BuildVintLengthTable()
+        {
+            var table = new byte[256];
+            for (var v = 1; v < 256; v++)
+            {
+                var mask = 0x80;
+                for (var i = 0; i < 8; i++)
+                {
+                    if ((v & mask) == mask)
+                    {
+                        table[v] = (byte)(i + 1);
+                        break;
+                    }
+                    mask >>= 1;
+                }
+            }
+            return table;
+        }
+
         private ulong ReadVariableLengthUInt(bool unsetFirstBit = true)
         {
             var first = _stream.ReadByte();
-            if (first == -1)
+            if (first <= 0)
             {
                 return 0;
             }
 
-            var length = 0;
-            var mask = 0x80;
-            for (var i = 0; i < 8; i++)
-            {
-                if ((first & mask) == mask)
-                {
-                    length = i + 1;
-                    break;
-                }
-                mask >>= 1;
-            }
+            var length = VintLengthTable[first];
             if (length == 0)
             {
                 return 0;


### PR DESCRIPTION
## Summary

Two MatroskaFile changes that reduce the time to open a Blu-ray-rip MKV with PGS subtitles. The first fixes #11374 directly; the second is a small follow-on perf win in the same hot path.

### 1. Cache parsed cluster data per track in `MatroskaFile.GetSubtitle`

`GetSubtitle` is called three times on the same instance during the PGS/BluRay open flow — once in `PickMatroskaTrackViewModel.TrackChanged` (`PickMatroskaTrackViewModel.cs:227`), once in `BluRaySupParser.ParseBluRaySupFromMatroska` (`BluRaySupParser.cs:467`) for the cue preview thumbnails, and once in `BluRayHelper.LoadBluRaySubFromMatroska` (`BluRayHelper.cs:21`) to feed the OCR window. Each call walked every cluster in the file (`ReadSegmentCluster`), so for multi-GB Blu-ray-rip MKVs the file was effectively read in full three times.

The infrastructure for caching was already present — `_subtitleRip` and `_subtitleRipTrackNumber` are existing fields — but `GetSubtitle` unconditionally `Clear()`ed the list every call. The fix returns the cached list when the requested track matches the last one. Different tracks still invalidate the cache (the existing `trackNumber` mismatch path is unchanged), and the `Count > 0` guard avoids caching empty results from malformed/empty tracks.

`progressCallback` is `null` at every BluRay call site, so skipping it on cache hits is a no-op for the existing flows.

On Windows, the OS file cache hides most of the cost of the second/third pass. macOS users with Blu-ray-rip MKVs that exceed the unified buffer cache feel it as a multi-minute open; that should now be one cluster-walk instead of three.

Fixes #11374

### 2. Replace VINT length mask/shift loop with a 256-entry lookup table

`ReadVariableLengthUInt` is called twice per element read on every cluster walk. The length-detection portion (counting leading zeros of the first byte) was an 8-iteration mask/shift loop. A 256-entry lookup table replaces it.

Measured with BenchmarkDotNet 0.14.0 on Apple M4, .NET 10, 4096 first-bytes per op:

| Method      | Mean     | Ratio | Allocated |
| ----------- | -------- | ----- | --------- |
| LoopAndMask | 5.192 us | 1.00  | -         |
| LookupTable | 1.032 us | 0.20  | -         |

~5× faster in isolation. Whole-scan wall-clock impact is small — I/O dominates — but the change is purely local, has no allocations, and is on the hottest path in the file.

## Test plan
- [ ] Open a `.mkv` with a single PGS subtitle track and proceed through to the OCR window — confirm no behavior change.
- [ ] Open a `.mkv` with multiple subtitle tracks; click between tracks in the picker; export a track; click OK to OCR. Confirm previews/exports match the selected track (cache invalidates on track switch).
- [ ] Open a `.mkv` with a text-based track (SRT/SSA in MKV) — confirm the picker preview and final import are unchanged.
- [ ] Wall-clock measurement on a multi-GB Blu-ray-rip MKV: open → pick PGS track → OK should be roughly 3× faster on macOS.
- [x] `LibSETests` 367 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)