### PR TITLE
Fix OCR hang/OOM on stray '<' (issue #11479)

### DIFF
--- a/src/ui/Features/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/ui/Features/Ocr/FixEngine/OcrFixEngine.cs
@@ -76,7 +76,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         var wordsToIgnore = new List<string>();
 
         var replacedLine = ReplaceLineFixes(index, item, wordsToIgnore);
-        var splitLine = SplitLine(replacedLine, item, index);
+        var splitLine = SplitLine(replacedLine, index);
         if (replacedLine != item.Text)
         {
             splitLine.ReplacementUsed = new ReplacementUsedItem(item.Text, replacedLine, index);
@@ -123,7 +123,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         return replacedLine;
     }
 
-    private OcrFixLineResult SplitLine(string line, OcrSubtitleItem p, int index)
+    internal static OcrFixLineResult SplitLine(string line, int index)
     {
         var result = new OcrFixLineResult
         {
@@ -209,6 +209,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
             }
             // Everything else is special characters
             var specialCharStart = i;
+            i++; // consume at least one char so a stray '<' (no matching '>') cannot cause an infinite loop
             while (i < line.Length &&
                    !char.IsLetterOrDigit(line[i]) &&
                    !char.IsWhiteSpace(line[i]) &&

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+public class OcrFixEngineSplitLineTests
+{
+    // Regression test for https://github.com/SubtitleEdit/subtitleedit/issues/11479
+    // A stray '<' (no matching '>') used to make SplitLine spin forever, adding empty
+    // words until the process ran out of memory (OutOfMemoryException).
+    [Theory]
+    [InlineData("a < b")]
+    [InlineData("<")]
+    [InlineData("3 < 5 and 7 > 2")]
+    [InlineData("<unfinished tag")]
+    [InlineData("end with <")]
+    public void SplitLine_StrayLessThan_DoesNotHangAndKeepsAllText(string line)
+    {
+        var result = OcrFixEngine.SplitLine(line, 0);
+
+        // No characters lost or duplicated: concatenated parts must equal the input.
+        Assert.Equal(line, string.Concat(result.Words.Select(w => w.Word)));
+        // No empty parts (the infinite loop produced zero-length words).
+        Assert.DoesNotContain(result.Words, w => w.Word.Length == 0);
+    }
+
+    [Fact]
+    public void SplitLine_ValidTag_IsParsedAsTag()
+    {
+        var result = OcrFixEngine.SplitLine("<i>Hello</i>", 0);
+
+        var tags = result.Words.Where(w => w.LinePartType == OcrFixLinePartType.Tag).ToList();
+        Assert.Equal(2, tags.Count);
+        Assert.Equal("<i>", tags[0].Word);
+        Assert.Equal("</i>", tags[1].Word);
+        Assert.Equal("<i>Hello</i>", string.Concat(result.Words.Select(w => w.Word)));
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #11479 — during OCR, a stray `<` (an open angle bracket with no matching `>`, e.g. from `3 < 5`) makes Subtitle Edit hang and consume up to ~64 GB of RAM, eventually throwing `OutOfMemoryException` in `OcrFixEngine.SplitLine`. It happens regardless of OCR engine (Tesseract, Google Lens, Paddle).

## Root cause

In `OcrFixEngine.SplitLine`:

1. For a `<` with no matching `>`, `FindTagEnd` returns `startIndex`, so `tagEnd > tagStart` is false and the tag branch is skipped.
2. `<` is not whitespace or a letter/digit, so control reaches the "special characters" branch.
3. That loop's condition explicitly excludes `<` (`line[i] != '<'`), so it consumes nothing and `i` never advances.
4. The outer `while (i < line.Length)` loop spins forever, appending empty-string words until memory is exhausted.

## Fix

Consume at least one character in the special-characters branch (`i++` before the loop), guaranteeing forward progress. A stray `<` is now emitted as a one-character special part; valid `<...>` tags are still handled by the tag branch above.

## Tests

`SplitLine` is changed from `private` to `internal static` (the `UITests` assembly already has `InternalsVisibleTo`), and its unused `OcrSubtitleItem` parameter is dropped so it can be tested without constructing an `IOcrSubtitle`. Added `OcrFixEngineSplitLineTests` covering several stray-`<` inputs (which previously hung) plus a valid-tag sanity check. UI project and tests build and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)