### PR TITLE
Tweak shift-click/shift+arrow range selection across all grids and fix various bugs

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17158,6 +17158,9 @@ public partial class MainViewModel :
             _subtitleGridIsLeftClick = props.IsLeftButtonPressed;
             _subtitleGridIsRightClick = props.IsRightButtonPressed;
             _subtitleGridIsControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
+            // On macOS, Cmd (Meta) is the multi-select modifier; Ctrl triggers the context menu instead
+            var isMultiSelectModifier = _subtitleGridIsControlPressed
+                || (OperatingSystem.IsMacOS() && e.KeyModifiers.HasFlag(KeyModifiers.Meta));
 
             var hitTest = SubtitleGrid.InputHitTest(e.GetPosition(SubtitleGrid));
             var current = hitTest as Control;
@@ -17215,18 +17218,18 @@ public partial class MainViewModel :
                     return;
                 }
             }
-            else if (!_subtitleGridIsControlPressed || rowIndex < 0)
+            else if (!isMultiSelectModifier || rowIndex < 0)
             {
                 _shiftSelectAnchorIndex = -1;
                 _shiftSelectCurrentIndex = -1;
             }
             else if (_shiftSelectAnchorIndex >= 0)
             {
-                // Ctrl+click on a row: preserve the existing anchor, suppress SelectionChanged reset
+                // Ctrl/Cmd+click on a row: preserve the existing anchor, suppress SelectionChanged reset
                 _mouseClickSetAnchor = true;
             }
 
-            if (_subtitleGridIsLeftClick && !_subtitleGridIsControlPressed && rowIndex >= 0)
+            if (_subtitleGridIsLeftClick && !isMultiSelectModifier && rowIndex >= 0)
             {
                 _shiftSelectAnchorIndex = rowIndex;
                 _shiftSelectCurrentIndex = rowIndex;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17132,6 +17132,7 @@ public partial class MainViewModel :
     private int _dragSelectLastIndex = -1;
     private int _shiftSelectAnchorIndex = -1;
     private int _shiftSelectCurrentIndex = -1;
+    private bool _mouseClickSetAnchor;
     private int _dragSelectAutoScrollDirection;
     private int _dragSelectAutoScrollStep = 1;
     private bool _dragSelectHasMoved;
@@ -17149,8 +17150,6 @@ public partial class MainViewModel :
         _dragSelectStartIndex = -1;
         _dragSelectLastIndex = -1;
         _dragSelectHasMoved = false;
-        _shiftSelectAnchorIndex = -1;
-        _shiftSelectCurrentIndex = -1;
         IsSubtitleGridFlyoutHeaderVisible = false;
 
         if (sender is Control { ContextFlyout: not null } control)
@@ -17168,20 +17167,57 @@ public partial class MainViewModel :
                 {
                     IsSubtitleGridFlyoutHeaderVisible = true;
                     IsMergeWithNextOrPreviousVisible = false;
+                    _shiftSelectAnchorIndex = -1;
+                    _shiftSelectCurrentIndex = -1;
                     return;
                 }
 
                 current = current.Parent as Control;
             }
 
