### PR TITLE
Fix wrong language tags in three auto-translate engines

### DIFF
--- a/src/libse/AutoTranslate/BaiduTranslate.cs
+++ b/src/libse/AutoTranslate/BaiduTranslate.cs
@@ -181,6 +181,18 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                     return "vie";
                 case "id":
                     return "id";
+                case "da":
+                    return "dan";
+                case "fi":
+                    return "fin";
+                case "sv":
+                    return "swe";
+                case "ro":
+                    return "rom";
+                case "et":
+                    return "est";
+                case "sl":
+                    return "slo";
                 default:
                     return code;
             }

--- a/src/libse/AutoTranslate/MyMemoryApi.cs
+++ b/src/libse/AutoTranslate/MyMemoryApi.cs
@@ -200,7 +200,10 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
 
         private static TranslationPair MakeLanguage(string code, string name)
         {
-            var twoLetterIsoName = code.Remove(0, code.Length - 2).ToLowerInvariant();
+            // The code is an RFC3066 locale ("af-ZA"), so the language tag is the
+            // part before the dash. Taking the last two chars instead would yield
+            // the country (e.g. "rm-RO" -> "ro" = Romanian, "ja-JP" -> "jp").
+            var twoLetterIsoName = code.Split('-')[0].ToLowerInvariant();
             return new TranslationPair(name, code, twoLetterIsoName);
         }
 

--- a/src/libse/AutoTranslate/SeamlessM4TTranslate.cs
+++ b/src/libse/AutoTranslate/SeamlessM4TTranslate.cs
@@ -108,7 +108,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 "nl",
                 "pl",
                 "pt",
-                "ru",
+                "ro",
                 "ru",
                 "sk",
                 "sv",


### PR DESCRIPTION
## Summary

Bug hunt for incorrect language tags in the auto-translate engines (`src/libse/AutoTranslate/`). Three distinct bugs found and fixed.

## 1. MyMemory — two-letter language tag was the *country* code

`MyMemoryApi.cs` — `MakeLanguage` built `TwoLetterIsoLanguageName` from the **last** two chars of the RFC3066 locale (the country), not the language:

- `MakeLanguage("rm-RO", "Balkan Gipsy")` → `"ro"` — literally **Romanian**''s code (collides with the real `ro-RO` entry)
- CJK all broke: `zh-CN`→`"cn"`, `ja-JP`→`"jp"`, `ko-KR`→`"kr"`

That field drives source/target pre-selection (`BatchConvertViewModel`), `GoogleTranslateLast*Language` persistence, and CJK-aware line splitting (`MergeAndSplitHelper`/`TextSplit`). Fixed by taking the part before the dash.

## 2. Baidu — standard ISO codes sent instead of Baidu''s codes for 6 languages

`BaiduTranslate.cs` — `ConvertLanguageCode` (called for every translation) mapped the quirky codes but fell through to `default: return code` for several languages it advertises, so the wrong tag was sent to the API:

| Language | was sent | Baidu expects |
|---|---|---|
| Danish | `da` | `dan` |
| Finnish | `fi` | `fin` |
| Swedish | `sv` | `swe` |
| Romanian | `ro` | `rom` |
| Estonian | `et` | `est` |
| Slovenian | `sl` | `slo` |

Those six languages failed to translate. Added the missing `case`s.

## 3. SeamlessM4T — duplicated `"ru"`, Romanian missing

`SeamlessM4TTranslate.cs` — `"ru"` was listed twice. The list is strictly alphabetical (`...pt, ru, ru, sk...`); the first slot between `pt` and `ru` was meant for Romanian (`"ro"`), which was absent. Restored `"ro"`.

## Testing

`dotnet build src/libse/libse.csproj` — clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)