### PR TITLE
Fix find highlight and Find Next not advancing (plain text box mode)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9710,7 +9710,7 @@ public partial class MainViewModel :
 
         var subs = Subtitles.Select(p => p.Text).ToList();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
-        var currentCharIndex = EditTextBox.CaretIndex;
+        var currentCharIndex = EditTextBox.SelectionEnd;
         var idx = _findService.FindNext(_findService.SearchText, subs, currentLineIndex, currentCharIndex);
 
         if (idx < 0)

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
@@ -53,7 +53,6 @@ public class TextBoxWrapper : ITextBoxWrapper
     {
         _textBox.SelectionStart = start;
         _textBox.SelectionEnd = start + length;
-        _textBox.CaretIndex = start + length;
     }
 
     public int CaretIndex


### PR DESCRIPTION
  ## Problem

  When color tags are **disabled** (the default plain `TextBox` mode), two related bugs affected the Find feature:

  1. **No highlight** — searching with F3 / Find dialog showed the correct subtitle and positioned the caret after the match, but the found text was never highlighted.
  2. **Find Next stuck** — pressing F3 a second time kept re-finding the same hit instead of advancing to the next occurrence.

  Both issues were confined to the plain `TextBox` path. The AvaloniaEdit path (color tags enabled) was unaffected.

  ## Root cause

  **Highlight bug** (`TextBoxWrapper.Select`): After setting `SelectionStart`/`SelectionEnd`, the method also set `CaretIndex = start + length`. In Avalonia's `TextBox`, setting `CaretIndex` to a new value fires `PropertyChanged` for `CaretIndexProperty`, which internally collapses the selection to a zero-length caret — erasing the highlight that was just applied.

  **Advancement bug** (`FindNext` shortcut): The shortcut read `EditTextBox.CaretIndex` as the search-start position. With the selection now non-collapsed, `CaretIndex` reflected `SelectionStart` (the beginning of the found text), so the next search re-found the same occurrence. The Find dialog already used `EditTextBox.SelectionEnd` correctly; the shortcut was inconsistent.

  ## Changes

  - **`TextBoxWrapper.Select()`** — remove the redundant `CaretIndex` assignment; `SelectionEnd` positions the caret automatically.
  - **`MainViewModel.FindNext()`** — use `EditTextBox.SelectionEnd` as the search start, matching the Find dialog path.