-            if (_subtitleGridIsLeftClick && !_subtitleGridIsControlPressed)
+            var isShiftPressed = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+            var rowIndex = GetDataGridRowIndexFromPoint(e.GetPosition(SubtitleGrid));
+
+            if (_subtitleGridIsLeftClick && isShiftPressed && rowIndex >= 0)
             {
-                var rowIndex = GetDataGridRowIndexFromPoint(e.GetPosition(SubtitleGrid));
-                if (rowIndex >= 0)
+                var anchor = _shiftSelectAnchorIndex >= 0
+                    ? _shiftSelectAnchorIndex
+                    : (SubtitleGrid.SelectedItem is SubtitleLineViewModel sel
+                        ? Subtitles.IndexOf(sel) : -1);
+
+                if (anchor >= 0)
                 {
-                    _dragSelectStartIndex = rowIndex;
-                    _dragSelectLastIndex = rowIndex;
+                    _shiftSelectAnchorIndex = anchor;
+                    _shiftSelectCurrentIndex = rowIndex;
+
+                    var startIdx = Math.Min(anchor, rowIndex);
+                    var endIdx = Math.Max(anchor, rowIndex);
+
+                    _subtitleGridSelectionChangedSkip = true;
+                    SubtitleGrid.SelectedItems.Clear();
+                    for (var i = startIdx; i <= endIdx; i++)
+                        SubtitleGrid.SelectedItems.Add(Subtitles[i]);
+                    _subtitleGridSelectionChangedSkip = false;
+
+                    SubtitleGrid.ScrollIntoView(Subtitles[rowIndex], null);
+                    SubtitleGridSelectionChanged();
+                    e.Handled = true;
+                    return;
                 }
+            }
+            else
+            {
+                _shiftSelectAnchorIndex = -1;
+                _shiftSelectCurrentIndex = -1;
+            }
+
+            if (_subtitleGridIsLeftClick && !_subtitleGridIsControlPressed && rowIndex >= 0)
+            {
+                _shiftSelectAnchorIndex = rowIndex;
+                _shiftSelectCurrentIndex = rowIndex;
+                _mouseClickSetAnchor = true;
+                _dragSelectStartIndex = rowIndex;
+                _dragSelectLastIndex = rowIndex;
             }
         }
     }
@@ -17482,14 +17518,20 @@ public partial class MainViewModel :
             return;
         }
 
-        // Any user-driven selection change that isn't our own shift-arrow manipulation
-        // (HandleShiftArrowSelection sets _subtitleGridSelectionChangedSkip and short-circuits
-        // above) obsoletes the shift-select anchor. Plain Up/Down already clear it in the
-        // key handler, but PageUp/PageDown, mouse clicks, Home/End, programmatic jumps,
-        // etc. all land here and must reset the anchor so the next Shift+Down starts from
-        // the current row instead of resuming an old range.
-        _shiftSelectAnchorIndex = -1;
-        _shiftSelectCurrentIndex = -1;
+        // Any user-driven selection change that isn't our own shift-arrow or shift-click
+        // manipulation obsoletes the shift-select anchor. Plain Up/Down already clear it in
+        // the key handler, but PageUp/PageDown, Home/End, programmatic jumps, etc. all land
+        // here and must reset it. Exception: a plain mouse click sets _mouseClickSetAnchor so
+        // we preserve the anchor through the DataGrid's own SelectionChanged for that click.
+        if (_mouseClickSetAnchor)
+        {
+            _mouseClickSetAnchor = false;
+        }
+        else
+        {
+            _shiftSelectAnchorIndex = -1;
+            _shiftSelectCurrentIndex = -1;
+        }
 
         var selectedItems = SubtitleGrid.SelectedItems;
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17223,7 +17223,7 @@ public partial class MainViewModel :
                 _shiftSelectAnchorIndex = -1;
                 _shiftSelectCurrentIndex = -1;
             }
-            else if (_shiftSelectAnchorIndex >= 0)
+            else if (_subtitleGridIsLeftClick && _shiftSelectAnchorIndex >= 0)
             {
                 // Ctrl/Cmd+click on a row: preserve the existing anchor, suppress SelectionChanged reset
                 _mouseClickSetAnchor = true;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17194,10 +17194,20 @@ public partial class MainViewModel :
                     var endIdx = Math.Max(anchor, rowIndex);
 
                     _subtitleGridSelectionChangedSkip = true;
-                    SubtitleGrid.SelectedItems.Clear();
-                    for (var i = startIdx; i <= endIdx; i++)
-                        SubtitleGrid.SelectedItems.Add(Subtitles[i]);
-                    _subtitleGridSelectionChangedSkip = false;
+                    try
+                    {
+                        SubtitleGrid.SelectedItems.Clear();
+                        SubtitleGrid.SelectedItems.Add(Subtitles[rowIndex]);
+                        for (var i = startIdx; i <= endIdx; i++)
+                        {
+                            if (i != rowIndex)
+                                SubtitleGrid.SelectedItems.Add(Subtitles[i]);
+                        }
+                    }
+                    finally
+                    {
+                        _subtitleGridSelectionChangedSkip = false;
+                    }
 
                     SubtitleGrid.ScrollIntoView(Subtitles[rowIndex], null);
                     SubtitleGridSelectionChanged();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17215,10 +17215,15 @@ public partial class MainViewModel :
                     return;
                 }
             }
