### PR TITLE
Qwen3 TTS (CrispASR): add real voice cloning + fix CustomVoice speakers

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -266,12 +266,15 @@ public class Qwen3TtsCrispAsr : ITtsEngine
     private static bool _voiceSeedAttempted;
 
     /// <summary>
-    /// One-time best-effort copy of WAV reference voices from the existing qwen3-tts.cpp
-    /// engine's voices folder. The same files work for both engines (just 24 kHz mono
-    /// reference audio with optional .txt sidecars), so users who already downloaded the
-    /// qwen3-tts.cpp voice pack get them for free here without a second ~10 MB download.
-    /// Users who never installed qwen3-tts.cpp get voices.zip pulled by the
-    /// DownloadTtsViewModel flow that chains after model download.
+    /// One-time best-effort seeding of reference voices from the existing qwen3-tts.cpp engine's
+    /// voices folder, so users who already have that voice pack get the WAVs here for free. The
+    /// Base (Voice clone) backend strictly requires a 24 kHz mono reference, so each WAV is
+    /// resampled on the way in rather than plain-copied (the qwen3-tts.cpp pack ships 22.05/48 kHz
+    /// clips). The .txt sidecars in that pack are Wikimedia attribution blurbs, NOT spoken
+    /// transcriptions — feeding them as ref-text produces runaway, off-voice output — so they are
+    /// deliberately NOT copied. Cloning a seeded voice prompts for the real transcript via the
+    /// Speak pre-check / re-import flow. Users who never installed qwen3-tts.cpp get voices.zip
+    /// pulled by the DownloadTtsViewModel flow that chains after model download.
     /// </summary>
     private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
     {
@@ -297,21 +300,23 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
-                if (!File.Exists(dest))
+                if (File.Exists(dest))
                 {
-                    File.Copy(src, dest);
+                    continue;
                 }
 
-                // Copy the matching .txt sidecar too (CrispASR uses it as the reference
-                // transcription for CustomVoice cloning).
-                var sidecar = Path.ChangeExtension(src, ".txt");
-                if (File.Exists(sidecar))
+                try
                 {
-                    var sidecarDest = Path.ChangeExtension(dest, ".txt");
-                    if (!File.Exists(sidecarDest))
+                    // Resample to 24 kHz mono — the Base backend rejects any other rate.
+                    var process = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
+                    if (process.Start())
                     {
-                        File.Copy(sidecar, sidecarDest);
+                        process.WaitForExit();
                     }
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, $"Qwen3 TTS (CrispASR): failed to resample seeded voice {Path.GetFileName(src)}");
                 }
             }
         }

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -24,10 +24,14 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// comparison engine since CrispASR's qwen3-tts backends emit EOS reliably on short prompts
 /// where qwen3-tts.cpp 0.6B doesn't (see PR investigation notes from May 2026).
 ///
-/// Two CrispASR sub-backends are wired up:
+/// Three CrispASR sub-backends are wired up, one per model key:
 ///  - qwen3-tts-1.7b-voicedesign — VoiceDesign model, requires an `instructions` field
 ///    per request (free-text voice description, e.g. "a calm female voice").
-///  - qwen3-tts-1.7b-customvoice — voice cloning, takes a reference WAV + transcription.
+///  - qwen3-tts-1.7b-customvoice — picks one of nine fixed speakers baked into the GGUF by
+///    name (e.g. "vivian"); does NOT clone and ignores any reference WAV.
+///  - qwen3-tts-1.7b-base — runtime ICL voice cloning from an imported reference WAV plus its
+///    transcript (the <name>.txt sidecar the backend auto-loads as ref-text). This is the
+///    model the "1.7B Voice clone" key maps to.
 ///
 /// The 1.7B VoiceDesign talker GGUF is the same file the qwen3-tts.cpp engine uses (cstr's
 /// upload, new tensor names). The CrispASR-style codec/tokenizer GGUF is a different file
