### PR TITLE
Improve BinaryEditWindow controls layout and resize constraints

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -510,7 +510,7 @@ public class BinaryEditWindow : Window
 
     private static Grid MakeControls(BinaryEditViewModel vm)
     {
-        // 7-column × 5-row Grid: Show/Duration | gap | X/Y/Pos | gap | SW/SH | spacer(*) | icon buttons
+        // 7-column × 6-row Grid: Show/Duration | gap | X/Y/Pos | gap | SW/SH | spacer(*) | icon buttons
         var grid = new Grid { Margin = new Thickness(0, 10, 0, 0), MinWidth = 600 };
         grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
         grid.ColumnDefinitions.Add(new ColumnDefinition(15, GridUnitType.Pixel));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -555,7 +555,7 @@ public class BinaryEditWindow : Window
 
         controlsPanel.Children.Add(firstRowPanel);
 
-        // Second row - X, Y, Buttons
+        // Second row - X, Y, Screen Width, Screen Height (all geometry together)
         var secondRowPanel = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -610,38 +610,6 @@ public class BinaryEditWindow : Window
         yPanel.Children.Add(yUpDown);
         secondRowPanel.Children.Add(yPanel);
 
-        // Buttons
-        var buttonsPanel = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 5,
-            VerticalAlignment = VerticalAlignment.Bottom,
-        };
-
-        var exportImageButton = UiUtil.MakeButton(vm.ExportImageCommand, IconNames.Export);
-        ToolTip.SetTip(exportImageButton, Se.Language.General.Export);
-        buttonsPanel.Children.Add(exportImageButton);
-
-        var importImageButton = UiUtil.MakeButton(vm.ImportImageCommand, IconNames.Import);
-        ToolTip.SetTip(importImageButton, Se.Language.General.Import);
-        buttonsPanel.Children.Add(importImageButton);
-
-        var setTextButton = UiUtil.MakeButton(vm.SetTextCommand, IconNames.NewText);
-        ToolTip.SetTip(setTextButton, Se.Language.Tools.ImageBasedEdit.SetTextForSubtitle);
-        buttonsPanel.Children.Add(setTextButton);
-
-        secondRowPanel.Children.Add(buttonsPanel);
-
-        controlsPanel.Children.Add(secondRowPanel);
-
-        // Third row - Screen Width, Screen Height
-        var thirdRowPanel = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 10,
-            Margin = new Thickness(0, 10, 0, 0),
-        };
-
         // Screen Width
         var screenWidthPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
         screenWidthPanel.Children.Add(new TextBlock
@@ -664,7 +632,7 @@ public class BinaryEditWindow : Window
             },
         };
         screenWidthPanel.Children.Add(screenWidthUpDown);
-        thirdRowPanel.Children.Add(screenWidthPanel);
+        secondRowPanel.Children.Add(screenWidthPanel);
 
         // Screen Height
         var screenHeightPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
@@ -688,7 +656,33 @@ public class BinaryEditWindow : Window
             },
         };
         screenHeightPanel.Children.Add(screenHeightUpDown);
