### PR TITLE
Binary edit: forced flag support, dirty-state tracking, and UX polish

### DIFF
--- a/src/ui/Features/Ocr/OcrSubtitle/IOcrSubtitle.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/IOcrSubtitle.cs
@@ -11,6 +11,7 @@ public interface IOcrSubtitle
     TimeSpan GetStartTime(int index);
     TimeSpan GetEndTime(int index);
     List<OcrSubtitleItem> MakeOcrSubtitleItems();
+    bool GetIsForced(int index);
     SKPointI GetPosition(int index);
     SKSizeI GetScreenSize(int index);
 }

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrImportImage.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrImportImage.cs
@@ -42,6 +42,8 @@ public class OcrImportImage : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index) => false;
+
     public SKPointI GetPosition(int index)
     {
         return new SKPointI(0, 0);

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBdn.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBdn.cs
@@ -275,6 +275,16 @@ public class OcrSubtitleBdn : IOcrSubtitle
     }
 
 
+    public bool GetIsForced(int index)
+    {
+        if (index < 0 || index >= _bdnXmlSubtitle.Paragraphs.Count)
+        {
+            return false;
+        }
+
+        return _bdnXmlSubtitle.Paragraphs[index].Forced;
+    }
+
     public TimeSpan GetStartTime(int index)
     {
         return _bdnXmlSubtitle.Paragraphs[index].StartTime.TimeSpan;

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBluRay.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBluRay.cs
@@ -48,6 +48,16 @@ public class OcrSubtitleBluRay : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index)
+    {
+        if (index < 0 || index >= _pcsDataList.Count)
+        {
+            return false;
+        }
+
+        return _pcsDataList[index].IsForced;
+    }
+
     public SKPointI GetPosition(int index)
     {
         if (index < 0 || index >= _pcsDataList.Count)

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleDivX.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleDivX.cs
@@ -44,6 +44,8 @@ public class OcrSubtitleDivX : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index) => false;
+
     public SKPointI GetPosition(int index)
     {
         return new SKPointI(-1, -1);

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleDummy.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleDummy.cs
@@ -42,6 +42,8 @@ public class OcrSubtitleDummy : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index) => false;
+
     public SKPointI GetPosition(int index)
     {
         return new SKPointI(-1, -1);

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleIBinaryParagraph.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleIBinaryParagraph.cs
@@ -42,6 +42,16 @@ public class OcrSubtitleIBinaryParagraph : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index)
+    {
+        if (index < 0 || index >= _list.Count)
+        {
+            return false;
+        }
+
+        return _list[index].IsForced;
+    }
+
     public SKPointI GetPosition(int index)
     {
         var position = _list[index].GetPosition();

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleImageParameter.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleImageParameter.cs
@@ -49,6 +49,8 @@ public class OcrSubtitleImageParameter : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index) => false;
+
     public SKPointI GetPosition(int index)
     {
         if (index < 0 || index >= _imageParameterList.Count)

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleMkvBluRay.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleMkvBluRay.cs
@@ -50,6 +50,16 @@ public class OcrSubtitleMkvBluRay : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index)
+    {
+        if (index < 0 || index >= Count)
+        {
+            return false;
+        }
+
+        return _pcsDataList[index].IsForced;
+    }
+
     public SKPointI GetPosition(int index)
     {
         var position = _pcsDataList[index].GetPosition();

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleMkvDvb.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleMkvDvb.cs
@@ -49,9 +49,11 @@ public class OcrSubtitleMkvDvb : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index) => false;
+
     public SKPointI GetPosition(int index)
     {
-        var position = _subtitleImages[index].GetPosition();    
+        var position = _subtitleImages[index].GetPosition();
         return new SKPointI(position.Left, position.Top);
     }
 

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleMp4VobSub.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleMp4VobSub.cs
@@ -46,6 +46,8 @@ public class OcrSubtitleMp4VobSub : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index) => false;
+
     public SKPointI GetPosition(int index)
     {
         return new SKPointI(-1, -1);

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleSpDvdSupImages.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleSpDvdSupImages.cs
@@ -73,6 +73,8 @@ public class OcrSubtitleSpDvdSupImages : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index) => false;
+
     public SKPointI GetPosition(int index)
     {
         return new SKPointI(_spList[index].Picture.ImageDisplayArea.Left, _spList[index].Picture.ImageDisplayArea.Top);

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleTransportStream.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleTransportStream.cs
@@ -46,6 +46,16 @@ public class OcrSubtitleTransportStream : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index)
+    {
+        if (index < 0 || index >= _subtitles.Count)
+        {
+            return false;
+        }
+
+        return _subtitles[index].IsForced;
+    }
+
     public SKPointI GetPosition(int index)
     {
         var position = _subtitles[index].GetPosition();

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleVobSub.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleVobSub.cs
@@ -62,6 +62,16 @@ public class OcrSubtitleVobSub : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index)
+    {
+        if (index < 0 || index >= _vobSubMergedPack.Count)
+        {
+            return false;
+        }
+
+        return _vobSubMergedPack[index].IsForced;
+    }
+
     public SubPicture? GetSubPicture(int index)
     {
         if (index < 0 || index >= _vobSubMergedPack.Count)

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleWebVttImages.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleWebVttImages.cs
@@ -46,6 +46,8 @@ public class OcrSubtitleWebVttImages : IOcrSubtitle
         return ocrSubtitleItems;
     }
 