@@ -46,11 +50,25 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
     public const string ModelKeyVoiceDesign = "1.7B VoiceDesign";
     public const string ModelKeyCustomVoice = "1.7B CustomVoice";
+    public const string ModelKeyClone = "1.7B Voice clone";
     public const string DefaultModelKey = ModelKeyVoiceDesign;
 
     public const string VoiceDesignTalkerFileName = "qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf";
     public const string CustomVoiceTalkerFileName = "qwen3-tts-12hz-1.7b-customvoice-q8_0.gguf";
+    public const string BaseTalkerFileName = "qwen3-tts-12hz-1.7b-base-q8_0.gguf";
     public const string CodecFileName = "qwen3-tts-tokenizer-12hz.gguf";
+
+    /// <summary>
+    /// The nine fixed speakers baked into the CustomVoice talker GGUF, in the order the model
+    /// exposes them (first entry, <c>aiden</c>, is the backend's default when none is picked).
+    /// CustomVoice selects one of these by name via the request's <c>voice</c> field — it does
+    /// NOT clone from a reference WAV (that is what <see cref="ModelKeyClone"/> / the Base
+    /// backend does). Names must match the GGUF metadata exactly; they are sent verbatim.
+    /// </summary>
+    public static readonly string[] CustomVoiceSpeakers =
+    {
+        "aiden", "dylan", "eric", "ono_anna", "ryan", "serena", "sohee", "uncle_fu", "vivian",
+    };
 
     // Exact byte size of each GGUF on cstr's HuggingFace repos (X-Linked-Size). Used to reject
     // truncated files that crispasr's own --auto-download may have left behind in ~/.cache/crispasr/
@@ -64,6 +82,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
     {
         [VoiceDesignTalkerFileName] = 2042225536L,
         [CustomVoiceTalkerFileName] = 2042225952L,
+        [BaseTalkerFileName] = 2066258176L,
         [CodecFileName] = 358453280L,
     };
 
@@ -97,33 +116,57 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
     public static string ResolveModelKey(string? modelKey)
     {
-        if (string.IsNullOrEmpty(modelKey))
-        {
-            var saved = Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel;
-            return string.IsNullOrEmpty(saved) ? DefaultModelKey : saved;
-        }
+        var key = string.IsNullOrEmpty(modelKey)
+            ? Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel
+            : modelKey;
 
-        return modelKey == ModelKeyCustomVoice ? ModelKeyCustomVoice : ModelKeyVoiceDesign;
+        if (key == ModelKeyCustomVoice)
+        {
+            return ModelKeyCustomVoice;
+        }
+        if (key == ModelKeyClone)
+        {
+            return ModelKeyClone;
+        }
+        return ModelKeyVoiceDesign;
     }
 
     public static string GetTalkerFileName(string? modelKey) =>
-        ResolveModelKey(modelKey) == ModelKeyCustomVoice ? CustomVoiceTalkerFileName : VoiceDesignTalkerFileName;
+        ResolveModelKey(modelKey) switch
+        {
+            ModelKeyCustomVoice => CustomVoiceTalkerFileName,
+            ModelKeyClone => BaseTalkerFileName,
+            _ => VoiceDesignTalkerFileName,
+        };
 
     /// <summary>
-    /// CrispASR sub-backend name matching <paramref name="modelKey"/>.
-    /// VoiceDesign → qwen3-tts-1.7b-voicedesign, CustomVoice → qwen3-tts-1.7b-customvoice.
+    /// CrispASR sub-backend name matching <paramref name="modelKey"/>:
+    /// VoiceDesign → qwen3-tts-1.7b-voicedesign, CustomVoice → qwen3-tts-1.7b-customvoice,
+    /// Voice clone → qwen3-tts-1.7b-base (the ICL voice-cloning backend).
     /// </summary>
     public static string GetBackendName(string? modelKey) =>
