### PR TITLE
Text to speech: add settings window for Piper engine

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -142,6 +142,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ChatterboxTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
@@ -413,6 +414,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<VoxCPM2CrispAsrSettingsViewModel>();
         collection.AddTransient<KokoroTtsSettingsViewModel>();
         collection.AddTransient<ChatterboxTtsSettingsViewModel>();
+        collection.AddTransient<PiperSettingsViewModel>();
         collection.AddTransient<OpenFromUrlViewModel>();
         collection.AddTransient<DownloadVideoFromUrlViewModel>();
         collection.AddTransient<PickOnlineSubtitleViewModel>();

--- a/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsViewModel.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
+
+public partial class PiperSettingsViewModel : ObservableObject
+{
+    // Piper is pinned to a single fixed rhasspy/piper release (see TtsDownloadService.cs).
+    private const string PiperReleaseTag = "2023.11.14-2";
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _backendLabel = string.Empty;
+    [ObservableProperty] private string _statusLabel = string.Empty;
+    [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
+    [ObservableProperty] private string _releaseTag = PiperReleaseTag;
+    [ObservableProperty] private string _installFolder = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private bool _isInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private DownloadHashManager.UpdateStatus _engineUpdateStatus;
+
+    // "Download" when not installed, "Update" when a newer engine release is available,
+    // otherwise "Re-download".
+    public string DownloadButtonLabel
+    {
+        get
+        {
+            if (!IsInstalled)
+            {
+                return Se.Language.General.Download;
+            }
+
+            return EngineUpdateStatus == DownloadHashManager.UpdateStatus.UpdateAvailable
+                ? Se.Language.General.Update
+                : Se.Language.General.Redownload;
+        }
+    }
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public PiperSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        InstallFolder = Piper.GetSetPiperFolder();
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        IsInstalled = File.Exists(Piper.GetPiperExecutableFileName());
+        BackendLabel = IsInstalled ? DetectInstalledBackend() : Se.Language.General.NotInstalled;
+        EngineUpdateStatus = IsInstalled ? Piper.GetEngineUpdateStatus() : DownloadHashManager.UpdateStatus.Unknown;
+        ApplyStatus(EngineUpdateStatus, IsInstalled);
+    }
+
+    private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)
+    {
+        if (!installed)
+        {
+            StatusLabel = Se.Language.General.NotInstalled;
+            StatusBrush = new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));   // red
+            return;
+        }
+
+        switch (status)
+        {
+            case DownloadHashManager.UpdateStatus.UpToDate:
+                StatusLabel = Se.Language.General.UpToDate;
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
+                break;
+            case DownloadHashManager.UpdateStatus.UpdateAvailable:
+                StatusLabel = Se.Language.General.UpdateAvailable;
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
+                break;
+            default:
+                StatusLabel = Se.Language.General.UnknownNoInstallRecord;
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
+                break;
+        }
+    }
+
+    // Piper ships a single build per platform, so the backend label is purely OS+arch.
+    private static string DetectInstalledBackend()
+    {
+        if (Configuration.IsRunningOnMac)
+        {
+            return "macOS x64";
+        }
+
+        if (Configuration.IsRunningOnLinux)
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "Linux ARM64"
+                : "Linux x64";
+        }
+
+        return "Windows x64";
+    }
+
+    [RelayCommand]
+    private async Task Redownload()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var answer = await MessageBox.Show(
+            Window,
+            "Re-download Piper",
+            $"{Environment.NewLine}Download the latest Piper now?",
+            MessageBoxButtons.YesNoCancel,
+            MessageBoxIcon.Question);
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window, vm => vm.StartDownloadPiper());
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(InstallFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, InstallFolder);
+        }
+        catch
+        {
+            // ignore - best-effort UX, the path label is still shown
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsWindow.cs
@@ -1,0 +1,223 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
+
+public class PiperSettingsWindow : Window
+{
+    private const int LabelWidth = 110;
+    private const int ValueWidth = 360;
+
+    private readonly PiperSettingsViewModel _vm;
+
+    public PiperSettingsWindow(PiperSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Video.TextToSpeech.PiperSettings;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 540;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(PiperSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "Piper",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new Piper(null!).Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(PiperSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel(Se.Language.General.Backend), 0, 0);
+        grid.Add(MakeValue(nameof(vm.BackendLabel)), 0, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Status), 1, 0);
+        var statusDot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(nameof(vm.StatusBrush)),
+        };
+        var statusText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusLabel)),
+        };
+        var statusPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { statusDot, statusText },
+        };
+        grid.Add(statusPanel, 1, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Release), 2, 0);
+        var releaseText = new TextBlock
+        {
+            FontFamily = new FontFamily("Cascadia Mono,Consolas,Menlo,Monaco,monospace"),
+            FontSize = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.ReleaseTag)),
+        };
+        grid.Add(releaseText, 2, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 3, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.InstallFolder)),
+        };
+        grid.Add(folderText, 3, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static Grid BuildActions(PiperSettingsViewModel vm)
+    {
+        var redownload = UiUtil.MakeButton(string.Empty, vm.RedownloadCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonLabel));
+        var openFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { redownload, openFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    private static TextBlock MakeValue(string bindingPath) => new()
+    {
+        FontWeight = FontWeight.SemiBold,
+        VerticalAlignment = VerticalAlignment.Center,
+        [!TextBlock.TextProperty] = new Binding(bindingPath),
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -23,6 +23,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
@@ -1094,6 +1095,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is ChatterboxTtsCpp)
         {
             await _windowService.ShowDialogAsync<ChatterboxTtsSettingsWindow, ChatterboxTtsSettingsViewModel>(Window!, vm => vm.Initialize());
+        }
+        else if (SelectedEngine is Piper)
+        {
+            await _windowService.ShowDialogAsync<PiperSettingsWindow, PiperSettingsViewModel>(Window!, vm => vm.Initialize());
         }
         else
         {
@@ -3015,6 +3020,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                 IsEngineSettingsVisible = true;
             }
             else if (SelectedEngine is OmniVoiceTtsCpp)
+            {
+                IsEngineSettingsVisible = true;
+            }
+            else if (SelectedEngine is Piper)
             {
                 IsEngineSettingsVisible = true;
             }

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -65,6 +65,7 @@ public class LanguageTextToSpeech
     public string Qwen3TtsSettings { get; set; }
     public string KokoroTtsSettings { get; set; }
     public string ChatterboxTtsSettings { get; set; }
+    public string PiperSettings { get; set; }
     public string VoiceInstruction { get; set; }
     public string VoiceInstructionHint { get; set; }
     public string VoiceGender { get; set; }
@@ -154,6 +155,7 @@ public class LanguageTextToSpeech
         Qwen3TtsSettings = "Qwen3 TTS settings";
         KokoroTtsSettings = "Kokoro TTS settings";
         ChatterboxTtsSettings = "Chatterbox TTS settings";
+        PiperSettings = "Piper settings";
         VoiceInstruction = "Voice design";
         VoiceInstructionHint = "Optional - e.g. \"Speak in a calm and friendly tone\"";
         VoiceGender = "Gender";


### PR DESCRIPTION
@
## Summary

Adds a settings gear button + settings window for the **Piper** engine in the Text to speech window, matching what Kokoro TTS and the other install-based engines already have.

When Piper is selected, the gear button now appears next to the engine combo and opens a `PiperSettingsWindow`. The window mirrors the Kokoro settings dialog:

- **Header**: "Piper" + its description
- **Details**: Backend (OS+arch), install Status (red/amber/green dot), Release tag (`2023.11.14-2`, the pinned rhasspy/piper release), and the install folder path
- **Actions**: Download/Update/Re-download (label adapts to install state, reusing the existing `StartDownloadPiper` flow), Open-folder, and Close

Piper was a natural fit because, like Kokoro, it is an install-based engine with an executable, install folder, download flow, and `GetEngineUpdateStatus()` already in place — so the window reuses all of that. Piper has no tunable runtime parameters today, so this window is install/status management only (consistent with the Kokoro window).

## Changes

- New `PiperSettings/PiperSettingsViewModel.cs` + `PiperSettingsWindow.cs` (modeled on the Kokoro settings pair)
- `TextToSpeechViewModel.cs`: show the gear for Piper and open the new window
- `DependencyInjectionExtensions.cs`: register `PiperSettingsViewModel`
- `LanguageTextToSpeech.cs`: add the "Piper settings" window title string

## Testing

- `dotnet build src/ui/UI.csproj` succeeds (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@