### PR TITLE
Fix transparent-video output-folder/subtitle bugs (+ shared .ass detect)

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -1452,7 +1452,7 @@ public partial class BurnInViewModel : ObservableObject
         }
 
         var assa = Path.ChangeExtension(fileName, ".ass");
-        if (File.Exists(srt))
+        if (File.Exists(assa))
         {
             return assa;
         }

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -437,7 +437,8 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     private async Task<Process?> GetFfmpegProcess(BurnInJobItem jobItem)
     {
         var ts = TimeSpan.FromSeconds(jobItem.TotalSeconds);
-        var timeCode = string.Format($"{ts.Hours:00}\\\\:{ts.Minutes:00}\\\\:{ts.Seconds:00}");
+        // Use total hours so durations >= 24h are not silently wrapped by TimeSpan.Hours.
+        var timeCode = $"{(int)ts.TotalHours:00}\\\\:{ts.Minutes:00}\\\\:{ts.Seconds:00}";
 
         var ffmpegParameters = FfmpegGenerator.GenerateTransparentVideoFile(
             jobItem.AssaSubtitleFileName,
@@ -663,7 +664,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         sub.Header = AdvancedSubStationAlpha.AddTagToHeader("PlayResX",
             "PlayResX: " + (VideoWidth ?? 1920).ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
         sub.Header = AdvancedSubStationAlpha.AddTagToHeader("PlayResY",
-            "PlayResY: " + (VideoHeight ?? 1920).ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
+            "PlayResY: " + (VideoHeight ?? 1080).ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
     }
 
     private string MakeOutputFileName(string videoFileName)
@@ -682,7 +683,15 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         var i = 2;
         while (File.Exists(fileName))
         {
-            fileName = Path.Combine(Se.Settings.Video.BurnIn.OutputFolder, $"{nameNoExt}{suffix}_{i}{ext}");
+            if (Se.Settings.Video.BurnIn.UseOutputFolder && !string.IsNullOrEmpty(Se.Settings.Video.BurnIn.OutputFolder))
+            {
+                fileName = Path.Combine(Se.Settings.Video.BurnIn.OutputFolder, $"{nameNoExt}{suffix}_{i}{ext}");
+            }
+            else
+            {
+                fileName = Path.Combine(Path.GetDirectoryName(videoFileName) ?? Path.GetTempPath(), $"{nameNoExt}{suffix}_{i}{ext}");
+            }
+
             i++;
         }
 
@@ -946,7 +955,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         FontFixRtl = settings.NonAssaFixRtlUnicode;
         SelectedFontAlignment = FontAlignments.First(p => p.Code == settings.NonAssaAlignment);
         OutputFolder = settings.OutputFolder;
-        UseOutputFolderVisible = settings.UseSourceResolution;
+        UseOutputFolderVisible = settings.UseOutputFolder;
         UseSourceFolderVisible = !settings.UseOutputFolder;
         UseSourceResolution = settings.UseSourceResolution;
 
@@ -1047,7 +1056,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         }
 
         var assa = Path.ChangeExtension(fileName, ".ass");
-        if (File.Exists(srt))
+        if (File.Exists(assa))
         {
             return assa;
         }
@@ -1077,15 +1086,19 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
 
     private void UpdateOutputProperties()
     {
-        if (Se.Settings.Video.Transparent.UseOutputFolder &&
-            string.IsNullOrWhiteSpace(Se.Settings.Video.Transparent.OutputFolder))
+        // Use the BurnIn output-folder settings: the "Output properties" dialog
+        // (BurnInSettingsWindow) and MakeOutputFileName both read/write BurnIn.*,
+        // so the UI must read the same store or it would show a stale/empty folder.
+        if (Se.Settings.Video.BurnIn.UseOutputFolder &&
+            string.IsNullOrWhiteSpace(Se.Settings.Video.BurnIn.OutputFolder))
         {
-            Se.Settings.Video.Transparent.UseOutputFolder = true;
+            // Output-folder mode is on but no folder is configured - fall back to the source folder.
+            Se.Settings.Video.BurnIn.UseOutputFolder = false;
         }
 
-        UseSourceFolderVisible = !Se.Settings.Video.Transparent.UseOutputFolder;
-        UseOutputFolderVisible = Se.Settings.Video.Transparent.UseOutputFolder;
-        OutputFolder = Se.Settings.Video.Transparent.OutputFolder;
+        UseSourceFolderVisible = !Se.Settings.Video.BurnIn.UseOutputFolder;
+        UseOutputFolderVisible = Se.Settings.Video.BurnIn.UseOutputFolder;
+        OutputFolder = Se.Settings.Video.BurnIn.OutputFolder;
     }
 
     public void BoxTypeChanged(object? sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
Checked "Generate transparent video with subtitle" (`TransparentSubtitlesViewModel`) for the same class of bugs found in the burn-in window. It carried several, most copied from burn-in.

## Output folder
1. **No-op fallback** — `UpdateOutputProperties` set `UseOutputFolder = true` inside an `if (UseOutputFolder && folder is blank)` guard (a no-op). Now sets it to `false` (fall back to source folder).
2. **Two different settings stores (display ≠ behavior)** — `MakeOutputFileName` and `LoadSettings` read `Se.Settings.Video.BurnIn.*`, but `UpdateOutputProperties` read `Se.Settings.Video.Transparent.*`, while the shared "Output properties" dialog (`BurnInSettingsWindow`) writes `BurnIn.*`. So the folder shown in the UI was unrelated to where files were actually written. Standardized on `BurnIn.*` everywhere (matches the dialog and the write path).
3. **Copy-paste wiring** — `LoadSettings` set `UseOutputFolderVisible = settings.UseSourceResolution` → `settings.UseOutputFolder`.
4. **Dedup loop ignored folder mode** — on a filename collision, the loop always wrote to `BurnIn.OutputFolder`, which is empty in source-folder mode → `Path.Combine("", …)` produced a relative path (wrong directory). Now mirrors burn-in's output-folder vs source-folder branch.

## Subtitle / style
5. **`PlayResY` fallback** — was `VideoHeight ?? 1920`; corrected to `1080`.
6. **`.ass` sidecar never auto-detected** — `TryGetSubtitleFileName` checked `File.Exists(srt)` where it must check `File.Exists(assa)`. The first block already returns when the `.srt` exists, so the `.ass` branch could never succeed. Fixed here **and in `BurnInViewModel`**, where the method is actually used (batch-adding a video with only an `.ass` sidecar).

## Minor
7. The transparent clip duration timecode used `TimeSpan.Hours` (wraps at 24h); now uses total hours.

Built locally (UI project) — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)