### PR TITLE
Persist burn-in encoding settings between sessions

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -1234,6 +1234,32 @@ public partial class BurnInViewModel : ObservableObject
         UseSourceFolderVisible = !settings.UseOutputFolder;
         UseSourceResolution = settings.UseSourceResolution;
 
+        FontMarginHorizontal = (int)settings.NonAssaMarginHorizontal;
+        FontMarginVertical = (int)settings.NonAssaMarginVertical;
+        SelectedFontBoxType = FontBoxTypes.FirstOrDefault(p => (int)p.BoxType == settings.NonAssaBoxType) ?? FontBoxTypes[0];
+
+        SelectedVideoEncoding = VideoEncodings.FirstOrDefault(p => p.Codec == settings.Encoding) ?? VideoEncodings[0];
+        SelectedVideoPixelFormat = VideoPixelFormats.FirstOrDefault(p => p.Codec == settings.PixelFormat) ?? VideoPixelFormats[0];
+        FillPreset(SelectedVideoEncoding.Codec);
+        FillCrf(SelectedVideoEncoding.Codec);
+        if (!string.IsNullOrEmpty(settings.Preset) && VideoPresets.Contains(settings.Preset))
+        {
+            SelectedVideoPreset = settings.Preset;
+        }
+        if (!string.IsNullOrEmpty(settings.Crf) && VideoCrf.Contains(settings.Crf))
+        {
+            SelectedVideoCrf = settings.Crf;
+        }
+
+        SelectedAudioEncoding = AudioEncodings.Contains(settings.AudioEncoding) ? settings.AudioEncoding : AudioEncodings[0];
+        AudioIsStereo = settings.AudioForceStereo;
+        SelectedAudioSampleRate = AudioSampleRates.FirstOrDefault(p => p.Replace("Hz", string.Empty).Trim() == settings.AudioSampleRate) ?? AudioSampleRates[1];
+        SelectedAudioBitRate = AudioBitRates.Contains(settings.AudioBitRate) ? settings.AudioBitRate : AudioBitRates[2];
+
+        UseTargetFileSize = settings.TargetFileSize;
+        TargetFileSize = settings.TargetFileSizeMb;
+        PromptForFfmpegParameters = settings.PromptFfmpegParameters;
+
         var effectsAsStringArray = settings.Effects?.Split(',') ?? [];
         _selectedEffects = BurnInEffectItem.List().Where(p => effectsAsStringArray.Contains(p.Name)).ToList();
         DisplayEffect = string.Join(", ", _selectedEffects.Select(p => p.Name));
@@ -1254,6 +1280,23 @@ public partial class BurnInViewModel : ObservableObject
         settings.NonAssaFixRtlUnicode = FontFixRtl;
         settings.NonAssaAlignment = SelectedFontAlignment.Code;
         settings.UseSourceResolution = UseSourceResolution;
+        settings.NonAssaMarginHorizontal = FontMarginHorizontal ?? 0;
+        settings.NonAssaMarginVertical = FontMarginVertical ?? 0;
+        settings.NonAssaBoxType = (int)SelectedFontBoxType.BoxType;
+
+        settings.Encoding = SelectedVideoEncoding.Codec;
+        settings.Preset = SelectedVideoPreset ?? string.Empty;
+        settings.Crf = SelectedVideoCrf ?? string.Empty;
+        settings.PixelFormat = SelectedVideoPixelFormat?.Codec ?? string.Empty;
+
+        settings.AudioEncoding = SelectedAudioEncoding;
+        settings.AudioForceStereo = AudioIsStereo;
+        settings.AudioSampleRate = SelectedAudioSampleRate.Replace("Hz", string.Empty).Trim();
+        settings.AudioBitRate = SelectedAudioBitRate;
+
+        settings.TargetFileSize = UseTargetFileSize;
+        settings.TargetFileSizeMb = TargetFileSize ?? 0;
+        settings.PromptFfmpegParameters = PromptForFfmpegParameters;
 
         settings.Effects = string.Join(",", _selectedEffects.Select(p => p.Name).Distinct());
 
