### PR TITLE
Tweak: change default bookmark color to dark amber for light theme readability

### DIFF
--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -95,7 +95,7 @@ public class SeAppearance
         DarkModeForegroundColor = new Color(255, 220, 220, 220).FromColorToHex();
         UseFocusedButtonBackgroundColor = true;
         FocusedButtonBackgroundColor = new Color(99, 30, 144, 255).FromColorToHex();
-        BookmarkColor = Colors.Gold.FromColorToHex();
+        BookmarkColor = Color.Parse("#C07800").FromColorToHex();
         GridCompactMode = true;
         ShowLayer = true;
         ShowUpDownStartTime = true;


### PR DESCRIPTION
  The default bookmark color (gold, `#FFD700`) is nearly invisible on light backgrounds due to insufficient contrast.
  
  Changes the default to dark amber (`#C07800`), which retains the warm bookmark-feel of gold while being legible on both light and dark themes.
  
  | | Before | After | 
  |---|---|---|
  | Color | `#FFD700` (gold) | `#C07800` (dark amber) |
  | Light theme | ❌ Low contrast | ✅ Readable |
  | Dark theme | ✅ Readable | ✅ Readable |
  
  The bookmark color remains user-configurable in Options → Settings → Appearance.

  This is just my recommendation: #C07800 — a dark amber. It's the same warm bookmark-feel as gold but about 25% darker in luminance, which gives it enough contrast on light backgrounds while remaining clearly visible on dark ones. It avoids the "invisible on white" problem that pure yellow has.

<img width="816" height="95" alt="FFC07800 - light" src="https://github.com/user-attachments/assets/d5eade79-62d8-4602-98c7-c21026e08de1" />
<img width="781" height="90" alt="FFC07800 - dark" src="https://github.com/user-attachments/assets/de98f513-49c1-4518-a37f-2514ba609e47" />

  ### Alternatives I considered

  #D97706 (Tailwind amber-600) — slightly warmer/orange, also works on both

<img width="796" height="82" alt="FFD97706 - light" src="https://github.com/user-attachments/assets/7e0c03cb-a5bb-4705-930a-c8b9f77463e9" />
<img width="766" height="85" alt="FFD97706 - dark" src="https://github.com/user-attachments/assets/1b65c7bf-15d0-4bf7-a4a9-6bf5ff2f81fd" />

  
-----
  #2196F3 (medium blue) — completely unambiguous on any background, but loses the "bookmark" warm-color convention.

<img width="794" height="89" alt="FF2196F3 - light" src="https://github.com/user-attachments/assets/712f148a-944d-43d3-8bac-4e6396d06d34" />
<img width="791" height="78" alt="FF2196F3 - dark" src="https://github.com/user-attachments/assets/7a8d7251-0dcc-4bfe-8deb-c00e2bd7acac" />


  