### PR TITLE
Align BinaryEdit video player behavior with main window

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -150,6 +150,7 @@ public partial class OcrViewModel : ObservableObject
     public readonly List<SubtitleLineViewModel> OcredSubtitle;
 
     private IOcrSubtitle? _ocrSubtitle;
+    private string _sourceFileName = string.Empty;
     private readonly INOcrCaseFixer _nOcrCaseFixer;
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
@@ -575,7 +576,7 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(string.Empty, _ocrSubtitle); });
+        var result = await _windowService.ShowDialogAsync<BinaryEditWindow, BinaryEditViewModel>(Window, vm => { vm.Initialize(_sourceFileName, _ocrSubtitle); });
         _isCtrlDown = false;
     }
 
@@ -3972,6 +3973,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void Initialize(List<BluRaySupParser.PcsData> subtitles, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleBluRay(subtitles);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -3979,6 +3981,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void Initialize(List<VobSubMergedPack> vobSubMergedPackList, List<SKColor> palette, string vobSubFileName)
     {
+        _sourceFileName = vobSubFileName;
         Title = string.Format(Se.Language.Ocr.OcrX, vobSubFileName);
         _ocrSubtitle = new OcrSubtitleVobSub(vobSubMergedPackList, palette);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -3988,6 +3991,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void Initialize(Trak mp4SubtitleTrack, List<Paragraph> paragraphs, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMp4VobSub(mp4SubtitleTrack, paragraphs);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -3995,6 +3999,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void Initialize(List<VobSubMergedPack> mergedVobSubPacks, List<SKColor> palette, MatroskaTrackInfo matroskaSubtitleInfo, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleVobSub(mergedVobSubPacks, palette);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4004,6 +4009,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void Initialize(MatroskaTrackInfo matroskaSubtitleInfo, Subtitle subtitle, List<DvbSubPes> subtitleImages, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMkvDvb(matroskaSubtitleInfo, subtitle, subtitleImages);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4011,6 +4017,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void Initialize(MatroskaTrackInfo matroskaSubtitleInfo, List<BluRaySupParser.PcsData> pcsDataList, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMkvBluRay(matroskaSubtitleInfo, pcsDataList);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4018,6 +4025,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void Initialize(IList<IBinaryParagraphWithPosition> list, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleIBinaryParagraph(list);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4025,6 +4033,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void InitializeBdn(Subtitle subtitle, string fileName, bool isSon)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleBdn(subtitle, fileName, isSon);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4032,6 +4041,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void InitializeWebVtt(Subtitle subtitle, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleWebVttImages(subtitle, fileName);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4039,6 +4049,7 @@ public partial class OcrViewModel : ObservableObject
 
     public void InitializeSpDvdSup(string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleSpDvdSupImages(fileName);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4046,6 +4057,7 @@ public partial class OcrViewModel : ObservableObject
 
     internal void Initialize(TransportStreamParser tsParser, List<TransportStreamSubtitle> subtitles, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleTransportStream(tsParser, subtitles, fileName);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4053,6 +4065,7 @@ public partial class OcrViewModel : ObservableObject
 
     internal void Initialize(List<ImportImageItem> images)
     {
+        _sourceFileName = string.Empty;
         Title = string.Format(Se.Language.Ocr.OcrX, Se.Language.General.Images);
         _ocrSubtitle = new OcrImportImage(images);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
@@ -4060,6 +4073,7 @@ public partial class OcrViewModel : ObservableObject
 
     internal void InitializeDivX(List<XSub> list, string fileName)
     {
+        _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, "DivX");
         _ocrSubtitle = new OcrSubtitleDivX(list, fileName);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -36,6 +36,7 @@ public partial class BinaryEditViewModel : ObservableObject
 {
     [ObservableProperty] private string _fileName;
     [ObservableProperty] private BinarySubtitleItem? _selectedSubtitle;
+    [ObservableProperty] private BinarySubtitleItem? _displayedSubtitle;
     [ObservableProperty] private int _screenWidth;
     [ObservableProperty] private int _screenHeight;
     [ObservableProperty] private string _statusText;
@@ -63,6 +64,7 @@ public partial class BinaryEditViewModel : ObservableObject
     private readonly IBluRayHelper _bluRayHelper;
 
     private string _loadFileName = string.Empty;
+    private int _lastPlaybackSubtitleIndex = -2;
 
     public BinaryEditViewModel(IFileHelper fileHelper, IWindowService windowService, IFolderHelper folderHelper, IShortcutManager shortcutManager, IBluRayHelper bluRayHelper)
     {
@@ -130,6 +132,12 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     partial void OnSelectedSubtitleChanged(BinarySubtitleItem? value)
+    {
+        DisplayedSubtitle = value;
+        UpdateOverlayPosition();
+    }
+
+    partial void OnDisplayedSubtitleChanged(BinarySubtitleItem? value)
     {
         UpdateOverlayPosition();
     }
@@ -242,13 +250,13 @@ public partial class BinaryEditViewModel : ObservableObject
         VideoContentBorder.Margin = new Avalonia.Thickness(rectX, rectY, 0, 0);
 
         // Update subtitle overlay
-        if (SubtitleOverlayImage == null || SelectedSubtitle == null || SelectedSubtitle.Bitmap == null)
+        if (SubtitleOverlayImage == null || DisplayedSubtitle == null || DisplayedSubtitle.Bitmap == null)
         {
             return;
         }
 
-        var subtitleScreenWidth = SelectedSubtitle.ScreenSize.Width;
-        var subtitleScreenHeight = SelectedSubtitle.ScreenSize.Height;
+        var subtitleScreenWidth = DisplayedSubtitle.ScreenSize.Width;
+        var subtitleScreenHeight = DisplayedSubtitle.ScreenSize.Height;
 
         if (subtitleScreenWidth <= 0 || subtitleScreenHeight <= 0)
         {
@@ -260,14 +268,14 @@ public partial class BinaryEditViewModel : ObservableObject
         var scaleY = rectHeight / subtitleScreenHeight;
 
         // Get original bitmap dimensions and set scaled size on image
-        var bitmapWidth = SelectedSubtitle.Bitmap.Size.Width;
-        var bitmapHeight = SelectedSubtitle.Bitmap.Size.Height;
+        var bitmapWidth = DisplayedSubtitle.Bitmap.Size.Width;
+        var bitmapHeight = DisplayedSubtitle.Bitmap.Size.Height;
         SubtitleOverlayImage.Width = bitmapWidth * scaleX;
         SubtitleOverlayImage.Height = bitmapHeight * scaleY;
 
         // Position: rectangle position + scaled subtitle position
-        var overlayX = rectX + (SelectedSubtitle.X * scaleX);
-        var overlayY = rectY + (SelectedSubtitle.Y * scaleY);
+        var overlayX = rectX + (DisplayedSubtitle.X * scaleX);
+        var overlayY = rectY + (DisplayedSubtitle.Y * scaleY);
         SubtitleOverlayImage.Margin = new Avalonia.Thickness(overlayX, overlayY, 0, 0);
     }
 
@@ -1808,6 +1816,46 @@ public partial class BinaryEditViewModel : ObservableObject
         });
     }
 
+    internal void OnVideoPositionChanged(double positionSeconds)
+    {
+        var subtitleIndex = FindActiveSubtitleIndex(Subtitles, TimeSpan.FromSeconds(positionSeconds));
+        if (subtitleIndex < 0)
+        {
+            if (_lastPlaybackSubtitleIndex == -1 && DisplayedSubtitle == null)
+            {
+                return;
+            }
+
+            _lastPlaybackSubtitleIndex = -1;
+            DisplayedSubtitle = null;
+            return;
+        }
+
+        var subtitle = Subtitles[subtitleIndex];
+        if (_lastPlaybackSubtitleIndex == subtitleIndex && ReferenceEquals(DisplayedSubtitle, subtitle))
+        {
+            return;
+        }
+
+        _lastPlaybackSubtitleIndex = subtitleIndex;
+        DisplayedSubtitle = subtitle;
+        SelectAndScrollToRow(subtitleIndex);
+    }
+
+    internal static int FindActiveSubtitleIndex(IReadOnlyList<BinarySubtitleItem> subtitles, TimeSpan position)
+    {
+        for (var i = 0; i < subtitles.Count; i++)
+        {
+            var subtitle = subtitles[i];
+            if (subtitle.StartTime <= position && position < subtitle.EndTime)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
     private void SelectAndScrollToRow(int index)
     {
         if (index < 0 || SubtitleGrid == null)
@@ -1919,4 +1967,3 @@ public partial class BinaryEditViewModel : ObservableObject
         vp.Position = item.StartTime.TotalSeconds;
     }
 }
-

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -37,6 +37,7 @@ public partial class BinaryEditViewModel : ObservableObject
     [ObservableProperty] private string _fileName;
     [ObservableProperty] private BinarySubtitleItem? _selectedSubtitle;
     [ObservableProperty] private BinarySubtitleItem? _displayedSubtitle;
+    [ObservableProperty] private bool _selectCurrentSubtitleWhilePlaying;
     [ObservableProperty] private int _screenWidth;
     [ObservableProperty] private int _screenHeight;
     [ObservableProperty] private string _statusText;
@@ -74,6 +75,7 @@ public partial class BinaryEditViewModel : ObservableObject
         _shortcutManager = shortcutManager;
         _bluRayHelper = bluRayHelper;
         _fileName = string.Empty;
+        _selectCurrentSubtitleWhilePlaying = Se.Settings.Tools.BinEditSelectCurrentSubtitleWhilePlaying;
         Subtitles = new ObservableCollection<BinarySubtitleItem>();
         StatusText = string.Empty;
         CurrentPositionAndSize = string.Empty;
@@ -133,13 +135,22 @@ public partial class BinaryEditViewModel : ObservableObject
 
     partial void OnSelectedSubtitleChanged(BinarySubtitleItem? value)
     {
-        DisplayedSubtitle = value;
+        if (VideoPlayerControl?.IsPlaying != true)
+        {
+            DisplayedSubtitle = value;
+        }
+
         UpdateOverlayPosition();
     }
 
     partial void OnDisplayedSubtitleChanged(BinarySubtitleItem? value)
     {
         UpdateOverlayPosition();
+    }
+
+    partial void OnSelectCurrentSubtitleWhilePlayingChanged(bool value)
+    {
+        Se.Settings.Tools.BinEditSelectCurrentSubtitleWhilePlaying = value;
     }
 
     internal void SubtitleGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -1500,6 +1511,12 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void ToggleCurrentSubtitleWhilePlaying()
+    {
+        SelectCurrentSubtitleWhilePlaying = !SelectCurrentSubtitleWhilePlaying;
+    }
+
+    [RelayCommand]
     private async Task Settings()
     {
         if (Window == null)
@@ -1832,14 +1849,18 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         var subtitle = Subtitles[subtitleIndex];
-        if (_lastPlaybackSubtitleIndex == subtitleIndex && ReferenceEquals(DisplayedSubtitle, subtitle))
+        if (_lastPlaybackSubtitleIndex != subtitleIndex || !ReferenceEquals(DisplayedSubtitle, subtitle))
         {
-            return;
+            _lastPlaybackSubtitleIndex = subtitleIndex;
+            DisplayedSubtitle = subtitle;
         }
 
-        _lastPlaybackSubtitleIndex = subtitleIndex;
-        DisplayedSubtitle = subtitle;
-        SelectAndScrollToRow(subtitleIndex);
+        if (SelectCurrentSubtitleWhilePlaying &&
+            VideoPlayerControl?.IsPlaying == true &&
+            SubtitleGrid?.SelectedIndex != subtitleIndex)
+        {
+            SelectAndScrollToRow(subtitleIndex);
+        }
     }
 
     internal static int FindActiveSubtitleIndex(IReadOnlyList<BinarySubtitleItem> subtitles, TimeSpan position)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -477,9 +477,9 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         var videoFileName = TryGetVideoFileName(fileName);
-        if (!string.IsNullOrEmpty(videoFileName) && VideoPlayerControl != null)
+        if (ShouldAutoOpenMatchingVideo(Se.Settings.Video.AutoOpen, videoFileName) && VideoPlayerControl != null)
         {
-            await VideoPlayerControl.Open(videoFileName);
+            await VideoPlayerControl.Open(videoFileName!);
         }
     }
 
@@ -1510,6 +1510,16 @@ public partial class BinaryEditViewModel : ObservableObject
         await VideoPlayerControl.Open(videoFileName);
     }
 
+    internal void VideoPlayerAreaPointerPressed()
+    {
+        if (VideoPlayerControl == null || !ShouldOpenVideoPickerOnSurfaceClick(VideoPlayerControl.VideoPlayer.FileName))
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() => OpenVideoCommand.Execute(null));
+    }
+
     [RelayCommand]
     private void ToggleCurrentSubtitleWhilePlaying()
     {
@@ -1875,6 +1885,16 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         return -1;
+    }
+
+    internal static bool ShouldAutoOpenMatchingVideo(bool autoOpenVideo, string? videoFileName)
+    {
+        return autoOpenVideo && !string.IsNullOrEmpty(videoFileName);
+    }
+
+    internal static bool ShouldOpenVideoPickerOnSurfaceClick(string? videoFileName)
+    {
+        return string.IsNullOrEmpty(videoFileName);
     }
 
     private void SelectAndScrollToRow(int index)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -300,6 +300,21 @@ public class BinaryEditWindow : Window
                     Command = vm.OpenVideoCommand,
                     Icon = new Icon { Value = IconNames.Play },
                 },
+                new MenuItem
+                {
+                    Header = l.ToggleSelectSubtitleWhilePlayingCurrentlyOn,
+                    Command = vm.ToggleCurrentSubtitleWhilePlayingCommand,
+                    [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.SelectCurrentSubtitleWhilePlaying)),
+                },
+                new MenuItem
+                {
+                    Header = l.ToggleSelectSubtitleWhilePlayingCurrentlyOff,
+                    Command = vm.ToggleCurrentSubtitleWhilePlayingCommand,
+                    [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.SelectCurrentSubtitleWhilePlaying))
+                    {
+                        Converter = new InverseBooleanConverter(),
+                    },
+                },
             },
         });
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -657,6 +657,9 @@ public class BinaryEditWindow : Window
     {
         var vp = InitVideoPlayer.MakeVideoPlayer();
         vp.FullScreenIsVisible = false;
+        vp.Volume = Se.Settings.Video.Volume;
+        vp.VolumeChanged += v => { Se.Settings.Video.Volume = v; };
+        vp.SurfacePointerPressed += (_, _) => vm.VideoPlayerAreaPointerPressed();
 
         // Create a grid to hold the video player and overlay image
         var videoGrid = new Grid

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -8,6 +8,7 @@ using Avalonia.Media;
 using System;
 using System.Collections;
 using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -670,11 +671,11 @@ public class BinaryEditWindow : Window
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Top,
             Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.Hand),
-            [!Visual.IsVisibleProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.Bitmap)}")
+            [!Visual.IsVisibleProperty] = new Binding($"{nameof(vm.DisplayedSubtitle)}.{nameof(BinarySubtitleItem.Bitmap)}")
             {
                 Converter = new NotNullConverter()
             },
-            [!Image.SourceProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.Bitmap)}"),
+            [!Image.SourceProperty] = new Binding($"{nameof(vm.DisplayedSubtitle)}.{nameof(BinarySubtitleItem.Bitmap)}"),
         };
 
         videoGrid.Children.Add(overlayImage);
