### PR TITLE
Fix Option+Arrow word navigation in edit box when Option+Arrow shortcut is assigned (macOS)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17037,7 +17037,10 @@ public partial class MainViewModel :
                 // "allow single-letter shortcuts in text box" is on (#11357).
                 if ((keyEventArgs.Key == Key.Left || keyEventArgs.Key == Key.Right)
                     && (keyEventArgs.KeyModifiers == KeyModifiers.None
-                        || keyEventArgs.KeyModifiers == KeyModifiers.Control))
+                        || keyEventArgs.KeyModifiers == KeyModifiers.Control
+                        || (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                            && (keyEventArgs.KeyModifiers == KeyModifiers.Alt
+                                || keyEventArgs.KeyModifiers == (KeyModifiers.Shift | KeyModifiers.Alt)))))
                 {
                     return;
                 }


### PR DESCRIPTION
This PR fixes a macOS-only keyboard navigation issue, triggered by recent shortcut additions in 6a0a75e

The workaround is to just re-assign or reset conflicting shortcuts like the one below, or ship a macOS keyboard layout (would be a nice addition later). But this specific option-arrow issue is worth fixing in the code.

  ## Problem

  On macOS, assigning a shortcut to Option+Left or Option+Right (e.g. "Move video 500ms back/forward") breaks word navigation in the subtitle text edit box. Pressing Option+Arrow fires the shortcut instead of moving the caret by word, making it impossible to use both features at the same time.

  Plain Left/Right and Ctrl+Left/Right already had explicit protection: when a text input is focused, the shortcut handler returns early before processing, letting the edit box handle the event natively. Option+Left/Right lacked this same protection.

  ## Fix

  Extend the existing caret-navigation guard in `MainViewModel.OnKeyDownHandler` to also cover `Alt` and `Shift+Alt` (word selection) modifier combinations — but only on macOS, since Alt+Arrow carries no native text-navigation meaning on Windows or Linux and should remain freely assignable as a shortcut there.

  ## Behaviour after this fix

  | Context | Key | Result |
  |---|---|---|
  | Edit box focused | Option+Left/Right | Moves caret by word (macOS native) |
  | Edit box focused | Shift+Option+Left/Right | Extends selection by word |
  | Grid / waveform focused | Option+Left/Right | Shortcut fires normally |
  | Windows / Linux (any focus) | Alt+Left/Right | Unchanged — shortcut fires |
