### PR TITLE
Color Show/Hide cells red on overlap

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -190,14 +190,28 @@ public static partial class InitListViewAndEditBox
                 })
         });
 
-        var startColumn = new DataGridTextColumn
+        var startColumn = new DataGridTemplateColumn
         {
             Header = Se.Language.General.Show,
             Tag = SubtitleGridColumnKeys.Start,
-            Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter, Mode = BindingMode.OneWay },
             Width = new DataGridLength(120),
             MinWidth = 100,
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) =>
+            {
+                var border = new Border
+                {
+                    Padding = new Thickness(4, 2),
+                    [!Border.BackgroundProperty] = new Binding(nameof(SubtitleLineViewModel.StartTimeBackgroundBrush)),
+                };
+                var textBlock = new TextBlock
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!TextBlock.TextProperty] = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter, Mode = BindingMode.OneWay },
+                };
+                border.Child = textBlock;
+                return border;
+            }),
         };
         vm.SubtitleGrid.Columns.Add(startColumn);
         startColumn.Bind(DataGridColumn.IsVisibleProperty, new Binding(nameof(vm.ShowColumnStartTime))
@@ -206,14 +220,28 @@ public static partial class InitListViewAndEditBox
             Source = vm
         });
 
-        var hideColumn = new DataGridTextColumn
+        var hideColumn = new DataGridTemplateColumn
         {
             Header = Se.Language.General.Hide,
             Tag = SubtitleGridColumnKeys.End,
-            Binding = new Binding(nameof(SubtitleLineViewModel.EndTime)) { Converter = fullTimeConverter, Mode = BindingMode.OneWay },
             Width = new DataGridLength(120),
             MinWidth = 100,
             CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) =>
+            {
+                var border = new Border
+                {
+                    Padding = new Thickness(4, 2),
+                    [!Border.BackgroundProperty] = new Binding(nameof(SubtitleLineViewModel.EndTimeBackgroundBrush)),
+                };
+                var textBlock = new TextBlock
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!TextBlock.TextProperty] = new Binding(nameof(SubtitleLineViewModel.EndTime)) { Converter = fullTimeConverter, Mode = BindingMode.OneWay },
+                };
+                border.Child = textBlock;
+                return border;
+            }),
         };
         vm.SubtitleGrid.Columns.Add(hideColumn);
         hideColumn.Bind(DataGridColumn.IsVisibleProperty, new Binding(nameof(vm.ShowColumnEndTime))

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18214,11 +18214,14 @@ public partial class MainViewModel :
 
             var hasLayers = _visibleLayers != null && Se.Settings.Assa.HideLayersFromSubtitleGrid;
 
+            Subtitles[0].PreviousGap = double.MaxValue;
+
             for (var i = 0; i < Subtitles.Count - 1; i++)
             {
                 var p = Subtitles[i];
                 var next = Subtitles[i + 1];
                 p.Gap = next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds;
+                next.PreviousGap = p.Gap;
 
                 p.IsHidden = hasLayers && !_visibleLayers!.Contains(p.Layer);
             }

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -49,6 +49,9 @@ public partial class SubtitleLineViewModel : ObservableObject
     private double _gap;
 
     [ObservableProperty]
+    private double _previousGap;
+
+    [ObservableProperty]
     private bool _isHidden;
 
     public Paragraph? Paragraph { get; set; }
@@ -337,7 +340,6 @@ public partial class SubtitleLineViewModel : ObservableObject
         {
             if ((Se.Settings.General.ColorDurationTooShort && Duration.TotalMilliseconds < Se.Settings.General.SubtitleMinimumDisplayMilliseconds) ||
                 (Se.Settings.General.ColorDurationTooLong && Duration.TotalMilliseconds > Se.Settings.General.SubtitleMaximumDisplayMilliseconds) ||
-                (Se.Settings.General.ColorTimeCodeOverlap && Gap < 0) ||
                 // CPS too high == the duration is too short for this much text. SE4 lit up
                 // the Duration column for this case and users (issue #11307) rely on it
                 // being visible there, not just in the CPS column. Reuse the same gate
@@ -350,6 +352,12 @@ public partial class SubtitleLineViewModel : ObservableObject
             return _transparentBrush;
         }
     }
+
+    public IBrush EndTimeBackgroundBrush =>
+        Se.Settings.General.ColorTimeCodeOverlap && Gap < 0 ? _errorBrush : _transparentBrush;
+
+    public IBrush StartTimeBackgroundBrush =>
+        Se.Settings.General.ColorTimeCodeOverlap && PreviousGap < 0 ? _errorBrush : _transparentBrush;
 
     public IBrush CpsBackgroundBrush
     {
@@ -388,6 +396,12 @@ public partial class SubtitleLineViewModel : ObservableObject
 
         OnPropertyChanged(nameof(GapBackgroundBrush));
         OnPropertyChanged(nameof(DurationBackgroundBrush));
+        OnPropertyChanged(nameof(EndTimeBackgroundBrush));
+    }
+
+    partial void OnPreviousGapChanged(double value)
+    {
+        OnPropertyChanged(nameof(StartTimeBackgroundBrush));
     }
 
     public IBrush GapBackgroundBrush


### PR DESCRIPTION
This PR improves feature parity with SE4: When subtitle A overlaps subtitle B, SE4 colored A's Hide (end time) cell and B's Show (start time) cell red. SE5 was coloring the Duration cell instead.

The Duration cell was combining related but distinct causes together and it was hard to figure out why it was red. In SE4 it can be red because

1.  the duration is too low or high - comes from Rules
2. CPS column is not visible and as a fallback, Duration is colored red instead

In SE5, it was also red because of timecode overlap.

This PR aligns timecode behavior with SE4: the Show/Hide cells are colored, and removes the overlap condition from DurationBackgroundBrush.

Related PR: #11533 (they will have a minor conflict when merging)

<img width="735" height="142" alt="Screenshot 2026-06-10 at 6 26 31 PM" src="https://github.com/user-attachments/assets/9ab4afe3-32d7-466d-832a-5bd169013307" />
