### PR TITLE
macOS: use system font (SF Pro) as default UI font

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -379,7 +379,7 @@ public partial class SettingsViewModel : ObservableObject
         SelectedIconTheme = IconThemes[0];
 
         FontNames = new ObservableCollection<string>(FontHelper.GetSystemFonts());
-        FontNames.Insert(0, "Default");
+        FontNames.Insert(0, OperatingSystem.IsMacOS() ? "System Font" : "Default");
         SelectedFontName = FontNames.First();
 
         ScrollView = new ScrollViewer();
@@ -693,7 +693,17 @@ public partial class SettingsViewModel : ObservableObject
         SelectedIconTheme = IconThemes.FirstOrDefault(p => p == appearance.IconTheme) ?? IconThemes.First();
         MatchIconColorToDarkTheme = appearance.MatchIconColorToDarkTheme;
         LayoutScale = (int)Math.Round(appearance.LayoutScale * 100.0, MidpointRounding.AwayFromZero);
-        SelectedFontName = FontNames.FirstOrDefault(p => p == appearance.FontName) ?? FontNames.First();
+        if (OperatingSystem.IsMacOS())
+        {
+            SelectedFontName = appearance.FontName is ".AppleSystemUIFont" or "Default"
+                               || FontNames.All(p => p != appearance.FontName)
+                ? "System Font"
+                : appearance.FontName;
+        }
+        else
+        {
+            SelectedFontName = FontNames.FirstOrDefault(p => p == appearance.FontName) ?? FontNames.First();
+        }
         ShowToolbarNew = appearance.ToolbarShowFileNew;
         ShowToolbarOpen = appearance.ToolbarShowFileOpen;
         ShowToolbarVideoFileOpen = appearance.ToolbarShowVideoFileOpen;
@@ -1368,9 +1378,18 @@ public partial class SettingsViewModel : ObservableObject
         appearance.IconTheme = SelectedIconTheme;
         appearance.MatchIconColorToDarkTheme = MatchIconColorToDarkTheme;
         appearance.LayoutScale = LayoutScale / 100.0;
-        appearance.FontName = SelectedFontName == FontNames.First()
-            ? new Label().FontFamily.Name
-            : SelectedFontName;
+        if (OperatingSystem.IsMacOS())
+        {
+            appearance.FontName = SelectedFontName == "System Font"
+                ? ".AppleSystemUIFont"
+                : SelectedFontName;
+        }
+        else
+        {
+            appearance.FontName = SelectedFontName == "Default"
+                ? new Label().FontFamily.Name
+                : SelectedFontName;
+        }
         appearance.ToolbarShowFileNew = ShowToolbarNew;
         appearance.ToolbarShowFileOpen = ShowToolbarOpen;
         appearance.ToolbarShowVideoFileOpen = ShowToolbarVideoFileOpen;


### PR DESCRIPTION
macOS users are accustomed to seeing San Francisco as the default UI font. Without it, the application feels unfamiliar. Using this font brings us closer to the native app experience.

This font is excluded from the list due to a system restriction, so it cannot be selected by name.

On macOS, this PR replaces the 'Default' (Inter) entry in the UI font picker with 'System Font', which maps to .AppleSystemUIFont. 

This lets Core Text resolve San Francisco at runtime despite Apple excluding it from font enumeration APIs. Existing users with 'Default' stored migrate automatically to 'System Font'.

Windows/Linux behaviour is unchanged.