### PR TITLE
Fix: Toggle focus grid↔waveform not working in waveform→grid direction

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11420,6 +11420,19 @@ public partial class MainViewModel :
         });
     }
 
+    private void FocusSubtitleGrid()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (AudioVisualizer != null && AudioVisualizer.IsFocused)
+            {
+                AudioVisualizer.SkipNextPointerEntered = true;
+            }
+
+            SubtitleGrid.Focus();
+        });
+    }
+
     [RelayCommand]
     private void WaveformInsertAtPositionAndFocusTextBox()
     {
@@ -12060,12 +12073,7 @@ public partial class MainViewModel :
         }
         else
         {
-            if (AudioVisualizer.IsFocused)
-            {
-                AudioVisualizer.SkipNextPointerEntered = true;
-            }
-
-            SubtitleGrid.Focus();
+            FocusSubtitleGrid();
         }
 
         _updateAudioVisualizer = true;


### PR DESCRIPTION
  ## Problem

  The "Toggle focus between subtitle grid and waveform/spectrogram" shortcut only worked in one direction. Pressing it from the subtitle grid moved focus to the waveform correctly, but pressing it again from the waveform did nothing — focus stayed on the waveform.

  ## Root cause

  `ToggleFocusGridAndWaveform()` called `SubtitleGrid.Focus()` synchronously during key-event dispatch while the `AudioVisualizer` still held focus. Avalonia reverts focus back to the previously focused control before the event is fully resolved, so the focus change was silently lost.

  The analogous `ToggleFocusTextBoxAndWaveform` command works in both directions because its waveform→textbox path defers the focus change via `Dispatcher.UIThread.Post` inside `FocusEditTextBox()`.

  ## Fix

  Introduced a `FocusSubtitleGrid()` helper that mirrors `FocusEditTextBox()`: it defers the `SubtitleGrid.Focus()` call via `Dispatcher.UIThread.Post` and re-evaluates the `SkipNextPointerEntered` flag at execution time (preventing `FocusOnMouseOver` from stealing focus back if the mouse is hovering over the waveform). `ToggleFocusGridAndWaveform()` now uses this helper for the waveform→grid direction.
