### PR TITLE
Persist last-used Modify Selection rule and value (#11429)

### DIFF
--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
@@ -128,6 +128,14 @@ public partial class ModifySelectionViewModel : ObservableObject
             Se.Settings.Edit.ModifySelectionMode = "new";
         }
 
+        if (SelectedRule != null)
+        {
+            Se.Settings.Edit.ModifySelectionRule = SelectedRule.RuleType.ToString();
+            Se.Settings.Edit.ModifySelectionText = SelectedRule.Text;
+            Se.Settings.Edit.ModifySelectionMatchCase = SelectedRule.MatchCase;
+            Se.Settings.Edit.ModifySelectionNumber = SelectedRule.Number;
+        }
+
         Se.SaveSettings();
     }
 
@@ -171,13 +179,38 @@ public partial class ModifySelectionViewModel : ObservableObject
             Rules.Add(rule);
         }
 
-        SelectedRule = Rules.First();
+        SelectedRule = GetSavedRuleOrDefault();
 
         _previewTimer.Start();
     }
 
     internal void OnRuleChanged()
     {
-        _isDirty = true;        
+        _isDirty = true;
+    }
+
+    // Restore the rule type, text, match-case and number last used (persisted across
+    // restarts, like SE 4), falling back to the first rule when nothing is saved (#11429).
+    private ModifySelectionRule GetSavedRuleOrDefault()
+    {
+        var savedRuleType = Se.Settings.Edit.ModifySelectionRule;
+        var rule = Rules.FirstOrDefault(r => r.RuleType.ToString() == savedRuleType) ?? Rules.First();
+
+        if (rule.HasText)
+        {
+            rule.Text = Se.Settings.Edit.ModifySelectionText ?? string.Empty;
+        }
+
+        if (rule.HasMatchCase)
+        {
+            rule.MatchCase = Se.Settings.Edit.ModifySelectionMatchCase;
+        }
+
+        if (rule.HasNumber)
+        {
+            rule.Number = Se.Settings.Edit.ModifySelectionNumber;
+        }
+
+        return rule;
     }
 }

--- a/src/ui/Logic/Config/SeEdit.cs
+++ b/src/ui/Logic/Config/SeEdit.cs
@@ -5,9 +5,15 @@ public class SeEdit
     public SeEditMultipleReplace MultipleReplace { get; set; } = new SeEditMultipleReplace();
     public SeEditFind Find { get; set; } = new SeEditFind();
     public string ModifySelectionMode { get; set; }
+    public string ModifySelectionRule { get; set; }
+    public string ModifySelectionText { get; set; }
+    public bool ModifySelectionMatchCase { get; set; }
+    public double ModifySelectionNumber { get; set; }
 
     public SeEdit()
     {
         ModifySelectionMode = "New";
+        ModifySelectionRule = "Contains";
+        ModifySelectionText = string.Empty;
     }
 }


### PR DESCRIPTION
## Problem
Fixes #11429.

In SE 4, the **Edit → Modify Selection** window pre-selected the last-used option (e.g. *Starts with* + `♪`) on entry and kept it across restarts. In SE 5 the rule always reset to *Contains* with no value retained, because `Initialize()` hard-set `SelectedRule = Rules.First()` and only the selection *mode* (new/add/subtract/intersect) was ever persisted.

## Change
- Added `ModifySelectionRule`, `ModifySelectionText`, `ModifySelectionMatchCase`, and `ModifySelectionNumber` to `SeEdit` settings.
- On **OK**, save the selected rule's type, text, match-case flag, and number.
- On open, restore the saved rule type and re-apply its text/match-case/number.

Values are only re-applied to the matching saved rule type, so every other rule keeps its built-in default (numeric rules keep their sensible defaults like CPS=15, duration=2.0). The Style/Actor multi-select lists are per-file and intentionally not persisted.

## Test plan
- [ ] Open Modify Selection, choose *Starts with*, type `♪`, click OK. Reopen — *Starts with* + `♪` are pre-filled.
- [ ] Restart SE, reopen — still *Starts with* + `♪`.
- [ ] Choose a numeric rule (e.g. *Duration less than*), set a value, OK, reopen — value retained.
- [ ] Toggle *Case sensitive*, OK, reopen — state retained.
- [ ] Fresh settings (no saved value) defaults to *Contains*, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)