### PR TITLE
Fix multi-line subtitle rendering in subtitle grid

### DIFF
--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -324,8 +324,16 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         var firstLine = true;
         foreach (var line in str.SplitToLines())
         {
-            if (!firstLine) inlines.Add(new LineBreak());
-            if (line.Length > 0) inlines.Add(new Run(line));
+            if (!firstLine)
+            {
+                inlines.Add(new LineBreak());
+            }
+
+            if (line.Length > 0)
+            {
+                inlines.Add(new Run(line));
+            }
+
             firstLine = false;
         }
         return SpellCheckLines(inlines);
@@ -715,7 +723,10 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             // Handle line breaks
-            if (AppendLineBreak(inlines, c, c2, ref i)) continue;
+            if (AppendLineBreak(inlines, c, c2, ref i))
+            {
+                continue;
+            }
 
             // Regular text - add character by character until we hit special markup
             var textStart = i;
@@ -864,7 +875,10 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             // Handle line breaks
-            if (AppendLineBreak(inlines, c, c2, ref i)) continue;
+            if (AppendLineBreak(inlines, c, c2, ref i))
+            {
+                continue;
+            }
 
             // Regular text - collect characters until we hit special markup
             var textStart = i;
@@ -1348,7 +1362,10 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
     private static bool AppendLineBreak(InlineCollection inlines, char c, char c2, ref int i)
     {
         if (c != '\n' && c != '\r' && c != '\u2028')
+        {
             return false;
+        }
+
         inlines.Add(new LineBreak());
         i += c == '\r' && c2 == '\n' ? 2 : 1;
         return true;

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -324,9 +324,8 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         var firstLine = true;
         foreach (var line in str.SplitToLines())
         {
-            if (line.Length == 0) continue;
             if (!firstLine) inlines.Add(new LineBreak());
-            inlines.Add(new Run(line));
+            if (line.Length > 0) inlines.Add(new Run(line));
             firstLine = false;
         }
         return SpellCheckLines(inlines);
@@ -1348,10 +1347,10 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
     private static bool AppendLineBreak(InlineCollection inlines, char c, char c2, ref int i)
     {
-        if (c != '\n' && !(c == '\r' && c2 == '\n'))
+        if (c != '\n' && c != '\r')
             return false;
         inlines.Add(new LineBreak());
-        i += c == '\r' ? 2 : 1;
+        i += c == '\r' && c2 == '\n' ? 2 : 1;
         return true;
     }
 

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -321,12 +321,13 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
         // No formatting (default)
         var inlines = new InlineCollection();
-        var parts = str.Split('\n');
-        for (var idx = 0; idx < parts.Length; idx++)
+        var firstLine = true;
+        foreach (var line in str.SplitToLines())
         {
-            var part = parts[idx].TrimEnd('\r');
-            if (idx > 0) inlines.Add(new LineBreak());
-            if (part.Length > 0) inlines.Add(new Run(part));
+            if (line.Length == 0) continue;
+            if (!firstLine) inlines.Add(new LineBreak());
+            inlines.Add(new Run(line));
+            firstLine = false;
         }
         return SpellCheckLines(inlines);
     }
@@ -715,12 +716,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             // Handle line breaks
-            if (c == '\n' || (c == '\r' && c2 == '\n'))
-            {
-                inlines.Add(new LineBreak());
-                i += c == '\r' ? 2 : 1;
-                continue;
-            }
+            if (AppendLineBreak(inlines, c, c2, ref i)) continue;
 
             // Regular text - add character by character until we hit special markup
             var textStart = i;
@@ -869,12 +865,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             // Handle line breaks
-            if (c == '\n' || (c == '\r' && c2 == '\n'))
-            {
-                inlines.Add(new LineBreak());
-                i += c == '\r' ? 2 : 1;
-                continue;
-            }
+            if (AppendLineBreak(inlines, c, c2, ref i)) continue;
 
             // Regular text - collect characters until we hit special markup
             var textStart = i;
@@ -1353,6 +1344,15 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 }
             }
         }
