### PR TITLE
Fix merge selection focus + add CJK unbreak actions

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10808,7 +10808,14 @@ public partial class MainViewModel :
 
         foreach (var s in selectedItems)
         {
-            s.Text = s.Text.Replace(Environment.NewLine, string.Empty).Replace("\n", string.Empty);
+            // Normalize line endings first so \r-only breaks don't leak through,
+            // then drop the break together with any spaces around it - same
+            // normalization as MergeManager.BreakMode.UnbreakNoSpace.
+            var text = s.Text.Replace("\r\n", "\n").Replace("\r", "\n");
+            s.Text = text.Replace(" \n ", string.Empty)
+                .Replace("\n ", string.Empty)
+                .Replace(" \n", string.Empty)
+                .Replace("\n", string.Empty);
         }
 
         _updateAudioVisualizer = true;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8878,6 +8878,18 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void MergeSelectedLinesAndUnbreak()
+    {
+        MergeLinesSelected(MergeManager.BreakMode.Unbreak);
+    }
+
+    [RelayCommand]
+    private void MergeSelectedLinesAndUnbreakCjk()
+    {
+        MergeLinesSelected(MergeManager.BreakMode.UnbreakNoSpace);
+    }
+
+    [RelayCommand]
     private void ToggleCasing()
     {
         if (IsSubtitleGridFocused())
@@ -10778,6 +10790,25 @@ public partial class MainViewModel :
         foreach (var s in selectedItems)
         {
             s.Text = Utilities.UnbreakLine(s.Text);
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
+    private void UnbreakNoSpace()
+    {
+        // Unbreak without joining with a space - intended for CJK text where
+        // words are not space-separated (SE 4's "Unbreak without space (CJK)").
+        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var s in selectedItems)
+        {
+            s.Text = s.Text.Replace(Environment.NewLine, string.Empty).Replace("\n", string.Empty);
         }
 
         _updateAudioVisualizer = true;
@@ -16429,19 +16460,19 @@ public partial class MainViewModel :
         }
     }
 
