### PR TITLE
Fix layout shift when found text contains newlines in Find/Replace

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9681,7 +9681,7 @@ public partial class MainViewModel :
                 SubtitleGrid.SelectedItem = subtitle;
                 SubtitleGrid.ScrollIntoView(subtitle, null);
 
-                ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, _findService.CurrentTextFound, _findService.CurrentLineNumber + 1, _findService.CurrentTextIndex + 1));
+                ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, _findService.CurrentTextFound.Replace("\r\n", "·").Replace("\n", "·"), _findService.CurrentLineNumber + 1, _findService.CurrentTextIndex + 1));
 
                 if (EditTextBox.Text != subtitle.Text)
                 {
@@ -9747,7 +9747,7 @@ public partial class MainViewModel :
             SubtitleGrid.SelectedItem = subtitle;
             SubtitleGrid.ScrollIntoView(subtitle, null);
 
-            ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText, foundLine + 1, foundIndex + 1));
+            ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText.Replace("\r\n", "·").Replace("\n", "·"), foundLine + 1, foundIndex + 1));
 
             if (EditTextBox.Text != subtitle.Text)
             {
@@ -9814,7 +9814,7 @@ public partial class MainViewModel :
             SubtitleGrid.SelectedItem = subtitle;
             SubtitleGrid.ScrollIntoView(subtitle, null);
 
-            ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText, foundLine + 1, foundIndex + 1));
+            ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText.Replace("\r\n", "·").Replace("\n", "·"), foundLine + 1, foundIndex + 1));
 
             if (EditTextBox.Text != subtitle.Text)
             {
@@ -10086,7 +10086,7 @@ public partial class MainViewModel :
 
                 EditTextBox.Select(foundIndex, foundText.Length);
 
-                ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText, foundLine + 1, foundIndex + 1));
+                ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText.Replace("\r\n", "·").Replace("\n", "·"), foundLine + 1, foundIndex + 1));
             });
         }
     }

--- a/src/ui/Features/Ocr/FixEngine/GuessUsedItem.cs
+++ b/src/ui/Features/Ocr/FixEngine/GuessUsedItem.cs
@@ -22,8 +22,8 @@ public class GuessUsedItem
 
     public override string ToString()
     {
-        var from = From.Replace("\r\n", "↵").Replace("\n", "↵");
-        var to = To.Replace("\r\n", "↵").Replace("\n", "↵");
+        var from = From.Replace("\r\n", "·").Replace("\n", "·");
+        var to = To.Replace("\r\n", "·").Replace("\n", "·");
         return $"#{LineIndex + 1}: {from} → {to}";
     }
 }

--- a/src/ui/Features/Ocr/FixEngine/ReplacementUsedItem.cs
+++ b/src/ui/Features/Ocr/FixEngine/ReplacementUsedItem.cs
@@ -22,8 +22,8 @@ public class ReplacementUsedItem
 
     public override string ToString()
     {
-        var from = From.Replace("\r\n", "↵").Replace("\n", "↵");
-        var to = To.Replace("\r\n", "↵").Replace("\n", "↵");
+        var from = From.Replace("\r\n", "·").Replace("\n", "·");
+        var to = To.Replace("\r\n", "·").Replace("\n", "·");
         return $"#{LineIndex + 1}: {from} → {to}";
     }
 }

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -114,8 +114,8 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
                     if (rebalancedText != item.Text)
                     {
                         rebalanceCount++;
-                        var beforePreview = GetTextPreview(item.Text.Replace("\r\n", " ↵ ").Replace("\n", " ↵ "), 60);
-                        var afterPreview = GetTextPreview(rebalancedText.Replace("\r\n", " ↵ ").Replace("\n", " ↵ "), 60);
+                        var beforePreview = GetTextPreview(item.Text.Replace("\r\n", " · ").Replace("\n", " · "), 60);
+                        var afterPreview = GetTextPreview(rebalancedText.Replace("\r\n", " · ").Replace("\n", " · "), 60);
                         var fixDescription = $"'{beforePreview}' → '{afterPreview}'";
                         var fixItem = new SplitBreakLongLinesItem(Se.Language.Tools.SplitBreakLongLines.RebalanceLongLine, index + 1, fixDescription, item);
                         Fixes.Add(fixItem);


### PR DESCRIPTION
  ## Problem

  When searching with a regex pattern containing `\n` (e.g. `\]\n`), the matched text can include a literal newline character. This newline was embedded directly into the "Found '…' in line X, position Y" status message and displayed in a plain `TextBlock` in the main window footer. The TextBlock rendered the newline as a second line, doubling the footer height and causing all main window components (subtitle grid, toolbar, waveform) to shift upward. The shift reversed when the status message faded out after 3 seconds.

https://github.com/user-attachments/assets/600c09f0-b2a2-456b-b331-22f1b556948a


  ## Fix

  Replace `\r\n` and `\n` with a middle dot (`·`, U+00B7) in the matched text before embedding it in the status message. The middle dot is in the Latin-1 block and is present in every font a user might select.

  The same replacement is applied consistently in the OCR All Fixes list (`ReplacementUsedItem`, `GuessUsedItem`) and the **Split/Break Long Lines** preview (`SplitBreakLongLinesViewModel`), which previously used `↵` (U+21B5). That character is absent from several popular fonts (including the macOS default system font), causing it to render as a box when the user had switched away from Avalonia's default Inter font.

  ## Files changed

  - `src/ui/Features/Main/MainViewModel.cs` — sanitize `foundText` at all four `FoundXInLineYZ` call sites (Find, FindNext, FindPrevious, HandleReplaceResult)
  - `src/ui/Features/Ocr/FixEngine/ReplacementUsedItem.cs`
  - `src/ui/Features/Ocr/FixEngine/GuessUsedItem.cs`
  - `src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs`
