### PR TITLE
Fix subtitle editor focus border not following system accent color

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1723,7 +1723,7 @@ public static partial class InitListViewAndEditBox
         var textEditor = MakeTextEditor();
 
         var defaultBorderBrush = UiUtil.GetBorderBrush();
-        var focusedBorderBrush = new SolidColorBrush(Colors.DodgerBlue);
+        var focusedBorderBrush = UiUtil.GetAccentBrush();
 
         var textEditorBorder = new Border
         {
@@ -1830,7 +1830,7 @@ public static partial class InitListViewAndEditBox
         var textEditor = MakeTextEditor();
 
         var defaultBorderBrush = UiUtil.GetBorderBrush();
-        var focusedBorderBrush = new SolidColorBrush(Colors.DodgerBlue);
+        var focusedBorderBrush = UiUtil.GetAccentBrush();
 
         var textEditorBorder = new Border
         {

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -166,6 +166,18 @@ public static class UiUtil
         return new SolidColorBrush(Colors.Black, 0.5);
     }
 
+    public static IBrush GetAccentBrush()
+    {
+        var app = Application.Current;
+        if (app != null)
+        {
+            app.TryGetResource("SystemAccentColor", app.ActualThemeVariant, out var resource);
+            if (resource is Color color)
+                return new SolidColorBrush(color);
+        }
+        return new SolidColorBrush(Colors.DodgerBlue);
+    }
+
     public static Color GetBorderColor()
     {
         var color = Colors.Black;


### PR DESCRIPTION
The focused border brush for the AvaloniaEdit-based subtitle text box was hardcoded to Colors.DodgerBlue in both MakeTextEditor and MakeOriginalTextEditor. Every other focusable control in the app relies on Avalonia's Fluent theme to supply the system accent color automatically, so users who changed their accent saw a jarring blue border that stood out from the rest of the UI.

  ### Root cause
Commit 39068ba1b (today) set FocusAdorner = null on the TextEditor and its inner TextArea in order to suppress Avalonia's default focus adorner and let the wrapper Border render the focus ring instead. Before that change the FocusAdorner was drawn by the Fluent theme using the system accent color and was the primary visible focus cue. Removing it left the hardcoded DodgerBlue Border as the only indicator, which does not follow the accent.

  ### Fix
Add UiUtil.GetAccentBrush(), which resolves SystemAccentColor from the Fluent theme resource dictionary at call time (same Application.Current + ActualThemeVariant pattern used by GetBorderBrush). Replace both hardcoded SolidColorBrush(Colors.DodgerBlue) call sites with UiUtil.GetAccentBrush(). DodgerBlue is retained as the fallback for the rare case where the theme resource is unavailable during startup.

  ### Before -> After

<img width="831" height="387" alt="before" src="https://github.com/user-attachments/assets/586b935f-1ce1-4014-9e8d-693761a9d47b" />
<img width="823" height="382" alt="after" src="https://github.com/user-attachments/assets/31f10460-e032-4bee-90ee-7bf1815ef020" />
