### PR TITLE
Fix min-duration for last subtitle in Apply duration limits

### DIFF
--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
@@ -113,7 +113,7 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
 
                     if (item.Duration.TotalMilliseconds < minMs && FixMinDurationMs)
                     {
-                        var newEndTime = TimeSpan.FromMilliseconds(item.EndTime.TotalMilliseconds + minMs);
+                        var newEndTime = TimeSpan.FromMilliseconds(item.StartTime.TotalMilliseconds + minMs);
                         Update(item, newEndTime);
                         fixCount++;
                     }


### PR DESCRIPTION
## Summary
Fixes a bug in **Tools → Apply duration limits** where the minimum-duration fix was applied incorrectly to the **last** subtitle.

In the `next == null` branch, the new end time was computed as `EndTime + minMs` instead of `StartTime + minMs`. As a result a paragraph with a 900ms duration and a 1000ms minimum became 1900ms instead of the intended 1000ms.

This now matches the logic already used for non-last subtitles (`StartTime + minMs`).

## Test plan
- Open a subtitle whose last line is shorter than the minimum duration (e.g. 900ms with min 1000ms)
- Run Tools → Apply duration limits
- The last line's duration is now set to exactly the minimum (1000ms), not extended by the minimum

🤖 Generated with [Claude Code](https://claude.com/claude-code)