### PR TITLE
Use the correct font for subtitle grid column width measurements

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -94,10 +94,6 @@ public static partial class InitListViewAndEditBox
             HorizontalGridLinesBrush = UiUtil.GetBorderBrush(),
             FontSize = Se.Settings.Appearance.SubtitleGridFontSize,
         };
-        if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
-        {
-            vm.SubtitleGrid.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
-        }
 
         // hack to make drag and drop work on the DataGrid - also on empty rows
         var dropHost = new Border


### PR DESCRIPTION
This PR makes sure that auto-sized subtitle grid columns get their width based on the correct font so the inexplicably large white space after the Show and Hide columns is gone.


  It was a subtitle grid font-scoping issue where changing the subtitle text font could widen the `Show` / `Hide` columns even though those columns were still rendered with the UI font. You can see this in the video below: changing the subtitle text font changes the width of the Show and Hide columns, for no reason.


https://github.com/user-attachments/assets/16197e15-bd72-4c0d-bebc-6c54454be564


  ## Problem

  The main subtitle `DataGrid` was assigning `SubtitleTextBoxAndGridFontName` to the grid itself.

  That caused two different behaviors:

  - The visible `Show` / `Hide` cells still rendered with the UI font because they are plain `TextBlock`s and the app-level UI font style applies directly to `TextBlock`.
  - The `Show` / `Hide` column auto-fit logic measured width from `SubtitleGrid.FontFamily`, so switching to a wider subtitle font such as `SF Mono` produced wider timing columns.

  Result: the rendered cells looked correct, but the measured widths were based on the wrong font.

  ## Fix

  - Remove the grid-level subtitle font override from the main subtitle `DataGrid`
  - Keep the subtitle font scoped to subtitle text content only
  - Let timing and other non-text columns inherit the normal UI font for both rendering and auto-fit measurement

  ## Result

  - `Show` / `Hide` widths no longer change when only the subtitle text font changes
  - Subtitle text and the subtitle editor still use the selected subtitle font
  - Non-text grid columns stay aligned with the UI font

  ## Testing

  - Verified the following behavior manually:
      - changing subtitle font from Charter to SF Mono no longer changes Show / Hide column width
      - subtitle text still uses the selected subtitle font
      - timing columns continue to render with the UI font
