### PR TITLE
Add Parakeet RNNT models and SenseVoice-Small ASR

### DIFF
--- a/src/libse/AudioToText/WhisperChoice.cs
+++ b/src/libse/AudioToText/WhisperChoice.cs
@@ -28,6 +28,7 @@
         public const string CrispAsrKyutai = "Crisp ASR Kyutai";
         public const string CrispAsrMadlad = "Crisp ASR MADLAD";
         public const string CrispAsrMega = "Crisp ASR Mega";
+        public const string CrispAsrSenseVoice = "Crisp ASR SenseVoice";
         public const string OpenAiCompatible = "OpenAI Compatible";
     }
 }

--- a/src/ui/Assets/SpeechToText/CrispASRSenseVoice.txt
+++ b/src/ui/Assets/SpeechToText/CrispASRSenseVoice.txt
@@ -1,0 +1,7 @@
+
+🎙️ SenseVoice-Small
+
+Type: Encoder-only CTC ASR (non-autoregressive, ~15× faster than Whisper-Large)
+Focus: 🎯 Chinese, Cantonese, English, Japanese and Korean
+Extras: native language ID, emotion and audio-event tags in a single pass
+

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -32,6 +32,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
             new CrispAsrMega(),
             new CrispAsrOmni(),
             new CrispAsrKyutai(),
+            new CrispAsrSenseVoice(),
         };
 
         SelectedBackend = _backends[0];

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -84,6 +84,42 @@ public class CrispAsrParakeet : CrispAsrEngineBase
                     "https://huggingface.co/cstr/parakeet-tdt-0.6b-ja-GGUF/resolve/main/parakeet-tdt-0.6b-ja.gguf",
                 ],
             },
