### PR TITLE
Fix Common Errors: inline editor and grid consistency improvements

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7823,6 +7823,7 @@ public partial class MainViewModel :
 
         _errorColor = Se.Settings.General.ErrorColor.FromHexToColor();
         _errorBrush = new SolidColorBrush(_errorColor);
+        SubtitleTextInfoHelper.RefreshErrorBrush();
         if (AreVideoControlsUndocked)
         {
             VideoUndockControls();
@@ -17858,78 +17859,15 @@ public partial class MainViewModel :
 
     private void MakeSubtitleTextInfo(string text, SubtitleLineViewModel item)
     {
-        if (_subtitleGridSelectionChangedSkip)
-        {
-            return;
-        }
-
-        text ??= string.Empty;
-
-        // Cache settings and frequently accessed values
-        var colorTextTooLong = Se.Settings.General.ColorTextTooLong;
-        var maxLineLength = Se.Settings.General.SubtitleLineMaximumLength;
-        var maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
-
-        // Remove HTML tags once
-        var cleanText = HtmlUtil.RemoveHtmlTags(text, true);
-        var totalLength = (double)cleanText.CountCharacters(false);
-
-        // Calculate CPS once using cached values
-        var duration = item.EndTime.TotalMilliseconds - item.StartTime.TotalMilliseconds;
-        var cps = duration > 0.001 ? totalLength / (duration / 1000.0) : 0.0;
-
-        // Split lines once and cache count
-        var lines = cleanText.SplitToLines();
-        var lineCount = lines.Count;
-
-        // Pre-allocate panel children capacity: label + (lines + separators)
-        var childrenCapacity = 1 + lineCount + Math.Max(0, lineCount - 1);
-        var children = new List<Control>(childrenCapacity);
-
-        // Add header label
-        children.Add(UiUtil.MakeTextBlock(Se.Language.Main.SingleLineLength)
-            .WithFontSize(12)
-            .WithPadding(2));
-
-        // Process lines with minimal allocations
-        for (var i = 0; i < lineCount; i++)
-        {
-            if (i > 0)
-            {
-                children.Add(UiUtil.MakeTextBlock("/")
-                    .WithFontSize(12)
-                    .WithPadding(2));
-            }
-
-            var lineLength = (int)lines[i].CountCharacters(false);
-            var tb = UiUtil.MakeTextBlock(lineLength.ToString(CultureInfo.InvariantCulture))
-                .WithFontSize(12)
-                .WithPadding(2);
-
-            if (colorTextTooLong && lineLength > maxLineLength)
-            {
-                tb.Background = _errorBrush;
-            }
-
-            children.Add(tb);
-        }
-
-        // Batch update to minimize layout recalculations
-        PanelSingleLineLengths.Children.Clear();
-        PanelSingleLineLengths.Children.AddRange(children);
-
-        // Update CPS display with formatted string
-        EditTextCharactersPerSecond = string.Format(Se.Language.Main.CharactersPerSecond, $"{cps:0.0}");
-        EditTextTotalLength = string.Format(Se.Language.Main.TotalCharacters, totalLength);
-
-        // Use cached brush instances
-        EditTextCharactersPerSecondBackground = colorTextTooLong && cps > maxCps
-            ? _errorBrush
-            : _transparentBrush;
-
-        EditTextTotalLengthBackground = colorTextTooLong && totalLength > maxLineLength * lineCount
-            ? _errorBrush
-            : _transparentBrush;
+        if (_subtitleGridSelectionChangedSkip) return;
+        SubtitleTextInfoHelper.Populate(
+            text ?? string.Empty, item, PanelSingleLineLengths,
+            out var cpsText, out var cpsBg,
+            out var totalText, out var totalBg);
+        EditTextCharactersPerSecond = cpsText;
+        EditTextCharactersPerSecondBackground = cpsBg;
+        EditTextTotalLength = totalText;
+        EditTextTotalLengthBackground = totalBg;
     }
 
     private void MakeSubtitleTextInfoOriginal(string text, SubtitleLineViewModel item)
@@ -18280,28 +18218,12 @@ public partial class MainViewModel :
     {
         try
         {
-            if (Subtitles.Count == 0)
-            {
-                return;
-            }
+            SubtitleTextInfoHelper.UpdateGaps(Subtitles);
 
             var hasLayers = _visibleLayers != null && Se.Settings.Assa.HideLayersFromSubtitleGrid;
-
-            Subtitles[0].PreviousGap = double.MaxValue;
-
-            for (var i = 0; i < Subtitles.Count - 1; i++)
-            {
-                var p = Subtitles[i];
-                var next = Subtitles[i + 1];
-                p.Gap = next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds;
-                next.PreviousGap = p.Gap;
-
-                p.IsHidden = hasLayers && !_visibleLayers!.Contains(p.Layer);
-            }
-
-            Subtitles[Subtitles.Count - 1].Gap = double.MaxValue;
-            Subtitles[Subtitles.Count - 1].IsHidden = hasLayers && !_visibleLayers!.Contains(Subtitles.Last().Layer);
-            ;
+            if (!hasLayers) return;
+            foreach (var p in Subtitles)
+                p.IsHidden = !_visibleLayers!.Contains(p.Layer);
         }
         catch
         {

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -59,6 +59,7 @@ public partial class SubtitleLineViewModel : ObservableObject
     public string Language { get; set; }
     public string Region { get; set; }
     public Guid Id { get; set; }
+    public bool IsCpsColumnVisible { get; set; } = true;
     public bool IsDefault => Text == string.Empty && Number == 0 && Duration == TimeSpan.Zero && StartTime == TimeSpan.Zero;
 
 
@@ -342,7 +343,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             if ((general.ColorDurationTooShort && Duration.TotalMilliseconds < general.SubtitleMinimumDisplayMilliseconds) ||
                 (general.ColorDurationTooLong && Duration.TotalMilliseconds > general.SubtitleMaximumDisplayMilliseconds) ||
                 // SE4 fallback: when the CPS column is hidden, surface CPS-too-high on the Duration cell instead
-                (!general.ShowColumnCps && general.ColorCharactersPerSecond && CharactersPerSecond > general.SubtitleMaximumCharactersPerSeconds))
+                ((!general.ShowColumnCps || !IsCpsColumnVisible) && general.ColorCharactersPerSecond && CharactersPerSecond > general.SubtitleMaximumCharactersPerSeconds))
             {
                 return _errorBrush;
             }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
@@ -38,6 +39,10 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [ObservableProperty] private bool _step2IsVisible;
     [ObservableProperty] private string _step2Title;
     [ObservableProperty] private string _fixesAppliedText = string.Empty;
+    [ObservableProperty] private string _editTextTotalLength = string.Empty;
+    [ObservableProperty] private IBrush _editTextTotalLengthBackground = Brushes.Transparent;
+
+    public StackPanel? PanelSingleLineLengths { get; set; }
 
     public Window? Window { get; set; }
 
@@ -299,6 +304,13 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         if (newValue != null)
         {
             newValue.PropertyChanged += SelectedParagraph_PropertyChanged;
+            UpdateSubtitleTextInfo(newValue);
+        }
+        else
+        {
+            EditTextTotalLength = string.Empty;
+            EditTextTotalLengthBackground = Brushes.Transparent;
+            PanelSingleLineLengths?.Children.Clear();
         }
     }
 
@@ -315,12 +327,30 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
     private void SelectedParagraph_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(SubtitleLineViewModel.Text) &&
-            sender is SubtitleLineViewModel vm &&
-            vm.Paragraph != null)
+        if (sender is not SubtitleLineViewModel vm || vm.Paragraph == null)
+        {
+            return;
+        }
+
+        if (e.PropertyName == nameof(SubtitleLineViewModel.Text))
         {
             vm.Paragraph.Text = vm.Text;
+            UpdateSubtitleTextInfo(vm);
         }
