### PR TITLE
Fix Shift+End scrolling to top after large-range selection (#11529 regression)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17572,7 +17572,8 @@ public partial class MainViewModel :
 
         // Shift+Ctrl+Home/End can extend the selection across the whole file in one
         // keypress, so detach for large ranges to avoid the per-row hang (#11529).
-        BatchGridSelection(endIdx - startIdx + 1 > GridSelectionDetachThreshold, () =>
+        var detach = endIdx - startIdx + 1 > GridSelectionDetachThreshold;
+        BatchGridSelection(detach, () =>
         {
             SubtitleGrid.SelectedItems.Clear();
             for (var i = startIdx; i <= endIdx; i++)
@@ -17581,7 +17582,24 @@ public partial class MainViewModel :
             }
         });
 
-        SubtitleGrid.ScrollIntoView(Subtitles[_shiftSelectCurrentIndex], null);
+        var scrollTarget = _shiftSelectCurrentIndex;
+        if (detach)
+        {
+            // After detach/reattach, rows aren't realized until the layout pass fires,
+            // so ScrollIntoView fails silently when called synchronously here.
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (scrollTarget < Subtitles.Count)
+                {
+                    SubtitleGrid.ScrollIntoView(Subtitles[scrollTarget], null);
+                }
+            }, DispatcherPriority.Background);
+        }
+        else
+        {
+            SubtitleGrid.ScrollIntoView(Subtitles[scrollTarget], null);
+        }
+
         SubtitleGridSelectionChanged();
     }
 


### PR DESCRIPTION
  ## Problem

  After #11529 (5d4328162), pressing Shift+End (or Shift+Home) in the subtitle grid with a large file scrolls the view back to the top instead of keeping the selection visible. The selection itself is correct — the status bar shows the right count — but the grid repositions to row 1.

  ## Root cause

  The detach/reattach fix in `BatchGridSelection` resets the DataGrid's scroll to 0 when `ItemsSource` is set to `null`. The subsequent `ScrollIntoView` call was made synchronously, before the layout pass fires — at which point no rows are realized yet, so it silently fails. The layout pass then renders the grid at position 0.

  ## Fix

  Defer `ScrollIntoView` via `Dispatcher.UIThread.Post(..., DispatcherPriority.Background)` when detach was used, so it runs after the layout pass and rows are realized. The synchronous path is kept for small selections (≤ `GridSelectionDetachThreshold`) where no detach occurs and the original behavior was correct.