-        ResolveModelKey(modelKey) == ModelKeyCustomVoice
-            ? "qwen3-tts-1.7b-customvoice"
-            : "qwen3-tts-1.7b-voicedesign";
+        ResolveModelKey(modelKey) switch
+        {
+            ModelKeyCustomVoice => "qwen3-tts-1.7b-customvoice",
+            ModelKeyClone => "qwen3-tts-1.7b-base",
+            _ => "qwen3-tts-1.7b-voicedesign",
+        };
 
     /// <summary>
     /// True when the resolved model is the instruction-tuned VoiceDesign variant. Only this
-    /// model honours the voice instruction; CustomVoice ignores it and uses voice cloning.
+    /// model honours the voice instruction; CustomVoice picks a fixed speaker and the Base
+    /// (Voice clone) model clones from a reference WAV.
     /// </summary>
     public static bool IsVoiceDesignModel(string? modelKey) =>
         ResolveModelKey(modelKey) == ModelKeyVoiceDesign;
+
+    /// <summary>
+    /// True when the resolved model is the Base talker used for runtime voice cloning. This is
+    /// the only model that consumes an imported reference WAV (plus its <c>.txt</c> transcript);
+    /// CustomVoice and VoiceDesign ignore imported voices.
+    /// </summary>
+    public static bool IsCloneModel(string? modelKey) =>
+        ResolveModelKey(modelKey) == ModelKeyClone;
 
     private static readonly HttpClient HttpClient = new()
     {
@@ -343,16 +386,32 @@ public class Qwen3TtsCrispAsr : ITtsEngine
     public Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
-
-        // VoiceDesign has a baked default voice (the instruction string drives the rest).
-        // CustomVoice is pure voice cloning and refuses requests without a reference WAV,
-        // so don't offer a "Default" entry there — the user must import a voice first.
         var modelKey = ResolveModelKey(Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel);
+
         if (modelKey == ModelKeyVoiceDesign)
         {
+            // VoiceDesign has no speaker encoder — the instruction string drives the voice, so
+            // a single "Default" entry is all the combo needs.
             result.Add(new Voice(new Qwen3TtsVoice("Default", string.Empty)));
+            return Task.FromResult(result.ToArray());
         }
 
+        if (modelKey == ModelKeyCustomVoice)
+        {
+            // CustomVoice picks one of the fixed speakers baked into the GGUF, selected by name.
+            // The on-disk reference WAVs in the voices folder belong to the Voice clone (Base)
+            // model, not here — sending a WAV path to CustomVoice just makes the backend fall
+            // back to its first speaker. FilePath stays empty: Speak sends Voice (the name).
+            foreach (var speaker in CustomVoiceSpeakers)
+            {
+                result.Add(new Voice(new Qwen3TtsVoice(speaker, string.Empty)));
+            }
+            return Task.FromResult(result.ToArray());
+        }
+
+        // Voice clone (Base): list the imported reference WAVs. Voice cloning refuses requests
+        // without a reference, so there is no "Default" entry — the user must import a voice
+        // (with its transcript) first.
         var voicesFolder = GetSetVoicesFolder();
         if (Directory.Exists(voicesFolder))
         {
@@ -370,7 +429,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
     public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
 
-    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyVoiceDesign, ModelKeyCustomVoice });
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyVoiceDesign, ModelKeyCustomVoice, ModelKeyClone });
 
     public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
 
@@ -393,15 +452,27 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
         var modelKey = ResolveModelKey(model);
 
