### PR TITLE
Fix corrupted ellipsis character in custom continuation style dropdown

### DIFF
--- a/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
+++ b/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
@@ -45,7 +45,7 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
         {
             string.Empty,
             "...",
-            "�",
+            "…",
             "..",
             "-",
         });


### PR DESCRIPTION
CustomContinuationStyleViewModel has a dropdown list (PreAndSuffixes) used for selecting prefix/suffix characters. One entry is supposed to be the Unicode ellipsis … (U+2026) but is stored as the Unicode replacement character � (U+FFFD, renders as "…").

This was fixed in the fix/continuation-style-setting branch (commit 4433b4662) but not included in the upstream merge (PR #11510 / c95548b). The corrupted character will show as "…" in the dropdown instead of "…".


<img width="291" height="289" alt="Ellipsis" src="https://github.com/user-attachments/assets/9f8f76b7-494f-45ba-9920-94f2655d9741" />
