### PR TITLE
Fix #11426: Auto-publish SeConv assets for every release

### DIFF
--- a/.github/workflows/build-seconv.yml
+++ b/.github/workflows/build-seconv.yml
@@ -27,6 +27,25 @@ on:
         default: ''
         type: string
 
+  workflow_call:
+    inputs:
+      build_configuration:
+        required: true
+        default: 'Release'
+        type: string
+      create_release:
+        required: true
+        default: true
+        type: boolean
+      is_prerelease:
+        required: true
+        default: true
+        type: boolean
+      release_tag:
+        required: false
+        default: ''
+        type: string
+
 jobs:
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -671,6 +671,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_tag: ${{ steps.tag.outputs.tag }}
     
     steps:
       - uses: actions/checkout@v5
@@ -753,3 +755,13 @@ jobs:
             ./release-assets/SubtitleEdit-Linux-x64.tar.gz
             ./release-assets/SubtitleEdit-Linux-ARM64.tar.gz
             ./release-assets/SubtitleEdit-linux-x64.flatpak
+
+  call-seconv:
+    needs: [create-release]
+    uses: ./.github/workflows/build-seconv.yml
+    with:
+      build_configuration: ${{ inputs.build_configuration }}
+      create_release: true
+      is_prerelease: ${{ inputs.is_prerelease }}
+      release_tag: ${{ needs.create-release.outputs.release_tag }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds a `workflow_call` trigger to `build-seconv.yml` so it can be invoked by other workflows
- Exposes the generated release tag as a job output from `create-release` in `build-ui.yml`
- Adds a `call-seconv` job in `build-ui.yml` that runs automatically after `create-release`, passing through the same tag, build configuration, and pre-release flag

## Result
Triggering `build-ui.yml` once now builds and publishes both `SubtitleEdit-*` and `SeConv-*` assets under the same release tag — no need to manually run `build-seconv.yml` separately. The standalone `SeConv` binaries will be consistently present for every release going forward.

Fixes #11426

🤖 Generated with [Claude Code](https://claude.com/claude-code)