-        // CustomVoice does voice cloning and rejects requests without a `voice` field.
-        // Surface a clear up-front error instead of letting the backend return 500.
-        if (modelKey == ModelKeyCustomVoice && string.IsNullOrEmpty(qwen3Voice.FilePath))
+        // Voice clone (Base) needs a reference WAV plus its transcript. The backend resolves the
+        // bare voice name against --voice-dir and auto-loads the matching <name>.txt as ref-text;
+        // without that transcript it returns "ref-text not set" (HTTP 500). Surface both gaps
+        // up-front with an actionable message instead of an opaque server error.
+        if (modelKey == ModelKeyClone)
         {
-            throw new InvalidOperationException(
-                "Qwen3 TTS (CrispASR) CustomVoice requires a reference voice WAV. "
-                + "Import one via the voice settings, then pick it in the voice combo. "
-                + "Reference WAV should be 24 kHz mono; an adjacent .txt file with the "
-                + "spoken transcription is required for best cloning quality.");
+            if (string.IsNullOrEmpty(qwen3Voice.FilePath))
+            {
+                throw new InvalidOperationException(
+                    "Qwen3 TTS (CrispASR) voice cloning requires a reference voice. "
+                    + "Import one via the voice settings (you'll be asked for its transcript), "
+                    + "then pick it in the voice combo.");
+            }
+
+            var transcriptPath = Path.ChangeExtension(qwen3Voice.FilePath, ".txt");
+            if (!File.Exists(transcriptPath) || string.IsNullOrWhiteSpace(File.ReadAllText(transcriptPath)))
+            {
+                throw new InvalidOperationException(
+                    $"Qwen3 TTS (CrispASR) voice cloning needs the spoken transcription of '{qwen3Voice.Voice}'. "
+                    + "Re-import the voice and enter the exact words spoken in the reference WAV.");
+            }
         }
 
         await EnsureServerRunningAsync(modelKey, cancellationToken);
@@ -412,33 +483,39 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         // regardless of which Qwen3 engine they're testing with.
         var instruction = Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction ?? string.Empty;
 
-        // OpenAI-compatible /v1/audio/speech payload. CrispASR's qwen3-tts backends look at:
-        //   - `input`             — the text to synthesise
-        //   - `response_format`   — "wav"
-        //   - `voice`             — absolute WAV path or filename in --voice-dir
-        //                           (required for CustomVoice; ignored by VoiceDesign)
-        //   - `instructions`      — free-text style/voice description
-        //                           (required for VoiceDesign; ignored by CustomVoice)
+        // OpenAI-compatible /v1/audio/speech payload. The crispasr backend interprets `voice`
+        // differently per model (see crispasr_backend_qwen3_tts.cpp):
+        //   - Voice clone (Base): `voice` is a BARE name (no path, no extension) resolved against
+        //     --voice-dir to <name>.wav + the auto-loaded <name>.txt transcript. Sending the
+        //     absolute path instead skips the sidecar load and fails — so send the basename only.
+        //   - CustomVoice: `voice` is a fixed SPEAKER NAME (e.g. "vivian"); a .wav value would
+        //     make the backend silently fall back to its first speaker.
+        //   - VoiceDesign: ignores `voice`; the voice comes from `instructions`.
         var payload = new Dictionary<string, object>
         {
             ["input"] = inputText,
             ["response_format"] = "wav",
         };
-        if (!string.IsNullOrEmpty(qwen3Voice.FilePath))
+        if (modelKey == ModelKeyClone && !string.IsNullOrEmpty(qwen3Voice.FilePath))
         {
-            payload["voice"] = qwen3Voice.FilePath;
-            // CustomVoice cloning is gated behind a consent attestation (CrispASR v0.7.0 returns
-            // HTTP 400 consent_required without it). The user supplies their own reference voice
-            // by importing a WAV into SE, which is the act being attested here. VoiceDesign (no
-            // FilePath) does not clone, so it doesn't need this.
+            payload["voice"] = Path.GetFileNameWithoutExtension(qwen3Voice.FilePath);
+            // The reference is the user's own imported WAV — attest consent so the request also
+            // works against CrispASR builds that gate cloning on it.
             payload["consent_attestation"] = "I have the speaker's consent, or it is my own voice.";
             // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
             // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA
             // provenance metadata stay embedded regardless (defaults to true server-side).
             payload["spoken_disclaimer"] = false;
         }
