### PR TITLE
Fix bookmark icon misaligning row numbers in subtitle grid

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -118,6 +118,7 @@ public static partial class InitListViewAndEditBox
         var doubleRoundedConverter = new DoubleToOneDecimalConverter();
         var cpsWmpConverter = new DoubleToOneDecimalHideMaxConverter();
         var notNullConverter = new NotNullConverter();
+        var nullToOpacityConverter = new NullToOpacityConverter();
         var syntaxHighlightingConverter = new TextWithSubtitleSyntaxHighlightingConverter();
         vm.SubtitleDataGridSyntaxHighlighting = syntaxHighlightingConverter;
         var gapConverter = new DoubleToDisplayShortConverter();
@@ -183,7 +184,8 @@ public static partial class InitListViewAndEditBox
                             Value = IconNames.Bookmark,
                             Foreground = new SolidColorBrush(Se.Settings.Appearance.BookmarkColor.FromHexToColor()),
                             VerticalAlignment = VerticalAlignment.Center,
-                            [!Visual.IsVisibleProperty] = new Binding(nameof(SubtitleLineViewModel.Bookmark)) { Converter = notNullConverter },
+                            IsHitTestVisible = false,
+                            [!Visual.OpacityProperty] = new Binding(nameof(SubtitleLineViewModel.Bookmark)) { Converter = nullToOpacityConverter },
                          },
                          UiUtil.MakeLabel().WithBindText(value, new Binding(nameof(SubtitleLineViewModel.Number)))
                     }

--- a/src/ui/Logic/ValueConverters/NullToOpacityConverter.cs
+++ b/src/ui/Logic/ValueConverters/NullToOpacityConverter.cs
@@ -1,0 +1,18 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Logic.ValueConverters;
+
+public class NullToOpacityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value != null ? 1.0 : 0.0;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
  ## Problem

  When a subtitle row is bookmarked, an icon appears in the `#` column alongside the row number. Because the icon used an `IsVisible` binding (which collapses the element in Avalonia when `false`), bookmarked rows were wider by the icon's width, shifting their row numbers to the right relative to non-bookmarked rows.

  ## Fix

  Switch the icon from an `IsVisible` binding to an `Opacity` binding via a new `NullToOpacityConverter`. The icon now always occupies its layout space — transparent when there is no bookmark, opaque when one exists — so all row numbers align at the same horizontal position.

  ## Changes

  - `src/ui/Logic/ValueConverters/NullToOpacityConverter.cs` — new converter returning `0.0` for null, `1.0` for non-null
  - `src/ui/Features/Main/Layout/InitListViewAndEditBox.cs` — use opacity binding on the bookmark icon in the number column cell template; also set `IsHitTestVisible = false` so the invisible icon does
  not intercept pointer events

  ## Before -> After screenshots


<img width="171" height="515" alt="bookmarks - before-cropped" src="https://github.com/user-attachments/assets/2b488842-bfd8-4ca9-8915-5103d67ceaea" />

<img width="171" height="515" alt="bookmarks - after-cropped" src="https://github.com/user-attachments/assets/fe482bf8-7e84-44af-8b18-7273bca36714" />
