### PR TITLE
Add subtitle count/selection status to OCR and Binary Edit windows

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -575,9 +575,7 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : 0;
-        var selectedIndices = SubtitleGrid?.SelectedItems?.Cast<OcrSubtitleItem>().Select(i => OcrSubtitleItems.IndexOf(i)).Where(i => i >= 0).ToList();
-        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle, selectedIndex, selectedIndices); });
+        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle); });
         _isCtrlDown = false;
     }
 
@@ -589,10 +587,8 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : 0;
-        var selectedIndices = SubtitleGrid?.SelectedItems?.Cast<OcrSubtitleItem>().Select(i => OcrSubtitleItems.IndexOf(i)).Where(i => i >= 0).ToList();
         var items = OcrSubtitleItems.ToList();
-        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items, selectedIndex, selectedIndices); });
+        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items); });
         _isCtrlDown = false;
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -86,6 +86,7 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private string _llamaCppOcrServerButtonText;
     [ObservableProperty] private string _progressText;
     [ObservableProperty] private double _progressValue;
+    [ObservableProperty] private string _statusTextRight;
     [ObservableProperty] private Bitmap? _currentImageSource;
     [ObservableProperty] private string _currentBitmapInfo;
     [ObservableProperty] private string _currentText;
@@ -206,6 +207,7 @@ public partial class OcrViewModel : ObservableObject
         CurrentBitmapInfo = string.Empty;
         CurrentText = string.Empty;
         ProgressText = string.Empty;
+        StatusTextRight = string.Empty;
         OllamaModel = string.Empty;
         OllamaUrl = string.Empty;
         LlamaCppUrl = string.Empty;
@@ -573,7 +575,8 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle); });
+        var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : 0;
+        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle, selectedIndex); });
         _isCtrlDown = false;
     }
 
@@ -585,8 +588,9 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
+        var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : 0;
         var items = OcrSubtitleItems.ToList();
-        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items); });
+        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items, selectedIndex); });
         _isCtrlDown = false;
     }
 
@@ -4195,6 +4199,23 @@ public partial class OcrViewModel : ObservableObject
     {
         ShowContextMenu = OcrSubtitleItems.Count > 0;
         HasMultipleLinesSelected = SubtitleGrid != null && SubtitleGrid.SelectedItems.Count > 1;
+    }
+
+    internal void SubtitleGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        var selectedCount = SubtitleGrid?.SelectedItems?.Count ?? 0;
+        if (selectedCount == 0)
+        {
+            StatusTextRight = string.Empty;
+        }
+        else if (selectedCount == 1 && SelectedOcrSubtitleItem != null)
+        {
+            StatusTextRight = $"{OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) + 1}/{OcrSubtitleItems.Count}";
+        }
+        else
+        {
+            StatusTextRight = string.Format(Se.Language.Main.XLinesSelectedOfY, selectedCount, OcrSubtitleItems.Count);
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -575,8 +575,7 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : -1;
-        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle, selectedIndex); });
+        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle); });
         _isCtrlDown = false;
     }
 
@@ -588,9 +587,8 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : -1;
         var items = OcrSubtitleItems.ToList();
-        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items, selectedIndex); });
+        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items); });
         _isCtrlDown = false;
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -86,7 +86,7 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private string _llamaCppOcrServerButtonText;
     [ObservableProperty] private string _progressText;
     [ObservableProperty] private double _progressValue;
-    [ObservableProperty] private string _statusTextRight;
+    [ObservableProperty] private string _selectionStatus;
     [ObservableProperty] private Bitmap? _currentImageSource;
     [ObservableProperty] private string _currentBitmapInfo;
     [ObservableProperty] private string _currentText;
@@ -207,7 +207,7 @@ public partial class OcrViewModel : ObservableObject
         CurrentBitmapInfo = string.Empty;
         CurrentText = string.Empty;
         ProgressText = string.Empty;
