### PR TITLE
FindNext/FindPrevious: fix selection overflow crash, off-by-one, and overlapping regex matches

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9568,9 +9568,7 @@ public partial class MainViewModel :
                     EditTextBox.Text = subtitle.Text;
                 }
 
-                EditTextBox.CaretIndex = _findService.CurrentTextIndex;
-                EditTextBox.SelectionStart = _findService.CurrentTextIndex;
-                EditTextBox.SelectionEnd = _findService.CurrentTextIndex + _findService.CurrentTextFound.Length;
+                EditTextBox.Select(_findService.CurrentTextIndex, _findService.CurrentTextFound.Length);
             });
         }
     }
@@ -9631,17 +9629,12 @@ public partial class MainViewModel :
 
             ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText, foundLine + 1, foundIndex + 1));
 
-            // The text-box may still be empty if the SelectedItem binding hasn't propagated
-            // yet by the time this dispatcher post runs; fall back to writing the text
-            // ourselves so the selection range below lands on real characters.
-            if (EditTextBox.Text == string.Empty)
+            if (EditTextBox.Text != subtitle.Text)
             {
                 EditTextBox.Text = subtitle.Text;
             }
 
-            EditTextBox.CaretIndex = foundIndex;
-            EditTextBox.SelectionStart = foundIndex;
-            EditTextBox.SelectionEnd = foundIndex + foundText.Length;
+            EditTextBox.Select(foundIndex, foundText.Length);
         });
 
         FocusEditTextBox();
@@ -9703,17 +9696,12 @@ public partial class MainViewModel :
 
             ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText, foundLine + 1, foundIndex + 1));
 
-            // The text-box may still be empty if the SelectedItem binding hasn't propagated
-            // yet by the time this dispatcher post runs; fall back to writing the text
-            // ourselves so the selection range below lands on real characters.
-            if (EditTextBox.Text == string.Empty)
+            if (EditTextBox.Text != subtitle.Text)
             {
                 EditTextBox.Text = subtitle.Text;
             }
 
-            EditTextBox.CaretIndex = foundIndex;
-            EditTextBox.SelectionStart = foundIndex;
-            EditTextBox.SelectionEnd = foundIndex + foundText.Length;
+            EditTextBox.Select(foundIndex, foundText.Length);
         });
 
         FocusEditTextBox();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9591,7 +9591,7 @@ public partial class MainViewModel :
         var subs = Subtitles.Select(p => p.Text).ToList();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
         var currentCharIndex = EditTextBox.CaretIndex;
-        var idx = _findService.FindNext(_findService.SearchText, subs, currentLineIndex, currentCharIndex + 1);
+        var idx = _findService.FindNext(_findService.SearchText, subs, currentLineIndex, currentCharIndex);
 
         if (idx < 0)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9964,9 +9964,7 @@ public partial class MainViewModel :
                     EditTextBox.Text = subtitle.Text;
                 }
 
-                EditTextBox.CaretIndex = foundIndex;
-                EditTextBox.SelectionStart = foundIndex;
-                EditTextBox.SelectionEnd = foundIndex + foundText.Length;
+                EditTextBox.Select(foundIndex, foundText.Length);
 
                 ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText, foundLine + 1, foundIndex + 1));
             });

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
@@ -53,6 +53,7 @@ public class TextBoxWrapper : ITextBoxWrapper
     {
         _textBox.SelectionStart = start;
         _textBox.SelectionEnd = start + length;
+        _textBox.CaretIndex = start + length;
     }
 
     public int CaretIndex

--- a/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
@@ -74,6 +74,9 @@ public class TextEditorWrapper : ITextBoxWrapper
 
     public void Select(int start, int length)
     {
+        // AvaloniaEdit's SelectionStart setter calls Select(value, currentSelectionLength),
+        // which throws if value + currentSelectionLength > DocumentLength. Clear first.
+        _textEditor.SelectionLength = 0;
         _textEditor.SelectionStart = start;
         _textEditor.SelectionLength = length;
     }

--- a/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
@@ -79,6 +79,7 @@ public class TextEditorWrapper : ITextBoxWrapper
         _textEditor.SelectionLength = 0;
         _textEditor.SelectionStart = start;
         _textEditor.SelectionLength = length;
+        _textEditor.CaretOffset = start;
     }
 
     public int CaretIndex

--- a/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
@@ -79,7 +79,7 @@ public class TextEditorWrapper : ITextBoxWrapper
         _textEditor.SelectionLength = 0;
         _textEditor.SelectionStart = start;
         _textEditor.SelectionLength = length;
-        _textEditor.CaretOffset = start;
+        _textEditor.CaretOffset = start + length;
     }
 
     public int CaretIndex

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -563,11 +563,22 @@ public partial class FindService : IFindService
             var searchLine = line.Substring(0, Math.Min(startIndex + 1, line.Length));
             var originalLength = searchLine.Length;
             searchLine = NormalizeLineEndingsForRegex(searchLine, out var indexMap);
-            var matches = Regex.Matches(searchLine, searchText);
 
-            if (matches.Count > 0)
+            // Advance by 1 after each match so overlapping matches are found
+            // (e.g. two long lines sharing the \n between them).
+            var regex = new Regex(searchText);
+            Match? lastMatch = null;
+            var pos = 0;
+            while (pos < searchLine.Length)
             {
-                var lastMatch = matches[matches.Count - 1];
+                var m = regex.Match(searchLine, pos);
+                if (!m.Success) break;
+                lastMatch = m;
+                pos = m.Index + 1;
+            }
+
+            if (lastMatch != null)
+            {
                 return (true, MapNormalizedIndex(indexMap, lastMatch.Index, originalLength), lastMatch.Value);
             }
         }

