### PR TITLE
Fix Modify Selection numeric defaults and persistence

### DIFF
--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
@@ -154,8 +154,8 @@ public class ModifySelectionRule
                 HasNumber = true,
                 NumberMinValue = 0,
                 NumberMaxValue = 200,
-                DefaultValue = 42,
-                Number = 42,
+                DefaultValue = Se.Settings.General.SubtitleLineMaximumLength,
+                Number = Se.Settings.General.SubtitleLineMaximumLength,
             },
             new()
             {
@@ -164,8 +164,8 @@ public class ModifySelectionRule
                 HasNumber = true,
                 NumberMinValue = 0,
                 NumberMaxValue = 200,
-                DefaultValue = 42,
-                Number = 42,
+                DefaultValue = Se.Settings.General.SubtitleLineMaximumLength,
+                Number = Se.Settings.General.SubtitleLineMaximumLength,
             },
             new()
             {

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
@@ -31,6 +31,8 @@ public partial class ModifySelectionViewModel : ObservableObject
 
     private List<SubtitleLineViewModel> _allSubtitles;
     private readonly System.Timers.Timer _previewTimer;
+    private readonly Dictionary<RuleType, double> _ruleNumbers;
+    private RuleType? _activeRuleType;
     private bool _isDirty;
 
     public ModifySelectionViewModel()
@@ -38,6 +40,7 @@ public partial class ModifySelectionViewModel : ObservableObject
         Rules = new ObservableCollection<ModifySelectionRule>();
         Subtitles = new ObservableCollection<PreviewItem>();
         Selection = new List<SubtitleLineViewModel>();
+        _ruleNumbers = new Dictionary<RuleType, double>();
 
         _allSubtitles = new List<SubtitleLineViewModel>();
 
@@ -173,20 +176,50 @@ public partial class ModifySelectionViewModel : ObservableObject
     internal void Initialize(List<SubtitleLineViewModel> subtitleLineViewModels, List<SubtitleLineViewModel> selectedItems)
     {
         _allSubtitles = subtitleLineViewModels;
+        InitializeRules(subtitleLineViewModels);
+        _previewTimer.Start();
+    }
 
+    internal void InitializeRules(List<SubtitleLineViewModel> subtitleLineViewModels)
+    {
+        Rules.Clear();
+        _ruleNumbers.Clear();
+        _activeRuleType = null;
         foreach (var rule in ModifySelectionRule.List(subtitleLineViewModels))
         {
+            if (rule.HasNumber)
+            {
+                rule.Number = GetDefaultNumber(rule);
+                _ruleNumbers[rule.RuleType] = rule.Number;
+            }
+
             Rules.Add(rule);
         }
 
         SelectedRule = GetSavedRuleOrDefault();
-
-        _previewTimer.Start();
     }
 
     internal void OnRuleChanged()
     {
         _isDirty = true;
+    }
+
+    partial void OnSelectedRuleChanged(ModifySelectionRule? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        SaveActiveRuleNumber();
+
+        if (value.HasNumber && _ruleNumbers.TryGetValue(value.RuleType, out var number))
+        {
+            value.Number = number;
+        }
+
+        _activeRuleType = value.RuleType;
+        OnRuleChanged();
     }
 
     // Restore the rule type, text, match-case and number last used (persisted across
@@ -208,9 +241,42 @@ public partial class ModifySelectionViewModel : ObservableObject
 
         if (rule.HasNumber)
         {
-            rule.Number = Se.Settings.Edit.ModifySelectionNumber;
+            if (rule.RuleType.ToString() == savedRuleType)
+            {
+                rule.Number = Se.Settings.Edit.ModifySelectionNumber;
+                _ruleNumbers[rule.RuleType] = rule.Number;
+            }
+            else
+            {
+                rule.Number = GetDefaultNumber(rule);
+                _ruleNumbers[rule.RuleType] = rule.Number;
+            }
         }
 
         return rule;
+    }
+
+    private void SaveActiveRuleNumber()
+    {
+        if (_activeRuleType == null)
+        {
+            return;
+        }
+
+        var activeRule = Rules.FirstOrDefault(r => r.RuleType == _activeRuleType);
+        if (activeRule?.HasNumber == true)
+        {
+            _ruleNumbers[activeRule.RuleType] = activeRule.Number;
+        }
+    }
+
+    private static double GetDefaultNumber(ModifySelectionRule rule)
+    {
+        return rule.RuleType switch
+        {
+            RuleType.LengthLessThan or RuleType.LengthGreaterThan => Se.Settings.General.SubtitleLineMaximumLength,
+            RuleType.PixelWidthLengthGreaterThan => Se.Settings.General.SubtitleLineMaximumPixelWidth,
+            _ => rule.DefaultValue,
+        };
     }
 }

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
@@ -136,7 +136,10 @@ public partial class ModifySelectionViewModel : ObservableObject
             Se.Settings.Edit.ModifySelectionRule = SelectedRule.RuleType.ToString();
             Se.Settings.Edit.ModifySelectionText = SelectedRule.Text;
             Se.Settings.Edit.ModifySelectionMatchCase = SelectedRule.MatchCase;
