### PR TITLE
Fix toggle focus shortcuts not working when waveform/video is undocked on Windows

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5710,7 +5710,7 @@ public partial class MainViewModel :
     {
         if (PlayerSelectedLines(false))
         {
-            AudioVisualizer?.Focus();
+            FocusAudioVisualizer();
         }
     }
 
@@ -5719,7 +5719,7 @@ public partial class MainViewModel :
     {
         if (PlayerSelectedLines(true))
         {
-            AudioVisualizer?.Focus();
+            FocusAudioVisualizer();
         }
     }
 
@@ -11415,10 +11415,26 @@ public partial class MainViewModel :
                 AudioVisualizer.SkipNextPointerEntered = true;
             }
 
+            ActivateWindow(Window);
             EditTextBox.Focus();
             Task.Delay(10);
             EditTextBox.Focus();
         });
+    }
+
+    private static void ActivateWindow(Window? window)
+    {
+        if (window == null)
+        {
+            return;
+        }
+
+        if (window.WindowState == WindowState.Minimized)
+        {
+            window.WindowState = WindowState.Normal;
+        }
+
+        window.Activate();
     }
 
     private void FocusSubtitleGrid()
@@ -11430,7 +11446,22 @@ public partial class MainViewModel :
                 AudioVisualizer.SkipNextPointerEntered = true;
             }
 
+            ActivateWindow(Window);
             SubtitleGrid.Focus();
+        });
+    }
+
+    private void FocusAudioVisualizer()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (AudioVisualizer == null)
+            {
+                return;
+            }
+
+            ActivateWindow(TopLevel.GetTopLevel(AudioVisualizer) as Window);
+            AudioVisualizer.Focus();
         });
     }
 
@@ -12070,7 +12101,7 @@ public partial class MainViewModel :
 
         if (IsSubtitleGridFocused())
         {
-            AudioVisualizer.Focus();
+            FocusAudioVisualizer();
         }
         else
         {
@@ -12094,12 +12125,7 @@ public partial class MainViewModel :
         }
         else if (EditTextBox.IsFocused)
         {
-            if (AudioVisualizer.IsFocused)
-            {
-                AudioVisualizer.SkipNextPointerEntered = true;
-            }
-
-            AudioVisualizer.Focus();
+            FocusAudioVisualizer();
         }
 
         _updateAudioVisualizer = true;


### PR DESCRIPTION
## Problem

The toggle focus shortcuts (grid↔waveform, textbox↔waveform) stopped working when the video/waveform controls were undocked into a separate window.

When the undocked waveform window had OS focus, calling `Focus()` on a control in the main window silently failed — Avalonia/Win32 will not give input focus to a control in an inactive window. The main window had to be activated first.

The grid↔waveform toggle had an additional issue: `IsSubtitleGridFocused()` resolves focus via the main window's `FocusManager`, which returns `null` when the main window is not the active OS window, causing the toggle to always go in
the wrong direction.

## Changes

- Added `ActivateWindow(Window?)` helper — restores a minimized window to normal state before activating, matching the pattern already used in Find/Replace/AdjustAllTimes
- Added `FocusAudioVisualizer()` — defers focus via `Dispatcher.UIThread.Post`, resolves the AudioVisualizer's parent window dynamically with `TopLevel.GetTopLevel()` (works whether docked or undocked), then activates
  before focusing
- `FocusSubtitleGrid()` and `FocusEditTextBox()` now call `ActivateWindow(Window)` before focusing their respective controls
- Replaced all direct `AudioVisualizer?.Focus()` call sites with `FocusAudioVisualizer()` for consistency
- Removed a dead `if (AudioVisualizer.IsFocused)` guard inside `ToggleFocusTextBoxAndWaveform` that was always `false` at that point


  ## Testing

  I was only able to test on macOS where this issue was magically handled by the window manager and I only found it based on [a user report](https://github.com/SubtitleEdit/subtitleedit/pull/11550#issuecomment-4685859781).

  That being said, now that we explicitly activate the window we are giving focus to, even on macOS the traffic light window controls light up as they should, and a minimized window is pulled back up before it gets focus so I'd conclude that the fix is explicit and works. Nevertheless, giving it a try on Windows would be the ultimate proof.

https://github.com/user-attachments/assets/a2aa6717-61a1-4a4f-817a-e132c5f003b5
