### PR TITLE
Fix AddMissingQuotes to check for even quote count

### DIFF
--- a/src/libse/Forms/FixCommonErrors/AddMissingQuotes.cs
+++ b/src/libse/Forms/FixCommonErrors/AddMissingQuotes.cs
@@ -39,7 +39,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         }
                         else if (next.Text.Replace("<i>", string.Empty).TrimStart().TrimStart('-').TrimStart().StartsWith('"') &&
                                  next.Text.Replace("</i>", string.Empty).TrimEnd().EndsWith('"') &&
-                                 Utilities.CountTagInText(next.Text, '"') == 2)
+                                 Utilities.CountTagInText(next.Text, '"') % 2 == 0)
                         {
                             next = null; // seems to have valid quotes, so no spanning
                         }


### PR DESCRIPTION
@
## Summary
- In `AddMissingQuotes`, treat a subtitle line as already having valid quotes when the quote count is even (`% 2 == 0`) instead of requiring exactly two quotes.
- This prevents incorrectly spanning quotes across lines when a line legitimately contains more than one quote pair.

## Test plan
- [ ] Run Fix Common Errors → Add missing quotes on a subtitle where a line contains two valid quote pairs (4 quotes); confirm it is left unchanged.
- [ ] Confirm a line with a single valid quote pair (2 quotes) still behaves as before.
- [ ] Confirm a line with an odd number of quotes still triggers quote spanning.
- [ ] `dotnet test tests/libse/LibSETests.csproj --filter "ClassName~AddMissingQuotes"` passes.
@