### PR TITLE
Fix several SE5 RC issues from OmrSi's report (#10766)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1821,6 +1821,23 @@ public partial class MainViewModel :
 
             await SubtitleOpen(recentFile.SubtitleFileName, recentFile.VideoFileName, recentFile.SelectedLine, desiredAudioTrackId: recentFile.AudioTrack);
 
+            // Seek the video to the restored line, like SE 4 did — otherwise Reopen leaves it
+            // at 0:00. Mirrors the startup file-restore path: the video opens asynchronously, so
+            // wait for the players to be ready before seeking, then re-apply after layout settles.
+            var vp = GetVideoPlayerControl();
+            if (!string.IsNullOrEmpty(_videoFileName) && SelectedSubtitle != null && vp != null)
+            {
+                await vp.WaitForPlayersReadyAsync();
+                await Task.Delay(200);
+                var s = SelectedSubtitle;
+                if (vp != null && s != null)
+                {
+                    vp.Position = s.StartTime.TotalSeconds;
+                    Dispatcher.UIThread.Post(() => { vp.Position = SelectedSubtitle.StartTime.TotalSeconds; });
+                    CenterAudioVisualizerOnCurrentVideoPosition();
+                }
+            }
+
             if (!string.IsNullOrEmpty(recentFile.SubtitleFileNameOriginal) &&
                 File.Exists(recentFile.SubtitleFileNameOriginal))
             {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17287,7 +17287,10 @@ public partial class MainViewModel :
                 }
             }
 
-            if (EditTextBox.IsFocused)
+            // Route SubtitleGridAndTextBox shortcuts when either edit box is focused — the
+            // original/translation box should behave the same as the normal one (e.g. so
+            // "Toggle dialog dashes" works in whichever text box has focus, like SE 4).
+            if (EditTextBox.IsFocused || EditTextBoxOriginal.IsFocused)
             {
                 var relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.SubtitleGridAndTextBox.ToString());
                 if (relayCommand != null)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15671,7 +15671,12 @@ public partial class MainViewModel :
         var trackNumber = _audioTrack?.FfIndex ?? -1;
         var peakWaveFileName = WavePeakGenerator2.GetPeakWaveFileName(videoFileName, trackNumber);
         var spectrogramFileName = WavePeakGenerator2.SpectrogramDrawer.GetSpectrogramFileName(videoFileName, trackNumber);
-        if (!File.Exists(peakWaveFileName) || (Se.Settings.Waveform.GenerateSpectrogram && !File.Exists(spectrogramFileName)))
+        var needToGenerate = !File.Exists(peakWaveFileName) || (Se.Settings.Waveform.GenerateSpectrogram && !File.Exists(spectrogramFileName));
+
+        // Hidden setting: when WaveformAutoGenerate is off, never kick off ffmpeg extraction on
+        // video open. Cached peaks still load via the branch below, so existing waveforms keep
+        // showing; the user generates new ones on demand.
+        if (needToGenerate && Se.Settings.Waveform.WaveformAutoGenerate)
         {
             if (FfmpegHelper.IsFfmpegInstalled())
             {
@@ -15691,7 +15696,7 @@ public partial class MainViewModel :
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
         }
-        else
+        else if (File.Exists(peakWaveFileName))
         {
             ShowStatus(Se.Language.Main.LoadingWaveInfoFromCache);
             var wavePeaks = WavePeakData2.FromDisk(peakWaveFileName);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8062,11 +8062,23 @@ public partial class MainViewModel :
             if (Subtitles[i].Bookmark != null)
             {
                 SelectAndScrollToSubtitle(Subtitles[i]);
+                SeekVideoToSubtitleStart(Subtitles[i]);
                 return;
             }
         }
 
         ShowStatus(Se.Language.General.NoBookmarksFound);
+    }
+
+    // Move the video to a line's start, like SE 4's bookmark navigation did. No-op when no
+    // video is loaded. Used by "go to next/previous bookmark" and the Reopen flow.
+    private void SeekVideoToSubtitleStart(SubtitleLineViewModel subtitle)
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp != null)
+        {
+            vp.Position = subtitle.StartTime.TotalSeconds;
+        }
     }
 
     [RelayCommand]