-        StatusTextRight = string.Empty;
+        SelectionStatus = string.Empty;
         OllamaModel = string.Empty;
         OllamaUrl = string.Empty;
         LlamaCppUrl = string.Empty;
@@ -575,7 +575,8 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle); });
+        var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : -1;
+        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle, selectedIndex); });
         _isCtrlDown = false;
     }
 
@@ -587,8 +588,9 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
+        var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : -1;
         var items = OcrSubtitleItems.ToList();
-        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items); });
+        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items, selectedIndex); });
         _isCtrlDown = false;
     }
 
@@ -4204,15 +4206,16 @@ public partial class OcrViewModel : ObservableObject
         var selectedCount = SubtitleGrid?.SelectedItems?.Count ?? 0;
         if (selectedCount == 0)
         {
-            StatusTextRight = string.Empty;
+            SelectionStatus = string.Empty;
         }
-        else if (selectedCount == 1 && SelectedOcrSubtitleItem != null)
+        else if (selectedCount == 1)
         {
-            StatusTextRight = $"{OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) + 1}/{OcrSubtitleItems.Count}";
+            var index = SubtitleGrid?.SelectedIndex ?? -1;
+            SelectionStatus = index >= 0 ? $"{index + 1}/{OcrSubtitleItems.Count}" : $"1/{OcrSubtitleItems.Count}";
         }
         else
         {
-            StatusTextRight = string.Format(Se.Language.Main.XLinesSelectedOfY, selectedCount, OcrSubtitleItems.Count);
+            SelectionStatus = string.Format(Se.Language.Main.XLinesSelectedOfY, selectedCount, OcrSubtitleItems.Count);
         }
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -576,7 +576,8 @@ public partial class OcrViewModel : ObservableObject
         }
 
         var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : 0;
-        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle, selectedIndex); });
+        var selectedIndices = SubtitleGrid?.SelectedItems?.Cast<OcrSubtitleItem>().Select(i => OcrSubtitleItems.IndexOf(i)).Where(i => i >= 0).ToList();
+        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle, selectedIndex, selectedIndices); });
         _isCtrlDown = false;
     }
 
@@ -589,8 +590,9 @@ public partial class OcrViewModel : ObservableObject
         }
 
         var selectedIndex = SelectedOcrSubtitleItem != null ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem) : 0;
+        var selectedIndices = SubtitleGrid?.SelectedItems?.Cast<OcrSubtitleItem>().Select(i => OcrSubtitleItems.IndexOf(i)).Where(i => i >= 0).ToList();
         var items = OcrSubtitleItems.ToList();
-        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items, selectedIndex); });
+        await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(items, selectedIndex, selectedIndices); });
         _isCtrlDown = false;
     }
 

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -1005,7 +1005,7 @@ public class OcrWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             Margin = new Thickness(5, 0, 0, 0),
         };
-        subtitleCountText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusTextRight)) { Source = vm });
+        subtitleCountText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.SelectionStatus)) { Source = vm });
         subtitleCountText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = new InverseBooleanConverter() });
 
         grid.Add(progressBar, 0, 0);

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -472,6 +472,7 @@ public class OcrWindow : Window
         dataGridSubtitle.DoubleTapped += (s, e) => vm.SubtitleGridDoubleTapped();
         dataGridSubtitle.AddHandler(InputElement.PointerPressedEvent, vm.DataGridSubtitleMacPointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         dataGridSubtitle.AddHandler(InputElement.PointerReleasedEvent, vm.DataGridSubtitleMacPointerReleased, Avalonia.Interactivity.RoutingStrategies.Tunnel);
+        dataGridSubtitle.SelectionChanged += vm.SubtitleGridSelectionChanged;
         vm.SubtitleGrid = dataGridSubtitle;
 
         // Create a Flyout for the DataGrid
@@ -998,8 +999,18 @@ public class OcrWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
+        var subtitleCountText = new TextBlock
+        {
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(5, 0, 0, 0),
+        };
+        subtitleCountText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusTextRight)));
+        subtitleCountText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = new InverseBooleanConverter() });
+
         grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);
