### PR TITLE
Fix burn-in passing 0x0 resolution to ffmpeg for audio-only input

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInJobItem.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInJobItem.cs
@@ -25,6 +25,12 @@ public partial class BurnInJobItem : ObservableObject
     public double TotalSeconds { get; set; }
     public string VideoBitRate { get; set; }
 
+    /// <summary>
+    /// Input has audio but no video stream (e.g. karaoke from a .wav + .ass), so the
+    /// subtitles are burned onto a generated black canvas at the chosen resolution.
+    /// </summary>
+    public bool InputIsAudioOnly { get; set; }
+
     [ObservableProperty] private string _size;
 
     [ObservableProperty] private string _status;

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -261,8 +261,14 @@ public partial class BurnInViewModel : ObservableObject
                 _mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
                 Dispatcher.UIThread.Post(() =>
                 {
-                    VideoWidth = _mediaInfo.Dimension.Width;
-                    VideoHeight = _mediaInfo.Dimension.Height;
+                    // Audio-only files have no video stream (0x0) - keep the configured
+                    // resolution instead of overwriting the fields with zeros (issue #11570).
+                    if (_mediaInfo.Dimension.Width > 0 && _mediaInfo.Dimension.Height > 0)
+                    {
+                        VideoWidth = _mediaInfo.Dimension.Width;
+                        VideoHeight = _mediaInfo.Dimension.Height;
+                    }
+
                     UseSourceResolution = false;
                 });
             });
@@ -453,8 +459,23 @@ public partial class BurnInViewModel : ObservableObject
         var mediaInfo = FfmpegMediaInfo.Parse(jobItem.InputVideoFileName);
         jobItem.TotalFrames = mediaInfo.GetTotalFrames();
         jobItem.TotalSeconds = mediaInfo.Duration.TotalSeconds;
-        jobItem.Width = mediaInfo.Dimension.Width;
-        jobItem.Height = mediaInfo.Dimension.Height;
+        if (mediaInfo.Dimension.Width > 0 && mediaInfo.Dimension.Height > 0)
+        {
+            jobItem.Width = mediaInfo.Dimension.Width;
+            jobItem.Height = mediaInfo.Dimension.Height;
+        }
+        else
+        {
+            // No video stream to read a resolution from - keep the resolution chosen in the
+            // UI and burn the subtitles onto a generated black canvas (issue #11570).
+            jobItem.InputIsAudioOnly = mediaInfo.Tracks.Any(p => p.TrackType == FfmpegTrackType.Audio) &&
+                                       !mediaInfo.Tracks.Any(p => p.TrackType == FfmpegTrackType.Video);
+            if (jobItem.InputIsAudioOnly)
+            {
+                // The black canvas is generated at 25 fps, so derive the frame count for progress.
+                jobItem.TotalFrames = (long)Math.Round(jobItem.TotalSeconds * 25.0);
+            }
+        }
         jobItem.UseTargetFileSize = UseTargetFileSize;
         jobItem.TargetFileSize = UseTargetFileSize ? TargetFileSize ?? 0 : 0;
         jobItem.AssaSubtitleFileName = MakeAssa(jobItem.SubtitleFileName);
@@ -668,7 +689,8 @@ public partial class BurnInViewModel : ObservableObject
             cutStart,
             cutEnd,
             audioCutTracks,
-            BurnInLogo);
+            BurnInLogo,
+            jobItem.InputIsAudioOnly);
 
         if (PromptForFfmpegParameters)
         {
@@ -735,10 +757,13 @@ public partial class BurnInViewModel : ObservableObject
         }
 
         _mediaInfo = FfmpegMediaInfo2.Parse(VideoFileName);
-        VideoWidth = _mediaInfo.Dimension.Width;
-        VideoHeight = _mediaInfo.Dimension.Height;
+        if (_mediaInfo.Dimension.Width > 0 && _mediaInfo.Dimension.Height > 0)
+        {
+            VideoWidth = _mediaInfo.Dimension.Width;
+            VideoHeight = _mediaInfo.Dimension.Height;
+        }
 
