### PR TITLE
CPS fallback: color Duration red because of CP only when CPS column is hidden

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8423,6 +8423,10 @@ public partial class MainViewModel :
         Se.Settings.General.ShowColumnCps = !Se.Settings.General.ShowColumnCps;
         ShowColumnCps = Se.Settings.General.ShowColumnCps;
         AutoFitColumns();
+        foreach (var row in Subtitles)
+        {
+            row.RefreshAfterSettingsChanged();
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8423,10 +8423,16 @@ public partial class MainViewModel :
         Se.Settings.General.ShowColumnCps = !Se.Settings.General.ShowColumnCps;
         ShowColumnCps = Se.Settings.General.ShowColumnCps;
         AutoFitColumns();
-        foreach (var row in Subtitles)
+        // AutoFitColumns() calls UpdateLayout() repeatedly, which settles the visual tree
+        // before our property-change notifications can render. Post the refresh so it runs
+        // after the layout pass, letting Avalonia pick up the new brush values.
+        Dispatcher.UIThread.Post(() =>
         {
-            row.RefreshAfterSettingsChanged();
-        }
+            foreach (var row in Subtitles)
+            {
+                row.RefreshAfterSettingsChanged();
+            }
+        });
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -335,14 +335,12 @@ public partial class SubtitleLineViewModel : ObservableObject
     {
         get
         {
-            if ((Se.Settings.General.ColorDurationTooShort && Duration.TotalMilliseconds < Se.Settings.General.SubtitleMinimumDisplayMilliseconds) ||
-                (Se.Settings.General.ColorDurationTooLong && Duration.TotalMilliseconds > Se.Settings.General.SubtitleMaximumDisplayMilliseconds) ||
-                (Se.Settings.General.ColorTimeCodeOverlap && Gap < 0) ||
-                // CPS too high == the duration is too short for this much text. SE4 lit up
-                // the Duration column for this case and users (issue #11307) rely on it
-                // being visible there, not just in the CPS column. Reuse the same gate
-                // setting so users who turn duration colouring off get a uniform behaviour.
-                (Se.Settings.General.ColorDurationTooLong && CharactersPerSecond > Se.Settings.General.SubtitleMaximumCharactersPerSeconds))
+            var general = Se.Settings.General;
+            if ((general.ColorDurationTooShort && Duration.TotalMilliseconds < general.SubtitleMinimumDisplayMilliseconds) ||
+                (general.ColorDurationTooLong && Duration.TotalMilliseconds > general.SubtitleMaximumDisplayMilliseconds) ||
+                (general.ColorTimeCodeOverlap && Gap < 0) ||
+                // SE4 fallback: when the CPS column is hidden, surface CPS-too-high on the Duration cell instead
+                (!general.ShowColumnCps && general.ColorDurationTooShort && CharactersPerSecond > general.SubtitleMaximumCharactersPerSeconds))
             {
                 return _errorBrush;
             }


### PR DESCRIPTION
  ### Problem

  DurationBackgroundBrush was coloring the Duration cell red for two related but distinct reasons: duration too short/long, and CPS too high. (A third reason was also squeezed into this cell, I fixed that in #11532.) These are distinct conditions that should not share a single visual signal: the Duration cell has not much to do with characters-per-second; that's what the dedicated CPS column is for.

  Unconditionally coloring Duration for high CPS is not a defensible design choice. It duplicates the CPS column's signal, creates ambiguity about why the Duration cell is red (of the 4 reasons originally in SE5), and clutters the grid for users who have the CPS column visible. With this and the aforementioned PR, Duration is only red when there is a duration problem (controlled under Rules), or as a fallback when CPS is not visible (would not want to throw it away due to being legacy.)

  ### What SE4 actually did

  I checked the SE4 source (SubtitleListView.cs). SE4 colored the Duration cell for CPS-too-high only as a fallback when the CPS column was hidden:

  ```csharp
  if (charactersPerSecond > max)
  {
      if (ColumnIndexCps >= 0)
          item.SubItems[ColumnIndexCps].BackColor = errorColor;   // CPS column visible
      else if (ColumnIndexDuration >= 0)
          item.SubItems[ColumnIndexDuration].BackColor = errorColor;  // fallback
  }
  ```

  If the CPS column was visible, SE4 colored that cell, never both. The Duration fallback existed purely so a user without the CPS column could still see the error somewhere. The user in #11307 did not have the CPS column visible.

  ### This PR

  - Restores the SE4 fallback logic exactly: Duration turns red for high CPS only when the CPS column is hidden, gated by the same ColorDurationTooShort setting SE4 used
  - When the CPS column is shown, only the CPS cell turns red, Duration is unaffected
  - Toggling the CPS column updates Duration cells immediately (via Dispatcher.UIThread.Post to ensure the refresh runs after AutoFitColumns() has settled the layout)

  The principle: related but distinct error conditions belong in their own columns. The Duration cell should only reflect problems with the duration itself. Carrying the SE4 fallback is a reasonable legacy accommodation; unconditionally coloring Duration for CPS would be making an existing design problem worse.