-            Se.Settings.Edit.ModifySelectionNumber = SelectedRule.Number;
+            if (SelectedRule.HasNumber)
+            {
+                Se.Settings.Edit.ModifySelectionNumber = SelectedRule.Number;
+            }
         }
 
         Se.SaveSettings();

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
@@ -94,7 +94,13 @@ public class ModifySelectionWindow : Window
         textBoxRuleText.BindIsVisible(vm, nameof(vm.SelectedRule) + "." + nameof(vm.SelectedRule.HasText));
         textBoxRuleText.TextChanged += (sender, args) => vm.OnRuleChanged();
 
-        var numericUpDownRuleNumber = UiUtil.MakeNumericUpDownInt(0, 10000, 100, 150, vm, nameof(vm.SelectedRule) + "." + nameof(vm.SelectedRule.Number));
+        var numericUpDownRuleNumber = UiUtil.MakeNumericUpDownInt(0, 10000, 0, 150, vm);
+        numericUpDownRuleNumber.Bind(NumericUpDown.ValueProperty, new Binding
+        {
+            Path = nameof(vm.SelectedRule) + "." + nameof(vm.SelectedRule.Number),
+            Mode = BindingMode.TwoWay,
+            Converter = new NullableDoubleConverter(),
+        });
         numericUpDownRuleNumber.BindIsVisible(vm, nameof(vm.SelectedRule) + "." + nameof(vm.SelectedRule.HasNumber));
         numericUpDownRuleNumber.ValueChanged += (sender, args) => vm.OnRuleChanged();
 

--- a/src/ui/Logic/ValueConverters/NullableDoubleConverter.cs
+++ b/src/ui/Logic/ValueConverters/NullableDoubleConverter.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Data.Converters;
 using System;
 using System.Globalization;
@@ -45,6 +46,6 @@ public class NullableDoubleConverter : IValueConverter
             return (double)intValue;
         }
 
-        return DefaultValue;
+        return AvaloniaProperty.UnsetValue;
     }
 }

--- a/src/ui/Logic/ValueConverters/NullableDoubleConverter.cs
+++ b/src/ui/Logic/ValueConverters/NullableDoubleConverter.cs
@@ -1,0 +1,50 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Logic.ValueConverters;
+
+public class NullableDoubleConverter : IValueConverter
+{
+    public double DefaultValue { get; set; } = 0;
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is decimal decimalValue)
+        {
+            return decimalValue;
+        }
+
+        if (value is double doubleValue)
+        {
+            return (decimal)doubleValue;
+        }
+
+        if (value is int intValue)
+        {
+            return (decimal)intValue;
+        }
+
+        return (decimal)DefaultValue;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is decimal decimalValue)
+        {
+            return (double)decimalValue;
+        }
+
+        if (value is double doubleValue)
+        {
+            return doubleValue;
+        }
+
+        if (value is int intValue)
+        {
+            return (double)intValue;
+        }
+
+        return DefaultValue;
+    }
+}