-        thirdRowPanel.Children.Add(screenHeightPanel);
+        secondRowPanel.Children.Add(screenHeightPanel);
+
+        controlsPanel.Children.Add(secondRowPanel);
+
+        // Third row - Actions: Export/Import (file I/O) grouped separately from Set Text (conversion)
+        var thirdRowPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 12,
+            Margin = new Thickness(0, 10, 0, 0),
+        };
+
+        var fileIoPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
+
+        var exportImageButton = UiUtil.MakeButton(vm.ExportImageCommand, IconNames.Export);
+        ToolTip.SetTip(exportImageButton, Se.Language.General.Export);
+        fileIoPanel.Children.Add(exportImageButton);
+
+        var importImageButton = UiUtil.MakeButton(vm.ImportImageCommand, IconNames.Import);
+        ToolTip.SetTip(importImageButton, Se.Language.General.Import);
+        fileIoPanel.Children.Add(importImageButton);
+
+        thirdRowPanel.Children.Add(fileIoPanel);
+
+        var setTextButton = UiUtil.MakeButton(vm.SetTextCommand, IconNames.NewText);
+        ToolTip.SetTip(setTextButton, Se.Language.Tools.ImageBasedEdit.SetTextForSubtitle);
+        thirdRowPanel.Children.Add(setTextButton);
 
         controlsPanel.Children.Add(thirdRowPanel);
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -511,7 +511,7 @@ public class BinaryEditWindow : Window
     private static Grid MakeControls(BinaryEditViewModel vm)
     {
         // 7-column × 6-row Grid: Show/Duration | gap | X/Y/Pos | gap | SW/SH | spacer(*) | icon buttons
-        var grid = new Grid { Margin = new Thickness(0, 10, 0, 0), MinWidth = 600 };
+        var grid = new Grid { Margin = new Thickness(0, 10, 0, 0), MinWidth = 600 }; // pre-load fallback; overridden dynamically in Loaded
         grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
         grid.ColumnDefinitions.Add(new ColumnDefinition(15, GridUnitType.Pixel));
         grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -50,24 +50,25 @@ public class BinaryEditWindow : Window
         mainGrid.Add(menu, 0);
 
         // Content area (grid + video)
+        var leftColumnDef = new ColumnDefinition(GridLength.Star);
         var contentGrid = new Grid
         {
             ColumnDefinitions =
             {
-                new ColumnDefinition(GridLength.Star),
+                leftColumnDef,
                 new ColumnDefinition(GridLength.Auto),
                 new ColumnDefinition(GridLength.Star),
             },
         };
 
         // Left section - grid with subtitles lines + controls
-        var leftContent = MakeLayoutListViewAndEditBox(vm);
+        var leftContent = MakeLayoutListViewAndEditBox(vm, out var controlsGrid);
         contentGrid.Add(leftContent, 0);
 
-        // Vertical splitter
+        const double splitterWidth = UiUtil.SplitterWidthOrHeight;
         var splitter = new GridSplitter
         {
-            Width = UiUtil.SplitterWidthOrHeight,
+            Width = splitterWidth,
             HorizontalAlignment = HorizontalAlignment.Center,
             VerticalAlignment = VerticalAlignment.Stretch,
         };
@@ -116,6 +117,16 @@ public class BinaryEditWindow : Window
         AddHandler(KeyUpEvent, (_, args) => vm.OnKeyUp(args), handledEventsToo: true);
         Loaded += (_, _) =>
         {
+            // Measure controls at natural (unconstrained) size so MinWidth is font-size-aware
+            controlsGrid.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            const double borderAndMarginOverhead = 22; // MakeBorderForControl: padding(10) + border(2); mainGrid margin: 10
+            var leftPanelMin = controlsGrid.DesiredSize.Width + borderAndMarginOverhead;
+            leftColumnDef.MinWidth = leftPanelMin;   // prevents splitter from squeezing the controls
+            var computedMinWidth = Math.Ceiling(leftPanelMin * 2 + splitterWidth) + 10;
+            MinWidth = computedMinWidth;
+            if (Width < MinWidth)
+                Width = MinWidth;
+
             if (OperatingSystem.IsMacOS())
             {
                 InitNativeMacMenuBinaryEdit.Setup(this, vm);
@@ -309,7 +320,7 @@ public class BinaryEditWindow : Window
         return menu;
     }
 
-    private static Grid MakeLayoutListViewAndEditBox(BinaryEditViewModel vm)
+    private static Grid MakeLayoutListViewAndEditBox(BinaryEditViewModel vm, out Grid controlsGrid)
     {
         var mainGrid = new Grid
         {
@@ -491,85 +502,40 @@ public class BinaryEditWindow : Window
 
         mainGrid.Add(dataGridBorder, 0);
 
-        var controlsPanel = MakeControls(vm);
-        mainGrid.Add(UiUtil.MakeBorderForControl(controlsPanel), 1);
+        controlsGrid = MakeControls(vm);
+        mainGrid.Add(UiUtil.MakeBorderForControl(controlsGrid), 1);
 
         return mainGrid;
     }
 
-    private static StackPanel MakeControls(BinaryEditViewModel vm)
+    private static Grid MakeControls(BinaryEditViewModel vm)
     {
-        // Controls section - using vertical StackPanel with two rows
-        var controlsPanel = new StackPanel
-        {
-            Orientation = Orientation.Vertical,
-            Margin = new Thickness(0, 10, 0, 0),
-        };
+        // 7-column × 5-row Grid: Show/Duration | gap | X/Y/Pos | gap | SW/SH | spacer(*) | icon buttons
+        var grid = new Grid { Margin = new Thickness(0, 10, 0, 0), MinWidth = 600 };
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(15, GridUnitType.Pixel));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(15, GridUnitType.Pixel));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(20, GridUnitType.Pixel));
+        grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+        for (var i = 0; i < 6; i++)
+            grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
-        // First row - Start Time, Duration, Forced
-        var firstRowPanel = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 10,
-            Margin = new Thickness(0, 0, 0, 10),
-        };
+        // Row 0: first labels
+        grid.Add(new TextBlock { Text = Se.Language.General.Show, FontWeight = FontWeight.Bold, Margin = new Thickness(0, 0, 0, 2) }, 0, 0);
+        grid.Add(new TextBlock { Text = "X", FontWeight = FontWeight.Bold, Margin = new Thickness(0, 0, 0, 2) }, 0, 2);
+        grid.Add(new TextBlock { Text = Se.Language.Tools.ImageBasedEdit.ScreenWidth, FontWeight = FontWeight.Bold, Margin = new Thickness(0, 0, 0, 2) }, 0, 4);
 
