### PR TITLE
Add hidden setting for alternating subtitle grid row colors

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -126,6 +126,17 @@ public static partial class InitListViewAndEditBox
         var booleanToGridLengthConverter = new BooleanToGridLengthConverter();
         var booleanAndConverter = BooleanAndConverter.Instance;
 
+        // Optional alternating row background (hidden setting, no UI yet)
+        IBrush alternatingRowBrush = null;
+        if (Se.Settings.Appearance.GridAlternatingRows)
+        {
+            var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
+            var altColorHex = isDark
+                ? Se.Settings.Appearance.GridAlternatingRowColorDark
+                : Se.Settings.Appearance.GridAlternatingRowColor;
+            alternatingRowBrush = new SolidColorBrush(altColorHex.FromHexToColor());
+        }
+
         // Set up data binding for row visibility based on IsHidden property
         vm.SubtitleGrid.LoadingRow += (sender, e) =>
         {
@@ -133,6 +144,13 @@ public static partial class InitListViewAndEditBox
             {
                 Converter = inverseBooleanConverter
             });
+
+            // Tint every other row. Rows are recycled on scroll, so LoadingRow re-fires with the
+            // updated index. Selection still wins because :selected overrides BackgroundRectangle.Fill.
+            if (alternatingRowBrush != null)
+            {
+                e.Row.Background = e.Row.GetIndex() % 2 == 1 ? alternatingRowBrush : Brushes.Transparent;
+            }
         };
 
         vm.SubtitleGrid.Columns.Add(new DataGridTemplateColumn

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -134,7 +134,17 @@ public static partial class InitListViewAndEditBox
             var altColorHex = isDark
                 ? Se.Settings.Appearance.GridAlternatingRowColorDark
                 : Se.Settings.Appearance.GridAlternatingRowColor;
-            alternatingRowBrush = new SolidColorBrush(altColorHex.FromHexToColor());
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(altColorHex))
+                {
+                    alternatingRowBrush = new SolidColorBrush(altColorHex.FromHexToColor());
+                }
+            }
+            catch
+            {
+                alternatingRowBrush = null;
+            }
         }
 
         // Set up data binding for row visibility based on IsHidden property

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -127,7 +127,7 @@ public static partial class InitListViewAndEditBox
         var booleanAndConverter = BooleanAndConverter.Instance;
 
         // Optional alternating row background (hidden setting, no UI yet)
-        IBrush alternatingRowBrush = null;
+        IBrush? alternatingRowBrush = null;
         if (Se.Settings.Appearance.GridAlternatingRows)
         {
             var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -31,6 +31,9 @@ public class SeAppearance
     public bool UseFocusedButtonBackgroundColor { get; set; }
     public string FocusedButtonBackgroundColor { get; set; }
     public string GridLinesAppearance { get; set; }
+    public bool GridAlternatingRows { get; set; }
+    public string GridAlternatingRowColor { get; set; }
+    public string GridAlternatingRowColorDark { get; set; }
     public bool ShowHorizontalLineAboveToolbar { get; set; }
 
     public bool ToolbarShowFileNew { get; set; }
@@ -85,6 +88,9 @@ public class SeAppearance
         SubtitleTextBoxLiveSpellCheck = false;
         SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.ShowFormatting;
         GridLinesAppearance = DataGridGridLinesVisibility.None.ToString();
+        GridAlternatingRows = false;
+        GridAlternatingRowColor = new Color(255, 245, 245, 245).FromColorToHex();
+        GridAlternatingRowColorDark = new Color(255, 45, 45, 45).FromColorToHex();
         DarkModeBackgroundColor = new Color(255, 33, 33, 33).FromColorToHex();
         DarkModeForegroundColor = new Color(255, 220, 220, 220).FromColorToHex();
         UseFocusedButtonBackgroundColor = true;


### PR DESCRIPTION
## Summary
Adds a hidden setting to tint every other row in the subtitle grid. There is no UI control yet — it is off by default and configurable via `Settings.json`.

### Settings (`SeAppearance`)
- `GridAlternatingRows` (bool) — default `false`
- `GridAlternatingRowColor` (hex) — light-theme tint, default `#FFF5F5F5`
- `GridAlternatingRowColorDark` (hex) — dark-theme tint, default `#FF2D2D2D`

### Rendering (`InitListViewAndEditBox`)
Wired into the existing `DataGrid.LoadingRow` handler: odd rows get the tint brush, even rows stay transparent. Because rows are recycled on scroll, `LoadingRow` re-fires with the updated index so parity stays correct. The tint is applied to `DataGridRow.Background`, which feeds the row template's `BackgroundRectangle.Fill` only in the normal state — the `:selected` pseudo-class style still overrides it, so selection highlighting is unaffected. The active theme (`ActualThemeVariant`) selects the light vs dark color.

### Notes
- Settings persist/reload automatically via the source-generated `SeJsonContext`. Existing `Settings.json` files fall back to the constructor defaults until first save.
- The color is resolved at grid-build time, so a theme switch or hand-edit takes effect on the next layout rebuild / restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)