### PR TITLE
Add braces around every bracketless if/else if/else in src/ui

### DIFF
--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectAudioTextPulse.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectAudioTextPulse.cs
@@ -24,7 +24,10 @@ public class AdvancedEffectAudioTextPulse : IAdvancedEffectDisplay
         string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         const int frameMs = 50; // 20 fps
 
@@ -44,7 +47,10 @@ public class AdvancedEffectAudioTextPulse : IAdvancedEffectDisplay
             double localPeak = ComputeLocalPeak(wavePeaks,
                 sub.StartTime.TotalSeconds - 1.0,
                 sub.EndTime.TotalSeconds + 1.0);
-            if (localPeak <= 0) localPeak = 1;
+            if (localPeak <= 0)
+            {
+                localPeak = 1;
+            }
 
             for (double t = 0; t < durationMs; t += frameMs)
             {
@@ -62,11 +68,26 @@ public class AdvancedEffectAudioTextPulse : IAdvancedEffectDisplay
 
                 // Glow colour ramp — same green→yellow→orange→red scale (ASS BGR)
                 string glowColor;
-                if (amp > 0.85) glowColor = "&H0000FF&"; // red
-                else if (amp > 0.70) glowColor = "&H0066FF&"; // orange
-                else if (amp > 0.55) glowColor = "&H00FFFF&"; // yellow
-                else if (amp > 0.35) glowColor = "&H00FF00&"; // bright green
-                else glowColor = "&H007800&"; // dark green (quiet)
+                if (amp > 0.85)
+                {
+                    glowColor = "&H0000FF&";
+                } // red
+                else if (amp > 0.70)
+                {
+                    glowColor = "&H0066FF&";
+                } // orange
+                else if (amp > 0.55)
+                {
+                    glowColor = "&H00FFFF&";
+                } // yellow
+                else if (amp > 0.35)
+                {
+                    glowColor = "&H00FF00&";
+                } // bright green
+                else
+                {
+                    glowColor = "&H007800&";
+                } // dark green (quiet)
 
                 var frame = new SubtitleLineViewModel(sub, generateNewId: true);
                 frame.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(t));
@@ -82,12 +103,18 @@ public class AdvancedEffectAudioTextPulse : IAdvancedEffectDisplay
     private static double GetAverageAmplitude(
         WavePeakData2? wavePeaks, double centerSec, double windowSec, double localPeak)
     {
-        if (wavePeaks == null || localPeak <= 0) return 0;
+        if (wavePeaks == null || localPeak <= 0)
+        {
+            return 0;
+        }
         double half = windowSec / 2.0;
         int start = Math.Max(0, (int)((centerSec - half) * wavePeaks.SampleRate));
         int end = Math.Min(wavePeaks.Peaks.Count - 1,
                                 (int)((centerSec + half) * wavePeaks.SampleRate));
-        if (start > end) return 0;
+        if (start > end)
+        {
+            return 0;
+        }
         long sum = 0;
         for (int i = start; i <= end; i++)
             sum += wavePeaks.Peaks[i].Abs;
@@ -97,14 +124,20 @@ public class AdvancedEffectAudioTextPulse : IAdvancedEffectDisplay
     private static double ComputeLocalPeak(
         WavePeakData2? wavePeaks, double startSec, double endSec)
     {
-        if (wavePeaks == null) return 1;
+        if (wavePeaks == null)
+        {
+            return 1;
+        }
         int start = Math.Max(0, (int)(startSec * wavePeaks.SampleRate));
         int end = Math.Min(wavePeaks.Peaks.Count - 1, (int)(endSec * wavePeaks.SampleRate));
         int peak = 0;
         for (int i = start; i <= end; i++)
         {
             int abs = wavePeaks.Peaks[i].Abs;
-            if (abs > peak) peak = abs;
+            if (abs > peak)
+            {
+                peak = abs;
+            }
         }
         return peak > 0 ? peak : Math.Max(1, wavePeaks.HighestPeak);
     }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectBounceIn.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectBounceIn.cs
@@ -45,7 +45,9 @@ public class AdvancedEffectBounceIn : IAdvancedEffectDisplay
             for (int i = 0; i < chars.Length; i++)
             {
                 if (chars[i] == ' ' || chars[i] == '\n')
+                {
                     continue;
+                }
 
                 var line = new SubtitleLineViewModel(sub, generateNewId: true);
                 line.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(i * staggerMs));

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectConfetti.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectConfetti.cs
@@ -51,7 +51,10 @@ public class AdvancedEffectConfetti : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         int w = width > 0 ? width : 1280;
         int h = height > 0 ? height : 720;
@@ -128,14 +131,20 @@ public class AdvancedEffectConfetti : IAdvancedEffectDisplay
                 for (; oi < origins.Length - 1; oi++)
                 {
                     cumulative += origins[oi].Weight;
-                    if (roll < cumulative) break;
+                    if (roll < cumulative)
+                    {
+                        break;
+                    }
                 }
                 var (bx, by, aMin, aMax, _) = origins[oi];
 
                 // Staggered launch: most pieces fire in first 250 ms, a few trail up to 450 ms
                 double delay = Math.Pow(rng.NextDouble(), 1.6) * 450;
                 double pieceDur = durationMs - delay;
-                if (pieceDur < 300) continue;
+                if (pieceDur < 300)
+                {
+                    continue;
+                }
 
                 var piece = new SubtitleLineViewModel(sub, generateNewId: true);
                 piece.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(delay));

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectEndCreditsScroll.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectEndCreditsScroll.cs
@@ -18,7 +18,10 @@ public class AdvancedEffectEndCreditsScroll : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         int screenWidth = width > 0 ? width : 1356;
         int screenHeight = height > 0 ? height : 678;
@@ -35,7 +38,10 @@ public class AdvancedEffectEndCreditsScroll : IAdvancedEffectDisplay
         {
             string processedText = sub.Text.Replace("\\N", "\n").Replace("\\n", "\n");
             var clean = Utilities.RemoveSsaTags(processedText);
-            if (string.IsNullOrWhiteSpace(clean)) continue;
+            if (string.IsNullOrWhiteSpace(clean))
+            {
+                continue;
+            }
 
             var lines = clean.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -44,7 +50,10 @@ public class AdvancedEffectEndCreditsScroll : IAdvancedEffectDisplay
                 var charLine = new SubtitleLineViewModel(sub, generateNewId: true);
 
                 double startTimeMs = sub.StartTime.TotalMilliseconds - leadTimeMs;
-                if (startTimeMs < 0) startTimeMs = 0;
+                if (startTimeMs < 0)
+                {
+                    startTimeMs = 0;
+                }
 
                 charLine.StartTime = TimeSpan.FromMilliseconds(startTimeMs);
                 charLine.EndTime = charLine.StartTime.Add(TimeSpan.FromMilliseconds(travelDurationMs));

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeIn.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeIn.cs
@@ -15,7 +15,10 @@ public class AdvancedEffectFadeIn : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         int w = width > 0 ? width : 1280;
         int h = height > 0 ? height : 720;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeOut.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeOut.cs
@@ -17,7 +17,10 @@ public class AdvancedEffectFadeOut : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         int w = width > 0 ? width : 1280;
         int h = height > 0 ? height : 720;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFancyKaraoke.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFancyKaraoke.cs
@@ -80,7 +80,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             var newSub = new SubtitleLineViewModel(sub, generateNewId: true);
             string posTags = ExtractPositionalTags(sub.Text);
             var sb = new StringBuilder();
-            if (!string.IsNullOrEmpty(posTags)) sb.Append(posTags);
+            if (!string.IsNullOrEmpty(posTags))
+            {
+                sb.Append(posTags);
+            }
 
             // Inactive tags now explicitly set \1c to InactiveWordColor so color resets after active word.
             string inactiveTags = $"{{\\alpha&H{(255 -InactiveWordColor.A):X2}&\\1c{ToAssColor(InactiveWordColor)}\\bord0\\shad0\\blur0\\fscx100\\fscy100}}";
@@ -98,7 +101,9 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
                 var (before, active, after) = parsed.Value;
 
                 if (!string.IsNullOrEmpty(before))
+                {
                     sb.Append(inactiveTags).Append(before);
+                }
 
                 // Build active tag depending on ApplyGlow
                 string activeTag;
@@ -118,7 +123,9 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
                 sb.Append(activeTag).Append(active);
 
                 if (!string.IsNullOrEmpty(after))
+                {
                     sb.Append(inactiveTags).Append(after);
+                }
             }
 
             newSub.Text = sb.ToString();
@@ -135,7 +142,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
     {
         // Remove SSA tags for tokenization and normalize newlines.
         var cleanText = Utilities.RemoveSsaTags(sub.Text);
-        if (string.IsNullOrWhiteSpace(cleanText)) return null;
+        if (string.IsNullOrWhiteSpace(cleanText))
+        {
+            return null;
+        }
         cleanText = cleanText.Replace("\r\n", "\n").Replace("\r", "\n");
 
         // Tokenize into runs of non-whitespace (words/punctuation) and whitespace (spaces/newlines)
@@ -145,7 +155,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
 
         // Count words (non-whitespace tokens)
         var wordCount = tokens.Count(t => !string.IsNullOrWhiteSpace(t));
-        if (wordCount == 0) return null;
+        if (wordCount == 0)
+        {
+            return null;
+        }
 
         var totalMs = sub.Duration.TotalMilliseconds;
         var msPerWord = totalMs / wordCount;
@@ -182,7 +195,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
 
             // Build text for this word index
             var sb = new StringBuilder();
-            if (!string.IsNullOrEmpty(posTags)) sb.Append(posTags);
+            if (!string.IsNullOrEmpty(posTags))
+            {
+                sb.Append(posTags);
+            }
 
             string? currentColor = null;
             int localWordCounter = 0;
@@ -249,30 +265,50 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
     private static string ExtractPositionalTags(string text)
     {
         var firstBlock = System.Text.RegularExpressions.Regex.Match(text, @"^\{([^}]*)\}");
-        if (!firstBlock.Success) return string.Empty;
+        if (!firstBlock.Success)
+        {
+            return string.Empty;
+        }
         string inner = firstBlock.Groups[1].Value;
         var sb = new StringBuilder("{");
         var anM = System.Text.RegularExpressions.Regex.Match(inner, @"\\an\d");
-        if (anM.Success) sb.Append(anM.Value);
+        if (anM.Success)
+        {
+            sb.Append(anM.Value);
+        }
         var posM = System.Text.RegularExpressions.Regex.Match(inner, @"\\pos\([^)]+\)");
-        if (posM.Success) sb.Append(posM.Value);
+        if (posM.Success)
+        {
+            sb.Append(posM.Value);
+        }
         var moveM = System.Text.RegularExpressions.Regex.Match(inner, @"\\move\([^)]+\)");
-        if (moveM.Success) sb.Append(moveM.Value);
+        if (moveM.Success)
+        {
+            sb.Append(moveM.Value);
+        }
         sb.Append("}");
         return sb.Length > 2 ? sb.ToString() : string.Empty;
     }
 
     private static (string Before, string Active, string After)? ParseActiveWord(string text)
     {
-        if (string.IsNullOrEmpty(text)) return null;
+        if (string.IsNullOrEmpty(text))
+        {
+            return null;
+        }
         var segments = BuildSegments(text);
-        if (segments.Count == 0) return null;
+        if (segments.Count == 0)
+        {
+            return null;
+        }
 
         // Strategy 1: explicit underline {\u1}
         for (int i = 0; i < segments.Count; i++)
             if (System.Text.RegularExpressions.Regex.IsMatch(segments[i].Tags, @"\\u1")
                 && !string.IsNullOrWhiteSpace(segments[i].Text))
+            {
                 return BuildResult(segments, i);
+            }
 
         // Strategy 2: least-common \1c color is the highlight
         var colorCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
@@ -282,17 +318,26 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             if (m.Success)
             {
                 string c = m.Groups[1].Value.ToUpperInvariant();
-                if (!colorCounts.TryGetValue(c, out int cnt)) cnt = 0;
+                if (!colorCounts.TryGetValue(c, out int cnt))
+                {
+                    cnt = 0;
+                }
                 colorCounts[c] = cnt + 1;
             }
         }
-        if (colorCounts.Count == 0) return null;
+        if (colorCounts.Count == 0)
+        {
+            return null;
+        }
 
         string highlightColor;
         if (colorCounts.Count == 1)
         {
             var singleColor = colorCounts.Keys.First();
-            if (!IsColorfulAssColor(singleColor)) return null;
+            if (!IsColorfulAssColor(singleColor))
+            {
+                return null;
+            }
             highlightColor = singleColor;
         }
         else
@@ -309,7 +354,9 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             if (m.Success
                 && m.Groups[1].Value.Equals(highlightColor, StringComparison.OrdinalIgnoreCase)
                 && !string.IsNullOrWhiteSpace(segments[i].Text))
+            {
                 return BuildResult(segments, i);
+            }
         }
         return null;
     }
@@ -336,7 +383,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             while (pos < text.Length && text[pos] == '{')
             {
                 int end = text.IndexOf('}', pos);
-                if (end < 0) break;
+                if (end < 0)
+                {
+                    break;
+                }
                 tags.Append(text, pos, end - pos + 1);
                 pos = end + 1;
             }
@@ -344,7 +394,9 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             while (pos < text.Length && text[pos] != '{') pos++;
             string plainText = text[textStart..pos];
             if (tags.Length > 0 || !string.IsNullOrEmpty(plainText))
+            {
                 result.Add((tags.ToString(), plainText));
+            }
         }
         return result;
     }
