### PR TITLE
Also ignore Ctrl+Left/Right in text input for word-jump navigation (#11357)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16923,11 +16923,12 @@ public partial class MainViewModel :
 
             if (IsTextInputFocused())
             {
-                // Bare Left/Right are fundamental caret navigation in any text
-                // input — never override them with shortcuts even when
+                // Bare and Ctrl+Left/Right are fundamental caret navigation in any
+                // text input — never override them with shortcuts even when
                 // "allow single-letter shortcuts in text box" is on (#11357).
                 if ((keyEventArgs.Key == Key.Left || keyEventArgs.Key == Key.Right)
-                    && keyEventArgs.KeyModifiers == KeyModifiers.None)
+                    && (keyEventArgs.KeyModifiers == KeyModifiers.None
+                        || keyEventArgs.KeyModifiers == KeyModifiers.Control))
                 {
                     return;
                 }


### PR DESCRIPTION
## Summary
Follow-up to #11403 / #11357.

PR #11403 bailed on bare Left/Right inside a focused text input so caret navigation was no longer overridden by shortcuts. The reporter noted in [this comment](https://github.com/SubtitleEdit/subtitleedit/issues/11357#issuecomment-4633186581) that **Ctrl+Left/Right** (word-jump) still fires shortcuts instead of moving the caret one word.

## Change
Extend the existing guard in `MainViewModel.OnKeyDownHandler` to also return early when `KeyModifiers.Control` is the only modifier:

```csharp
if ((keyEventArgs.Key == Key.Left || keyEventArgs.Key == Key.Right)
    && (keyEventArgs.KeyModifiers == KeyModifiers.None
        || keyEventArgs.KeyModifiers == KeyModifiers.Control))
{
    return;
}
```

Ctrl+Shift+Left/Right (extend selection by word) is unaffected — those still go through normal shortcut resolution. Only the pure Ctrl+Left/Right combination is protected.

## Test plan
- [ ] Bind Ctrl+Left to a video shortcut. Click into the subtitle text box, press Ctrl+Left. Confirm the caret jumps back one word and the video shortcut does **not** fire.
- [ ] Same for Ctrl+Right.
- [ ] Ctrl+Shift+Left/Right still extends the selection (or fires a bound shortcut), unchanged.
- [ ] Bare Left/Right still work as before (from #11403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)