### PR TITLE
Add bordered UI sections to main editor and Fix Common Errors dialog

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -545,8 +545,10 @@ public static partial class InitListViewAndEditBox
             Source = vm,
         };
 
-        Grid.SetRow(dropHost, 0);
-        mainGrid.Children.Add(dropHost);
+        var dropHostBorder = UiUtil.MakeBorderForControlNoPadding(dropHost);
+        dropHostBorder.Margin = new Thickness(UiUtil.SplitterWidthOrHeight, UiUtil.SplitterWidthOrHeight, UiUtil.SplitterWidthOrHeight, 0);
+        Grid.SetRow(dropHostBorder, 0);
+        mainGrid.Children.Add(dropHostBorder);
 
         // Create a Flyout for the DataGrid
         var flyout = new MenuFlyout();
@@ -1583,8 +1585,10 @@ public static partial class InitListViewAndEditBox
         Grid.SetColumn(textEditGrid, 1);
         editGrid.Children.Add(textEditGrid);
 
-        Grid.SetRow(editGrid, 1);
-        mainGrid.Children.Add(editGrid);
+        var editGridBorder = UiUtil.MakeBorderForControlNoPadding(editGrid);
+        editGridBorder.Margin = new Thickness(UiUtil.SplitterWidthOrHeight, UiUtil.SplitterWidthOrHeight, UiUtil.SplitterWidthOrHeight, 0);
+        Grid.SetRow(editGridBorder, 1);
+        mainGrid.Children.Add(editGridBorder);
 
 
         textEditGrid.ColumnDefinitions[1].Bind(ColumnDefinition.WidthProperty, new Binding(nameof(vm.ShowColumnOriginalText))

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -27,7 +27,7 @@ public class FixCommonErrorsWindow : Window
         Title = Se.Language.Tools.FixCommonErrors.Title;
         Width = 1024;
         Height = 720;
-        MinWidth = 800;
+        MinWidth = 920;
         MinHeight = 600;
         CanResize = true;
 
@@ -45,9 +45,32 @@ public class FixCommonErrorsWindow : Window
         var labelStep2 = new Label
         {
             VerticalAlignment = VerticalAlignment.Center,
+            Padding = new Thickness(0),
         };
         labelStep2.Bind(Label.ContentProperty, new Binding(nameof(vm.Step2Title)));
-        labelStep2.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
+
+        var labelFixesApplied = UiUtil.MakeTextBlock(string.Empty);
+        labelFixesApplied.Bind(TextBlock.TextProperty, new Binding(nameof(vm.FixesAppliedText)));
+        labelFixesApplied.VerticalAlignment = VerticalAlignment.Center;
+
+        var appliedPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(12, 0, 0, 0),
+            Children = { UiUtil.MakeVerticalSeparator(1, 0.4, new Thickness(0, 4, 12, 4)), labelFixesApplied },
+        };
+        appliedPanel.Bind(IsVisibleProperty, new Binding(nameof(vm.FixesAppliedText))
+        {
+            Converter = new Avalonia.Data.Converters.FuncValueConverter<string?, bool>(s => !string.IsNullOrEmpty(s))
+        });
+
+        var step2HeaderPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { labelStep2, appliedPanel },
+        };
+        step2HeaderPanel.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
 
         var textBoxSearch = UiUtil.MakeTextBox(250, vm, nameof(vm.SearchText)).WithMarginRight(25);
         textBoxSearch.PlaceholderText = Se.Language.Tools.FixCommonErrors.SearchRulesDotDotDot;
@@ -120,8 +143,6 @@ public class FixCommonErrorsWindow : Window
         new DataGridCheckboxMultiSelect<FixRuleDisplayItem>(rulesGrid,
             item => item.IsSelected, (item, v) => item.IsSelected = v);
 
-        var step2Grid = MakeStep2Grid();
-        step2Grid.Bind(IsVisibleProperty, new Binding(nameof(_vm.Step2IsVisible)));
         var comboProfile = UiUtil.MakeComboBox(vm.Profiles, vm, nameof(vm.SelectedProfile));
         var buttonPanelRules = UiUtil.MakeButtonBar(
             UiUtil.MakeButton(Se.Language.General.SelectAll, vm.RulesSelectAllCommand),
@@ -137,19 +158,24 @@ public class FixCommonErrorsWindow : Window
             .BindIsVisible(vm, nameof(vm.Step1IsVisible));
 
         var buttonBackToFixList = UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.BackToFixList, vm.BackToFixListCommand)