@@ -1443,6 +1486,7 @@ public partial class BurnInViewModel : ObservableObject
     private void FillPreset(string videoCodec)
     {
         VideoPresetText = "Preset";
+        var previousPreset = SelectedVideoPreset;
         SelectedVideoPreset = null;
 
         var items = new List<string>
@@ -1578,7 +1622,11 @@ public partial class BurnInViewModel : ObservableObject
 
         VideoPresets.Clear();
         VideoPresets.AddRange(items);
-        if (VideoPresets.Contains(defaultItem))
+        if (!string.IsNullOrEmpty(previousPreset) && VideoPresets.Contains(previousPreset))
+        {
+            SelectedVideoPreset = previousPreset;
+        }
+        else if (VideoPresets.Contains(defaultItem))
         {
             SelectedVideoPreset = defaultItem;
         }
@@ -1586,6 +1634,7 @@ public partial class BurnInViewModel : ObservableObject
 
     public void FillCrf(string videoCodec)
     {
+        var previousCrf = SelectedVideoCrf;
         SelectedVideoCrf = null;
         VideoCrfText = "CRF";
         VideoCrfHint = string.Empty;
@@ -1668,6 +1717,11 @@ public partial class BurnInViewModel : ObservableObject
             VideoCrf.Clear();
             VideoCrf.AddRange(items);
             SelectedVideoCrf = "23";
+        }
+
+        if (!string.IsNullOrWhiteSpace(previousCrf) && VideoCrf.Contains(previousCrf))
+        {
+            SelectedVideoCrf = previousCrf;
         }
     }
 

--- a/src/ui/Logic/Config/SeVideoBurnIn.cs
+++ b/src/ui/Logic/Config/SeVideoBurnIn.cs
@@ -18,7 +18,11 @@ public class SeVideoBurnIn
     public string AudioEncoding { get; set; }
     public bool AudioForceStereo { get; set; }
     public string AudioSampleRate { get; set; }
+    public string AudioBitRate { get; set; }
     public bool TargetFileSize { get; set; }
+    public int TargetFileSizeMb { get; set; }
+    public bool PromptFfmpegParameters { get; set; }
+    public int NonAssaBoxType { get; set; }
     public bool NonAssaBox { get; set; }
     public bool GenTransparentVideoNonAssaBox { get; set; }
     public bool GenTransparentVideoNonAssaBoxPerLine { get; set; }
@@ -55,6 +59,8 @@ public class SeVideoBurnIn
         AudioEncoding = "copy";
         AudioForceStereo = true;
         AudioSampleRate = "48000";
+        AudioBitRate = "128k";
+        TargetFileSizeMb = 100;
         FontBold = true;
         OutlineWidth = 6;
         ShadowWidth = 3;


### PR DESCRIPTION
Addresses the **settings-persistence** part of #11460 ("It also does not save the settings from one time to another, each new task sets the default setting") for the SE5 *Generate video with burned-in subtitle* window.

### Problem
`BurnInViewModel.LoadSettings`/`SaveSettings` only persisted font styling. Everything on the encoding side reset to defaults on every launch:

- Video codec, preset, CRF, pixel format
- Audio codec, force-stereo, sample rate, bit rate
- Font margins (H/V) and box type
- Target file size (use + value)
- Prompt-for-ffmpeg-parameters

### Fix
- Save and restore all of the above in `LoadSettings`/`SaveSettings`, adding the few missing fields to `SeVideoBurnIn` (`AudioBitRate`, `TargetFileSizeMb`, `PromptFfmpegParameters`, `NonAssaBoxType`).
- `FillPreset`/`FillCrf` previously always reset the preset/CRF to the codec default. They now keep a still-valid current selection, so the restored preset/CRF survive the encoding combo's binding initialization (which re-fires `VideoEncodingChanged`). Switching to a codec where the value isn't valid still falls back to that codec's default.

### Notes
- The MP4/MKV-only complaint in the issue relates to the *embed soft-subs* flow, whose `EmbedOutputExt`/`EmbedOutputSuffix` settings exist in `SeVideoBurnIn` but aren't wired into any SE5 window yet — out of scope for this change, which covers the save/restore part as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
