### PR TITLE
Log unhandled UI-thread exceptions (issue #11515)

### DIFF
--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -39,6 +39,17 @@ namespace Nikse.SubtitleEdit
                     Se.LogError(exception ?? new Exception(), "Unhandled AppDomain Exception");
                 };
 
+                // UI-thread exception handling. Avalonia routes exceptions thrown from
+                // command/event handlers (e.g. a key binding) here, not through
+                // AppDomain.UnhandledException - so without this they could crash the app
+                // with nothing written to error-log.txt (see issue #11515). Log it and mark
+                // it handled so the app stays alive and the user gets a stack trace.
+                Dispatcher.UIThread.UnhandledException += (sender, e) =>
+                {
+                    Se.LogError(e.Exception, "Unhandled UI thread Exception");
+                    e.Handled = true;
+                };
+
                 // Setup application lifetime
                 var lifetime = new ClassicDesktopStyleApplicationLifetime
                 {

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -46,7 +46,7 @@ namespace Nikse.SubtitleEdit
                 // it handled so the app stays alive and the user gets a stack trace.
                 Dispatcher.UIThread.UnhandledException += (sender, e) =>
                 {
-                    Se.LogError(e.Exception, "Unhandled UI thread Exception");
+                    Se.LogError(e.Exception, "Unhandled UI thread exception");
                     e.Handled = true;
                 };
 


### PR DESCRIPTION
## Problem

Crash reports like #11515 (app vanishes on a key press, no dialog) are impossible to diagnose because **no `error-log.txt` is written**.

The global handler in `Program.cs` only hooks `AppDomain.CurrentDomain.UnhandledException`. Avalonia routes exceptions thrown from command/event handlers (e.g. a key binding such as Delete) through `Dispatcher.UIThread.UnhandledException` instead — so those crash the app with nothing logged.

## Change

Add a `Dispatcher.UIThread.UnhandledException` handler that:
- logs the exception via `Se.LogError` (so it lands in `error-log.txt`), and
- sets `e.Handled = true` so the app stays alive instead of disappearing, and the user can retrieve the stack trace.

## Notes

- Catches **managed** UI-thread exceptions. Native crashes (e.g. libmpv access violations) and `StackOverflowException` remain uncatchable — for those, the Windows Event Viewer faulting-module is still the way to diagnose.
- `Dispatcher` was already imported; no new usings.
- Builds clean (`dotnet build src/ui/UI.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)