### PR TITLE
Fix Change All not replacing current item in BinaryImageCompare OCR mode

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3112,6 +3112,7 @@ public partial class OcrViewModel : ObservableObject
                         }
                         else if (result.ChangeAllPressed)
                         {
+                            ChangeWord(item, unknownWord, result.Word);
                             _ocrFixEngine.ChangeAll(unknownWord.Word.Word, result.Word);
                         }
                         else if (result.SkipOncePressed)


### PR DESCRIPTION
  When "Prompt for unknown words" is enabled during OCR, clicking **Change All** in the spell check dialog was silently skipping the current subtitle item in the BinaryImageCompare engine. The replacement was registered for future items (so subsequent occurrences were auto-fixed), but the item that triggered the prompt was left unchanged. 
  
  This meant that if a word appeared only once, **Change All** appeared to do nothing at all.
  
  The other two OCR paths (nOCR/BinaryOCR and Tesseract) both call `ChangeWord` on the current item before registering the replacement — the BinaryImageCompare path was missing that call.
  
  **Fix:** add the missing `ChangeWord` call in the `BinaryImageCompareOcr` `ChangeAllPressed` branch of `OcrViewModel.cs`.