-    private void MergeLinesSelected()
+    private void MergeLinesSelected(MergeManager.BreakMode breakMode = MergeManager.BreakMode.Normal)
     {
         var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
-        var selectedItem = SelectedSubtitle;
-        if (selectedItems.Count == 0 || selectedItem == null)
+        if (selectedItems.Count == 0 || SelectedSubtitle == null)
         {
             return;
         }
 
-        var index = Subtitles.IndexOf(selectedItem);
+        // The merged line always lands at the lowest selected index, so keep the
+        // selection there regardless of the order the rows were clicked in.
+        var index = selectedItems.Min(item => Subtitles.IndexOf(item));
 
-        _mergeManager.MergeSelectedLines(Subtitles,
-            SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList());
+        _mergeManager.MergeSelectedLines(Subtitles, selectedItems, breakMode: breakMode);
 
         SelectAndScrollToRow(index);
         Renumber();

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -204,6 +204,10 @@ public static class Se4ShortcutsImporter
         ["MainTextBoxSelectionToUpper"] = nameof(MainViewModel.SelectionToUpperCommand),
         ["MainTextBoxAutoBreak"] = nameof(MainViewModel.AutoBreakCommand),
         ["MainTextBoxUnbreak"] = nameof(MainViewModel.UnbreakCommand),
+        // SE 4 serializes this element with a typo ("Unbrek"); also accept the
+        // corrected spelling in case it is ever fixed upstream.
+        ["MainTextBoxUnbrekNoSpace"] = nameof(MainViewModel.UnbreakNoSpaceCommand),
+        ["MainTextBoxUnbreakNoSpace"] = nameof(MainViewModel.UnbreakNoSpaceCommand),
         ["MainTextBoxInsertUnicodeSymbol"] = nameof(MainViewModel.TextBoxInsertUnicodeSymbolCommand),
 
         // Create / adjust
@@ -298,6 +302,10 @@ public static class Se4ShortcutsImporter
         ["GeneralFocusTextBox"] = nameof(MainViewModel.FocusTextBoxCommand),
         ["GeneralCycleAudioTrack"] = nameof(MainViewModel.ToggleAudioTracksCommand),
         ["GeneralMergeSelectedLines"] = nameof(MainViewModel.MergeSelectedLinesCommand),
+        ["GeneralMergeSelectedLinesAndUnbreak"] = nameof(MainViewModel.MergeSelectedLinesAndUnbreakCommand),
+        ["GeneralMergeSelectedLinesAndUnbreakCjk"] = nameof(MainViewModel.MergeSelectedLinesAndUnbreakCjkCommand),
+        // SE 4 used "...NoSpace" before renaming the action to "...Cjk"; map both.
+        ["GeneralMergeSelectedLinesAndUnbreakNoSpace"] = nameof(MainViewModel.MergeSelectedLinesAndUnbreakCjkCommand),
         ["GeneralMergeSelectedLinesBilingual"] = nameof(MainViewModel.MergeSelectedLinesBilingualCommand),
         ["GeneralMergeOriginalAndTranslation"] = nameof(MainViewModel.MergeOriginalIntoTranslationSelectedLinesCommand),
         ["GeneralMergeWithNext"] = nameof(MainViewModel.MergeWithLineAfterCommand),

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -24,6 +24,7 @@ public class LanguageSettingsShortcuts
     public string GeneralMergeSelectedLinesAndAutoBreak { get; set; }
     public string GeneralMergeSelectedLinesAndUnbreak { get; set; }
     public string GeneralMergeSelectedLinesAndUnbreakCjk { get; set; }
+    public string GeneralUnbreakNoSpaceCjk { get; set; }
     public string GeneralMergeSelectedLinesOnlyFirstText { get; set; }
     public string GeneralMergeSelectedLinesBilingual { get; set; }
     public string GeneralMergeWithPreviousBilingual { get; set; }
@@ -317,6 +318,7 @@ public class LanguageSettingsShortcuts
         GeneralMergeSelectedLinesAndAutoBreak = "Merge selected lines and auto-break";
         GeneralMergeSelectedLinesAndUnbreak = "Merge selected lines and unbreak";
         GeneralMergeSelectedLinesAndUnbreakCjk = "Merge selected lines and unbreak CJK";
+        GeneralUnbreakNoSpaceCjk = "Unbreak without space (CJK)";
         GeneralMergeSelectedLinesOnlyFirstText = "Merge selected lines only first text";
         GeneralMergeSelectedLinesBilingual = "Merge selected lines bilingual";
         GeneralMergeWithPreviousBilingual = "Merge with previous bilingual";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -296,6 +296,9 @@ public static class ShortcutsMain
         { nameof(MainViewModel.MergeSelectedLinesCommand), Se.Language.General.MergeSelectedLines },
         { nameof(MainViewModel.MergeSelectedLinesDialogCommand), Se.Language.General.MergeSelectedLinesDialog },
         { nameof(MainViewModel.MergeSelectedLinesBilingualCommand), Se.Language.Options.Shortcuts.GeneralMergeSelectedLinesBilingual },
+        { nameof(MainViewModel.MergeSelectedLinesAndUnbreakCommand), Se.Language.Options.Shortcuts.GeneralMergeSelectedLinesAndUnbreak },
+        { nameof(MainViewModel.MergeSelectedLinesAndUnbreakCjkCommand), Se.Language.Options.Shortcuts.GeneralMergeSelectedLinesAndUnbreakCjk },
+        { nameof(MainViewModel.UnbreakNoSpaceCommand), Se.Language.Options.Shortcuts.GeneralUnbreakNoSpaceCjk },
         { nameof(MainViewModel.ShowColorPickerCommand), Se.Language.General.ChooseColorDotDotDot },
         { nameof(MainViewModel.FetchFirstWordFromNextSubtitleCommand), Se.Language.Options.Shortcuts.FetchFirstWordFromNextSubtitle },
         { nameof(MainViewModel.WaveformSetEndAndStartOfNextAfterGapCommand), Se.Language.Options.Shortcuts.WaveformSetEndAndStartOfNextAfterGap },
@@ -502,6 +505,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SaveLanguageFileCommand, nameof(vm.SaveLanguageFileCommand), ShortcutCategory.General);
 
         AddShortcut(shortcuts, vm.UnbreakCommand, nameof(vm.UnbreakCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.UnbreakNoSpaceCommand, nameof(vm.UnbreakNoSpaceCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.AutoBreakCommand, nameof(vm.AutoBreakCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitCommand, nameof(vm.SplitCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitAtVideoPositionCommand, nameof(vm.SplitAtVideoPositionCommand), ShortcutCategory.General);
@@ -635,6 +639,8 @@ public static class ShortcutsMain
 
         AddShortcut(shortcuts, vm.MergeSelectedLinesDialogCommand, nameof(vm.MergeSelectedLinesDialogCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MergeSelectedLinesBilingualCommand, nameof(vm.MergeSelectedLinesBilingualCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.MergeSelectedLinesAndUnbreakCommand, nameof(vm.MergeSelectedLinesAndUnbreakCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.MergeSelectedLinesAndUnbreakCjkCommand, nameof(vm.MergeSelectedLinesAndUnbreakCjkCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowColorPickerCommand, nameof(vm.ShowColorPickerCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.FetchFirstWordFromNextSubtitleCommand, nameof(vm.FetchFirstWordFromNextSubtitleCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MoveLastWordToNextSubtitleCommand, nameof(vm.MoveLastWordToNextSubtitleCommand), ShortcutCategory.General);


### PR DESCRIPTION
## Summary

Two related fixes around merging/unbreaking subtitle lines.

### Fix #11453 — merge moves selection depending on click order
When merging selected lines, focus jumped to the *next* row when the lines were selected top-to-bottom, but stayed put when selected bottom-to-top.

`MergeLinesSelected()` re-selected the index of `SelectedSubtitle` (the focused/last-clicked row). The merged line always lands at the **lowest** selected index, so when the anchor was the lower row, the re-selected index pointed one row past the merged line. Now it re-selects the minimum selected index, so focus stays on the merged row regardless of click order.

### Fix #11461 — "Unbreak without space (CJK)" actions missing + SE4 shortcuts dropped on import
SE5 had no CJK unbreak actions, so the matching SE 4 shortcut elements imported as "no matching SE 5 actions" (the "12 skipped" the reporter saw). The display strings already existed in the language file but were never wired to commands.

- Added commands: `UnbreakNoSpace`, `MergeSelectedLinesAndUnbreak`, `MergeSelectedLinesAndUnbreakCjk` (the CJK variant reuses the existing `MergeManager.BreakMode.UnbreakNoSpace`).
- Registered them as available shortcuts so they appear and are bindable in Settings → Shortcuts.
- Added importer mappings for SE 4's serialized element names — including SE 4's `MainTextBoxUnbrekNoSpace` typo, with corrected-spelling and legacy `...NoSpace` aliases for robustness.
- Added the `GeneralUnbreakNoSpaceCjk` label ("Unbreak without space (CJK)").

Part 2 of #11461 (the mpv "handle preview text" dropdown) is a separate video-player feature and is not included here.

## Test plan
- [x] `dotnet build` clean (0 warnings, 0 errors)
- [ ] Merge two lines selecting top→bottom and bottom→top; selection stays on the merged row both ways
- [ ] New actions appear in Settings → Shortcuts and can be bound
- [ ] Importing an SE 4 shortcut file maps the unbreak/merge-CJK actions instead of skipping them

🤖 Generated with [Claude Code](https://claude.com/claude-code)