-        if (!string.IsNullOrEmpty(instruction))
+        else if (modelKey == ModelKeyCustomVoice && !string.IsNullOrEmpty(qwen3Voice.Voice))
         {
+            payload["voice"] = qwen3Voice.Voice;
+        }
+
+        if (modelKey != ModelKeyClone && !string.IsNullOrEmpty(instruction))
+        {
+            // VoiceDesign treats this as the voice description; CustomVoice as optional style.
+            // The Base clone model has no instruct path, so don't send it there.
             payload["instructions"] = instruction;
         }
         else if (modelKey == ModelKeyVoiceDesign)
@@ -777,7 +854,16 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         return candidate;
     }
 
-    public bool ImportVoice(string fileName)
+    public bool ImportVoice(string fileName) => ImportVoiceInternal(fileName, null);
+
+    /// <summary>
+    /// Imports a reference voice for the Base (Voice clone) model, writing the supplied
+    /// <paramref name="transcript"/> as the <c>.txt</c> sidecar the backend needs as ref-text.
+    /// Used by the voice-settings dialog, which prompts for the transcription on import.
+    /// </summary>
+    public bool ImportVoice(string fileName, string transcript) => ImportVoiceInternal(fileName, transcript);
+
+    private bool ImportVoiceInternal(string fileName, string? transcript)
     {
         if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
         {
@@ -788,9 +874,9 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         var baseName = Path.GetFileNameWithoutExtension(fileName);
         var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
 
-        // CrispASR's qwen3-tts CustomVoice backend expects a 24 kHz mono reference WAV.
-        // Always resample on import via ffmpeg so the saved file is in the right shape
-        // regardless of what the user picked.
+        // CrispASR's qwen3-tts backend expects a 24 kHz mono reference WAV. Always resample on
+        // import via ffmpeg so the saved file is in the right shape regardless of what the user
+        // picked.
         try
         {
             var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
@@ -812,16 +898,20 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             return false;
         }
 
-        // CustomVoice voice cloning expects a matching .txt sidecar holding the spoken
-        // transcription of the reference WAV. If the source had one (same basename, .txt),
-        // copy it alongside the imported WAV under the de-duplicated destination name.
+        // Voice cloning needs a matching .txt sidecar holding the spoken transcription of the
+        // reference WAV (the backend auto-loads it as ref-text). Prefer the transcript the user
+        // typed in the import dialog; fall back to copying a sibling .txt next to the source.
         try
         {
-            var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
-            if (File.Exists(sourceSidecar))
+            var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+            if (!string.IsNullOrWhiteSpace(transcript))
             {
-                var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
-                if (!File.Exists(destSidecar))
+                File.WriteAllText(destSidecar, transcript.Trim());
+            }
+            else
+            {
+                var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+                if (File.Exists(sourceSidecar) && !File.Exists(destSidecar))
                 {
                     File.Copy(sourceSidecar, destSidecar);
                 }
@@ -829,10 +919,9 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         }
         catch (Exception ex)
         {
-            // Sidecar copy is best-effort — log and continue. The imported WAV alone is
-            // still usable; CustomVoice quality drops without the transcription but it
-            // doesn't fail outright.
-            Se.LogError(ex, "Qwen3 TTS (CrispASR) voice import: failed to copy .txt sidecar");
+            // Sidecar write is best-effort — log and continue. The imported WAV is still saved;
+            // Speak surfaces a clear error if the transcript is missing when cloning.
+            Se.LogError(ex, "Qwen3 TTS (CrispASR) voice import: failed to write .txt sidecar");
         }
 
         return true;

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
@@ -41,6 +41,9 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
     [ObservableProperty] private string _customVoiceTalkerLabel = string.Empty;
     [ObservableProperty] private IBrush _customVoiceTalkerBrush = Grey();
 
+    [ObservableProperty] private string _cloneTalkerLabel = string.Empty;
+    [ObservableProperty] private IBrush _cloneTalkerBrush = Grey();
+
     [ObservableProperty] private string _codecLabel = string.Empty;
     [ObservableProperty] private IBrush _codecBrush = Grey();
 
@@ -134,6 +137,11 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
         ApplyModelStatus(File.Exists(customVoicePath), IsEngineInstalled,
             label => CustomVoiceTalkerLabel = label,
             brush => CustomVoiceTalkerBrush = brush);
+
+        var clonePath = Qwen3TtsCrispAsr.GetTalkerPath(Qwen3TtsCrispAsr.ModelKeyClone);
+        ApplyModelStatus(File.Exists(clonePath), IsEngineInstalled,
+            label => CloneTalkerLabel = label,
+            brush => CloneTalkerBrush = brush);
 
         var codecPath = Qwen3TtsCrispAsr.GetCodecPath();
         ApplyModelStatus(File.Exists(codecPath), IsEngineInstalled,

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
@@ -104,6 +104,7 @@ public class Qwen3TtsCrispAsrSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 12,
             RowSpacing = 10,
@@ -124,19 +125,22 @@ public class Qwen3TtsCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel("1.7B CustomVoice"), 2, 0);
         grid.Add(MakeStatusPanel(nameof(vm.CustomVoiceTalkerBrush), nameof(vm.CustomVoiceTalkerLabel)), 2, 1);
 
-        grid.Add(MakeLabel("Codec (12 Hz)"), 3, 0);
-        grid.Add(MakeStatusPanel(nameof(vm.CodecBrush), nameof(vm.CodecLabel)), 3, 1);
+        grid.Add(MakeLabel("1.7B Voice clone"), 3, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CloneTalkerBrush), nameof(vm.CloneTalkerLabel)), 3, 1);
 
-        grid.Add(MakeLabel("Voices"), 4, 0);
+        grid.Add(MakeLabel("Codec (12 Hz)"), 4, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CodecBrush), nameof(vm.CodecLabel)), 4, 1);
+
+        grid.Add(MakeLabel("Voices"), 5, 0);
         var voicesText = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,
             FontWeight = FontWeight.SemiBold,
             [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
         };
