### PR TITLE
Honor user video shortcuts in fullscreen video window

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10551,13 +10551,20 @@ public partial class MainViewModel :
                     vm => vm.Initialize(fileName, mediaInfo));
             });
         };
+
+        // Forward user-configured video shortcuts into the fullscreen window so
+        // that e.g. "Right = 1 sec forward" works there too (issue #11392). The
+        // commands themselves operate on GetVideoPlayerControl() which returns
+        // _fullScreenVideoPlayerControl while fullscreen is open.
+        var extraBindings = BuildFullScreenShortcutBindings();
+
         var fullScreenWindow = new FullScreenVideoWindow(_fullScreenVideoPlayerControl, _videoFileName, _subtitleFileName ?? string.Empty, position, volume, () =>
         {
             control!.Position = _fullScreenVideoPlayerControl.Position;
             control!.Volume = _fullScreenVideoPlayerControl.Volume;
             _fullScreenVideoPlayerControl = null;
             Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
-        }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy);
+        }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy, extraBindings);
         fullScreenWindow.Show(Window!);
         _shortcutManager.ClearKeys();
 
@@ -10577,6 +10584,48 @@ public partial class MainViewModel :
         }
 
         RefreshSubtitlePreview();
+    }
+
+    private List<(string name, List<string> keys, IRelayCommand command)> BuildFullScreenShortcutBindings()
+    {
+        // Commands that should be honored while the fullscreen video window is
+        // active. Volume up/down are intentionally not listed — there are no
+        // Volume RelayCommands in the view model, so the fullscreen window's
+        // hardcoded Up/Down fallback is the only keyboard volume control.
+        var commands = new (string Name, IRelayCommand Command)[]
+        {
+            (nameof(Video100MsBackCommand),         Video100MsBackCommand),
+            (nameof(Video100MsForwardCommand),      Video100MsForwardCommand),
+            (nameof(Video500MsBackCommand),         Video500MsBackCommand),
+            (nameof(Video500MsForwardCommand),      Video500MsForwardCommand),
+            (nameof(VideoOneSecondBackCommand),     VideoOneSecondBackCommand),
+            (nameof(VideoOneSecondForwardCommand),  VideoOneSecondForwardCommand),
+            (nameof(VideoOneFrameBackCommand),      VideoOneFrameBackCommand),
+            (nameof(VideoOneFrameForwardCommand),   VideoOneFrameForwardCommand),
+            (nameof(VideoMoveCustom1BackCommand),   VideoMoveCustom1BackCommand),
+            (nameof(VideoMoveCustom1ForwardCommand),VideoMoveCustom1ForwardCommand),
+            (nameof(VideoMoveCustom2BackCommand),   VideoMoveCustom2BackCommand),
+            (nameof(VideoMoveCustom2ForwardCommand),VideoMoveCustom2ForwardCommand),
+            (nameof(PlayCommand),                   PlayCommand),
+            (nameof(PauseCommand),                  PauseCommand),
+            (nameof(TogglePlayPauseCommand),        TogglePlayPauseCommand),
+            (nameof(TogglePlayPause2Command),       TogglePlayPause2Command),
+            (nameof(VideoToggleBrightnessCommand),  VideoToggleBrightnessCommand),
+        };
+
+        var bindings = new List<(string name, List<string> keys, IRelayCommand command)>(commands.Length);
+        foreach (var (name, command) in commands)
+        {
+            var keys = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == name)?.Keys;
+            if (keys == null || keys.Count == 0)
+            {
+                continue;
+            }
+
+            bindings.Add((name, keys, command));
+        }
+
+        return bindings;
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -26,7 +26,8 @@ public class FullScreenVideoWindow : Window
         Action onClose,
         List<string>? toggleShortcutKeys = null,
         List<string>? showMediaInformationKeys = null,
-        Action<Window>? showMediaInformation = null)
+        Action<Window>? showMediaInformation = null,
+        IReadOnlyList<(string name, List<string> keys, IRelayCommand command)>? extraBindings = null)
     {
         WindowState = WindowState.FullScreen;
         WindowDecorations = WindowDecorations.None;
@@ -62,6 +63,28 @@ public class FullScreenVideoWindow : Window
                 showMediaInformationKeys,
                 ShortcutCategory.General,
                 new RelayCommand(() => showMediaInformation(this))));
+        }
+
+        // Honor the user-configured video shortcuts (jump back/forward, play/pause,
+        // brightness, etc.) by registering them on the local shortcut manager.
+        // The commands themselves come from the main view model and operate on
+        // the fullscreen player because GetVideoPlayerControl() returns it while
+        // fullscreen is open.
+        if (extraBindings != null)
+        {
+            foreach (var (name, keys, command) in extraBindings)
+            {
+                if (keys == null || keys.Count == 0)
+                {
+                    continue;
+                }
+
+                shortcutManager.RegisterShortcut(new ShortCut(
+                    nameof(FullScreenVideoWindow) + "_" + name,
+                    keys,
+                    ShortcutCategory.General,
+                    command));
+            }
         }
 
         // Poll for actual cursor position using platform APIs
