### PR TITLE
Add more built-in default shortcuts from SE4

### DIFF
--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -788,10 +788,47 @@ public static class ShortcutsMain
             new(nameof(vm.GoToNextErrorCommand), [nameof(Avalonia.Input.Key.F8)], ShortcutCategory.SubtitleGrid),
             new(nameof(vm.ShowSpellCheckCommand), ["Alt", nameof(Avalonia.Input.Key.F7)], ShortcutCategory.SubtitleGrid),
             new(nameof(vm.ShowToolsChangeCasingCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.C)], ShortcutCategory.General),
+            new(nameof(vm.ShowToolsFixCommonErrorsCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.F)], ShortcutCategory.General),
+            new(nameof(vm.ShowToolsBatchConvertCommand), [cmd, nameof(Avalonia.Input.Key.B)], ShortcutCategory.General),
             new(nameof(vm.ShowToolsRemoveTextForHearingImpairedCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.H)], ShortcutCategory.General),
             new(nameof(vm.ShowSyncAdjustAllTimesCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.A)], ShortcutCategory.General),
             new(nameof(vm.WaveformPasteFromClipboardCommand), [cmd, nameof(Avalonia.Input.Key.V)], ShortcutCategory.Waveform),
             new(nameof(vm.FillSelectedLinesWithClipboardCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.V)], ShortcutCategory.SubtitleGrid),
+
+            // Tools / dialogs (V4 defaults)
+            new(nameof(vm.CommandFileSaveAsCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.S)], ShortcutCategory.General),
+            new(nameof(vm.MergeSelectedLinesCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.M)], ShortcutCategory.General),
+            new(nameof(vm.ShowAutoTranslateCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.G)], ShortcutCategory.General),
+            new(nameof(vm.ShowPointSyncCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.P)], ShortcutCategory.General),
+            new(nameof(vm.ShowFindDoubleWordsCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.D)], ShortcutCategory.General),
+            new(nameof(vm.ShowAddToNameListCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.L)], ShortcutCategory.General),
+            new(nameof(vm.RightToLeftToggleCommand), [cmd, "Shift", "Alt", nameof(Avalonia.Input.Key.R)], ShortcutCategory.General),
+
+            // Timing / creation (V4 defaults)
+            new(nameof(vm.WaveformSetStartCommand), [nameof(Avalonia.Input.Key.F11)], ShortcutCategory.General),
+            new(nameof(vm.WaveformSetEndCommand), [nameof(Avalonia.Input.Key.F12)], ShortcutCategory.General),
+            new(nameof(vm.WaveformSetEndAndGoToNextCommand), [nameof(Avalonia.Input.Key.F10)], ShortcutCategory.General),
+            new(nameof(vm.InsertLineAfterCommand), ["Alt", nameof(Avalonia.Input.Key.Insert)], ShortcutCategory.General),
+            new(nameof(vm.InsertLineBeforeCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.Insert)], ShortcutCategory.General),
+            new(nameof(vm.AutoBreakCommand), [cmd, nameof(Avalonia.Input.Key.R)], ShortcutCategory.General),
+            new(nameof(vm.PlaySelectedLinesWithoutLoopCommand), [nameof(Avalonia.Input.Key.F5)], ShortcutCategory.General),
+            new(nameof(vm.ExtendSelectedToNextCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.E)], ShortcutCategory.General),
+            new(nameof(vm.ExtendSelectedToPreviousCommand), ["Alt", "Shift", nameof(Avalonia.Input.Key.E)], ShortcutCategory.General),
+
+            // Text casing / split (V4 defaults)
+            new(nameof(vm.SelectionToLowerCommand), [cmd, nameof(Avalonia.Input.Key.U)], ShortcutCategory.General),
+            new(nameof(vm.SelectionToUpperCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.U)], ShortcutCategory.General),
+            new(nameof(vm.ToggleCasingCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.F3)], ShortcutCategory.General),
+            new(nameof(vm.SplitAtTextBoxCursorPositionCommand), [cmd, "Alt", nameof(Avalonia.Input.Key.V)], ShortcutCategory.General),
+
+            // Video / waveform / navigation (V4 defaults)
+            new(nameof(vm.FocusSelectedLineCommand), [cmd, nameof(Avalonia.Input.Key.L)], ShortcutCategory.General),
+            new(nameof(vm.Video500MsBackCommand), ["Alt", nameof(Avalonia.Input.Key.Left)], ShortcutCategory.General),
+            new(nameof(vm.Video500MsForwardCommand), ["Alt", nameof(Avalonia.Input.Key.Right)], ShortcutCategory.General),
+            new(nameof(vm.VideoFullScreenCommand), ["Alt", nameof(Avalonia.Input.Key.Return)], ShortcutCategory.General),
+            new(nameof(vm.WaveformVerticalZoomInCommand), ["Shift", nameof(Avalonia.Input.Key.Add)], ShortcutCategory.General),
+            new(nameof(vm.WaveformVerticalZoomOutCommand), ["Shift", nameof(Avalonia.Input.Key.Subtract)], ShortcutCategory.General),
+            new(nameof(vm.PauseCommand), [cmd, "Alt", nameof(Avalonia.Input.Key.P)], ShortcutCategory.General),
         ];
     }
 


### PR DESCRIPTION
@
## Summary

Several built-in keyboard shortcuts that shipped as defaults in SE4 have no default key binding in SE5 (the SE5 default set in `GetDefaultShortcuts()` is much smaller than SE4s `Shortcuts()` constructor). This was reported by a user migrating from SE4.

This PR restores the SE4 defaults that **map cleanly** to an existing SE5 command and use keys that **do not conflict** with the current SE5 defaults. No new commands were added — only default bindings for commands that already existed.

## Added defaults

**Tools / dialogs**
- Fix common errors — `Ctrl+Shift+F`
- Batch convert — `Ctrl+B`
- Save as — `Ctrl+Shift+S`
- Merge selected lines — `Ctrl+Shift+M`
- Auto-translate — `Ctrl+Shift+G`
- Point sync — `Ctrl+Shift+P`
- Find double words — `Ctrl+Shift+D`
- Add word to names list — `Ctrl+Shift+L`
- Right-to-left — `Ctrl+Shift+Alt+R`

**Timing / creation**
- Set start — `F11`, Set end — `F12`, Set end & go to next — `F10`
- Insert after — `Alt+Insert`, Insert before — `Ctrl+Shift+Insert`
- Auto-break — `Ctrl+R`
- Play selected lines — `F5`
- Extend to next / previous subtitle — `Ctrl+Shift+E` / `Alt+Shift+E`

**Text casing / split**
- Selection to lower / upper — `Ctrl+U` / `Ctrl+Shift+U`
- Toggle casing — `Ctrl+Shift+F3`
- Split at cursor — `Ctrl+Alt+V`

**Video / waveform / navigation**
- Focus selected line — `Ctrl+L`
- 500 ms back / forward — `Alt+Left` / `Alt+Right`
- Fullscreen — `Alt+Return`
- Waveform vertical zoom in / out — `Shift+Add` / `Shift+Subtract`
- Pause — `Ctrl+Alt+P`

## Intentionally left out (conflicts)

Two SE4 defaults clash with existing SE5 bindings and are **not** included, pending a decision on alternative keys:
- Set start & offset the rest (`Ctrl+Space`) — taken by Toggle play/pause (2)
- Visual sync (`Ctrl+Shift+V`) — taken by Fill selected lines with clipboard

## Notes
- All new entries use `ShortcutCategory.General`, which the key handler always checks as the final fallback regardless of focus — matching SE4s global behavior.
- Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@