-        grid.Add(voicesText, 4, 1);
+        grid.Add(voicesText, 5, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 5, 0);
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 6, 0);
         var folderText = new TextBox
         {
             IsReadOnly = true,
@@ -148,7 +152,7 @@ public class Qwen3TtsCrispAsrSettingsWindow : Window
             FontSize = 12,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
-        grid.Add(folderText, 5, 1);
+        grid.Add(folderText, 6, 1);
 
         return new Border
         {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -485,8 +485,9 @@ public partial class TextToSpeechViewModel : ObservableObject
         UpdateVoiceLock();
 
         // Qwen3 (CrispASR) returns a different voice list per model — VoiceDesign exposes
-        // "Default", CustomVoice only shows imported WAVs since it can't synthesise without
-        // a reference. Persist the model change first so GetVoices reads the new value, then
+        // "Default", CustomVoice exposes the nine fixed built-in speakers, and Voice clone
+        // lists the imported reference WAVs. Persist the model change first so GetVoices reads
+        // the new value, then
         // re-pull the voice list. Wrap the fire-and-forget in a try/catch so any throw doesn't
         // surface later as an unobserved task exception; the worst case is the combo keeps
         // showing the old voice list.

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -159,6 +159,32 @@ public partial class VoiceSettingsViewModel : ObservableObject
 
             ok = f5Engine.ImportVoice(fileName, result.Text.Trim());
         }
+        else if (_engine is Qwen3TtsCrispAsr qwenCrispEngine)
+        {
+            // The Qwen3 (CrispASR) "Voice clone" (Base) model needs the spoken transcription of
+            // the reference WAV — the backend loads it as ref-text and errors without it. Always
+            // prompt (matching CosyVoice3), autofilling from a sibling .txt, with the STT helper.
+            var transcript = TryReadSiblingTranscript(fileName) ?? string.Empty;
+            var audioFileName = fileName;
+            var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window!, vm =>
+            {
+                vm.Initialize(
+                    Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
+                    transcript,
+                    500,
+                    150);
+                vm.ConfigureExtraButton(
+                    Se.Language.Video.TextToSpeech.UseSpeechToTextDotDotDot,
+                    () => RunSpeechToTextAsync(audioFileName));
+            });
+
+            if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text))
+            {
+                return;
+            }
+
+            ok = qwenCrispEngine.ImportVoice(fileName, result.Text.Trim());
+        }
         else if (_engine is VoxCPM2CrispAsr voxEngine)
         {
             // VoxCPM2 clones zero-shot from audio alone; a transcription (ref-text) is optional

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -118,6 +118,7 @@ public static class DownloadHashManager
         // each key holds a single hash rather than a release-pinned list.
         public const string VoiceDesignTalker = "Qwen3TtsCrispAsr.VoiceDesignTalker";
         public const string CustomVoiceTalker = "Qwen3TtsCrispAsr.CustomVoiceTalker";
+        public const string BaseTalker = "Qwen3TtsCrispAsr.BaseTalker";
         public const string Codec = "Qwen3TtsCrispAsr.Codec";
     }
 
