### PR TITLE
Fix grid coloring: honor too-many-lines and add independent CPS/WPM toggles

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -280,6 +280,15 @@ public partial class SubtitleLineViewModel : ObservableObject
                 }
             }
 
+            if (Se.Settings.General.ColorTextTooManyLines)
+            {
+                stripped ??= HtmlUtil.RemoveHtmlTags(Text, true);
+                if (stripped.SplitToLines().Count > Se.Settings.General.MaxNumberOfLines)
+                {
+                    return _errorBrush;
+                }
+            }
+
             return _transparentBrush;
         }
     }
@@ -346,7 +355,7 @@ public partial class SubtitleLineViewModel : ObservableObject
     {
         get
         {
-            if (Se.Settings.General.ColorDurationTooLong &&
+            if (Se.Settings.General.ColorCharactersPerSecond &&
                 CharactersPerSecond > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
             {
                 return _errorBrush;
@@ -360,7 +369,7 @@ public partial class SubtitleLineViewModel : ObservableObject
     {
         get
         {
-            if (Se.Settings.General.ColorDurationTooLong &&
+            if (Se.Settings.General.ColorWordsPerMinute &&
                 WordsPerMinute > Se.Settings.General.SubtitleMaximumWordsPerMinute)
             {
                 return _errorBrush;

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -364,6 +364,9 @@ public class SettingsPage : UserControl
 
             MakeCheckboxSetting(Se.Language.Options.Settings.ColorTextTooManyLines, nameof(_vm.ColorTextTooManyLines)),
             MakeSeparator(),
+            MakeCheckboxSetting(Se.Language.Options.Settings.ColorCharactersPerSecond, nameof(_vm.ColorCharactersPerSecond)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.ColorWordsPerMinute, nameof(_vm.ColorWordsPerMinute)),
+            MakeSeparator(),
             MakeCheckboxSetting(Se.Language.Options.Settings.ColorOverlap, nameof(_vm.ColorOverlap)),
             MakeSeparator(),
             MakeCheckboxSetting(Se.Language.Options.Settings.ColorGapTooShort, nameof(_vm.ColorGapTooShort)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -200,6 +200,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private int _colorTextTooWideFontSize;
     [ObservableProperty] private string _colorTextTooWideFontName;
     [ObservableProperty] private bool _colorTextTooManyLines;
+    [ObservableProperty] private bool _colorCharactersPerSecond;
+    [ObservableProperty] private bool _colorWordsPerMinute;
     [ObservableProperty] private bool _colorOverlap;
     [ObservableProperty] private bool _colorGapTooShort;
     [ObservableProperty] private Color _errorColor;
@@ -830,6 +832,8 @@ public partial class SettingsViewModel : ObservableObject
         ColorTextTooWideFontName = general.ColorTextTooWideFontName;
         ColorTextTooWideFontSize = general.ColorTextTooWideFontSize;
         ColorTextTooManyLines = general.ColorTextTooManyLines;
+        ColorCharactersPerSecond = general.ColorCharactersPerSecond;
+        ColorWordsPerMinute = general.ColorWordsPerMinute;
         ColorOverlap = general.ColorTimeCodeOverlap;
         ColorGapTooShort = general.ColorGapTooShort;
         ErrorColor = general.ErrorColor.FromHexToColor();
@@ -1489,6 +1493,8 @@ public partial class SettingsViewModel : ObservableObject
         general.ColorTextTooWideFontName = ColorTextTooWideFontName;
         general.ColorTextTooWideFontSize = ColorTextTooWideFontSize;
         general.ColorTextTooManyLines = ColorTextTooManyLines;
+        general.ColorCharactersPerSecond = ColorCharactersPerSecond;
+        general.ColorWordsPerMinute = ColorWordsPerMinute;
         general.ColorTimeCodeOverlap = ColorOverlap;
         general.ColorGapTooShort = ColorGapTooShort;
         general.ErrorColor = ErrorColor.FromColorToHex();
@@ -2164,6 +2170,8 @@ public partial class SettingsViewModel : ObservableObject
                 Se.Settings.General.ColorTextTooLong = g.ColorTextTooLong;
                 Se.Settings.General.ColorTextTooWide = g.ColorTextTooWide;
                 Se.Settings.General.ColorTextTooManyLines = g.ColorTextTooManyLines;
+                Se.Settings.General.ColorCharactersPerSecond = g.ColorCharactersPerSecond;
+                Se.Settings.General.ColorWordsPerMinute = g.ColorWordsPerMinute;
                 Se.Settings.General.ColorTimeCodeOverlap = g.ColorTimeCodeOverlap;
                 Se.Settings.General.ColorGapTooShort = g.ColorGapTooShort;
                 Se.Settings.General.ErrorColor = g.ErrorColor;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -117,6 +117,8 @@ public class LanguageSettings
     public string ColorTextTooLong { get; set; }
     public string ColorTextTooWide { get; set; }
     public string ColorTextTooManyLines { get; set; }
+    public string ColorCharactersPerSecond { get; set; }
+    public string ColorWordsPerMinute { get; set; }
     public string ColorOverlap { get; set; }
     public string ColorGapTooShort { get; set; }
     public string ErrorBackgroundColor { get; set; }
@@ -420,6 +422,8 @@ public class LanguageSettings
         ColorTextTooLong = "Color text if too long";
         ColorTextTooWide = "Color text if too wide (pixels)";
         ColorTextTooManyLines = "Color text if more than 2 lines";
+        ColorCharactersPerSecond = "Color characters/sec if too high";
+        ColorWordsPerMinute = "Color words/min if too high";
         ColorOverlap = "Color time code overlap";
         ColorGapTooShort = "Color if gap is too short";
         ErrorBackgroundColor = "Error background color";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -74,6 +74,8 @@ public class SeGeneral
     public string ColorTextTooWideFontName { get; set; }
     public int ColorTextTooWideFontSize { get; set; }
     public bool ColorTextTooManyLines { get; set; }
+    public bool ColorCharactersPerSecond { get; set; }
+    public bool ColorWordsPerMinute { get; set; }
     public bool ColorTimeCodeOverlap { get; set; }
     public bool ColorGapTooShort { get; set; }
     public string ErrorColor { get; set; }
@@ -181,6 +183,8 @@ public class SeGeneral
         ColorTextTooWideFontName = "Arial";
         ColorTextTooWideFontSize = 40;
         ColorTextTooManyLines = true;
+        ColorCharactersPerSecond = true;
+        ColorWordsPerMinute = true;
         ColorTimeCodeOverlap = true;
         ColorGapTooShort = true;
         ErrorColor = Color.FromArgb(50, 255, 0, 0).FromColorToHex();


### PR DESCRIPTION
Fixes two issues in the subtitle grid syntax-coloring logic, surfaced from the [discussions](https://github.com/SubtitleEdit/subtitleedit/discussions/11195).

## 1. "Color text if more than 2 lines" did nothing
`ColorTextTooManyLines` has a settings checkbox (and is `true` by default), but `SubtitleLineViewModel.TextBackgroundBrush` only ever checked `ColorTextTooLong` and `ColorTextTooWide`. The setting was never read, so subtitles with too many lines were never highlighted.

`TextBackgroundBrush` now returns the error brush when the line count exceeds `MaxNumberOfLines`.

## 2. CPS / WPM coloring could not be controlled independently
`CpsBackgroundBrush` and `WpmBackgroundBrush` were both gated on `ColorDurationTooLong`. Consequences:
- No way to toggle CPS or WPM highlighting on their own.
- Turning off "color duration too long" silently disabled CPS and WPM warnings too.

Added dedicated `ColorCharactersPerSecond` and `ColorWordsPerMinute` settings (default `true`) and gated the two brushes on them. Wired through the settings dialog (load / save / reset-to-default), added checkboxes in the Syntax Coloring section, and added English language strings.

> Note: the CPS-too-high branch in `DurationBackgroundBrush` is intentionally left on `ColorDurationTooLong` — it carries an explicit comment tying it to #11307 (SE4 deliberately lit up the Duration column for high CPS).

## Files
- `SeGeneral.cs` — two new settings + defaults
- `SubtitleLineViewModel.cs` — the two fixes
- `SettingsViewModel.cs` — observable properties + load/save/reset
- `SettingsPage.cs` — two checkboxes
- `LanguageSettings.cs` — labels

Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)