-        var jobItem = new BurnInJobItem(VideoFileName, _mediaInfo.Dimension.Width, _mediaInfo.Dimension.Height)
+        var jobItem = new BurnInJobItem(VideoFileName, VideoWidth ?? 0, VideoHeight ?? 0)
         {
             InputVideoFileName = VideoFileName,
             OutputVideoFileName = outputVideoFileName,

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -68,7 +68,7 @@ public class FfmpegGenerator
     /// <summary>
     /// Generate ffmpeg parameters for a video with a burned-in Advanced Sub Station Alpha subtitle.
     /// </summary>
-    public static string GenerateHardcodedVideoFile(string inputVideoFileName, string assaSubtitleFileName, string outputVideoFileName, int width, int height, string videoEncoding, string preset, string pixelFormat, string crf, string audioEncoding, bool forceStereo, string sampleRate, string tune, string audioBitRate, string pass, string twoPassBitRate, string? cutStart = null, string? cutEnd = null, string audioCutTrack = "", Features.Video.BurnIn.BurnInLogo? burnInLogo = null)
+    public static string GenerateHardcodedVideoFile(string inputVideoFileName, string assaSubtitleFileName, string outputVideoFileName, int width, int height, string videoEncoding, string preset, string pixelFormat, string crf, string audioEncoding, bool forceStereo, string sampleRate, string tune, string audioBitRate, string pass, string twoPassBitRate, string? cutStart = null, string? cutEnd = null, string audioCutTrack = "", Features.Video.BurnIn.BurnInLogo? burnInLogo = null, bool inputIsAudioOnly = false)
     {
         if (width % 2 == 1)
         {
@@ -213,6 +213,21 @@ public class FfmpegGenerator
             cutEnd = " ";
         }
 
+        // Audio-only input (e.g. karaoke from an audio + subtitle file) has no video stream to
+        // burn subtitles into, so synthesize a black canvas at the requested resolution and stop
+        // encoding when the audio ends (the lavfi color source runs forever).
+        var canvasInput = string.Empty;
+        var shortestParameter = string.Empty;
+        var mainVideoStream = "[0:v]";
+        var logoVideoStream = "[1:v]";
+        if (inputIsAudioOnly)
+        {
+            canvasInput = $" -f lavfi -i color=c=black:s={width}x{height}:r=25";
+            shortestParameter = " -shortest";
+            mainVideoStream = "[1:v]";
+            logoVideoStream = "[2:v]";
+        }
+
         // Add logo overlay if specified
         var logoInput = string.Empty;
         var filterParameter = $"-vf \"scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}\"";
@@ -226,18 +241,18 @@ public class FfmpegGenerator
             var sizePercent = burnInLogo.Size.ToString(CultureInfo.InvariantCulture);
 
             // Build filter_complex for video with logo overlay
-            // 1. Scale main video and apply subtitles
+            // 1. Scale main video (or the generated canvas for audio-only input) and apply subtitles
             // 2. Scale logo by size percentage and apply alpha transparency
             // 3. Overlay logo at specified X, Y position
-            var filterComplex = $"[0:v]scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}[withsubs];" +
-                               $"[1:v]scale=iw*{sizePercent}/100:ih*{sizePercent}/100,format=rgba,colorchannelmixer=aa={alphaValue}[logo];" +
+            var filterComplex = $"{mainVideoStream}scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}[withsubs];" +
+                               $"{logoVideoStream}scale=iw*{sizePercent}/100:ih*{sizePercent}/100,format=rgba,colorchannelmixer=aa={alphaValue}[logo];" +
                                $"[withsubs][logo]overlay={burnInLogo.X}:{burnInLogo.Y}";
 
             filterParameter = $"-filter_complex \"{filterComplex}\"";
         }
 
         return
-            $"{cutStart}-i \"{inputVideoFileName}\"{logoInput}{cutEnd} {filterParameter} -g 30 -bf 2 -s {width}x{height} {videoEncodingSettings} {passSettings} {presetSettings} {crfSettings} {pixelFormat} {audioSettings}{tuneParameter} -use_editlist 0 -movflags +faststart {outputVideoFileName}";
+            $"{cutStart}-i \"{inputVideoFileName}\"{canvasInput}{logoInput}{cutEnd} {filterParameter} -g 30 -bf 2 -s {width}x{height} {videoEncodingSettings} {passSettings} {presetSettings} {crfSettings} {pixelFormat} {audioSettings}{tuneParameter} -use_editlist 0 -movflags +faststart{shortestParameter} {outputVideoFileName}";
     }
 
     private static Process GetFFmpegProcess(string imageFileName, string outputFileName, int videoWidth, int videoHeight, int seconds, decimal frameRate, bool addTimeCode = false, string addTimeColor = "white")


### PR DESCRIPTION
Fixes #11570

## Problem

With only a subtitle and a pure audio file (.wav/.mp3) loaded (karaoke workflow), *Video -> Generate video with burned-in subtitles* passed `-vf "scale=0:0,..."` and `-s 0x0` to ffmpeg - even when the user typed a valid resolution like 1920x1080 in the fields.

## Root cause

1. The parsed media dimension (0x0 for an audio file) unconditionally overwrote both the UI resolution fields (`Initialize`, `GetCurrentVideoAsJobItems`) and the job item at generate time (`InitAndStartJobItem`), discarding whatever the user entered.
2. Even with correct numbers, an audio file has no video stream for `-vf` to burn subtitles into.

## Fix

- Only take width/height from parsed media info when non-zero, so the user-chosen resolution survives for audio-only input.
- When the input has audio but no video stream (detected via the parsed track list), synthesize a black canvas with `-f lavfi -i color=c=black:s=WxH:r=25`, burn the subtitles onto it, and add `-shortest` so encoding stops when the audio ends. This is the same lavfi approach the mpv audio-only preview already uses (`LibMpvDynamicPlayer`), matching the behaviour @dask-music described in the issue.
- Logo overlay still works: the `filter_complex` stream labels shift to `[1:v]`/`[2:v]` when the canvas input is present.
- Progress frame count for audio input derived from duration x 25 fps (the canvas rate).

Generated command now (audio-only input):
```
ffmpeg -i "input.wav" -f lavfi -i color=c=black:s=1920x1080:r=25 -vf "scale=1920:1080,ass=sub.ass" -g 30 -bf 2 -s 1920x1080 -c:v libx264 -preset medium -crf 25 -pix_fmt yuv420p -c:a aac -ar 44100 -use_editlist 0 -movflags +faststart -shortest "out.mkv"
```
Video-file inputs are unchanged - dimensions still come from the source when non-zero.

## Verification

- `dotnet build`: 0 errors / 0 warnings (full solution).
- End-to-end with ffmpeg on Windows: a 5 s sine `.wav` + a minimal `.ass` produces a 1920x1080 H.264/AAC file with duration matching the audio (5.02 s - `-shortest` terminates the otherwise-infinite color source).
- Subtitle rendering confirmed via signalstats luma (YAVG 16.52 on a subtitle frame vs 16.00 black floor).
- Logo-overlay variant with the remapped stream labels verified the same way.

## Out of scope

The issue's secondary request for an mp4 output option is intentionally left out to keep this a focused fix.
