### PR TITLE
Fix SSA styles not saving/loading in main grid (#11415)

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -127,7 +127,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         Id = Guid.TryParse(paragraph.Id, out var guid) ? guid : Guid.NewGuid();
         Paragraph = paragraph;
 
-        if (subtitleFormat is AdvancedSubStationAlpha)
+        if (subtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
         {
             Style = paragraph.Extra;
         }
@@ -149,7 +149,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             Bookmark = Bookmark,
         };
 
-        if (subtitleFormat != null && subtitleFormat is AdvancedSubStationAlpha)
+        if (subtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
         {
             p.Extra = Style;
         }
@@ -173,7 +173,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             Bookmark = Bookmark,
         };
 
-        if (subtitleFormat != null && subtitleFormat is AdvancedSubStationAlpha)
+        if (subtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
         {
             p.Extra = Style;
         }
@@ -534,7 +534,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         Style = p.Style;
         Layer = p.Layer;
         Extra = p.Extra;
-        if (subtitleFormat is AdvancedSubStationAlpha)
+        if (subtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
         {
             Style = p.Extra;
         }


### PR DESCRIPTION
## Problem

Reported in #11415: in the new UI, SSA (Sub Station Alpha) styles don't behave like ASSA — the style editor shows a usage count of `0` for every style, style assignments are written out as `*Default` on save, and assignments are gone after reopening the file.

## Root cause

`SubStationAlpha` (SSA) and `AdvancedSubStationAlpha` (ASSA) are sibling formats that both store a paragraph's style name in `Paragraph.Extra`. However, `SubtitleLineViewModel` only mapped the grid `Style` column to/from `Paragraph.Extra` when the format `is AdvancedSubStationAlpha` — SSA fell through and got nothing.

The damage funnels through `GetUpdateSubtitle()`, which rebuilds `_subtitle.Paragraphs` from the grid via `ToParagraph(format)` and runs constantly (preview refresh, mpv/vlc reload, **and save**). For SSA, `Extra` was never set, so:

- the style editor counts `_subtitle.Paragraphs[].Extra`, which had been blanked → **usage count 0**
- save uses `GetUpdateSubtitle()` → every line written as **`*Default`**
- the reverse mapping (`Style = Extra`) was also SSA-blind → **styles missing after reload**

The libse `SubStationAlpha` `ToText`/`LoadSubtitle` round-trip was already correct; the bug was entirely in the UI view-model mapping.

## Fix

Extend the four `Style` ↔ `Extra` mappings in `SubtitleLineViewModel` to also handle `SubStationAlpha` (`is AdvancedSubStationAlpha or SubStationAlpha`). This matches the existing `HasFormatStyle` gate in `MainViewModel`, which already shows the Style column for SSA.

Note: the unrelated "column widths reset on restart" item from the issue is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)