### PR TITLE
Add multi-select to batch convert file grid

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -220,6 +220,7 @@ public partial class BatchConvertViewModel : ObservableObject
     [ObservableProperty] private bool _sortByDescending;
 
     public Window? Window { get; set; }
+    public DataGrid FileGrid { get; set; } = new();
 
     public bool OkPressed { get; private set; }
     public ScrollViewer FunctionContainer { get; internal set; }
@@ -1572,8 +1573,13 @@ public partial class BatchConvertViewModel : ObservableObject
     [RelayCommand]
     private async Task RemoveSelectedFiles()
     {
-        var selected = SelectedBatchItem;
-        if (selected == null || Window == null)
+        if (Window == null)
+        {
+            return;
+        }
+
+        var selectedItems = FileGrid.SelectedItems.Cast<BatchConvertItem>().ToList();
+        if (selectedItems.Count == 0)
         {
             return;
         }
@@ -1593,8 +1599,13 @@ public partial class BatchConvertViewModel : ObservableObject
             }
         }
 
-        var idx = BatchItems.IndexOf(selected);
-        BatchItems.Remove(selected);
+        var idx = selectedItems.Min(item => BatchItems.IndexOf(item));
+        foreach (var item in selectedItems)
+        {
+            BatchItems.Remove(item);
+            _allBatchItems.Remove(item);
+        }
+
         if (BatchItems.Count > 0)
         {
             if (idx >= BatchItems.Count)
@@ -1604,8 +1615,6 @@ public partial class BatchConvertViewModel : ObservableObject
 
             SelectedBatchItem = BatchItems[idx];
         }
-
-        _allBatchItems.Remove(selected);
 
         MakeBatchItemsInfo();
     }
@@ -2328,8 +2337,8 @@ public partial class BatchConvertViewModel : ObservableObject
 
     internal void FileGridContextMenuOpening()
     {
-        IsRemoveVisible = SelectedBatchItem != null;
-        IsOpenContainingFolderVisible = SelectedBatchItem != null;
+        IsRemoveVisible = FileGrid.SelectedItems.Count > 0;
+        IsOpenContainingFolderVisible = FileGrid.SelectedItems.Count == 1;
     }
 
     internal void ComboBoxSubtitleFormatPointerPressed(object? sender, PointerPressedEventArgs e)

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -143,7 +143,7 @@ public class BatchConvertWindow : Window
         var dataGrid = new DataGrid
         {
             AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
+            SelectionMode = DataGridSelectionMode.Extended,
             CanUserResizeColumns = true,
             CanUserSortColumns = true,
             HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -189,6 +189,7 @@ public class BatchConvertWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchItem)) { Source = vm });
+        vm.FileGrid = dataGrid;
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
             if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)


### PR DESCRIPTION
## Summary
Restores multi-select in the Batch Convert file grid (regression from v4), as requested in #11407.

- File `DataGrid` now uses `DataGridSelectionMode.Extended`, so **SHIFT+Click** (range) and **CTRL+Click** (toggle) work for selecting multiple files.
- **Remove** (toolbar button and context-menu item) now deletes all selected rows at once, removing them from both the visible and full file lists, then re-selects a sensible neighbour.
- Context menu: **Remove** shows when one or more rows are selected; **Open containing folder** shows only when exactly one row is selected.

The view model reads `FileGrid.SelectedItems`, following the existing pattern used by `AssaStylesViewModel`/`MainViewModel`.

Fixes #11407

🤖 Generated with [Claude Code](https://claude.com/claude-code)