### PR TITLE
Fix three burn-in bugs (output-folder visibility/fallback, cut precision)

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -641,11 +641,11 @@ public partial class BurnInViewModel : ObservableObject
         if (IsCutActive && !preview)
         {
             var start = CutFrom;
-            cutStart = $"-ss {start.Hours:00}:{start.Minutes:00}:{start.Seconds:00}";
+            cutStart = $"-ss {(int)start.TotalHours:00}:{start.Minutes:00}:{start.Seconds:00}.{start.Milliseconds:000}";
 
             var end = CutTo;
             var duration = end - start;
-            cutEnd = $"-t {duration.Hours:00}:{duration.Minutes:00}:{duration.Seconds:00}";
+            cutEnd = $"-t {(int)duration.TotalHours:00}:{duration.Minutes:00}:{duration.Seconds:00}.{duration.Milliseconds:000}";
         }
 
         var ffmpegParameters = FfmpegGenerator.GenerateHardcodedVideoFile(
@@ -1243,7 +1243,7 @@ public partial class BurnInViewModel : ObservableObject
         FontFixRtl = settings.NonAssaFixRtlUnicode;
         SelectedFontAlignment = FontAlignments.First(p => p.Code == settings.NonAssaAlignment);
         OutputFolder = settings.OutputFolder;
-        UseOutputFolderVisible = settings.UseSourceResolution;
+        UseOutputFolderVisible = settings.UseOutputFolder;
         UseSourceFolderVisible = !settings.UseOutputFolder;
         UseSourceResolution = settings.UseSourceResolution;
 
@@ -1743,7 +1743,8 @@ public partial class BurnInViewModel : ObservableObject
         if (Se.Settings.Video.BurnIn.UseOutputFolder &&
             string.IsNullOrWhiteSpace(Se.Settings.Video.BurnIn.OutputFolder))
         {
-            Se.Settings.Video.BurnIn.UseOutputFolder = true;
+            // Output-folder mode is on but no folder is configured - fall back to the source folder.
+            Se.Settings.Video.BurnIn.UseOutputFolder = false;
         }
 
         UseSourceFolderVisible = !Se.Settings.Video.BurnIn.UseOutputFolder;


### PR DESCRIPTION
A small bug hunt in the burn-in window (`BurnInViewModel.cs`) turned up three genuine bugs.

## 1. Wrong setting wired to output-folder visibility (copy-paste)
In `LoadSettings`, `UseOutputFolderVisible` was read from `settings.UseSourceResolution` instead of `settings.UseOutputFolder` (the correct version exists at `UpdateOutputProperties`). Currently masked because `UpdateOutputProperties()` runs right after `LoadSettings()` in the constructor, but the code is wrong and fragile.

```diff
-UseOutputFolderVisible = settings.UseSourceResolution;
+UseOutputFolderVisible = settings.UseOutputFolder;
```

## 2. Output-folder fallback was a no-op
In `UpdateOutputProperties`, the guard "output mode on but no folder configured" set `UseOutputFolder = true` — but the `if` already requires it to be `true`, so it did nothing. It should fall back to the source folder.

```diff
 if (UseOutputFolder && string.IsNullOrWhiteSpace(OutputFolder))
 {
-    Se.Settings.Video.BurnIn.UseOutputFolder = true;
+    Se.Settings.Video.BurnIn.UseOutputFolder = false;
 }
```

## 3. Cut times dropped sub-second precision (and wrapped at 24h)
The `-ss`/`-t` ffmpeg arguments were built from `TimeSpan` component properties (`.Hours/.Minutes/.Seconds`), silently discarding milliseconds (the `TimeCodeUpDown` lets users enter ms) and wrapping at 24 hours. Now built from `TotalHours` with milliseconds included.

```diff
-cutStart = $"-ss {start.Hours:00}:{start.Minutes:00}:{start.Seconds:00}";
-cutEnd   = $"-t {duration.Hours:00}:{duration.Minutes:00}:{duration.Seconds:00}";
+cutStart = $"-ss {(int)start.TotalHours:00}:{start.Minutes:00}:{start.Seconds:00}.{start.Milliseconds:000}";
+cutEnd   = $"-t {(int)duration.TotalHours:00}:{duration.Minutes:00}:{duration.Seconds:00}.{duration.Milliseconds:000}";
```

Built locally (UI project) - succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)