### PR TITLE
Fix Replace & find next silently skipping current match

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9800,7 +9800,18 @@ public partial class MainViewModel :
                 var fixedReplaceText = RegexUtils.FixNewLine(result.ReplaceText);
                 var regex = new Regex(result.SearchText);
                 var match = regex.Match(line, matchIndex);
-                if (!match.Success || match.Index != matchIndex)
+
+                // Bail unless the match starts exactly at the recorded index AND
+                // the matched text is what we found before. The value check
+                // guards against (a) the subtitle being edited between Find and
+                // Replace and the new line happening to produce a different
+                // match of the same length at the same offset, and (b) any
+                // CRLF/LF-normalization drift between the FindService (which
+                // normalizes line endings) and the un-normalized line we're
+                // re-matching here.
+                if (!match.Success
+                    || match.Index != matchIndex
+                    || !string.Equals(match.Value, matchText, StringComparison.Ordinal))
                 {
                     newLine = line;
                     return null;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9791,6 +9791,49 @@ public partial class MainViewModel :
         _shortcutManager.ClearKeys();
     }
 
+    private static int? TryBuildReplacement(string line, int matchIndex, string matchText, ReplaceViewModel result, out string newLine)
+    {
+        if (result.FindMode == FindMode.RegularExpression)
+        {
+            try
+            {
+                var fixedReplaceText = RegexUtils.FixNewLine(result.ReplaceText);
+                var regex = new Regex(result.SearchText);
+                var match = regex.Match(line, matchIndex);
+                if (!match.Success || match.Index != matchIndex)
+                {
+                    newLine = line;
+                    return null;
+                }
+
+                var replaced = match.Result(fixedReplaceText);
+                newLine = line.Substring(0, matchIndex) + replaced + line.Substring(matchIndex + match.Length);
+                return replaced.Length;
+            }
+            catch (ArgumentException)
+            {
+                newLine = line;
+                return null;
+            }
+        }
+
+        // Verify the matched slice is still at the recorded position before
+        // mutating — the line may have been edited since the find ran.
+        var actualAtMatch = line.Substring(matchIndex, matchText.Length);
+        var comparison = result.FindMode == FindMode.CaseSensitive
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase;
+        if (!string.Equals(actualAtMatch, matchText, comparison))
+        {
+            newLine = line;
+            return null;
+        }
+
+        var replacement = result.ReplaceText ?? string.Empty;
+        newLine = line.Substring(0, matchIndex) + replacement + line.Substring(matchIndex + matchText.Length);
+        return replacement.Length;
+    }
+
     public async Task HandleReplaceResult(ReplaceViewModel result)
     {
         result.ResultFound = false;
@@ -9805,7 +9848,16 @@ public partial class MainViewModel :
         {
             var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
             var subs = Subtitles.Select(p => p.Text).ToList();
-            var savedCurrentTextFound = _findService.CurrentTextFound;
+
+            // Save the previous find result before Initialize wipes it. The
+            // replace path uses these — not the EditTextBox selection — to
+            // know which match to replace, so that focus changes, line-ending
+            // normalization, or async TextBox updates can't break the replace
+            // step (issue #11388).
+            var savedFoundLine = _findService.CurrentLineNumber;
+            var savedFoundIndex = _findService.CurrentTextIndex;
+            var savedFoundText = _findService.CurrentTextFound;
+
             _findService.Initialize(subs, SelectedSubtitleIndex ?? 0, result.WholeWord, result.FindMode);
 
             var idx = -1;
@@ -9832,34 +9884,32 @@ public partial class MainViewModel :
             }
             else // replace requested
             {
-                var selectedText = EditTextBox.SelectedText;
-                if (!string.IsNullOrEmpty(savedCurrentTextFound) && selectedText == savedCurrentTextFound)
+                var nextStartIndex = EditTextBox.SelectionEnd;
+                var nextStartLine = currentLineIndex;
+
+                if (savedFoundLine >= 0
+                    && savedFoundLine < subs.Count
+                    && savedFoundIndex >= 0
+                    && !string.IsNullOrEmpty(savedFoundText))
                 {
-                    if (result.FindMode == FindMode.RegularExpression)
+                    var line = subs[savedFoundLine];
+                    if (savedFoundIndex + savedFoundText.Length <= line.Length)
                     {
-                        try
+                        var replaced = TryBuildReplacement(line, savedFoundIndex, savedFoundText, result, out var newLine);
+                        if (replaced.HasValue)
                         {
-                            var fixedReplaceText = RegexUtils.FixNewLine(result.ReplaceText);
-                            var regex = new Regex(result.SearchText);
-                            var match = regex.Match(EditTextBox.Text, EditTextBox.SelectionStart);
-                            if (match.Success && match.Index == EditTextBox.SelectionStart)
+                            subs[savedFoundLine] = newLine;
+                            if (savedFoundLine < Subtitles.Count)
                             {
-                                EditTextBox.Text = regex.Replace(EditTextBox.Text, fixedReplaceText, 1, EditTextBox.SelectionStart);
+                                Subtitles[savedFoundLine].Text = newLine;
                             }
-                        }
-                        catch (ArgumentException)
-                        {
-                            // Invalid regex pattern - skip replacement
+                            nextStartLine = savedFoundLine;
+                            nextStartIndex = savedFoundIndex + replaced.Value;
                         }
                     }
-                    else
-                    {
-                        EditTextBox.SelectedText = result.ReplaceText;
-                    }
-                    subs[currentLineIndex] = EditTextBox.Text; // reflect replacement so FindNext won't re-match here
                 }
 
-                idx = _findService.FindNext(result.SearchText, subs, currentLineIndex, EditTextBox.SelectionEnd);
+                idx = _findService.FindNext(result.SearchText, subs, nextStartLine, nextStartIndex);
             }
 
             if (idx < 0)


### PR DESCRIPTION
## Summary
Fixes #11388. In the Edit → Replace dialog, the **Replace** button (which acts as "Replace & find next") was driven by `EditTextBox.SelectedText` and `EditTextBox.SelectionStart`. When that UI state didn't perfectly match the last find result — focus changes, line-ending normalization on a multi-line subtitle, an in-flight TextBox text update — the guard `selectedText == savedCurrentTextFound` failed, the replacement block was skipped entirely, and `FindNext` still ran and advanced past the unmodified match. The user's reproducer (regex ` ([?!\.,])` → `$1` against `coming ! Look!`) hits exactly this path.

## What changed
`HandleReplaceResult` now drives the replace path from the FindService's saved match — `CurrentLineNumber` / `CurrentTextIndex` / `CurrentTextFound`, captured **before** `Initialize` wipes them. The replacement is applied to the underlying subtitle text (`Subtitles[line].Text`), and `FindNext` resumes from the position immediately after the replacement.

Both modes also defensively verify the saved match still describes what's actually in the line, so an in-flight edit to the subtitle can't be corrupted:
- **Regex**: re-runs the pattern at `savedFoundIndex` and bails unless `match.Success && match.Index == savedFoundIndex`. `match.Result(replacement)` properly expands `$1`/`$2`/etc.
- **Non-regex**: compares `line.Substring(savedFoundIndex, savedFoundText.Length)` to the saved match under the configured case-sensitivity mode and bails on mismatch.

Side benefit: the non-regex path previously did `EditTextBox.SelectedText = ReplaceText`, which when the selection had collapsed just inserted at the caret instead of replacing. That class of bug goes away too.

## Test plan
- [ ] Reproduce the original issue: paste the user's two-line subtitle, set regex ` ([?!\\.,])` → `\$1`, ensure case-insensitive regex mode. Click Find next, then Replace. Confirm the space is removed and the cursor advances.
- [ ] Click Replace repeatedly across multiple matches in different subtitles. Each press should replace the current match and jump to the next.
- [ ] Non-regex case-insensitive: Find a word, click Replace, confirm replacement.
- [ ] Non-regex case-sensitive: same.
- [ ] Replace All still works.
- [ ] Find next (without Replace) still works.
- [ ] Edit the subtitle text manually between Find and Replace — the replace should bail rather than corrupt the edited line.
- [x] Build clean; libse tests pass (367/367); UI tests pass (306/306).

🤖 Generated with [Claude Code](https://claude.com/claude-code)