-            else
+            else if (!_subtitleGridIsControlPressed || rowIndex < 0)
             {
                 _shiftSelectAnchorIndex = -1;
                 _shiftSelectCurrentIndex = -1;
+            }
+            else if (_shiftSelectAnchorIndex >= 0)
+            {
+                // Ctrl+click on a row: preserve the existing anchor, suppress SelectionChanged reset
+                _mouseClickSetAnchor = true;
             }
 
             if (_subtitleGridIsLeftClick && !_subtitleGridIsControlPressed && rowIndex >= 0)

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -459,16 +459,6 @@ public class OcrWindow : Window
         };
         dataGridSubtitle.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedOcrSubtitleItem)) { Source = vm });
         dataGridSubtitle.KeyDown += vm.SubtitleGridKeyDown;
-        dataGridSubtitle.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key is Key.Home or Key.End && !e.KeyModifiers.HasFlag(KeyModifiers.Shift) && dataGridSubtitle.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGridSubtitle.SelectedItem = target;
-                dataGridSubtitle.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         dataGridSubtitle.DoubleTapped += (s, e) => vm.SubtitleGridDoubleTapped();
         dataGridSubtitle.AddHandler(InputElement.PointerPressedEvent, vm.DataGridSubtitleMacPointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         dataGridSubtitle.AddHandler(InputElement.PointerReleasedEvent, vm.DataGridSubtitleMacPointerReleased, Avalonia.Interactivity.RoutingStrategies.Tunnel);

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -461,7 +461,7 @@ public class OcrWindow : Window
         dataGridSubtitle.KeyDown += vm.SubtitleGridKeyDown;
         dataGridSubtitle.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key is Key.Home or Key.End && dataGridSubtitle.ItemsSource is IList items && items.Count > 0)
+            if (e.Key is Key.Home or Key.End && !e.KeyModifiers.HasFlag(KeyModifiers.Shift) && dataGridSubtitle.ItemsSource is IList items && items.Count > 0)
             {
                 var target = e.Key == Key.Home ? items[0] : items[^1];
                 dataGridSubtitle.SelectedItem = target;
@@ -474,6 +474,7 @@ public class OcrWindow : Window
         dataGridSubtitle.AddHandler(InputElement.PointerReleasedEvent, vm.DataGridSubtitleMacPointerReleased, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         dataGridSubtitle.SelectionChanged += vm.SubtitleGridSelectionChanged;
         vm.SubtitleGrid = dataGridSubtitle;
+        new DataGridCheckboxMultiSelect<OcrSubtitleItem>(dataGridSubtitle);
 
         // Create a Flyout for the DataGrid
         var flyout = new MenuFlyout();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -399,6 +399,10 @@ public class BinaryEditWindow : Window
 
         vm.SubtitleGrid = dataGrid;
         dataGrid.SelectionChanged += vm.SubtitleGridSelectionChanged;
+        new DataGridCheckboxMultiSelect<BinarySubtitleItem>(
+            dataGrid,
+            item => item.IsForced,
+            (item, v) => item.IsForced = v);
 
         var dataGridBorder = UiUtil.MakeBorderForControlNoPadding(dataGrid);
         dataGridBorder.Margin = new Thickness(0, 0, 0, 5);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -422,7 +422,8 @@ public class BinaryEditWindow : Window
                     Child = new CheckBox
                     {
                         [!ToggleButton.IsCheckedProperty] = new Binding(nameof(BinarySubtitleItem.IsForced)),
-                        HorizontalAlignment = HorizontalAlignment.Center
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Focusable = false
                     }
                 }),
         });

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -143,7 +143,6 @@ public class BatchConvertWindow : Window
         var dataGrid = new DataGrid
         {
             AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Extended,
             CanUserResizeColumns = true,
             CanUserSortColumns = true,
             HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -190,16 +189,7 @@ public class BatchConvertWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchItem)) { Source = vm });
         vm.FileGrid = dataGrid;
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
-        {
-            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
-            {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
-                e.Handled = true;
-            }
-        }, RoutingStrategies.Tunnel);
+        new DataGridCheckboxMultiSelect<BatchConvertItem>(dataGrid, onFocusedItemChanged: item => vm.SelectedBatchItem = item);
 
         var comboBoxSubtitleFormat = UiUtil.MakeComboBox(vm.TargetFormats, vm, nameof(vm.SelectedTargetFormat));
         comboBoxSubtitleFormat.SelectionChanged += (_, _) => vm.ComboBoxSubtitleFormatChanged();

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -189,7 +189,7 @@ public class BatchConvertWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchItem)) { Source = vm });
         vm.FileGrid = dataGrid;
