### PR TITLE
Expose accessible names on main editor controls (#11553)

### DIFF
--- a/src/ui/Controls/SecondsUpDown.cs
+++ b/src/ui/Controls/SecondsUpDown.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -142,6 +143,12 @@ public class SecondsUpDown : TemplatedControl
         if (_textBox != null)
         {
             _textBox.Text = FormatTime(Value);
+
+            // The inner text box is the element that actually receives keyboard focus,
+            // so the accessible name set on this control must be forwarded to it for
+            // screen readers to announce it (e.g. "Duration") instead of just the value.
+            _textBox.Bind(AutomationProperties.NameProperty, this.GetObservable(AutomationProperties.NameProperty));
+
             _textBox.KeyDown += OnTextBoxKeyDown;
             _textBox.LostFocus += (_, _) => ParseAndUpdate();
             _textBox.PointerWheelChanged += (_, args) =>

--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -94,6 +95,11 @@ namespace Nikse.SubtitleEdit.Controls
             {
                 _textBuffer = FormatTime(Value);
                 _textBox.Text = _textBuffer;
+
+                // The inner text box is the element that actually receives keyboard focus,
+                // so the accessible name set on this control must be forwarded to it for
+                // screen readers to announce it (e.g. "Start time") instead of just the value.
+                _textBox.Bind(AutomationProperties.NameProperty, this.GetObservable(AutomationProperties.NameProperty));
 
                 _textBox.AddHandler(TextInputEvent, OnTextInput, RoutingStrategies.Tunnel);
                 _textBox.AddHandler(KeyDownEvent, OnTextBoxKeyDown, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -1099,6 +1100,7 @@ public static partial class InitListViewAndEditBox
         {
             DataContext = vm,
             UseVideoOffset = true,
+            [AutomationProperties.NameProperty] = Se.Language.General.StartTime,
         };
         var startTimeBindingName = nameof(vm.SelectedSubtitle) + "." + (Se.Settings.Appearance.ShowUpDownEndTime
             ? nameof(SubtitleLineViewModel.StartTimeOnly)
@@ -1134,6 +1136,7 @@ public static partial class InitListViewAndEditBox
         var endCodeUpDown = new TimeCodeUpDown
         {
             DataContext = vm,
+            [AutomationProperties.NameProperty] = Se.Language.General.EndTime,
             [!TimeCodeUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(SubtitleLineViewModel.EndTime)}")
             {
                 Mode = BindingMode.TwoWay,
@@ -1164,6 +1167,7 @@ public static partial class InitListViewAndEditBox
         var durationUpDown = new SecondsUpDown
         {
             DataContext = vm,
+            [AutomationProperties.NameProperty] = Se.Language.General.Duration,
             [!SecondsUpDown.ValueProperty] = new Binding($"{nameof(vm.SelectedSubtitle)}.{nameof(SubtitleLineViewModel.Duration)}")
             {
                 Mode = BindingMode.TwoWay,
@@ -1195,6 +1199,7 @@ public static partial class InitListViewAndEditBox
         }.WithBindVisible(vm, nameof(vm.ShowUpDownLabels));
         panelLayer.Children.Add(labelLayer);
         var upDownLayer = UiUtil.MakeNumericUpDownInt(int.MinValue, int.MaxValue, 0, double.NaN, vm, $"{nameof(vm.SelectedSubtitle)}.{nameof(SubtitleLineViewModel.Layer)}");
+        AutomationProperties.SetName(upDownLayer, Se.Language.General.Layer);
         upDownLayer.HorizontalAlignment = HorizontalAlignment.Stretch;
         if (!vm.ShowUpDownLabels && Se.Settings.Appearance.ShowHints)
         {
@@ -1691,6 +1696,7 @@ public static partial class InitListViewAndEditBox
                 FontWeight = Se.Settings.Appearance.SubtitleTextBoxFontBold ? FontWeight.Bold : FontWeight.Normal,
                 IsUndoEnabled = false,
                 ClearSelectionOnLostFocus = false,
+                [AutomationProperties.NameProperty] = Se.Language.General.Text,
             };
             if (Se.Settings.Appearance.SubtitleTextBoxCenterText)
             {
@@ -1763,6 +1769,11 @@ public static partial class InitListViewAndEditBox
             Focusable = true,
             Padding = new Thickness(6, 4, 4, 4),
         };
+
+        // Expose an accessible name for screen readers. The TextArea is the element
+        // that actually receives keyboard focus, so it needs the name too.
+        AutomationProperties.SetName(textEditor, Se.Language.General.Text);
+        AutomationProperties.SetName(textEditor.TextArea, Se.Language.General.Text);
 
         // Add syntax highlighting transformer
         textEditor.TextArea.TextView.LineTransformers.Add(new SubtitleSyntaxHighlighting());

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformPreviewControl.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformPreviewControl.cs
@@ -1,6 +1,8 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 
@@ -33,6 +35,10 @@ public class WaveformPreviewControl : Control
     {
         _vm = vm;
         _peaks = GenerateSyntheticPeaks(SampleCount);
+
+        // Custom-drawn control with no automation peer of its own; give it a name so
+        // screen readers announce it instead of an unlabeled element (issue #11553).
+        AutomationProperties.SetName(this, Se.Language.General.Preview);
 
         // Repaint whenever any color on the view-model changes
         _vm.PropertyChanged += (_, _) => InvalidateVisual();

--- a/src/ui/Features/Shared/ColorPicker/ColorWheelControl.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorWheelControl.cs
@@ -1,10 +1,12 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
+using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
 
@@ -39,6 +41,10 @@ public class ColorWheelControl : Control
         Width = 200;
         Height = 200;
         ClipToBounds = true;
+
+        // Custom-drawn control with no automation peer of its own; give it a name
+        // so screen readers can announce it (issue #11553).
+        AutomationProperties.SetName(this, Se.Language.General.Color);
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/src/ui/Features/Tools/BeautifyTimeCodes/Profile/CuesPreviewControl.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/Profile/CuesPreviewControl.cs
@@ -1,8 +1,10 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Globalization;
 
@@ -51,6 +53,10 @@ public sealed class CuesPreviewControl : Control
         Height = 70;
         HorizontalAlignment = HorizontalAlignment.Stretch;
         ClipToBounds = true;
+
+        // Custom-drawn control with no automation peer of its own; give it a name so
+        // screen readers announce it instead of an unlabeled element (issue #11553).
+        AutomationProperties.SetName(this, Se.Language.General.Preview);
     }
 
     public override void Render(DrawingContext context)

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1,5 +1,7 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Input;
@@ -1989,6 +1991,8 @@ public static class UiUtil
             e.Handled = true;
         });
 
+        ForwardAutomationNameToInnerTextBox(control);
+
         return control;
     }
 
@@ -2028,6 +2032,7 @@ public static class UiUtil
         }
 
         MakeNumeriUpDownMouseWheelHandler(control);
+        ForwardAutomationNameToInnerTextBox(control);
 
         return control;
     }
@@ -2066,6 +2071,7 @@ public static class UiUtil
         }
 
         MakeNumeriUpDownMouseWheelHandler(control);
+        ForwardAutomationNameToInnerTextBox(control);
 
         return control;
     }
@@ -2105,6 +2111,7 @@ public static class UiUtil
         }
 
         MakeNumeriUpDownMouseWheelHandler(control);