+    }
+
+    private void UpdateGaps()
+    {
+        try { SubtitleTextInfoHelper.UpdateGaps(Paragraphs); }
+        catch { }
+    }
+
+    private void UpdateSubtitleTextInfo(SubtitleLineViewModel item)
+    {
+        if (PanelSingleLineLengths == null) return;
+        var info = SubtitleTextInfoHelper.PopulateLineLengthsAndTotal(item.Text ?? string.Empty, PanelSingleLineLengths);
+        EditTextTotalLength = info.TotalText;
+        EditTextTotalLengthBackground = info.TotalBackground;
     }
 
     private void RefreshFixes()
@@ -357,6 +387,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
         Paragraphs.Clear();
         Paragraphs.AddRange(FixedSubtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, _subtitleFormat)));
+        UpdateGaps();
 
         Step2Title = string.Format(Se.Language.Tools.FixCommonErrors.FixCommonOcrErrorsStep2FixesFoundX, Fixes.Count);
     }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -386,7 +386,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         }
 
         Paragraphs.Clear();
-        Paragraphs.AddRange(FixedSubtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, _subtitleFormat)));
+        Paragraphs.AddRange(FixedSubtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, _subtitleFormat) { IsCpsColumnVisible = false }));
         UpdateGaps();
 
         Step2Title = string.Format(Se.Language.Tools.FixCommonErrors.FixCommonOcrErrorsStep2FixesFoundX, Fixes.Count);

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -6,7 +6,6 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
-using Avalonia.Threading;
 using Avalonia.Media;
 using System;
 using System.Collections;
