### PR TITLE
Fix macOS native menu bar reverting to English after restart (#11505)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -159,7 +159,7 @@ public static partial class InitListViewAndEditBox
             // updated index. Selection still wins because :selected overrides BackgroundRectangle.Fill.
             if (alternatingRowBrush != null)
             {
-                e.Row.Background = e.Row.GetIndex() % 2 == 1 ? alternatingRowBrush : Brushes.Transparent;
+                e.Row.Background = e.Row.Index % 2 == 1 ? alternatingRowBrush : Brushes.Transparent;
             }
         };
 

--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -8,9 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.Config.Language;
 using System;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Main;
@@ -50,24 +48,9 @@ public class MainView : ViewBase
             };
         }
 
-        // load language
-        Se.Settings.General.Language = Se.Settings.General.Language ?? "English"; // default to English if not set
-        if (Se.Settings.General.Language != "English")
-        {
-            var jsonFileName = System.IO.Path.Combine(Se.TranslationFolder, Se.Settings.General.Language + ".json");
-            if (System.IO.File.Exists(jsonFileName))
-            {
-                var json = System.IO.File.ReadAllText(jsonFileName, Encoding.UTF8);
-                var language = System.Text.Json.JsonSerializer.Deserialize<SeLanguage>(json, new System.Text.Json.JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                });
-                if (language != null)
-                {
-                    Se.Language = language;
-                }
-            }
-        }
+        // Load language (normally already loaded in Program.Main before the window is built; this
+        // is a no-op safety net for windows created via other entry points).
+        Se.LoadLanguage();
 
         var root = new DockPanel();
 

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -289,6 +289,45 @@ public class Se
         UpdateLibSeSettings();
     }
 
+    /// <summary>
+    /// Loads the UI translation named in <see cref="Settings"/>.General.Language into the global
+    /// <see cref="Language"/>. Must run before the main window is built: on macOS the native menu
+    /// bar is constructed at startup and reads <see cref="Language"/> directly, so the translation
+    /// has to be in place by then or the menu bar renders in English (issue #11505). English — or a
+    /// missing/unreadable translation file — leaves the built-in English defaults untouched.
+    /// </summary>
+    public static void LoadLanguage()
+    {
+        Settings.General.Language ??= "English";
+        if (Settings.General.Language == "English")
+        {
+            return;
+        }
+
+        try
+        {
+            var jsonFileName = Path.Combine(TranslationFolder, Settings.General.Language + ".json");
+            if (!System.IO.File.Exists(jsonFileName))
+            {
+                return;
+            }
+
+            var json = System.IO.File.ReadAllText(jsonFileName, Encoding.UTF8);
+            var language = JsonSerializer.Deserialize<SeLanguage>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            });
+            if (language != null)
+            {
+                Language = language;
+            }
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Failed to load UI language");
+        }
+    }
+
     private static void SetDefaultValues()
     {
         if (Settings.Tools == null)

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -54,6 +54,10 @@ namespace Nikse.SubtitleEdit
                 // Load settings
                 Se.LoadSettings();
 
+                // Load the UI translation before any window or the macOS native menu bar is built,
+                // so the menu bar isn't constructed with the default English strings (issue #11505).
+                Se.LoadLanguage();
+
                 // Build and configure the app
                 var appBuilder = AppBuilder.Configure<Application>()
                     .UsePlatformDetect()


### PR DESCRIPTION
Fixes #11505.

## Problem

On macOS, after changing the UI language and restarting SE, the **native top menu bar** (File, Edit, Tools, …) shows in **English** even though the rest of the window is correctly localized.

## Root cause

The native `NSMenuBar` is built in `Program.Main` immediately after `SetupMainWindow`, and `InitNativeMacMenu.MakeStructure` reads `Se.Language` directly. But the translation was loaded *inside* `MainView.Build()`, which (as an `Avalonia.Markup.Declarative` `ViewBase`) runs **lazily on attach** during `lifetime.Start()` — i.e. *after* the native menu has already been constructed from the default English strings.

Runtime language switches were never affected because they call `InitNativeMacMenu.Rebuild()`.

## Fix

- Add `Se.LoadLanguage()` — loads the translation named in settings into `Se.Language` (English / missing / unreadable file ⇒ English defaults, errors logged).
- Call it in `Program.Main` right after `Se.LoadSettings()`, **before** any window or the native menu bar is built. This is the actual fix.
- Replace the duplicated inline load in `MainView` with the shared call (and drop two now-unused imports).
- Also fix a pre-existing build warning: `DataGridRow.GetIndex()` (obsolete) → `.Index`.

Build is **0 warnings, 0 errors**.

## Verification

Confirmed on macOS (Apple Silicon): set UI language to a non-English translation, restart — the native menu bar now appears localized. English startup path verified healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)