+        grid.Add(subtitleCountText, 0, 0);
         grid.Add(buttonStart, 0, 1);
         grid.Add(buttonPause, 0, 2);
         grid.Add(buttonInspect, 0, 3);

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -1005,7 +1005,7 @@ public class OcrWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             Margin = new Thickness(5, 0, 0, 0),
         };
-        subtitleCountText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusTextRight)));
+        subtitleCountText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusTextRight)) { Source = vm });
         subtitleCountText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = new InverseBooleanConverter() });
 
         grid.Add(progressBar, 0, 0);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -64,6 +64,7 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private string _loadFileName = string.Empty;
     private int _initialSelectedIndex = -1;
+    private IList<int> _initialSelectedIndices = Array.Empty<int>();
 
     public BinaryEditViewModel(IFileHelper fileHelper, IWindowService windowService, IFolderHelper folderHelper, IShortcutManager shortcutManager, IBluRayHelper bluRayHelper)
     {
@@ -78,10 +79,11 @@ public partial class BinaryEditViewModel : ObservableObject
         CurrentPositionAndSize = string.Empty;
     }
 
-    public void Initialize(string fileName, IOcrSubtitle? subtitle, int selectedIndex = -1)
+    public void Initialize(string fileName, IOcrSubtitle? subtitle, int selectedIndex = -1, IList<int>? selectedIndices = null)
     {
         _loadFileName = fileName;
         _initialSelectedIndex = selectedIndex;
+        _initialSelectedIndices = selectedIndices ?? Array.Empty<int>();
 
         if (subtitle != null && string.IsNullOrEmpty(fileName) && subtitle.Count > 0)
         {
@@ -99,7 +101,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
     }
 
-    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, int selectedIndex = -1)
+    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, int selectedIndex = -1, IList<int>? selectedIndices = null)
     {
         if (ocrSubtitleItems == null || ocrSubtitleItems.Count == 0)
         {
@@ -107,6 +109,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         _initialSelectedIndex = selectedIndex;
+        _initialSelectedIndices = selectedIndices ?? Array.Empty<int>();
         var screenSize = ocrSubtitleItems[0].GetScreenSize();
         ScreenWidth = screenSize.Width;
         ScreenHeight = screenSize.Height;
@@ -150,11 +153,15 @@ public partial class BinaryEditViewModel : ObservableObject
             StatusText = $"0/{Subtitles.Count}";
             CurrentPositionAndSize = string.Empty;
         }
-        else if (selectedCount == 1 && SelectedSubtitle != null)
+        else if (selectedCount == 1)
         {
-            StatusText = $"{Subtitles.IndexOf(SelectedSubtitle) + 1}/{Subtitles.Count}";
-            CurrentPositionAndSize = string.Format(Se.Language.General.PositionX, $"{SelectedSubtitle.X},{SelectedSubtitle.Y}") + Environment.NewLine +
-                                     string.Format(Se.Language.General.SizeX, $"{SelectedSubtitle.Bitmap?.Size.Width}x{SelectedSubtitle.Bitmap?.Size.Height}");
+            var index = SubtitleGrid?.SelectedIndex ?? -1;
+            var item = SubtitleGrid?.SelectedItem as BinarySubtitleItem;
+            StatusText = index >= 0 ? $"{index + 1}/{Subtitles.Count}" : $"1/{Subtitles.Count}";
+            CurrentPositionAndSize = item != null
+                ? string.Format(Se.Language.General.PositionX, $"{item.X},{item.Y}") + Environment.NewLine +
+                  string.Format(Se.Language.General.SizeX, $"{item.Bitmap?.Size.Width}x{item.Bitmap?.Size.Height}")
+                : string.Empty;
         }
         else
         {
@@ -1794,7 +1801,11 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (string.IsNullOrEmpty(_loadFileName))
         {
-            if (_initialSelectedIndex >= 0 && Subtitles.Count > 0)
+            if (_initialSelectedIndices.Count > 0 && Subtitles.Count > 0)
+            {
+                SelectAndScrollToRows(_initialSelectedIndices);
+            }
+            else if (_initialSelectedIndex >= 0 && Subtitles.Count > 0)
             {
                 SelectAndScrollToRow(_initialSelectedIndex);
             }
@@ -1822,6 +1833,29 @@ public partial class BinaryEditViewModel : ObservableObject
             }
 
             SubtitleGrid.ScrollIntoView(SubtitleGrid.SelectedItem, null);
+        });
+    }
+
+    private void SelectAndScrollToRows(IList<int> indices)
+    {
+        if (indices.Count == 0 || SubtitleGrid == null)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            SubtitleGrid.SelectedItems.Clear();
+            foreach (var i in indices.Where(i => i >= 0 && i < Subtitles.Count))
+            {
+                SubtitleGrid.SelectedItems.Add(Subtitles[i]);
+            }
+
+            var first = indices.Where(i => i >= 0 && i < Subtitles.Count).DefaultIfEmpty(-1).Min();
+            if (first >= 0)
+            {
+                SubtitleGrid.ScrollIntoView(Subtitles[first], null);
+            }
         });
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -63,6 +63,7 @@ public partial class BinaryEditViewModel : ObservableObject
     private readonly IBluRayHelper _bluRayHelper;
 
     private string _loadFileName = string.Empty;
