### PR TITLE
Fix burn-in window showing effect text in the logo label

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -221,7 +221,7 @@ public class BurnInWindow : Window
 
         var labelLogo = UiUtil.MakeLabel(Se.Language.General.Logo);
         var buttonLogo = UiUtil.MakeButtonBrowse(vm.ShowLogoCommand);
-        var labelLogoInfo = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.DisplayEffect)).WithMarginRight(3);
+        var labelLogoInfo = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.LogoInfo)).WithMarginRight(3);
         var panelLogo = new StackPanel
         {
             Orientation = Orientation.Horizontal,


### PR DESCRIPTION
## Problem

In the **Video → Burn-in** window, selecting an effect also made the effect text appear next to the **Logo** row.

## Cause

In `BurnInWindow.cs`, the logo info label (`labelLogoInfo`) was bound to `vm.DisplayEffect` instead of `vm.LogoInfo` — a copy-paste leftover from the effect panel just above it.

## Fix

Bind `labelLogoInfo` to `nameof(vm.LogoInfo)`. `LogoInfo` is an `[ObservableProperty]` populated by `UpdateLogoInfo()` (logo filename + position), so the Logo row now reflects the chosen logo and no longer mirrors the effect text.

Verified the UI project builds cleanly and the app runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)