@@ -685,6 +686,13 @@ public class BinaryEditWindow : Window
 
         // Update position when video player size changes
         vp.SizeChanged += (_, _) => vm.UpdateOverlayPosition();
+        vp.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == VideoPlayerControl.PositionProperty)
+            {
+                vm.OnVideoPositionChanged(vp.Position);
+            }
+        };
 
         // Implement mouse dragging for overlay image
         Point? dragStartPoint = null;

--- a/src/ui/Features/Shared/BinaryEdit/BinarySubtitleItem.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinarySubtitleItem.cs
@@ -88,6 +88,19 @@ public partial class BinarySubtitleItem : ObservableObject
         OcrSubtitleIndex = -1;
     }
 
+    internal BinarySubtitleItem(TimeSpan startTime, TimeSpan endTime)
+    {
+        _startTime = startTime;
+        _endTime = endTime;
+        _duration = endTime - startTime;
+        _screenWidth = 1920;
+        _screenHeight = 1080;
+        Number = 0;
+        IsForced = false;
+        Text = string.Empty;
+        OcrSubtitleIndex = -1;
+    }
+
     public int OcrSubtitleIndex { get; set; }
     public int Number { get; set; }
     public string Text { get; set; }

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.ComponentModel;
 
 namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
 
@@ -51,6 +52,29 @@ public static class InitNativeMacMenuBinaryEdit
         // Video menu
         var videoMenu = new NativeMenu();
         Add(videoMenu, l.OpenVideo, vm.OpenVideoCommand);