+    private int _initialSelectedIndex = -1;
 
     public BinaryEditViewModel(IFileHelper fileHelper, IWindowService windowService, IFolderHelper folderHelper, IShortcutManager shortcutManager, IBluRayHelper bluRayHelper)
     {
@@ -77,9 +78,10 @@ public partial class BinaryEditViewModel : ObservableObject
         CurrentPositionAndSize = string.Empty;
     }
 
-    public void Initialize(string fileName, IOcrSubtitle? subtitle)
+    public void Initialize(string fileName, IOcrSubtitle? subtitle, int selectedIndex = 0)
     {
         _loadFileName = fileName;
+        _initialSelectedIndex = selectedIndex;
 
         if (subtitle != null && string.IsNullOrEmpty(fileName) && subtitle.Count > 0)
         {
@@ -97,13 +99,14 @@ public partial class BinaryEditViewModel : ObservableObject
         }
     }
 
-    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems)
+    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, int selectedIndex = 0)
     {
         if (ocrSubtitleItems == null || ocrSubtitleItems.Count == 0)
         {
             return;
         }
 
+        _initialSelectedIndex = selectedIndex;
         var screenSize = ocrSubtitleItems[0].GetScreenSize();
         ScreenWidth = screenSize.Width;
         ScreenHeight = screenSize.Height;
@@ -139,13 +142,13 @@ public partial class BinaryEditViewModel : ObservableObject
     {
         if (SelectedSubtitle == null)
         {
-            StatusText = string.Format(Se.Language.General.XSubtitles, Subtitles.Count);
+            StatusText = string.Empty;
             CurrentPositionAndSize = string.Empty;
         }
         else
         {
             var index = Subtitles.IndexOf(SelectedSubtitle);
-            StatusText = string.Format(Se.Language.General.SubtitleXOfY, index + 1, Subtitles.Count);
+            StatusText = $"{index + 1}/{Subtitles.Count}";
             CurrentPositionAndSize = string.Format(Se.Language.General.PositionX, $"{SelectedSubtitle.X},{SelectedSubtitle.Y}") + Environment.NewLine +
                                      string.Format(Se.Language.General.SizeX, $"{SelectedSubtitle.Bitmap?.Size.Width}x{SelectedSubtitle.Bitmap?.Size.Height}");
         }
@@ -1782,6 +1785,10 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (string.IsNullOrEmpty(_loadFileName))
         {
+            if (_initialSelectedIndex >= 0 && Subtitles.Count > 0)
+            {
+                SelectAndScrollToRow(_initialSelectedIndex);
+            }
             return;
         }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -135,22 +135,31 @@ public partial class BinaryEditViewModel : ObservableObject
     partial void OnSelectedSubtitleChanged(BinarySubtitleItem? value)
     {
         UpdateOverlayPosition();
-        UpdateStatusText();
     }
 
-    private void UpdateStatusText()
+    internal void SubtitleGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (SelectedSubtitle == null)
+        RefreshStatusText();
+    }
+
+    private void RefreshStatusText()
+    {
+        var selectedCount = SubtitleGrid?.SelectedItems?.Count ?? 0;
+        if (selectedCount == 0)
         {
             StatusText = $"0/{Subtitles.Count}";
             CurrentPositionAndSize = string.Empty;
         }
-        else
+        else if (selectedCount == 1 && SelectedSubtitle != null)
         {
-            var index = Subtitles.IndexOf(SelectedSubtitle);
-            StatusText = $"{index + 1}/{Subtitles.Count}";
+            StatusText = $"{Subtitles.IndexOf(SelectedSubtitle) + 1}/{Subtitles.Count}";
             CurrentPositionAndSize = string.Format(Se.Language.General.PositionX, $"{SelectedSubtitle.X},{SelectedSubtitle.Y}") + Environment.NewLine +
                                      string.Format(Se.Language.General.SizeX, $"{SelectedSubtitle.Bitmap?.Size.Width}x{SelectedSubtitle.Bitmap?.Size.Height}");
+        }
+        else
+        {
+            StatusText = string.Format(Se.Language.Main.XLinesSelectedOfY, selectedCount, Subtitles.Count);
+            CurrentPositionAndSize = string.Empty;
         }
     }
 
@@ -443,7 +452,7 @@ public partial class BinaryEditViewModel : ObservableObject
             SelectAndScrollToRow(0);
             ScreenWidth = Subtitles[0].ScreenSize.Width;
             ScreenHeight = Subtitles[0].ScreenSize.Height;
-            UpdateStatusText();
+            RefreshStatusText();
             Window.Title = string.Format(Se.Language.Tools.ImageBasedEdit.EditImagedBaseSubtitleX, fileName);
         }
 