@@ -352,7 +404,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
     private static bool IsColorfulAssColor(string assColor)
     {
         string hex = assColor.Replace("&", "").Replace("H", "").ToUpperInvariant();
-        if (hex.Length != 6) return false;
+        if (hex.Length != 6)
+        {
+            return false;
+        }
         int b = Convert.ToInt32(hex[0..2], 16);
         int g = Convert.ToInt32(hex[2..4], 16);
         int r = Convert.ToInt32(hex[4..6], 16);

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFireflies.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFireflies.cs
@@ -26,7 +26,10 @@ public class AdvancedEffectFireflies : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         Random rng = new Random(subtitles[0].Text.GetHashCode());
 
@@ -75,7 +78,10 @@ public class AdvancedEffectFireflies : IAdvancedEffectDisplay
                 fly.StartTime = globalStart.Add(TimeSpan.FromMilliseconds(currentTimeMs));
                 fly.EndTime = fly.StartTime.Add(TimeSpan.FromMilliseconds(flightDuration));
 
-                if (fly.StartTime >= globalEnd) break;
+                if (fly.StartTime >= globalEnd)
+                {
+                    break;
+                }
 
                 // Organic drift: move to a nearby random position
                 int startX = rng.Next(40, w - 40);

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectGlitch.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectGlitch.cs
@@ -22,7 +22,10 @@ public class AdvancedEffectGlitch : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         int w = width > 0 ? width : 1280;
         int h = height > 0 ? height : 720;
@@ -46,7 +49,10 @@ public class AdvancedEffectGlitch : IAdvancedEffectDisplay
             for (double t = 0; t < totalMs;)
             {
                 int frameDur = (int)Math.Min(rng.Next(60, 350), totalMs - t);
-                if (frameDur <= 0) break;
+                if (frameDur <= 0)
+                {
+                    break;
+                }
 
                 var frame = new SubtitleLineViewModel(sub, generateNewId: true);
                 frame.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(t));
@@ -70,7 +76,10 @@ public class AdvancedEffectGlitch : IAdvancedEffectDisplay
 
                 var startTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(glitchStartMs));
                 var endTime = startTime.Add(TimeSpan.FromMilliseconds(glitchDurMs));
-                if (endTime > sub.EndTime) continue;
+                if (endTime > sub.EndTime)
+                {
+                    continue;
+                }
 
                 var glitch = new SubtitleLineViewModel(sub, generateNewId: true);
                 glitch.StartTime = startTime;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectHearts.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectHearts.cs
@@ -46,7 +46,10 @@ public class AdvancedEffectHearts : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         int w = width > 0 ? width : 1280;
         int h = height > 0 ? height : 720;
@@ -92,7 +95,10 @@ public class AdvancedEffectHearts : IAdvancedEffectDisplay
                 const double preRollMs = 700;
                 double heartStartOffset = launchMs - preRollMs;
                 double actualDur = durationMs - heartStartOffset;
-                if (actualDur < 600) continue;
+                if (actualDur < 600)
+                {
+                    continue;
+                }
 
                 var heart = new SubtitleLineViewModel(sub, generateNewId: true);
                 heart.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(heartStartOffset));

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectMatrix.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectMatrix.cs
@@ -32,7 +32,10 @@ public class AdvancedEffectMatrix : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         var rng = new Random(subtitles[0].Text.GetHashCode());
 