-        // Start Time
-        var startTimePanel = new StackPanel { Orientation = Orientation.Vertical };
-        startTimePanel.Children.Add(new TextBlock
-        {
-            Text = Se.Language.General.Show,
-            FontWeight = FontWeight.Bold,
-            Margin = new Thickness(0, 0, 0, 2),
-        });
+        // Row 1: first controls — VerticalAlignment=Bottom aligns bottom edges across columns
         var startTimeUpDown = new TimeCodeUpDown
         {
+            VerticalAlignment = VerticalAlignment.Bottom,
             DataContext = vm,
-            [!TimeCodeUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.StartTime)}")
-            {
-                Mode = BindingMode.TwoWay,
-            },
+            [!TimeCodeUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.StartTime)}") { Mode = BindingMode.TwoWay },
         };
-        startTimePanel.Children.Add(startTimeUpDown);
-        firstRowPanel.Children.Add(startTimePanel);
+        grid.Add(startTimeUpDown, 1, 0);
 
-        // Duration
-        var durationPanel = new StackPanel { Orientation = Orientation.Vertical };
-        durationPanel.Children.Add(new TextBlock
-        {
-            Text = Se.Language.General.Duration,
-            FontWeight = FontWeight.Bold,
-            Margin = new Thickness(0, 0, 0, 2),
-        });
-        var durationUpDown = new SecondsUpDown
-        {
-            DataContext = vm,
-            [!SecondsUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.Duration)}")
-            {
-                Mode = BindingMode.TwoWay
-            },
-        };
-        durationPanel.Children.Add(durationUpDown);
-        firstRowPanel.Children.Add(durationPanel);
-        firstRowPanel.Children.Add(UiUtil.MakeLabel().WithBindText(vm, nameof(vm.CurrentPositionAndSize)));
-
-        controlsPanel.Children.Add(firstRowPanel);
-
-        // Second row - X, Y, Screen Width, Screen Height (all geometry together)
-        var secondRowPanel = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 10,
-        };
-
-        // X Position
-        var xPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
-        xPanel.Children.Add(new TextBlock
-        {
-            Text = "X",
-            FontWeight = FontWeight.Bold,
-            VerticalAlignment = VerticalAlignment.Center,
-        });
         var xUpDown = new NumericUpDown
         {
             Width = 130,
@@ -577,47 +543,12 @@ public class BinaryEditWindow : Window
             Maximum = int.MaxValue,
             Increment = 1,
             FormatString = "F0",
+            VerticalAlignment = VerticalAlignment.Bottom,
             DataContext = vm,
-            [!NumericUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.X)}")
-            {
-                Mode = BindingMode.TwoWay
-            },
+            [!NumericUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.X)}") { Mode = BindingMode.TwoWay },
         };