@@ -8089,6 +8101,7 @@ public partial class MainViewModel :
             if (Subtitles[i].Bookmark != null)
             {
                 SelectAndScrollToSubtitle(Subtitles[i]);
+                SeekVideoToSubtitleStart(Subtitles[i]);
                 return;
             }
         }

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Features.Options.Shortcuts;
 using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Shared;
 
@@ -204,10 +205,22 @@ public class FullScreenVideoWindow : Window
 
             await videoPlayer.Open(videoFileName);
             await videoPlayer.WaitForPlayersReadyAsync();
+
+            // The freshly opened player starts at 0:00; seek back to where the user was. The seek
+            // doesn't reliably stick right after the player reports ready — it can leave fullscreen
+            // sitting at the beginning, most visibly when paused on an empty stretch of the timeline
+            // where nothing else re-seeks afterwards. Settle briefly and re-apply, the same pattern
+            // used by the startup file-restore and Reopen paths.
+            await Task.Delay(200);
             videoPlayer.VideoPlayer.Pause();
             videoPlayer.VideoPlayer.Position = position;
             videoPlayer.Position = position;
             videoPlayer.Volume = volume;
+            Dispatcher.UIThread.Post(() =>
+            {
+                videoPlayer.VideoPlayer.Position = position;
+                videoPlayer.Position = position;
+            });
         };
     }
 }

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -44,6 +44,12 @@ public class SeWaveform
     public double SeekSilenceMaxVolume { get; set; }
     public bool SeekSilenceSeekForward { get; set; }
     public bool GenerateSpectrogram { get; set; }
+
+    // Hidden setting (Settings.json only, no UI yet): when false, the waveform/peaks are not
+    // generated automatically when a video is opened. Cached peaks still load, so previously
+    // generated waveforms keep showing; new ones are only made on demand. Defaults to true.
+    public bool WaveformAutoGenerate { get; set; }
+
     public string SpectrogramStyle { get; set; }
     public string WaveformDrawStyle { get; set; }
     public string LastDisplayMode { get; set; }
@@ -114,6 +120,7 @@ public class SeWaveform
         SeekSilenceMinDurationSeconds = 0.3;
         SeekSilenceMaxVolume = 0.1;
         WaveformMinimumSampleRate = 126;
+        WaveformAutoGenerate = true;
 
         ExtractAudioFormat = "wav";
         ExtractAudioSampleRate = 0; // keep source sample rate

