### PR TITLE
Use default ASSA storage style for new/converted subtitles

### DIFF
--- a/src/ui/Features/Assa/AssaStyleStorageHelper.cs
+++ b/src/ui/Features/Assa/AssaStyleStorageHelper.cs
@@ -1,0 +1,90 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Assa;
+
+public static class AssaStyleStorageHelper
+{
+    /// <summary>
+    /// Returns the ASSA storage style that is marked as default (if any).
+    /// </summary>
+    public static SeAssaStyle? GetDefaultStorageStyle()
+    {
+        return Se.Settings.Assa.StoredStyles.FirstOrDefault(s => s.IsDefault);
+    }
+
+    /// <summary>
+    /// Decides which style name a new ASSA paragraph should use:
+    /// if the file already defines styles, the first file style is used; otherwise the default
+    /// ASSA storage style (if any) becomes the file's style and is used. Falls back to "Default".
+    /// The subtitle header is updated when the storage default style is applied.
+    /// </summary>
+    public static string GetStyleNameForNewParagraph(Subtitle subtitle)
+    {
+        // if the file already defines styles, use the first one
+        if (!string.IsNullOrEmpty(subtitle.Header) &&
+            subtitle.Header.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
+        {
+            var existingStyles = AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header);
+            if (existingStyles.Count > 0)
+            {
+                return existingStyles[0];
+            }
+        }
+
+        // otherwise use the default ASSA storage style (if any) as the file's style
+        var defaultStorageStyle = GetDefaultStorageStyle();
+        if (defaultStorageStyle != null)
+        {
+            var style = new StyleDisplay(defaultStorageStyle).ToSsaStyle();
+            subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(
+                AdvancedSubStationAlpha.DefaultHeader, new List<SsaStyle> { style });
+            return style.Name;
+        }
+
+        // fall back to the standard default style
+        if (string.IsNullOrEmpty(subtitle.Header))
+        {
+            subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
+        }
+
+        return AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header).FirstOrDefault() ?? "Default";
+    }
+
+    /// <summary>
+    /// Applies the default ASSA storage style (if any) to a subtitle that is about to use the
+    /// Advanced SubStation Alpha format - used when creating a new subtitle or converting to ASSA
+    /// from a format without ASSA styles. The default storage style becomes the only style in the
+    /// header and existing paragraphs are re-pointed to it.
+    /// </summary>
+    /// <returns>True if a default storage style was applied; otherwise false.</returns>
+    public static bool ApplyDefaultStorageStyle(Subtitle subtitle)
+    {
+        var defaultStorageStyle = GetDefaultStorageStyle();
+        if (defaultStorageStyle == null)
+        {
+            return false;
+        }
+
+        var style = new StyleDisplay(defaultStorageStyle).ToSsaStyle();
+
+        var header = subtitle.Header;
+        if (string.IsNullOrEmpty(header) || !header.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
+        {
+            header = AdvancedSubStationAlpha.DefaultHeader;
+        }
+
+        subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(header, new List<SsaStyle> { style });
+
+        foreach (var p in subtitle.Paragraphs)
+        {
+            p.Extra = style.Name;
+        }
+
+        return true;
+    }
+}

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1506,6 +1506,11 @@ public partial class MainViewModel :
                            Encodings[0];
         _subtitleFileName = string.Empty;
         _subtitle = new Subtitle();
+        if (SelectedSubtitleFormat is AdvancedSubStationAlpha)
+        {
+            AssaStyleStorageHelper.ApplyDefaultStorageStyle(_subtitle);
+        }
+
         _changeSubtitleHash = GetFastHash();
 
         _subtitleFileNameOriginal = string.Empty;
@@ -18099,8 +18104,24 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
+    /// <summary>
+    /// Sets the style of a newly created ASSA paragraph to the default ASSA storage style (if any).
+    /// Used by insert paths that bypass <see cref="IInsertService"/> (e.g. typing the first line or
+    /// inserting from a waveform selection).
+    /// </summary>
+    private void SetDefaultAssaStyleForNewParagraph(SubtitleLineViewModel newParagraph)
+    {
+        if (SelectedSubtitleFormat is not AdvancedSubStationAlpha)
+        {
+            return;
+        }
+
+        newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(_subtitle);
+    }
+
     public void AudioVisualizerOnNewSelectionInsert(object sender, ParagraphEventArgs e)
     {
+        SetDefaultAssaStyleForNewParagraph(e.Paragraph);
         var index = _insertService.InsertInCorrectPosition(Subtitles, e.Paragraph);
         SelectAndScrollToRow(index);
         Renumber();
@@ -18957,7 +18978,11 @@ public partial class MainViewModel :
                 Number = 1
             };
 
-            if (SelectedSubtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
+            if (SelectedSubtitleFormat is AdvancedSubStationAlpha)
+            {
+                newSubtitle.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(_subtitle);
+            }
+            else if (SelectedSubtitleFormat is SubStationAlpha)
             {
                 if (string.IsNullOrEmpty(_subtitle.Header))
                 {
@@ -19040,6 +19065,11 @@ public partial class MainViewModel :
                     else if (oldFormat is AdvancedSubStationAlpha && string.IsNullOrEmpty(_subtitle.Header))
                     {
                         _subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
+                    }
+                    else if (oldFormat is not AdvancedSubStationAlpha)
+                    {
+                        // converting from a format without ASSA styles - use the default style from the storage styles (if any)
+                        AssaStyleStorageHelper.ApplyDefaultStorageStyle(_subtitle);
                     }
 
                     SetAssaResolution(true);

--- a/src/ui/Logic/InsertService.cs
+++ b/src/ui/Logic/InsertService.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -280,6 +281,9 @@ public class InsertService : IInsertService
                     newParagraph.Extra = c.Extra;
                     newParagraph.Actor = c.Actor;
                 }
+
+                // use the first style from the file, or the default ASSA storage style for a new file
+                newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle);
             }
         }
     }


### PR DESCRIPTION
## Summary

When the ASSA format is used, new content now picks up the **default style from the ASSA styles storage** (if a storage style is marked as default). Previously new lines always used the generic `Default` style.

This applies when:
- Creating a new subtitle (File > New) with the ASSA format
- Converting to ASSA from a format without ASSA styles
- Inserting a new line — insert before/after, typing the first line in an empty grid, and inserting from a waveform selection

## Precedence

The decision is centralized in `AssaStyleStorageHelper.GetStyleNameForNewParagraph`:

1. **If the file already defines styles** → use the **first style from the file**.
2. **Otherwise** (fresh/empty header) → use the **default ASSA storage style**, writing it into the header so it becomes the file's style.
3. If no storage default is set → fall back to `Default`.

## Changes

- **`src/ui/Features/Assa/AssaStyleStorageHelper.cs`** (new) — `GetDefaultStorageStyle`, `GetStyleNameForNewParagraph`, and `ApplyDefaultStorageStyle` helpers.
- **`src/ui/Logic/InsertService.cs`** — ASSA branch of `SetStyleForNewParagraph` uses the new decision method.
- **`src/ui/Features/Main/MainViewModel.cs`** — wires the helper into `ResetSubtitle` (new), `ComboBoxSubtitleFormatChanged` (convert), `SubtitleTextBoxGotFocus` (first line), and `AudioVisualizerOnNewSelectionInsert` (waveform). SSA keeps its original behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)