### PR TITLE
Speech to text: status dots + post-download auto-select for forced aligner

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ForcedAlignerOption.cs
@@ -33,6 +33,13 @@ public class ForcedAlignerOption
     public string Url { get; }
     public string Size { get; }
 
+    /// <summary>
+    /// Whether this aligner's GGUF is present on disk for the current engine.
+    /// Set by the view model when it (re)builds the combo so each row's status
+    /// dot can be rendered without re-hitting the file system per row.
+    /// </summary>
+    public bool IsInstalled { get; set; }
+
     public bool IsBuiltIn => Choice == BuiltInChoice;
 
     public ForcedAlignerOption(string display, string choice, string fileName, string url, string size)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -365,7 +365,8 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         foreach (var opt in newOptions)
         {
-            opt.Display = BuildAlignerDisplay(opt, crispEngine);
+            opt.IsInstalled = IsAlignerInstalled(opt, crispEngine);
+            opt.Display = opt.BaseDisplay;
         }
 
         ForcedAligners.Clear();
@@ -391,38 +392,18 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
     }
 
-    private static string BuildAlignerDisplay(ForcedAlignerOption option, ICrispAsrEngine? crispEngine)
+    // Whether the aligner GGUF is already on disk for the given engine. A partial/aborted
+    // download leaves a tiny stub behind, so require a plausible model size (> 10 MB) before
+    // treating it as installed.
+    private static bool IsAlignerInstalled(ForcedAlignerOption option, ICrispAsrEngine? crispEngine)
     {
-        if (option.IsBuiltIn || string.IsNullOrEmpty(option.FileName))
+        if (option.IsBuiltIn || string.IsNullOrEmpty(option.FileName) || crispEngine is not CrispAsrEngineBase baseEngine)
         {
-            return option.BaseDisplay;
+            return false;
         }
 
-        var installed = false;
-        if (crispEngine is CrispAsrEngineBase baseEngine)
-        {
-            var path = baseEngine.GetModelForCmdLine(option.FileName);
-            if (File.Exists(path) && new FileInfo(path).Length > 10_000_000)
-            {
-                installed = true;
-            }
-        }
-
-        var size = string.IsNullOrEmpty(option.Size) ? string.Empty : option.Size;
-        if (installed && !string.IsNullOrEmpty(size))
-        {
-            return $"{option.BaseDisplay} ({size})";
-        }
-        if (installed)
-        {
-            return option.BaseDisplay;
-        }
-        if (!string.IsNullOrEmpty(size))
-        {
-            return $"{option.BaseDisplay} ({size}, not installed)";
-        }
-
-        return $"{option.BaseDisplay} (not installed)";
+        var path = baseEngine.GetModelForCmdLine(option.FileName);
+        return File.Exists(path) && new FileInfo(path).Length > 10_000_000;
     }
 
     private void UpdateWhisperCppBackendUi()
@@ -2379,13 +2360,26 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         preSelected ??= displays[0];
 
+        DownloadSpeechToTextModelsViewModel? downloadViewModel = null;
         await _windowService.ShowDialogAsync<DownloadSpeechToTextModelsWindow, DownloadSpeechToTextModelsViewModel>(
             Window, viewModel =>
             {
+                downloadViewModel = viewModel;
                 viewModel.SetModels(displays, engine, preSelected);
             });
 
         UpdateForcedAlignerUi();
+
+        // After a successful download, switch the combo to the model that was just downloaded
+        // instead of leaving it on the engine's default aligner.
+        if (downloadViewModel is { OkPressed: true, SelectedModel.Model.Name: { } downloadedFileName })
+        {
+            var downloaded = ForcedAligners.FirstOrDefault(a => a.FileName == downloadedFileName);
+            if (downloaded != null)
+            {
+                SelectedForcedAligner = downloaded;
+            }
+        }
     }
 
     private static string GetForcedAlignerPath(ICrispAsrEngine crispEngine, ForcedAlignerOption aligner)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -112,6 +112,7 @@ public class SpeechToTextWindow : Window
             .WithMinWidth(220)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
             .WithMarginTop(10);
+        comboForcedAligner.ItemTemplate = MakeForcedAlignerItemTemplate();
         var buttonForcedAlignerDownload = UiUtil.MakeButtonBrowse(vm.DownloadForcedAlignerCommand)
             .WithMarginTop(10)
             .WithMarginLeft(5)
@@ -741,5 +742,21 @@ public class SpeechToTextWindow : Window
             model => model.Engine.IsModelInstalled(model.Model)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled);
+    }
+
+    // Forced-aligner combo item template: same dot + download-size treatment as the model combo.
+    // The built-in aligner needs no download, so it gets no dot or size; downloadable aligners show
+    // green (on disk) or grey (not downloaded yet). Install state is snapshotted on each option by
+    // the view model when it rebuilds the list.
+    private static FuncDataTemplate<ForcedAlignerOption> MakeForcedAlignerItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<ForcedAlignerOption>(
+            aligner => aligner.BaseDisplay,
+            aligner => aligner.IsBuiltIn ? null : aligner.Size,
+            aligner => aligner.IsBuiltIn
+                ? DownloadDotStatus.None
+                : aligner.IsInstalled
+                    ? DownloadDotStatus.UpToDate
+                    : DownloadDotStatus.NotInstalled);
     }
 }


### PR DESCRIPTION
## What

Two fixes for the CrispASR forced aligner picker in the **Speech to text** window:

1. **Coloured download-status dots.** The forced aligner combo now uses the same status-dot item template as the engine and model combos:
   - 🟢 green — aligner GGUF is on disk (ready)
   - ⚪ grey — downloadable but not downloaded yet
   - no dot for the built-in aligner (nothing to download)
   - download size shown as a dimmed suffix, with the install state also in the tooltip / accessible name (not colour-only)

   This replaces the old plain-text `(~212 MB, not installed)` suffix, making it much easier to see at a glance which aligner models are already downloaded.

2. **Auto-select after download.** After downloading an aligner, the combo now switches to the model that was just downloaded instead of resetting to the engine's default aligner.

## How

- `ForcedAlignerOption` gets an `IsInstalled` snapshot flag, set by the view model when it (re)builds the combo, so each row's dot renders without re-hitting the file system.
- `SpeechToTextViewModel.UpdateForcedAlignerUi` computes install state per option; the old text-suffix builder is replaced by a small `IsAlignerInstalled` helper.
- `SpeechToTextViewModel.DownloadForcedAligner` captures the download dialog's view model and, on success, selects the downloaded aligner.
- `SpeechToTextWindow` adds `MakeForcedAlignerItemTemplate()` (built on the shared `StatusDots.ComboItemTemplate`) and wires it to the aligner combo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)