### PR TITLE
Write frames as two digits in custom export

### DIFF
--- a/src/libuilogic/Export/CustomTextFormatter.cs
+++ b/src/libuilogic/Export/CustomTextFormatter.cs
@@ -235,7 +235,7 @@ public static class CustomTextFormatter
             .Replace("ff", $"{SubtitleFormat.MillisecondsToFrames(timeCode.TotalMilliseconds):00}")
             .Replace("h", $"{Math.Abs(timeCode.Hours)}")
             .Replace("m", $"{Math.Abs(timeCode.Minutes)}")
-            .Replace("f", $"{SubtitleFormat.MillisecondsToFramesMaxFrameRate(timeCode.Milliseconds)}");
+            .Replace("f", $"{SubtitleFormat.MillisecondsToFramesMaxFrameRate(timeCode.Milliseconds):00}");
     }
 
     internal static string GetParagraph(string template, string start, string end, string text, string originalText, int number, string actor, TimeCode duration, string gap, string timeCodeTemplate, Paragraph p, string videoFileName)


### PR DESCRIPTION
Zero-pad the single `f` frames token in custom text export so `HH:MM:SS:10` is no longer written as `HH:MM:SS:1`.

This applies the fix from #11459 to the SE5 (`libuilogic`) codebase. The same bug existed in `CustomTextFormatter.ReplaceStandardComponents`, where the single `f` token wasn't zero-padded (the `ff` token already was).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