@@ -393,6 +392,7 @@ public class FixCommonErrorsWindow : Window
 
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
+        var syntaxHighlightingConverter = new TextWithSubtitleSyntaxHighlightingConverter();
         var dataGridSubtitles = new DataGrid
         {
             AutoGenerateColumns = false,
@@ -405,6 +405,8 @@ public class FixCommonErrorsWindow : Window
             Height = double.NaN,
             DataContext = _vm,
             ItemsSource = _vm.Paragraphs,
+            FontSize = Se.Settings.Appearance.SubtitleGridFontSize,
+            Margin = new Thickness(Se.Settings.Appearance.GridCompactMode ? 0 : 2),
             Columns =
             {
                 new DataGridTextColumn
@@ -414,34 +416,88 @@ public class FixCommonErrorsWindow : Window
                     IsReadOnly = true,
                     CellTheme = UiUtil.DataGridNoBorderCellTheme,
                 },
-                new DataGridTextColumn
+                new DataGridTemplateColumn
                 {
                     Header = Se.Language.General.Show,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter },
-                    IsReadOnly = true,
                     CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    IsReadOnly = true,
+                    CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((_, _) =>
+                    {
+                        var border = new Border
+                        {
+                            Padding = new Thickness(4, 2),
+                            [!Border.BackgroundProperty] = new Binding(nameof(SubtitleLineViewModel.StartTimeBackgroundBrush)),
+                        };
+                        border.Child = new TextBlock
+                        {
+                            VerticalAlignment = VerticalAlignment.Center,
+                            [!TextBlock.TextProperty] = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter },
+                        };
+                        return border;
+                    }),
                 },
-                new DataGridTextColumn
+                new DataGridTemplateColumn
                 {
                     Header = Se.Language.General.Hide,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.EndTime)) { Converter = fullTimeConverter },
-                    IsReadOnly = true,
                     CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    IsReadOnly = true,
+                    CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((_, _) =>
+                    {
+                        var border = new Border
+                        {
+                            Padding = new Thickness(4, 2),
+                            [!Border.BackgroundProperty] = new Binding(nameof(SubtitleLineViewModel.EndTimeBackgroundBrush)),
+                        };
+                        border.Child = new TextBlock
+                        {
+                            VerticalAlignment = VerticalAlignment.Center,
+                            [!TextBlock.TextProperty] = new Binding(nameof(SubtitleLineViewModel.EndTime)) { Converter = fullTimeConverter },
+                        };
+                        return border;
+                    }),
                 },
-                new DataGridTextColumn
+                new DataGridTemplateColumn
                 {
                     Header = Se.Language.General.Duration,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.Duration)) { Converter = shortTimeConverter },
-                    IsReadOnly = true,
                     CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    IsReadOnly = true,
+                    CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((_, _) =>
+                        new Border
+                        {
+                            Padding = new Thickness(4, 2),
+                            [!Border.BackgroundProperty] = new Binding(nameof(SubtitleLineViewModel.DurationBackgroundBrush)),
+                            Child = new TextBlock
+                            {
+                                VerticalAlignment = VerticalAlignment.Center,
+                                [!TextBlock.TextProperty] = new Binding(nameof(SubtitleLineViewModel.Duration)) { Converter = shortTimeConverter },
+                            },
+                        }),
                 },
-                new DataGridTextColumn
+                new DataGridTemplateColumn
                 {
                     Header = Se.Language.General.Text,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
-                    IsReadOnly = true,
                     CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    IsReadOnly = true,
                     Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                    CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((_, _) =>
+                    {
+                        var textBlock = new TextBlock
+                        {
+                            VerticalAlignment = VerticalAlignment.Center,
+                            TextWrapping = TextWrapping.NoWrap,
+                            [!TextBlock.InlinesProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = syntaxHighlightingConverter },
+                        };
+                        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+                        {
+                            textBlock.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+                        }
+                        return new Border
+                        {
+                            Padding = new Thickness(4, 2),
+                            [!Border.BackgroundProperty] = new Binding(nameof(SubtitleLineViewModel.TextBackgroundBrush)),
+                            Child = textBlock,
+                        };
+                    }),
                 },
             },
         };
