### PR TITLE
Fix: KeepGapPrev/KeepGapNext shortcuts fail to preserve gap when subtitles are frame-aligned

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8701,7 +8701,7 @@ public partial class MainViewModel :
         var prev = idx > 0 ? Subtitles[idx - 1] : null;
         var prevGapMs = 0.0;
         var prevIsClose = false;
-        var oneFrameMsStart = Math.Abs(FramesToMilliseconds(1));
+        var oneFrameMsStart = FramesToMilliseconds(1);
         if (keepGapPrevIfClose && prev != null
             && prev.EndTime.TotalMilliseconds <= s.StartTime.TotalMilliseconds
             && prev.EndTime.TotalMilliseconds + gapMs + oneFrameMsStart >= s.StartTime.TotalMilliseconds)
@@ -8753,7 +8753,7 @@ public partial class MainViewModel :
         var next = idx >= 0 && idx + 1 < Subtitles.Count ? Subtitles[idx + 1] : null;
         var nextGapMs = 0.0;
         var nextIsClose = false;
-        var oneFrameMsEnd = Math.Abs(FramesToMilliseconds(1));
+        var oneFrameMsEnd = FramesToMilliseconds(1);
         if (keepGapNextIfClose && next != null
             && s.EndTime.TotalMilliseconds <= next.StartTime.TotalMilliseconds
             && s.EndTime.TotalMilliseconds + gapMs + oneFrameMsEnd >= next.StartTime.TotalMilliseconds)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8701,9 +8701,10 @@ public partial class MainViewModel :
         var prev = idx > 0 ? Subtitles[idx - 1] : null;
         var prevGapMs = 0.0;
         var prevIsClose = false;
+        var oneFrameMsStart = Math.Abs(FramesToMilliseconds(1));
         if (keepGapPrevIfClose && prev != null
             && prev.EndTime.TotalMilliseconds <= s.StartTime.TotalMilliseconds
-            && prev.EndTime.TotalMilliseconds + gapMs >= s.StartTime.TotalMilliseconds)
+            && prev.EndTime.TotalMilliseconds + gapMs + oneFrameMsStart >= s.StartTime.TotalMilliseconds)
         {
             prevIsClose = true;
             prevGapMs = s.StartTime.TotalMilliseconds - prev.EndTime.TotalMilliseconds;
@@ -8752,9 +8753,10 @@ public partial class MainViewModel :
         var next = idx >= 0 && idx + 1 < Subtitles.Count ? Subtitles[idx + 1] : null;
         var nextGapMs = 0.0;
         var nextIsClose = false;
+        var oneFrameMsEnd = Math.Abs(FramesToMilliseconds(1));
         if (keepGapNextIfClose && next != null
             && s.EndTime.TotalMilliseconds <= next.StartTime.TotalMilliseconds
-            && s.EndTime.TotalMilliseconds + gapMs >= next.StartTime.TotalMilliseconds)
+            && s.EndTime.TotalMilliseconds + gapMs + oneFrameMsEnd >= next.StartTime.TotalMilliseconds)
         {
             nextIsClose = true;
             nextGapMs = next.StartTime.TotalMilliseconds - s.EndTime.TotalMilliseconds;


### PR DESCRIPTION
  ### Problem

  The **Move start one frame back/forward (keep gap to previous)** keyboard shortcuts (`MoveStartOneFrameBackKeepGapPrev` / `MoveStartOneFrameForwardKeepGapPrev`) silently stopped co-moving the previous subtitle when the gap between the two was frame-aligned and slightly above `MinimumBetweenLines`:

  - **Back**: only the current subtitle's start moved back — the gap shrank to ~one frame
  - **Forward**: only the current subtitle's start moved forward — the gap widened

  The equivalent waveform gesture (Alt-drag the start edge) always preserved the gap correctly because it does not check the gap size before co-moving; it always moves both edges by the same delta.

  ### Root cause

  Both `MoveStartByFrames` and `MoveEndByFrames` gated the co-move on:

  ```csharp
  prev.EndTime.TotalMilliseconds + gapMs >= s.StartTime.TotalMilliseconds
  // i.e. actual_gap <= gapMs
  ```

  Frame-snapped timecodes round gaps up to the next frame boundary. At 24 fps, 2 frames = 83.333 ms. With MinimumBetweenLines = 83 ms (Netflix default rule), 83.333 > 83, so the condition was always false and the previous subtitle was never co-moved.

  ### Fix

  Add a one-frame tolerance to the threshold in both methods so that any gap within one frame of MinimumBetweenLines is treated as "close":
  
  ### Reproduction

  1. Open Options → Settings → Rules and select a profile with Netflix Rules (or set Minimum gap between subtitles to 83 ms manually).
  2. Open a subtitle file and select a subtitle long enough to split.
  3. Edit → Split line — this leaves the two resulting subtitles with an 83 ms gap.
  4. Select the second subtitle. On the waveform, Alt-drag its left (start) edge left or right — the previous subtitle's end follows, the gap stays at 83 ms. ✓
  5. Without moving anything else, press the shortcut bound to "Move start one frame back (keep gap to previous)":
    - Before this fix: only the start moves back ~42 ms; the gap shrinks to ~41 ms.
    - After this fix: both edges move back by one frame; the gap stays at 83 ms. ✓

  The same scenario applies to the forward variant (gap widens instead of shrinking) and to the symmetric MoveEndOneFrameForwardKeepGapNext / MoveEndOneFrameBackKeepGapNext shortcuts.