+    public bool GetIsForced(int index) => false;
+
     public SKPointI GetPosition(int index)
     {
         return new SKPointI(-1, -1);

--- a/src/ui/Features/Ocr/OcrSubtitleItem.cs
+++ b/src/ui/Features/Ocr/OcrSubtitleItem.cs
@@ -88,6 +88,8 @@ public partial class OcrSubtitleItem : ObservableObject
         return cropped.ToAvaloniaBitmap();
     }
 
+    public bool IsForced => _ocrSubtitle.GetIsForced(_index);
+
     public SKPointI GetPosition()
     {
         return _ocrSubtitle.GetPosition(_index);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -811,6 +811,25 @@ public partial class BinaryEditViewModel : ObservableObject
         await DoExport(new ExportHandlerFcp(), string.Empty, false);
     }
 
+    private string GetSuggestedExportFileName(string extension)
+    {
+        if (string.IsNullOrEmpty(_loadFileName))
+        {
+            return "export";
+        }
+
+        var dir = Path.GetDirectoryName(_loadFileName) ?? string.Empty;
+        var stem = Path.GetFileNameWithoutExtension(_loadFileName);
+        var suggested = Path.Combine(dir, stem + extension);
+
+        if (string.Equals(suggested, _loadFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            suggested = Path.Combine(dir, stem + "_export" + extension);
+        }
+
+        return suggested;
+    }
+
     private async Task<bool> DoExport(IExportHandler exportHandler, string extension, bool isTargetFile = true)
     {
         if (Window == null)
@@ -826,7 +845,7 @@ public partial class BinaryEditViewModel : ObservableObject
         var fileOrFolderName = string.Empty;
         if (isTargetFile)
         {
-            fileOrFolderName = await _fileHelper.PickSaveFile(Window, extension, "export", Se.Language.General.SaveFileAsTitle);
+            fileOrFolderName = await _fileHelper.PickSaveFile(Window, extension, GetSuggestedExportFileName(extension), Se.Language.General.SaveFileAsTitle);
         }
         else
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1546,6 +1546,12 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void CloseVideo()
+    {
+        VideoPlayerControl?.Close();
+    }
+
+    [RelayCommand]
     private void ToggleCurrentSubtitleWhilePlaying()
     {
         SelectCurrentSubtitleWhilePlaying = !SelectCurrentSubtitleWhilePlaying;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1628,6 +1628,36 @@ public partial class BinaryEditViewModel : ObservableObject
         }
     }
 
+    [RelayCommand]
+    private void SelectForcedLines()
+    {
+        if (SubtitleGrid == null)
+        {
+            return;
+        }
+
+        SubtitleGrid.SelectedItems.Clear();
+        foreach (var item in Subtitles.Where(s => s.IsForced))
+        {
+            SubtitleGrid.SelectedItems.Add(item);
+        }
+    }
+
+    [RelayCommand]
+    private void SelectNonForcedLines()
+    {
+        if (SubtitleGrid == null)
+        {
+            return;
+        }
+
+        SubtitleGrid.SelectedItems.Clear();
+        foreach (var item in Subtitles.Where(s => !s.IsForced))
+        {
+            SubtitleGrid.SelectedItems.Add(item);
+        }
+    }
+
     private void Renumber()
     {
         for (int i = 0; i < Subtitles.Count; i++)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -25,6 +25,8 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -66,6 +68,8 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private string _loadFileName = string.Empty;
     private int _lastPlaybackSubtitleIndex = -2;
+    private bool _isDirty;
+    private bool _dirtyTrackingActive;
 
     public BinaryEditViewModel(IFileHelper fileHelper, IWindowService windowService, IFolderHelper folderHelper, IShortcutManager shortcutManager, IBluRayHelper bluRayHelper)
     {
@@ -305,6 +309,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         await DoFileOpen(fileName);
+        _isDirty = false;
     }
 
     [RelayCommand]
@@ -855,6 +860,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         exportHandler.WriteFooter();
+        _isDirty = false;
         return true;
     }
 
@@ -1836,18 +1842,46 @@ public partial class BinaryEditViewModel : ObservableObject
         _shortcutManager.OnKeyReleased(this, e);
     }
 
