### PR TITLE
Add "Beautify time codes..." to subtitle grid selected lines context menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -957,7 +957,7 @@ public static partial class InitListViewAndEditBox
                 new MenuItem
                 {
                     Header = Se.Language.Main.Menu.BeautifyTimeCodes,
-                    Command = vm.ShowBeautifyTimeCodesCommand,
+                    Command = vm.ShowBeautifyTimeCodesSelectedLinesCommand,
                     DataContext = vm,
                 },
                 new Separator { DataContext = vm },

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -954,6 +954,12 @@ public static partial class InitListViewAndEditBox
                     Command = vm.MultipleReplaceSelectedLinesCommand,
                     DataContext = vm,
                 },
+                new MenuItem
+                {
+                    Header = Se.Language.Main.Menu.BeautifyTimeCodes,
+                    Command = vm.ShowBeautifyTimeCodesCommand,
+                    DataContext = vm,
+                },
                 new Separator { DataContext = vm },
                 new MenuItem
                 {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7494,6 +7494,50 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task ShowBeautifyTimeCodesSelectedLines()
+    {
+        if (Window == null || AudioVisualizer == null || string.IsNullOrEmpty(_videoFileName))
+        {
+            return;
+        }
+
+        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>()
+            .OrderBy(p => p.StartTime)
+            .ToList();
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var viewModel = await ShowDialogAsync<BeautifyTimeCodesWindow, BeautifyTimeCodesViewModel>(
+            vm => { vm.Initialize(selectedItems, AudioVisualizer, _videoFileName); });
+
+        if (!viewModel.OkPressed)
+        {
+            return;
+        }
+
+        // Beautify preserves paragraph count and start-time ordering, so map results
+        // back onto the live grid rows by start-time order.
+        var beautified = viewModel.GetBeautifiedSubtitles()
+            .OrderBy(p => p.StartTime)
+            .ToList();
+        if (beautified.Count != selectedItems.Count)
+        {
+            return;
+        }
+
+        for (var i = 0; i < beautified.Count; i++)
+        {
+            selectedItems[i].StartTime = beautified[i].StartTime;
+            selectedItems[i].EndTime = beautified[i].EndTime;
+            selectedItems[i].UpdateDuration();
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
     private async Task FixCommonErrorsSelectedLines()
     {
         var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7484,13 +7484,33 @@ public partial class MainViewModel :
             return;
         }
 
+        var lines = Subtitles.OrderBy(p => p.StartTime).ToList();
         var viewModel = await ShowDialogAsync<BeautifyTimeCodesWindow, BeautifyTimeCodesViewModel>(
-            vm => { vm.Initialize(Subtitles.ToList(), AudioVisualizer, _videoFileName); });
+            vm => { vm.Initialize(lines, AudioVisualizer, _videoFileName); });
 
         if (!viewModel.OkPressed)
         {
             return;
         }
+
+        // Beautify preserves paragraph count and start-time ordering, so map results
+        // back onto the live grid rows by start-time order.
+        var beautified = viewModel.GetBeautifiedSubtitles()
+            .OrderBy(p => p.StartTime)
+            .ToList();
+        if (beautified.Count != lines.Count)
+        {
+            return;
+        }
+
+        for (var i = 0; i < beautified.Count; i++)
+        {
+            lines[i].StartTime = beautified[i].StartTime;
+            lines[i].EndTime = beautified[i].EndTime;
+            lines[i].UpdateDuration();
+        }
+
+        _updateAudioVisualizer = true;
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
Adds a **"Beautify time codes..."** item to the subtitle grid context menu's **"Selected lines"** submenu (after **Multiple replace**), and fixes the Beautify dialog's results never being applied back to the grid.

## Changes
- **New context-menu item** — adds "Beautify time codes..." to the grid's "Selected lines" submenu, reusing the existing `Se.Language.Main.Menu.BeautifyTimeCodes` language string.
- **Selected-lines beautify** — the menu item invokes a new `ShowBeautifyTimeCodesSelectedLines` command that passes only the selected rows to the dialog and writes the beautified start/end times back onto those rows.
- **Fix all-lines beautify write-back** — the existing Tools-menu "Beautify time codes" command opened the dialog but never applied its results to the grid. It now writes the beautified times back as well.

Both code paths map the dialog's results onto the live grid rows by **start-time order** (the dialog regenerates paragraph IDs on OK, but beautify preserves paragraph count and ordering, so order-based mapping is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
