### PR TITLE
Fix Find/Replace dialogs stealing focus on app reactivation

### DIFF
--- a/src/ui/Features/Edit/Find/FindWindow.cs
+++ b/src/ui/Features/Edit/Find/FindWindow.cs
@@ -153,8 +153,8 @@ public class FindWindow : Window
 
         Content = grid;
 
-        Activated += delegate 
-        { 
+        Opened += delegate
+        {
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
                 textBoxFind.GetVisualDescendants()
@@ -162,7 +162,7 @@ public class FindWindow : Window
                            .FirstOrDefault()?
                            .Focus();
             });
-        }; // hack to make OnKeyDown work
+        };
         AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);
         Closing += (_, _) => vm.SaveSettings();
     }

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -197,8 +197,8 @@ public class ReplaceWindow : Window
 
         Content = grid;
 
-        Activated += delegate 
-        { 
+        Opened += delegate
+        {
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
                 textBoxFind.GetVisualDescendants()
@@ -206,7 +206,7 @@ public class ReplaceWindow : Window
                            .FirstOrDefault()?
                            .Focus();
             });
-        }; // hack to make OnKeyDown work
+        };
         AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);
         Closing += (_, _) => vm.SaveSettings();
     }


### PR DESCRIPTION
This PR maintains the smooth flow of opening the Find or Replace dialog, allowing users to type immediately into the Find field. However, it eliminates the unexpected focus shift when switching to another app (e.g., to copy the replacement string), ensuring that pasting does not occur in the search textbox.

## Problem

The Find and Replace dialogs subscribed to the `Activated` event to focus the Find textbox on open. `Activated` fires every time the window becomes active — including when the user switches back to the app from another window — so it unconditionally stole focus from whatever control the user had previously clicked (e.g. the Replace textbox, a radio button, or a button).

Stealing focus is usually a bad UX pattern. An immediate example I have is that I use Raycast to paste a snippet directly into the active application, for things I don't want to always type, or for characters I can't easily type on a US English layout. But when Raycast switches back to the "active application", Subtitle Edit with its Replace dialog, the focus gets stolen, and the paste goes into the Find field so it's impossible to paste into the Replace field: I have to manually copy the text I want to paste, go again to the Replace field (two keystrokes or a click), and then paste (one more keystroke).

## Fix

Replace `Activated` with `Opened` in both `FindWindow` and `ReplaceWindow`. `Opened` fires exactly once when the window first appears, so the Find textbox gets focus on open as intended, and focus is left alone on subsequent
app activations.

## Files changed

- `src/ui/Features/Edit/Find/FindWindow.cs`
- `src/ui/Features/Edit/Replace/ReplaceWindow.cs`

## Testing

1. Open the Replace (or Find) dialog — Find textbox should have focus.
2. Click into the Replace textbox or any other control.
3. Switch to another app and back — focus should remain on the last-clicked control.
4. Confirm keyboard shortcuts (Enter for Find Next, Escape to close) still work on first open.