### PR TITLE
Fix wrong "After" preview in Fix Common Errors dialog (doubled text)

### DIFF
--- a/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
+++ b/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
@@ -267,6 +267,10 @@ public static class TextDiffHighlighter
                     middleCommon1.Add((commonStart + pos1, length));
                     middleCommon2.Add((commonStart + pos2, length));
                 }
+
+                // middleCommon1 is sorted by pos1 (text1 positions); sort middleCommon2 by its own positions
+                // so BuildDiffRuns can process text2 in forward order
+                middleCommon2.Sort((a, b) => a.start.CompareTo(b.start));
             }
         }
 

--- a/tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs
+++ b/tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs
@@ -1,0 +1,39 @@
+using Nikse.SubtitleEdit.Features.Files.Compare;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace UITests.Features.Files.Compare;
+
+public class TextDiffHighlighterTests
+{
+    [Fact]
+    public void FindCommonParts_WhenContentIsReordered_MiddleCommon2IsSortedByText2Positions()
+    {
+        // Regression test for: <i>[KITT] text</i> → [KITT] <i>text</i>
+        // "<i>" (pos 0 in text1, pos 7 in text2) and "[KITT] " (pos 3 in text1,
+        // pos 0 in text2) are the two common middle substrings. Before the fix,
+        // middleCommon2 was sorted by text1 positions → [(7,3),(0,7)], causing
+        // BuildDiffRuns to walk backwards and emit duplicate text.
+        var method = typeof(TextDiffHighlighter).GetMethod(
+            "FindCommonParts", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(null, [
+            "<i>[KITT] Why is that, Michael?</i>",
+            "[KITT] <i>Why is that, Michael?</i>"
+        ])!;
+
+        var middleCommon2 = (List<(int start, int length)>)result.GetType()
+            .GetField("Item4")!.GetValue(result)!;
+
+        Assert.True(middleCommon2.Count >= 2,
+            "Expected at least 2 common middle substrings for this input");
+
+        for (var i = 1; i < middleCommon2.Count; i++)
+        {
+            Assert.True(middleCommon2[i - 1].start <= middleCommon2[i].start,
+                $"middleCommon2[{i - 1}].start ({middleCommon2[i - 1].start}) " +
+                $"must be <= middleCommon2[{i}].start ({middleCommon2[i].start})");
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses a correctness issue in the TextDiffHighlighter. It was a latent bug. To trigger it, I created a "Fix invalid italic tag" rule that moves the italic tag behind the bracket, as required by Netflix guidelines. This action revealed the latent issue.

<img width="1141" height="325" alt="Double italics" src="https://github.com/user-attachments/assets/eb56e8b1-836e-462c-a781-bd15a5342c2e" />

This was only a diff issue, the subtitle itself was corrected as expected (no double text there).

 None of the fix rules currently on main would trigger this rendering bug:

  The bug requires two common substrings (each ≥ 3 chars) to appear in reversed order between the before and after texts. That only happens when content is genuinely rearranged — like \<i\>[NAME] → [NAME] \<i\> where the tag swaps positions with the bracket name.

  Every main-branch rule does one of:
  - Pure deletion (FixDoubleGreaterThan removes >> , FixEllipsesStart removes ...)
  - Pure insertion (FixMissingOpenBracket adds [)
  - Character substitution (FixDoubleApostrophes, NormalizeStrings, FixAloneLowercaseIToUppercaseI)
  - Move-from-prefix (FixHyphensInDialog can move -  between lines, but this still produces only one long common substring — the line content — so there's no ordering ambiguity)

  ## Problem

  With the test rule, in the Fix Common Errors step-2 dialog, the **After** column displayed garbled, doubled text for the "Fix invalid italic tag" rule. For example:

  | Before | After (buggy) |
  |--------|---------------|
  | `<i>[KITT] It's a van, Michael.</i>` | `[KITT] <i>[KITT] <i>It's a van, Michael.</i>` |

  The correct after text is `[KITT] <i>It's a van, Michael.</i>`. The fix was applied correctly to the subtitle file — only the preview rendering was wrong.

  ## Root cause

  `TextDiffHighlighter.FindCommonParts` returns two position lists:
  - `middleCommon1` — positions of matched substrings within **text1**
  - `middleCommon2` — positions of the same matches within **text2**

  Both lists were sorted by `pos1` (text1 positions). When content is rearranged between before and after (e.g. `<i>[KITT]` → `[KITT] <i>`), the matched substrings appear in a different relative order in text2. `BuildDiffRuns` processes the list with a forward-only cursor, so out-of-order positions caused it to walk backwards and emit text fragments twice.

  ## Fix

  Sort `middleCommon2` by its own positions (independent of `middleCommon1`) before returning from `FindCommonParts`. Since the LCS algorithm marks each position as used at most once, the positions within `middleCommon2` never overlap, so independent sorting is safe.

  The fix is a single `.Sort()` call in `TextDiffHighlighter.cs`.

  ## Changes

  - `src/ui/Features/Files/Compare/TextDiffHighlighter.cs` — one-line fix
  - `tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs` — regression test