### PR TITLE
Fix video state management when opening image-based subtitle formats

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14035,7 +14035,7 @@ public partial class MainViewModel :
                         _converted = true;
                         SelectAndScrollToRow(0);
 
-                        if (Se.Settings.General.AutoOpenVideo)
+                        if (Se.Settings.General.AutoOpenVideo && !IsImageSubtitleTrack(result.SelectedMatroskaTrack))
                         {
                             if (fileName.EndsWith("mkv", StringComparison.OrdinalIgnoreCase))
                             {
@@ -14053,7 +14053,7 @@ public partial class MainViewModel :
             var ext = Path.GetExtension(matroska.Path).ToLowerInvariant();
             if (await LoadMatroskaSubtitle(subtitleList[0], matroska, fileName))
             {
-                if (Se.Settings.General.AutoOpenVideo)
+                if (Se.Settings.General.AutoOpenVideo && !IsImageSubtitleTrack(subtitleList[0]))
                 {
                     if (ext == ".mkv")
                     {
@@ -14093,6 +14093,10 @@ public partial class MainViewModel :
                         }
                     }
                 }
+                else
+                {
+                    matroska.Dispose();
+                }
             }
             else
             {
@@ -14117,11 +14121,16 @@ public partial class MainViewModel :
 
                 if (result.OkPressed)
                 {
+                    VideoCloseFile();
                     _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                     _converted = true;
                     ReplaceSubtitles(result.OcredSubtitle);
                     Renumber();
                     SelectAndScrollToRow(0);
+                    if (Se.Settings.General.AutoOpenVideo && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
+                    {
+                        await VideoOpenFile(fileName);
+                    }
                 }
             });
 
@@ -14146,6 +14155,7 @@ public partial class MainViewModel :
         var sub = matroska.GetSubtitle(matroskaSubtitleInfo.TrackNumber, null);
         var subtitle = new Subtitle();
         var format = Utilities.LoadMatroskaTextSubtitle(matroskaSubtitleInfo, matroska, sub, subtitle);
+        VideoCloseFile();
         ResetSubtitle(format);
         _subtitle = subtitle;
         _subtitle.Renumber();
@@ -14154,6 +14164,11 @@ public partial class MainViewModel :
 
         return true;
     }
+
+    private static bool IsImageSubtitleTrack(MatroskaTrackInfo track) =>
+        track.CodecId.Equals("S_HDMV/PGS", StringComparison.OrdinalIgnoreCase) ||
+        track.CodecId.Equals("S_DVBSUB", StringComparison.OrdinalIgnoreCase) ||
+        track.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase);
 
     private bool LoadDvbFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska, string fileName)
     {
@@ -14248,12 +14263,17 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 Renumber();
                 SelectAndScrollToRow(0);
                 ShowStatus(string.Format(Se.Language.General.SubtitleLoadedX, fileName));
+                if (Se.Settings.General.AutoOpenVideo && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
+                {
+                    await VideoOpenFile(fileName);
+                }
             }
         });
 
@@ -14315,9 +14335,14 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
+                VideoCloseFile();
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 SelectAndScrollToRow(0);
+                if (Se.Settings.General.AutoOpenVideo && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
+                {
+                    await VideoOpenFile(fileName);
+                }
             }
         });
 
@@ -14334,6 +14359,7 @@ public partial class MainViewModel :
         ShowStatus(Se.Language.Main.ParsingMatroskaFile);
         var sub = matroska.GetSubtitle(matroskaSubtitleInfo.TrackNumber, MatroskaProgress);
 
+        VideoCloseFile();
         _subtitle.Paragraphs.Clear();
         Utilities.LoadMatroskaTextSubtitle(matroskaSubtitleInfo, matroska, sub, _subtitle);
         Utilities.ParseMatroskaTextSt(matroskaSubtitleInfo, sub, _subtitle);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14098,6 +14098,7 @@ public partial class MainViewModel :
                 }
                 else
                 {
+                    // Image track data was fully extracted before the OCR dialog was posted, so matroska is safe to dispose now.
                     matroska.Dispose();
                 }
             }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1717,7 +1717,6 @@ public partial class MainViewModel :
         var fileName = await _fileHelper.PickOpenSubtitleFile(Window!, Se.Language.General.OpenSubtitleFileTitle, lastOpenedFilePath: _subtitleFileName);
         if (!string.IsNullOrEmpty(fileName))
         {
-            VideoCloseFile();
             await SubtitleOpen(fileName);
         }
 
