### PR TITLE
Binary edit: remove detail-pane forced checkbox, tidy detail layout

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -43,7 +43,8 @@ public partial class BinaryEditViewModel : ObservableObject
     [ObservableProperty] private int _screenWidth;
     [ObservableProperty] private int _screenHeight;
     [ObservableProperty] private string _statusText;
-    [ObservableProperty] private string _currentPositionAndSize;
+    [ObservableProperty] private string _currentPosition;
+    [ObservableProperty] private string _currentSize;
     [ObservableProperty] private bool _isDeleteVisible;
     [ObservableProperty] private bool _isInsertBeforeVisible;
     [ObservableProperty] private bool _isInsertAfterVisible;
@@ -82,7 +83,8 @@ public partial class BinaryEditViewModel : ObservableObject
         _selectCurrentSubtitleWhilePlaying = Se.Settings.Tools.BinEditSelectCurrentSubtitleWhilePlaying;
         Subtitles = new ObservableCollection<BinarySubtitleItem>();
         StatusText = string.Empty;
-        CurrentPositionAndSize = string.Empty;
+        CurrentPosition = string.Empty;
+        CurrentSize = string.Empty;
     }
 
     public void Initialize(string fileName, IOcrSubtitle? subtitle)
@@ -168,22 +170,26 @@ public partial class BinaryEditViewModel : ObservableObject
         if (selectedCount == 0)
         {
             StatusText = $"0/{Subtitles.Count}";
-            CurrentPositionAndSize = string.Empty;
+            CurrentPosition = string.Empty;
+            CurrentSize = string.Empty;
         }
         else if (selectedCount == 1)
         {
             var index = SubtitleGrid?.SelectedIndex ?? -1;
             var item = SubtitleGrid?.SelectedItem as BinarySubtitleItem;
             StatusText = index >= 0 ? $"{index + 1}/{Subtitles.Count}" : $"1/{Subtitles.Count}";
-            CurrentPositionAndSize = item != null
-                ? string.Format(Se.Language.General.PositionX, $"{item.X},{item.Y}") + Environment.NewLine +
-                  string.Format(Se.Language.General.SizeX, $"{item.Bitmap?.Size.Width}x{item.Bitmap?.Size.Height}")
+            CurrentPosition = item != null
+                ? string.Format(Se.Language.General.PositionX, $"{item.X},{item.Y}")
+                : string.Empty;
+            CurrentSize = item != null
+                ? string.Format(Se.Language.General.SizeX, $"{item.Bitmap?.Size.Width}x{item.Bitmap?.Size.Height}")
                 : string.Empty;
         }
         else
         {
             StatusText = string.Format(Se.Language.Main.XLinesSelectedOfY, selectedCount, Subtitles.Count);
-            CurrentPositionAndSize = string.Empty;
+            CurrentPosition = string.Empty;
+            CurrentSize = string.Empty;
         }
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -471,8 +471,8 @@ public class BinaryEditWindow : Window
         dataGrid.Columns.Add(new DataGridTemplateColumn
         {
             Header = Se.Language.General.Forced,
-            Width = new DataGridLength(60),
-            MinWidth = 50,
+            Width = new DataGridLength(90),
+            MinWidth = 80,
             CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
             CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<BinarySubtitleItem>((_, _) =>
                 new Border
@@ -501,8 +501,8 @@ public class BinaryEditWindow : Window
         dataGrid.Columns.Add(new DataGridTextColumn
         {
             Header = Se.Language.General.Show,
-            Width = new DataGridLength(120),
-            MinWidth = 100,
+            Width = new DataGridLength(105),
+            MinWidth = 90,
             IsReadOnly = true,
             Binding = new Binding(nameof(BinarySubtitleItem.StartTime)) { Converter = new TimeSpanToDisplayFullConverter() },
             CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
@@ -511,8 +511,8 @@ public class BinaryEditWindow : Window
         dataGrid.Columns.Add(new DataGridTextColumn
         {
             Header = Se.Language.General.Duration,
-            Width = new DataGridLength(80),
-            MinWidth = 60,
+            Width = new DataGridLength(90),
+            MinWidth = 70,
             IsReadOnly = true,
             Binding = new Binding(nameof(BinarySubtitleItem.Duration)) { Converter = new TimeSpanToDisplayShortConverter() },
             CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
@@ -663,19 +663,14 @@ public class BinaryEditWindow : Window
         // Row 4: gap between second controls row and position label
         grid.Add(new TextBlock { Margin = new Thickness(0, 6, 0, 2) }, 4, 0);
 
-        // Row 5: Forced checkbox (Col 0), Position/Size label (Col 2)
-        var forcedCheckBox = new CheckBox
-        {
-            Content = Se.Language.General.Forced,
-            VerticalAlignment = VerticalAlignment.Center,
-            DataContext = vm,
-            [!ToggleButton.IsCheckedProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(BinarySubtitleItem.IsForced)}") { Mode = BindingMode.TwoWay },
-        };
-        grid.Add(forcedCheckBox, 5, 0);
+        // Row 5: Position label (Col 2, under X/Y), Size label (Col 4, under screen width/height) — forced flag lives only in the grid column
+        var positionLabel = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.CurrentPosition));
+        positionLabel.VerticalAlignment = VerticalAlignment.Center;
+        grid.Add(positionLabel, 5, 2);
 
-        var posLabel = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.CurrentPositionAndSize));
-        posLabel.VerticalAlignment = VerticalAlignment.Center;
-        grid.Add(posLabel, 5, 2);
+        var sizeLabel = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.CurrentSize));
+        sizeLabel.VerticalAlignment = VerticalAlignment.Center;
+        grid.Add(sizeLabel, 5, 4);
 
         xUpDown.ValueChanged += (_, _) => vm.UpdateOverlayPosition();
         yUpDown.ValueChanged += (_, _) => vm.UpdateOverlayPosition();


### PR DESCRIPTION
Follow-up to #11498.

## Changes
- **Removed the forced checkbox** from the detail pane at the bottom of the Binary Edit window. The forced flag is now edited only via the grid's **Forced** column (click or Space to toggle across selected rows).
- **Verified the forced binding**: the grid checkbox binds to `BinarySubtitleItem.IsForced` (Avalonia's `IsChecked` defaults to TwoWay), and `DataGridCheckboxMultiSelect` toggles all selected rows — no functionality lost by dropping the detail-pane checkbox.
- **Detail-pane layout**: the position/size status was split into two separate **Position** and **Size** labels, aligned under the X/Y and screen width/height fields respectively (previously a single two-line label).
- **Grid column widths**: widened the **Forced** column, narrowed **Show** slightly, and widened **Duration** by ~10px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)