-        xPanel.Children.Add(xUpDown);
-        secondRowPanel.Children.Add(xPanel);
+        grid.Add(xUpDown, 1, 2);
 
-        // Y Position
-        var yPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
-        yPanel.Children.Add(new TextBlock
-        {
-            Text = "Y",
-            FontWeight = FontWeight.Bold,
-            VerticalAlignment = VerticalAlignment.Center,
-        });
-        var yUpDown = new NumericUpDown
-        {
-            Width = 130,
-            Minimum = int.MinValue,
-            Maximum = int.MaxValue,
-            Increment = 1,
-            FormatString = "F0",
-            DataContext = vm,
-            [!NumericUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.Y)}")
-            {
-                Mode = BindingMode.TwoWay
-            },
-        };
-        yPanel.Children.Add(yUpDown);
-        secondRowPanel.Children.Add(yPanel);
-
-        // Screen Width
-        var screenWidthPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
-        screenWidthPanel.Children.Add(new TextBlock
-        {
-            Text = Se.Language.Tools.ImageBasedEdit.ScreenWidth,
-            FontWeight = FontWeight.Bold,
-            VerticalAlignment = VerticalAlignment.Center,
-        });
         var screenWidthUpDown = new NumericUpDown
         {
             Width = 130,
@@ -625,23 +556,39 @@ public class BinaryEditWindow : Window
             Maximum = int.MaxValue,
             Increment = 1,
             FormatString = "F0",
+            VerticalAlignment = VerticalAlignment.Bottom,
             DataContext = vm,
-            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.ScreenWidth))
-            {
-                Mode = BindingMode.TwoWay
-            },
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.ScreenWidth)) { Mode = BindingMode.TwoWay },
         };
-        screenWidthPanel.Children.Add(screenWidthUpDown);
-        secondRowPanel.Children.Add(screenWidthPanel);
+        grid.Add(screenWidthUpDown, 1, 4);
 
-        // Screen Height
-        var screenHeightPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
-        screenHeightPanel.Children.Add(new TextBlock
+        // Row 2: second labels
+        grid.Add(new TextBlock { Text = Se.Language.General.Duration, FontWeight = FontWeight.Bold, Margin = new Thickness(0, 6, 0, 2) }, 2, 0);
+        grid.Add(new TextBlock { Text = "Y", FontWeight = FontWeight.Bold, Margin = new Thickness(0, 6, 0, 2) }, 2, 2);
+        grid.Add(new TextBlock { Text = Se.Language.Tools.ImageBasedEdit.ScreenHeight, FontWeight = FontWeight.Bold, Margin = new Thickness(0, 6, 0, 2) }, 2, 4);
+
+        // Row 3: second controls — VerticalAlignment=Bottom aligns bottom edges across columns
+        var durationUpDown = new SecondsUpDown
         {
-            Text = Se.Language.Tools.ImageBasedEdit.ScreenHeight,
-            FontWeight = FontWeight.Bold,
-            VerticalAlignment = VerticalAlignment.Center,
-        });
+            VerticalAlignment = VerticalAlignment.Bottom,
+            DataContext = vm,
+            [!SecondsUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.Duration)}") { Mode = BindingMode.TwoWay },
+        };
+        grid.Add(durationUpDown, 3, 0);
+
+        var yUpDown = new NumericUpDown
+        {
+            Width = 130,
+            Minimum = int.MinValue,
+            Maximum = int.MaxValue,
+            Increment = 1,
+            FormatString = "F0",
+            VerticalAlignment = VerticalAlignment.Bottom,
+            DataContext = vm,
+            [!NumericUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.Y)}") { Mode = BindingMode.TwoWay },
+        };
+        grid.Add(yUpDown, 3, 2);
+
         var screenHeightUpDown = new NumericUpDown
         {
             Width = 130,
@@ -649,49 +596,45 @@ public class BinaryEditWindow : Window
             Maximum = int.MaxValue,
             Increment = 1,
             FormatString = "F0",
+            VerticalAlignment = VerticalAlignment.Bottom,
             DataContext = vm,
-            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.ScreenHeight))
-            {
-                Mode = BindingMode.TwoWay
-            },
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.ScreenHeight)) { Mode = BindingMode.TwoWay },
         };