@@ -667,6 +668,11 @@ public static class DownloadHashManager
             [Qwen3TtsCrispAsr.VoiceDesignTalker] = new[]
             {
                 "ce9c6d69146891f7854ac46be3bf4e40f803fbebbfe7cdbd12ae3a4b24777295", // qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf
+            },
+            // HF LFS oid (= SHA-256) for cstr/qwen3-tts-1.7b-base-GGUF.
+            [Qwen3TtsCrispAsr.BaseTalker] = new[]
+            {
+                "bbb93ab1f4a3f771f94fc6f68404b2b969bdf3b14c6303473dbf64c63011520d", // qwen3-tts-12hz-1.7b-base-q8_0.gguf
             },
             [Qwen3TtsCrispAsr.Codec] = new[]
             {

--- a/src/ui/Logic/Download/Qwen3TtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3TtsCrispAsrDownloadService.cs
@@ -19,9 +19,10 @@ public interface IQwen3TtsCrispAsrDownloadService
 /// ~/.cache/crispasr/. Keeping models inside SE's data folder means uninstalling SE removes them,
 /// portable installs stay self-contained, and the engine settings dialog can report accurate sizes.
 ///
-/// Three files are tracked:
+/// Talker GGUFs are tracked per model, sharing one codec:
 ///  - VoiceDesign talker  : qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf (cstr's HF upload)
 ///  - CustomVoice talker  : qwen3-tts-12hz-1.7b-customvoice-q8_0.gguf (cstr's HF upload)
+///  - Base talker (clone) : qwen3-tts-12hz-1.7b-base-q8_0.gguf (cstr's HF upload)
 ///  - 12 Hz codec/tokenizer: qwen3-tts-tokenizer-12hz.gguf (distinct from qwen3-tts.cpp's q8_0 tokenizer)
 ///
 /// If a file already lives in ~/.cache/crispasr/ from an earlier crispasr auto-download the engine's
@@ -38,6 +39,8 @@ public class Qwen3TtsCrispAsrDownloadService : IQwen3TtsCrispAsrDownloadService
             "https://huggingface.co/cstr/qwen3-tts-1.7b-voicedesign-GGUF/resolve/main/qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf",
         [Qwen3TtsCrispAsr.CustomVoiceTalkerFileName] =
             "https://huggingface.co/cstr/qwen3-tts-1.7b-customvoice-GGUF/resolve/main/qwen3-tts-12hz-1.7b-customvoice-q8_0.gguf",
+        [Qwen3TtsCrispAsr.BaseTalkerFileName] =
+            "https://huggingface.co/cstr/qwen3-tts-1.7b-base-GGUF/resolve/main/qwen3-tts-12hz-1.7b-base-q8_0.gguf",
         [Qwen3TtsCrispAsr.CodecFileName] =
             "https://huggingface.co/cstr/qwen3-tts-tokenizer-12hz-GGUF/resolve/main/qwen3-tts-tokenizer-12hz.gguf",
     };