@@ -62,12 +65,18 @@ public class AdvancedEffectMatrix : IAdvancedEffectDisplay
                 for (int j = 0; j < streamLen; j++)
                 {
                     double charStartMs = streamStart + j * interval;
-                    if (charStartMs >= totalVideoMs) break;
+                    if (charStartMs >= totalVideoMs)
+                    {
+                        break;
+                    }
 
                     var entry = new SubtitleLineViewModel();
                     entry.StartTime = globalStart.Add(TimeSpan.FromMilliseconds(charStartMs));
                     entry.EndTime = entry.StartTime.Add(TimeSpan.FromMilliseconds(fallDur));
-                    if (entry.StartTime >= globalEnd) continue;
+                    if (entry.StartTime >= globalEnd)
+                    {
+                        continue;
+                    }
 
                     char ch = MatrixPool[rng.Next(MatrixPool.Length)];
 
@@ -146,7 +155,10 @@ public class AdvancedEffectMatrix : IAdvancedEffectDisplay
                 int colIdx = Math.Min(startCol + i, cols - 1);
                 int charX = colIdx * colW + colW / 2;
 
-                if (chars[i] == ' ') continue;
+                if (chars[i] == ' ')
+                {
+                    continue;
+                }
 
                 double revealFrac = visibleCount > 1
                     ? revealFracStart + (revealFracEnd - revealFracStart) * visIdx / (visibleCount - 1)

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectNeonBurst.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectNeonBurst.cs
@@ -18,7 +18,10 @@ public class AdvancedEffectNeonBurst : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         Random rng = new Random(subtitles[0].Text.GetHashCode());
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectOldMovie.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectOldMovie.cs
@@ -18,7 +18,10 @@ public class AdvancedEffectOldMovie : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         Random rng = new Random(subtitles[0].Text.GetHashCode());
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectRain.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectRain.cs
@@ -18,7 +18,10 @@ public class AdvancedEffectRain : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         Random rng = new Random(subtitles[0].Text.GetHashCode());
 
@@ -75,7 +78,10 @@ public class AdvancedEffectRain : IAdvancedEffectDisplay
                 drop.StartTime = globalStart.Add(TimeSpan.FromMilliseconds(currentTimeMs));
                 drop.EndTime = drop.StartTime.Add(TimeSpan.FromMilliseconds(fallDuration));
 
-                if (drop.StartTime >= globalEnd) break;
+                if (drop.StartTime >= globalEnd)
+                {
+                    break;
+                }
 
                 int startX = rng.Next(-100, screenWidth + 100);
                 int endX = startX + rng.Next(15, 40);

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectRainbowPulse.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectRainbowPulse.cs
@@ -28,9 +28,13 @@ public class AdvancedEffectRainbowPulse : IAdvancedEffectDisplay
             foreach (System.Text.RegularExpressions.Match m in matches)
             {
                 if (m.Value.StartsWith("{"))
+                {
                     fullParts.Add((m.Value, true));
+                }
                 else
+                {
                     fullParts.Add((m.Value, false));
+                }
             }
 
             // 2. Map every visible character to its position in the full string
@@ -53,7 +57,10 @@ public class AdvancedEffectRainbowPulse : IAdvancedEffectDisplay
             for (int i = 0; i < visibleChars.Count; i++)
             {
                 var target = visibleChars[i];
-                if (char.IsWhiteSpace(target.Character)) continue;
+                if (char.IsWhiteSpace(target.Character))
+                {
+                    continue;
+                }
 
                 var charLine = new SubtitleLineViewModel(sub, generateNewId: true);
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSnow.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSnow.cs
@@ -19,7 +19,10 @@ public class AdvancedEffectSnow : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         Random rng = new Random(subtitles[0].Text.GetHashCode());
 
@@ -75,7 +78,10 @@ public class AdvancedEffectSnow : IAdvancedEffectDisplay
                 flake.StartTime = globalStart.Add(TimeSpan.FromMilliseconds(currentTimeMs));
                 flake.EndTime = flake.StartTime.Add(TimeSpan.FromMilliseconds(fallDuration));
 
-                if (flake.StartTime >= globalEnd) break;
+                if (flake.StartTime >= globalEnd)
+                {
+                    break;
+                }
 
                 int startX = rng.Next(-100, screenWidth + 100);
                 int endX = startX + xDrift;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectStarWarsScroll.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectStarWarsScroll.cs
@@ -17,7 +17,10 @@ public class AdvancedEffectStarWarsScroll : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         int screenWidth = width > 0 ? width : 1356;
         int screenHeight = height > 0 ? height : 678;
@@ -37,7 +40,10 @@ public class AdvancedEffectStarWarsScroll : IAdvancedEffectDisplay
         {
             string processedText = sub.Text.Replace("\\N", "\n").Replace("\\n", "\n");
             var clean = Utilities.RemoveSsaTags(processedText);
-            if (string.IsNullOrWhiteSpace(clean)) continue;
+            if (string.IsNullOrWhiteSpace(clean))
+            {
+                continue;
+            }
 
             var lines = clean.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -46,7 +52,10 @@ public class AdvancedEffectStarWarsScroll : IAdvancedEffectDisplay
                 var charLine = new SubtitleLineViewModel(sub, generateNewId: true);
 
                 double startTimeMs = sub.StartTime.TotalMilliseconds - leadTimeMs;
-                if (startTimeMs < 0) startTimeMs = 0;
+                if (startTimeMs < 0)
+                {
+                    startTimeMs = 0;
+                }
 
                 charLine.StartTime = TimeSpan.FromMilliseconds(startTimeMs);
                 // We give it an extra 2 seconds of life to ensure the fade finishes

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectStarfield.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectStarfield.cs
@@ -20,7 +20,10 @@ public class AdvancedEffectStarfield : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
-        if (subtitles.Count == 0) return result;
+        if (subtitles.Count == 0)
+        {
+            return result;
+        }
 
         Random rng = new Random(subtitles[0].Text.GetHashCode());
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWave.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWave.cs
@@ -40,7 +40,10 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
             for (int i = 0; i < visibleChars.Count; i++)
             {
                 var target = visibleChars[i];
-                if (char.IsWhiteSpace(target.Character)) continue;
+                if (char.IsWhiteSpace(target.Character))
+                {
+                    continue;
+                }
 
                 var charLine = new SubtitleLineViewModel(sub, generateNewId: true);
 
@@ -62,7 +65,10 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
                 var finalString = new System.Text.StringBuilder();
                 for (int p = 0; p < fullParts.Count; p++)
                 {
-                    if (fullParts[p].IsTag) finalString.Append(fullParts[p].Content);
+                    if (fullParts[p].IsTag)
+                    {
+                        finalString.Append(fullParts[p].Content);
+                    }
                     else if (p == target.PartIndex)
                     {
                         string partText = fullParts[p].Content;
@@ -71,7 +77,10 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
                                    .Append(@"{\alpha&H00&" + waveTransforms + "}").Append(target.Character)
                                    .Append(@"{\alpha&HFF&}").Append(partText.Substring(target.CharIndex + 1));
                     }
-                    else finalString.Append(@"{\alpha&HFF&}").Append(fullParts[p].Content);
+                    else
+                    {
+                        finalString.Append(@"{\alpha&HFF&}").Append(fullParts[p].Content);
+                    }
                 }
 
                 charLine.Text = finalString.ToString();

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWaveBlue.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWaveBlue.cs
@@ -38,7 +38,10 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
             for (int i = 0; i < visibleChars.Count; i++)
             {
                 var target = visibleChars[i];
-                if (char.IsWhiteSpace(target.Character)) continue;
+                if (char.IsWhiteSpace(target.Character))
+                {
+                    continue;
+                }
 
                 var charLine = new SubtitleLineViewModel(sub, generateNewId: true);
                 string oceanTransforms = "";
@@ -66,7 +69,10 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
                 var finalString = new System.Text.StringBuilder();
                 for (int p = 0; p < fullParts.Count; p++)
                 {
-                    if (fullParts[p].IsTag) finalString.Append(fullParts[p].Content);
+                    if (fullParts[p].IsTag)
+                    {
+                        finalString.Append(fullParts[p].Content);
+                    }
                     else if (p == target.PartIndex)
                     {
                         string partText = fullParts[p].Content;
@@ -75,7 +81,10 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
                                    .Append(@"{\alpha&H00&\1c&HFF8800&" + oceanTransforms + "}").Append(target.Character)
                                    .Append(@"{\alpha&HFF&}").Append(partText.Substring(target.CharIndex + 1));
                     }
-                    else finalString.Append(@"{\alpha&HFF&}").Append(fullParts[p].Content);
+                    else
+                    {
+                        finalString.Append(@"{\alpha&HFF&}").Append(fullParts[p].Content);
+                    }
                 }
 
                 charLine.Text = finalString.ToString();

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWordSpacing.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWordSpacing.cs
@@ -36,7 +36,9 @@ public class AdvancedEffectWordSpacing : IAdvancedEffectDisplay
     private string ProcessTextWithSpacing(string text)
     {
         if (string.IsNullOrEmpty(text))
+        {
             return text;
+        }
 
         var result = new StringBuilder();
         bool insideTags = false;

--- a/src/ui/Features/Assa/AssaDraw/AssaDrawViewModel.cs
+++ b/src/ui/Features/Assa/AssaDraw/AssaDrawViewModel.cs
@@ -777,15 +777,42 @@ public partial class AssaDrawViewModel : ObservableObject
     private static string GetColorName(Color color)
     {
         // Create a readable color name based on RGB values
-        if (color is { R: 255, G: 255, B: 255 }) return "White";
-        if (color.R == 0 && color is { G: 0, B: 0 }) return "Black";
-        if (color is { R: 255, G: 0, B: 0 }) return "Red";
-        if (color is { R: 0, G: 255, B: 0 }) return "Green";
-        if (color is { R: 0, G: 0, B: 255 }) return "Blue";
-        if (color is { R: 255, G: 255, B: 0 }) return "Yellow";
-        if (color is { R: 255, G: 0, B: 255 }) return "Magenta";
-        if (color is { R: 0, G: 255, B: 255 }) return "Cyan";
-        if (color is { R: 255, G: 165, B: 0 }) return "Orange";
+        if (color is { R: 255, G: 255, B: 255 })
+        {
+            return "White";
+        }
+        if (color.R == 0 && color is { G: 0, B: 0 })
+        {
+            return "Black";
+        }
+        if (color is { R: 255, G: 0, B: 0 })
+        {
+            return "Red";
+        }
+        if (color is { R: 0, G: 255, B: 0 })
+        {
+            return "Green";
+        }
+        if (color is { R: 0, G: 0, B: 255 })
+        {
+            return "Blue";
+        }
+        if (color is { R: 255, G: 255, B: 0 })
+        {
+            return "Yellow";
+        }
+        if (color is { R: 255, G: 0, B: 255 })
+        {
+            return "Magenta";
+        }
+        if (color is { R: 0, G: 255, B: 255 })
+        {
+            return "Cyan";
+        }
+        if (color is { R: 255, G: 165, B: 0 })
+        {
+            return "Orange";
+        }
         
         // For other colors, use hex representation
         return $"{color.R:X2}{color.G:X2}{color.B:X2}";
@@ -979,11 +1006,15 @@ public partial class AssaDrawViewModel : ObservableObject
         // Read resolution from header
         var playResX = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResX", "[Script Info]", subtitle.Header);
         if (int.TryParse(playResX, out var width) && width >= 125 && width <= 4096)
+        {
             CanvasWidth = width;
+        }
 
         var playResY = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResY", "[Script Info]", subtitle.Header);
         if (int.TryParse(playResY, out var height) && height >= 125 && height <= 4096)
+        {
             CanvasHeight = height;
+        }
 
         var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header);
 
@@ -993,7 +1024,10 @@ public partial class AssaDrawViewModel : ObservableObject
             if (!string.IsNullOrEmpty(paragraph.Extra))
             {
                 var style = styles.FirstOrDefault(s => s.Name.Equals(paragraph.Extra, StringComparison.OrdinalIgnoreCase));
-                if (style != null) color = style.Primary.ToAvaloniaColor();
+                if (style != null)
+                {
+                    color = style.Primary.ToAvaloniaColor();
+                }
             }
 
             // Handle iclip

--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -834,15 +834,42 @@ public partial class AssaStylesViewModel : ObservableObject
 
     private static int GetAlignment(StyleDisplay style)
     {
-        if (style.AlignmentAn1) return 1;
-        if (style.AlignmentAn2) return 2;
-        if (style.AlignmentAn3) return 3;
-        if (style.AlignmentAn4) return 4;
-        if (style.AlignmentAn5) return 5;
-        if (style.AlignmentAn6) return 6;
-        if (style.AlignmentAn7) return 7;
-        if (style.AlignmentAn8) return 8;
-        if (style.AlignmentAn9) return 9;
+        if (style.AlignmentAn1)
+        {
+            return 1;
+        }
+        if (style.AlignmentAn2)
+        {
+            return 2;
+        }
+        if (style.AlignmentAn3)
+        {
+            return 3;
+        }
+        if (style.AlignmentAn4)
+        {
+            return 4;
+        }
+        if (style.AlignmentAn5)
+        {
+            return 5;
+        }
+        if (style.AlignmentAn6)
+        {
+            return 6;
+        }
+        if (style.AlignmentAn7)
+        {
+            return 7;
+        }
+        if (style.AlignmentAn8)
+        {
+            return 8;
+        }
+        if (style.AlignmentAn9)
+        {
+            return 9;
+        }
         return 2;
     }
 

--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -71,7 +71,10 @@ public partial class FindViewModel : ObservableObject
         FindNextPressed = false;
         FindPreviousPressed = true;
         SaveSettings();
-        if (_findResult != null) await _findResult.HandleFindResult(this);
+        if (_findResult != null)
+        {
+            await _findResult.HandleFindResult(this);
+        }
     }
 
     [RelayCommand]
@@ -81,7 +84,10 @@ public partial class FindViewModel : ObservableObject
         FindNextPressed = true;
         FindPreviousPressed = false;
         SaveSettings();
-        if (_findResult != null) await _findResult.HandleFindResult(this);
+        if (_findResult != null)
+        {
+            await _findResult.HandleFindResult(this);
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -476,7 +476,9 @@ public class MultipleReplaceWindow : Window
 
                 var iconLabel = new Label { Padding = new Thickness(0, 0, 2, 0), VerticalAlignment = VerticalAlignment.Center };
                 if (hit.RuleTreeNode != null)
+                {
                     Attached.SetIcon(iconLabel, hit.RuleTreeNode.IconName);
+                }
 
                 var findBlock = new TextBlock
                 {

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -65,7 +65,10 @@ public partial class ReplaceViewModel : ObservableObject
         ReplaceAllPressed = false;
         FindNextPressed = false;
         SaveSettings();
-        if (_findResult != null) await _findResult.HandleReplaceResult(this);
+        if (_findResult != null)
+        {
+            await _findResult.HandleReplaceResult(this);
+        }
     }
 
     [RelayCommand]
@@ -75,7 +78,10 @@ public partial class ReplaceViewModel : ObservableObject
         ReplaceAllPressed = true;
         FindNextPressed = false;
         SaveSettings();
-        if (_findResult != null) await _findResult.HandleReplaceResult(this);
+        if (_findResult != null)
+        {
+            await _findResult.HandleReplaceResult(this);
+        }
     }
 
     [RelayCommand]
@@ -85,7 +91,10 @@ public partial class ReplaceViewModel : ObservableObject
         ReplaceAllPressed = false;
         FindNextPressed = true;
         SaveSettings();
-        if (_findResult != null) await _findResult.HandleReplaceResult(this);
+        if (_findResult != null)
+        {
+            await _findResult.HandleReplaceResult(this);
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
+++ b/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
@@ -34,14 +34,18 @@ public static class TextDiffHighlighter
     private static IBrush GetForegroundAddedColor()
     {
         if (UiTheme.IsDarkThemeEnabled())
+        {
             return new SolidColorBrush(Color.FromRgb(100, 255, 100));
+        }
         return new SolidColorBrush(Color.FromRgb(27, 94, 32));
     }
 
     private static IBrush GetBackAddedColor()
     {
         if (UiTheme.IsDarkThemeEnabled())
+        {
             return new SolidColorBrush(Color.FromRgb(30, 80, 30));
+        }
         return new SolidColorBrush(Color.FromRgb(200, 250, 205));
     }
 
@@ -119,10 +123,14 @@ public static class TextDiffHighlighter
         var after = new TextBlock { TextWrapping = TextWrapping.Wrap };
 
         if (before.Inlines == null || after.Inlines == null)
+        {
             return (before, after);
+        }
 
         if (string.IsNullOrEmpty(text1) && string.IsNullOrEmpty(text2))
+        {
             return (before, after);
+        }
 
         if (string.IsNullOrEmpty(text1))
         {
@@ -281,11 +289,17 @@ public static class TextDiffHighlighter
             // Build LCS table for unused parts
             for (int i = 0; i < s1.Length; i++)
             {
-                if (used1[i]) continue;
+                if (used1[i])
+                {
+                    continue;
+                }
 
                 for (int j = 0; j < s2.Length; j++)
                 {
-                    if (used2[j]) continue;
+                    if (used2[j])
+                    {
+                        continue;
+                    }
 
                     int len = 0;
                     while (i + len < s1.Length && j + len < s2.Length &&

--- a/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsViewModel.cs
+++ b/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsViewModel.cs
@@ -460,17 +460,41 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
     private static CsvColumnRole GuessRoleFromHeader(string headerName)
     {
         var name = headerName.Trim();
-        if (StartHeaderNames.Contains(name)) return CsvColumnRole.Start;
-        if (EndHeaderNames.Contains(name)) return CsvColumnRole.End;
-        if (DurationHeaderNames.Contains(name)) return CsvColumnRole.Duration;
-        if (TextHeaderNames.Contains(name)) return CsvColumnRole.Text;
-        if (CharacterHeaderNames.Contains(name)) return CsvColumnRole.Character;
+        if (StartHeaderNames.Contains(name))
+        {
+            return CsvColumnRole.Start;
+        }
+        if (EndHeaderNames.Contains(name))
+        {
+            return CsvColumnRole.End;
+        }
+        if (DurationHeaderNames.Contains(name))
+        {
+            return CsvColumnRole.Duration;
+        }
+        if (TextHeaderNames.Contains(name))
+        {
+            return CsvColumnRole.Text;
+        }
+        if (CharacterHeaderNames.Contains(name))
+        {
+            return CsvColumnRole.Character;
+        }
 
         // Loose ms-suffixed matches (e.g., "startMs", "endMillis").
         var compact = name.Replace(" ", string.Empty).Replace("_", string.Empty).ToLowerInvariant();
-        if (compact.StartsWith("start") || compact.StartsWith("from")) return CsvColumnRole.Start;
-        if (compact.StartsWith("end") || compact.StartsWith("to") || compact.StartsWith("stop")) return CsvColumnRole.End;
-        if (compact.StartsWith("duration") || compact.StartsWith("dur")) return CsvColumnRole.Duration;
+        if (compact.StartsWith("start") || compact.StartsWith("from"))
+        {
+            return CsvColumnRole.Start;
+        }
+        if (compact.StartsWith("end") || compact.StartsWith("to") || compact.StartsWith("stop"))
+        {
+            return CsvColumnRole.End;
+        }
+        if (compact.StartsWith("duration") || compact.StartsWith("dur"))
+        {
+            return CsvColumnRole.Duration;
+        }
         return CsvColumnRole.None;
     }
 

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -364,12 +364,16 @@ public static class InitNativeMacMenu
     public static void Rebuild(MainViewModel vm)
     {
         if (_root == null || _window == null)
+        {
             return;
+        }
         _root.Items.Clear();
         MakeStructure(_root, _window);
         NativeMenu.SetMenu(_window, _root);
         if (Application.Current != null)
+        {
             SetupAppMenu(Application.Current);
+        }
         Sync(vm);
     }
 
@@ -380,7 +384,9 @@ public static class InitNativeMacMenu
     public static void Sync(MainViewModel vm)
     {
         if (_handler != null && _vm != null)
+        {
             _vm.PropertyChanged -= _handler;
+        }
 
         _vm = vm;
 
@@ -402,18 +408,31 @@ public static class InitNativeMacMenu
             item.Header = getHeader(vm);
 
         if (_pluginsItem != null)
+        {
             _pluginsItem.IsEnabled = Se.Settings.Appearance.ShowPluginsMenu;
+        }
 
         _handler = (s, e) =>
         {
             if (s is not MainViewModel v2 || e.PropertyName is null)
+            {
                 return;
+            }
             foreach (var (item, isVisible, props) in _visibilities)
-                if (props.Contains(e.PropertyName)) item.IsVisible = isVisible(v2);
+                if (props.Contains(e.PropertyName))
+                {
+                    item.IsVisible = isVisible(v2);
+                }
             foreach (var (item, isChecked, props) in _toggles)
-                if (props.Contains(e.PropertyName)) item.IsChecked = isChecked(v2);
+                if (props.Contains(e.PropertyName))
+                {
+                    item.IsChecked = isChecked(v2);
+                }
             foreach (var (item, getHeader, props) in _dynamicHeaders)
-                if (props.Contains(e.PropertyName)) item.Header = getHeader(v2);
+                if (props.Contains(e.PropertyName))
+                {
+                    item.Header = getHeader(v2);
+                }
         };
         vm.PropertyChanged += _handler;
 
@@ -426,7 +445,9 @@ public static class InitNativeMacMenu
     public static void UpdateRecentFiles(MainViewModel vm)
     {
         if (vm.NativeMenuReopen?.Menu is not NativeMenu menu)
+        {
             return;
+        }
 
         menu.Items.Clear();
 
@@ -437,7 +458,9 @@ public static class InitNativeMacMenu
         vm.NativeMenuReopen.IsEnabled = files.Count > 0;
 
         if (files.Count == 0)
+        {
             return;
+        }
 
         foreach (var file in files)
         {
@@ -450,7 +473,9 @@ public static class InitNativeMacMenu
                     : file.SubtitleFileNameOriginal;
             }
             if (header.Length > 80)
+            {
                 header = "…" + header[^77..];
+            }
 
             var recentItem = new NativeMenuItem(header);
             var captured = file;
@@ -467,7 +492,9 @@ public static class InitNativeMacMenu
     public static void UpdatePluginsMenu(MainViewModel vm)
     {
         if (vm.NativeMenuPlugins?.Menu is not NativeMenu menu)
+        {
             return;
+        }
 
         menu.Items.Clear();
 
@@ -500,7 +527,9 @@ public static class InitNativeMacMenu
     public static void UpdateAudioTracksMenu(MainViewModel vm, IList<AudioTrackInfo> tracks, AudioTrackInfo? current)
     {
         if (vm.NativeMenuAudioTracks?.Menu is not NativeMenu menu)
+        {
             return;
+        }
 
         menu.Items.Clear();
 
@@ -513,7 +542,9 @@ public static class InitNativeMacMenu
                 trackName += string.IsNullOrEmpty(lang?.EnglishName) ? $" - {track.Language}" : $" - {lang.EnglishName}";
             }
             if (!string.IsNullOrEmpty(track.Title))
+            {
                 trackName += $" - {track.Title}";
+            }
 
             var item = new NativeMenuItem(trackName);
             item.ToggleType = MenuItemToggleType.CheckBox;
@@ -538,7 +569,10 @@ public static class InitNativeMacMenu
     private static NativeMenuItem Item(string? header, Func<MainViewModel, IRelayCommand> getCmd)
     {
         var item = new NativeMenuItem(header ?? string.Empty);
-        item.Click += (_, _) => { var v = GetVm(); if (v != null) getCmd(v).Execute(null); };
+        item.Click += (_, _) => { var v = GetVm(); if (v != null)
+        {
+            getCmd(v).Execute(null);
+        } };
         _gestureItems.Add((getCmd, item));
         return item;
     }
@@ -556,7 +590,10 @@ public static class InitNativeMacMenu
     {
         var item = new NativeMenuItem(header ?? string.Empty);
         item.ToggleType = MenuItemToggleType.CheckBox;
-        item.Click += (_, _) => { var v = GetVm(); if (v != null) getCmd(v).Execute(null); };
+        item.Click += (_, _) => { var v = GetVm(); if (v != null)
+        {
+            getCmd(v).Execute(null);
+        } };
         _toggles.Add((item, isChecked, propertyNames));
         _gestureItems.Add((getCmd, item));
         return item;
@@ -567,7 +604,9 @@ public static class InitNativeMacMenu
         foreach (var sc in shortcuts)
         {
             if (ReferenceEquals(sc.Action, command))
+            {
                 return InitMenu.ToKeyGesture(sc);
+            }
         }
         return null;
     }

--- a/src/ui/Features/Main/MainHelpers/DivXSubParser.cs
+++ b/src/ui/Features/Main/MainHelpers/DivXSubParser.cs
@@ -74,7 +74,10 @@ public static class DivXSubParser
         xSub = null;
         Span<byte> header = stackalloc byte[26 + 14 + 12]; // Timecode + Metadata + Colors
 
-        if (stream.Read(header) < header.Length) return false;
+        if (stream.Read(header) < header.Length)
+        {
+            return false;
+        }
 
         string timeCode = Encoding.ASCII.GetString(header.Slice(0, 25));
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1871,7 +1871,9 @@ public partial class MainViewModel :
         Se.Settings.File.RecentFiles.Clear();
         InitMenu.UpdateRecentFiles(this);
         if (OperatingSystem.IsMacOS())
+        {
             Layout.InitNativeMacMenu.UpdateRecentFiles(this);
+        }
         _shortcutManager.ClearKeys();
     }
 
@@ -3604,8 +3606,14 @@ public partial class MainViewModel :
         foreach (var idx in indices)
         {
             var insertAt = idx + delta;
-            if (insertAt < 0) insertAt = 0;
-            if (insertAt > texts.Count) insertAt = texts.Count;
+            if (insertAt < 0)
+            {
+                insertAt = 0;
+            }
+            if (insertAt > texts.Count)
+            {
+                insertAt = texts.Count;
+            }
             texts.Insert(insertAt, string.Empty);
             delta++;
         }
@@ -4891,7 +4899,9 @@ public partial class MainViewModel :
         await ShowDialogAsync<PluginManagerWindow, PluginManagerViewModel>(vm => vm.Initialize());
         Layout.InitMenu.UpdatePluginsMenu(this);
         if (OperatingSystem.IsMacOS())
+        {
             Layout.InitNativeMacMenu.UpdatePluginsMenu(this);
+        }
     }
 
     [RelayCommand]
@@ -7835,7 +7845,9 @@ public partial class MainViewModel :
         await ShowDialogAsync<ShortcutsWindow, ShortcutsViewModel>(vm => { vm.LoadShortCuts(this); });
         ReloadShortcuts();
         if (OperatingSystem.IsMacOS())
+        {
             Layout.InitNativeMacMenu.UpdateShortcuts(this);
+        }
     }
 
     [RelayCommand]
@@ -8272,7 +8284,9 @@ public partial class MainViewModel :
         // reload current layout
         InitMenu.Make(this);
         if (OperatingSystem.IsMacOS())
+        {
             Layout.InitNativeMacMenu.Rebuild(this);
+        }
         SetLayout(Se.Settings.General.LayoutNumber);
 
         if (Toolbar is Border toolbarBorder)
@@ -9716,7 +9730,10 @@ public partial class MainViewModel :
 
     private async Task<MessageBoxResult> ShowWrapAroundDialog(string message)
     {
-        if (Window == null) return MessageBoxResult.No;
+        if (Window == null)
+        {
+            return MessageBoxResult.No;
+        }
         var findWin = _findViewModel?.Window;
         var replaceWin = _replaceViewModel?.Window;
         var dialogWindow = (findWin?.IsVisible == true ? findWin : null)
@@ -12537,7 +12554,9 @@ public partial class MainViewModel :
 
             var undoRedoObject = _undoRedoManager.Undo()!;
             if (undoRedoObject?.Subtitles == null)
+            {
                 return;
+            }
 
             RestoreUndoRedoState(undoRedoObject);
             RestoreSelectionToPreviousIndex(preIndex);
@@ -14926,7 +14945,9 @@ public partial class MainViewModel :
         {
             InitMenu.UpdateRecentFiles(this);
             if (OperatingSystem.IsMacOS())
+            {
                 Layout.InitNativeMacMenu.UpdateRecentFiles(this);
+            }
         }
     }
 
@@ -15102,7 +15123,9 @@ public partial class MainViewModel :
     internal void OnLoaded()
     {
         if (OperatingSystem.IsMacOS())
+        {
             Layout.InitNativeMacMenu.Sync(this);
+        }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && string.IsNullOrEmpty(Se.Settings.General.LibMpvPath))
         {
@@ -15575,7 +15598,9 @@ public partial class MainViewModel :
                         IsAudioTracksVisible = false;
                         AudioTraksMenuItem.Items.Clear();
                         if (OperatingSystem.IsMacOS())
+                        {
                             Layout.InitNativeMacMenu.UpdateAudioTracksMenu(this, [], null);
+                        }
                     });
                     return;
                 }
@@ -15628,7 +15653,9 @@ public partial class MainViewModel :
 
                     IsAudioTracksVisible = AudioTraksMenuItem.Items.Count > 1;
                     if (OperatingSystem.IsMacOS())
+                    {
                         Layout.InitNativeMacMenu.UpdateAudioTracksMenu(this, audioTracks, _audioTrack);
+                    }
                 });
             }
         }

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -549,7 +549,9 @@ public partial class SubtitleLineViewModel : ObservableObject
     internal void UpdateFrom(SubtitleLineViewModel src)
     {
         if (src.Paragraph != null)
+        {
             Paragraph = src.Paragraph;
+        }
         Text = src.Text;
         Actor = src.Actor;
         Style = src.Style;

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddWindow.cs
@@ -106,7 +106,9 @@ public class BinaryOcrCharacterAddWindow : Window
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
         var image = new Image
         {
             Margin = new Thickness(5),

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterHistoryWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterHistoryWindow.cs
@@ -96,7 +96,9 @@ public class BinaryOcrCharacterHistoryWindow : Window
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
         var image = new Image
         {
             Margin = new Thickness(5),

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
@@ -120,7 +120,9 @@ public class BinaryOcrDbEditWindow : Window
 
         vm.TextBoxItem = UiUtil.MakeTextBox(100, vm, nameof(vm.ItemText));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxItem.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
         vm.TextBoxItem.Bind(TextBox.FontStyleProperty, new Binding(nameof(vm.IsItemItalic)) { Converter = new BoolToFontStyleConverter() });
 
         var image = new Image

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectWindow.cs
@@ -123,7 +123,9 @@ public class BinaryOcrInspectWindow : Window
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText))
             .WithBindEnabled(nameof(vm.IsEditControlsEnabled));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
 
         var image = new Image
         {

--- a/src/ui/Features/Ocr/Engines/GoogleLensOcrSharp.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleLensOcrSharp.cs
@@ -25,7 +25,10 @@ public class GoogleLensOcrSharp
 
         foreach (var bmpInput in input)
         {
-            if (cancellationToken.IsCancellationRequested) break;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
 
             if (bmpInput.Bitmap == null)
             {

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterAddWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterAddWindow.cs
@@ -105,7 +105,9 @@ public class NOcrCharacterAddWindow : Window
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
         vm.TextBoxNew.FontStyle = vm.IsNewTextItalic ? FontStyle.Italic : FontStyle.Normal;
 
         var image = new Image

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterHistoryWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterHistoryWindow.cs
@@ -98,7 +98,9 @@ public class NOcrCharacterHistoryWindow : Window
 
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
         var image = new Image
         {
             Margin = new Thickness(5),

--- a/src/ui/Features/Ocr/NOcr/NOcrDbEditWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrDbEditWindow.cs
@@ -123,7 +123,9 @@ public class NOcrDbEditWindow : Window
 
         vm.TextBoxItem = UiUtil.MakeTextBox(100, vm, nameof(vm.ItemText));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxItem.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
 
         var panelCurrent = new StackPanel
         {

--- a/src/ui/Features/Ocr/NOcr/NOcrInspectWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrInspectWindow.cs
@@ -129,7 +129,9 @@ public class NOcrInspectWindow : Window
         vm.TextBoxNew = UiUtil.MakeTextBox(100, vm, nameof(vm.NewText))
             .WithBindEnabled(nameof(vm.IsEditControlsEnabled));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxNew.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
 
         var image = new Image
         {

--- a/src/ui/Features/Ocr/OcrSubtitleItem.cs
+++ b/src/ui/Features/Ocr/OcrSubtitleItem.cs
@@ -114,11 +114,15 @@ public partial class OcrSubtitleItem : ObservableObject
     public TextBlock CreateFormattedText()
     {
         if (FixResult != null)
+        {
             return FixResult.GetFormattedText();
+        }
 
         var tb = new TextBlock { Text = Text };
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             tb.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
         return tb;
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4569,7 +4569,10 @@ public partial class OcrViewModel : ObservableObject
                 var startY = i * lineHeight;
                 var endY = Math.Min(startY + lineHeight, height);
 
-                if (startY >= height) break;
+                if (startY >= height)
+                {
+                    break;
+                }
 
                 // Check if this region has text content (simplified detection)
                 if (HasTextInRegion(bitmap, 0, startY, width, endY - startY))

--- a/src/ui/Features/Ocr/PickOllamaModelViewModel.cs
+++ b/src/ui/Features/Ocr/PickOllamaModelViewModel.cs
@@ -170,7 +170,9 @@ public partial class PickOllamaModelViewModel : ObservableObject
     public static string GetBaseUrl(string url)
     {
         if (string.IsNullOrEmpty(url))
+        {
             return string.Empty;
+        }
 
         try
         {

--- a/src/ui/Features/Ocr/PreProcessingSettings.cs
+++ b/src/ui/Features/Ocr/PreProcessingSettings.cs
@@ -74,10 +74,22 @@ public class PreProcessingSettings
 
                 if (alpha > 0) // Non-transparent pixel
                 {
-                    if (x < left) left = x;
-                    if (x > right) right = x;
-                    if (y < top) top = y;
-                    if (y > bottom) bottom = y;
+                    if (x < left)
+                    {
+                        left = x;
+                    }
+                    if (x > right)
+                    {
+                        right = x;
+                    }
+                    if (y < top)
+                    {
+                        top = y;
+                    }
+                    if (y > bottom)
+                    {
+                        bottom = y;
+                    }
                 }
             }
         }
@@ -228,10 +240,16 @@ public class PreProcessingSettings
         for (var i = 0; i < 256; i++)
         {
             wB += histogram[i];
-            if (wB == 0) continue;
+            if (wB == 0)
+            {
+                continue;
+            }
 
             wF = totalPixels - wB;
-            if (wF == 0) break;
+            if (wF == 0)
+            {
+                break;
+            }
 
             sumB += i * histogram[i];
             float mB = sumB / wB;

--- a/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
@@ -95,7 +95,9 @@ public partial class PromptUnknownWordViewModel : ObservableObject
         var textBlock = new TextBlock();
         var fontName = Se.Settings.Appearance.SubtitleTextBoxAndGridFontName;
         if (!string.IsNullOrEmpty(fontName))
+        {
             textBlock.FontFamily = new FontFamily(fontName);
+        }
         var idx = word.Word.WordIndex;
         var paragraph = word.Result.GetText();
         var w = word.Word.FixedWord;
@@ -108,7 +110,9 @@ public partial class PromptUnknownWordViewModel : ObservableObject
                 // still not found - just show the whole text without highlighting
                 var run = new Run(paragraph);
                 if (!string.IsNullOrEmpty(fontName))
+                {
                     run.FontFamily = new FontFamily(fontName);
+                }
                 textBlock.Inlines!.Add(run);
                 PanelWholeText.Children.Clear();
                 PanelWholeText.Children.Add(textBlock);
@@ -120,7 +124,9 @@ public partial class PromptUnknownWordViewModel : ObservableObject
         {
             var run = new Run(paragraph.Substring(0, idx));
             if (!string.IsNullOrEmpty(fontName))
+            {
                 run.FontFamily = new FontFamily(fontName);
+            }
             textBlock.Inlines!.Add(run);
         }
 
@@ -131,14 +137,18 @@ public partial class PromptUnknownWordViewModel : ObservableObject
             Foreground = Brushes.Red
         };
         if (!string.IsNullOrEmpty(fontName))
+        {
             highlightRun.FontFamily = new FontFamily(fontName);
+        }
         textBlock.Inlines!.Add(highlightRun);
 
         if (idx + w.Length < paragraph.Length)
         {
             var run = new Run(paragraph.Substring(idx + w.Length));
             if (!string.IsNullOrEmpty(fontName))
+            {
                 run.FontFamily = new FontFamily(fontName);
+            }
             textBlock.Inlines!.Add(run);
         }
 

--- a/src/ui/Features/Ocr/PromptUnknownWordWindow.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordWindow.cs
@@ -97,7 +97,9 @@ public class PromptUnknownWordWindow : Window
             .WithHeight(88)
             .WithBindIsVisible(nameof(vm.DoEditWholeText));
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxWholeText.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
 
         vm.PanelWholeText.Width = double.NaN;
         vm.PanelWholeText.HorizontalAlignment = HorizontalAlignment.Left;
@@ -171,7 +173,9 @@ public class PromptUnknownWordWindow : Window
             .WithBindEnabled(nameof(vm.DoEditWholeText), new InverseBooleanConverter())
             .Bind(TextBox.TextProperty, new Binding(nameof(vm.Word)) { Mode = BindingMode.TwoWay });
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             vm.TextBoxWord.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
         var buttonChangeAll = UiUtil.MakeButton(Se.Language.General.ChangeAll, vm.ChangeAllCommand)
             .WithHorizontalAlignmentStretch()
             .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());

--- a/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
@@ -140,9 +140,13 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
         {
             using var p = new SKPaint { Color = new SKColor(50, 220, 50), StrokeWidth = 2, IsAntialias = false };
             if (safeLeft >= 0 && safeLeft <= bitmapWidth)
+            {
                 canvas.DrawLine(safeLeft, 0, safeLeft, previewHeight, p);
+            }
             if (safeRight >= 0 && safeRight <= bitmapWidth)
+            {
                 canvas.DrawLine(safeRight, 0, safeRight, previewHeight, p);
+            }
         }
 
         // Outer box border

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformPreviewControl.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformPreviewControl.cs
@@ -42,7 +42,10 @@ public class WaveformPreviewControl : Control
     {
         var width = Bounds.Width;
         var height = Bounds.Height;
-        if (width <= 0 || height <= 0) return;
+        if (width <= 0 || height <= 0)
+        {
+            return;
+        }
 
         var boundsRect = new Rect(0, 0, width, height);
         using var _ = context.PushClip(boundsRect);
@@ -89,8 +92,14 @@ public class WaveformPreviewControl : Control
             // Clamp
             yMax = Math.Max(0, Math.Min(height, yMax));
             yMin = Math.Max(0, Math.Min(height, yMin));
-            if (yMin < yMax) (yMin, yMax) = (yMax, yMin);
-            if (yMin - yMax < 1) yMin = yMax + 1;
+            if (yMin < yMax)
+            {
+                (yMin, yMax) = (yMax, yMin);
+            }
+            if (yMin - yMax < 1)
+            {
+                yMin = yMax + 1;
+            }
 
             // Use selected color inside the paragraph overlay region
             var isInParagraph = x >= pLeft && x <= pRight;

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
@@ -91,7 +91,10 @@ public partial class WaveformThemesViewModel : ObservableObject
 
     partial void OnSelectedThemeChanged(WaveformThemeDisplay? value)
     {
-        if (value == null) return;
+        if (value == null)
+        {
+            return;
+        }
 
         TextColor = value.TextColor;
         WaveformColor = value.WaveformColor;
@@ -109,7 +112,10 @@ public partial class WaveformThemesViewModel : ObservableObject
     [RelayCommand]
     private async Task SaveAsCustomTheme()
     {
-        if (Window == null) return;
+        if (Window == null)
+        {
+            return;
+        }
 
         _customThemeCount++;
         var vm = new PromptTextBoxViewModel();
@@ -159,10 +165,16 @@ public partial class WaveformThemesViewModel : ObservableObject
     [RelayCommand]
     private async Task LoadTheme()
     {
-        if (Window == null) return;
+        if (Window == null)
+        {
+            return;
+        }
 
         var topLevel = TopLevel.GetTopLevel(Window);
-        if (topLevel == null) return;
+        if (topLevel == null)
+        {
+            return;
+        }
 
         var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
         {
@@ -177,10 +189,16 @@ public partial class WaveformThemesViewModel : ObservableObject
             },
         });
 
-        if (files.Count == 0) return;
+        if (files.Count == 0)
+        {
+            return;
+        }
 
         var path = files[0].Path.LocalPath;
-        if (!File.Exists(path)) return;
+        if (!File.Exists(path))
+        {
+            return;
+        }
 
         try
         {
@@ -189,7 +207,10 @@ public partial class WaveformThemesViewModel : ObservableObject
             {
                 PropertyNameCaseInsensitive = true,
             });
-            if (dto == null) return;
+            if (dto == null)
+            {
+                return;
+            }
 
             var theme = dto.ToThemeDisplay(Path.GetFileNameWithoutExtension(path));
             Themes.Add(theme);
@@ -204,10 +225,16 @@ public partial class WaveformThemesViewModel : ObservableObject
     [RelayCommand]
     private async Task ExportTheme()
     {
-        if (Window == null) return;
+        if (Window == null)
+        {
+            return;
+        }
 
         var topLevel = TopLevel.GetTopLevel(Window);
-        if (topLevel == null) return;
+        if (topLevel == null)
+        {
+            return;
+        }
 
         var suggestedName = (SelectedTheme?.Name ?? "custom").Replace(' ', '_');
 
@@ -225,7 +252,10 @@ public partial class WaveformThemesViewModel : ObservableObject
             },
         });
 
-        if (file == null) return;
+        if (file == null)
+        {
+            return;
+        }
 
         var dto = WaveformThemeDto.FromColors(
             name: SelectedTheme?.Name ?? suggestedName,

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesWindow.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesWindow.cs
@@ -161,7 +161,10 @@ public class WaveformThemesWindow : Window
 
         button.Click += async (_, _) =>
         {
-            if (TopLevel.GetTopLevel(button) is not Window window) return;
+            if (TopLevel.GetTopLevel(button) is not Window window)
+            {
+                return;
+            }
 
             var propInfo = typeof(WaveformThemesViewModel).GetProperty(propertyName);
             var currentColor = propInfo?.GetValue(vm) is Color c ? c : Colors.White;

--- a/src/ui/Features/Options/Settings/WaveformToolbarItems/WaveformToolbarItemsViewModel.cs
+++ b/src/ui/Features/Options/Settings/WaveformToolbarItems/WaveformToolbarItemsViewModel.cs
@@ -47,19 +47,28 @@ public partial class WaveformToolbarItemsViewModel : ObservableObject
 
     partial void OnSelectedFontSizeChanged(int value)
     {
-        if (_updatingFromSelection || SelectedToolbarItem == null) return;
+        if (_updatingFromSelection || SelectedToolbarItem == null)
+        {
+            return;
+        }
         SelectedToolbarItem.FontSize = value;
     }
 
     partial void OnSelectedLeftMarginChanged(int value)
     {
-        if (_updatingFromSelection || SelectedToolbarItem == null) return;
+        if (_updatingFromSelection || SelectedToolbarItem == null)
+        {
+            return;
+        }
         SelectedToolbarItem.LeftMargin = value;
     }
 
     partial void OnSelectedRightMarginChanged(int value)
     {
-        if (_updatingFromSelection || SelectedToolbarItem == null) return;
+        if (_updatingFromSelection || SelectedToolbarItem == null)
+        {
+            return;
+        }
         SelectedToolbarItem.RightMargin = value;
     }
 

--- a/src/ui/Features/Shared/ColorPicker/ColorWheelControl.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorWheelControl.cs
@@ -103,7 +103,10 @@ public class ColorWheelControl : Control
 
         // Calculate angle in degrees (0-360)
         var angle = Math.Atan2(dy, dx) * 180 / Math.PI;
-        if (angle < 0) angle += 360;
+        if (angle < 0)
+        {
+            angle += 360;
+        }
 
         // Convert to HSV
         var hue = (int)(angle / 360 * 255);
@@ -165,7 +168,10 @@ public class ColorWheelControl : Control
         var width = (int)Bounds.Width;
         var height = (int)Bounds.Height;
 
-        if (width <= 0 || height <= 0) return;
+        if (width <= 0 || height <= 0)
+        {
+            return;
+        }
 
         _wheelBitmap?.Dispose();
         _wheelBitmap = new SKBitmap(width, height);
@@ -188,7 +194,10 @@ public class ColorWheelControl : Control
                 if (distance <= radius)
                 {
                     var angle = Math.Atan2(dy, dx) * 180 / Math.PI;
-                    if (angle < 0) angle += 360;
+                    if (angle < 0)
+                    {
+                        angle += 360;
+                    }
 
                     var hue = (float)angle;
                     var saturation = (float)(distance / radius * 100);
@@ -224,7 +233,10 @@ public class ColorWheelControl : Control
         public void Render(ImmediateDrawingContext context)
         {
             var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
-            if (leaseFeature == null || _bitmap == null) return;
+            if (leaseFeature == null || _bitmap == null)
+            {
+                return;
+            }
 
             using var lease = leaseFeature.Lease();
             var canvas = lease.SkCanvas;
@@ -306,15 +318,24 @@ public class ColorWheelControl : Control
         {
             s = delta / max;
             if (Math.Abs(r - max) < 0.01)
+            {
                 h = (g - b) / delta;
+            }
             else if (Math.Abs(g - max) < 0.01)
+            {
                 h = 2 + (b - r) / delta;
+            }
             else
+            {
                 h = 4 + (r - g) / delta;
+            }
         }
 
         h *= 60;
-        if (h < 0) h += 360;
+        if (h < 0)
+        {
+            h += 360;
+        }
 
         return ((int)(h / 360 * 255), (int)(s * 255), (int)(v * 255));
     }

--- a/src/ui/Features/Shared/IndeterminateProgressHelper.cs
+++ b/src/ui/Features/Shared/IndeterminateProgressHelper.cs
@@ -90,8 +90,14 @@ public class IndeterminateProgressHelper : IDisposable
 
     private static double EaseInOutCubic(double x)
     {
-        if (x <= 0) return 0;
-        if (x >= 1) return 1;
+        if (x <= 0)
+        {
+            return 0;
+        }
+        if (x >= 1)
+        {
+            return 1;
+        }
         return x < 0.5 ? 4 * x * x * x : 1 - Math.Pow(-2 * x + 2, 3) / 2;
     }
 

--- a/src/ui/Features/Shared/ShowImage/ShowImageWindow.cs
+++ b/src/ui/Features/Shared/ShowImage/ShowImageWindow.cs
@@ -53,7 +53,9 @@ public class ShowImageWindow : Window
 
         var label = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.Text)).WithFontSize(30).WithMarginTop(20).WithAlignmentCenter();
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             label.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonPanel = UiUtil.MakeButtonBar(buttonOk);

--- a/src/ui/Features/SpellCheck/EditWholeText/EditWholeTextWindow.cs
+++ b/src/ui/Features/SpellCheck/EditWholeText/EditWholeTextWindow.cs
@@ -38,7 +38,9 @@ public class EditWholeTextWindow : Window
             Height = 100,
         };
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             textBoxWholeText.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -503,13 +503,17 @@ public partial class SpellCheckViewModel : ObservableObject
         var textBlock = new TextBlock();
         var fontName = Se.Settings.Appearance.SubtitleTextBoxAndGridFontName;
         if (!string.IsNullOrEmpty(fontName))
+        {
             textBlock.FontFamily = new FontFamily(fontName);
+        }
         var idx = word.Index;
         if (idx > 0)
         {
             var run = new Run(paragraph.Text.Substring(0, idx));
             if (!string.IsNullOrEmpty(fontName))
+            {
                 run.FontFamily = new FontFamily(fontName);
+            }
             textBlock.Inlines!.Add(run);
         }
 
@@ -520,14 +524,18 @@ public partial class SpellCheckViewModel : ObservableObject
             Foreground = Brushes.Red
         };
         if (!string.IsNullOrEmpty(fontName))
+        {
             highlightRun.FontFamily = new FontFamily(fontName);
+        }
         textBlock.Inlines!.Add(highlightRun);
 
         if (idx + word.Text.Length < paragraph.Text.Length)
         {
             var run = new Run(paragraph.Text.Substring(idx + word.Text.Length));
             if (!string.IsNullOrEmpty(fontName))
+            {
                 run.FontFamily = new FontFamily(fontName);
+            }
             textBlock.Inlines!.Add(run);
         }
 

--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -117,7 +117,9 @@ public class SpellCheckWindow : Window
         };
         vm.TextBoxWordNotFound = textBoxWord;
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
             textBoxWord.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
 
         var buttonChange = new Button
         {

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -795,15 +795,42 @@ public partial class SsaStylesViewModel : ObservableObject
 
     private static int GetAlignment(StyleDisplay style)
     {
-        if (style.AlignmentAn1) return 1;
-        if (style.AlignmentAn2) return 2;
-        if (style.AlignmentAn3) return 3;
-        if (style.AlignmentAn4) return 4;
-        if (style.AlignmentAn5) return 5;
-        if (style.AlignmentAn6) return 6;
-        if (style.AlignmentAn7) return 7;
-        if (style.AlignmentAn8) return 8;
-        if (style.AlignmentAn9) return 9;
+        if (style.AlignmentAn1)
+        {
+            return 1;
+        }
+        if (style.AlignmentAn2)
+        {
+            return 2;
+        }
+        if (style.AlignmentAn3)
+        {
+            return 3;
+        }
+        if (style.AlignmentAn4)
+        {
+            return 4;
+        }
+        if (style.AlignmentAn5)
+        {
+            return 5;
+        }
+        if (style.AlignmentAn6)
+        {
+            return 6;
+        }
+        if (style.AlignmentAn7)
+        {
+            return 7;
+        }
+        if (style.AlignmentAn8)
+        {
+            return 8;
+        }
+        if (style.AlignmentAn9)
+        {
+            return 9;
+        }
         return 2;
     }
 

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -202,8 +202,14 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
             ChangeNotes = string.Empty;
             CanGoPrevious = false;
             CanGoNext = false;
-            if (AudioVisualizerOriginal != null) AudioVisualizerOriginal.AllSelectedParagraphs = new List<SubtitleLineViewModel>();
-            if (AudioVisualizerBeautified != null) AudioVisualizerBeautified.AllSelectedParagraphs = new List<SubtitleLineViewModel>();
+            if (AudioVisualizerOriginal != null)
+            {
+                AudioVisualizerOriginal.AllSelectedParagraphs = new List<SubtitleLineViewModel>();
+            }
+            if (AudioVisualizerBeautified != null)
+            {
+                AudioVisualizerBeautified.AllSelectedParagraphs = new List<SubtitleLineViewModel>();
+            }
             return;
         }
 
@@ -259,7 +265,10 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         var endDeltaMs = beautified.EndTime.TotalMilliseconds - original.EndTime.TotalMilliseconds;
         if (Math.Abs(endDeltaMs) > 0.5)
         {
-            if (sb.Length > 6) sb.Append("    ");
+            if (sb.Length > 6)
+            {
+                sb.Append("    ");
+            }
             sb.Append(Se.Language.General.EndTime).Append(": ")
               .Append(FormatTime(original.EndTime))
               .Append(" → ")
@@ -312,7 +321,10 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         }
 
         var snap = DetectShotChangeSnap(beautified.StartTime, isOutCue: false);
-        if (snap != null) return snap;
+        if (snap != null)
+        {
+            return snap;
+        }
 
         // Min-gap-to-previous: new start equals previous end + min-gap
         if (prev != null)
@@ -337,7 +349,10 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         }
 
         var snap = DetectShotChangeSnap(beautified.EndTime, isOutCue: true);
-        if (snap != null) return snap;
+        if (snap != null)
+        {
+            return snap;
+        }
 
         if (next != null)
         {
@@ -427,7 +442,10 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
 
     private void CenterVisualizerOn(Controls.AudioVisualizerControl.AudioVisualizer? av, double seconds)
     {
-        if (av == null) return;
+        if (av == null)
+        {
+            return;
+        }
 
         var peaks = av.WavePeaks;
         if (peaks == null || av.Bounds.Width <= 0 || av.ZoomFactor <= 0)

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesWindow.cs
@@ -81,11 +81,17 @@ public class BeautifyTimeCodesWindow : Window
         avOriginal.PropertyChanged += (s, e) =>
         {
             if (e.Property.Name == "StartPositionSeconds")
+            {
                 avBeautified.StartPositionSeconds = avOriginal.StartPositionSeconds;
+            }
             else if (e.Property.Name == "ZoomFactor")
+            {
                 avBeautified.ZoomFactor = avOriginal.ZoomFactor;
+            }
             else if (e.Property.Name == "VerticalZoomFactor")
+            {
                 avBeautified.VerticalZoomFactor = avOriginal.VerticalZoomFactor;
+            }
         };
 
         var grid = new Grid

--- a/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileViewModel.cs
@@ -277,38 +277,65 @@ public partial class BeautifyTimeCodesProfileViewModel : ObservableObject
     // Enforce greenZone >= redZone (matches SE4 ValidateZones())
     partial void OnInCuesLeftRedZoneChanged(int value)
     {
-        if (InCuesLeftGreenZone < value) InCuesLeftGreenZone = value;
+        if (InCuesLeftGreenZone < value)
+        {
+            InCuesLeftGreenZone = value;
+        }
     }
     partial void OnInCuesRightRedZoneChanged(int value)
     {
-        if (InCuesRightGreenZone < value) InCuesRightGreenZone = value;
+        if (InCuesRightGreenZone < value)
+        {
+            InCuesRightGreenZone = value;
+        }
     }
     partial void OnOutCuesLeftRedZoneChanged(int value)
     {
-        if (OutCuesLeftGreenZone < value) OutCuesLeftGreenZone = value;
+        if (OutCuesLeftGreenZone < value)
+        {
+            OutCuesLeftGreenZone = value;
+        }
     }
     partial void OnOutCuesRightRedZoneChanged(int value)
     {
-        if (OutCuesRightGreenZone < value) OutCuesRightGreenZone = value;
+        if (OutCuesRightGreenZone < value)
+        {
+            OutCuesRightGreenZone = value;
+        }
     }
     partial void OnConnectedLeftRedZoneChanged(int value)
     {
-        if (ConnectedLeftGreenZone < value) ConnectedLeftGreenZone = value;
+        if (ConnectedLeftGreenZone < value)
+        {
+            ConnectedLeftGreenZone = value;
+        }
     }
     partial void OnConnectedRightRedZoneChanged(int value)
     {
-        if (ConnectedRightGreenZone < value) ConnectedRightGreenZone = value;
+        if (ConnectedRightGreenZone < value)
+        {
+            ConnectedRightGreenZone = value;
+        }
     }
     partial void OnChainingGeneralLeftRedZoneChanged(int value)
     {
-        if (ChainingGeneralLeftGreenZone < value) ChainingGeneralLeftGreenZone = value;
+        if (ChainingGeneralLeftGreenZone < value)
+        {
+            ChainingGeneralLeftGreenZone = value;
+        }
     }
     partial void OnChainingInOnShotLeftRedZoneChanged(int value)
     {
-        if (ChainingInOnShotLeftGreenZone < value) ChainingInOnShotLeftGreenZone = value;
+        if (ChainingInOnShotLeftGreenZone < value)
+        {
+            ChainingInOnShotLeftGreenZone = value;
+        }
     }
     partial void OnChainingOutOnShotRightRedZoneChanged(int value)
     {
-        if (ChainingOutOnShotRightGreenZone < value) ChainingOutOnShotRightGreenZone = value;
+        if (ChainingOutOnShotRightGreenZone < value)
+        {
+            ChainingOutOnShotRightGreenZone = value;
+        }
     }
 }

--- a/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileWindow.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileWindow.cs
@@ -407,10 +407,22 @@ public class BeautifyTimeCodesProfileWindow : Window
         };
 
         var nudFields = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6 };
-        if (leftGreenPath != null) nudFields.Children.Add(MakeFrameNud(leftGreenPath));
-        if (leftRedPath != null) nudFields.Children.Add(MakeFrameNud(leftRedPath));
-        if (rightRedPath != null) nudFields.Children.Add(MakeFrameNud(rightRedPath));
-        if (rightGreenPath != null) nudFields.Children.Add(MakeFrameNud(rightGreenPath));
+        if (leftGreenPath != null)
+        {
+            nudFields.Children.Add(MakeFrameNud(leftGreenPath));
+        }
+        if (leftRedPath != null)
+        {
+            nudFields.Children.Add(MakeFrameNud(leftRedPath));
+        }
+        if (rightRedPath != null)
+        {
+            nudFields.Children.Add(MakeFrameNud(rightRedPath));
+        }
+        if (rightGreenPath != null)
+        {
+            nudFields.Children.Add(MakeFrameNud(rightGreenPath));
+        }
         nudFields.Bind(IsEnabledProperty, new Binding(useZonesPath) { Source = _vm });
         var zonesRow = new StackPanel
         {
@@ -563,8 +575,14 @@ public class BeautifyTimeCodesProfileWindow : Window
     {
         public object? Convert(object? value, System.Type targetType, object? parameter, CultureInfo culture)
         {
-            if (value is int i && parameter is int p) return i == p;
-            if (value is int i2 && int.TryParse(parameter?.ToString(), out var pi)) return i2 == pi;
+            if (value is int i && parameter is int p)
+            {
+                return i == p;
+            }
+            if (value is int i2 && int.TryParse(parameter?.ToString(), out var pi))
+            {
+                return i2 == pi;
+            }
             return false;
         }
 

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -326,7 +326,10 @@ public class FixCommonErrorsWindow : Window
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
         new DataGridCheckboxMultiSelect<FixDisplayItem>(dataGridFixes,
             item => item.IsSelected, (item, v) => item.IsSelected = v,
-            onFocusedItemChanged: item => { if (item != null) _vm.SelectAndScrollTo(item); });
+            onFocusedItemChanged: item => { if (item != null)
+            {
+                _vm.SelectAndScrollTo(item);
+            } });
 
         var leftButtons = new StackPanel
         {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1303,7 +1303,10 @@ public partial class SpeechToTextViewModel : ObservableObject
                 // accumulating up to N×23 MB of WAV in temp for long runs. The
                 // entry stays in _filesToDelete for the outer sweep as a
                 // safety net in case Delete throws here.
-                try { if (File.Exists(chunkPath)) File.Delete(chunkPath); } catch { /* swept later */ }
+                try { if (File.Exists(chunkPath))
+                {
+                    File.Delete(chunkPath);
+                } } catch { /* swept later */ }
             }
         }
     }

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsViewModel.cs
@@ -138,11 +138,26 @@ public partial class ActorVoiceRowSettingsViewModel : ObservableObject
     private string BuildOmniVoiceInstruction()
     {
         var parts = new List<string>();
-        if (IsReal(SelectedOmniVoiceGender)) parts.Add(SelectedOmniVoiceGender);
-        if (IsReal(SelectedOmniVoiceAge)) parts.Add(SelectedOmniVoiceAge);
-        if (IsReal(SelectedOmniVoicePitch)) parts.Add(SelectedOmniVoicePitch);
-        if (IsReal(SelectedOmniVoiceAccent)) parts.Add(SelectedOmniVoiceAccent);
-        if (OmniVoiceWhisper) parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        if (IsReal(SelectedOmniVoiceGender))
+        {
+            parts.Add(SelectedOmniVoiceGender);
+        }
+        if (IsReal(SelectedOmniVoiceAge))
+        {
+            parts.Add(SelectedOmniVoiceAge);
+        }
+        if (IsReal(SelectedOmniVoicePitch))
+        {
+            parts.Add(SelectedOmniVoicePitch);
+        }
+        if (IsReal(SelectedOmniVoiceAccent))
+        {
+            parts.Add(SelectedOmniVoiceAccent);
+        }
+        if (OmniVoiceWhisper)
+        {
+            parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        }
         return string.Join(", ", parts);
     }
 

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -720,7 +720,10 @@ public partial class DownloadTtsViewModel : ObservableObject
                 }
                 // Voices are optional — log and close with success.
                 var ex = _downloadTaskVibeVoiceCrispAsrVoices.Exception?.InnerException ?? _downloadTaskVibeVoiceCrispAsrVoices.Exception;
-                if (ex != null) Se.LogError(ex);
+                if (ex != null)
+                {
+                    Se.LogError(ex);
+                }
                 OkPressed = true;
                 Close();
             }
@@ -801,7 +804,10 @@ public partial class DownloadTtsViewModel : ObservableObject
                     return;
                 }
                 var ex = _downloadTaskIndexTtsCrispAsrVoices.Exception?.InnerException ?? _downloadTaskIndexTtsCrispAsrVoices.Exception;
-                if (ex != null) Se.LogError(ex);
+                if (ex != null)
+                {
+                    Se.LogError(ex);
+                }
                 OkPressed = true;
                 Close();
             }
@@ -887,7 +893,10 @@ public partial class DownloadTtsViewModel : ObservableObject
                     return;
                 }
                 var ex = _downloadTaskCosyVoice3CrispAsrVoices.Exception?.InnerException ?? _downloadTaskCosyVoice3CrispAsrVoices.Exception;
-                if (ex != null) Se.LogError(ex);
+                if (ex != null)
+                {
+                    Se.LogError(ex);
+                }
                 OkPressed = true;
                 Close();
             }
