### PR TITLE
Align list box hover and unfocused selection styling with DataGrid

### DIFF
--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -1,4 +1,11 @@
-﻿<Styles xmlns="https://github.com/avaloniaui">
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Styles.Resources>
+        <SolidColorBrush x:Key="DataGridRowHoveredBackgroundColor" Color="Transparent"/>
+        <x:Double x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity">0.2</x:Double>
+        <StaticResource x:Key="DataGridRowSelectedHoveredBackgroundOpacity" ResourceKey="DataGridRowSelectedBackgroundOpacity"/>
+        <x:Double x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundOpacity">0.2</x:Double>
+    </Styles.Resources>
     <Style Selector="DataGridCell:focus /template/ Grid#FocusVisual">
         <Setter Property="IsVisible" Value="False"/>
     </Style>
@@ -8,14 +15,11 @@
     <Style Selector="DataGridColumnHeader:pointerover /template/ Grid#PART_ColumnHeaderRoot">
         <Setter Property="Background" Value="Transparent"/>
     </Style>
-    <Style Selector="DataGridRow:not(:selected):pointerover /template/ Rectangle#BackgroundRectangle">
-        <Setter Property="Fill" Value="Transparent"/>
+    <Style Selector="DataGrid:focus-within DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
+        <Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedBackgroundBrush}"/>
+        <Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedBackgroundOpacity}"/>
     </Style>
-    <Style Selector="DataGridRow:selected:pointerover /template/ Rectangle#BackgroundRectangle">
-        <Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundBrush}"/>
-        <Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedUnfocusedBackgroundOpacity}"/>
-    </Style>
-    <Style Selector="DataGridRow:selected:pointerover:focus /template/ Rectangle#BackgroundRectangle">
+    <Style Selector="DataGrid:focus-within DataGridRow:selected:pointerover /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedBackgroundBrush}"/>
         <Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedBackgroundOpacity}"/>
     </Style>

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -5,6 +5,9 @@
         <x:Double x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity">0.2</x:Double>
         <StaticResource x:Key="DataGridRowSelectedHoveredBackgroundOpacity" ResourceKey="DataGridRowSelectedBackgroundOpacity"/>
         <x:Double x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundOpacity">0.2</x:Double>
+        <SolidColorBrush x:Key="ListBoxItemSelectedUnfocusedBackgroundBrush"
+                         Color="{DynamicResource SystemAccentColor}"
+                         Opacity="0.2"/>
     </Styles.Resources>
     <Style Selector="DataGridCell:focus /template/ Grid#FocusVisual">
         <Setter Property="IsVisible" Value="False"/>
@@ -22,5 +25,20 @@
     <Style Selector="DataGrid:focus-within DataGridRow:selected:pointerover /template/ Rectangle#BackgroundRectangle">
         <Setter Property="Fill" Value="{DynamicResource DataGridRowSelectedBackgroundBrush}"/>
         <Setter Property="Opacity" Value="{DynamicResource DataGridRowSelectedBackgroundOpacity}"/>
+    </Style>
+    <Style Selector="ListBoxItem:not(:selected):pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="Transparent"/>
+    </Style>
+    <Style Selector="ListBox:focus-within ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}"/>
+    </Style>
+    <Style Selector="ListBox:focus-within ListBoxItem:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}"/>
+    </Style>
+    <Style Selector="ListBox:not(:focus-within) ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ListBoxItemSelectedUnfocusedBackgroundBrush}"/>
+    </Style>
+    <Style Selector="ListBox:not(:focus-within) ListBoxItem:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ListBoxItemSelectedUnfocusedBackgroundBrush}"/>
     </Style>
 </Styles>


### PR DESCRIPTION
  ### Summary
  This updates the shared Avalonia `ListBoxItem` styling to match the selection-focus behavior I recently applied to `DataGrid` in #11562

> [!CAUTION]
> Merge #11562 first - this branch and the tweaks are on top of data grid tweaks.

  ### Changes
  - Remove the grey background on unselected list box item hover
  - Keep selected list box items visually strong only while the owning list box has focus
  - Render unfocused selected list box items with a lighter accent background
  - Keep selected-hover state from becoming stronger than the base selected state

  ### Scope
  This affects shared `ListBoxItem` visuals across the app, including windows such as:
  - spell check and OCR suggestion lists
  - plugin and settings lists
  - word list editors
  - subtitle format/model pickers
  - other standard `ListBox`-based pickers and history views

  No behavior, selection logic, bindings, or non-`ListBox` controls were changed.


https://github.com/user-attachments/assets/2d0e665e-0915-48cc-9dd3-a69fc91f77de


