### PR TITLE
Unify error log filename to error-log.txt

### DIFF
--- a/src/libse/Common/SeLogger.cs
+++ b/src/libse/Common/SeLogger.cs
@@ -7,7 +7,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     public static class SeLogger
     {
-        public static string ErrorFile => Path.Combine(Configuration.DataDirectory, "error_log.txt");
+        public static string ErrorFile => Path.Combine(Configuration.DataDirectory, "error-log.txt");
 
         public static void Error(Exception exception, string message = null)
         {
@@ -52,8 +52,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             try
             {
-                var filePath = Path.Combine(Configuration.DataDirectory, "error_log.txt");
-                using (var writer = new StreamWriter(filePath, true, Encoding.UTF8))
+                using (var writer = new StreamWriter(ErrorFile, true, Encoding.UTF8))
                 {
                     writer.WriteLine("-----------------------------------------------------------------------------");
                     writer.WriteLine($"Date: {DateTime.Now.ToString(CultureInfo.InvariantCulture)}");


### PR DESCRIPTION
Follow-up to #11519.

`SeLogger` (libse) wrote crash/error output to `error_log.txt` (underscore), while the SE5 UI logger (`Se.LogError` / `GetErrorLogFilePath`) and the Settings **Show error log file** link use `error-log.txt` (hyphen). Both target the same data folder (`Se.cs` sets `Configuration.DataDirectory = DataFolder`), so errors were split across two files and the one the UI links to could miss `SeLogger` output — which is exactly the kind of confusion seen in #11515, where the reporter looked for `error_log.txt` and found nothing.

## Change
- Point `SeLogger` at `error-log.txt` (hyphen).
- Dedupe the second hardcoded path in `Error(string)` to reuse the `ErrorFile` property so the name cannot drift again.

libse builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)