@@ -499,24 +555,13 @@ public class FixCommonErrorsWindow : Window
 
     private Grid MakeStep2EditPanel()
     {
-        var grid = new Grid
+        var textEditGrid = new Grid
         {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-            },
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-            },
-            RowSpacing = 2,
-            Margin = new Thickness(4),
+            RowDefinitions = new RowDefinitions("*,Auto"),
+            Margin = new Thickness(10),
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
-
-        var labelText = UiUtil.MakeTextBlock(Se.Language.General.Text);
 
         var textBox = new TextBox
         {
@@ -526,22 +571,41 @@ public class FixCommonErrorsWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch,
             MinHeight = 60,
+            FontSize = Se.Settings.Appearance.SubtitleTextBoxFontSize,
+            FontWeight = Se.Settings.Appearance.SubtitleTextBoxFontBold ? FontWeight.Bold : FontWeight.Normal,
             [!TextBox.TextProperty] = new Binding($"{nameof(_vm.SelectedParagraph)}.{nameof(SubtitleLineViewModel.Text)}")
             {
                 Mode = BindingMode.TwoWay,
                 UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
             },
         };
+        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
+        {
+            textBox.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
+        }
+        textEditGrid.Add(textBox, 0, 0);
 
-        grid.Children.Add(labelText);
-        Grid.SetRow(labelText, 0);
-        Grid.SetColumn(labelText, 0);
+        var panelSingleLineLengths = new StackPanel
+        {
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            Orientation = Orientation.Horizontal,
+        };
+        _vm.PanelSingleLineLengths = panelSingleLineLengths;
+        textEditGrid.Add(panelSingleLineLengths, 1, 0);
 
-        grid.Children.Add(textBox);
-        Grid.SetRow(textBox, 1);
-        Grid.SetColumn(textBox, 0);
+        var totalLengthLabel = new TextBlock
+        {
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+            FontSize = 12,
+            Padding = new Thickness(2),
+        };
+        totalLengthLabel.Bind(TextBlock.TextProperty, new Binding(nameof(_vm.EditTextTotalLength)) { Source = _vm });
+        totalLengthLabel.Bind(TextBlock.BackgroundProperty, new Binding(nameof(_vm.EditTextTotalLengthBackground)) { Source = _vm });
+        textEditGrid.Add(totalLengthLabel, 1, 0);
 