-    public void Closing()
+    internal async void OnClosing(object? sender, WindowClosingEventArgs e)
+    {
+        if (_isDirty && Window != null)
+        {
+            e.Cancel = true;
+            try
+            {
+                var result = await MessageBox.Show(
+                    Window,
+                    "Unexported changes",
+                    "You have unexported changes. Close and discard them?",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Question);
+
+                if (result != MessageBoxResult.Yes)
+                    return;
+
+                Window.Closing -= OnClosing;
+                PerformCleanup();
+                Window.Close();
+            }
+            catch (Exception ex)
+            {
+                Se.LogError(ex, "BinaryEditViewModel.OnClosing");
+                Window.Closing -= OnClosing;
+                PerformCleanup();
+                Window.Close();
+            }
+            return;
+        }
+
+        PerformCleanup();
+    }
+
+    private void PerformCleanup()
     {
         if (VideoPlayerControl == null)
-        {
             return;
-        }
-
         if (string.IsNullOrWhiteSpace(VideoPlayerControl.VideoPlayer.FileName))
-        {
             return;
-        }
-
         VideoPlayerControl.VideoPlayer.CloseFile();
         UiUtil.SaveWindowPosition(Window);
     }
@@ -1864,13 +1898,38 @@ public partial class BinaryEditViewModel : ObservableObject
             {
                 SelectAndScrollToRow(0);
             }
+            EnableDirtyTracking();
             return;
         }
 
         Dispatcher.UIThread.InvokeAsync(async () =>
         {
             await DoFileOpen(_loadFileName);
+            EnableDirtyTracking();
+            _isDirty = false;
         });
+    }
+
+    private void EnableDirtyTracking()
+    {
+        if (_dirtyTrackingActive) return;
+        _dirtyTrackingActive = true;
+        Subtitles.CollectionChanged += OnSubtitlesCollectionChanged;
+        foreach (var item in Subtitles)
+            item.PropertyChanged += OnSubtitleItemPropertyChanged;
+    }
+
+    private void OnSubtitlesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems != null)
+            foreach (BinarySubtitleItem item in e.NewItems)
+                item.PropertyChanged += OnSubtitleItemPropertyChanged;
+        _isDirty = true;
+    }
+
+    private void OnSubtitleItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        _isDirty = true;
     }
 
     internal void OnVideoPositionChanged(double positionSeconds)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1946,6 +1946,9 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private void OnSubtitlesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
+        if (e.OldItems != null)
+            foreach (BinarySubtitleItem item in e.OldItems)
+                item.PropertyChanged -= OnSubtitleItemPropertyChanged;
         if (e.NewItems != null)
             foreach (BinarySubtitleItem item in e.NewItems)
                 item.PropertyChanged += OnSubtitleItemPropertyChanged;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2009,6 +2009,7 @@ public partial class BinaryEditViewModel : ObservableObject
                 item.Bitmap?.Dispose();
             }
 
+            Renumber();
             RefreshStatusText();
 
             return;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -658,7 +658,16 @@ public class BinaryEditWindow : Window
         // Row 4: gap between second controls row and position label
         grid.Add(new TextBlock { Margin = new Thickness(0, 6, 0, 2) }, 4, 0);
 
-        // Row 5: Position/Size label
+        // Row 5: Forced checkbox (Col 0), Position/Size label (Col 2)
+        var forcedCheckBox = new CheckBox
+        {
+            Content = Se.Language.General.Forced,
+            VerticalAlignment = VerticalAlignment.Center,
+            DataContext = vm,
+            [!ToggleButton.IsCheckedProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.IsForced)}") { Mode = BindingMode.TwoWay },
+        };
+        grid.Add(forcedCheckBox, 5, 0);
+
         var posLabel = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.CurrentPositionAndSize));
         posLabel.VerticalAlignment = VerticalAlignment.Center;
         grid.Add(posLabel, 5, 2);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -423,6 +423,22 @@ public class BinaryEditWindow : Window
         flyout.Items.Add(menuItemToggleForced);
         menuItemToggleForced.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsToggleForcedVisible)));
 
