### PR TITLE
Fix CPS-too-high Duration fallback gated on wrong color setting

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -342,7 +342,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             if ((general.ColorDurationTooShort && Duration.TotalMilliseconds < general.SubtitleMinimumDisplayMilliseconds) ||
                 (general.ColorDurationTooLong && Duration.TotalMilliseconds > general.SubtitleMaximumDisplayMilliseconds) ||
                 // SE4 fallback: when the CPS column is hidden, surface CPS-too-high on the Duration cell instead
-                (!general.ShowColumnCps && general.ColorDurationTooShort && CharactersPerSecond > general.SubtitleMaximumCharactersPerSeconds))
+                (!general.ShowColumnCps && general.ColorCharactersPerSecond && CharactersPerSecond > general.SubtitleMaximumCharactersPerSeconds))
             {
                 return _errorBrush;
             }


### PR DESCRIPTION
The fallback that highlights Duration when the CPS column is hidden was gated on ColorDurationTooShort instead of ColorCharactersPerSecond, causing it to fire based on a semantically unrelated setting.

  ## What

  The "surface CPS-too-high on the Duration cell when the CPS column is hidden" fallback in `SubtitleLineViewModel.DurationBackgroundBrush` was guarded by `ColorDurationTooShort` instead of `ColorCharactersPerSecond`.

  ## Why it was wrong

  The fallback fires when CPS exceeds the maximum — it has nothing to do with duration length. Using `ColorDurationTooShort` meant:

  - If the user had CPS coloring enabled but duration-too-short coloring **disabled**, the Duration cell would never turn red for high CPS even with the CPS column hidden.
  - If the user had duration-too-short coloring enabled but CPS coloring **disabled**, the Duration cell would incorrectly turn red for high CPS.
