### PR TITLE
Don't override bare Left/Right when a text input is focused (#11357)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16763,6 +16763,15 @@ public partial class MainViewModel :
 
             if (IsTextInputFocused())
             {
+                // Bare Left/Right are fundamental caret navigation in any text
+                // input — never override them with shortcuts even when
+                // "allow single-letter shortcuts in text box" is on (#11357).
+                if ((keyEventArgs.Key == Key.Left || keyEventArgs.Key == Key.Right)
+                    && keyEventArgs.KeyModifiers == KeyModifiers.None)
+                {
+                    return;
+                }
+
                 var currentKeys = _shortcutManager.GetActiveKeys();
                 if (currentKeys.Count == 1)
                 {


### PR DESCRIPTION
## Summary
Bare Left/Right are fundamental caret navigation in every text input on every platform. The existing protection in `OnKeyDownHandler` only returned early when the **Allow single-letter shortcuts in text box** setting was off; with that setting on (or for an arrow key that the user has happened to bind), Left/Right inside the subtitle text box, the Find dialog, or any other TextBox / TextEditor / MaskedTextBox would fire the SE shortcut instead of moving the caret.

From the reporter (#11357):

> When I am editing text in the text box, I want to use … LeftArrow to skip to the next/previous word. This is a global Windows standard keyboard shortcut that works in every other app.

## Change
At the top of the `IsTextInputFocused()` branch in `MainViewModel.OnKeyDownHandler` (`MainViewModel.cs:16764`), bail out when the pressed key is bare Left or Right (no modifiers):

```csharp
if ((keyEventArgs.Key == Key.Left || keyEventArgs.Key == Key.Right)
    && keyEventArgs.KeyModifiers == KeyModifiers.None)
{
    return;
}
```

Modified combinations (Ctrl+Left, Shift+Right, Ctrl+Shift+Left, etc.) keep going through the normal shortcut resolution — some users do bind those, and overriding them would surprise them.

The check uses the existing `IsTextInputFocused()` helper, so it applies broadly: subtitle text box, original text box, Find dialog, any future window with a text input.

## Test plan
- [ ] In **Options → Settings → Tools**, turn on **Allow single-letter shortcuts in text box**, bind Left arrow to "Video go back 1 second", click into the subtitle text box, press Left. Confirm the caret moves left and the video does NOT move.
- [ ] Same setup, press Right. Caret moves right; video does not move.
- [ ] Same setup, press Ctrl+Left. Ctrl+Left still triggers whatever shortcut the user has bound to it (if any), matching existing behavior for modifier combinations.
- [ ] Bare Left/Right while the subtitle grid is focused still works as before (does whatever the user has bound to those keys).
- [ ] Bare Left/Right inside the Find dialog still moves the caret.
- [x] Build clean; UI tests pass (306/306).

🤖 Generated with [Claude Code](https://claude.com/claude-code)