### PR TITLE
Add bookmark count status line to bookmarks list window

### DIFF
--- a/src/ui/Features/Shared/Bookmarks/BookmarksListViewModel.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarksListViewModel.cs
@@ -18,6 +18,7 @@ public partial class BookmarksListViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _subtitles;
     [ObservableProperty] private SubtitleLineViewModel? _selectedSubtitle;
     [ObservableProperty] private bool _hasBookmarks;
+    [ObservableProperty] private string _countText = string.Empty;
 
     public Window? Window { get; set; }
 
@@ -26,7 +27,11 @@ public partial class BookmarksListViewModel : ObservableObject
     public BookmarksListViewModel()
     {
         Subtitles = new ObservableCollection<SubtitleLineViewModel>();
+        Subtitles.CollectionChanged += (_, _) => UpdateCountText();
     }
+
+    private void UpdateCountText() =>
+        CountText = $"{Se.Language.General.Count}: {Subtitles.Count}";
 
     [RelayCommand]
     private async Task Clear()
@@ -124,6 +129,7 @@ public partial class BookmarksListViewModel : ObservableObject
         }
 
         HasBookmarks = SelectedSubtitle != null;
+        UpdateCountText();
     }
 
     internal void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
@@ -31,11 +31,15 @@ public class BookmarksListWindow : Window
         var buttonCancel = UiUtil.MakeButtonDone(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonGoTo, buttonClear, buttonCancel);
 
+        var labelCount = new TextBlock { HorizontalAlignment = HorizontalAlignment.Left };
+        labelCount.Bind(TextBlock.TextProperty, new Binding(nameof(vm.CountText)) { Source = vm });
+
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -50,7 +54,8 @@ public class BookmarksListWindow : Window
         };
 
         grid.Add(MakeBookmarkGridView(vm), 0);
-        grid.Add(panelButtons, 1);
+        grid.Add(labelCount, 1);
+        grid.Add(panelButtons, 2);
 
         Content = grid;
 

--- a/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
@@ -31,7 +31,12 @@ public class BookmarksListWindow : Window
         var buttonCancel = UiUtil.MakeButtonDone(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonGoTo, buttonClear, buttonCancel);
 
-        var labelCount = new TextBlock { HorizontalAlignment = HorizontalAlignment.Left };
+        var labelCount = new TextBlock
+        {
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            Margin = new Thickness(0, 0, 0, 10),
+        };
         labelCount.Bind(TextBlock.TextProperty, new Binding(nameof(vm.CountText)) { Source = vm });
 
         var grid = new Grid
@@ -39,7 +44,6 @@ public class BookmarksListWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -55,7 +59,7 @@ public class BookmarksListWindow : Window
 
         grid.Add(MakeBookmarkGridView(vm), 0);
         grid.Add(labelCount, 1);
-        grid.Add(panelButtons, 2);
+        grid.Add(panelButtons, 1);
 
         Content = grid;
 


### PR DESCRIPTION
This PR adds bookmark count status line to bookmarks list window.

Changes

- BookmarksListViewModel: adds a CountText observable property (e.g. "Count: 3") backed by a CollectionChanged subscription on Subtitles, so the count stays in sync automatically as items are removed
- BookmarksListWindow: adds a status row between the data grid and the button bar, with a left-aligned TextBlock bound to CountText

Behaviour

- Count is shown on open and decrements live when deleting via the trash icon, the Delete key, or the context menu
- Closing via Clear does not need a count update since the window closes immediately after


<img width="712" height="840" alt="bookmark count" src="https://github.com/user-attachments/assets/993f871f-0464-4c57-be4e-a5de2f8d4a55" />