+        ForwardAutomationNameToInnerTextBox(control);
 
         return control;
     }
@@ -2118,6 +2125,21 @@ public static class UiUtil
                                         control.Maximum);
             e.Handled = true;
         });
+    }
+
+    /// <summary>
+    /// Forwards the accessible name set on a <see cref="NumericUpDown"/> to its inner
+    /// PART_TextBox. The text box is the element that actually receives keyboard focus,
+    /// so without this a screen reader would announce the focused field with no name
+    /// (issue #11553). Callers just set <c>AutomationProperties.Name</c> on the control.
+    /// </summary>
+    private static void ForwardAutomationNameToInnerTextBox(NumericUpDown control)
+    {
+        control.TemplateApplied += (_, e) =>
+        {
+            var textBox = e.NameScope.Find<TextBox>("PART_TextBox");
+            textBox?.Bind(AutomationProperties.NameProperty, control.GetObservable(AutomationProperties.NameProperty));
+        };
     }
 
     public static Label WithBindText(this Label control, object viewModel, string contentPropertyPath)

--- a/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
+++ b/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Themes.Fluent;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Logic;
+using UITests.Logic.Accessibility;
+
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+
+namespace UITests.Logic.Accessibility;
+
+public class TestApp : Application
+{
+    public override void Initialize()
+    {
+        // The custom up/down controls embed a ButtonSpinner + TextBox that need a
+        // theme to resolve their templates when shown in a headless window.
+        Styles.Add(new FluentTheme());
+    }
+}
+
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<TestApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions())
+            .WithInterFont();
+}
+
+/// <summary>
+/// Verifies the editor's time/duration controls expose an accessible Name to the
+/// platform automation layer (what NVDA / JAWS / Narrator / VoiceOver read aloud).
+/// The custom controls receive keyboard focus on an inner PART_TextBox, so the name
+/// set on the outer control must be forwarded to that text box (issue #11553).
+/// </summary>
+public class EditBoxAccessibilityNameTests
+{
+    private static TextBox GetInnerTextBox(Control control)
+    {
+        // Force the control's template to apply so PART_TextBox exists and the
+        // name-forwarding in OnApplyTemplate runs.
+        var window = new Window { Content = control, Width = 320, Height = 120 };
+        window.Show();
+        control.ApplyTemplate();
+
+        return control.GetVisualDescendants().OfType<TextBox>().Single();
+    }
+
+    private static string? AutomationName(Control control)
+        => ControlAutomationPeer.CreatePeerForElement(control)?.GetName();
+
+    [AvaloniaFact]
+    public void StartTime_NameReachesAutomationPeer()
+    {
+        var startTime = new TimeCodeUpDown();
+        AutomationProperties.SetName(startTime, "Start time");
+
+        var inner = GetInnerTextBox(startTime);
+
+        Assert.Equal("Start time", AutomationProperties.GetName(inner));
+        Assert.Equal("Start time", AutomationName(inner));
+    }
+
+    [AvaloniaFact]
+    public void EndTime_NameReachesAutomationPeer()
+    {
+        var endTime = new TimeCodeUpDown();
+        AutomationProperties.SetName(endTime, "Hide time");
+
+        var inner = GetInnerTextBox(endTime);
+
+        Assert.Equal("Hide time", AutomationName(inner));
+    }
+
+    [AvaloniaFact]
+    public void Duration_NameReachesAutomationPeer()
+    {
+        var duration = new SecondsUpDown();
+        AutomationProperties.SetName(duration, "Duration");
+
+        var inner = GetInnerTextBox(duration);
+
+        Assert.Equal("Duration", AutomationName(inner));
+    }
+
+    [AvaloniaFact]
+    public void PlainTextBox_NameReachesAutomationPeer()
+    {
+        // The non-color-tag editor path is a plain TextBox; the name is set directly.
+        var textBox = new TextBox();
+        AutomationProperties.SetName(textBox, "Text");
+
+        Assert.Equal("Text", AutomationName(textBox));
+    }
+
+    [AvaloniaFact]
+    public void NumericUpDown_ForwardsAccessibleNameToInnerTextBox()
+    {
+        // Built via the real UiUtil factory, which wires up name forwarding to the
+        // inner PART_TextBox (the focused element). Covers the Layer field and every
+        // other numeric field in the app.
+        var nud = UiUtil.MakeNumericUpDownInt(0, 100, 0, double.NaN, new object());
+        AutomationProperties.SetName(nud, "Layer");
+
+        var inner = GetInnerTextBox(nud);
+
+        Assert.Equal("Layer", AutomationName(inner));
+    }
+}