+        var selectSubtitleWhilePlayingItem = new NativeMenuItem(Clean(l.SelectSubtitleWhilePlaying))
+        {
+            ToggleType = MenuItemToggleType.CheckBox,
+            IsChecked = vm.SelectCurrentSubtitleWhilePlaying,
+        };
+        selectSubtitleWhilePlayingItem.Click += (_, _) => vm.ToggleCurrentSubtitleWhilePlayingCommand.Execute(null);
+        PropertyChangedEventHandler? handler = null;
+        handler = (_, e) =>
+        {
+            if (e.PropertyName == nameof(BinaryEditViewModel.SelectCurrentSubtitleWhilePlaying))
+            {
+                selectSubtitleWhilePlayingItem.IsChecked = vm.SelectCurrentSubtitleWhilePlaying;
+            }
+        };
+        vm.PropertyChanged += handler;
+        window.Closed += (_, _) =>
+        {
+            if (handler != null)
+            {
+                vm.PropertyChanged -= handler;
+            }
+        };
+        videoMenu.Items.Add(selectSubtitleWhilePlayingItem);
         root.Items.Add(new NativeMenuItem(Clean(l.Video)) { Menu = videoMenu });
 
         // Options menu

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -76,6 +76,7 @@ public class SeTools
     public string BinEditBackgroundColor { get; set; }
     public decimal BinEditOutlineWidth { get; set; }
     public decimal BinEditShadowWidth { get; set; }
