### PR TITLE
Rebuild toolbar icons when system dark/light mode changes

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -494,6 +494,7 @@ public partial class MainViewModel :
         AudioTraksMenuItem = new MenuItem();
         SubtitleDataGridSyntaxHighlighting = new TextWithSubtitleSyntaxHighlightingConverter();
         Toolbar = new Border();
+        UiTheme.SystemThemeChangedCallback = RebuildToolbar;
         ButtonWaveformPlay = new Button();
         _subtitle = new Subtitle();
         _subtitleOriginal = new Subtitle();
@@ -7721,16 +7722,8 @@ public partial class MainViewModel :
         }
     }
 
-    public void ApplySettings()
+    private void RebuildToolbar()
     {
-        UiUtil.SetFontName(Se.Settings.Appearance.FontName);
-        UiTheme.SetCurrentTheme();
-
-        if (ToolbarTopSeparator != null)
-        {
-            ToolbarTopSeparator.IsVisible = Se.Settings.Appearance.ShowHorizontalLineAboveToolbar;
-        }
-
         if (Toolbar is Border toolbarBorder)
         {
             var tb = InitToolbar.Make(this);
@@ -7741,6 +7734,19 @@ public partial class MainViewModel :
                 toolbarBorder.Child = grid;
             }
         }
+    }
+
+    public void ApplySettings()
+    {
+        UiUtil.SetFontName(Se.Settings.Appearance.FontName);
+        UiTheme.SetCurrentTheme();
+
+        if (ToolbarTopSeparator != null)
+        {
+            ToolbarTopSeparator.IsVisible = Se.Settings.Appearance.ShowHorizontalLineAboveToolbar;
+        }
+
+        RebuildToolbar();
 
         MenuPlugins.IsVisible = Se.Settings.Appearance.ShowPluginsMenu;
 
@@ -8349,16 +8355,7 @@ public partial class MainViewModel :
         }
         SetLayout(Se.Settings.General.LayoutNumber);
 
-        if (Toolbar is Border toolbarBorder)
-        {
-            var tb = InitToolbar.Make(this);
-            if (tb is Border newToolbarBorder)
-            {
-                var grid = newToolbarBorder.Child;
-                newToolbarBorder.Child = null;
-                toolbarBorder.Child = grid;
-            }
-        }
+        RebuildToolbar();
 
         ReloadShortcuts();
     }

--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -103,11 +103,14 @@ public static class UiTheme
         ApplyLayoutScaleToAllWindows();
     }
 
+    public static Action? SystemThemeChangedCallback { get; set; }
+
     private static void OnActualThemeVariantChanged(object? sender, EventArgs e)
     {
         if (Se.Settings.Appearance.Theme == ThemeNameSystem && Application.Current != null)
         {
             SetCurrentTheme();
+            SystemThemeChangedCallback?.Invoke();
         }
     }
 


### PR DESCRIPTION
When Theme is set to System, switching macOS between dark and light mode fired ActualThemeVariantChanged but only re-applied button/menu styles — the toolbar PNG icons (loaded from Dark/ or Light/ theme folder at startup) were never reloaded, leaving them faded/inverted (see screenshot below).

Add a SystemThemeChangedCallback on UiTheme and invoke it after SetCurrentTheme(); MainViewModel wires it to a new RebuildToolbar() helper (extracted from the existing ApplySettings and LoadLanguage inline copies).


<img width="788" height="245" alt="dark to light issue" src="https://github.com/user-attachments/assets/729858e9-47b6-4a32-81ff-1823c7782a02" />
