### PR TITLE
Fix Modify Selection length rules to use longest visible line

### DIFF
--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
@@ -1,4 +1,5 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
@@ -347,10 +348,10 @@ public class ModifySelectionRule
                 return item.CharactersPerSecond > Number;
 
             case RuleType.LengthLessThan:
-                return (text?.Length ?? 0) < (int)Number;
+                return Utilities.GetMaxLineLength(text) < (int)Number;
 
             case RuleType.LengthGreaterThan:
-                return (text?.Length ?? 0) > (int)Number;
+                return Utilities.GetMaxLineLength(text) > (int)Number;
 
             case RuleType.PixelWidthLengthGreaterThan:
                 return item.PixelWidth > (int)Number;

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
@@ -87,7 +87,7 @@ public class ModifySelectionWindow : Window
             VerticalAlignment = VerticalAlignment.Top,
         };
 
-        var comboBoxRules = UiUtil.MakeComboBox(vm.Rules, vm, nameof(vm.SelectedRule)).WithWidth(175).WithTopAlignment();
+        var comboBoxRules = UiUtil.MakeComboBox(vm.Rules, vm, nameof(vm.SelectedRule)).WithWidth(230).WithTopAlignment();
         comboBoxRules.SelectionChanged += (sender, args) => vm.OnRuleChanged();
 
         textBoxRuleText = UiUtil.MakeTextBox(150, vm, nameof(vm.SelectedRule) + "." + nameof(vm.SelectedRule.Text));

--- a/src/ui/Logic/Config/Language/Edit/LanguageModifySelection.cs
+++ b/src/ui/Logic/Config/Language/Edit/LanguageModifySelection.cs
@@ -47,8 +47,8 @@ public class LanguageModifySelection
         DurationGreaterThan = "Duration in ms >";
         CpsLessThan = "CPS <";
         CpsGreaterThan = "CPS >";
-        LengthLessThan = "Length <";
-        LengthGreaterThan = "Length >";
+        LengthLessThan = "Single line max length <";
+        LengthGreaterThan = "Single line max length >";
         PixelLengthGreaterThan = "Pixel length >";
         GapGreaterThan = "Gap in ms >";
         GapLessThan = "Gap in ms <";


### PR DESCRIPTION
  Length > and Length < in Modify selection checked the entire subtitle text (all lines combined), including HTML tags and ASS/SSA override tags like {\an8}, \<i\>, etc., and newline characters (\n).

  Combined subtitle length is rarely useful. CPS already captures "too much text for the timing." Combined length would only matter for formats with a hard total-character limit per subtitle (e.g., teletext with a 2×40-char budget), but that niche is tiny. The overwhelmingly useful case is max single line length: finding lines that exceed the wrap threshold, just like what the Rules section (e.g. Netflix: 42 characters) says.

  It's a semantic change so I updated the label as well to match the Settings/Rules section label: "Single line max length"

  ## Summary
                                                                                                                                           
  - `LengthLessThan` and `LengthGreaterThan` rules in Modify Selection now use `Utilities.GetMaxLineLength()` instead of the raw text length, so multi-line subtitles are evaluated against their longest visible line rather than the total character count including newlines.                                                                   
  - Renamed the rule labels from "Length <" / "Length >" to "Single line max length <" / "Single line max length >" to clarify what is being measured.
                                                                                                                                           
  ## Testing

  I opened a subtitle file with multi-line entries, used Modify Selection → length rules (< and >) and confirmed selection matches the longest visible line, not the combined length of all lines. The label text shows "Single line max length" in the Modify Selection UI.