### PR TITLE
Fix text wrapping in main edit box with color tags enabled

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1762,7 +1762,6 @@ public static partial class InitListViewAndEditBox
             Height = 92,
             FontSize = Se.Settings.Appearance.SubtitleTextBoxFontSize,
             FontWeight = Se.Settings.Appearance.SubtitleTextBoxFontBold ? FontWeight.Bold : FontWeight.Normal,
-            WordWrap = true,
             ShowLineNumbers = false,
             HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
             VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
@@ -1782,6 +1781,10 @@ public static partial class InitListViewAndEditBox
         {
             textEditor.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         }
+
+        // Enable word wrap after the editor is otherwise configured so AvaloniaEdit
+        // can apply its built-in "wrap disables horizontal scrolling" behavior.
+        textEditor.WordWrap = true;
 
         return textEditor;
     }

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -20,13 +20,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="12.0.4" />
+		<PackageReference Include="Avalonia" Version="12.0.3" />
 		<PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
 		<PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
-		<PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+		<PackageReference Include="Avalonia.Desktop" Version="12.0.3" />
 		<PackageReference Include="Avalonia.Markup.Declarative" Version="12.0.1" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.3" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.3" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
 		<PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2">
 			<IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>


### PR DESCRIPTION
This has been a major headache since Avalonia 12.0.4 introduced TextRunCache and cached bidi-run changes in the text stack, with some regressions and incompatibilities that have remained unfixed so far.

One regression is that in our main edit box when color tags are enabled, turning on text wrapping to match the behavior of the non-color tag edit box and get rid of the horizontal scroll bar results in a “visible text is right, caret math is wrong” situation: the caret is calculated incorrectly and it's not where you see it. Editing is impossible like this, say, you position the caret where you want to split a line and it gets split 5-6 characters further down.

This is how it should work (and works after this fix); I can navigate in the wrapped text, no horizontal scrollbar, and when I hit enter the line splits where the caret is:


https://github.com/user-attachments/assets/778e9167-6f89-4e06-a6de-acd45e7c8a1e


[This upstream commit](https://github.com/AvaloniaUI/Avalonia/commit/aee3f68551b0ac4417e32996a6627f34462edbc3) looks promising as a fix but it's unreleased. I would not want to carry a fork of upstream so I did not bother confirming if it does fix our issue.

I had to manually bisect the wrapped color-tag editor regression on macOS which showed that Avalonia 12.0.4 is the first bad version for the AvaloniaEdit-based subtitle editor path, while 12.0.2 and 12.0.3 both behave correctly. 

Avalonia.AvaloniaEdit, Avalonia.Controls.DataGrid, and AvaloniaEdit.TextMate were on 12.0.0, there's no change there. This fix only pins the main Avalonia runtime packages back to 12.0.3 to avoid the 12.0.4 caret-position regression.

Enabling WordWrap after the TextEditor is otherwise configured lets AvaloniaEdit apply its built-in behavior that disables horizontal scrolling when wrapping is active. That resolves the horizontal scrollbar issue independently of the 12.0.4 caret bug, so it is in the change set alongside the framework pin.

  ### Risk assessment 

  The downgrade is narrower than it looks.

  What we are losing in Subtitle Edit is the text-performance cache, but that is also the most suspicious regression source for our bug. We do not deal with large text files in the text editor, only a single subtitle, so the performance related change is unnoticeable. Their improvement is for editing large documents.

   Only core Avalonia packages moved from 12.0.4 to 12.0.3; AvaloniaEdit, DataGrid, and TextMate were already on 12.0.0. In this repo, that means we are mostly giving up a small set of framework fixes only.

  The app areas most prone to regressions are:

- The main edit box and any other AvaloniaEdit path. The critical path is src/ui/Features/Main/Layout/InitListViewAndEditBox.cs:1768, where the color-tag editor uses TextEditor with wrapping. This is also exactly where 12.0.4 broke our app, so for this path _12.0.3 is the safer runtime, not the risky one._

- Selection-heavy grids. The main subtitle grid has fairly intricate SelectionChanged logic in src/ui/Features/Main/MainViewModel.cs:17819, and the repo has many other DataGrid/ComboBox selection handlers. If 12.0.4 included useful selection fixes, this is where we would miss them. Real risk: moderate, but easy to test. I have not found any regression.

- File dialogs and storage provider behavior. File picking is used everywhere through src/ui/Logic/Media/FileHelper.cs:19. If there were platform dialog fixes in 12.0.4, this is the app surface that would feel them.

  All the other changes are not meaningfully lost.

  My practical read is: 12.0.3 is a good temporary production pin. The real regression cost is low compared to the confirmed editor break in 12.0.4. The smoke test I did prioritized subtitle-grid multi-select and file open/save dialogs, and everything looked good.