+    }
+
+    private static bool AppendLineBreak(InlineCollection inlines, char c, char c2, ref int i)
+    {
+        if (c != '\n' && !(c == '\r' && c2 == '\n'))
+            return false;
+        inlines.Add(new LineBreak());
+        i += c == '\r' ? 2 : 1;
+        return true;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -719,7 +719,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
             // Regular text - add character by character until we hit special markup
             var textStart = i;
-            while (i < str.Length && str[i] != '<' && str[i] != '{' && str[i] != '\r' && str[i] != '\n')
+            while (i < str.Length && str[i] != '<' && str[i] != '{' && str[i] != '\r' && str[i] != '\n' && str[i] != '\u2028')
             {
                 i++;
             }
@@ -876,7 +876,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 var ch = str[i];
 
                 // Check for special characters that require immediate handling
-                if (ch == '<' || ch == '\r' || ch == '\n')
+                if (ch == '<' || ch == '\r' || ch == '\n' || ch == '\u2028')
                 {
                     break;
                 }
@@ -1347,7 +1347,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
     private static bool AppendLineBreak(InlineCollection inlines, char c, char c2, ref int i)
     {
-        if (c != '\n' && c != '\r')
+        if (c != '\n' && c != '\r' && c != '\u2028')
             return false;
         inlines.Add(new LineBreak());
         i += c == '\r' && c2 == '\n' ? 2 : 1;

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -321,7 +321,13 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
         // No formatting (default)
         var inlines = new InlineCollection();
-        inlines.Add(new Run(str));
+        var parts = str.Split('\n');
+        for (var idx = 0; idx < parts.Length; idx++)
+        {
+            var part = parts[idx].TrimEnd('\r');
+            if (idx > 0) inlines.Add(new LineBreak());
+            if (part.Length > 0) inlines.Add(new Run(part));
+        }
         return SpellCheckLines(inlines);
     }
 
@@ -711,7 +717,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             // Handle line breaks
             if (c == '\n' || (c == '\r' && c2 == '\n'))
             {
-                inlines.Add(new Run(Environment.NewLine));
+                inlines.Add(new LineBreak());
                 i += c == '\r' ? 2 : 1;
                 continue;
             }
@@ -865,7 +871,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             // Handle line breaks
             if (c == '\n' || (c == '\r' && c2 == '\n'))
             {
-                inlines.Add(new Run(Environment.NewLine));
+                inlines.Add(new LineBreak());
                 i += c == '\r' ? 2 : 1;
                 continue;
             }


### PR DESCRIPTION
Some multi-line subtitles were not displaying both lines in the main window DataGrid. The symptom was most visible with subtitles starting and ending with a music note symbol (e.g. ♪ <i>When your touch\nis so exciting?</i> ♪), where only the first line was rendered. See screenshots below.

  #### Problem

Multi-line subtitle text was not rendering correctly in the subtitle grid. In Avalonia 12, `Run(Environment.NewLine)` inside `TextBlock.Inlines` does not produce a visual line break — a dedicated `LineBreak` inline element is required.

  #### Changes

  - Replace `Run(Environment.NewLine)` with `LineBreak()` in all three rendering paths (default, `ShowFormatting`, `ShowTags`)
  - Default path now splits on all line-ending variants (`\r\n`, `\n`, `\r`, `\u2028`) using `SplitToLines()` instead of wrapping the whole text in a single `Run`
  - Extract shared `AppendLineBreak()` helper to de-duplicate line-break handling in the `ShowFormatting` and `ShowTags` parsing loops
  - Fix off-by-one in line-break advance logic: bare `\r` now advances by 1 (not 2)
  - Preserve blank lines in multi-line subtitles

  #### Screenshots

Before:

<img width="689" height="570" alt="before" src="https://github.com/user-attachments/assets/44790842-4bf4-45b2-a5af-770dab4ad415" />


After:

<img width="734" height="580" alt="after" src="https://github.com/user-attachments/assets/d7c82c1b-8669-47cd-aa87-f2cb2a652408" />
