### PR TITLE
Fix latent NRE in Reopen seek and remove dead local

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1834,7 +1834,7 @@ public partial class MainViewModel :
                 if (vp != null && s != null)
                 {
                     vp.Position = s.StartTime.TotalSeconds;
-                    Dispatcher.UIThread.Post(() => { vp.Position = SelectedSubtitle.StartTime.TotalSeconds; });
+                    Dispatcher.UIThread.Post(() => { vp.Position = s.StartTime.TotalSeconds; });
                     CenterAudioVisualizerOnCurrentVideoPosition();
                 }
             }

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -38,7 +38,6 @@ internal static class SubtitleTextInfoHelper
         out IBrush totalBackground)
     {
         var info = PopulateLineLengthsAndTotal(text, panel);
-        var colorTextTooLong = Se.Settings.General.ColorTextTooLong;
         var maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
 
         var cps = GetCharactersPerSecond(text, item.StartTime, item.EndTime);


### PR DESCRIPTION
## Summary

Two small fixes found while bug-hunting the recent commits:

1. **Latent NRE in the Reopen video-seek flow** (`MainViewModel.cs`). The deferred seek lambda re-read the `SelectedSubtitle` *property* instead of the already null-checked local snapshot `s`:

   ```csharp
   var s = SelectedSubtitle;
   if (vp != null && s != null)
   {
       vp.Position = s.StartTime.TotalSeconds;
       Dispatcher.UIThread.Post(() => { vp.Position = SelectedSubtitle.StartTime.TotalSeconds; }); // re-reads property
   ```

   Because the `Post` runs on a later UI tick, closing the file or clearing the selection in that window would make `SelectedSubtitle` null and throw an NRE on the UI thread. Now uses the captured local `s`. (The analogous fullscreen path already captures a `position` local and was unaffected.)

2. **Dead local** in `SubtitleTextInfoHelper.Populate` — `colorTextTooLong` became unused when the CPS background gate was switched to `ColorCharactersPerSecond`. Removed (CS0219 cleanup).

## Testing

- `dotnet build src/ui/UI.csproj` — succeeds, 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)