### PR TITLE
Fix title bar showing *Untitled on startup with no file to reopen

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -512,6 +512,8 @@ public partial class MainViewModel :
 
         Encodings = new ObservableCollection<TextEncoding>(EncodingHelper.GetEncodings());
         SelectedEncoding = Encodings.FirstOrDefault(p => p.DisplayName == Se.Settings.General.DefaultEncoding) ?? Encodings[0];
+        _changeSubtitleHash = GetFastHash();
+        _changeSubtitleHashOriginal = GetFastHashOriginal();
 
         FrameRates = new ObservableCollection<string>
         {


### PR DESCRIPTION
  ### Summary

  When launching the app with no recent file to reopen, the title bar incorrectly showed *Untitled — the asterisk that normally indicates unsaved changes — even though nothing had been modified.

<img width="242" height="28" alt="Screenshot 2026-06-13 at 9 35 29 AM" src="https://github.com/user-attachments/assets/3fa0a4bb-30b5-4f5e-99b3-c506c8f78903" />

  ### Root Cause

  _changeSubtitleHash was field-initialized to -1, but GetFastHash() never returns -1 (it computes a hash seeded from 17). The slow timer fires UpdateTitleStatus() shortly after startup and sees _changeSubtitleHash (-1) != GetFastHash(), treating the clean initial state as modified.

  _changeSubtitleHash only gets a real value inside ResetSubtitle(), which is called when opening a file or clicking File > New — never during a cold start with no file.

  ### Fix

  Seed both _changeSubtitleHash and _changeSubtitleHashOriginal from the actual initial state in the constructor, immediately after SelectedEncoding is set (the encoding is an input to the hash).

  SelectedEncoding = Encodings.FirstOrDefault(...) ?? Encodings[0];
  _changeSubtitleHash = GetFastHash();
  _changeSubtitleHashOriginal = GetFastHashOriginal();

  ### Testing

  1. Launch the app with no recent file (or clear recent files first).
  2. Verify the title bar shows Untitled - Subtitle Edit x.x with no leading *.
  3. Type in a subtitle line and verify * appears.
  4. Save and verify * disappears.
