### PR TITLE
Live video preview in burn-in window (issue #11480)

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -6,13 +6,16 @@ using Avalonia.Skia;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -117,6 +120,14 @@ public partial class BurnInViewModel : ObservableObject
     private string _inputVideoFileName;
     private List<BurnInEffectItem> _selectedEffects;
 
+    public VideoPlayerControl? VideoPlayerControl { get; set; }
+    private LibMpvDynamicPlayer? _mpvPreviewPlayer;
+    private VideoPlayerControl? _fullScreenVideoPlayerControl;
+    private DispatcherTimer? _previewTimer;
+    private string _oldPreviewAssa = string.Empty;
+    private readonly string _tempPreviewAssaFileName;
+    private bool _isPreviewSubtitleLoaded;
+
     private readonly IWindowService _windowService;
     private readonly IFolderHelper _folderHelper;
     private readonly IFileHelper _fileHelper;
@@ -126,6 +137,8 @@ public partial class BurnInViewModel : ObservableObject
         _folderHelper = folderHelper;
         _fileHelper = fileHelper;
         _windowService = windowService;
+
+        _tempPreviewAssaFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".ass");
 
         FontNames = new ObservableCollection<string>(FontHelper.GetLibAssaFonts());
         SelectedFontName = FontNames.FirstOrDefault(p => p == Se.Settings.Video.BurnIn.FontName) ?? FontNames[0];
@@ -763,7 +776,7 @@ public partial class BurnInViewModel : ObservableObject
                 }
             }
 
-            SetStyleForNonAssa(subtitle);
+            SetStyleForNonAssa(subtitle, jobItem.Width, jobItem.Height);
         }
 
         var assa = new AdvancedSubStationAlpha();
@@ -772,11 +785,11 @@ public partial class BurnInViewModel : ObservableObject
         return assaFileName;
     }
 