-        screenHeightPanel.Children.Add(screenHeightUpDown);
-        secondRowPanel.Children.Add(screenHeightPanel);
+        grid.Add(screenHeightUpDown, 3, 4);
 
-        controlsPanel.Children.Add(secondRowPanel);
+        // Col 6 buttons — stacked with top edge of Export aligned with top of first controls row
+        var exportBtn = UiUtil.MakeButton(Se.Language.General.Export, vm.ExportImageCommand);
+        exportBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
 
-        // Third row - Actions: Export/Import (file I/O) grouped separately from Set Text (conversion)
-        var thirdRowPanel = new StackPanel
+        var importBtn = UiUtil.MakeButton(Se.Language.General.Import, vm.ImportImageCommand);
+        importBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+
+        var setTextBtn = UiUtil.MakeButton(Se.Language.Tools.ImageBasedEdit.SetText, vm.SetTextCommand);
+        setTextBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+
+        var buttonStack = new StackPanel
         {
-            Orientation = Orientation.Horizontal,
-            Spacing = 12,
-            Margin = new Thickness(0, 10, 0, 0),
+            Orientation = Orientation.Vertical,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Top,
         };
+        buttonStack.Children.Add(exportBtn);
+        buttonStack.Children.Add(importBtn);
+        buttonStack.Children.Add(setTextBtn);
+        grid.Add(buttonStack, 1, 6, rowSpan: 5);
 
-        var fileIoPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
+        // Row 4: gap between second controls row and position label
+        grid.Add(new TextBlock { Margin = new Thickness(0, 6, 0, 2) }, 4, 0);
 
-        var exportImageButton = UiUtil.MakeButton(vm.ExportImageCommand, IconNames.Export);
-        ToolTip.SetTip(exportImageButton, Se.Language.General.Export);
-        fileIoPanel.Children.Add(exportImageButton);
+        // Row 5: Position/Size label
+        var posLabel = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.CurrentPositionAndSize));
+        posLabel.VerticalAlignment = VerticalAlignment.Center;
+        grid.Add(posLabel, 5, 2);
 
-        var importImageButton = UiUtil.MakeButton(vm.ImportImageCommand, IconNames.Import);
-        ToolTip.SetTip(importImageButton, Se.Language.General.Import);
-        fileIoPanel.Children.Add(importImageButton);
-
-        thirdRowPanel.Children.Add(fileIoPanel);
-
-        var setTextButton = UiUtil.MakeButton(vm.SetTextCommand, IconNames.NewText);
-        ToolTip.SetTip(setTextButton, Se.Language.Tools.ImageBasedEdit.SetTextForSubtitle);
-        thirdRowPanel.Children.Add(setTextButton);
-
-        controlsPanel.Children.Add(thirdRowPanel);
-
-        // Subscribe to X and Y changes to update overlay position
         xUpDown.ValueChanged += (_, _) => vm.UpdateOverlayPosition();
         yUpDown.ValueChanged += (_, _) => vm.UpdateOverlayPosition();
 
-
-        return controlsPanel;
+        return grid;
     }
 
     private static Grid MakeVideoPlayer(BinaryEditViewModel vm)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
@@ -100,7 +100,7 @@ public partial class BinaryResizeImagesViewModel : ObservableObject
         var resizedBitmap = ResizeBitmap(originalBitmap, newWidth, newHeight);
         PreviewBitmap = resizedBitmap.ToAvaloniaBitmap();
         