-        new DataGridCheckboxMultiSelect<BatchConvertItem>(dataGrid, onFocusedItemChanged: item => vm.SelectedBatchItem = item);
+        new DataGridCheckboxMultiSelect<BatchConvertItem>(dataGrid);
 
         var comboBoxSubtitleFormat = UiUtil.MakeComboBox(vm.TargetFormats, vm, nameof(vm.SelectedTargetFormat));
         comboBoxSubtitleFormat.SelectionChanged += (_, _) => vm.ComboBoxSubtitleFormatChanged();

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -65,7 +65,14 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
         };
     }
 
-    private IList? GetItems() => _grid.ItemsSource as IList;
+    private IList? GetItems()
+    {
+        // CollectionView returns items in the grid's current display order (respecting sort/filter),
+        // unlike ItemsSource which is always in the original insertion order.
+        if (_grid.CollectionView is IList sortedList)
+            return sortedList;
+        return _grid.ItemsSource as IList;
+    }
 
     private int GetRowIndexFromPoint(Avalonia.Point position)
     {

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -109,20 +109,26 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             var endIdx = Math.Max(anchor, rowIndex);
 
             _selectionChangedSkip = true;
-            _grid.SelectedItems.Clear();
-            _grid.SelectedItems.Add(items[_shiftCurrentIndex]);
-            for (var i = startIdx; i <= endIdx; i++)
+            try
             {
-                if (i != _shiftCurrentIndex)
-                    _grid.SelectedItems.Add(items[i]);
+                _grid.SelectedItems.Clear();
+                _grid.SelectedItems.Add(items[_shiftCurrentIndex]);
+                for (var i = startIdx; i <= endIdx; i++)
+                {
+                    if (i != _shiftCurrentIndex)
+                        _grid.SelectedItems.Add(items[i]);
+                }
             }
-            _selectionChangedSkip = false;
+            finally
+            {
+                _selectionChangedSkip = false;
+            }
 
             _grid.ScrollIntoView(items[rowIndex], null);
             _onFocusedItemChanged?.Invoke(items[rowIndex] as TItem);
             e.Handled = true;
         }