@@ -1301,7 +1310,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         UpdateOverlayPosition();
-        UpdateStatusText();
+        RefreshStatusText();
     }
 
     [RelayCommand]
@@ -1625,7 +1634,7 @@ public partial class BinaryEditViewModel : ObservableObject
             selectedItem.Bitmap = skBitmap.ToAvaloniaBitmap();
 
             UpdateOverlayPosition();
-            UpdateStatusText();
+            RefreshStatusText();
         }
         catch (Exception ex)
         {
@@ -1661,7 +1670,7 @@ public partial class BinaryEditViewModel : ObservableObject
 
             // Update the overlay
             UpdateOverlayPosition();
-            UpdateStatusText();
+            RefreshStatusText();
 
             // Clean up
             result.ResultBitmap.Dispose();
@@ -1722,7 +1731,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         Renumber();
-        UpdateStatusText();
+        RefreshStatusText();
     }
 
     public void OnKeyDown(KeyEventArgs e)
@@ -1880,7 +1889,7 @@ public partial class BinaryEditViewModel : ObservableObject
                 item.Bitmap?.Dispose();
             }
 
-            UpdateStatusText();
+            RefreshStatusText();
 
             return;
         });

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1798,9 +1798,9 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (string.IsNullOrEmpty(_loadFileName))
         {
-            if (_initialSelectedIndex >= 0 && Subtitles.Count > 0)
+            if (Subtitles.Count > 0)
             {
-                SelectAndScrollToRow(_initialSelectedIndex);
+                SelectAndScrollToRow(Math.Max(0, _initialSelectedIndex));
             }
             return;
         }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -78,7 +78,7 @@ public partial class BinaryEditViewModel : ObservableObject
         CurrentPositionAndSize = string.Empty;
     }
 
