### PR TITLE
Fix continuation action sorting in Fix Common Errors

### DIFF
--- a/src/libse/Common/FixActionKey.cs
+++ b/src/libse/Common/FixActionKey.cs
@@ -1,0 +1,37 @@
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Separates the user-visible fix action label from an internal variant key so the UI can
+    /// group/sort equivalent actions while the apply/selection pipeline still distinguishes them.
+    /// </summary>
+    public static class FixActionKey
+    {
+        private const char Separator = '\u001F';
+
+        public static string Create(string actionDisplay, string variant)
+        {
+            if (string.IsNullOrEmpty(variant))
+            {
+                return actionDisplay ?? string.Empty;
+            }
+
+            return (actionDisplay ?? string.Empty) + Separator + variant;
+        }
+
+        public static string GetDisplay(string actionKey)
+        {
+            if (string.IsNullOrEmpty(actionKey))
+            {
+                return string.Empty;
+            }
+
+            var separatorIndex = actionKey.IndexOf(Separator);
+            if (separatorIndex >= 0)
+            {
+                return actionKey.Substring(0, separatorIndex);
+            }
+
+            return actionKey;
+        }
+    }
+}

--- a/src/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
+++ b/src/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
@@ -9,6 +9,9 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {
     public class FixContinuationStyle : IFixCommonError
     {
+        private const string SuffixVariant = "suffix";
+        private const string PrefixVariant = "prefix";
+
         public static class Language
         {
             public static string FixUnnecessaryLeadingDots { get; set; } = "Remove unnecessary leading dots";
@@ -21,6 +24,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
             var fixCount = 0;
+            var suffixActionKey = FixActionKey.Create(FixAction, SuffixVariant);
+            var prefixActionKey = FixActionKey.Create(FixAction, PrefixVariant);
 
             var isLanguageWithoutCaseDistinction = ContinuationUtilities.IsLanguageWithoutCaseDistinction(callbacks.Language);
 
@@ -165,7 +170,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         var newText = ContinuationUtilities.AddSuffixIfNeeded(oldTextWithoutSuffix, _continuationProfile, gap, addComma);
 
                         // Commit if changed
-                        if (oldText != newText && callbacks.AllowFix(p, FixAction))
+                        if (oldText != newText && callbacks.AllowFix(p, suffixActionKey))
                         {
                             // Convert back for Arabic
                             if (callbacks.Language == "ar")
@@ -180,7 +185,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             }
 
                             fixCount++;
-                            callbacks.AddFixToListView(p, FixAction, oldText, newText, isChecked);
+                            callbacks.AddFixToListView(p, suffixActionKey, oldText, newText, isChecked);
                         }
 
 
@@ -190,7 +195,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         var newTextNext = ContinuationUtilities.AddPrefixIfNeeded(oldTextNextWithoutPrefix, _continuationProfile, gap);
 
                         // Commit if changed
-                        if (oldTextNext != newTextNext && callbacks.AllowFix(pNext, FixAction + " "))
+                        if (oldTextNext != newTextNext && callbacks.AllowFix(pNext, prefixActionKey))
                         {
                             // Convert back for Arabic
                             if (callbacks.Language == "ar")
@@ -205,7 +210,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             }
 
                             fixCount++;
-                            callbacks.AddFixToListView(pNext, FixAction + " ", oldTextNext, newTextNext, isChecked);
+                            callbacks.AddFixToListView(pNext, prefixActionKey, oldTextNext, newTextNext, isChecked);
                         }
                     }
                 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -284,7 +284,7 @@ public class FixCommonErrorsWindow : Window
                 {
                     Header = Se.Language.Tools.FixCommonErrors.Action,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(FixDisplayItem.Action)),
+                    Binding = new Binding(nameof(FixDisplayItem.ActionDisplay)),
                     IsReadOnly = true,
                 },
                 new DataGridTemplateColumn