-        return grid;
+        return textEditGrid;
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -1,0 +1,113 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+internal static class SubtitleTextInfoHelper
+{
+    private static IBrush _errorBrush = MakeErrorBrush();
+    private static readonly IBrush _transparentBrush = Brushes.Transparent;
+
+    internal static void RefreshErrorBrush()
+        => _errorBrush = MakeErrorBrush();
+
+    private static IBrush MakeErrorBrush()
+        => new SolidColorBrush(Se.Settings.General.ErrorColor.FromHexToColor());
+
+    /// <summary>
+    /// Populates <paramref name="panel"/> with per-line character count labels and
+    /// writes formatted CPS / total-length strings with their error backgrounds to
+    /// the four out parameters.
+    /// </summary>
+    /// <param name="text">Raw subtitle text (HTML tags are stripped internally).</param>
+    /// <param name="item">Provides timing for the CPS calculation.</param>
+    internal static void Populate(
+        string text,
+        SubtitleLineViewModel item,
+        StackPanel panel,
+        out string cpsText,
+        out IBrush cpsBackground,
+        out string totalText,
+        out IBrush totalBackground)
+    {
+        var info = PopulateLineLengthsAndTotal(text, panel);
+        var colorTextTooLong = Se.Settings.General.ColorTextTooLong;
+        var maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
+
+        var cps = GetCharactersPerSecond(info.TotalLength, item);
+        cpsText = string.Format(Se.Language.Main.CharactersPerSecond, $"{cps:0.0}");
+        cpsBackground = colorTextTooLong && cps > maxCps ? _errorBrush : _transparentBrush;
+        totalText = info.TotalText;
+        totalBackground = info.TotalBackground;
+    }
+
+    internal static TextTotalInfo PopulateLineLengthsAndTotal(string text, StackPanel panel)
+    {
+        var colorTextTooLong = Se.Settings.General.ColorTextTooLong;
+        var maxLineLength = Se.Settings.General.SubtitleLineMaximumLength;
+
+        var cleanText = HtmlUtil.RemoveHtmlTags(text, true);
+        var totalLength = (double)cleanText.CountCharacters(false);
+        var lines = cleanText.SplitToLines();
+        var lineCount = lines.Count;
+
+        var children = new List<Control>(1 + lineCount + Math.Max(0, lineCount - 1));
+        children.Add(UiUtil.MakeTextBlock(Se.Language.Main.SingleLineLength).WithFontSize(12).WithPadding(2));
+        for (var i = 0; i < lineCount; i++)
+        {
+            if (i > 0)
+            {
+                children.Add(UiUtil.MakeTextBlock("/").WithFontSize(12).WithPadding(2));
+            }
+
+            var lineLength = (int)lines[i].CountCharacters(false);
+            var tb = UiUtil.MakeTextBlock(lineLength.ToString(CultureInfo.InvariantCulture)).WithFontSize(12).WithPadding(2);
+            if (colorTextTooLong && lineLength > maxLineLength)
+            {
+                tb.Background = _errorBrush;
+            }
+
+            children.Add(tb);
+        }
+
+        panel.Children.Clear();
+        panel.Children.AddRange(children);
+
+        var totalBackground = colorTextTooLong && totalLength > maxLineLength * lineCount
+            ? _errorBrush
+            : _transparentBrush;
+        return new TextTotalInfo(
+            totalLength,
+            string.Format(Se.Language.Main.TotalCharacters, totalLength),
+            totalBackground);
+    }
+
+    internal static void UpdateGaps(IList<SubtitleLineViewModel> items)
+    {
+        if (items.Count == 0) return;
+        items[0].PreviousGap = double.MaxValue;
+        for (var i = 0; i < items.Count - 1; i++)
+        {
+            var p = items[i];
+            var next = items[i + 1];
+            p.Gap = next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds;
+            next.PreviousGap = p.Gap;
+        }
+        items[items.Count - 1].Gap = double.MaxValue;
+    }
+
+    private static double GetCharactersPerSecond(double totalLength, SubtitleLineViewModel item)
+    {
+        var duration = item.EndTime.TotalMilliseconds - item.StartTime.TotalMilliseconds;
+        return duration > 0.001 ? totalLength / (duration / 1000.0) : 0.0;
+    }
+
+    internal sealed record TextTotalInfo(double TotalLength, string TotalText, IBrush TotalBackground);
+}


### PR DESCRIPTION
  This PR enhances the appearance of the Fix Common Errors subtitle grid and edit box. There are no functional changes, only aesthetic improvements. The fixes grid at the top has not been modified at all (see #11547 for a tweak). See screenshot below. I deliberately set a monospace subtitle edit box font to make it obvious where it's applied.

### Background

  Subtitle Edit 4 had a fully-featured editor inside the Fix Common Errors dialog — format buttons, timing controls, CPS display, and full keyboard shortcuts. SE5's current dialog is a step back: the grid uses a different font, size, and color scheme from the main window, and the edit box ignores the user's font and size settings entirely. This creates a jarring experience when users work through the fix list and need to make manual corrections alongside the automated fixes.

  ### What this PR does

  This is a deliberately scoped improvement, not a full port of the main window grid/edit box or the SE4 editor. The goal was to close the most painful gaps with the smallest reasonable change:

  - **Grid**: font, size, highlighting/cell coloring now match the main window but it's deliberately kept as a fixed column-set
  - **Edit box**: respects the user's configured subtitle font and size; line-length feedback is shown
  - **Refactor**: extracted `SubtitleTextInfoHelper` to share text-info and `UpdateGaps` logic between `MainViewModel` and `FixCommonErrorsViewModel`, removing pre-existing duplication

  ### What is deliberately omitted

  Format buttons, timing controls, keyboard shortcuts, CPS label, and color tag editing are not included. The dialog is intended as a lightweight environment for minor corrections — correcting line splits, fixing punctuation, small wording changes — while keeping major editing in the main window. This matches real workflows I've observed: users stepping through the fix list and tweaking text as they go.

  ### Why not bring back the full SE4 editor now?

  That would be a significantly larger undertaking. This PR is only a net +130 lines of product code (part of the diff is the helper extraction). It delivers a consistent, aesthetically coherent editing experience for the common case without taking on the full scope of rebuilding the SE4 feature set.

<img width="1533" height="873" alt="Screenshot 2026-06-11 at 12 08 06 AM" src="https://github.com/user-attachments/assets/a3bc7194-e1bb-46d2-822d-865d54cd2bd8" />