-    private void SetStyleForNonAssa(Subtitle sub)
+    private void SetStyleForNonAssa(Subtitle sub, int width, int height)
     {
         sub.Header = AdvancedSubStationAlpha.DefaultHeader;
         var style = AdvancedSubStationAlpha.GetSsaStyle("Default", sub.Header);
-        style.FontSize = CalculateFontSize(JobItems[_jobItemIndex].Width, JobItems[_jobItemIndex].Height, FontFactor ?? 0);
+        style.FontSize = CalculateFontSize(width, height, FontFactor ?? 0);
         style.Bold = FontIsBold;
         style.FontName = SelectedFontName;
         style.Background = FontShadowColor.ToSKColor();
@@ -806,9 +819,9 @@ public partial class BurnInViewModel : ObservableObject
             AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(sub.Header,
                 new List<SsaStyle> { style });
         sub.Header = AdvancedSubStationAlpha.AddTagToHeader("PlayResX",
-            "PlayResX: " + (VideoWidth ?? 1920).ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
+            "PlayResX: " + width.ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
         sub.Header = AdvancedSubStationAlpha.AddTagToHeader("PlayResY",
-            "PlayResY: " + (VideoHeight ?? 1024).ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
+            "PlayResY: " + height.ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
     }
 
     private static string MakeOutputFileName(string videoFileName)
@@ -1989,9 +2002,204 @@ public partial class BurnInViewModel : ObservableObject
 
     internal void Loaded()
     {
-        Dispatcher.UIThread.Post(() =>
+        Dispatcher.UIThread.Post(LoadVideoPreview);
+    }
+
+    /// <summary>
+    /// Builds the ASSA text for the live preview from the current style/effect settings.
+    /// This mirrors <see cref="MakeAssa"/> but is independent of the burn-in job pipeline
+    /// so it can run while the user is still tweaking settings.
+    /// </summary>
+    private string? GeneratePreviewAssaText()
+    {
+        if (_subtitle.Paragraphs.Count == 0)
         {
-            UpdateNonAssaPreview();
+            return null;
+        }
+
+        var width = VideoWidth ?? _mediaInfo?.Dimension.Width ?? 1920;
+        var height = VideoHeight ?? _mediaInfo?.Dimension.Height ?? 1080;
+
+        var subtitle = new Subtitle(_subtitle, false);
+        var isAssa = _subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat };
+        if (!isAssa)
+        {
+            foreach (var s in subtitle.Paragraphs)
+            {
+                foreach (var effect in _selectedEffects)
+                {
+                    var fontSize = CalculateFontSize(width, height, FontFactor ?? 0);
+                    var durationMs = (int)s.Duration.TotalMilliseconds;
+                    s.Text = effect.ApplyEffect(s.Text, width, height, fontSize, durationMs);
+                }
+            }
+
+            SetStyleForNonAssa(subtitle, width, height);
+        }
+
+        var assa = new AdvancedSubStationAlpha();
+        return assa.ToText(subtitle, string.Empty);
+    }
+
+    private async void LoadVideoPreview()
+    {
+        if (VideoPlayerControl == null ||
+            string.IsNullOrWhiteSpace(VideoFileName) ||
+            !File.Exists(VideoFileName))
+        {
+            return;
+        }
+
+        try
+        {
+            await VideoPlayerControl.Open(VideoFileName);
+            await VideoPlayerControl.WaitForPlayersReadyAsync();
+            SetActivePreviewPlayer(VideoPlayerControl.VideoPlayer as LibMpvDynamicPlayer, alreadyHasSubtitle: false);
+
+            // Seek to the first subtitle so the user immediately sees styled text.
+            if (_subtitle.Paragraphs.Count > 0)
+            {
+                VideoPlayerControl.SetPosition(_subtitle.Paragraphs[0].StartTime.TotalSeconds + 0.05);
+            }
+
+            StartPreviewTimer();
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Failed to start burn-in video preview");
+        }
+    }
+
+    private void StartPreviewTimer()
+    {
+        _previewTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
+        _previewTimer.Tick += (_, _) =>
+        {
+            if (_mpvPreviewPlayer == null || _loading)
+            {
+                return;
+            }
+
+            string? assaText;
+            try
+            {
+                assaText = GeneratePreviewAssaText();
+            }
+            catch
+            {
+                return; // ignore transient errors while the user is editing settings
+            }
+
+            if (string.IsNullOrEmpty(assaText) || assaText == _oldPreviewAssa)
+            {
+                return;
+            }
+
+            _oldPreviewAssa = assaText;
+            File.WriteAllText(_tempPreviewAssaFileName, assaText);
+            if (!_isPreviewSubtitleLoaded)
+            {
+                _isPreviewSubtitleLoaded = true;
+                _mpvPreviewPlayer.SubAdd(_tempPreviewAssaFileName);
+            }
+            else
+            {
+                _mpvPreviewPlayer.SubReload();
+            }
+        };
+        _previewTimer.Start();
+    }
+
+    /// <summary>
+    /// Points the live-preview timer at a specific mpv player (the embedded one or the
+    /// fullscreen one). Forces a refresh on the next tick so the styled subtitle is
+    /// (re)applied to the now-active player.
+    /// </summary>
+    private void SetActivePreviewPlayer(LibMpvDynamicPlayer? mpv, bool alreadyHasSubtitle)
+    {
+        _mpvPreviewPlayer = mpv;
+        _isPreviewSubtitleLoaded = alreadyHasSubtitle;
+        _oldPreviewAssa = string.Empty;
+    }
+
+    [RelayCommand]
+    private void PreviewFullScreen()
+    {
+        var control = VideoPlayerControl;
+        if (control == null || control.IsFullScreen ||
+            string.IsNullOrWhiteSpace(VideoFileName) || !File.Exists(VideoFileName) ||
+            _fullScreenVideoPlayerControl != null)
+        {
+            return;
+        }
+
+        control.VideoPlayer.Pause();
+        var position = control.Position;
+        var volume = control.Volume;
+
+        // Mirror the main window: use a separate fullscreen player rather than
+        // reparenting the embedded one (avoids airspace/reparent issues).
+        _fullScreenVideoPlayerControl = InitVideoPlayer.MakeVideoPlayer();
+        _fullScreenVideoPlayerControl.IsFullScreen = true;
+
+        var fullScreenWindow = new FullScreenVideoWindow(
+            _fullScreenVideoPlayerControl,
+            VideoFileName,
+            string.Empty,
+            position,
+            volume,
+            () =>
+            {
+                var fs = _fullScreenVideoPlayerControl;
+                _fullScreenVideoPlayerControl = null;
+                if (fs != null)
+                {
+                    control.SetPosition(fs.Position);
+                }
+
+                // The embedded player kept its file + subtitle loaded, so reload (not re-add).
+                SetActivePreviewPlayer(control.VideoPlayer as LibMpvDynamicPlayer, alreadyHasSubtitle: true);
+            });
+        fullScreenWindow.Show(Window!);
+
+        // Once the fullscreen player has opened the file, route the preview to it so
+        // style/effect changes keep updating live while fullscreen.
+        var fsControl = _fullScreenVideoPlayerControl;
+        Dispatcher.UIThread.Post(async () =>
+        {
+            await fsControl.WaitForPlayersReadyAsync();
+            if (_fullScreenVideoPlayerControl == fsControl) // still fullscreen (not closed in the meantime)
+            {
+                SetActivePreviewPlayer(fsControl.VideoPlayer as LibMpvDynamicPlayer, alreadyHasSubtitle: false);
+            }
         });
+    }
+
+    public void CleanupPreview()
+    {
+        _previewTimer?.Stop();
+        _previewTimer = null;
+        _mpvPreviewPlayer = null;
+
+        try
+        {
+            VideoPlayerControl?.Close();
+        }
+        catch
+        {
+            // ignore
+        }
+
+        try
+        {
+            if (File.Exists(_tempPreviewAssaFileName))
+            {
+                File.Delete(_tempPreviewAssaFileName);
+            }
+        }
+        catch
+        {
+            // ignore
+        }
     }
 }

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -15,8 +16,11 @@ namespace Nikse.SubtitleEdit.Features.Video.BurnIn;
 
 public class BurnInWindow : Window
 {
+    private readonly BurnInViewModel _vm;
+
     public BurnInWindow(BurnInViewModel vm)
     {
+        _vm = vm;
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = Se.Language.Video.BurnIn.Title;
         SizeToContent = SizeToContent.WidthAndHeight;
@@ -108,6 +112,12 @@ public class BurnInWindow : Window
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         Loaded += (_, _) => vm.Loaded();
         KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        base.OnClosing(e);
+        _vm.CleanupPreview();
     }
 
     private static Border MakeSubtitlesView(BurnInViewModel vm)
@@ -432,7 +442,8 @@ public class BurnInWindow : Window
     {
         var checkBoxCut = UiUtil.MakeCheckBox(Se.Language.Video.BurnIn.Cut, vm, nameof(vm.IsCutActive));
 
-        var buttonCutFrom = UiUtil.MakeButtonBrowse(vm.BrowseCutFromCommand).WithMarginTop(10).WithRightAlignment();
+        var buttonCutFrom = UiUtil.MakeButtonBrowse(vm.BrowseCutFromCommand);
+        buttonCutFrom.VerticalAlignment = VerticalAlignment.Center;
         var labelFromTime = UiUtil.MakeLabel(Se.Language.Video.BurnIn.FromTime);
         var timeUpDownFrom = new TimeCodeUpDown
         {
@@ -441,7 +452,8 @@ public class BurnInWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
         };
 
-        var buttonCutTo = UiUtil.MakeButtonBrowse(vm.BrowseCutToCommand).WithMarginTop(10).WithRightAlignment();
+        var buttonCutTo = UiUtil.MakeButtonBrowse(vm.BrowseCutToCommand);
+        buttonCutTo.VerticalAlignment = VerticalAlignment.Center;
         var labelToTime = UiUtil.MakeLabel(Se.Language.Video.BurnIn.ToTime);
         var timeUpDownTo = new TimeCodeUpDown
         {
@@ -457,11 +469,10 @@ public class BurnInWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
             },
@@ -473,13 +484,13 @@ public class BurnInWindow : Window
 
         grid.Add(checkBoxCut, 0, 0);
 
-        grid.Add(buttonCutFrom, 1, 1);
-        grid.Add(labelFromTime, 2, 0);
-        grid.Add(timeUpDownFrom, 2, 1);
+        grid.Add(labelFromTime, 1, 0);
+        grid.Add(timeUpDownFrom, 1, 1);
+        grid.Add(buttonCutFrom, 1, 2);
 
-        grid.Add(buttonCutTo, 3, 1);
-        grid.Add(labelToTime, 4, 0);
-        grid.Add(timeUpDownTo, 4, 1);
+        grid.Add(labelToTime, 2, 0);
+        grid.Add(timeUpDownTo, 2, 1);
+        grid.Add(buttonCutTo, 2, 2);
 
         return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);
     }
@@ -489,25 +500,16 @@ public class BurnInWindow : Window
 
         var labelPreview = UiUtil.MakeLabel(Se.Language.General.Preview);
 
-        var image = new Image
-        {
-            [!Image.SourceProperty] = new Binding(nameof(vm.ImagePreview)),
-            DataContext = vm,
-            HorizontalAlignment = HorizontalAlignment.Left,
-            VerticalAlignment = VerticalAlignment.Top,
-            Stretch = Stretch.None, // Prevents stretching of the image
-        };
-
-        var scrollViewer = new ScrollViewer
-        {
-            Content = image,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Width = 420,
-            Height = double.NaN,
-        };
+        // Live preview: the loaded video plays in an embedded mpv player while the
+        // current style/effects are generated as an ASSA subtitle and rendered on top
+        // via libass (sub-add/sub-reload) - see BurnInViewModel.LoadVideoPreview.
+        vm.VideoPlayerControl = InitVideoPlayer.MakeVideoPlayer();
+        vm.VideoPlayerControl.FullScreenIsVisible = true;
+        vm.VideoPlayerControl.FullScreenCommand = vm.PreviewFullScreenCommand;
+        vm.VideoPlayerControl.Width = 480;
+        vm.VideoPlayerControl.Height = 270;
+        vm.VideoPlayerControl.HorizontalAlignment = HorizontalAlignment.Left;
+        vm.VideoPlayerControl.VerticalAlignment = VerticalAlignment.Top;
 
         var grid = new Grid
         {
@@ -527,7 +529,7 @@ public class BurnInWindow : Window
         };
 
         grid.Add(labelPreview, 0, 0);
-        grid.Add(scrollViewer, 1, 0);
+        grid.Add(vm.VideoPlayerControl, 1, 0);
 
         return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);
     }


