### PR TITLE
Fix CPS metrics and error highlighting consistency

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17935,7 +17935,7 @@ public partial class MainViewModel :
         EditTextCharactersPerSecondOriginal = string.Format(Se.Language.Main.CharactersPerSecond, $"{cps:0.0}");
         EditTextTotalLengthOriginal = string.Format(Se.Language.Main.TotalCharacters, totalLength);
 
-        EditTextCharactersPerSecondBackgroundOriginal = Se.Settings.General.ColorTextTooLong &&
+        EditTextCharactersPerSecondBackgroundOriginal = Se.Settings.General.ColorCharactersPerSecond &&
                                                         cps > Se.Settings.General.SubtitleMaximumCharactersPerSeconds
             ? _errorBrush
             : _transparentBrush;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17900,13 +17900,11 @@ public partial class MainViewModel :
     {
         text ??= string.Empty;
 
-        text = HtmlUtil.RemoveHtmlTags(text, true);
-        var totalLength = text.CountCharacters(false);
-        var cps = new Paragraph(text, item.StartTime.TotalMilliseconds, item.EndTime.TotalMilliseconds)
-            .GetCharactersPerSecond();
+        text = SubtitleTextInfoHelper.StripHtml(text);
+        var totalLength = SubtitleTextInfoHelper.GetTotalLength(text);
+        var cps = SubtitleTextInfoHelper.GetCharactersPerSecond(text, item.StartTime, item.EndTime);
 
         var lines = text.SplitToLines();
-        var lineLenghts = new List<string>(lines);
         PanelSingleLineLengthsOriginal.Children.Clear();
         PanelSingleLineLengthsOriginal.Children.Add(UiUtil.MakeTextBlock(Se.Language.Main.SingleLineLength)
             .WithFontSize(12)
@@ -17923,9 +17921,10 @@ public partial class MainViewModel :
                 PanelSingleLineLengthsOriginal.Children.Add(UiUtil.MakeTextBlock("/").WithFontSize(12).WithPadding(2));
             }
 
-            var tb = UiUtil.MakeTextBlock(lineLenghts[i].Length.ToString(CultureInfo.InvariantCulture)).WithFontSize(12).WithPadding(2);
+            var lineLength = SubtitleTextInfoHelper.GetLineLength(lines[i]);
+            var tb = UiUtil.MakeTextBlock(lineLength.ToString(CultureInfo.InvariantCulture)).WithFontSize(12).WithPadding(2);
             if (Se.Settings.General.ColorTextTooLong &&
-                lineLenghts[i].Length > Se.Settings.General.SubtitleLineMaximumLength)
+                lineLength > Se.Settings.General.SubtitleLineMaximumLength)
             {
                 tb.Background = _errorBrush;
             }

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -224,7 +224,7 @@ public partial class SubtitleLineViewModel : ObservableObject
                 return 999.0;
             }
 
-            return (double)HtmlUtil.RemoveHtmlTags(Text, true).CountCharacters(forCps: true) / Duration.TotalSeconds;
+            return SubtitleTextInfoHelper.GetCharactersPerSecond(Text, StartTime, EndTime);
         }
     }
 