-        ImageSizeText = $"Original: {_originalWidth} × {_originalHeight} px\nNew: {newWidth} × {newHeight} px";
+        ImageSizeText = $"Original: {_originalWidth} Ã— {_originalHeight} px\nNew: {newWidth} Ã— {newHeight} px";
     }
 
     public void ApplyResize()

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -11,6 +11,7 @@ public class LanguageImageBasedEdit
     public string CropImages { get; set; }
     public string ImportTimeCodes { get; set; }
     public string SetTextForSubtitle { get; set; }
+    public string SetText { get; set; }
     public string ScreenWidth { get; set; }
     public string ScreenHeight { get; set; }
     public string AlphaThresholdInfo { get; set; }
@@ -36,6 +37,7 @@ public class LanguageImageBasedEdit
         CropImages = "Crop images";
         ImportTimeCodes = "Import time codes...";
         SetTextForSubtitle = "Set text for subtitle";
+        SetText = "Set text";
         ScreenWidth = "Screen width";
         ScreenHeight = "Screen height";
         AlphaThresholdInfo = "Pixels with alpha below threshold become fully transparent";

--- a/src/ui/packages.lock.json
+++ b/src/ui/packages.lock.json
@@ -139,12 +139,6 @@
           "Microsoft.Extensions.Options": "11.0.0-preview.2.26159.112"
         }
       },
-      "Microsoft.NET.ILLink.Tasks": {
-        "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
-      },
       "Optris.Icons.Avalonia": {
         "type": "Direct",
         "requested": "[12.0.6, )",
@@ -618,65 +612,6 @@
           "CommunityToolkit.Mvvm": "[8.4.2, )",
           "SkiaSharp.HarfBuzz": "[3.119.4, )",
           "libse": "[1.0.0, )"
-        }
-      }
-    },
-    "net10.0/osx-arm64": {
-      "SkiaSharp.NativeAssets.Linux": {
-        "type": "Direct",
-        "requested": "[3.119.4, )",
-        "resolved": "3.119.4",
-        "contentHash": "UAyVzbqNfZsZbKbzj68zXLyUyF/SbTKmzTfOO6qDu++dtIUMMTzPBe8oOuzU/DiewpfKoUUlOSsJmqWc6blxBw=="
-      },
-      "Avalonia.Angle.Windows.Natives": {
-        "type": "Transitive",
-        "resolved": "2.1.27548.20260419",
-        "contentHash": "l17nI3XVDN3oMnpjf2pnmJg0YTwK4m6NLsn/itAjDMdObTFxN77D5F1M9sRMSfViSY3KKcse1ROczwgoWLJsnA=="
-      },
-      "Avalonia.Native": {
-        "type": "Transitive",
-        "resolved": "12.0.4",
-        "contentHash": "N1Mxv+R9kQ9UDOybaQLNviDZ91k0RmY3m84Vj1gXsJcc+qMmGr0jvs0dBNcsvTHqkfY8gZC+u8CWdJUfLtRMAQ==",
-        "dependencies": {
-          "Avalonia": "12.0.4"
-        }
-      },
-      "HarfBuzzSharp.NativeAssets.Linux": {
-        "type": "Transitive",
-        "resolved": "8.3.1.3",
-        "contentHash": "RI6A1LgmooU30+4QIyFt5rmBCzP0VzTR+587IJSGvYIsHHWlahFufihYxtraLfsIhW7I8dn6+xX+DZGygOPKWQ=="
-      },
-      "HarfBuzzSharp.NativeAssets.macOS": {
-        "type": "Transitive",
-        "resolved": "8.3.1.5",
-        "contentHash": "TWSbMOIBiGvCTnR2MUlmhnP92L7qwYmpDXSNOkYQUh6Iuc7W7Y3z/Q+X3N6scvbZbDmfbZjqbNUqDEz/JzpwBg=="
-      },
-      "HarfBuzzSharp.NativeAssets.Win32": {
-        "type": "Transitive",
-        "resolved": "8.3.1.5",
-        "contentHash": "p95FW4SwP50qD4cq6e2/P5DP7As6c6aQU5qHvsdCKorX5GFLHUMIx/zQgiLvB871xQrhdN24sZyMbCufnTHvsQ=="
-      },
-      "Onigwrap": {
-        "type": "Transitive",
-        "resolved": "1.0.10",
-        "contentHash": "eujNEpEhCl4UiqHTG0CeG/sWS8v/iYXGqUpaVkgBmYRZp3Utmz/aw38fuFL2rcnhj1FNfHwHaxGDeLY34a3nEA=="
-      },
-      "SkiaSharp.NativeAssets.macOS": {
-        "type": "Transitive",
-        "resolved": "3.119.4",
-        "contentHash": "fgBOWEqbY012x7gMfJU4ezgz6dfhJb30Z6YdW35h85Zoe39+a8YNbAAwL29ihPfWoppg5AjvyKNzD1oCvlqWwA=="
-      },
-      "SkiaSharp.NativeAssets.Win32": {
-        "type": "Transitive",
-        "resolved": "3.119.4",
-        "contentHash": "XOpbx/4CReO2wYsq2s6rbvdauc6dntG4Zv499sHGTJ87bwZaFXszFkwql3+FIZMc8kUPeaj3Mx2ezIJmo8a1Kg=="
-      },
-      "System.Management": {
-        "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "/qEUN91mP/MUQmJnM5y5BdT7ZoPuVrtxnFlbJ8a3kBJGhe2wCzBfnPFtK2wTtEEcf3DMGR9J00GZZfg6HRI6yA==",
-        "dependencies": {
-          "System.CodeDom": "7.0.0"
         }
       }
     }