+    public bool BinEditSelectCurrentSubtitleWhilePlaying { get; set; }
 
     public string ImportTextSplitting { get; set; }
     public string ImportTextSplittingLineMode { get; set; }

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
 
 namespace UITests.Features.Shared.BinaryEdit;
@@ -31,5 +32,13 @@ public class BinaryEditViewModelTests
         var result = BinaryEditViewModel.FindActiveSubtitleIndex(subtitles, TimeSpan.FromSeconds(3));
 
         Assert.Equal(-1, result);
+    }
+
+    [Fact]
+    public void SeTools_BinaryEditSelectCurrentSubtitleWhilePlaying_DefaultsToFalse()
+    {
+        var settings = new SeTools();
+
+        Assert.False(settings.BinEditSelectCurrentSubtitleWhilePlaying);
     }
 }

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
@@ -35,6 +35,25 @@ public class BinaryEditViewModelTests
     }
 
     [Fact]
+    public void ShouldAutoOpenMatchingVideo_RequiresSettingAndMatchingPath()
+    {
+        Assert.True(BinaryEditViewModel.ShouldAutoOpenMatchingVideo(true, "video.mkv"));
+        Assert.False(BinaryEditViewModel.ShouldAutoOpenMatchingVideo(false, "video.mkv"));
+        Assert.False(BinaryEditViewModel.ShouldAutoOpenMatchingVideo(true, string.Empty));
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("video.mkv", false)]
+    public void ShouldOpenVideoPickerOnSurfaceClick_OnlyWhenNoVideoIsLoaded(string? fileName, bool expected)
+    {
+        var result = BinaryEditViewModel.ShouldOpenVideoPickerOnSurfaceClick(fileName);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
     public void SeTools_BinaryEditSelectCurrentSubtitleWhilePlaying_DefaultsToFalse()
     {
         var settings = new SeTools();

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
@@ -1,0 +1,35 @@
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+using System.Collections.Generic;
+
+namespace UITests.Features.Shared.BinaryEdit;
+
+public class BinaryEditViewModelTests
+{
+    [Fact]
+    public void FindActiveSubtitleIndex_IncludesCueStartAndExcludesCueEnd()
+    {
+        var subtitles = new List<BinarySubtitleItem>
+        {
+            new(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3)),
+            new(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5)),
+        };
+
+        Assert.Equal(0, BinaryEditViewModel.FindActiveSubtitleIndex(subtitles, TimeSpan.FromSeconds(1)));
+        Assert.Equal(1, BinaryEditViewModel.FindActiveSubtitleIndex(subtitles, TimeSpan.FromSeconds(3)));
+        Assert.Equal(-1, BinaryEditViewModel.FindActiveSubtitleIndex(subtitles, TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public void FindActiveSubtitleIndex_ReturnsMinusOneInsideGap()
+    {
+        var subtitles = new List<BinarySubtitleItem>
+        {
+            new(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)),
+            new(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(5)),
+        };
+
+        var result = BinaryEditViewModel.FindActiveSubtitleIndex(subtitles, TimeSpan.FromSeconds(3));
+
+        Assert.Equal(-1, result);
+    }
+}


### PR DESCRIPTION
  This PR aligns the BinaryEdit window's video player behavior with the main window. Three main features are added:

  1. Subtitle overlay syncs with playback — the displayed subtitle updates as video plays, without requiring a grid selection change.
  2. "Select subtitle while playing" toggle — optional; persisted in settings; exposed in both the regular menu and the macOS native menu.
  3. Video player housekeeping — volume persistence, auto-open respects the AutoOpen setting, clicking the empty video surface opens the file picker.

  ## Summary

  - Subtitle overlay now tracks playback position in real time — the displayed image updates as the video plays, without requiring a manual grid selection change
  - Adds a toggleable "select subtitle while playing" option that scrolls and selects the active grid row during playback; persisted in settings; accessible via the Video menu and macOS native menu
  - Volume is now restored on open and persisted on change, matching main window behavior
  - Auto-opening a matching video on file load now respects the `AutoOpen` setting
  - Clicking the empty video surface opens the video file picker (matches main window behavior)
  - Preserve the original OCR source subtitle filename when launching BinaryEdit from the OCR window, so video auto-loading now works there the same way it already does in the direct image-based subtitle edit flow.

  ## Changes

  - **`BinaryEditViewModel`** — introduces `DisplayedSubtitle` (what the overlay shows) separate from `SelectedSubtitle` (grid selection); `OnVideoPositionChanged` drives `DisplayedSubtitle` during playback; `SelectCurrentSubtitleWhilePlaying` toggle persisted via `Se.Settings.Tools.BinEditSelectCurrentSubtitleWhilePlaying`
  - **`BinaryEditWindow`** — wires up `PositionProperty` change listener, volume persistence, surface pointer press, and updated overlay bindings to `DisplayedSubtitle`
  - **`InitNativeMacMenuBinaryEdit`** — adds checkbox menu item for the toggle with proper `PropertyChanged` subscription/cleanup
  - **`SeTools`** — new `BinEditSelectCurrentSubtitleWhilePlaying` setting (defaults to `false`)
  - **`BinarySubtitleItem`** — adds `internal` test constructor
  - **Tests** — new `BinaryEditViewModelTests` covering `FindActiveSubtitleIndex`, `ShouldAutoOpenMatchingVideo`, `ShouldOpenVideoPickerOnSurfaceClick`, and settings default

  ## Testing

  I tested the following cases on macOS:

  - Open a PGS/VobSub file with a matching video via the Import path — verify video auto-opens (when Auto Open is enabled)
  - Open a PGS/VobSub file with a matching video via the Open -> OCR window path — verify video auto-opens (when Auto Open is enabled)
  - Play video — verify subtitle overlay updates in sync with playback position
  - Play video with "Select subtitle while playing" ON — verify grid selection follows playback
  - Play video with "Select subtitle while playing" OFF — verify grid selection stays put
  - Seek in video — verify the correct subtile being displayed (and grid selection follows if enabled)
  - Toggle the setting via macOS native Video menu — verify checkbox state reflects correctly
  - Click empty video area with no video loaded — verify file picker opens
  - Adjust volume, close and reopen — verify volume is restored