+            new WhisperModel
+            {
+                Name = "parakeet-rnnt-0.6b-q4_k.gguf",
+                Size = "468 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-rnnt-0.6b-GGUF/resolve/main/parakeet-rnnt-0.6b-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-rnnt-0.6b-f16.gguf",
+                Size = "1.24 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-rnnt-0.6b-GGUF/resolve/main/parakeet-rnnt-0.6b-f16.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-rnnt-1.1b-q4_k.gguf",
+                Size = "808 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-rnnt-1.1b-GGUF/resolve/main/parakeet-rnnt-1.1b-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-rnnt-1.1b-f16.gguf",
+                Size = "2.14 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-rnnt-1.1b-GGUF/resolve/main/parakeet-rnnt-1.1b-f16.gguf",
+                ],
+            },
        };
 
     public override string Extension => string.Empty;

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrSenseVoice.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrSenseVoice.cs
@@ -1,0 +1,152 @@
+﻿using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+public class CrispAsrSenseVoice : CrispAsrEngineBase
+{
+    public static string StaticName => "Crisp ASR SenseVoice";
+    public override string Name => StaticName;
+    public override string Choice => WhisperChoice.CrispAsrSenseVoice;
+    public override string BackendName => "sensevoice";
+    public override string DefaultLanguage => "auto";
+    public override bool IncludeLanguage => true;
+    public override string Url => "https://github.com/CrispStrobe/CrispASR";
+
+    // SenseVoice-Small (FunAudioLLM) officially covers these five languages plus
+    // native language identification ("auto"), emotion and audio-event tags.
+    public override List<WhisperLanguage> Languages =>
+        new()
+        {
+            new WhisperLanguage("auto", "Auto detect"),
+            new WhisperLanguage("zh", "chinese"),
+            new WhisperLanguage("yue", "cantonese"),
+            new WhisperLanguage("en", "english"),
+            new WhisperLanguage("ja", "japanese"),
+            new WhisperLanguage("ko", "korean"),
+        };
+
+    public override List<WhisperModel> Models =>
+       new()
+       {
+            new WhisperModel
+            {
+                Name = "sensevoice-small-q4_k.gguf",
+                Size = "136 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/sensevoice-small-GGUF/resolve/main/sensevoice-small-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "sensevoice-small-q8_0.gguf",
+                Size = "252 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/sensevoice-small-GGUF/resolve/main/sensevoice-small-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "sensevoice-small-f16.gguf",
+                Size = "469 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/sensevoice-small-GGUF/resolve/main/sensevoice-small-f16.gguf",
+                ],
+            },
+       };
+
+    public override string Extension => string.Empty;
+    public override string UnpackSkipFolder => string.Empty;
+
+    public override bool IsEngineInstalled()
+    {
+        var executableFile = GetExecutable();
+        return File.Exists(executableFile);
+    }
+
+    public override string ToString()
+    {
+        return CrispAsrEngine.GetBackendDisplayName(this);
+    }
+
+    public override string GetAndCreateWhisperFolder()
+    {
+        var folder = Se.CrispAsrFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = GetAndCreateWhisperFolder();
+        var modelsFolder = Path.Combine(folder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public override string GetExecutable()
+    {
+        string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+        return fullPath;
+    }
+
+    public override bool IsModelInstalled(WhisperModel model)
+    {
+        var modelFile = GetModelForCmdLine(model.Name);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string GetModelForCmdLine(string modelName)
+    {
+        var modelFileName = Path.Combine(GetAndCreateWhisperModelFolder(null), modelName);
+        return modelFileName;
+    }
+
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        var folder = GetAndCreateWhisperModelFolder(whisperModel);
+        var fileNameOnly = Path.GetFileName(url);
+        var fileName = Path.Combine(folder, fileNameOnly);
+        return fileName;
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "crispasr.exe";
+        }
+
+        return "crispasr";
+    }
+
+    public override bool CanBeDownloaded()
+    {
+        return true;
+    }
+
+    public override string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrSenseVoice;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrSenseVoice = value;
+    }
+}

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -57,6 +57,7 @@ public class SeAudioToText
     public string CommandLineParameterCrispAsrOmni { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrKyutai { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrMega { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrSenseVoice { get; set; } = "--max-len 50 --split-on-punct";
     public string CrispAsrForcedAligner { get; set; } = "built-in";
 
     public string WhisperExtraSettingsHistory { get; set; } = string.Empty;

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -178,6 +178,9 @@
 		<AvaloniaResource Include="Assets\SpeechToText\CrispASRMega.txt">
 		  <CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>
+		<AvaloniaResource Include="Assets\SpeechToText\CrispASRSenseVoice.txt">
+		  <CopyToOutputDirectory></CopyToOutputDirectory>
+		</AvaloniaResource>
 		<AvaloniaResource Include="Assets\Themes.zip" />
 		<AvaloniaResource Include="Assets\SpeechToText\PurfviewFasterWhisper.txt">
 			<CopyToOutputDirectory></CopyToOutputDirectory>


### PR DESCRIPTION
## Summary
Exposes two new CrispASR v0.7.0 ASR capabilities in SE. (Builds on the v0.7.0 runtime update in #11473, now merged.)

### Parakeet RNNT models
The `parakeet` backend runs RNN-T checkpoints as of v0.7.0, so this adds four model entries to the existing `CrispAsrParakeet` engine (no new engine needed):
- `parakeet-rnnt-0.6b` — q4_k (468 MB), f16 (1.24 GB)
- `parakeet-rnnt-1.1b` — q4_k (808 MB), f16 (2.14 GB)

### SenseVoice-Small (new backend)
New CrispASR backend `sensevoice` — encoder-only CTC, non-autoregressive (~15× faster than Whisper-Large), with native language ID + emotion + audio-event tags. Full wiring:
- `CrispAsrSenseVoice.cs` engine class
- `WhisperChoice.CrispAsrSenseVoice` constant
- registered in `CrispAsrEngine._backends`
- `CommandLineParameterCrispAsrSenseVoice` setting
- `CrispASRSenseVoice.txt` help asset + `UI.csproj` resource
- Languages: auto / zh / yue / en / ja / ko; models q4_k (136 MB) / q8_0 (252 MB) / f16 (469 MB)

### Verification
- Backend token `sensevoice` confirmed against the [v0.7.0 README](https://github.com/CrispStrobe/CrispASR/blob/v0.7.0/README.md).
- All 7 new GGUF download URLs return HTTP 206 (resolve + ranged download).
- `dotnet build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)