--- a/src/ui/packages.lock.json
+++ b/src/ui/packages.lock.json
@@ -139,6 +139,12 @@
           "Microsoft.Extensions.Options": "11.0.0-preview.2.26159.112"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
+      },
       "Optris.Icons.Avalonia": {
         "type": "Direct",
         "requested": "[12.0.6, )",
@@ -612,6 +618,65 @@
           "CommunityToolkit.Mvvm": "[8.4.2, )",
           "SkiaSharp.HarfBuzz": "[3.119.4, )",
           "libse": "[1.0.0, )"
+        }
+      }
+    },
+    "net10.0/osx-arm64": {
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Direct",
+        "requested": "[3.119.4, )",
+        "resolved": "3.119.4",
+        "contentHash": "UAyVzbqNfZsZbKbzj68zXLyUyF/SbTKmzTfOO6qDu++dtIUMMTzPBe8oOuzU/DiewpfKoUUlOSsJmqWc6blxBw=="
+      },
+      "Avalonia.Angle.Windows.Natives": {
+        "type": "Transitive",
+        "resolved": "2.1.27548.20260419",
+        "contentHash": "l17nI3XVDN3oMnpjf2pnmJg0YTwK4m6NLsn/itAjDMdObTFxN77D5F1M9sRMSfViSY3KKcse1ROczwgoWLJsnA=="
+      },
+      "Avalonia.Native": {
+        "type": "Transitive",
+        "resolved": "12.0.4",
+        "contentHash": "N1Mxv+R9kQ9UDOybaQLNviDZ91k0RmY3m84Vj1gXsJcc+qMmGr0jvs0dBNcsvTHqkfY8gZC+u8CWdJUfLtRMAQ==",
+        "dependencies": {
+          "Avalonia": "12.0.4"
+        }
+      },
+      "HarfBuzzSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "8.3.1.3",
+        "contentHash": "RI6A1LgmooU30+4QIyFt5rmBCzP0VzTR+587IJSGvYIsHHWlahFufihYxtraLfsIhW7I8dn6+xX+DZGygOPKWQ=="
+      },
+      "HarfBuzzSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "8.3.1.5",
+        "contentHash": "TWSbMOIBiGvCTnR2MUlmhnP92L7qwYmpDXSNOkYQUh6Iuc7W7Y3z/Q+X3N6scvbZbDmfbZjqbNUqDEz/JzpwBg=="
+      },
+      "HarfBuzzSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "8.3.1.5",
+        "contentHash": "p95FW4SwP50qD4cq6e2/P5DP7As6c6aQU5qHvsdCKorX5GFLHUMIx/zQgiLvB871xQrhdN24sZyMbCufnTHvsQ=="
+      },
+      "Onigwrap": {
+        "type": "Transitive",
+        "resolved": "1.0.10",
+        "contentHash": "eujNEpEhCl4UiqHTG0CeG/sWS8v/iYXGqUpaVkgBmYRZp3Utmz/aw38fuFL2rcnhj1FNfHwHaxGDeLY34a3nEA=="
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "3.119.4",
+        "contentHash": "fgBOWEqbY012x7gMfJU4ezgz6dfhJb30Z6YdW35h85Zoe39+a8YNbAAwL29ihPfWoppg5AjvyKNzD1oCvlqWwA=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "3.119.4",
+        "contentHash": "XOpbx/4CReO2wYsq2s6rbvdauc6dntG4Zv499sHGTJ87bwZaFXszFkwql3+FIZMc8kUPeaj3Mx2ezIJmo8a1Kg=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "/qEUN91mP/MUQmJnM5y5BdT7ZoPuVrtxnFlbJ8a3kBJGhe2wCzBfnPFtK2wTtEEcf3DMGR9J00GZZfg6HRI6yA==",
+        "dependencies": {
+          "System.CodeDom": "7.0.0"
         }
       }
     }