+        var menuItemSelectForcedLines = new MenuItem
+        {
+            Header = Se.Language.General.SelectForcedLines,
+            DataContext = vm,
+            Command = vm.SelectForcedLinesCommand,
+        };
+        flyout.Items.Add(menuItemSelectForcedLines);
+
+        var menuItemSelectNonForcedLines = new MenuItem
+        {
+            Header = Se.Language.General.SelectNonForcedLines,
+            DataContext = vm,
+            Command = vm.SelectNonForcedLinesCommand,
+        };
+        flyout.Items.Add(menuItemSelectNonForcedLines);
+
         var separatorInsertSubtitle = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorInsertSubtitle);
         separatorInsertSubtitle.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertSubtitleVisible)));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -302,6 +302,11 @@ public class BinaryEditWindow : Window
                 },
                 new MenuItem
                 {
+                    Header = l.CloseVideoFile,
+                    Command = vm.CloseVideoCommand,
+                },
+                new MenuItem
+                {
                     Header = l.ToggleSelectSubtitleWhilePlayingCurrentlyOn,
                     Command = vm.ToggleCurrentSubtitleWhilePlayingCommand,
                     [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.SelectCurrentSubtitleWhilePlaying)),

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -134,7 +134,7 @@ public class BinaryEditWindow : Window
             }
             vm.Loaded();
         };
-        Closing += (_, _) => vm.Closing();
+        Closing += vm.OnClosing;
     }
 
     private static Menu MakeTopMenu(BinaryEditViewModel vm)

--- a/src/ui/Features/Shared/BinaryEdit/BinarySubtitleItem.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinarySubtitleItem.cs
@@ -29,7 +29,7 @@ public partial class BinarySubtitleItem : ObservableObject
         }
 
         Number = item.Number;
-        IsForced = false; // OcrSubtitleItem does not expose forced flag; default to false
+        IsForced = item.IsForced;
         Text = item.Text;
 
         // Store times as TimeSpan for use with TimeCodeUpDown and SecondsUpDown controls

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -52,6 +52,7 @@ public static class InitNativeMacMenuBinaryEdit
         // Video menu
         var videoMenu = new NativeMenu();
         Add(videoMenu, l.OpenVideo, vm.OpenVideoCommand);
+        Add(videoMenu, l.CloseVideoFile, vm.CloseVideoCommand);
         var selectSubtitleWhilePlayingItem = new NativeMenuItem(Clean(l.SelectSubtitleWhilePlaying))
         {
             ToggleType = MenuItemToggleType.CheckBox,

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -476,7 +476,9 @@ public class LanguageGeneral
     public string Seconds { get; set; }
     public string SelectAll { get; set; }
     public string SelectFilesToConvert { get; set; }
+    public string SelectForcedLines { get; set; }
     public string SelectNone { get; set; }
+    public string SelectNonForcedLines { get; set; }
     public string SelectSaveFolder { get; set; }
     public string SelectSubtitle { get; set; }
     public string SelectedAFolderToSaveTo { get; set; }
@@ -1200,7 +1202,9 @@ public class LanguageGeneral
         Seconds = "Seconds";
         SelectAll = "Select all";
         SelectFilesToConvert = "Select files to convert";
+        SelectForcedLines = "Select forced lines";
         SelectNone = "Select none";
+        SelectNonForcedLines = "Select non-forced lines";
         SelectSaveFolder = "Select a folder to save to";
         SelectSubtitle = "Select subtitle";
         SelectedAFolderToSaveTo = "Selected a folder to save to";

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterRunBinaryOcrTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterRunBinaryOcrTests.cs
@@ -93,6 +93,7 @@ public class BatchConverterRunBinaryOcrTests
         public TimeSpan GetStartTime(int index) => TimeSpan.FromSeconds(index + 1);
         public TimeSpan GetEndTime(int index) => TimeSpan.FromSeconds(index + 1) + TimeSpan.FromMilliseconds(500);
         public List<OcrSubtitleItem> MakeOcrSubtitleItems() => new();
+        public bool GetIsForced(int index) => false;
         public SKPointI GetPosition(int index) => new(-1, -1);
         public SKSizeI GetScreenSize(int index) => new(-1, -1);
     }


### PR DESCRIPTION
## Summary

This PR adds full forced-flag support to the binary subtitle editor, along with several UX improvements and fixes.

### Forced flags
- Preserve `IsForced` from the source file when loading binary subtitles (BluRay, BDN, VobSub, transport stream, MKV, DVB, etc.)
- Add a **Forced** checkbox to the detail pane for toggling the flag on the selected subtitle
- Add **Select forced lines** / **Select non-forced lines** context menu items

### Dirty-state tracking & close guard
- Track edits (subtitle collection changes and property mutations) via `CollectionChanged` / `PropertyChanged` subscriptions
- Prompt "You have unexported changes. Close and discard them?" when closing the window with un-exported edits
- Clear dirty state after a successful export or file open

### Export default filename
- Pre-populate the save-file dialog with a filename derived from the source file (same directory, same stem, with the target extension) instead of the generic `"export"` placeholder
- Appends `_export` to avoid accidentally overwriting the source when extension would collide

### Other UX / fixes
- Add **Close video file** menu item to the Video menu
- Renumber subtitles after a delete operation