### PR TITLE
Improve layout and spacing in Find and Replace dialogs

### DIFF
--- a/src/ui/Features/Edit/Find/FindWindow.cs
+++ b/src/ui/Features/Edit/Find/FindWindow.cs
@@ -120,7 +120,7 @@ public class FindWindow : Window
         {
             Orientation = Orientation.Vertical,
             HorizontalAlignment = HorizontalAlignment.Left,
-            Margin = new Thickness(0, 0, 50, 0),
+            VerticalAlignment = VerticalAlignment.Top,
             Children =
             {
                 buttonFindNext,
@@ -140,8 +140,8 @@ public class FindWindow : Window
             },
             ColumnDefinitions =
             {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
             },
             Margin = UiUtil.MakeWindowMargin(),
             ColumnSpacing = 10,

--- a/src/ui/Features/Edit/Find/FindWindow.cs
+++ b/src/ui/Features/Edit/Find/FindWindow.cs
@@ -38,17 +38,16 @@ public class FindWindow : Window
         {
             Content = Se.Language.Edit.Find.WholeWord,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 0, 10),
+            Margin = new Thickness(0, 0, 0, 3),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.WholeWord)) { Mode = BindingMode.TwoWay }
         };
-        
+
         var valueConverter = new FindModeValueConverter();
 
         var radioButtonCaseSensitive = new RadioButton
         {
             Content = Se.Language.Edit.Find.CaseSensitive,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(10, 0, 0, 3),
             [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.FindMode))
             {
                 Converter = valueConverter,
@@ -61,7 +60,6 @@ public class FindWindow : Window
         {
             Content = Se.Language.Edit.Find.CaseInsensitive,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(10, 0, 0, 3),
             [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.FindMode))
             {
                 Converter = valueConverter,
@@ -74,7 +72,6 @@ public class FindWindow : Window
         {
             Content = Se.Language.General.RegularExpression,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(10, 0, 0, 3),
             [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.FindMode))
             {
                 Converter = valueConverter,
@@ -87,7 +84,7 @@ public class FindWindow : Window
         {
             Orientation = Orientation.Vertical,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 0, 10),
+            Spacing = 0,
             Children =
             {
                 radioButtonCaseSensitive,

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -163,7 +163,7 @@ public class ReplaceWindow : Window
         {
             Orientation = Orientation.Vertical,
             HorizontalAlignment = HorizontalAlignment.Left,
-            Margin = new Thickness(0, 0, 50, 0),
+            VerticalAlignment = VerticalAlignment.Top,
             Children =
             {
                 buttonFindNext,
@@ -184,8 +184,8 @@ public class ReplaceWindow : Window
             },
             ColumnDefinitions =
             {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
             },
             Margin = UiUtil.MakeWindowMargin(),
             ColumnSpacing = 10,

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -39,7 +39,7 @@ public class ReplaceWindow : Window
         {
             Content = Se.Language.Edit.Find.WholeWord,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 0, 10),
+            Margin = new Thickness(0, 0, 0, 3),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.WholeWord)) { Mode = BindingMode.TwoWay }
         };
 
@@ -47,7 +47,7 @@ public class ReplaceWindow : Window
         {
             Orientation = Orientation.Vertical,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 0, 10),
+            Margin = new Thickness(0, 0, 0, 3),
             Children =
             {
                 textBoxFind,
@@ -88,7 +88,6 @@ public class ReplaceWindow : Window
         {
             Content = Se.Language.Edit.Find.CaseSensitive,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(10, 0, 0, 3),
             [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.FindMode))
             {
                 Converter = valueConverter,
@@ -101,7 +100,6 @@ public class ReplaceWindow : Window
         {
             Content = Se.Language.Edit.Find.CaseInsensitive,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(10, 0, 0, 3),
             [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.FindMode))
             {
                 Converter = valueConverter,
@@ -114,7 +112,6 @@ public class ReplaceWindow : Window
         {
             Content = Se.Language.General.RegularExpression,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(10, 0, 0, 3),
             [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.FindMode))
             {
                 Converter = valueConverter,
@@ -127,7 +124,7 @@ public class ReplaceWindow : Window
         {
             Orientation = Orientation.Vertical,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 0, 10),
+            Spacing = 0,
             Children =
             {
                 radioButtonNormal,


### PR DESCRIPTION
  ## Summary

  - Swap grid columns from `(Auto, Star)` to `(Star, Auto)` so the left side (search box and options) expands to fill available width, and the buttons column is sized to fit its content — eliminating the dead space on the right edge
  - Remove the hardcoded 50 px right margin from the buttons panel
  - Align radio buttons with the checkbox by removing their left indent
  - Unify vertical spacing: checkbox bottom margin reduced from 10 px to 3 px, radio buttons packed using `StackPanel.Spacing = 0` instead of per-item margins
  - In the Replace dialog, reduce the gap between the search/checkbox section and the "Replace with" field from 20 px to 6 px

  ## Before -> After

Find dialog:

<img width="546" height="368" alt="Find - before" src="https://github.com/user-attachments/assets/807aadb7-a658-48eb-afad-e50bde814ee3" />
<img width="496" height="366" alt="Find - after" src="https://github.com/user-attachments/assets/7ef84394-4575-4d3c-aa00-e1e9519e276c" />

Replace dialog:

<img width="546" height="443" alt="Replace - before" src="https://github.com/user-attachments/assets/1ed6ecc7-922d-438a-8ca2-79571b97aa0b" />
<img width="496" height="410" alt="Replace - after" src="https://github.com/user-attachments/assets/84cfabe5-c651-46ef-9324-0bd2cf80223c" />