-            .WithIconLeft("fa-solid fa-arrow-left")
-            .BindIsVisible(vm, nameof(vm.Step2IsVisible));
+            .WithIconLeft("fa-solid fa-arrow-left");
 
-        var buttonDone = UiUtil.MakeButton(Se.Language.General.Done, vm.OkCommand)
-            .BindIsVisible(vm, nameof(vm.Step2IsVisible));
+        var buttonDone = UiUtil.MakeButton(Se.Language.General.Done, vm.OkCommand);
         buttonDone.IsDefault = true;
 
-        var buttonPanelRight = UiUtil.MakeButtonBar(
+        var step2NavButtons = UiUtil.MakeButtonBar(
             buttonBackToFixList,
-            buttonToApplyFixes,
             buttonDone,
             UiUtil.MakeButtonCancel(vm.CancelCommand)
         );
+
+        var buttonPanelRight = UiUtil.MakeButtonBar(
+            buttonToApplyFixes,
+            UiUtil.MakeButtonCancel(vm.CancelCommand)
+        ).BindIsVisible(vm, nameof(vm.Step1IsVisible));
+
+        var step2Grid = MakeStep2Grid(step2NavButtons);
+        step2Grid.Bind(IsVisibleProperty, new Binding(nameof(_vm.Step2IsVisible)));
 
         var grid = new Grid
         {
@@ -174,9 +200,9 @@ public class FixCommonErrorsWindow : Window
         grid.Children.Add(labelStep1);
         Grid.SetRow(labelStep1, 0);
         Grid.SetColumn(labelStep1, 0);
-        grid.Children.Add(labelStep2);
-        Grid.SetRow(labelStep2, 0);
-        Grid.SetColumn(labelStep2, 0);
+        grid.Children.Add(step2HeaderPanel);
+        Grid.SetRow(step2HeaderPanel, 0);
+        Grid.SetColumn(step2HeaderPanel, 0);
 
         grid.Children.Add(panelTopRight);
         Grid.SetRow(panelTopRight, 0);
@@ -197,15 +223,6 @@ public class FixCommonErrorsWindow : Window
         Grid.SetRow(buttonPanelRules, 2);
         Grid.SetColumn(buttonPanelRules, 0);
 
-        var labelFixesApplied = UiUtil.MakeTextBlock(string.Empty);
-        labelFixesApplied.Bind(TextBlock.TextProperty, new Binding(nameof(vm.FixesAppliedText)));
-        labelFixesApplied.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
-        labelFixesApplied.HorizontalAlignment = HorizontalAlignment.Left;
-        labelFixesApplied.VerticalAlignment = VerticalAlignment.Center;
-        grid.Children.Add(labelFixesApplied);
-        Grid.SetRow(labelFixesApplied, 2);
-        Grid.SetColumn(labelFixesApplied, 0);
-
         grid.Children.Add(buttonPanelRight);
         Grid.SetRow(buttonPanelRight, 2);
         Grid.SetColumn(buttonPanelRight, 1);
@@ -218,7 +235,7 @@ public class FixCommonErrorsWindow : Window
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
-    private Grid MakeStep2Grid()
+    private Grid MakeStep2Grid(Control navButtons)
     {
         // top
         var dataGridFixes = new DataGrid
@@ -479,9 +496,9 @@ public class FixCommonErrorsWindow : Window
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star), MinHeight = 80 },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star), MinHeight = 80 },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -493,10 +510,24 @@ public class FixCommonErrorsWindow : Window
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
+
+        var bottomRow = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        navButtons.VerticalAlignment = VerticalAlignment.Bottom;
+        bottomRow.Add(gridCurrentSubtbtitle, 0, 0);
+        bottomRow.Add(navButtons, 0, 2);
+
         grid.Add(borderFixes, 0, 0);
         grid.Add(buttonBarFixes, 1, 0);
         grid.Add(borderSubtitles, 2, 0);