@@ -970,7 +979,10 @@ public partial class DownloadTtsViewModel : ObservableObject
                     return;
                 }
                 var ex = _downloadTaskF5TtsCrispAsrVoices.Exception?.InnerException ?? _downloadTaskF5TtsCrispAsrVoices.Exception;
-                if (ex != null) Se.LogError(ex);
+                if (ex != null)
+                {
+                    Se.LogError(ex);
+                }
                 OkPressed = true;
                 Close();
             }

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -664,7 +664,10 @@ public class ChatterboxTtsCpp : ITtsEngine
 
     private static void HookProcessExitOnce()
     {
-        if (_processExitHooked) return;
+        if (_processExitHooked)
+        {
+            return;
+        }
         _processExitHooked = true;
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
@@ -683,7 +686,10 @@ public class ChatterboxTtsCpp : ITtsEngine
         _serverPort = 0;
         _serverModelKey = null;
         _serverLaunchCommand = null;
-        if (p == null) return;
+        if (p == null)
+        {
+            return;
+        }
         try
         {
             if (!p.HasExited)

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -298,7 +298,10 @@ public class CosyVoice3CrispAsr : ITtsEngine
                     catch (Exception ex)
                     {
                         Se.LogError(ex, $"CosyVoice3 (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                        try { if (!File.Exists(dest)) File.Copy(src, dest); } catch { }
+                        try { if (!File.Exists(dest))
+                        {
+                            File.Copy(src, dest);
+                        } } catch { }
                     }
                 }
 
@@ -764,7 +767,10 @@ public class CosyVoice3CrispAsr : ITtsEngine
 
     private static void HookProcessExitOnce()
     {
-        if (_processExitHooked) return;
+        if (_processExitHooked)
+        {
+            return;
+        }
         _processExitHooked = true;
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
@@ -780,7 +786,10 @@ public class CosyVoice3CrispAsr : ITtsEngine
         _serverModelKey = null;
         _serverVoiceArg = null;
         _serverRefText = null;
-        if (p == null) return;
+        if (p == null)
+        {
+            return;
+        }
         try
         {
             if (!p.HasExited)

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -244,7 +244,10 @@ public class F5TtsCrispAsr : ITtsEngine
                     catch (Exception ex)
                     {
                         Se.LogError(ex, $"F5-TTS (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                        try { if (!File.Exists(dest)) File.Copy(src, dest); } catch { }
+                        try { if (!File.Exists(dest))
+                        {
+                            File.Copy(src, dest);
+                        } } catch { }
                     }
                 }
 
@@ -672,7 +675,10 @@ public class F5TtsCrispAsr : ITtsEngine
 
     private static void HookProcessExitOnce()
     {
-        if (_processExitHooked) return;
+        if (_processExitHooked)
+        {
+            return;
+        }
         _processExitHooked = true;
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
@@ -688,7 +694,10 @@ public class F5TtsCrispAsr : ITtsEngine
         _serverModelKey = null;
         _serverVoicePath = null;
         _serverRefText = null;
-        if (p == null) return;
+        if (p == null)
+        {
+            return;
+        }
         try
         {
             if (!p.HasExited)

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
@@ -261,7 +261,10 @@ public class IndexTtsCrispAsr : ITtsEngine
                 catch (Exception ex)
                 {
                     Se.LogError(ex, $"IndexTTS (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                    try { if (!File.Exists(dest)) File.Copy(src, dest); } catch { }
+                    try { if (!File.Exists(dest))
+                    {
+                        File.Copy(src, dest);
+                    } } catch { }
                 }
             }
         }
@@ -684,7 +687,10 @@ public class IndexTtsCrispAsr : ITtsEngine
 
     private static void HookProcessExitOnce()
     {
-        if (_processExitHooked) return;
+        if (_processExitHooked)
+        {
+            return;
+        }
         _processExitHooked = true;
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
@@ -704,7 +710,10 @@ public class IndexTtsCrispAsr : ITtsEngine
         _serverLaunchCommand = null;
         _serverVoicePath = null;
         _serverModelKey = null;
-        if (p == null) return;
+        if (p == null)
+        {
+            return;
+        }
         try
         {
             if (!p.HasExited)

--- a/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -197,7 +197,10 @@ public class KokoroTtsCpp : ITtsEngine
                         foreach (var item in arr.EnumerateArray())
                         {
                             var s = item.GetString();
-                            if (!string.IsNullOrEmpty(s)) names.Add(s);
+                            if (!string.IsNullOrEmpty(s))
+                            {
+                                names.Add(s);
+                            }
                         }
                         if (names.Count > 0)
                         {
@@ -415,7 +418,10 @@ public class KokoroTtsCpp : ITtsEngine
 
     private static void HookProcessExitOnce()
     {
-        if (_processExitHooked) return;
+        if (_processExitHooked)
+        {
+            return;
+        }
         _processExitHooked = true;
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
@@ -425,7 +431,10 @@ public class KokoroTtsCpp : ITtsEngine
         var p = _serverProcess;
         _serverProcess = null;
         _serverPort = 0;
-        if (p == null) return;
+        if (p == null)
+        {
+            return;
+        }
         try
         {
             if (!p.HasExited)

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -484,7 +484,10 @@ public class Qwen3TtsCpp : ITtsEngine
 
     private static void HookProcessExitOnce()
     {
-        if (_processExitHooked) return;
+        if (_processExitHooked)
+        {
+            return;
+        }
         _processExitHooked = true;
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
@@ -496,7 +499,10 @@ public class Qwen3TtsCpp : ITtsEngine
         _serverPort = 0;
         _serverModelFileName = null;
         _serverStderr = null;
-        if (p == null) return;
+        if (p == null)
+        {
+            return;
+        }
         try
         {
             if (!p.HasExited)

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -706,7 +706,10 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
     private static void HookProcessExitOnce()
     {
-        if (_processExitHooked) return;
+        if (_processExitHooked)
+        {
+            return;
+        }
         _processExitHooked = true;
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
@@ -725,7 +728,10 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         _serverPort = 0;
         _serverModelKey = null;
         _serverLaunchCommand = null;
-        if (p == null) return;
+        if (p == null)
+        {
+            return;
+        }
         try
         {
             if (!p.HasExited)

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -253,7 +253,10 @@ public class VibeVoiceCrispAsr : ITtsEngine
                 catch (Exception ex)
                 {
                     Se.LogError(ex, $"VibeVoice (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                    try { if (!File.Exists(dest)) File.Copy(src, dest); } catch { }
+                    try { if (!File.Exists(dest))
+                    {
+                        File.Copy(src, dest);
+                    } } catch { }
                 }
             }
         }
@@ -649,7 +652,10 @@ public class VibeVoiceCrispAsr : ITtsEngine
 
     private static void HookProcessExitOnce()
     {
-        if (_processExitHooked) return;
+        if (_processExitHooked)
+        {
+            return;
+        }
         _processExitHooked = true;
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
     }
@@ -668,7 +674,10 @@ public class VibeVoiceCrispAsr : ITtsEngine
         _serverPort = 0;
         _serverLaunchCommand = null;
         _serverModelKey = null;
-        if (p == null) return;
+        if (p == null)
+        {
+            return;
+        }
         try
         {
             if (!p.HasExited)

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
@@ -145,8 +145,14 @@ public partial class OmniVoiceSettingsViewModel : ObservableObject
             }
         }
 
-        if (File.Exists(Path.Combine(folder, "ggml-cuda.dll"))) return "Windows x64 (CUDA)";
-        if (File.Exists(Path.Combine(folder, "ggml-vulkan.dll"))) return "Windows x64 (Vulkan)";
+        if (File.Exists(Path.Combine(folder, "ggml-cuda.dll")))
+        {
+            return "Windows x64 (CUDA)";
+        }
+        if (File.Exists(Path.Combine(folder, "ggml-vulkan.dll")))
+        {
+            return "Windows x64 (Vulkan)";
+        }
         return "Windows x64 (CPU)";
     }
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1292,11 +1292,26 @@ public partial class ReviewSpeechViewModel : ObservableObject
         }
 
         var parts = new List<string>();
-        if (IsReal(SelectedOmniVoiceGender)) parts.Add(SelectedOmniVoiceGender);
-        if (IsReal(SelectedOmniVoiceAge)) parts.Add(SelectedOmniVoiceAge);
-        if (IsReal(SelectedOmniVoicePitch)) parts.Add(SelectedOmniVoicePitch);
-        if (IsReal(SelectedOmniVoiceAccent)) parts.Add(SelectedOmniVoiceAccent);
-        if (OmniVoiceWhisper) parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        if (IsReal(SelectedOmniVoiceGender))
+        {
+            parts.Add(SelectedOmniVoiceGender);
+        }
+        if (IsReal(SelectedOmniVoiceAge))
+        {
+            parts.Add(SelectedOmniVoiceAge);
+        }
+        if (IsReal(SelectedOmniVoicePitch))
+        {
+            parts.Add(SelectedOmniVoicePitch);
+        }
+        if (IsReal(SelectedOmniVoiceAccent))
+        {
+            parts.Add(SelectedOmniVoiceAccent);
+        }
+        if (OmniVoiceWhisper)
+        {
+            parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        }
         Instruction = string.Join(", ", parts);
     }
 
@@ -1387,7 +1402,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
         // window close.
         foreach (var f in _tempAudioFiles)
         {
-            try { if (File.Exists(f)) File.Delete(f); } catch { /* ignore */ }
+            try { if (File.Exists(f))
+            {
+                File.Delete(f);
+            } } catch { /* ignore */ }
         }
         _tempAudioFiles.Clear();
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -652,11 +652,26 @@ public partial class TextToSpeechViewModel : ObservableObject
     private string BuildOmniVoiceInstruction()
     {
         var parts = new List<string>();
-        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceGender)) parts.Add(SelectedOmniVoiceGender);
-        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceAge)) parts.Add(SelectedOmniVoiceAge);
-        if (IsRealOmniVoiceKeyword(SelectedOmniVoicePitch)) parts.Add(SelectedOmniVoicePitch);
-        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceAccent)) parts.Add(SelectedOmniVoiceAccent);
-        if (OmniVoiceWhisper) parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceGender))
+        {
+            parts.Add(SelectedOmniVoiceGender);
+        }
+        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceAge))
+        {
+            parts.Add(SelectedOmniVoiceAge);
+        }
+        if (IsRealOmniVoiceKeyword(SelectedOmniVoicePitch))
+        {
+            parts.Add(SelectedOmniVoicePitch);
+        }
+        if (IsRealOmniVoiceKeyword(SelectedOmniVoiceAccent))
+        {
+            parts.Add(SelectedOmniVoiceAccent);
+        }
+        if (OmniVoiceWhisper)
+        {
+            parts.Add(OmniVoiceTtsCpp.InstructionWhisper);
+        }
         return string.Join(", ", parts);
     }
 