-    public void Initialize(string fileName, IOcrSubtitle? subtitle, int selectedIndex = 0)
+    public void Initialize(string fileName, IOcrSubtitle? subtitle, int selectedIndex = -1)
     {
         _loadFileName = fileName;
         _initialSelectedIndex = selectedIndex;
@@ -99,7 +99,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
     }
 
-    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, int selectedIndex = 0)
+    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, int selectedIndex = -1)
     {
         if (ocrSubtitleItems == null || ocrSubtitleItems.Count == 0)
         {
@@ -142,7 +142,7 @@ public partial class BinaryEditViewModel : ObservableObject
     {
         if (SelectedSubtitle == null)
         {
-            StatusText = string.Empty;
+            StatusText = $"0/{Subtitles.Count}";
             CurrentPositionAndSize = string.Empty;
         }
         else

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -64,7 +64,6 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private string _loadFileName = string.Empty;
     private int _initialSelectedIndex = -1;
-    private IList<int> _initialSelectedIndices = Array.Empty<int>();
 
     public BinaryEditViewModel(IFileHelper fileHelper, IWindowService windowService, IFolderHelper folderHelper, IShortcutManager shortcutManager, IBluRayHelper bluRayHelper)
     {
@@ -79,11 +78,10 @@ public partial class BinaryEditViewModel : ObservableObject
         CurrentPositionAndSize = string.Empty;
     }
 
-    public void Initialize(string fileName, IOcrSubtitle? subtitle, int selectedIndex = -1, IList<int>? selectedIndices = null)
+    public void Initialize(string fileName, IOcrSubtitle? subtitle, int selectedIndex = -1)
     {
         _loadFileName = fileName;
         _initialSelectedIndex = selectedIndex;
-        _initialSelectedIndices = selectedIndices ?? Array.Empty<int>();
 
         if (subtitle != null && string.IsNullOrEmpty(fileName) && subtitle.Count > 0)
         {
@@ -101,7 +99,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
     }
 
-    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, int selectedIndex = -1, IList<int>? selectedIndices = null)
+    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, int selectedIndex = -1)
     {
         if (ocrSubtitleItems == null || ocrSubtitleItems.Count == 0)
         {
@@ -109,7 +107,6 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         _initialSelectedIndex = selectedIndex;
-        _initialSelectedIndices = selectedIndices ?? Array.Empty<int>();
         var screenSize = ocrSubtitleItems[0].GetScreenSize();
         ScreenWidth = screenSize.Width;
         ScreenHeight = screenSize.Height;
@@ -1801,11 +1798,7 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (string.IsNullOrEmpty(_loadFileName))
         {
-            if (_initialSelectedIndices.Count > 0 && Subtitles.Count > 0)
-            {
-                SelectAndScrollToRows(_initialSelectedIndices);
-            }
-            else if (_initialSelectedIndex >= 0 && Subtitles.Count > 0)
+            if (_initialSelectedIndex >= 0 && Subtitles.Count > 0)
             {
                 SelectAndScrollToRow(_initialSelectedIndex);
             }
@@ -1833,29 +1826,6 @@ public partial class BinaryEditViewModel : ObservableObject
             }
 
             SubtitleGrid.ScrollIntoView(SubtitleGrid.SelectedItem, null);
-        });
-    }
-
-    private void SelectAndScrollToRows(IList<int> indices)
-    {
-        if (indices.Count == 0 || SubtitleGrid == null)
-        {
-            return;
-        }
-
-        Dispatcher.UIThread.Post(() =>
-        {
-            SubtitleGrid.SelectedItems.Clear();
-            foreach (var i in indices.Where(i => i >= 0 && i < Subtitles.Count))
-            {
-                SubtitleGrid.SelectedItems.Add(Subtitles[i]);
-            }
-
-            var first = indices.Where(i => i >= 0 && i < Subtitles.Count).DefaultIfEmpty(-1).Min();
-            if (first >= 0)
-            {
-                SubtitleGrid.ScrollIntoView(Subtitles[first], null);
-            }
         });
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -63,7 +63,6 @@ public partial class BinaryEditViewModel : ObservableObject
     private readonly IBluRayHelper _bluRayHelper;
 
     private string _loadFileName = string.Empty;
-    private int _initialSelectedIndex = -1;
 
     public BinaryEditViewModel(IFileHelper fileHelper, IWindowService windowService, IFolderHelper folderHelper, IShortcutManager shortcutManager, IBluRayHelper bluRayHelper)
     {
@@ -78,10 +77,9 @@ public partial class BinaryEditViewModel : ObservableObject
         CurrentPositionAndSize = string.Empty;
     }
 
-    public void Initialize(string fileName, IOcrSubtitle? subtitle, int selectedIndex = -1)
+    public void Initialize(string fileName, IOcrSubtitle? subtitle)
     {
         _loadFileName = fileName;
-        _initialSelectedIndex = selectedIndex;
 
         if (subtitle != null && string.IsNullOrEmpty(fileName) && subtitle.Count > 0)
         {
@@ -99,14 +97,13 @@ public partial class BinaryEditViewModel : ObservableObject
         }
     }
 
-    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, int selectedIndex = -1)
+    public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems)
     {
         if (ocrSubtitleItems == null || ocrSubtitleItems.Count == 0)
         {
             return;
         }
 
-        _initialSelectedIndex = selectedIndex;
         var screenSize = ocrSubtitleItems[0].GetScreenSize();
         ScreenWidth = screenSize.Width;
         ScreenHeight = screenSize.Height;
@@ -1800,7 +1797,7 @@ public partial class BinaryEditViewModel : ObservableObject
         {
             if (Subtitles.Count > 0)
             {
-                SelectAndScrollToRow(Math.Max(0, _initialSelectedIndex));
+                SelectAndScrollToRow(0);
             }
             return;
         }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -398,6 +398,7 @@ public class BinaryEditWindow : Window
         menuItemInsertSubtitle.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertSubtitleVisible)));
 
         vm.SubtitleGrid = dataGrid;