--- a/tests/UI/Logic/FindServiceTests.cs
+++ b/tests/UI/Logic/FindServiceTests.cs
@@ -21,4 +21,53 @@ public class FindServiceTests
         Assert.Equal(0, service.FindNext(@"(?m)-$", [text], 0, 6));
         Assert.Equal(14, service.CurrentTextIndex);
     }
+
+    // Regression: regex (^|\n).{N,}($|\n) on a two-line subtitle produces overlapping
+    // matches sharing the \n boundary. FindNext must find the second line's match in full;
+    // FindPrevious traversing backwards must find the second-line match before the first.
+    [Fact]
+    public void RegexOverlappingNewlineBoundary_FindNext_FindsSecondLineInFull()
+    {
+        var line1 = new string('A', 40);  // 40 chars — satisfies .{38,}
+        var line2 = new string('B', 40);
+        var text = $"{line1}\n{line2}";   // "AAA...\nBBB..."
+        var service = new FindService();
+        service.Initialize([text], 0, false, FindService.FindMode.RegularExpression);
+        var pattern = @"(^|\n).{38,}($|\n)";
+
+        // First match: starts at 0 (via ^), value = "AAA...\n"
+        var idx = service.FindNext(pattern, [text], 0, 0);
+        Assert.Equal(0, idx);
+        var firstIndex = service.CurrentTextIndex;
+        var firstLength = service.CurrentTextFound.Length;
+
+        // Second match: searching from end of first match (SelectionEnd = firstIndex + firstLength)
+        // must find "BBB..." starting at line1.Length + 1 (first char of line 2), full length.
+        idx = service.FindNext(pattern, [text], 0, firstIndex + firstLength);
+        Assert.Equal(0, idx);
+        Assert.Equal(line1.Length + 1, service.CurrentTextIndex);
+        Assert.Equal(line2, service.CurrentTextFound);
+    }
+
+    [Fact]
+    public void RegexOverlappingNewlineBoundary_FindPrevious_FindsSecondLineBeforeFirst()
+    {
+        var line1 = new string('A', 40);
+        var line2 = new string('B', 40);
+        var text = $"{line1}\n{line2}";
+        var service = new FindService();
+        service.Initialize([text], 0, false, FindService.FindMode.RegularExpression);
+        var pattern = @"(^|\n).{38,}($|\n)";
+
+        // Approaching subtitle 0 from the end (startTextIndex = text.Length - 1):
+        // must find the second-line match first (it starts later in the text).
+        var idx = service.FindPrevious(pattern, [text], 0, text.Length - 1);
+        Assert.Equal(0, idx);
+        Assert.Equal(line1.Length, service.CurrentTextIndex);  // index of the \n before line2
+
+        // Then from that match's SelectionStart - 1, must find the first-line match.
+        idx = service.FindPrevious(pattern, [text], 0, service.CurrentTextIndex - 1);
+        Assert.Equal(0, idx);
+        Assert.Equal(0, service.CurrentTextIndex);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a cluster of related bugs in the Find/FindNext/FindPrevious flow that caused crashes, missed matches, and incorrect selections.

## Motivation

Four separate issues were found when using Find with AvaloniaEdit:

1. **Crash on selection overflow** — AvaloniaEdit's `SelectionStart` setter internally calls `Select(value, currentSelectionLength)`, which throws an `ArgumentOutOfRangeException` when the new start plus the existing selection length exceeds the document length (e.g. navigating from a long match to a short one).

2. **FindNext keyboard shortcut skips first character** — The shortcut was passing `currentCharIndex + 1` to `FindNext`, causing a one-character over-advance that made matches starting at the current caret position unreachable.

3. **Stale text guard too narrow** — The text-box sync check before setting a selection was `if (EditTextBox.Text == string.Empty)`, which missed the case where a stale subtitle (not empty, just wrong) was still displayed when the dispatcher callback ran.

4. **FindPrevious misses overlapping regex matches** — `FindWithRegexReverse` used `Regex.Matches()`, which does not yield overlapping results. A regex like `(^|\n).{38,}($|\n)` on a two-line subtitle produces two matches sharing the `\n` boundary; only the first was found, so traversing backwards would jump over the second-line match entirely.

## Changes

### `TextEditorWrapper.cs`
- Added a new `Select(int start, int length)` helper that clears the selection length before repositioning, avoiding the AvaloniaEdit overflow throw.
- Caret is placed at the end of the selection (consistent with standard find-highlight UX).

### `MainViewModel.cs`
- Replaced all four occurrences of the three-line selection pattern (`CaretIndex = x; SelectionStart = x; SelectionEnd = x + len`) with a single `EditTextBox.Select(index, length)` call.
- Fixed the `+ 1` off-by-one in the FindNext keyboard shortcut.
- Changed the text-box sync guard from `== string.Empty` to `!= subtitle.Text` so stale (not just empty) content is overwritten before a selection is applied.

### `FindService.cs`
- Rewrote `FindWithRegexReverse` to iterate through matches with a step of 1 after each hit (`pos = m.Index + 1`), ensuring overlapping matches sharing a boundary character are all found. The last match within the search prefix is returned, preserving the reverse-traversal semantic.

### `FindServiceTests.cs`
- Added `RegexOverlappingNewlineBoundary_FindNext_FindsSecondLineInFull` — verifies that FindNext advances past the first overlapping match and finds the second line's match in full.
- Added `RegexOverlappingNewlineBoundary_FindPrevious_FindsSecondLineBeforeFirst` — verifies that FindPrevious traversing from the end finds the second-line match before the first-line match.

## Testing

All existing tests pass. New regression tests cover the overlapping-boundary case in both directions.