### PR TITLE
Add Music Symbol settings to Fix Common Errors

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -607,6 +607,10 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptMergeContinuationLines, nameof(_vm.TextToSpeechPromptMergeContinuationLines)),
             MakeCheckboxSetting(Se.Language.Options.Settings.FixCommonErrorsSkipStep1, nameof(_vm.FixCommonErrorsSkipStep1)),
+            new SettingsItem(Se.Language.Options.Settings.MusicSymbol,
+                () => UiUtil.MakeTextBox(120, _vm, nameof(_vm.MusicSymbol))),
+            new SettingsItem(Se.Language.Options.Settings.MusicSymbolsToReplace,
+                () => UiUtil.MakeTextBox(300, _vm, nameof(_vm.MusicSymbolReplace))),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.Appearance,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -308,6 +308,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _existsToolsLogFile;
     [ObservableProperty] private bool _existsSettingsFile;
     [ObservableProperty] private bool _writeToolsLog;
+    [ObservableProperty] private string _musicSymbol = string.Empty;
+    [ObservableProperty] private string _musicSymbolReplace = string.Empty;
 
     private CustomContinuationStyle _editCustomContinuationStyle = new();
 
@@ -668,6 +670,8 @@ public partial class SettingsViewModel : ObservableObject
         TextToSpeechPromptMergeContinuationLines = Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines;
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
         FixCommonErrorsSkipStep1 = Se.Settings.Tools.FixCommonErrors.SkipStep1;
+        MusicSymbol = Se.Settings.Tools.MusicSymbol;
+        MusicSymbolReplace = Se.Settings.Tools.MusicSymbolReplace;
 
         SelectedTheme = MapThemeToTranslation(appearance.Theme);
         SelectedIconTheme = IconThemes.FirstOrDefault(p => p == appearance.IconTheme) ?? IconThemes.First();
@@ -1342,6 +1346,8 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.FixCommonErrors.SkipStep1 = FixCommonErrorsSkipStep1;
         Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
         Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
+        Se.Settings.Tools.MusicSymbol = MusicSymbol;
+        Se.Settings.Tools.MusicSymbolReplace = MusicSymbolReplace;
 
         appearance.Theme = MapThemeFromTranslation(SelectedTheme);
         appearance.IconTheme = SelectedIconTheme;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -281,6 +281,8 @@ public class LanguageSettings
     public string SpeechToTextSelectedLinesPromptFirstTimeOnly { get; set; }
     public string MultipleReplaceShowDotDotDotButtons { get; set; }
     public string GridFocusTextboxAfterInsertNew { get; set; }
+    public string MusicSymbol { get; set; }
+    public string MusicSymbolsToReplace { get; set; }
     public string TextToSpeechPromptMergeContinuationLines { get; set; }
     public string UseFocusedButtonBackgroundColor { get; set; }
     public string FocusedButtonBackgroundColor { get; set; }
@@ -585,6 +587,8 @@ public class LanguageSettings
         SpeechToTextSelectedLinesPromptFirstTimeOnly = "Speech to text: selected lines, prompt for language/engine first time only";
         MultipleReplaceShowDotDotDotButtons = "Multiple replace: show context menu buttons";
         GridFocusTextboxAfterInsertNew = "Grid: focus text box after insert new subtitle";
+        MusicSymbol = "Music symbol";
+        MusicSymbolsToReplace = "Music symbols to replace (separated by comma)";
         TextToSpeechPromptMergeContinuationLines = "Text to speech: prompt to merge continuation lines";
         UseFocusedButtonBackgroundColor = "Use focused button background color";
         FocusedButtonBackgroundColor = "Focused button background color";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -528,6 +528,9 @@ public class Se
         Configuration.Settings.Tools.ImportTextDurationAuto = Settings.Tools.ImportTextDurationAuto;
         Configuration.Settings.Tools.ImportTextFixedDuration = Settings.Tools.ImportTextFixedDuration;
 
+        Configuration.Settings.Tools.MusicSymbol = Settings.Tools.MusicSymbol;
+        Configuration.Settings.Tools.MusicSymbolReplace = Settings.Tools.MusicSymbolReplace;
+
         var dc = Settings.File.DCinemaSmpte;
         var ss = Configuration.Settings.SubtitleSettings;
         ss.DCinemaAutoGenerateSubtitleId = dc.DCinemaAutoGenerateSubtitleId;

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -62,6 +62,8 @@ public class SeTools
     public bool SplitRebalanceLongLinesSplit { get; set; }
     public bool SplitRebalanceLongLinesRebalance { get; set; }
     public string UnicodeSymbolsToInsert { get; set; }
+    public string MusicSymbol { get; set; }
+    public string MusicSymbolReplace { get; set; }
 
     public int BinEditLeftMargin { get; set; }
     public int BinEditTopMargin { get; set; }
@@ -160,6 +162,10 @@ public class SeTools
         SplitRebalanceLongLinesRebalance = true;
         SplitOddLinesAction = nameof(SplitOddLinesActionType.Smart);
         UnicodeSymbolsToInsert = "♪;♫;—;…;°;∙;©;®;☺;☹;♥;☮;☯;Σ;∞;≡;⇒;π";
+        MusicSymbol = "♪";
+        MusicSymbolReplace = "â™ª,â™," + // ♪ + ♫ in UTF-8 opened as ANSI
+                             "<s M/>,<s m/>," + // music symbols by subtitle creator
+                             "#,*,¶"; // common music symbols
 
         BinEditLeftMargin = 10;
         BinEditTopMargin = 10;


### PR DESCRIPTION
## What

Adds the **Music symbol** and **Music symbols to replace** settings to the new UI under **Settings → Tools**, restoring functionality that existed in SE4.

## Why

The Fix Common Errors rule `FixMusicNotation` (replace music symbols, e.g. ♫, with a preferred symbol) already reads `MusicSymbol` and `MusicSymbolReplace` from libse `Configuration.Settings.Tools`. The rule is wired into the new Fix Common Errors window, but the rewrite had no UI to edit these two values, so they were stuck at the built-in defaults. SE4 exposed them on its Settings → Tools tab.

## Changes

- **SeTools**: add `MusicSymbol` / `MusicSymbolReplace` properties with the same defaults libse uses.
- **Se.UpdateLibSeSettings**: mirror both into `Configuration.Settings.Tools` so the fix engine picks up user edits (`Se.SaveSettings()` already calls this).
- **SettingsViewModel**: load/save the two values.
- **SettingsPage**: add two text boxes to the Tools section.
- **LanguageSettings**: add the two labels.

## Testing

- `dotnet build src/ui/UI.csproj` succeeds with no warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