-        else if (!isShift && rowIndex >= 0)
+        else if (!isShift && !e.KeyModifiers.HasFlag(KeyModifiers.Control) && rowIndex >= 0)
         {
             _shiftAnchorIndex = rowIndex;
             _shiftCurrentIndex = rowIndex;

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -20,6 +20,7 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
     private int _shiftAnchorIndex = -1;
     private int _shiftCurrentIndex = -1;
     private bool _selectionChangedSkip;
+    private bool _mouseClickSetAnchor;
 
     // The caller does not need to store the returned instance.
     // Event subscriptions on dataGrid keep it alive for the lifetime of the grid.
@@ -39,6 +40,7 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
         dataGrid.SelectionMode = DataGridSelectionMode.Extended;
 
         dataGrid.AddHandler(InputElement.KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel);
+        dataGrid.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
         dataGrid.PointerReleased += (_, _) => Dispatcher.UIThread.Post(() => dataGrid.Focus());
 
         dataGrid.SelectionChanged += (_, e) =>
@@ -48,14 +50,89 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
                 return;
             }
 
-            _shiftAnchorIndex = -1;
-            _shiftCurrentIndex = -1;
+            if (_mouseClickSetAnchor)
+            {
+                _mouseClickSetAnchor = false;
+            }
+            else
+            {
+                _shiftAnchorIndex = -1;
+                _shiftCurrentIndex = -1;
+            }
 
             _onFocusedItemChanged?.Invoke(dataGrid.SelectedItem as TItem);
         };
     }
 
     private IList? GetItems() => _grid.ItemsSource as IList;
+
+    private int GetRowIndexFromPoint(Avalonia.Point position)
+    {
+        var hitTest = _grid.InputHitTest(position);
+        var current = hitTest as Control;
+        while (current != null)
+        {
+            if (current is DataGridRow row)
+                return row.Index;
+            current = current.Parent as Control;
+        }
+        return -1;
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var props = e.GetCurrentPoint(_grid).Properties;
+        if (!props.IsLeftButtonPressed)
+            return;
+
+        var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        var rowIndex = GetRowIndexFromPoint(e.GetPosition(_grid));
+
+        if (isShift && rowIndex >= 0)
+        {
+            var items = GetItems();
+            if (items == null)
+                return;
+
+            var anchor = _shiftAnchorIndex >= 0
+                ? _shiftAnchorIndex
+                : (_grid.SelectedItem != null ? items.IndexOf(_grid.SelectedItem) : -1);
+
+            if (anchor < 0)
+                return;
+
+            _shiftAnchorIndex = anchor;
+            _shiftCurrentIndex = rowIndex;
+
+            var startIdx = Math.Min(anchor, rowIndex);
+            var endIdx = Math.Max(anchor, rowIndex);
+
+            _selectionChangedSkip = true;
+            _grid.SelectedItems.Clear();
+            _grid.SelectedItems.Add(items[_shiftCurrentIndex]);
+            for (var i = startIdx; i <= endIdx; i++)
+            {
+                if (i != _shiftCurrentIndex)
+                    _grid.SelectedItems.Add(items[i]);
+            }
+            _selectionChangedSkip = false;
+
+            _grid.ScrollIntoView(items[rowIndex], null);
+            _onFocusedItemChanged?.Invoke(items[rowIndex] as TItem);
+            e.Handled = true;
+        }
+        else if (!isShift && rowIndex >= 0)
+        {
+            _shiftAnchorIndex = rowIndex;
+            _shiftCurrentIndex = rowIndex;
+            _mouseClickSetAnchor = true;
+        }
+        else if (!isShift)
+        {
+            _shiftAnchorIndex = -1;
+            _shiftCurrentIndex = -1;
+        }
+    }
 
     private void OnKeyDown(object? sender, KeyEventArgs e)
     {

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -134,6 +134,11 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             _shiftCurrentIndex = rowIndex;
             _mouseClickSetAnchor = true;
         }