### PR DESCRIPTION
This PR aims to improve the UX of the Edit image-based subtitle window: group controls, give dedicated labels to action buttons, fix resizing behavior.

Out of scope of this PR: There is no feature parity between the v4 and v5 version of this dialog, e.g. selecting non-forced lines to delete them is a useful way of creating forced subtitles when one does not exist. There are also discoverability issues, e.g appending a subtitle is only in the context menu of the last subtitle, and the behavior is different in v5 (timestamps are shifted) which makes some workflows challenging or impossible (e.g. merge forced subtitles from a sup file into one that does not contain them, then sort by timestamp - but timestamps are shifted now and sorting has not been ported yet.). I'll look into these in a separate PR.

This PR replaces the nested `StackPanel` rows in the controls section with a flat 7-column × 6-row `Grid`, aligning labels and inputs across all three columns (Show/Duration, X/Y, ScreenWidth/ScreenHeight) by baseline.

This PR also adds dynamic `MinWidth` computation (measured in `Loaded`, after font metrics are available) so the splitter can't squeeze the controls panel below its natural size.

## Changes

- **Controls layout** — `MakeControls` now returns a `Grid` instead of a `StackPanel`; labels and inputs share rows across columns so baselines align. Action buttons (Export / Import / Set text) stack vertically in the rightmost column spanning all rows.
- **Resize constraints** — `MinWidth` for the left column and the window itself are derived from the measured `DesiredSize` of the controls grid after load, making them font-size-aware rather than hard-coded.
- **Button labels** — Icon buttons replaced with labelled buttons; adds a shorter `SetText` string to `LanguageImageBasedEdit` for the button caption (the longer `SetTextForSubtitle` is kept for the existing tooltip).
- **Bug fix** — Corrupted `?` character in the Resize Images size label replaced with the correct `×`.

  ## Screenshots

Before

<img width="1312" height="840" alt="Binary edit - before" src="https://github.com/user-attachments/assets/b531b31a-0fcf-4e07-b64f-02a521df4e38" />

After

<img width="1370" height="840" alt="Binary edit - after" src="https://github.com/user-attachments/assets/294fdf1d-40c4-456e-b662-838624d70b58" />

Resize images dialog - Before

<img width="311" height="211" alt="Resize images - before" src="https://github.com/user-attachments/assets/edae578e-5db5-4135-8f1c-4591620aa9aa" />

Resize images dialog - After

<img width="312" height="199" alt="Resize images - after" src="https://github.com/user-attachments/assets/0a05e57d-b57b-4603-b789-1f12cd1f2b12" />

