### PR TITLE
Persist subtitle grid column widths across restarts (#11415)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -2,7 +2,7 @@
 Subtitle Edit Changelog
 
 
-v5.0.0 (5th June 2026)
+v5.0.0 (TBD)
 
 * Update Polish translation - thx potplayer-fanpack
 * Fix #11357: also ignore Ctrl+Left/Right word-jump navigation while a text box is focused

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -138,6 +138,7 @@ public static partial class InitListViewAndEditBox
         vm.SubtitleGrid.Columns.Add(new DataGridTemplateColumn
         {
             Header = Se.Language.General.NumberSymbol,
+            Tag = SubtitleGridColumnKeys.Number,
             Width = new DataGridLength(50),
             MinWidth = 40,
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
@@ -164,6 +165,7 @@ public static partial class InitListViewAndEditBox
         var startColumn = new DataGridTextColumn
         {
             Header = Se.Language.General.Show,
+            Tag = SubtitleGridColumnKeys.Start,
             Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter, Mode = BindingMode.OneWay },
             Width = new DataGridLength(120),
             MinWidth = 100,
@@ -179,6 +181,7 @@ public static partial class InitListViewAndEditBox
         var hideColumn = new DataGridTextColumn
         {
             Header = Se.Language.General.Hide,
+            Tag = SubtitleGridColumnKeys.End,
             Binding = new Binding(nameof(SubtitleLineViewModel.EndTime)) { Converter = fullTimeConverter, Mode = BindingMode.OneWay },
             Width = new DataGridLength(120),
             MinWidth = 100,
@@ -194,6 +197,7 @@ public static partial class InitListViewAndEditBox
         var columnDuration = new DataGridTemplateColumn
         {
             Header = Se.Language.General.Duration,
+            Tag = SubtitleGridColumnKeys.Duration,
             Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
             MinWidth = 60,
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
@@ -226,6 +230,7 @@ public static partial class InitListViewAndEditBox
         vm.SubtitleGrid.Columns.Add(new DataGridTemplateColumn
         {
             Header = Se.Language.General.Text,
+            Tag = SubtitleGridColumnKeys.Text,
             Width = new DataGridLength(1, DataGridLengthUnitType.Star),
             MinWidth = 100,
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
@@ -257,6 +262,7 @@ public static partial class InitListViewAndEditBox
         var originalColumn = new DataGridTemplateColumn
         {
             Header = Se.Language.General.OriginalText,
+            Tag = SubtitleGridColumnKeys.OriginalText,
             Width = new DataGridLength(1, DataGridLengthUnitType.Star), // Stretch text column
             MinWidth = 100,
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
@@ -293,6 +299,7 @@ public static partial class InitListViewAndEditBox
         var styleColumn = new DataGridTextColumn
         {
             Header = Se.Language.General.Style,
+            Tag = SubtitleGridColumnKeys.Style,
             Binding = new Binding(nameof(SubtitleLineViewModel.Style)),
             Width = new DataGridLength(120),
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
@@ -313,6 +320,7 @@ public static partial class InitListViewAndEditBox
         var columnGap = new DataGridTemplateColumn
         {
             Header = Se.Language.General.Gap,
+            Tag = SubtitleGridColumnKeys.Gap,
             Width = new DataGridLength(100),
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
             CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) =>
@@ -344,6 +352,7 @@ public static partial class InitListViewAndEditBox
         var actorColumn = new DataGridTextColumn
         {
             Header = Se.Language.General.Actor,
+            Tag = SubtitleGridColumnKeys.Actor,
             Binding = new Binding(nameof(SubtitleLineViewModel.Actor)) { Mode = BindingMode.OneWay },
             Width = new DataGridLength(120),
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
@@ -358,6 +367,7 @@ public static partial class InitListViewAndEditBox
         var cpsColumn = new DataGridTemplateColumn
         {
             Header = Se.Language.General.Cps,
+            Tag = SubtitleGridColumnKeys.Cps,
             Width = new DataGridLength(100),
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
             CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) =>
@@ -389,6 +399,7 @@ public static partial class InitListViewAndEditBox
         var wpmColumn = new DataGridTemplateColumn
         {
             Header = Se.Language.General.Wpm,
+            Tag = SubtitleGridColumnKeys.Wpm,
             Width = new DataGridLength(100),
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
             CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) =>
@@ -420,6 +431,7 @@ public static partial class InitListViewAndEditBox
         var pixelWidthColumn = new DataGridTemplateColumn
         {
             Header = Se.Language.General.PixelWidth,
+            Tag = SubtitleGridColumnKeys.PixelWidth,
             Width = new DataGridLength(100),
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
             CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) =>
@@ -443,6 +455,7 @@ public static partial class InitListViewAndEditBox
         var layerColumn = new DataGridTextColumn
         {
             Header = Se.Language.General.Layer,
+            Tag = SubtitleGridColumnKeys.Layer,
             Binding = new Binding(nameof(SubtitleLineViewModel.Layer)),
             Width = new DataGridLength(23),
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
@@ -453,6 +466,8 @@ public static partial class InitListViewAndEditBox
             Mode = BindingMode.OneWay,
             Source = vm,
         });
+
+        RestoreSubtitleGridColumnWidths(vm.SubtitleGrid);
 
         vm.SubtitleGrid.DataContext = vm.Subtitles;
         vm.SubtitleGrid.SelectionChanged += vm.SubtitleGrid_SelectionChanged;
@@ -1523,6 +1538,69 @@ public static partial class InitListViewAndEditBox
         vm.EditTextBoxBindingCoordinator = coordinator;
 
         return mainGrid;
+    }
+
+    // Stable keys (DataGridColumn.Tag) used to snapshot/restore subtitle grid column
+    // widths across restarts. Headers are localized, so they can't be used as keys (#11415).
+    internal static class SubtitleGridColumnKeys
+    {
+        public const string Number = "Number";
+        public const string Start = "Start";
+        public const string End = "End";
+        public const string Duration = "Duration";
+        public const string Text = "Text";
+        public const string OriginalText = "OriginalText";
+        public const string Style = "Style";
+        public const string Gap = "Gap";
+        public const string Actor = "Actor";
+        public const string Cps = "Cps";
+        public const string Wpm = "Wpm";
+        public const string PixelWidth = "PixelWidth";
+        public const string Layer = "Layer";
+    }
+
+    // The stretchy text columns keep filling the window, so their width is never stored.
+    private static bool IsStretchyColumn(string key)
+        => key == SubtitleGridColumnKeys.Text || key == SubtitleGridColumnKeys.OriginalText;
+
+    private static void RestoreSubtitleGridColumnWidths(DataGrid grid)
+    {
+        var saved = Se.Settings.General.SubtitleGridColumnWidths;
+        if (saved == null || saved.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var column in grid.Columns)
+        {
+            if (column.Tag is string key
+                && !IsStretchyColumn(key)
+                && saved.TryGetValue(key, out var width)
+                && width > 0)
+            {
+                column.Width = new DataGridLength(width, DataGridLengthUnitType.Pixel);
+            }
+        }
+    }
+
+    // Snapshot the current (actual) width of each fixed column so it can be restored on
+    // the next launch. Called on exit. Hidden columns report ActualWidth 0 and are skipped,
+    // keeping their previously stored width.
+    public static void SaveSubtitleGridColumnWidths(DataGrid? grid)
+    {
+        if (grid == null)
+        {
+            return;
+        }
+
+        var widths = Se.Settings.General.SubtitleGridColumnWidths ??= new();
+        foreach (var column in grid.Columns)
+        {
+            if (column.Tag is string key && !IsStretchyColumn(key) && column.ActualWidth > 0)
+            {
+                widths[key] = column.ActualWidth;
+            }
+        }
     }
 
     private static Avalonia.Controls.Control MakeTextBox(MainViewModel vm)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14999,6 +14999,7 @@ public partial class MainViewModel :
             Se.Settings.General.ShowColumnCps = ShowColumnCps;
             Se.Settings.General.ShowColumnWpm = ShowColumnWpm;
             Se.Settings.General.ShowColumnLayer = ShowColumnLayer;
+            Layout.InitListViewAndEditBox.SaveSubtitleGridColumnWidths(SubtitleGrid);
             Se.Settings.General.SelectCurrentSubtitleWhilePlaying = SelectCurrentSubtitleWhilePlaying;
             Se.Settings.Waveform.ShowToolbar = IsWaveformToolbarVisible;
             Se.Settings.Waveform.CenterVideoPosition = WaveformCenter;

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -105,6 +105,12 @@ public class SeGeneral
     public bool ShowColumnWpm { get; set; }
     public bool ShowColumnPixelWidth { get; set; }
     public bool ShowColumnLayer { get; set; }
+
+    // Subtitle grid column widths (pixels) keyed by column key (DataGridColumn.Tag),
+    // snapshotted on exit and restored on startup. The stretchy Text/OriginalText
+    // columns are intentionally not stored so they keep filling the window (#11415).
+    public Dictionary<string, double> SubtitleGridColumnWidths { get; set; } = new();
+
     public bool SelectCurrentSubtitleWhilePlaying { get; set; }
     public bool WriteAn2Tag { get; set; }
     public bool AutoTrimWhiteSpace { get; set; }


### PR DESCRIPTION
## Problem
Part of #11415 (the style-display half was fixed in RC3; this addresses the remaining request). The main subtitle grid has `CanUserResizeColumns = true`, but column widths were never persisted, so **every restart reset them to the hardcoded defaults**.

## Approach — snapshot on exit
- Added `SubtitleGridColumnWidths` (a `Dictionary<string,double>`) to `SeGeneral`.
- Each grid column now carries a stable key via `DataGridColumn.Tag` (`SubtitleGridColumnKeys`), since the headers are localized and can't be used as keys.
- **On exit** (`OnClosing`, alongside the existing column-visibility saves), each fixed column's `ActualWidth` is snapshotted.
- **On startup** (when the grid is built), saved widths are restored.

The stretchy **Text / Original** columns are intentionally *not* stored, so they keep filling the window width after restore (no empty gap on the right). `AutoFitColumns()` already preserves each column's existing pixel width (it saves and restores `originalWidth`), so the restored widths also survive within a session.

## Notes / limitations
- Hidden columns report `ActualWidth == 0` and are skipped on save, keeping their previously stored width.
- The very last visible column and the Show/Hide time columns are still managed by `AutoFitColumns` (pre-existing behavior), so those two are the least likely to retain a manual width; the common columns (Duration, Style, Gap, Actor, CPS, WPM, etc.) persist reliably.

## Test plan
- [ ] Resize Style / Duration / Gap columns, close SE, reopen → widths retained.
- [ ] Restart the machine / relaunch → widths still retained (persisted to settings.json).
- [ ] Text and Original columns still stretch to fill the window after restore.
- [ ] Hide a column, reopen → no crash; other widths intact.
- [ ] Fresh settings (no saved widths) → default layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)