--- a/src/ui/Features/Tools/FixCommonErrors/FixDisplayItem.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixDisplayItem.cs
@@ -5,7 +5,11 @@ namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 
 public partial class FixDisplayItem : ObservableObject
 {
+    // Internal identifier used to preserve selection/apply behavior for fixes that share the
+    // same visible label but must remain distinct entries.
     [ObservableProperty] private string _action;
+
+    [ObservableProperty] private string _actionDisplay;
 
     [ObservableProperty] private string _before;
 
@@ -21,6 +25,7 @@ public partial class FixDisplayItem : ObservableObject
         Paragraph = p;
         Number = number;
         Action = action;
+        ActionDisplay = FixActionKey.GetDisplay(action);
         Before = before;
         After = after;
         IsSelected = isChecked;

--- a/tests/UI/Features/Tools/FixCommonErrors/FixDisplayItemTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixDisplayItemTests.cs
@@ -1,0 +1,29 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
+
+namespace UITests.Features.Tools.FixCommonErrors;
+
+public class FixDisplayItemTests
+{
+    [Fact]
+    public void ContinuationVariants_KeepDistinctActionKeys_ButShareVisibleActionLabel()
+    {
+        const string action = "Fix continuation style: Custom";
+        var suffixItem = new FixDisplayItem(new Paragraph(), 1, FixActionKey.Create(action, "suffix"), "before", "after", true);
+        var prefixItem = new FixDisplayItem(new Paragraph(), 2, FixActionKey.Create(action, "prefix"), "before", "after", true);
+
+        Assert.NotEqual(suffixItem.Action, prefixItem.Action);
+        Assert.Equal(action, suffixItem.ActionDisplay);
+        Assert.Equal(action, prefixItem.ActionDisplay);
+    }
+
+    [Fact]
+    public void RegularActions_UseSameTextForActionKeyAndDisplay()
+    {
+        const string action = "Fix commas";
+        var item = new FixDisplayItem(new Paragraph(), 1, action, "before", "after", true);
+
+        Assert.Equal(action, item.Action);
+        Assert.Equal(action, item.ActionDisplay);
+    }
+}


### PR DESCRIPTION
  ### Summary
  This PR changes the Fix Common Errors action list so continuation-style fixes sort under a single visible action label while still keeping the two fix variants distinct internally.

  Previously, `FixContinuationStyle` used a trailing-space hack in the action text to distinguish the current-line suffix fix from the next-line prefix fix. That preserved selection/apply behavior, but it also caused sorting by `Action` to split the rows into two visually identical groups.

  In the screenshot below, the grid is sorted by Action, but the numbering restarts midway without any clear reason. This inconsistency prompted my investigation.

<img width="588" height="326" alt="Screenshot 2026-06-09 at 9 43 56 PM" src="https://github.com/user-attachments/assets/e3a4cee0-b699-4afd-b5d7-ffbbc9beef3e" />



  ### What changed
  - Added an internal `FixActionKey` helper to separate:
    - the internal action identity
    - the user-visible action label
  - Updated `FixContinuationStyle` to use explicit internal keys for:
    - suffix/current-paragraph fixes
    - prefix/next-paragraph fixes
  - Updated `FixDisplayItem` to expose:
    - `Action` as the internal key
    - `ActionDisplay` as the normalized visible label
  - Updated the Fix Common Errors grid to bind the `Action` column to `ActionDisplay`
  - Added a regression test covering the action-key/display split

  ### Result
  - Sorting by `Action` no longer creates two visually identical continuation-style groups
  - Continuation-style fix rows still remain distinct for selection persistence and apply behavior
  - No user-facing label changes were introduced

  ### Alternative solution

  This would have worked too: give the two continuation rows genuinely different action names, such as:

  - Fix continuation style: Custom (suffix)
  - Fix continuation style: Custom (prefix)

  or localized equivalents, the same way src/libse/Forms/FixCommonErrors/FixEmptyLines.cs:20 uses distinct labels for top/bottom/middle.

  I did not choose that approach because it changes the UI semantics:

  - it exposes an implementation detail the user may not care about
  - it would sort into separate visible groups by design
  - it would require new user-facing/localized strings if done cleanly

  The action-key/display split keeps the UI behavior as I expected it:

  - one visible action group: Fix continuation style: Custom
  - two internally distinct rows, so selection/apply still works correctly

  So a solution similar to RemovedEmptyLineAtTop pattern was a valid option, but it would have solved the identity problem by making the labels visibly different, whereas this fix solves it without changing the user-facing label.