@@ -261,11 +261,11 @@ public partial class SubtitleLineViewModel : ObservableObject
 
             if (Se.Settings.General.ColorTextTooLong)
             {
-                stripped = HtmlUtil.RemoveHtmlTags(Text, true);
+                stripped = SubtitleTextInfoHelper.StripHtml(Text);
 
                 foreach (var line in stripped.SplitToLines())
                 {
-                    if (line.CountCharacters(false) > Se.Settings.General.SubtitleLineMaximumLength)
+                    if (SubtitleTextInfoHelper.GetLineLength(line) > Se.Settings.General.SubtitleLineMaximumLength)
                     {
                         return _errorBrush;
                     }
@@ -274,7 +274,7 @@ public partial class SubtitleLineViewModel : ObservableObject
 
             if (Se.Settings.General.ColorTextTooWide)
             {
-                stripped ??= HtmlUtil.RemoveHtmlTags(Text, true);
+                stripped ??= SubtitleTextInfoHelper.StripHtml(Text);
                 foreach (var line in stripped.SplitToLines())
                 {
                     if (CalculatePixelWidth(line) > Se.Settings.General.ColorTextTooWidePixels)
@@ -286,7 +286,7 @@ public partial class SubtitleLineViewModel : ObservableObject
 
             if (Se.Settings.General.ColorTextTooManyLines)
             {
-                stripped ??= HtmlUtil.RemoveHtmlTags(Text, true);
+                stripped ??= SubtitleTextInfoHelper.StripHtml(Text);
                 if (stripped.SplitToLines().Count > Se.Settings.General.MaxNumberOfLines)
                 {
                     return _errorBrush;
@@ -613,7 +613,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             return 999;
         }
 
-        return (double)Text.CountCharacters(true) / Duration.TotalSeconds;
+        return SubtitleTextInfoHelper.GetCharactersPerSecond(Text, StartTime, EndTime);
     }
 
     public string GetErrors(SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
@@ -621,7 +621,8 @@ public partial class SubtitleLineViewModel : ObservableObject
         var errors = new StringBuilder();
 
         var general = Se.Settings.General;
-        var lines = Text.SplitToLines();
+        var strippedText = SubtitleTextInfoHelper.StripHtml(Text);
+        var lines = strippedText.SplitToLines();
         var lineCount = lines.Count;
 
         if (lineCount > general.MaxNumberOfLines && Se.Settings.General.ColorTextTooManyLines)
@@ -655,17 +656,17 @@ public partial class SubtitleLineViewModel : ObservableObject
         {
             foreach (var line in lines)
             {
-                if (line.Length > general.SubtitleLineMaximumLength)
+                var lineLength = SubtitleTextInfoHelper.GetLineLength(line);
+                if (lineLength > general.SubtitleLineMaximumLength)
                 {
-
-                    errors.AppendLine("Max line length: " + line.Length + " > " + general.SubtitleLineMaximumLength);
+                    errors.AppendLine("Max line length: " + lineLength + " > " + general.SubtitleLineMaximumLength);
                 }
             }
         }
 
         if (Se.Settings.General.ColorTextTooWide)
         {
-            foreach (var line in HtmlUtil.RemoveHtmlTags(Text, true).SplitToLines())
+            foreach (var line in lines)
             {
                 var pixelWidth = CalculatePixelWidth(line);
                 if (pixelWidth > general.ColorTextTooWidePixels)

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -631,7 +631,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         }
 
         var cpsRounded = Math.Round(CharactersPerSecond, 2, MidpointRounding.AwayFromZero);
-        if (cpsRounded > general.SubtitleMaximumCharactersPerSeconds && Se.Settings.General.ColorDurationTooShort)
+        if (cpsRounded > general.SubtitleMaximumCharactersPerSeconds && Se.Settings.General.ColorCharactersPerSecond)
         {
             errors.AppendLine("Cps: " + cpsRounded + " > " + general.SubtitleMaximumCharactersPerSeconds);
         }

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -43,7 +43,7 @@ internal static class SubtitleTextInfoHelper
 
         var cps = GetCharactersPerSecond(text, item.StartTime, item.EndTime);
         cpsText = string.Format(Se.Language.Main.CharactersPerSecond, $"{cps:0.0}");
-        cpsBackground = colorTextTooLong && cps > maxCps ? _errorBrush : _transparentBrush;
+        cpsBackground = Se.Settings.General.ColorCharactersPerSecond && cps > maxCps ? _errorBrush : _transparentBrush;
         totalText = info.TotalText;
         totalBackground = info.TotalBackground;
     }

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -41,7 +41,7 @@ internal static class SubtitleTextInfoHelper
         var colorTextTooLong = Se.Settings.General.ColorTextTooLong;
         var maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
 
-        var cps = GetCharactersPerSecond(info.TotalLength, item);
+        var cps = GetCharactersPerSecond(text, item.StartTime, item.EndTime);
         cpsText = string.Format(Se.Language.Main.CharactersPerSecond, $"{cps:0.0}");
         cpsBackground = colorTextTooLong && cps > maxCps ? _errorBrush : _transparentBrush;
         totalText = info.TotalText;
@@ -53,8 +53,8 @@ internal static class SubtitleTextInfoHelper
         var colorTextTooLong = Se.Settings.General.ColorTextTooLong;
         var maxLineLength = Se.Settings.General.SubtitleLineMaximumLength;
 
-        var cleanText = HtmlUtil.RemoveHtmlTags(text, true);
-        var totalLength = (double)cleanText.CountCharacters(false);
+        var cleanText = StripHtml(text);
+        var totalLength = GetTotalLength(cleanText);
         var lines = cleanText.SplitToLines();
         var lineCount = lines.Count;
 
@@ -67,7 +67,7 @@ internal static class SubtitleTextInfoHelper
                 children.Add(UiUtil.MakeTextBlock("/").WithFontSize(12).WithPadding(2));
             }
 
-            var lineLength = (int)lines[i].CountCharacters(false);
+            var lineLength = GetLineLength(lines[i]);
             var tb = UiUtil.MakeTextBlock(lineLength.ToString(CultureInfo.InvariantCulture)).WithFontSize(12).WithPadding(2);
             if (colorTextTooLong && lineLength > maxLineLength)
             {
@@ -103,10 +103,24 @@ internal static class SubtitleTextInfoHelper
         items[items.Count - 1].Gap = double.MaxValue;
     }
 
-    private static double GetCharactersPerSecond(double totalLength, SubtitleLineViewModel item)
+    internal static string StripHtml(string text)
+        => HtmlUtil.RemoveHtmlTags(text, true);
+
+    internal static double GetTotalLength(string text)
+        => (double)text.CountCharacters(false);
+
+    internal static int GetLineLength(string line)
+        => (int)line.CountCharacters(false);
+
+    internal static double GetCharactersPerSecond(string text, TimeSpan startTime, TimeSpan endTime)
     {
-        var duration = item.EndTime.TotalMilliseconds - item.StartTime.TotalMilliseconds;
-        return duration > 0.001 ? totalLength / (duration / 1000.0) : 0.0;
+        var duration = endTime.TotalMilliseconds - startTime.TotalMilliseconds;
+        if (duration <= 0.001)
+        {
+            return 0.0;
+        }
+
+        return (double)StripHtml(text).CountCharacters(forCps: true) / (duration / 1000.0);
     }
 
     internal sealed record TextTotalInfo(double TotalLength, string TotalText, IBrush TotalBackground);

--- a/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
+++ b/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
@@ -35,6 +35,37 @@ public class SubtitleMetricsRegressionTests
     }
 
     [Fact]
+    public void CpsError_IsGatedOnColorCharactersPerSecond_NotColorDurationTooShort()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleMaximumCharactersPerSeconds = 1;
+            Se.Settings.General.ColorCharactersPerSecond = true;
+            Se.Settings.General.ColorDurationTooShort = false;
+
+            var vm = new SubtitleLineViewModel
+            {
+                Text = "Hello world",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(1),
+            };
+
+            Assert.Contains("Cps:", vm.GetErrors(null, null), StringComparison.Ordinal);
+
+            Se.Settings.General.ColorCharactersPerSecond = false;
+            Se.Settings.General.ColorDurationTooShort = true;
+
+            Assert.DoesNotContain("Cps:", vm.GetErrors(null, null), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [Fact]
     public void StrategyAwareLineLength_IsConsistentBetweenHighlightAndErrors()
     {
         var originalSettings = Se.Settings;

--- a/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
+++ b/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
@@ -1,0 +1,68 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+
+namespace UITests.Features.Main;
+
+public class SubtitleMetricsRegressionTests
+{
+    [Fact]
+    public void CpsOnlyStrategy_AffectsCpsButNotLineLength()
+    {
+        var originalSettings = Se.Settings;
+        var originalStrategy = Configuration.Settings.General.CpsLineLengthStrategy;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.CpsLineLengthStrategy = nameof(CalcNoSpaceOrPunctuationCpsOnly);
+            Configuration.Settings.General.CpsLineLengthStrategy = Se.Settings.General.CpsLineLengthStrategy;
+
+            const string text = "A, B";
+            var stripped = SubtitleTextInfoHelper.StripHtml(text);
+
+            Assert.Equal(4, SubtitleTextInfoHelper.GetLineLength(stripped));
+            Assert.Equal(2.0, SubtitleTextInfoHelper.GetCharactersPerSecond(text, TimeSpan.Zero, TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            Configuration.Settings.General.CpsLineLengthStrategy = originalStrategy;
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [Fact]
+    public void StrategyAwareLineLength_IsConsistentBetweenHighlightAndErrors()
+    {
+        var originalSettings = Se.Settings;
+        var originalStrategy = Configuration.Settings.General.CpsLineLengthStrategy;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.CpsLineLengthStrategy = nameof(CalcNoSpaceOrPunctuation);
+            Se.Settings.General.ColorTextTooLong = true;
+            Se.Settings.General.SubtitleLineMaximumLength = 3;
+            Configuration.Settings.General.CpsLineLengthStrategy = Se.Settings.General.CpsLineLengthStrategy;
+
+            var vm = new SubtitleLineViewModel
+            {
+                Text = "A, B",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(2),
+            };
+
+            var brush = Assert.IsType<SolidColorBrush>(vm.TextBackgroundBrush);
+
+            Assert.Equal(Colors.Transparent, brush.Color);
+            Assert.DoesNotContain("Max line length", vm.GetErrors(null, null), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Configuration.Settings.General.CpsLineLengthStrategy = originalStrategy;
+            Se.Settings = originalSettings;
+        }
+    }
+}

--- a/tests/libse/Core/StringExtensionsTest.cs
+++ b/tests/libse/Core/StringExtensionsTest.cs
@@ -289,6 +289,16 @@ public class StringExtensionsTest
     }
 
     [Fact]
+    public void CountLetters7NoSpaceOrPunctuationCpsOnly()
+    {
+        const string input = "A, B";
+        var calc = CalcFactory.MakeCalculator(nameof(CalcNoSpaceOrPunctuationCpsOnly));
+
+        Assert.Equal(2, calc.CountCharacters(input, true));
+        Assert.Equal(4, calc.CountCharacters(input, false));
+    }
+
+    [Fact]
     public void ToggleCasing1()
     {
         var input = "how are you";


### PR DESCRIPTION
  This PR Fixes #11549 and CPS errors gated on wrong settings flags.

  ## Problem

  Two related CPS issues in the editor:

  **1. CPS calculation inconsistency**

  The edit-panel Chars/sec label derived CPS from the total-length counting path, so strategies such as *Count all except space, CPS only* and *No space or punctuation, CPS only* would update the grid column but leave the edit box showing a different value. Line-length validation also mixed strategy-aware counts with raw string length, causing the grid highlight and the Error List to disagree about whether a line was too long. I'm leaving some steps below to manually reproduce these but also added automated tests.

  **2. CPS highlights and errors gated on wrong settings flags**

  Three places were checking the wrong boolean setting for CPS-related highlighting, making the CPS cell color and CPS error messages appear or disappear based on unrelated options:

  | Location | Was using | Should use |
  |---|---|---|
  | Error list / tooltip (`GetErrors`) | `ColorDurationTooShort` | `ColorCharactersPerSecond` |
  | Edit-panel CPS cell (main track) | `ColorTextTooLong` | `ColorCharactersPerSecond` |
  | Edit-panel CPS cell (original track) | `ColorTextTooLong` | `ColorCharactersPerSecond` |

  ## Changes

  - Centralize counting rules in `SubtitleTextInfoHelper` and route all CPS and line-length calculations through it, so the grid, edit panel, and Error List all use the same strategy-aware counts.
  - Fix `GetErrors()`, `SubtitleTextInfoHelper.Populate()`, and `MakeSubtitleTextInfoOriginal()` to gate CPS highlights on
    `ColorCharactersPerSecond` rather than unrelated flags.
  - Regression tests for both layers: CPS-only strategies affecting CPS without changing line length, highlight/error path consistency, and correct `ColorCharactersPerSecond` gate behaviour.

  ## Steps to reproduce the issues

#### Issue 1

1. Open SE5 and create or select a subtitle with a fixed duration, for example 00:00:00,000 --> 00:00:01,000.
2. Enter text where spaces or punctuation matter, for example A, B.
3. Go to Options / Settings and change Cps/line-length to No space or punctuation, CPS only or Count all except space, cps only.
4. Return to the main editor and look at:
   - the live CPS label in the edit area
   - the CPS value in the subtitle grid

  Without the fix:

- the grid CPS changes to reflect the selected CPS only strategy
- the live CPS label in the edit area does not change and still behaves as if all visible characters were counted

  A concrete example:

- text: A, B
- duration: 1.0 second
- with No space or punctuation, CPS only
- correct CPS should be 2.0
- buggy edit-panel CPS would still show 4.0

To confirm the fix, repeat the same steps on the patched build. After the fix, both the grid and the edit-panel CPS show 2.0.

---
#### Issue 2

1. Open Options / Settings.
2. Set Cps/line-length to No space or punctuation ()[]-:;,.!?.
3. Make sure Color text if too long is enabled.
4. Keep Single line max. length at 42.
5. Create a subtitle with this exact one-line text:

  word1, word2, word3, word4, word5, word6, word7.

6. Select that subtitle and look at the main grid.

   Without the fix:

- the text cell is not red
- the line-length display under the edit box is not red

7. Now trigger List errors with Cmd+F8 on macOS.
8. In the error list, look for that same subtitle.

- the subtitle still appears in List errors
- the error text says something like:

  Max line length: 48 > 42

  Why this reproduces it:

- raw length is 48
- strategy-aware line length is 35
- without the fix SE used strategy-aware counting for the grid/highlight path
- but List errors used raw length in GetErrors()

  So the mismatch is:

- main editor says “fine”
- List errors says “too long”

  That is the second bug.