### PR TITLE
Use System.Threading.Lock for UI lock objects

### DIFF
--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -45,7 +45,7 @@ public partial class ImportPlainTextViewModel : ObservableObject
     private static readonly List<string> TextFilePatterns = TextFileExtensions.Select(e => "*" + e).ToList();
     private bool _dirty;
     private TaskCompletionSource? _previewFlushed;
-    private readonly object _previewFlushLock = new();
+    private readonly System.Threading.Lock _previewFlushLock = new();
     private readonly System.Timers.Timer _timerUpdatePreview;
 
     public ImportPlainTextViewModel(IFileHelper fileHelper, IWindowService windowService)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -335,7 +335,7 @@ public partial class MainViewModel :
     private PlaySelectionItem? _playSelectionItem;
     private int _pendingScrollIndex = -1;
     private SubtitleLineViewModel? _pendingScrollSubtitle = null;
-    private readonly object _scrollLock = new object();
+    private readonly Lock _scrollLock = new();
     private bool _changingFormatProgrammatically;
     private bool _formatChangedByUser;
     private SubtitleFormat? _formatChangedFrom;

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -173,7 +173,7 @@ public partial class OcrViewModel : ObservableObject
     private readonly NOcrAddHistoryManager _nOcrAddHistoryManager;
     private readonly BinaryOcrAddHistoryManager _binaryOcrAddHistoryManager;
     private int _pendingScrollIndex = -1;
-    private readonly object _scrollLock = new object();
+    private readonly Lock _scrollLock = new();
 
     public OcrViewModel(
         INOcrCaseFixer nOcrCaseFixer,

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ChangeCasing;
 
@@ -39,7 +40,7 @@ public partial class FixNamesViewModel : ObservableObject
     private string _oldNames;
     private readonly System.Timers.Timer _previewTimer;
     private bool _loading;
-    private readonly object _lock = new object();
+    private readonly Lock _lock = new();
 
     public FixNamesViewModel()
     {

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrVersion.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrVersion.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
@@ -25,7 +26,7 @@ public static class CrispAsrVersion
 {
     // Path -> (mtime, version). Cache invalidates when the binary on disk changes
     // (re-download / update) so we don't show a stale version after an update.
-    private static readonly object _cacheLock = new();
+    private static readonly Lock CacheLock = new();
     private static string? _cachedExePath;
     private static DateTime _cachedExeMtimeUtc;
     private static string? _cachedVersion;
@@ -59,7 +60,7 @@ public static class CrispAsrVersion
             return null;
         }
 
-        lock (_cacheLock)
+        lock (CacheLock)
         {
             if (_cachedExePath == exePath && _cachedExeMtimeUtc == mtime)
             {
@@ -69,7 +70,7 @@ public static class CrispAsrVersion
 
         var version = Probe(exePath);
 
-        lock (_cacheLock)
+        lock (CacheLock)
         {
             _cachedExePath = exePath;
             _cachedExeMtimeUtc = mtime;

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -18,7 +18,7 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
 public class OpenAiSttService
 {
     private static HttpClient? _sharedHttpClient;
-    private static readonly object _sharedHttpClientLock = new();
+    private static readonly Lock SharedHttpClientLock = new();
 
     /// <summary>
     /// Shared HttpClient for the OpenAI Compatible STT service. Created once,
@@ -36,7 +36,7 @@ public class OpenAiSttService
                 return _sharedHttpClient;
             }
 
-            lock (_sharedHttpClientLock)
+            lock (SharedHttpClientLock)
             {
                 if (_sharedHttpClient == null)
                 {

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -94,7 +94,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly MemoryStream _downloadStreamOmniVoice;
     private readonly MemoryStream _downloadStreamOmniVoices;
     private readonly IZipUnpacker _zipUnpacker;
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private string _modelFileName;
     private string _configFileName;
 

--- a/src/ui/Logic/Download/YtDlpDownloadService.cs
+++ b/src/ui/Logic/Download/YtDlpDownloadService.cs
@@ -342,7 +342,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
         progress.Report(clamped);
     }
 
-    private static readonly object _versionCheckCacheLock = new();
+    private static readonly Lock VersionCheckCacheLock = new();
     private static bool? _cachedIsOutdated;
 
     public static async Task<bool> IsInstalledVersionOutdated(CancellationToken cancellationToken, bool forceRefresh = false)
@@ -351,7 +351,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
 
         if (!forceRefresh)
         {
-            lock (_versionCheckCacheLock)
+            lock (VersionCheckCacheLock)
             {
                 if (_cachedIsOutdated is { } cached)
                 {
@@ -385,7 +385,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
             result = IsVersionOutdated(installedVersion);
         }
 
-        lock (_versionCheckCacheLock)
+        lock (VersionCheckCacheLock)
         {
             _cachedIsOutdated = result;
         }
@@ -395,7 +395,7 @@ public class YtDlpDownloadService : IYtDlpDownloadService
 
     public static void InvalidateInstalledVersionCache()
     {
-        lock (_versionCheckCacheLock)
+        lock (VersionCheckCacheLock)
         {
             _cachedIsOutdated = null;
         }

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicOpenGlControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicOpenGlControl.cs
@@ -3,6 +3,7 @@ using Avalonia.OpenGL;
 using Avalonia.OpenGL.Controls;
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 
@@ -19,7 +20,7 @@ public class LibVlcDynamicOpenGlControl : OpenGlControlBase
     private int _videoWidth;
     private int _videoHeight;
     private uint _textureId;
-    private readonly object _bufferLock = new object();
+    private readonly Lock _bufferLock = new();
 
     // OpenGL function delegates
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicSoftwareControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicSoftwareControl.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using System;
+using System.Threading;
 
 namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 
@@ -18,7 +19,7 @@ public class LibVlcDynamicSoftwareControl : Control
     private LibVlcDynamicPlayer? _vlcPlayer;
     private WriteableBitmap? _renderTarget;
     private bool _isInitialized;
-    private readonly object _frameLock = new object();
+    private readonly Lock _frameLock = new();
     private IntPtr _frameBuffer = IntPtr.Zero;
     private int _frameWidth;
     private int _frameHeight;


### PR DESCRIPTION
## Summary
- Migrate the remaining `object`-based lock fields in `src/ui` to the `System.Threading.Lock` type, matching the existing `OpenAiSttService` usage.
- Static lock fields renamed to PascalCase (`CacheLock`, `VersionCheckCacheLock`); instance fields keep their existing names.
- Affected files: `OpenAiSttService`, `CrispAsrVersion`, `YtDlpDownloadService`, `LibVlcDynamicSoftwareControl`, `LibVlcDynamicOpenGlControl`, `OcrViewModel`, `MainViewModel`, `ImportPlainTextViewModel`, `DownloadTtsViewModel`, `FixNamesViewModel`.
- `src/libse` is left untouched since it targets `netstandard2.1`, which lacks `System.Threading.Lock`.

## Test plan
- [ ] `dotnet build src/ui/UI.csproj` succeeds with no warnings or errors.
- [ ] Behavior is unchanged — every field is used only with plain `lock()` statements, so the swap is behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)