@@ -131,6 +134,10 @@ public class Qwen3TtsCrispAsrDownloadService : IQwen3TtsCrispAsrDownloadService
         if (string.Equals(fileName, Qwen3TtsCrispAsr.CustomVoiceTalkerFileName, StringComparison.OrdinalIgnoreCase))
         {
             return DownloadHashManager.Qwen3TtsCrispAsr.CustomVoiceTalker;
+        }
+        if (string.Equals(fileName, Qwen3TtsCrispAsr.BaseTalkerFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Qwen3TtsCrispAsr.BaseTalker;
         }
         if (string.Equals(fileName, Qwen3TtsCrispAsr.CodecFileName, StringComparison.OrdinalIgnoreCase))
         {


### PR DESCRIPTION
## Problem

The **Qwen3 TTS (CrispASR)** "1.7B CustomVoice" model was presented as voice cloning, but it never used the cloned voice.

Root cause: the crispasr `qwen3-tts-1.7b-customvoice` backend does **not** clone — it selects one of nine **fixed speakers** baked into the GGUF, chosen by name (`vivian`, `ryan`, …). SE was sending the imported reference WAV's **absolute path** as the request's `voice` field. The backend treats a `.wav` value as an invalid speaker name and silently falls back to its first speaker (`aiden`), so synthesis produced a generic voice, not the clone.

The actual voice-clone-from-WAV backend is `qwen3-tts-1.7b-base` (ICL cloning from a reference WAV + its transcript), which SE didn't wire up.

## Changes

Both features are now available, each mapped to the correct backend:

- **New "1.7B Voice clone" model** → `qwen3-tts-1.7b-base`. Real ICL cloning from an imported reference WAV + transcript.
  - Download wiring, byte-size guard, and SHA-256 for `qwen3-tts-12hz-1.7b-base-q8_0.gguf` (reuses the existing 12 Hz codec, so it's just the one talker file).
  - Sends the **bare voice name** (not the absolute path) so the server resolves `<voice-dir>/<name>.wav` and auto-loads `<name>.txt` as ref-text.
  - Cloning errors without a transcript, so the import flow now **prompts for the transcription** (sibling-`.txt` autofill + speech-to-text helper, matching CosyVoice3/F5) and writes the sidecar. `Speak()` surfaces a clear up-front error if the WAV or transcript is missing.
- **CustomVoice fixed** → now lists the nine real built-in speakers (`aiden`, `dylan`, `eric`, `ono_anna`, `ryan`, `serena`, `sohee`, `uncle_fu`, `vivian`) and sends the speaker name instead of a WAV path.
- Settings dialog shows install status for the new Base talker.

## Notes / migration

- Existing users on "1.7B CustomVoice" stay on it (now the built-in-speaker model). To clone an imported voice, pick **"1.7B Voice clone"** — this downloads the ~1.9 GB base talker on first use.
- Voices imported before this change have no transcript sidecar; re-import (or add a `<name>.txt`) to use them for cloning.

Related: SubtitleEdit/subtitleedit#10068

## Testing

- `dotnet build src/ui/UI.csproj` — clean (0 warnings, 0 errors).
- Backend semantics, the `voice`-field resolution, the `--voice-dir`/`.txt` auto-load, and the base GGUF size/SHA were verified against the CrispASR source (`crispasr_backend_qwen3_tts.cpp`, `crispasr_model_registry.cpp`) and HuggingFace metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)