### PR TITLE
Fix incomplete UI refresh when system theme switches dark → light

### DIFF
--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -107,11 +107,7 @@ public static class UiTheme
     {
         if (Se.Settings.Appearance.Theme == ThemeNameSystem && Application.Current != null)
         {
-            RemoveLighterDark();
-            if (Application.Current.ActualThemeVariant == ThemeVariant.Dark)
-            {
-                ApplyLighterDark();
-            }
+            SetCurrentTheme();
         }
     }
 


### PR DESCRIPTION
  ## Problem

  When macOS switches from dark to light while Subtitle Edit is using the **System** theme setting, several UI elements stay stuck in their dark-mode appearance:

  - The DataGrid column header keeps its dark background
  - The Show / Hide / Duration spinners keep their dark background
  - Subtitle text in the grid and the edit box remains light-gray (dimmed)

  Switching back to dark works correctly. Explicitly changing the theme to Light via Options → Appearance also works correctly. The glitch is specific to **live OS theme changes** when the in-app setting is System.

Before the fix

<img width="1798" height="1072" alt="incomplete" src="https://github.com/user-attachments/assets/8aeeda68-a4a3-4ed9-bcec-d20d3c76ea73" />

For reference:  how the interface should look like

<img width="1798" height="1072" alt="correct" src="https://github.com/user-attachments/assets/7f28331d-378b-46c9-b0e1-010abe6b0b54" />

  ## Root Cause

  Two code paths handle "switch away from dark":

  **Explicit settings change** (user picks Light in Options):
  ApplySettings() → SetCurrentTheme() → RemoveLighterDark()
                                       → RequestedThemeVariant = ThemeVariant.Light
                                       → ApplyMenuScaleStyle()   ← forces re-evaluation
                                       → ApplyLayoutScaleToAllWindows()

  **OS theme change** (macOS flips dark → light):
  OnActualThemeVariantChanged() → RemoveLighterDark()
                                  (stops here)

  The dark overlay is applied in `ApplyLighterDark()` by adding a `Styles` collection (`_lighterDarkStyle`) to `Application.Current.Styles`. This collection sets explicit `Background` and `Foreground` values on `DataGridColumnHeader`, `ButtonSpinner`, `TextBlock`, `TextBox`, `TextArea`, and several other types — overriding whatever the Fluent Light theme would otherwise provide.

  `RemoveLighterDark()` removes that collection from `Application.Current.Styles`. In theory, Avalonia should then re-evaluate all affected controls and fall back to the Fluent Light theme values. In practice, with Avalonia 12, a style **remove** alone does not reliably trigger a complete re-evaluation of all visual elements. A style **add** is what forces it. This behaviour is even called out in a comment inside `ApplyMenuScaleStyle()`:

  ```csharp
  // Create a new style each time with the scaled values baked in.
  // This forces re-evaluation on all controls including popup menus.
```

  The explicit-settings-change path calls SetCurrentTheme(), which ends with ApplyMenuScaleStyle(). That method removes the old menu-scale style and adds a new one — and it is that add which triggers the complete re-evaluation pass. The OS-change path never reaches ApplyMenuScaleStyle(), so the re-evaluation never happens, and the controls are left with stale dark styling.

  Fix

  Replace the inline logic in OnActualThemeVariantChanged with a single call to SetCurrentTheme(), making the OS-change path identical to the explicit-settings-change path:

   ```csharp
  // Before
  private static void OnActualThemeVariantChanged(object? sender, EventArgs e)
  {
      if (Se.Settings.Appearance.Theme == ThemeNameSystem && Application.Current != null)
      {
          RemoveLighterDark();
          if (Application.Current.ActualThemeVariant == ThemeVariant.Dark)
          {
              ApplyLighterDark();
          }
      }
  }

  // After
  private static void OnActualThemeVariantChanged(object? sender, EventArgs e)
  {
      if (Se.Settings.Appearance.Theme == ThemeNameSystem && Application.Current != null)
      {
          SetCurrentTheme();
      }
  }
  ```

  SetCurrentTheme() is safe to call from inside the event handler:

  - It unsubscribes OnActualThemeVariantChanged as its first step, so there is no risk of recursion.
  - It sets RequestedThemeVariant = ThemeVariant.Default, which is already the value when in System mode — no spurious ActualThemeVariantChanged re-fires.
  - It re-subscribes at the end, so future OS theme changes continue to be handled.
  - The ApplyMenuScaleStyle() call at the end adds a style to Application.Current.Styles, which is the missing trigger for a complete re-evaluation of all visual elements.

  Testing

  1. Set theme to System in Options → Appearance.
  2. Switch macOS system theme dark → light (System Settings → Appearance).
  3. Verify the DataGrid header, Show/Hide/Duration spinners, and subtitle text all update to the light theme immediately — no leftover dark areas.
  4. Switch light → dark and confirm the dark theme is also applied correctly.
