### PR TITLE
Add plugin data directory, video position, and subtitle encoding to plugin request

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -154,16 +154,19 @@ launched as `dotnet <entry> <requestFilePath>`.
   "requestType": "run",
   "responseFilePath": "C:\\Users\\...\\Temp\\SubtitleEditPlugins\\<id>\\response.json",
   "tempDirectory": "C:\\Users\\...\\Temp\\SubtitleEditPlugins\\<id>",
+  "pluginDataDirectory": "C:\\Users\\...\\Subtitle Edit\\Plugins\\Data\\Uppercase Selected Lines",
   "subtitle": {
     "format": "Advanced Sub Station Alpha",
     "fileName": "C:\\videos\\episode01.ass",
     "native": "[Script Info]\n...full subtitle in its original format...",
     "subRip": "1\n00:00:01,000 --> 00:00:03,000\nHello world\n\n..."
   },
+  "subtitleEncoding": "UTF-8 with BOM",
   "selectedIndices": [3, 4, 5],
   "videoFileName": "C:\\videos\\episode01.mkv",
   "frameRate": 23.976,
   "videoDurationSeconds": 1432.5,
+  "videoPositionSeconds": 142.0,
   "videoWidth": 1920,
   "videoHeight": 1080,
   "uiLanguage": "English",
@@ -186,6 +189,13 @@ launched as `dotnet <entry> <requestFilePath>`.
 - `subtitle.native` is the subtitle serialized in its **original format**;
   `subtitle.subRip` is the **same content as SubRip (.srt)** — use whichever is
   easier for your plugin.
+- `subtitleEncoding` is the display name of the encoding the file was loaded with
+  (e.g. `UTF-8 with BOM`). Empty when unknown / on older SE versions.
+- `pluginDataDirectory` is a **persistent, writable folder private to your plugin**
+  (under `Plugins/Data/<plugin name>`). Unlike `tempDirectory` it survives between
+  runs, and unlike your install folder it is **not** wiped when the plugin is
+  updated — use it for caches, downloaded models, dictionaries, etc. Subtitle Edit
+  creates it before the run. May be empty on older SE versions.
 - `selectedIndices` are zero-based line indices selected in the grid (empty if none).
 - `settings` is whatever JSON your plugin returned in its previous response;
   it is `null` on first run. Use it to persist plugin-private settings.
@@ -193,8 +203,9 @@ launched as `dotnet <entry> <requestFilePath>`.
   its previous response, handed back unchanged. Use it to migrate or reset old
   settings when you change your own schema. Null on first run, and on older SE
   versions that don't track it.
-- `videoDurationSeconds`, `videoWidth`, `videoHeight` describe the loaded video.
-  Null when no video is loaded (or on older SE versions). Saves you from
+- `videoDurationSeconds`, `videoPositionSeconds`, `videoWidth`, `videoHeight`
+  describe the loaded video; `videoPositionSeconds` is the current playhead
+  position. Null when no video is loaded (or on older SE versions). Saves you from
   re-opening the video file just to read these.
 - `theme` and `uiLanguage` let your plugin's own UI match Subtitle Edit.
 - `themeColors` carries the active theme's colors as `#AARRGGBB` hex strings so

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4814,8 +4814,11 @@ public partial class MainViewModel :
             settingsVersion = storedVersion;
         }
 
+        var videoPositionSeconds = _videoFileName != null ? GetVideoPlayerControl()?.Position : null;
+
         return new PluginRequest
         {
+            PluginDataDirectory = GetPluginDataDirectory(plugin),
             Subtitle = new PluginSubtitle
             {
                 Format = format.Name,
@@ -4823,10 +4826,12 @@ public partial class MainViewModel :
                 Native = subtitle.ToText(format),
                 SubRip = subtitle.ToText(new Nikse.SubtitleEdit.Core.SubtitleFormats.SubRip()),
             },
+            SubtitleEncoding = SelectedEncoding?.DisplayName ?? string.Empty,
             SelectedIndices = selectedIndices,
             VideoFileName = _videoFileName ?? string.Empty,
             FrameRate = frameRate,
             VideoDurationSeconds = _mediaInfo?.Duration?.TotalSeconds,
+            VideoPositionSeconds = videoPositionSeconds,
             VideoWidth = _mediaInfo?.Dimension.Width,
             VideoHeight = _mediaInfo?.Dimension.Height,
             UiLanguage = Se.Settings.General.Language ?? string.Empty,
@@ -4836,6 +4841,30 @@ public partial class MainViewModel :
             Settings = settings,
             SettingsVersion = settingsVersion,
         };