@@ -1818,7 +1817,6 @@ public partial class MainViewModel :
                 return;
             }
 
-            VideoCloseFile();
             await SubtitleOpen(recentFile.SubtitleFileName, recentFile.VideoFileName, recentFile.SelectedLine, desiredAudioTrackId: recentFile.AudioTrack);
 
             if (!string.IsNullOrEmpty(recentFile.SubtitleFileNameOriginal) &&
@@ -13404,6 +13402,11 @@ public partial class MainViewModel :
                     await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
+            }
+
+            if (!skipLoadVideo)
+            {
+                VideoCloseFile();
             }
 
             ResetSubtitle();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14031,15 +14031,18 @@ public partial class MainViewModel :
                 {
                     if (await LoadMatroskaSubtitle(result.SelectedMatroskaTrack, matroska, fileName))
                     {
-                        _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
-                        _converted = true;
-                        SelectAndScrollToRow(0);
-
-                        if (Se.Settings.General.AutoOpenVideo && !IsImageSubtitleTrack(result.SelectedMatroskaTrack))
+                        if (!IsImageSubtitleTrack(result.SelectedMatroskaTrack))
                         {
-                            if (fileName.EndsWith("mkv", StringComparison.OrdinalIgnoreCase))
+                            _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                            _converted = true;
+                            SelectAndScrollToRow(0);
+
+                            if (Se.Settings.General.AutoOpenVideo)
                             {
-                                await VideoOpenFile(fileName);
+                                if (fileName.EndsWith("mkv", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    await VideoOpenFile(fileName);
+                                }
                             }
                         }
                     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13083,6 +13083,7 @@ public partial class MainViewModel :
 
                         if (result.OkPressed)
                         {
+                            VideoCloseFile();
                             _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                             _converted = true;
                             ReplaceSubtitles(result.OcredSubtitle);
@@ -13175,6 +13176,7 @@ public partial class MainViewModel :
                         return;
                     }
 
+                    VideoCloseFile();
                     ResetSubtitle();
                     _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) +
                                         SelectedSubtitleFormat.Extension;
@@ -13195,6 +13197,7 @@ public partial class MainViewModel :
                 var f = new MacCaption10();
                 if (f.IsMine(lines, fileName))
                 {
+                    VideoCloseFile();
                     ResetSubtitle();
                     f.LoadSubtitle(_subtitle, lines, fileName);
                     SetSubtitles(_subtitle);
@@ -13591,6 +13594,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 _converted = true;
@@ -13634,6 +13638,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 _converted = true;
@@ -13654,6 +13659,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 _converted = true;
@@ -13674,6 +13680,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 _converted = true;
@@ -13727,6 +13734,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 _converted = true;
@@ -13782,6 +13790,7 @@ public partial class MainViewModel :
         if (tsParser.SubtitlePacketIds.Count == 0 && tsParser.TeletextSubtitlesLookup.Count == 1 &&
             tsParser.TeletextSubtitlesLookup.First().Value.Count == 1)
         {
+            VideoCloseFile();
             ResetSubtitle();
             _subtitle = new Subtitle(tsParser.TeletextSubtitlesLookup.First().Value.First().Value);
             _subtitle.Renumber();
@@ -13804,6 +13813,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed && result.SelectedTrack != null && result.SelectedTrack.IsTeletext)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 SelectAndScrollToRow(0);
                 SetSubtitles(result.TeletextSubtitle);
@@ -13835,6 +13845,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
+                VideoCloseFile();
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 SelectAndScrollToRow(0);
@@ -13866,6 +13877,7 @@ public partial class MainViewModel :
         {
             if (mp4Parser.VttcSubtitle?.Paragraphs.Count > 0)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == new WebVTT().Name) ??
                                   SelectedSubtitleFormat);
@@ -13898,6 +13910,7 @@ public partial class MainViewModel :
 
             if (captionsFromH264 != null)
             {
+                VideoCloseFile();
                 ResetSubtitle();
                 _subtitle = captionsFromH264;
                 _subtitle.Renumber();
@@ -13954,6 +13967,7 @@ public partial class MainViewModel :
 
                 if (result.OkPressed)
                 {
+                    VideoCloseFile();
                     ResetSubtitle();
                     _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                     _converted = true;
@@ -13966,6 +13980,7 @@ public partial class MainViewModel :
         }
         else
         {
+            VideoCloseFile();
             ResetSubtitle();
             _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
             _converted = true;
@@ -14397,6 +14412,7 @@ public partial class MainViewModel :
 
         if (result.OkPressed)
         {
+            VideoCloseFile();
             _subtitleFileName = Path.GetFileNameWithoutExtension(vobSubFileName);
             _converted = true;
             ReplaceSubtitles(result.OcredSubtitle);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14130,7 +14130,7 @@ public partial class MainViewModel :
                     ReplaceSubtitles(result.OcredSubtitle);
                     Renumber();
                     SelectAndScrollToRow(0);
-                    if (Se.Settings.General.AutoOpenVideo && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
+                    if (Se.Settings.Video.AutoOpen && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
                     {
                         await VideoOpenFile(fileName);
                     }
@@ -14273,7 +14273,7 @@ public partial class MainViewModel :
                 Renumber();
                 SelectAndScrollToRow(0);
                 ShowStatus(string.Format(Se.Language.General.SubtitleLoadedX, fileName));
-                if (Se.Settings.General.AutoOpenVideo && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
+                if (Se.Settings.Video.AutoOpen && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
                 {
                     await VideoOpenFile(fileName);
                 }
@@ -14342,7 +14342,7 @@ public partial class MainViewModel :
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 SelectAndScrollToRow(0);
-                if (Se.Settings.General.AutoOpenVideo && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
+                if (Se.Settings.Video.AutoOpen && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
                 {
                     await VideoOpenFile(fileName);
                 }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13796,7 +13796,7 @@ public partial class MainViewModel :
             _subtitle.Renumber();
             ReplaceSubtitles(_subtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
             SelectAndScrollToRow(0);
-            if (Se.Settings.General.AutoOpenVideo)
+            if (Se.Settings.Video.AutoOpen)
             {
                 await VideoOpenFile(fileName);
             }
@@ -13819,7 +13819,7 @@ public partial class MainViewModel :
                 SetSubtitles(result.TeletextSubtitle);
                 _subtitleFileName = Path.GetFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
                 _converted = true;
-                if (Se.Settings.General.AutoOpenVideo)
+                if (Se.Settings.Video.AutoOpen)
                 {
                     await VideoOpenFile(fileName);
                 }
@@ -13891,7 +13891,7 @@ public partial class MainViewModel :
                 ShowStatus(string.Format(Se.Language.General.SubtitleLoadedX, fileName));
                 SelectAndScrollToRow(0);
 
-                if (Se.Settings.General.AutoOpenVideo && mp4Parser.GetVideoTracks().Count > 0)
+                if (Se.Settings.Video.AutoOpen && mp4Parser.GetVideoTracks().Count > 0)
                 {
                     await VideoOpenFile(fileName);
                 }
@@ -13922,7 +13922,7 @@ public partial class MainViewModel :
                 ShowStatus(string.Format(Se.Language.General.SubtitleLoadedX, fileName));
                 SelectAndScrollToRow(0);
 
-                if (Se.Settings.General.AutoOpenVideo && mp4Parser.GetVideoTracks().Count > 0)
+                if (Se.Settings.Video.AutoOpen && mp4Parser.GetVideoTracks().Count > 0)
                 {
                     await VideoOpenFile(fileName);
                 }
@@ -13934,7 +13934,7 @@ public partial class MainViewModel :
         {
             LoadMp4Subtitle(fileName, mp4SubtitleTracks[0]);
 
-            if (Se.Settings.General.AutoOpenVideo && mp4Parser.GetVideoTracks().Count > 0)
+            if (Se.Settings.Video.AutoOpen && mp4Parser.GetVideoTracks().Count > 0)
             {
                 await VideoOpenFile(fileName);
             }
@@ -14037,7 +14037,7 @@ public partial class MainViewModel :
                             _converted = true;
                             SelectAndScrollToRow(0);
 
-                            if (Se.Settings.General.AutoOpenVideo)
+                            if (Se.Settings.Video.AutoOpen)
                             {
                                 if (fileName.EndsWith("mkv", StringComparison.OrdinalIgnoreCase))
                                 {
@@ -14056,7 +14056,7 @@ public partial class MainViewModel :
             var ext = Path.GetExtension(matroska.Path).ToLowerInvariant();
             if (await LoadMatroskaSubtitle(subtitleList[0], matroska, fileName))
             {
-                if (Se.Settings.General.AutoOpenVideo && !IsImageSubtitleTrack(subtitleList[0]))
+                if (Se.Settings.Video.AutoOpen && !IsImageSubtitleTrack(subtitleList[0]))
                 {
                     if (ext == ".mkv")
                     {

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -94,7 +94,7 @@ public class SeGeneral
     public string FfmpegPath { get; set; }
     public bool FfmpegUseCenterChannelOnly { get; set; }
     public string LibMpvPath { get; set; }
-    public bool AutoOpenVideo { get; set; }
+
     public bool ShowColumnStartTime { get; set; }
     public bool ShowColumnEndTime { get; set; }
     public bool ShowColumnGap { get; set; }
@@ -213,7 +213,6 @@ public class SeGeneral
 
         FfmpegPath = string.Empty;
         LibMpvPath = string.Empty;
-        AutoOpenVideo = true;
 
         ShowColumnStartTime = true;
         ShowColumnEndTime = true;


### PR DESCRIPTION
  When an SRT subtitle was open alongside its video, and the user opened a PGS/SUP file or selected an image-based subtitle track from an MKV, the video closed immediately, even before the OCR dialog appeared. The early closure was a straightforward programming choice, but it was inconvenient for some workflows.

  It left the user without video or waveform reference after closing the OCR window with Cancel. This scenario is common in my workflow when I work on an OCR'd SRT but need to check the source PGS SUP. Before this PR, I had to reopen the video each time I wanted to take a quick look at the SUP.

  The File -> Open (keep video) option is intended for a different scenario. For example, if I have an SDH and a regular SRT file for a movie, or SRT files in different languages, I want to keep the video open when I replace the SRT file in the main window. The scenario described above involves wanting to maintain the same SRT and video while opening a SUP file for a quick look, after which I can cancel the OCR dialog. I can also do this by selecting File -> Import -> Image-based subtitle for editing, but using the Open toolbar icon is more convenient.

  The same premature close affected all image-based subtitle paths: standalone PGS/SUP, BluRay/DVB/VobSub tracks inside MKV, and TS files with teletext subtitles.

  ### Changes

  **Video lifecycle for image subtitle tracks**
  - Video now stays open while the OCR dialog is shown, closing only when the user accepts the result
  - After accepting OCR, the video is re-opened automatically when `Video.AutoOpen` is enabled and the source file is an MKV

  **Subtitle filename/title**
  - No longer updated when picking an image track from MKV — the subtitle identity isn't known until OCR completes, so these are set in the accept handler instead

  **Settings**
  - Migrated `General.AutoOpenVideo` → `Video.AutoOpen` across all MKV and MP4 container paths
  - Removed the now-unused `AutoOpenVideo` property from `SeGeneral`

  **Resource management**
  - Fixed a `MatroskaFile` handle leak in the path where auto-open is skipped for image tracks
  - Added `IsImageSubtitleTrack()` helper to identify PGS (`S_HDMV/PGS`), DVB (`S_DVBSUB`), and VobSub (`S_VOBSUB`) codec IDs, replacing repeated inline string comparisons

  ### Affected formats

  | Format | Source |
  |---|---|
  | BluRay PGS | Standalone `.sup`, MKV `S_HDMV/PGS` track |
  | DVB subtitles | MKV `S_DVBSUB` track |
  | VobSub | Standalone `.sub`/`.idx`, MKV `S_VOBSUB` track |
  | Teletext | TS file |

  ### Example scenarios I tested

 1. Sync text track: SRT + video open. File → Open .mkv with SRT/ASS track → subtitle replaces, old video closes, MKV auto-opens as video. ✓
 2. Image track cancel: SRT + video open. File → Open .mkv with PGS track → pick track → OCR dialog appears → cancel → original SRT and video still open. ✓
 3. Image track accept: same setup → accept OCR → subtitle replaced, old video closed, MKV auto-opens as video. ✓
 4. VobSub/DVB in MKV: same cancel/accept checks for SVOBSUB codec track.
 5. AutoOpenVideo off: open MKV with image track, accept OCR → subtitle replaces, old video closes, no new video opened. ✓