@@ -870,10 +885,22 @@ public partial class TextToSpeechViewModel : ObservableObject
     /// </summary>
     private static void StopOtherCrispAsrServers(ITtsEngine? keepAlive)
     {
-        if (keepAlive is not Qwen3TtsCrispAsr) Qwen3TtsCrispAsr.StopServer();
-        if (keepAlive is not VibeVoiceCrispAsr) VibeVoiceCrispAsr.StopServer();
-        if (keepAlive is not IndexTtsCrispAsr) IndexTtsCrispAsr.StopServer();
-        if (keepAlive is not ChatterboxTtsCpp) ChatterboxTtsCpp.StopServer();
+        if (keepAlive is not Qwen3TtsCrispAsr)
+        {
+            Qwen3TtsCrispAsr.StopServer();
+        }
+        if (keepAlive is not VibeVoiceCrispAsr)
+        {
+            VibeVoiceCrispAsr.StopServer();
+        }
+        if (keepAlive is not IndexTtsCrispAsr)
+        {
+            IndexTtsCrispAsr.StopServer();
+        }
+        if (keepAlive is not ChatterboxTtsCpp)
+        {
+            ChatterboxTtsCpp.StopServer();
+        }
     }
 
     private static void StopAllCrispAsrServers() => StopOtherCrispAsrServers(null);

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -150,7 +150,9 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             for (var i = startIdx; i <= endIdx; i++)
             {
                 if (i != _shiftCurrentIndex)
+                {
                     _grid.SelectedItems.Add(items[i]);
+                }
             }
         }
         finally