+        else if (!isShift && e.KeyModifiers.HasFlag(KeyModifiers.Control) && _shiftAnchorIndex >= 0)
+        {
+            // Ctrl+click on a row: preserve the existing anchor, suppress SelectionChanged reset
+            _mouseClickSetAnchor = true;
+        }
         else if (!isShift)
         {
             _shiftAnchorIndex = -1;

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -13,8 +13,8 @@ namespace Nikse.SubtitleEdit.Logic;
 public class DataGridCheckboxMultiSelect<TItem> where TItem : class
 {
     private readonly DataGrid _grid;
-    private readonly Func<TItem, bool> _getChecked;
-    private readonly Action<TItem, bool> _setChecked;
+    private readonly Func<TItem, bool>? _getChecked;
+    private readonly Action<TItem, bool>? _setChecked;
     private readonly Func<TItem, bool>? _canToggle;
     private readonly Action<TItem?>? _onFocusedItemChanged;
     private int _shiftAnchorIndex = -1;
@@ -24,10 +24,11 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
 
     // The caller does not need to store the returned instance.
     // Event subscriptions on dataGrid keep it alive for the lifetime of the grid.
+    // Pass getChecked/setChecked as null for non-checkbox grids (shift-select only, Space key is a no-op).
     public DataGridCheckboxMultiSelect(
         DataGrid dataGrid,
-        Func<TItem, bool> getChecked,
-        Action<TItem, bool> setChecked,
+        Func<TItem, bool>? getChecked = null,
+        Action<TItem, bool>? setChecked = null,
         Func<TItem, bool>? canToggle = null,
         Action<TItem?>? onFocusedItemChanged = null)
     {
@@ -243,6 +244,9 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
 
     private void ToggleCheckboxForSelectedRows()
     {
+        if (_getChecked == null || _setChecked == null)
+            return;
+
         var selected = _grid.SelectedItems.OfType<TItem>().ToList();
         if (selected.Count == 0)
         {

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -94,6 +94,9 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             return;
 
         var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        // On macOS, Cmd (Meta) is the multi-select modifier
+        var isCtrl = e.KeyModifiers.HasFlag(KeyModifiers.Control)
+            || (OperatingSystem.IsMacOS() && e.KeyModifiers.HasFlag(KeyModifiers.Meta));
         var rowIndex = GetRowIndexFromPoint(e.GetPosition(_grid));
 
         if (isShift && rowIndex >= 0)
@@ -135,15 +138,15 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             _onFocusedItemChanged?.Invoke(items[rowIndex] as TItem);
             e.Handled = true;
         }
-        else if (!isShift && !e.KeyModifiers.HasFlag(KeyModifiers.Control) && rowIndex >= 0)
+        else if (!isShift && !isCtrl && rowIndex >= 0)
         {
             _shiftAnchorIndex = rowIndex;
             _shiftCurrentIndex = rowIndex;
             _mouseClickSetAnchor = true;
         }
-        else if (!isShift && e.KeyModifiers.HasFlag(KeyModifiers.Control) && _shiftAnchorIndex >= 0)
+        else if (!isShift && isCtrl && _shiftAnchorIndex >= 0)
         {
-            // Ctrl+click on a row: preserve the existing anchor, suppress SelectionChanged reset
+            // Ctrl/Cmd+click on a row: preserve the existing anchor, suppress SelectionChanged reset
             _mouseClickSetAnchor = true;
         }
         else if (!isShift)

--- a/src/ui/Logic/DataGridCheckboxMultiSelect.cs
+++ b/src/ui/Logic/DataGridCheckboxMultiSelect.cs
@@ -144,7 +144,7 @@ public class DataGridCheckboxMultiSelect<TItem> where TItem : class
             _shiftCurrentIndex = rowIndex;
             _mouseClickSetAnchor = true;
         }
-        else if (!isShift && isCtrl && _shiftAnchorIndex >= 0)
+        else if (!isShift && isCtrl && rowIndex >= 0 && _shiftAnchorIndex >= 0)
         {
             // Ctrl/Cmd+click on a row: preserve the existing anchor, suppress SelectionChanged reset
             _mouseClickSetAnchor = true;


### PR DESCRIPTION
This PR is a continuation of #11335 and #11394 aiming to bring consistent keyboard and mouse handling to data grids. With these three PRs combined, we have correct single and multi-select behavior, both for mouse and keyboard for the data grids that are wired up (there are 10+ grids not yet wired up - will come in a future PR). The grid selection/navigation logic has been slowly moving into a single place in these PRs, to reduce duplication and guarantee consistency.

Some fairly exotic cases have also been tweaked in this particular PR, like shift-click selection (including gaps in the selected range by cmd(ctrl)-clicking in the range somewhere).

Several related bugs have also been fixed (multi-select in sorted grids etc. - see below), partly as a side effect of wiring up the correct behavior rather than fixing bugs grid by grid.

The major data grid surgery is coming to an end, and we add mostly tweaks and wiring moving forward.

  #### Details
 This branch fixes a cluster of related bugs in multi-selection behavior across the subtitle grid (main window), OCR window, Binary Edit window, and Batch Convert window.

  #### What was wrong/tweaked

  - Shift-click didn't track a stable anchor. Clicking a row, Ctrl/Cmd+clicking another, then Shift+clicking a third would extend from the wrong row — or reset to row 0.
  - The anchor leaked through right-click and empty-space Ctrl+click. A right-click (to open the context menu) silently cleared the anchor at the wrong moment; an empty-space Ctrl+click also corrupted anchor state.
  - Sort order was ignored. GetItems() returned ItemsSource (insertion order), so a shift-click range after sorting by a column would select the wrong rows.
  - macOS Cmd+click didn't work as multi-select. On macOS, Ctrl triggers the context menu rather than multi-select; the code wasn't treating Cmd (Meta) as the multi-select modifier.
  - Space key double-toggled checkboxes in Binary Edit. The focusable checkbox inside the cell consumed the Space keydown natively on top of the grid's own handler, toggling the value twice.
  - Shift+Home/End and shift-select were missing in OCR and Batch Convert. Those windows had ad-hoc, incomplete key handlers instead of the shared infrastructure.

  #### What changed

  DataGridCheckboxMultiSelect<T> (Logic/DataGridCheckboxMultiSelect.cs):
  - Added a PointerPressedEvent (tunnel) handler that owns shift-click range selection: computes the anchor→target range, populates SelectedItems directly, and marks e.Handled so the DataGrid doesn't clobber the selection.
  - Introduced a _mouseClickSetAnchor flag to let a plain or Ctrl/Cmd left-click set/preserve the anchor through the DataGrid's own subsequent SelectionChanged without resetting it.
  - Fixed GetItems() to prefer CollectionView over ItemsSource, so range selection respects the current sort order.
  - Made getChecked/setChecked optional (default null) so the class can be attached to non-checkbox grids for shift-select-only behavior.
  
  MainViewModel (main subtitle grid, Features/Main/MainViewModel.cs):
  - Ported the same anchor/shift-click logic and _mouseClickSetAnchor flag.
  - Recognizes Cmd (Meta) as the multi-select modifier on macOS, alongside Ctrl on other platforms.
  - Moved the anchor reset into the right-click / empty-space branch so it only fires when the context menu opens or a click lands outside a row, not on every drag-select reset.

  OCR window (Features/Ocr/OcrWindow.cs):
  - Replaced the ad-hoc Home/End key handler with new DataGridCheckboxMultiSelect<OcrSubtitleItem>(dataGrid), giving the grid full shift-select, Shift+arrow, and Shift+Home/End support.
  
  Batch Convert window (Features/Tools/BatchConvert/BatchConvertWindow.cs):
  - Same as OCR: removed the partial Home/End handler, attached DataGridCheckboxMultiSelect<BatchConvertItem> (which also sets SelectionMode = Extended, so the explicit assignment was removed).

  Binary Edit window (Features/Shared/BinaryEdit/BinaryEditWindow.cs):
  - Attached DataGridCheckboxMultiSelect<BinarySubtitleItem> with the existing getter/setter.
  - Set Focusable = false on the inline CheckBox control so Space goes to the grid handler only, eliminating the double-toggle.