### PR TITLE
Fix wrong panel title in batch convert's "Apply minimum gaps" view

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewApplyMinGap.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewApplyMinGap.cs
@@ -11,7 +11,7 @@ public static class ViewApplyMinGap
     {
         var labelHeader = new Label
         {
-            Content = Se.Language.General.ChangeSpeed,
+            Content = Se.Language.Tools.ApplyMinGaps.Title,
             VerticalAlignment = VerticalAlignment.Center,
             FontWeight = Avalonia.Media.FontWeight.Bold
         };


### PR DESCRIPTION
The "Apply minimum gaps between subtitles" panel in Batch Convert was showing the "Change Speed" label instead of its own title. This was caused by a copy-paste error — the header label was referencing `Se.Language.General.ChangeSpeed` instead of `Se.Language.Tools.ApplyMinGaps.Title`.

  One-line fix in `ViewApplyMinGap.cs`.

Before

<img width="1136" height="880" alt="Apply - before" src="https://github.com/user-attachments/assets/3bc2f520-34f7-4baf-a2d1-300fbeec76ce" />

After

<img width="1136" height="880" alt="Apply - after" src="https://github.com/user-attachments/assets/70f7b826-bccb-4358-aa04-6d7f0c874372" />