-        grid.Add(gridCurrentSubtbtitle, 3, 0);
+        grid.Add(bottomRow, 3, 0);
 
         return grid;
     }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -221,24 +221,6 @@ public class FixCommonErrorsWindow : Window
     private Grid MakeStep2Grid()
     {
         // top
-        var gridFixes = new Grid
-        {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-            },
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-            },
-            ColumnSpacing = 0,
-            RowSpacing = 0,
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-        };
-
         var dataGridFixes = new DataGrid
         {
             AutoGenerateColumns = false,
@@ -362,34 +344,9 @@ public class FixCommonErrorsWindow : Window
         buttonBarFixes.Add(leftButtons, 0, 0);
         buttonBarFixes.Add(rightButtons, 0, 1);
 
-        gridFixes.Children.Add(dataGridFixes);
-        Grid.SetRow(dataGridFixes, 0);
-        Grid.SetColumn(dataGridFixes, 0);
-
-        gridFixes.Children.Add(buttonBarFixes);
-        Grid.SetRow(buttonBarFixes, 1);
-        Grid.SetColumn(buttonBarFixes, 0);
-
-        var borderFixes = UiUtil.MakeBorderForControlNoPadding(gridFixes).WithMarginBottom(5);
+        var borderFixes = UiUtil.MakeBorderForControlNoPadding(dataGridFixes).WithMarginBottom(5);
 
         // bottom
-        var gridSubtitles = new Grid
-        {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-            },
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-            },
-            ColumnSpacing = 10,
-            RowSpacing = 10,
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-        };
-
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
         var syntaxHighlightingConverter = new TextWithSubtitleSyntaxHighlightingConverter();
@@ -516,22 +473,16 @@ public class FixCommonErrorsWindow : Window
 
         var gridCurrentSubtbtitle = MakeStep2EditPanel();
 
-        gridSubtitles.Children.Add(dataGridSubtitles);
-        Grid.SetRow(dataGridSubtitles, 0);
-        Grid.SetColumn(dataGridSubtitles, 0);
-
-        gridSubtitles.Children.Add(gridCurrentSubtbtitle);
-        Grid.SetRow(gridCurrentSubtbtitle, 1);
-        Grid.SetColumn(gridCurrentSubtbtitle, 0);
-
-        var borderSubtitles = UiUtil.MakeBorderForControlNoPadding(gridSubtitles);
+        var borderSubtitles = UiUtil.MakeBorderForControlNoPadding(dataGridSubtitles).WithMarginBottom(5);
 
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -542,13 +493,10 @@ public class FixCommonErrorsWindow : Window
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
-        grid.Children.Add(borderFixes);
-        Grid.SetRow(borderFixes, 0);
-        Grid.SetColumn(borderFixes, 0);
-
-        grid.Children.Add(borderSubtitles);
-        Grid.SetRow(borderSubtitles, 1);
-        Grid.SetColumn(borderSubtitles, 0);
+        grid.Add(borderFixes, 0, 0);
+        grid.Add(buttonBarFixes, 1, 0);
+        grid.Add(borderSubtitles, 2, 0);
+        grid.Add(gridCurrentSubtbtitle, 3, 0);
 
         return grid;
     }
@@ -558,9 +506,9 @@ public class FixCommonErrorsWindow : Window
         var textEditGrid = new Grid
         {
             RowDefinitions = new RowDefinitions("*,Auto"),
-            Margin = new Thickness(10),
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Margin = new Thickness(0, 5, 0, 5),
+            Width = 500,
+            HorizontalAlignment = HorizontalAlignment.Left,
         };
 
         var textBox = new TextBox

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -548,8 +548,7 @@ public class FixCommonErrorsWindow : Window
             AcceptsReturn = true,
             TextWrapping = TextWrapping.Wrap,
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            MinHeight = 60,
+            Height = 60,
             FontSize = Se.Settings.Appearance.SubtitleTextBoxFontSize,
             FontWeight = Se.Settings.Appearance.SubtitleTextBoxFontBold ? FontWeight.Bold : FontWeight.Normal,
             [!TextBox.TextProperty] = new Binding($"{nameof(_vm.SelectedParagraph)}.{nameof(SubtitleLineViewModel.Text)}")


### PR DESCRIPTION
  ## Summary

  Addresses feedback that the subtitle list and edit area visually blend together.

  ### Main window
  - Wraps the subtitle DataGrid and the edit box (with timing, formatting, and info controls) in separate gray-bordered panels, replacing the plain horizontal separator between them.

<img width="1798" height="1072" alt="main window" src="https://github.com/user-attachments/assets/aa7ddac6-167b-476d-89a6-b5d2487a4ef7" />


  ### Fix Common Errors — Step 2
  - Each grid (fixes and subtitles) now has its own gray border.
  - The "Select all / Invert / Refresh / Apply" buttons sit in the visible gap between the two grids.
  - The edit panel is left-aligned with the subtitles grid at a fixed width, with navigation buttons (Back to fix list, Done, Cancel) anchored to its bottom-right.
  - The fixes-applied count moves next to the step title, separated by a vertical divider that hides when no fixes have been applied.
  - `MinWidth` raised to prevent button clipping on narrow windows.

<img width="1032" height="807" alt="Fix common errors" src="https://github.com/user-attachments/assets/26c1ae9f-dd2f-466b-9c68-6c44c5331b56" />