--- a/tests/UI/Features/Edit/ModifySelection/ModifySelectionViewModelTests.cs
+++ b/tests/UI/Features/Edit/ModifySelection/ModifySelectionViewModelTests.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Nikse.SubtitleEdit.Features.Edit.ModifySelection;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -139,14 +140,34 @@ public class ModifySelectionViewModelTests
     }
 
     [Fact]
-    public void NullableDoubleConverter_RoundTripsDoubleValues()
+    public void NullableDoubleConverter_NullInput_DoesNotZeroOutNumber()
     {
-        var converter = new NullableDoubleConverter { DefaultValue = 100 };
+        var converter = new NullableDoubleConverter();
 
-        var converted = converter.Convert(77.5, typeof(decimal), null, CultureInfo.InvariantCulture);
-        var roundTripped = converter.ConvertBack(77.5m, typeof(double), null, CultureInfo.InvariantCulture);
+        var result = converter.ConvertBack(null, typeof(double), null, CultureInfo.InvariantCulture);
 
-        Assert.Equal(77.5m, Assert.IsType<decimal>(converted));
-        Assert.Equal(77.5, Assert.IsType<double>(roundTripped));
+        Assert.Equal(AvaloniaProperty.UnsetValue, result);
+    }
+
+    [Fact]
+    public void Ok_OnNonNumericRule_DoesNotOverwriteSavedNumericThreshold()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.Edit.ModifySelectionNumber = 88;
+
+            var vm = new ModifySelectionViewModel();
+            vm.InitializeRules(new List<SubtitleLineViewModel>());
+            vm.SelectedRule = vm.Rules.First(r => !r.HasNumber);
+            vm.OkCommand.Execute(null);
+
+            Assert.Equal(88, Se.Settings.Edit.ModifySelectionNumber);
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
     }
 }

