### PR TITLE
Fix: cleared shortcuts being re-added from defaults on next startup

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -497,11 +497,7 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             if (shortcut == null) continue;
 
-            if (!IsEmpty(shortcut))
-            {
-                shortcuts.Add(new SeShortCut(shortcut));
-            }
-            else if (previouslyAssigned.Contains(shortcut.Name))
+            if (!IsEmpty(shortcut) || previouslyAssigned.Contains(shortcut.Name))
             {
                 shortcuts.Add(new SeShortCut(shortcut));
             }

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -489,10 +489,19 @@ public partial class ShortcutsViewModel : ObservableObject
             }
         }
 
+        var previouslyAssigned = new HashSet<string>(
+            Se.Settings.Shortcuts.Select(s => s.ActionName), StringComparer.Ordinal);
+
         var shortcuts = new List<SeShortCut>();
         foreach (var shortcut in _allShortcuts)
         {
-            if (shortcut != null && !IsEmpty(shortcut))
+            if (shortcut == null) continue;
+
+            if (!IsEmpty(shortcut))
+            {
+                shortcuts.Add(new SeShortCut(shortcut));
+            }
+            else if (previouslyAssigned.Contains(shortcut.Name))
             {
                 shortcuts.Add(new SeShortCut(shortcut));
             }


### PR DESCRIPTION
  I came across this after the recent default shortcut addition for Auto Translate (Cmd+Shift+G). It conflicts with the Find previous shortcut I configured (a standard macOS key combination). I reset it in Shortcuts but the reset never took effect, and the shortcut for Auto Translate re-appeared.

  ## Problem

  When a new default shortcut is introduced (e.g. Auto-translate → Cmd+Shift+G), `InitializeMainShortcuts()` adds it to the in-memory shortcut list for any user who doesn't already have it. The user then sees it in the Shortcuts dialog and clears it — but that cleared entry was silently dropped before saving, because `CommandOk()` filtered out all empty shortcuts.

  On the next startup the merge logic found the action name absent from the saved list and re-added the default, so the shortcut kept coming back regardless of what the user set.

  ## Fix

  Before saving, `CommandOk()` now snapshots the set of action names that were assigned prior to opening the dialog. Any shortcut the user explicitly cleared (was previously assigned, now empty) is written to `Settings.json` with an empty key list. `InitializeMainShortcuts()` already skips re-adding a default whenever the action name is present in the saved list, so no further changes were needed.
  
  ## Testing

  I had Cmd+Shift+G set for Find Previous. With that, I did the following:

  1. Open Shortcuts dialog — note Auto-translate is bound to Cmd+Shift+G
  2. Clear the Auto-translate shortcut → OK
  3. Reopen Shortcuts dialog — Auto-translate should be empty ✓
  4. Restart the app, reopen Shortcuts dialog — should still be empty ✓
  5. Cmd+Shift+G now works as Find Previous without conflict ✓