--- a/src/ui/Logic/Platform/Windows/WindowsDarkMode.cs
+++ b/src/ui/Logic/Platform/Windows/WindowsDarkMode.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Logic.Platform.Windows;
+
+/// <summary>
+/// Sets the Win32 "immersive dark mode" flag on a window so the OS-drawn title bar follows
+/// Subtitle Edit's dark/light theme instead of staying light (reported by OmrSi, #10766).
+/// No-op on non-Windows platforms.
+/// </summary>
+public static class WindowsDarkMode
+{
+    // Windows 10 1903+ and Windows 11 use attribute 20; Windows 10 1809 (build 17763) used 19.
+    // Try the modern attribute first and fall back so older Windows 10 still themes the caption.
+    private const int DwmwaUseImmersiveDarkMode = 20;
+    private const int DwmwaUseImmersiveDarkModeBefore20H1 = 19;
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int valueSize);
+
+    public static void Apply(IntPtr hwnd, bool dark)
+    {
+        if (hwnd == IntPtr.Zero || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var value = dark ? 1 : 0;
+        if (DwmSetWindowAttribute(hwnd, DwmwaUseImmersiveDarkMode, ref value, sizeof(int)) != 0)
+        {
+            DwmSetWindowAttribute(hwnd, DwmwaUseImmersiveDarkModeBefore20H1, ref value, sizeof(int));
+        }
+    }
+}

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -100,6 +100,19 @@ public class ShortcutManager : IShortcutManager
     {
         if (IsNumPadPhysicalKey(physicalKey))
         {
+            // The four arithmetic operators (+ - * /) are unaffected by NumLock and have no
+            // main-keyboard Key equivalent, so their plain Key name ("Add"/"Subtract"/
+            // "Multiply"/"Divide") is already unambiguous. Prefixing them ("NumPadAdd") only
+            // breaks matching against the Avalonia Key names used by the default shortcuts
+            // (e.g. Shift+Add waveform zoom), the shortcut-picker dropdown, and SE 4 import.
+            // Everything else on the numpad (digits, Decimal, Enter) DOES need the prefix to
+            // stay distinct across NumLock states and from the main Enter key.
+            if (physicalKey is PhysicalKey.NumPadAdd or PhysicalKey.NumPadSubtract or
+                PhysicalKey.NumPadMultiply or PhysicalKey.NumPadDivide)
+            {
+                return key.ToString();
+            }
+
             var keyName = key.ToString();
             return keyName.StartsWith("NumPad", StringComparison.Ordinal)
                 ? keyName
@@ -147,6 +160,14 @@ public class ShortcutManager : IShortcutManager
         ["OemPlus"] = "Equal",
         ["OemBackslash"] = "IntlBackslash",
         ["Oem102"] = "IntlBackslash",
+
+        // Numpad arithmetic operators were briefly emitted with a "NumPad" prefix
+        // (RC builds), which didn't match the bare Avalonia Key names used elsewhere.
+        // Migrate any such stored tokens back onto the bare names now produced again.
+        ["NumPadAdd"] = "Add",
+        ["NumPadSubtract"] = "Subtract",
+        ["NumPadMultiply"] = "Multiply",
+        ["NumPadDivide"] = "Divide",
     };
 
     public static void MigrateLegacyOemKeys(List<string> keys)

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -627,7 +627,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.MergeWithLineAfterKeepBreaksCommand, nameof(vm.MergeWithLineAfterKeepBreaksCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MergeWithLineBeforeAsDialogCommand, nameof(vm.MergeWithLineBeforeAsDialogCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MergeWithLineAfterAsDialogCommand, nameof(vm.MergeWithLineAfterAsDialogCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ToggleDialogDashesCommand, nameof(vm.ToggleDialogDashesCommand), ShortcutCategory.SubtitleGrid);
+        AddShortcut(shortcuts, vm.ToggleDialogDashesCommand, nameof(vm.ToggleDialogDashesCommand), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.MoveStartOneFrameBackCommand, nameof(vm.MoveStartOneFrameBackCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MoveStartOneFrameForwardCommand, nameof(vm.MoveStartOneFrameForwardCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MoveEndOneFrameBackCommand, nameof(vm.MoveEndOneFrameBackCommand), ShortcutCategory.General);

--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -129,6 +129,11 @@ public static class UiTheme
 
     public static void ApplyScaleToWindow(Window window)
     {
+        // Keep the OS-drawn title bar in sync with the app theme. Piggybacks on the universal
+        // per-window hook so it covers both window-open (every caller does ApplyScaleToWindow)
+        // and theme switches (ApplyLayoutScaleToAllWindows re-runs this for every open window).
+        ApplyTitleBarTheme(window);
+
         var factor = Se.Settings.Appearance.LayoutScale;
 
         if (window.Content is LayoutTransformControl ltc)
@@ -153,6 +158,39 @@ public static class UiTheme
                 LayoutTransform = new ScaleTransform(factor, factor)
             };
         }
+    }
+
+    /// <summary>
+    /// Applies the Windows immersive dark-mode title bar to <paramref name="window"/> based on the
+    /// current theme. The native window handle only exists once the window is shown, so when it
+    /// isn't ready yet (e.g. ShowDialog applies chrome before the window opens) this defers to the
+    /// window's Opened event. No-op on non-Windows platforms.
+    /// </summary>
+    public static void ApplyTitleBarTheme(Window window)
+    {
+        if (window == null || !OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var handle = window.TryGetPlatformHandle();
+        if (handle != null && handle.Handle != IntPtr.Zero)
+        {
+            Platform.Windows.WindowsDarkMode.Apply(handle.Handle, IsDarkThemeEnabled());
+            return;
+        }
+
+        void OnOpened(object? sender, EventArgs e)
+        {
+            window.Opened -= OnOpened;
+            var openedHandle = window.TryGetPlatformHandle();
+            if (openedHandle != null)
+            {
+                Platform.Windows.WindowsDarkMode.Apply(openedHandle.Handle, IsDarkThemeEnabled());
+            }
+        }
+
+        window.Opened += OnOpened;
     }
 
     public static void ApplyLayoutScaleToAllWindows()


### PR DESCRIPTION
Addresses several items from OmrSi's RC test report in discussion #10766. Each is a focused commit.

## Fixes

- **Numpad `+ - * /` shortcut keys** — the capture path prefixed every numpad key with `NumPad`, so the four arithmetic operators became `NumPadAdd`/`NumPadMultiply`/etc. and stopped matching the bare Avalonia `Key` names used by the shortcut dropdown, SE4 import, and the default bindings (the `Shift+Add`/`Shift+Subtract` waveform-zoom defaults were silently broken too). Stop prefixing those four; migrate any tokens stored during RC builds back to the bare names. Digits, `Decimal` and `Enter` keep the prefix. *(report #2)*
- **Go to bookmark seeks the video** — "go to next/previous bookmark" only moved the grid selection; SE4 also moved the video. *(report #3)*
- **Reopen seeks the video to the last line** — opening from the Reopen menu restored the last line but left the video at 0:00; now mirrors the startup file-restore path. *(report #11)*
- **"Toggle dialog dashes" works from the text boxes** — was registered as `SubtitleGrid` (grid-focus only). Moved to `SubtitleGridAndTextBox` and routed that category for the original/translation box too (previously only the normal box was routed), so it works from whichever text box has focus, like SE4. *(report #5)*
- **Windows dark-mode title bar** — SE never set the Win32 immersive dark-mode flag, so the OS title bar stayed light. Added a `DwmSetWindowAttribute` helper (attribute 20, falling back to 19 for older Windows 10) applied via the universal per-window hook, so every window gets it on open and on theme switches. No-op off Windows. *(report #9)*
- **Hidden setting to disable automatic waveform generation** — `Waveform.WaveformAutoGenerate` (Settings.json only, no UI yet, default `true`). When `false`, opening a video no longer kicks off ffmpeg extraction; cached peaks still load. *(report #10)*
- **Keep video position when entering fullscreen** — fullscreen opens a fresh player and seeks back to the saved position, but the seek was applied immediately after the player reported ready and didn't reliably stick — leaving fullscreen at 0:00, most visibly when paused on an empty stretch of the timeline. Settle briefly and re-apply, the same pattern as the file-restore/Reopen paths. (Tier 1: fixes the "resets to beginning"; the brief 0:00 flash from re-opening a second player is a separate, larger change.) *(report #1)*

## Testing

- `dotnet build src/ui/UI.csproj` — clean (0 warnings / 0 errors).
- **Not runtime-verified** — I don't have a Windows box, so the numpad-key, dialog-dashes, video-seek, fullscreen, and especially the dark-title-bar P/Invoke paths should be checked on a real Windows 10 install. Notes per item:
  - Dark title bar: on some Win10 builds the caption may not repaint until the window is re-activated; confirm live dark↔light switching updates open windows.
  - Numpad: capture a numpad key (combobox should now show it), import an SE4 file with numpad shortcuts, and verify `Shift+numpad +/-` zooms the waveform.
  - Fullscreen: the `Task.Delay(200)` settle value is empirical and may need tuning.

Remaining items from the report not addressed here: #4 (find scroll/highlight), #6/#7 (Find layout / grid separator), #8 (unfocused-selection color), #12 (missing SE4 shortcuts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)