--- a/tests/UI/UITests.csproj
+++ b/tests/UI/UITests.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Part of #11553 (screen-reader accessibility). Focused on the main editor's time/duration/text fields plus a few easy custom-drawn controls.

## Problem
Screen readers read a control's UI Automation peer `Name`. The custom `TimeCodeUpDown` / `SecondsUpDown` controls put keyboard focus on an inner `PART_TextBox` whose name was empty, and several fields had no name at all — so the editor announced unlabeled "edit" fields with only their raw values.

## Changes
- **`TimeCodeUpDown` / `SecondsUpDown`**: forward `AutomationProperties.Name` to the inner `PART_TextBox` (the focused element) in `OnApplyTemplate`.
- **`UiUtil.MakeNumericUpDown*`**: same forwarding for the built-in `NumericUpDown` → covers every numeric field in the app.
- **Main editor**: named Start time, End time, Duration, Text and Layer controls with existing localized strings.
- **`ColorWheelControl`, `WaveformPreviewControl`, `CuesPreviewControl`**: custom-drawn controls with no peer of their own now get a name.

## Tests
Adds a headless Avalonia test (`Avalonia.Headless.XUnit`) that builds the real controls, applies their templates, and asserts the **automation peer reports the expected name on the focused element** — the exact value a screen reader speaks. Verified the test fails without the fix (`Actual: null`) and passes with it.

## Notes
- Uses existing localized strings, so names are already translated.
- The three interactive custom canvases (`AudioVisualizer` waveform, `AssaDrawCanvas`, `NOcrDrawingCanvasView`) need bespoke `OnCreateAutomationPeer()` work and are left as a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)