### PR TITLE
Fix vertical text alignment in diff grid cells

### DIFF
--- a/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
+++ b/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
@@ -1,5 +1,6 @@
 ﻿﻿using Avalonia.Controls;
 using Avalonia.Controls.Documents;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using System;
@@ -62,8 +63,8 @@ public static class TextDiffHighlighter
 
     public static (TextBlock left, TextBlock right) Compare(string text1, string text2)
     {
-        var left = new TextBlock { TextWrapping = TextWrapping.Wrap };
-        var right = new TextBlock { TextWrapping = TextWrapping.Wrap };
+        var left = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
+        var right = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
 
         if (left.Inlines == null || right.Inlines == null)
         {
@@ -119,8 +120,8 @@ public static class TextDiffHighlighter
 
     public static (TextBlock before, TextBlock after) CompareReplacement(string text1, string text2)
     {
-        var before = new TextBlock { TextWrapping = TextWrapping.Wrap };
-        var after = new TextBlock { TextWrapping = TextWrapping.Wrap };
+        var before = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
+        var after = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
 
         if (before.Inlines == null || after.Inlines == null)
         {


### PR DESCRIPTION
  This PR is related to #11538 - Fix Common Errors visual / usability improvements

  In DataGrids that use `TextDiffHighlighter` (Fix Common Errors, Multiple Replace), the Before/After columns use `DataGridTemplateColumn` with a `TextBlock` child. Because `TextBlock` renders its content at the top of its layout box by default, single-line rows showed the diff text top-aligned while adjacent `DataGridTextColumn` cells (e.g. the Action/fix-name column) were vertically centered — causing a visible misalignment.

  ## Change

  Set `VerticalAlignment = Center` on all `TextBlock` instances created in `TextDiffHighlighter.Compare` and `TextDiffHighlighter.CompareReplacement`. This shrinks the text block to its natural content height and centers it within the cell, matching the default behavior of `DataGridTextColumn`.

  ## Affected dialogs

  - Fix Common Errors — fixes grid (Before / After columns)
  - Multiple Replace — results grid (Before / After columns)
  - Compare — no visible change; `VerticalAlignment` on a panel child has no effect there

  ## Before -> After Screenshots

  Fix Common Errors dialog

<img width="822" height="173" alt="before - top aligned" src="https://github.com/user-attachments/assets/8205e572-036f-4781-b7fa-d3c7750c162d" />
<img width="843" height="171" alt="after - center aligned" src="https://github.com/user-attachments/assets/af619a24-b3e2-419f-bbf0-e0b210118e0a" />

  Multiple Replace - also center aligned vertically now

<img width="710" height="314" alt="after - multiple replace" src="https://github.com/user-attachments/assets/3ab73364-772b-44f9-9d7f-8c7433098e6f" />