+    }
+
+    // Persistent, writable folder private to a plugin, keyed by its (sanitized) manifest name -
+    // the same identity used to persist plugin settings. Lives under Plugins/Data so it survives
+    // plugin updates (which replace the install folder). Created here so the plugin can rely on it.
+    private static string GetPluginDataDirectory(InstalledPlugin plugin)
+    {
+        var name = plugin.Manifest.Name;
+        foreach (var c in Path.GetInvalidFileNameChars())
+        {
+            name = name.Replace(c, '_');
+        }
+
+        var path = Path.Combine(Se.PluginsDataFolder, name);
+        try
+        {
+            Directory.CreateDirectory(path);
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Could not create plugin data directory: " + path);
+        }
+
+        return path;
     }
 
     private async Task<bool> ApplyPluginSubtitle(InstalledPlugin plugin, PluginResponse response)

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -118,6 +118,9 @@ public class Se
     public static string ShotChangesFolder => Path.Combine(DataFolder, "ShotChanges");
     public static string PluginsFolder => Path.Combine(DataFolder, "Plugins");
 
+    /// <summary>Root for persistent per-plugin data folders; not scanned for plugins (no manifest).</summary>
+    public static string PluginsDataFolder => Path.Combine(PluginsFolder, "Data");
+
     public static string OcrFolder => Path.Combine(DataFolder, "OCR");
     public static string TranslationFolder => Path.Combine(DataFolder, "Languages");
     public static string PaddleOcrFolder => Path.Combine(OcrFolder, "PaddleOCR3-1");

--- a/src/ui/Logic/Plugins/PluginRequest.cs
+++ b/src/ui/Logic/Plugins/PluginRequest.cs
@@ -20,7 +20,21 @@ public class PluginRequest
     /// <summary>A scratch directory the plugin may use; deleted by Subtitle Edit after the run.</summary>
     public string TempDirectory { get; set; } = string.Empty;
 
+    /// <summary>
+    /// A persistent, writable directory private to this plugin (keyed by plugin name).
+    /// Unlike <see cref="TempDirectory"/> it survives between runs, and unlike the plugin's
+    /// install folder it is not touched when the plugin is updated/reinstalled. Use it for
+    /// caches, downloaded models, dictionaries, etc. Subtitle Edit creates it before the run.
+    /// </summary>
+    public string PluginDataDirectory { get; set; } = string.Empty;
+
     public PluginSubtitle Subtitle { get; set; } = new();
+
+    /// <summary>
+    /// Display name of the encoding the subtitle file was loaded with, e.g. "UTF-8 with BOM".
+    /// Empty when unknown. Lets a plugin preserve the original encoding when relevant.
+    /// </summary>
+    public string SubtitleEncoding { get; set; } = string.Empty;
 
     /// <summary>Zero-based indices of the lines selected in the grid (empty if none).</summary>
     public List<int> SelectedIndices { get; set; } = new();
@@ -31,6 +45,9 @@ public class PluginRequest
 
     /// <summary>Total duration of the video in seconds. Null when no video is loaded.</summary>
     public double? VideoDurationSeconds { get; set; }
+
+    /// <summary>Current player position (playhead) in seconds. Null when no video is loaded.</summary>
+    public double? VideoPositionSeconds { get; set; }
 
     /// <summary>Video frame width in pixels. Null when no video is loaded.</summary>
     public int? VideoWidth { get; set; }


### PR DESCRIPTION
Three additive, non-breaking fields on `PluginRequest` (`apiVersion` stays at `1` — older plugins ignore them, older SE versions just omit them):

- **`pluginDataDirectory`** — a persistent, writable folder private to each plugin, under `Plugins/Data/<plugin name>`. Keyed by the manifest name (same identity used for plugin settings) and created before the run. Unlike `tempDirectory` it survives between runs, and unlike the install folder it is **not** wiped when the plugin is updated/reinstalled — so it is the right home for caches, downloaded models, dictionaries, etc.
- **`videoPositionSeconds`** — the current player playhead position. `null` when no video is loaded.
- **`subtitleEncoding`** — display name of the encoding the subtitle file was loaded with (e.g. `UTF-8 with BOM`).

### Notes
- `Plugins/Data` lives under the plugins root but is safely skipped by the catalog scan (no `plugin.json` inside).
- Data folder is keyed by manifest `Name` for consistency with existing settings persistence; renaming a plugin orphans the old folder (same as settings today).
- Removing a plugin intentionally leaves its data folder behind (survives reinstall/update). Optional purge-on-remove could be a follow-up.
- `docs/plugin.md` updated for all three fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)