@@ -104,53 +127,56 @@ public class FullScreenVideoWindow : Window
 
         KeyDown += (_, e) =>
         {
-            if (e.Key == Key.Escape)
+            // Window-management keys always win — Esc/F11 must close the
+            // fullscreen window regardless of user shortcut bindings.
+            if (e.Key == Key.Escape || e.Key == Key.F11)
             {
                 e.Handled = true;
                 Close();
-            }
-            else if (e.Key == Key.F11)
-            {
-                e.Handled = true;
-                Close();
-            }
-            else if (e.Key == Key.Space)
-            {
-                e.Handled = true;
-                videoPlayer.TogglePlayPause();
-            }
-            else if (e.Key == Key.Right)
-            {
-                e.Handled = true;
-                videoPlayer.Position += 2;
-            }
-            else if (e.Key == Key.Left)
-            {
-                e.Handled = true;
-                videoPlayer.Position -= 2;
-            }
-            else if (e.Key == Key.Up && e.KeyModifiers == KeyModifiers.None)
-            {
-                e.Handled = true;
-                videoPlayer.Volume += 2;
-            }
-            else if (e.Key == Key.Down && e.KeyModifiers == KeyModifiers.None)
-            {
-                e.Handled = true;
-                videoPlayer.Volume -= 2;
-            }
-            else
-            {
-                shortcutManager.OnKeyPressed(this, e);
-                var command = shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
-                if (command != null)
-                {
-                    e.Handled = true;
-                    command.Execute(null);
-                }
+                videoPlayer.NotifyUserActivity();
+                return;
             }
 
-            // Also notify on any key press
+            // User-configured shortcuts win over hardcoded defaults. Without
+            // this, a user with "1 sec forward" bound to Right would still get
+            // a hardcoded 2-second jump (issue #11392).
+            shortcutManager.OnKeyPressed(this, e);
+            var command = shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
+            if (command != null)
+            {
+                e.Handled = true;
+                command.Execute(null);
+                videoPlayer.NotifyUserActivity();
+                return;
+            }
+
+            // Fallbacks for keys the user hasn't bound to anything.
+            // Volume Up/Down stay here because there are no Volume RelayCommands
+            // in the main view model — these are the only way to control volume
+            // from the keyboard in fullscreen.
+            switch (e.Key)
+            {
+                case Key.Space:
+                    videoPlayer.TogglePlayPause();
+                    break;
+                case Key.Right:
+                    videoPlayer.Position += 2;
+                    break;
+                case Key.Left:
+                    videoPlayer.Position -= 2;
+                    break;
+                case Key.Up when e.KeyModifiers == KeyModifiers.None:
+                    videoPlayer.Volume += 2;
+                    break;
+                case Key.Down when e.KeyModifiers == KeyModifiers.None:
+                    videoPlayer.Volume -= 2;
+                    break;
+                default:
+                    videoPlayer.NotifyUserActivity();
+                    return;
+            }
+
+            e.Handled = true;
             videoPlayer.NotifyUserActivity();
         };
 


### PR DESCRIPTION
## Summary
- Fixes #11392: in fullscreen, Right/Left arrows always jumped 2 sec and Up/Down always changed volume by 2, regardless of the user's configured "1 sec / 100 ms / 5 sec" jump bindings.
- Root cause: `FullScreenVideoWindow`'s `KeyDown` handler hardcoded these keys *before* its local shortcut manager, and the local shortcut manager only knew about two commands (toggle fullscreen, show media info). Reordering alone wasn't enough — the user-configured shortcuts had no path to fire.

## Changes
- **`MainViewModel.VideoFullScreen`** now builds an `extraBindings` list of the relevant video commands and passes it to `FullScreenVideoWindow`. The commands themselves operate on `GetVideoPlayerControl()`, which already returns `_fullScreenVideoPlayerControl` while fullscreen is open, so no per-fullscreen variants are needed.
  - Commands forwarded: `Video100Ms{Back,Forward}`, `Video500Ms{Back,Forward}`, `VideoOneSecond{Back,Forward}`, `VideoOneFrame{Back,Forward}`, `VideoMoveCustom1{Back,Forward}`, `VideoMoveCustom2{Back,Forward}`, `Play`, `Pause`, `TogglePlayPause`, `TogglePlayPause2`, `VideoToggleBrightness`.
- **`FullScreenVideoWindow`** gains an optional `extraBindings` constructor parameter, registers each into the local shortcut manager, and the `KeyDown` handler is reordered:
  1. Esc/F11 — always close.
  2. User-configured shortcuts — first chance to claim the key.
  3. Hardcoded `Space` / `Right` / `Left` / `Up` / `Down` — fallbacks only when no user binding matched.
- Volume Up/Down stay hardcoded because there are no Volume `RelayCommand`s in the view model; the fullscreen defaults are the only keyboard-volume path.

## Test plan
- [ ] In Options > Shortcuts, set Right = "Video 1 sec forward" and Left = "Video 1 sec back". Enter fullscreen and confirm each press moves exactly 1 sec.
- [ ] Repeat with "100 ms" and "500 ms" bindings — confirm the jumps match the configured magnitude.
- [ ] With no Right/Left binding (or bindings cleared), confirm fullscreen still falls back to the original 2-second jumps.
- [ ] Confirm Space play/pause still works (with and without a `TogglePlayPause` binding).
- [ ] Confirm Up/Down still change volume by 2.
- [ ] Confirm Esc and F11 still exit fullscreen.
- [ ] Confirm the existing fullscreen-toggle key (e.g. F) still exits fullscreen (and the focus restoration from #11393 still works).
- [ ] Confirm `Show Media Information` shortcut still opens with the fullscreen window as owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)