--- a/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
@@ -106,19 +106,33 @@ public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadServ
     private static string? GetHashKey(string fileName)
     {
         if (string.Equals(fileName, CosyVoice3CrispAsr.LlmQ4KFileName, StringComparison.OrdinalIgnoreCase))
+        {
             return DownloadHashManager.CosyVoice3CrispAsr.LlmQ4K;
+        }
         if (string.Equals(fileName, CosyVoice3CrispAsr.LlmF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
             return DownloadHashManager.CosyVoice3CrispAsr.LlmF16;
+        }
         if (string.Equals(fileName, CosyVoice3CrispAsr.FlowF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
             return DownloadHashManager.CosyVoice3CrispAsr.FlowF16;
+        }
         if (string.Equals(fileName, CosyVoice3CrispAsr.HiftF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
             return DownloadHashManager.CosyVoice3CrispAsr.HiftF16;
+        }
         if (string.Equals(fileName, CosyVoice3CrispAsr.S3TokF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
             return DownloadHashManager.CosyVoice3CrispAsr.S3TokF16;
+        }
         if (string.Equals(fileName, CosyVoice3CrispAsr.CampPlusF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
             return DownloadHashManager.CosyVoice3CrispAsr.CampPlusF16;
+        }
         if (string.Equals(fileName, CosyVoice3CrispAsr.VoicesGgufFileName, StringComparison.OrdinalIgnoreCase))
+        {
             return DownloadHashManager.CosyVoice3CrispAsr.VoicesGguf;
+        }
         return null;
     }
 

--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -168,8 +168,14 @@ public class SplitManager : ISplitManager
                 if (total > 0)
                 {
                     startFactor = (double)firstTextLen / total;
-                    if (startFactor < 0.25) startFactor = 0.25;
-                    if (startFactor > 0.75) startFactor = 0.75;
+                    if (startFactor < 0.25)
+                    {
+                        startFactor = 0.25;
+                    }
+                    if (startFactor > 0.75)
+                    {
+                        startFactor = 0.75;
+                    }
                 }
             }
 
@@ -376,7 +382,10 @@ public class SplitManager : ISplitManager
         while ((idx = text.IndexOf(prefix, idx, StringComparison.OrdinalIgnoreCase)) >= 0)
         {
             var end = text.IndexOf('>', idx);
-            if (end < 0) break;
+            if (end < 0)
+            {
+                break;
+            }
             openTags.Add((idx, text.Substring(idx, end - idx + 1)));
             idx = end + 1;
         }
@@ -442,16 +451,25 @@ public class SplitManager : ISplitManager
             idx += prefix.Length;
         }
 
-        if (lastIdx < 0) return null;
+        if (lastIdx < 0)
+        {
+            return null;
+        }
 
         var blockStart = text.LastIndexOf('{', lastIdx);
         var blockEnd = text.IndexOf('}', lastIdx);
-        if (blockStart < 0 || blockEnd < 0) return null;
+        if (blockStart < 0 || blockEnd < 0)
+        {
+            return null;
+        }
 
         // Extract only the specific tag from within the block
         var tagStart = lastIdx;
         var tagEnd = text.IndexOf('}', tagStart);
-        if (tagEnd < 0) return null;
+        if (tagEnd < 0)
+        {
+            return null;
+        }
 
         return "{" + text.Substring(tagStart, tagEnd - tagStart + 1);
     }

--- a/src/ui/Logic/Media/FfmpegMediainfo2.cs
+++ b/src/ui/Logic/Media/FfmpegMediainfo2.cs
@@ -220,8 +220,14 @@ public class FfmpegMediaInfo2
 
         using (var process = GetFFmpegProcess(videoFileName))
         {
-            process.OutputDataReceived += (_, args) => { if (args.Data != null) sb.AppendLine(args.Data); };
-            process.ErrorDataReceived += (_, args) => { if (args.Data != null) sb.AppendLine(args.Data); };
+            process.OutputDataReceived += (_, args) => { if (args.Data != null)
+            {
+                sb.AppendLine(args.Data);
+            } };
+            process.ErrorDataReceived += (_, args) => { if (args.Data != null)
+            {
+                sb.AppendLine(args.Data);
+            } };
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
 

--- a/src/ui/Logic/Media/WaveToVisualizer2.cs
+++ b/src/ui/Logic/Media/WaveToVisualizer2.cs
@@ -620,8 +620,22 @@ public class WavePeakGenerator2 : IDisposable
 
                         float pos = 0, neg = 0;
 
-                        if (v1 < 0) neg += v1; else pos += v1;
-                        if (v2 < 0) neg += v2; else pos += v2;
+                        if (v1 < 0)
+                        {
+                            neg += v1;
+                        }
+                        else
+                        {
+                            pos += v1;
+                        }
+                        if (v2 < 0)
+                        {
+                            neg += v2;
+                        }
+                        else
+                        {
+                            pos += v2;
+                        }
 
                         chunkSamples[chunkSampleOffset++] = neg * sampleAndChannelScale;
                         chunkSamples[chunkSampleOffset++] = pos * sampleAndChannelScale;

--- a/src/ui/Logic/Ocr/GoogleLens/BoundingBox.cs
+++ b/src/ui/Logic/Ocr/GoogleLens/BoundingBox.cs
@@ -15,10 +15,14 @@ public class BoundingBox
     public BoundingBox(double[] box, int[] imageDimensions)
     {
         if (box == null || box.Length != 4)
+        {
             throw new ArgumentException("Bounding box array [centerPerX, centerPerY, perWidth, perHeight] not set or invalid");
+        }
         
         if (imageDimensions == null || imageDimensions.Length != 2)
+        {
             throw new ArgumentException("Image dimensions [width, height] not set or invalid");
+        }
 
         _imageDimensions = imageDimensions;
         CenterPerX = box[0];

--- a/src/ui/Logic/Ocr/GoogleLens/LensCore.cs
+++ b/src/ui/Logic/Ocr/GoogleLens/LensCore.cs
@@ -305,7 +305,10 @@ public class LensCore
 
     protected void SetCookies(IEnumerable<string> combinedCookieHeader)
     {
-        if (combinedCookieHeader == null) return;
+        if (combinedCookieHeader == null)
+        {
+            return;
+        }
 
         try
         {
@@ -328,7 +331,10 @@ public class LensCore
     {
         var parts = cookieHeader.Split(';');
         var cookieParts = parts[0].Split('=', 2);
-        if (cookieParts.Length != 2) return null;
+        if (cookieParts.Length != 2)
+        {
+            return null;
+        }
 
         var cookie = new Cookie
         {

--- a/src/ui/Logic/Platform/Windows/FileTypeAssociations.cs
+++ b/src/ui/Logic/Platform/Windows/FileTypeAssociations.cs
@@ -31,7 +31,10 @@ internal static class FileTypeAssociationsHelper
             using (var userChoice = Registry.CurrentUser.OpenSubKey($@"Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\{ext}\UserChoice"))
             {
                 var progIdValue = userChoice?.GetValue("Progid") as string;
-                if (progIdValue == progId) return true;
+                if (progIdValue == progId)
+                {
+                    return true;
+                }
             }
 
             // 2. Fallback: Check the old-school Software\Classes
@@ -114,7 +117,9 @@ internal static class FileTypeAssociationsHelper
             if (extKey != null)
             {
                 if (extKey.GetValue("")?.ToString() == progId)
+                {
                     extKey.DeleteValue("");
+                }
 
                 using (var openWith = extKey.OpenSubKey("OpenWithProgids", true))
                 {

--- a/src/ui/Logic/SkColorExtensions.cs
+++ b/src/ui/Logic/SkColorExtensions.cs
@@ -29,7 +29,9 @@ public static class SkColorExtensions
     public static SKColor FromHex(this string hex)
     {
         if (string.IsNullOrWhiteSpace(hex))
+        {
             throw new ArgumentException("Invalid hex string.");
+        }
 
         hex = hex.TrimStart('#');
 

--- a/src/ui/Logic/SubRipSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/SubRipSourceSyntaxHighlighting.cs
@@ -246,7 +246,9 @@ public partial class SubRipSourceSyntaxHighlighting : DocumentColorizingTransfor
                     // Find element name end
                     var elementStart = i + 1;
                     if (elementStart < lineText.Length && lineText[elementStart] == '/')
+                    {
                         elementStart++;
+                    }
 
                     var elementEnd = elementStart;
                     while (elementEnd < lineText.Length && !char.IsWhiteSpace(lineText[elementEnd]) &&
@@ -321,9 +323,13 @@ public partial class SubRipSourceSyntaxHighlighting : DocumentColorizingTransfor
                     var valueStart = i;
                     var valueEnd = lineText.IndexOf(quoteChar, i + 1);
                     if (valueEnd == -1)
+                    {
                         valueEnd = lineText.Length;
+                    }
                     else
+                    {
                         valueEnd++;
+                    }
 
                     // Color the quotes
                     ChangeLinePart(lineStartOffset + valueStart, lineStartOffset + valueStart + 1, element =>

--- a/src/ui/Logic/UndoRedo/UndoRedoManager.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoManager.cs
@@ -61,7 +61,10 @@ public sealed class UndoRedoManager : IUndoRedoManager
             var currentHash = _undoRedoClient?.GetFastHash() ?? 0;
             lock (_lock)
             {
-                if (_undoList.Count == 0) return false;
+                if (_undoList.Count == 0)
+                {
+                    return false;
+                }
                 return _undoList.Last().Hash != currentHash || _undoList.Count > 1;
             }
         }
@@ -114,7 +117,10 @@ public sealed class UndoRedoManager : IUndoRedoManager
                 throw new InvalidOperationException(
                     "Call SetupChangeDetection() before StartChangeDetection().");
 
-            if (_isChangeDetectionActive) return;
+            if (_isChangeDetectionActive)
+            {
+                return;
+            }
             _isChangeDetectionActive = true;
             _changeDetectionTimer.Change(_detectionInterval, _detectionInterval);
         }
@@ -124,7 +130,10 @@ public sealed class UndoRedoManager : IUndoRedoManager
     {
         lock (_lock)
         {
-            if (!_isChangeDetectionActive) return;
+            if (!_isChangeDetectionActive)
+            {
+                return;
+            }
             _isChangeDetectionActive = false;
             _changeDetectionTimer?.Change(
                 Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
@@ -147,7 +156,9 @@ public sealed class UndoRedoManager : IUndoRedoManager
         _redoList.Clear();
 
         if (_undoList.Count > MaxUndoItems)
+        {
             _undoList.RemoveAt(0);
+        }
     }
 
     public UndoRedoItem? Undo()
@@ -208,7 +219,10 @@ public sealed class UndoRedoManager : IUndoRedoManager
     {
         lock (_lock)
         {
-            if (_redoList.Count == 0) return null;
+            if (_redoList.Count == 0)
+            {
+                return null;
+            }
 
             var item = PopLast(_redoList);
 
@@ -216,7 +230,9 @@ public sealed class UndoRedoManager : IUndoRedoManager
             // redo for new user actions, redo should preserve remaining entries).
             _undoList.Add(UndoRedoItem.Clone(item)!);
             if (_undoList.Count > MaxUndoItems)
+            {
                 _undoList.RemoveAt(0);
+            }
 
             return UndoRedoItem.Clone(item);
         }
@@ -336,14 +352,26 @@ public sealed class UndoRedoManager : IUndoRedoManager
                 Math.Abs(o.EndTime.TotalMilliseconds - n.EndTime.TotalMilliseconds) > 0.5;
             var bookmarkChanged = o.Bookmark != n.Bookmark;
 
-            if (!textChanged && !timingChanged && !bookmarkChanged) continue;
+            if (!textChanged && !timingChanged && !bookmarkChanged)
+            {
+                continue;
+            }
 
             changedLines.Add(i + 1);
-            if (textChanged) textChanges++;
-            if (timingChanged) timingChanges++;
+            if (textChanged)
+            {
+                textChanges++;
+            }
+            if (timingChanged)
+            {
+                timingChanges++;
+            }
         }
 
-        if (changedLines.Count == 0) return false;
+        if (changedLines.Count == 0)
+        {
+            return false;
+        }
 
         next.Description = changedLines.Count switch
         {
@@ -386,8 +414,14 @@ public sealed class UndoRedoManager : IUndoRedoManager
     private static string FormatChangeTypes(int textChanges, int timingChanges)
     {
         var parts = new List<string>(2);
-        if (textChanges > 0) parts.Add($"{textChanges} text");
-        if (timingChanges > 0) parts.Add($"{timingChanges} timing");
+        if (textChanges > 0)
+        {
+            parts.Add($"{textChanges} text");
+        }
+        if (timingChanges > 0)
+        {
+            parts.Add($"{timingChanges} timing");
+        }
         return string.Join(" and ", parts);
     }
 
@@ -416,7 +450,10 @@ public sealed class UndoRedoManager : IUndoRedoManager
             _redoList.Clear();
         }
 
-        if (wasActive) StartChangeDetection();
+        if (wasActive)
+        {
+            StartChangeDetection();
+        }
     }
 
     public void Dispose()
@@ -442,7 +479,9 @@ public sealed class UndoRedoManager : IUndoRedoManager
     private static void PushIfNew(List<UndoRedoItem> stack, UndoRedoItem item)
     {
         if (stack.LastOrDefault()?.Hash != item.Hash)
+        {
             stack.Add(UndoRedoItem.Clone(item)!);
+        }
     }
 
     private static UndoRedoItem PopLast(List<UndoRedoItem> list)

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -453,19 +453,29 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         // Use IsSet() to only copy properties that were explicitly set locally,
         // not inherited/resolved values - this preserves the inheritance chain
         if (template.IsSet(TextElement.ForegroundProperty))
+        {
             run.Foreground = template.Foreground;
+        }
 
         if (template.IsSet(TextElement.FontStyleProperty))
+        {
             run.FontStyle = template.FontStyle;
+        }
 
         if (template.IsSet(TextElement.FontWeightProperty))
+        {
             run.FontWeight = template.FontWeight;
+        }
 
         if (template.IsSet(TextElement.FontFamilyProperty))
+        {
             run.FontFamily = template.FontFamily;
+        }
 
         if (template.IsSet(TextElement.FontSizeProperty))
+        {
             run.FontSize = template.FontSize;
+        }
 
         if (template.IsSet(Inline.TextDecorationsProperty) &&
             template.TextDecorations != null && template.TextDecorations.Count > 0)
@@ -1256,7 +1266,9 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             if (i >= attributesPart.Length)
+            {
                 break;
+            }
 
             // Read attribute name
             var attrStart = i;

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
@@ -423,7 +423,9 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
         _currentSubtitleFileName = fileName;
 
         if (_mediaPlayer == IntPtr.Zero || _libvlc_media_player_add_slave == null)
+        {
             return;
+        }
 
         // --- HYBRID LOGIC ---
         // If we've added more than 100 slaves, the track list is getting messy.
@@ -475,7 +477,10 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
     private int GetHighestSpuId()
     {
         IntPtr pTrackList = _libvlc_video_get_spu_description?.Invoke(_mediaPlayer) ?? IntPtr.Zero;
-        if (pTrackList == IntPtr.Zero) return -1;
+        if (pTrackList == IntPtr.Zero)
+        {
+            return -1;
+        }
 
         int highestId = -1;
         IntPtr pCurrent = pTrackList;
@@ -483,7 +488,10 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
         while (pCurrent != IntPtr.Zero)
         {
             var track = Marshal.PtrToStructure<TrackDescription>(pCurrent);
-            if (track.Id > highestId) highestId = track.Id;
+            if (track.Id > highestId)
+            {
+                highestId = track.Id;
+            }
             pCurrent = track.PNext;
         }
 
@@ -509,7 +517,10 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
         // Add the sub fresh (it will now be ID 1 again)
         await SubAdd(subFileName);
 
-        if (wasPlaying) Play();
+        if (wasPlaying)
+        {
+            Play();
+        }
     }
 
     private static string PathToUri(string path)
@@ -525,7 +536,10 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
 
     public void SubRemove()
     {
-        if (_mediaPlayer == IntPtr.Zero || _libvlc_video_set_spu == null) return;
+        if (_mediaPlayer == IntPtr.Zero || _libvlc_video_set_spu == null)
+        {
+            return;
+        }
 
         // -1 disables subtitle rendering
         _libvlc_video_set_spu(_mediaPlayer, -1);


### PR DESCRIPTION
## Summary
Project convention is Allman-style with braces on every branch, but 342 `if`/`else if`/`else` statements across 91 files in `src/ui` had been written without them — a mix of:

```csharp
if (x == null) return;
```

and

```csharp
if (x == null)
    Foo();
```

This change wraps every such body in braces:

```csharp
if (x == null)
{
    return;
}
```

A second pass also re-Allmans any `} else` that ended up on the same line as the closing brace of the if body — a side effect of unwrapping a one-liner `if (x) a(); else b();` — so the result matches the rest of the codebase. **Zero `} else` patterns remain in src/ui after this change.**

## How
Done mechanically via a Python script that tokenizes the source (skipping strings, char literals, `//` and `/* */` comments, and `#if`/`#else`/`#elif` preprocessor directives), finds each `if (...)`, `else if (...)`, or bare `else` at statement position whose body is not already a `{`, walks to the matching `;` accounting for nested parens/brackets, and splices `{ … }` around the body at the if-statement's indentation.

### Cases deliberately skipped (kept as-is for safety)
- bodies containing a comment between the `)` and the statement (so the comment isn't dropped);
- bodies spanning multiple lines (continuation lines would need manual re-indentation);
- bodies that are themselves another control-flow construct (`if (x) for (...)`, etc.) — rare and risky to rewrite blindly;
- preprocessor `#if` / `#else` / `#elif` (those aren't C# if statements and must not be touched).

## Stats
- 91 files changed
- 1176 insertions, 244 deletions
- 0 logic changes — purely brace insertions and Allman-cleanup of `} else`.

## Test plan
- [x] `dotnet build src/ui` clean (0 warnings, 0 errors).
- [x] `dotnet test tests/UI/UITests.csproj`: 305/306 pass. The single failing test (`TranscribeAsync_SseStream_AccumulatesDeltasAndReportsDoneSegments`) is a pre-existing flaky SSE-streaming test — it passes in isolation, and none of the OpenAi STT source files are modified by this change.
- [ ] Reviewer spot-check: confirm a few diffs look right (e.g. `src/ui/Logic/Media/WaveToVisualizer2.cs`, `src/ui/Features/Main/MainViewModel.cs`, `src/ui/Logic/UndoRedo/UndoRedoManager.cs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)