### PR DESCRIPTION
## Summary

Addresses #11480 — the "Generate video with burned-in subtitle" window only had a static placeholder preview ("This is a test" rendered on a transparent background). This replaces it with a **live video preview**: the loaded video plays in an embedded mpv player and the current burn-in style is rendered on top as an ASSA subtitle via libass (`sub-add`/`sub-reload`), updating live as you change font / colors / box / alignment / margins / effects.

Because both the preview and the real burn go through libass, the preview closely matches the final output. This follows the existing pattern used by the ASSA progress-bar / set-background / apply-effect windows.

## Changes

**Live preview** (`BurnInViewModel`)
- Embed a `VideoPlayerControl` + mpv player, a 500 ms refresh timer, and a temp `.ass` file.
- `GeneratePreviewAssaText()` builds the preview subtitle reusing the **same** style + effect logic as `MakeAssa`, so preview == output.
- Refactored `SetStyleForNonAssa(sub)` → `SetStyleForNonAssa(sub, width, height)` so it no longer depends on the burn-in job pipeline (also used for `PlayResX/Y`).
- `LoadVideoPreview()` opens the video, seeks to the first line; `CleanupPreview()` stops the timer, closes the player, deletes the temp file (called from `BurnInWindow.OnClosing`).

**Fullscreen button**
- Enabled the preview player's fullscreen button, wired like the main window (a separate fullscreen player rather than reparenting — avoids airspace issues). The live subtitle keeps updating while fullscreen; Esc/F11 exits.

**Compact Cut panel**
- Moved the browse (`...`) buttons onto the same row as their time-code controls, shrinking the panel from 5 rows to 3.

## Notes / limitations
- The subtitle overlay uses mpv (libass), same as the other preview windows. With the VLC player selected, the video plays but the overlay isn't shown.
- The old image-preview code (`UpdateNonAssaPreview`/`ImagePreview`) is left in place but no longer displayed; can be removed in a follow-up if desired.

Built locally (UI project) and smoke-tested by launching the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)