+        dataGrid.SelectionChanged += vm.SubtitleGridSelectionChanged;
 
         var dataGridBorder = UiUtil.MakeBorderForControlNoPadding(dataGrid);
         dataGridBorder.Margin = new Thickness(0, 0, 0, 5);


### PR DESCRIPTION
  ## Summary
  
  - **OCR window**: adds a selection status indicator in the status bar showing the current position (`1/42`) or multi-selection count (`3 lines selected of 42`). Hidden while OCR is running.
  - **Binary Edit window**: migrates status text from the `OnSelectedSubtitleChanged` callback to a `SelectionChanged` event handler, enabling accurate multi-selection counts (`N lines selected of M`). Always opens at row 0 when launched from the OCR window.

 ## Screenshots

OCR window - Status line in the bottom left corner

<img width="1349" height="825" alt="Status - OCR" src="https://github.com/user-attachments/assets/2260a955-d778-4f53-9ff8-c76bcba79b7a" />

OCR window - Status line hidden while OCR in progress

<img width="1349" height="825" alt="Status - OCR - Hidden" src="https://github.com/user-attachments/assets/27de8c23-1cd1-4d1d-b80a-554b256b3cbd" />

Edit window - Status line in the bottom left corner

<img width="1312" height="840" alt="Status - Edit" src="https://github.com/user-attachments/assets/ce8b24a6-4d83-4d7a-bb55-e86ce03e5713" />
