### PR TITLE
Fix stale ShortcutManager numpad-operator test

### DIFF
--- a/tests/UI/Logic/ShortcutManagerTests.cs
+++ b/tests/UI/Logic/ShortcutManagerTests.cs
@@ -40,10 +40,14 @@ public class ShortcutManagerTests
     [InlineData(Key.NumPad0, PhysicalKey.NumPad0, "NumPad0")]
     [InlineData(Key.NumPad9, PhysicalKey.NumPad9, "NumPad9")]
     [InlineData(Key.Decimal, PhysicalKey.NumPadDecimal, "NumPadDecimal")]
-    [InlineData(Key.Add, PhysicalKey.NumPadAdd, "NumPadAdd")]
-    [InlineData(Key.Subtract, PhysicalKey.NumPadSubtract, "NumPadSubtract")]
-    [InlineData(Key.Divide, PhysicalKey.NumPadDivide, "NumPadDivide")]
-    [InlineData(Key.Multiply, PhysicalKey.NumPadMultiply, "NumPadMultiply")]
+    // Numpad arithmetic operators (+ - * /) intentionally keep their bare Key names:
+    // they're unaffected by NumLock and have no main-keyboard equivalent, and prefixing
+    // them would break matching against the Avalonia Key names used by default shortcuts
+    // (e.g. Shift+Add waveform zoom). See ShortcutManager.GetShortcutKeyName.
+    [InlineData(Key.Add, PhysicalKey.NumPadAdd, "Add")]
+    [InlineData(Key.Subtract, PhysicalKey.NumPadSubtract, "Subtract")]
+    [InlineData(Key.Divide, PhysicalKey.NumPadDivide, "Divide")]
+    [InlineData(Key.Multiply, PhysicalKey.NumPadMultiply, "Multiply")]
     // Main-keyboard keys keep their plain names
     [InlineData(Key.Delete, PhysicalKey.Delete, "Delete")]
     [InlineData(Key.Home, PhysicalKey.Home, "Home")]


### PR DESCRIPTION
## Problem

`ShortcutManagerTests.GetShortcutKeyNameDifferentiatesNumpad` had four `InlineData` rows that had been failing since 2026-06-12:

```
Key.Add      + NumPadAdd      → expected "NumPadAdd",      actual "Add"
Key.Subtract + NumPadSubtract → expected "NumPadSubtract", actual "Subtract"
Key.Divide   + NumPadDivide   → expected "NumPadDivide",   actual "Divide"
Key.Multiply + NumPadMultiply → expected "NumPadMultiply", actual "Multiply"
```

## Cause

Commit `00a8dc176` ("Fix numpad +,-,*,/ shortcut keys not matching") **deliberately** changed `ShortcutManager.GetShortcutKeyName` to return the *bare* Key names for the four numpad arithmetic operators — they're unaffected by NumLock, have no main-keyboard equivalent, and prefixing them broke matching against the Avalonia Key names used by default shortcuts (e.g. Shift+Add waveform zoom). That commit also added a legacy-migration map converting old `"NumPadAdd"` tokens back to `"Add"`.

The test's expectations (last touched in the earlier commit `228bae062`) were never updated, so they contradicted the intended behavior.

## Fix

Test-only change: update the four expectations to the bare names and add a comment explaining why the operators differ from other numpad keys. The production code is correct and unchanged.

All 343 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)