### PR TITLE
Make bookmark add/toggle shortcuts work from the text editor

### DIFF
--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -430,8 +430,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.DoAlignmentAn7Command, nameof(vm.DoAlignmentAn7Command), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.DoAlignmentAn8Command, nameof(vm.DoAlignmentAn8Command), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.DoAlignmentAn9Command, nameof(vm.DoAlignmentAn9Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.AddOrEditBookmarkCommand, nameof(vm.AddOrEditBookmarkCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ToggleBookmarkSelectedLinesNoTextCommand, nameof(vm.ToggleBookmarkSelectedLinesNoTextCommand), ShortcutCategory.SubtitleGrid);
+        AddShortcut(shortcuts, vm.AddOrEditBookmarkCommand, nameof(vm.AddOrEditBookmarkCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ToggleBookmarkSelectedLinesNoTextCommand, nameof(vm.ToggleBookmarkSelectedLinesNoTextCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.CopyTextFromOriginalToTranslationCommand, nameof(vm.CopyTextFromOriginalToTranslationCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.SwitchOriginalAndTranslationTextSelectedLinesCommand, nameof(vm.SwitchOriginalAndTranslationTextSelectedLinesCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.MergeOriginalIntoTranslationSelectedLinesCommand, nameof(vm.MergeOriginalIntoTranslationSelectedLinesCommand), ShortcutCategory.SubtitleGrid);


### PR DESCRIPTION
Move AddOrEditBookmark and ToggleBookmarkSelectedLinesNoText from ShortcutCategory.SubtitleGrid to General so they fire regardless of focus, consistent with GoToNextBookmark, GoToPreviousBookmark, and ListBookmarks which were already General.

 ## Context

  Bookmark shortcuts were split across two categories in an inconsistent way:
  - GoToNextBookmark, GoToPreviousBookmark, ListBookmarks → General (work everywhere)
  - AddOrEditBookmark, ToggleBookmarkSelectedLinesNoText → SubtitleGrid (grid focus only)

  This means a user editing text in the subtitle text box could navigate to the previous/next bookmark but could not add or toggle one — a confusing inconsistency with no technical justification. One use case is when I navigate between subtitles using Option(Alt)-Up/Down, making minor edits as I go, but in order to bookmark a line I have to grab the mouse to change the focus to the subtitle grid.

  The two SubtitleGrid-only commands both use SubtitleGrid.SelectedItems, which still reflects the currently-selected subtitle when focus is in the text editor, so they work correctly when triggered from either context.
