### PR TITLE
Fix Binary OCR database editor behavior

### DIFF
--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
@@ -61,11 +61,6 @@ public partial class BinaryOcrDbEditViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        if (string.IsNullOrWhiteSpace(DatabaseName))
-        {
-            return;
-        }
-
         OkPressed = true;
         Close();
     }
@@ -176,6 +171,7 @@ public partial class BinaryOcrDbEditViewModel : ObservableObject
 
     internal void Initialize(string imageCompareName)
     {
+        DatabaseName = imageCompareName;
         _binaryImageCompareDatabase = new BinaryOcrDb(Path.Combine(Se.OcrFolder, imageCompareName + BinaryOcrDb.Extension), true);
         var allImages = _binaryImageCompareDatabase.AllCompareImages;
         var characters = allImages.Where(c => !string.IsNullOrWhiteSpace(c.Text))
@@ -194,7 +190,7 @@ public partial class BinaryOcrDbEditViewModel : ObservableObject
         SelectedCharacter = characters.FirstOrDefault();
         CharactersChanged();
 
-        Title = string.Format(Se.Language.Ocr.EditNOcrDatabaseXWithYItems, imageCompareName, allImages.Count);
+        Title = $"{Se.Language.Ocr.EditBinaryOcrDatabase}: {Path.GetFileNameWithoutExtension(imageCompareName)} ({allImages.Count:#,###,##0})";
     }
 
     internal void CharactersChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
@@ -190,7 +190,7 @@ public partial class BinaryOcrDbEditViewModel : ObservableObject
         SelectedCharacter = characters.FirstOrDefault();
         CharactersChanged();
 
-        Title = $"{Se.Language.Ocr.EditBinaryOcrDatabase}: {Path.GetFileNameWithoutExtension(imageCompareName)} ({allImages.Count:#,###,##0})";
+        Title = $"{Se.Language.Ocr.EditBinaryOcrDatabase}: {Path.GetFileNameWithoutExtension(imageCompareName)} ({allImages.Count:N0})";
     }
 
     internal void CharactersChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
@@ -12,7 +12,7 @@ public class BinaryOcrDbEditWindow : Window
 {
     public BinaryOcrDbEditWindow(BinaryOcrDbEditViewModel vm)
     {
-        Title = Se.Language.Ocr.EditNOcrDatabase;
+        Title = Se.Language.Ocr.EditBinaryOcrDatabase;
         vm.Window = this;
         UiUtil.InitializeWindow(this, GetType().Name);
         CanResize = true;
@@ -135,6 +135,7 @@ public class BinaryOcrDbEditWindow : Window
         {
             BorderBrush = UiUtil.GetBorderBrush(),
             BorderThickness = new Thickness(1),
+            Background = new SolidColorBrush(Colors.LightGray),
             Padding = new Thickness(5),
             Child = image,
             HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Left,

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
@@ -135,7 +135,6 @@ public class BinaryOcrDbEditWindow : Window
         {
             BorderBrush = UiUtil.GetBorderBrush(),
             BorderThickness = new Thickness(1),
-            Background = new SolidColorBrush(Colors.LightGray),
             Padding = new Thickness(5),
             Child = image,
             HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Left,


### PR DESCRIPTION
This PR corrects an incorrect window title and a dysfunctional OK button.

  ## Summary

  - **`DatabaseName` not initialized on open** — `Initialize()` now sets `DatabaseName` from the passed database name, so the property is always populated before the user can interact with the dialog. The null guard in `Ok()` that masked this gap is removed.

  - **Wrong language key on window title** — `EditNOcrDatabase` (an nOCR key) replaced with the correct `EditBinaryOcrDatabase`.

  - **Title format improved** — now shows the database name (extension stripped via `Path.GetFileNameWithoutExtension`) and item count with thousand separators (`N0`).

Image preview backgrounds (possibly theme-aware) will be addressed in a future PR.