--- a/tests/UI/Features/Edit/ModifySelection/ModifySelectionViewModelTests.cs
+++ b/tests/UI/Features/Edit/ModifySelection/ModifySelectionViewModelTests.cs
@@ -1,0 +1,152 @@
+using Nikse.SubtitleEdit.Features.Edit.ModifySelection;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace UITests.Features.Edit.ModifySelection;
+
+public class ModifySelectionViewModelTests
+{
+    [Fact]
+    public void InitializeRules_RestoresSavedNumberForSavedNumericRule()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleLineMaximumLength = 43;
+            Se.Settings.Edit.ModifySelectionRule = nameof(RuleType.LengthGreaterThan);
+            Se.Settings.Edit.ModifySelectionNumber = 77;
+
+            var vm = new ModifySelectionViewModel();
+            vm.InitializeRules(new List<SubtitleLineViewModel>());
+
+            Assert.Equal(RuleType.LengthGreaterThan, vm.SelectedRule!.RuleType);
+            Assert.Equal(77, vm.SelectedRule.Number);
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [Fact]
+    public void SelectingLengthRule_UsesCurrentSingleLineMaxLengthAsDefault()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleLineMaximumLength = 51;
+
+            var vm = new ModifySelectionViewModel();
+            vm.InitializeRules(new List<SubtitleLineViewModel>());
+            var lengthRule = vm.Rules.Single(r => r.RuleType == RuleType.LengthGreaterThan);
+
+            vm.SelectedRule = lengthRule;
+
+            Assert.Equal(51, lengthRule.Number);
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [Fact]
+    public void SelectingPixelWidthRule_UsesCurrentPixelWidthLimitAsDefault()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleLineMaximumPixelWidth = 640;
+
+            var vm = new ModifySelectionViewModel();
+            vm.InitializeRules(new List<SubtitleLineViewModel>());
+            var pixelRule = vm.Rules.Single(r => r.RuleType == RuleType.PixelWidthLengthGreaterThan);
+
+            vm.SelectedRule = pixelRule;
+
+            Assert.Equal(640, pixelRule.Number);
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [Fact]
+    public void SwitchingNumericRules_KeepsEachRuleSpecificValue()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleLineMaximumLength = 47;
+            Se.Settings.General.SubtitleLineMaximumPixelWidth = 580;
+
+            var vm = new ModifySelectionViewModel();
+            vm.InitializeRules(new List<SubtitleLineViewModel>());
+            var lengthRule = vm.Rules.Single(r => r.RuleType == RuleType.LengthGreaterThan);
+            var pixelRule = vm.Rules.Single(r => r.RuleType == RuleType.PixelWidthLengthGreaterThan);
+
+            vm.SelectedRule = lengthRule;
+            lengthRule.Number = 99;
+
+            vm.SelectedRule = pixelRule;
+            Assert.Equal(580, pixelRule.Number);
+
+            vm.SelectedRule = lengthRule;
+            Assert.Equal(99, lengthRule.Number);
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [Fact]
+    public void Ok_SavesNumericValueThatIsRestoredOnReopen()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleLineMaximumLength = 43;
+
+            var vm = new ModifySelectionViewModel();
+            vm.InitializeRules(new List<SubtitleLineViewModel>());
+            var lengthRule = vm.Rules.Single(r => r.RuleType == RuleType.LengthGreaterThan);
+            vm.SelectedRule = lengthRule;
+            lengthRule.Number = 88;
+
+            vm.OkCommand.Execute(null);
+
+            var reopened = new ModifySelectionViewModel();
+            reopened.InitializeRules(new List<SubtitleLineViewModel>());
+
+            Assert.Equal(RuleType.LengthGreaterThan, reopened.SelectedRule!.RuleType);
+            Assert.Equal(88, reopened.SelectedRule.Number);
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [Fact]
+    public void NullableDoubleConverter_RoundTripsDoubleValues()
+    {
+        var converter = new NullableDoubleConverter { DefaultValue = 100 };
+
+        var converted = converter.Convert(77.5, typeof(decimal), null, CultureInfo.InvariantCulture);
+        var roundTripped = converter.ConvertBack(77.5m, typeof(double), null, CultureInfo.InvariantCulture);
+
+        Assert.Equal(77.5m, Assert.IsType<decimal>(converted));
+        Assert.Equal(77.5, Assert.IsType<double>(roundTripped));
+    }
+}


### PR DESCRIPTION
  ## Summary

  Follow-up to the PR for #11429, which restored the saved rule type, text, and match-case across sessions. This PR completes the restore behavior for the numeric value that remained dysfunctional after the aforementioned changes.

The `NumericUpDown.Value` property in Avalonia is `decimal?`, but `ModifySelectionRule.Number` is `double`, so the original binding path (which assumed `int`) silently fell back to the hardcoded value `100` on every open instead of showing the saved or rule-specific default.

  - **SE4-style defaults** — Length < and Length > now initialize from `SubtitleLineMaximumLength` (Options → General) instead of the hardcoded value 42; Pixel width > initializes from `SubtitleLineMaximumPixelWidth`.
  - **Saved value restored on reopen** — the numeric value last used with a numeric rule is persisted and restored when that same rule is selected again on the next open.
  - **Per-rule value retention** — switching between numeric rules during a session no longer leaks the previous rule's value; each rule keeps its own in-memory number while the dialog is open.

  ### Tests

  - Saved numeric value restored on reopen for the matching rule type
  - SE4-style defaults for length and pixel-width rules
  - Per-rule value retention while switching rules in a session
  - Persisted value survives a save/reopen cycle
