### PR TITLE
Fix UI freeze on layout change (#11585)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -813,13 +813,20 @@ public partial class MainViewModel :
 
         if (vm.OkPressed && vm.SelectedLayout != null && vm.SelectedLayout != Se.Settings.General.LayoutNumber)
         {
-            if (AreVideoControlsUndocked)
+            // Defer to a fresh dispatcher cycle: SetLayout rebuilds the layout, which destroys and
+            // recreates the video player control (a native Win32 HWND on Windows with mpv-wid/VLC).
+            // Doing that inside the ShowDialog continuation races the modal dialog's teardown and can
+            // leave the main window disabled - a full UI freeze (#11585; same cause and fix as #10815).
+            Dispatcher.UIThread.Post(() =>
             {
-                VideoRedockControls();
-            }
+                if (AreVideoControlsUndocked)
+                {
+                    VideoRedockControls();
+                }
 
-            SetLayout(vm.SelectedLayout.Value);
-            AutoFitColumns();
+                SetLayout(vm.SelectedLayout.Value);
+                AutoFitColumns();
+            });
         }
     }
 


### PR DESCRIPTION
Fixes #11585

## Problem

Changing the layout freezes the main window. Per the reporter: with a subtitle loaded it *always* hangs; with nothing loaded it hangs intermittently (after a session in which a subtitle was loaded).

## Root cause

`CommandShowLayout` rebuilds the layout **inside the `await ShowDialogAsync` continuation**. `SetLayout` rebuilds the content, which destroys and recreates the video player control (a native Win32 HWND on Windows with mpv-wid/VLC). Doing that inside the modal dialog's continuation races the dialog's teardown and can leave the main window disabled - a full UI freeze.

This is exactly the cause and fix documented for the Settings-OK path in #10815; the Layout dialog path was simply never given the same treatment. It matches the repro: the freeze is reliable once a native video player exists (subtitle/video context), and intermittent otherwise.

## Fix

Defer the rebuild to a fresh dispatcher cycle (`Dispatcher.UIThread.Post(...)`) so it runs after the dialog finishes tearing down - the same one-line idiom already used for #10815.

## Verification

- Builds clean (0 warnings / 0 errors).
- Mirrors the merged #10815 fix for the identical pattern in a sibling code path.
- I don't have a Windows GUI to watch the freeze disappear directly, so I also produced a portable Windows test build from this branch for the reporter to confirm against the exact repro before merge. Happy to scope the defer differently (e.g. only the SetLayout call) if you prefer.