### PR TITLE
Suppress tooltips on windows that are not active

### DIFF
--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -170,6 +170,23 @@ namespace Nikse.SubtitleEdit
             {
                 UiUtil.SetFontName(Se.Settings.Appearance.FontName);
             }
+
+            // Suppress tooltips on windows that are not active. By default
+            // Avalonia opens tooltips on hover regardless of whether the owning
+            // window is foregrounded — on macOS this lets toolbar hints from
+            // SE leak in front of other apps the user is currently working in.
+            // Cancel any tooltip that tries to open on a control whose top-level
+            // Window isn't active. Also covers our own child windows: when a
+            // dialog is open the inactive main window stops showing hints.
+            ToolTip.IsOpenProperty.Changed.AddClassHandler<Control>((control, e) =>
+            {
+                if (e.NewValue is true
+                    && TopLevel.GetTopLevel(control) is Window window
+                    && !window.IsActive)
+                {
+                    ToolTip.SetIsOpen(control, false);
+                }
+            });
         }
 
         private static void SetupNativeMenu(Application app, ClassicDesktopStyleApplicationLifetime lifetime)


### PR DESCRIPTION
## Summary
Avalonia opens a tooltip on hover regardless of whether the owning window is foregrounded. On macOS this lets SE's toolbar hints leak in front of whatever other app the user is currently working in — they see "Open subtitle file" floating over their browser. Native macOS apps suppress tooltips when their window is not key.

Fixes the report that toolbar hints fire when other windows are active (at least on macOS).

## Change
Register a global `ToolTip.IsOpenProperty` class handler in `Program.ConfigureApplication` that cancels the open transition whenever the control's top-level Window isn't active:

```csharp
ToolTip.IsOpenProperty.Changed.AddClassHandler<Control>((control, e) =>
{
    if (e.NewValue is true
        && TopLevel.GetTopLevel(control) is Window window
        && !window.IsActive)
    {
        ToolTip.SetIsOpen(control, false);
    }
});
```

The check generalizes to our own child windows too: when a dialog is open, the inactive main window stops showing hints, which matches user expectations across platforms. The handler is no-op on tooltips hosted on non-Window TopLevels (popups), so context-menu and flyout tooltips behave as before.

Targeting `IsOpenProperty.Changed` (rather than the individual `Tip` property on every control) means we don't need to enumerate the toolbar buttons or track their original tooltip content. New windows added in the future inherit the behavior automatically.

## Test plan
- [ ] On macOS: open SE, switch to another app (Safari/Finder), hover the SE toolbar buttons through the still-visible main window. Confirm no tooltips appear.
- [ ] On macOS: open Find/Replace dialog, hover the (now-inactive) main toolbar. Confirm no tooltips appear.
- [ ] On macOS: bring SE main window forward, hover toolbar — tooltips appear as usual.
- [ ] On Windows / Linux: same checks; behavior should be identical.
- [ ] Confirm context-menu and flyout tooltips (if any) still work — they're hosted on non-Window TopLevels and the check skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)