### PR TITLE
Add subtitle grid text fit setting: clip / wrap / ellipsis (#11590)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using AvaloniaEdit;
 using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Features.Options.Settings;
 using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -118,6 +119,9 @@ public static partial class InitListViewAndEditBox
         var nullToOpacityConverter = new NullToOpacityConverter();
         var syntaxHighlightingConverter = new TextWithSubtitleSyntaxHighlightingConverter();
         vm.SubtitleDataGridSyntaxHighlighting = syntaxHighlightingConverter;
+        // How the Text/Original cells fit their text to the window (feature #11590). Read once here;
+        // the grid is rebuilt when settings are applied, so a changed mode takes effect then.
+        var gridTextDisplayMode = SubtitleGridTextDisplayModeDisplay.FromSettings();
         var gapConverter = new DoubleToDisplayShortConverter();
         var inverseBooleanConverter = new InverseBooleanConverter();
         var textOneLineShortConverter = new TextOneLineShortConverter();
@@ -300,9 +304,9 @@ public static partial class InitListViewAndEditBox
                 var textBlock = new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Center,
-                    TextWrapping = TextWrapping.NoWrap,
                     [!TextBlock.InlinesProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = syntaxHighlightingConverter, Mode = BindingMode.OneWay },
                 };
+                SubtitleGridTextDisplayModeDisplay.ApplyTo(textBlock, gridTextDisplayMode);
 
                 if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
                 {
@@ -331,9 +335,9 @@ public static partial class InitListViewAndEditBox
                 var textBlock = new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Center,
-                    TextWrapping = TextWrapping.NoWrap,
                     [!TextBlock.InlinesProperty] = new Binding(nameof(SubtitleLineViewModel.OriginalText)) { Converter = syntaxHighlightingConverter, Mode = BindingMode.OneWay },
                 };
+                SubtitleGridTextDisplayModeDisplay.ApplyTo(textBlock, gridTextDisplayMode);
 
                 if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
                 {

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -665,6 +665,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.SubtitleGridTextSingleLine, nameof(_vm.SubtitleGridTextSingleLine)),
             new SettingsItem(Se.Language.Options.Settings.SubtitleGridTextSingleLineSeparator,
                 () => UiUtil.MakeTextBox(150, _vm, nameof(_vm.SubtitleGridTextSingleLineSeparator))),
+            new SettingsItem(Se.Language.Options.Settings.SubtitleGridTextDisplay, () => UiUtil.MakeComboBox(_vm.SubtitleGridTextDisplayModes, _vm, nameof(_vm.SelectedSubtitleGridTextDisplayMode))),
             new SettingsItem(Se.Language.Options.Settings.SubtitleGridShowFormatting, () => UiUtil.MakeComboBox(_vm.SubtitleGridFormattings, _vm, nameof(_vm.SubtitleGridFormatting))),
             MakeCheckboxSetting(Se.Language.Options.Settings.SubtitleGridLiveSpellCheck, nameof(_vm.SubtitleGridLiveSpellCheck)),
             MakeNumericSetting(Se.Language.Options.Settings.TextBoxFontSize, nameof(_vm.TextBoxFontSize)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -308,6 +308,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _showHorizontalLineAboveToolbar;
     [ObservableProperty] private ObservableCollection<GridLinesVisibilityDisplay> _gridLinesVisibilities;
     [ObservableProperty] private GridLinesVisibilityDisplay _selectedGridLinesVisibility;
+    [ObservableProperty] private ObservableCollection<SubtitleGridTextDisplayModeDisplay> _subtitleGridTextDisplayModes;
+    [ObservableProperty] private SubtitleGridTextDisplayModeDisplay _selectedSubtitleGridTextDisplayMode;
     [ObservableProperty] private Color _darkModeForegroundColor;
     [ObservableProperty] private Color _darkModeBackgroundColor;
     [ObservableProperty] private bool _useFocusedButtonBackgroundColor;
@@ -547,6 +549,9 @@ public partial class SettingsViewModel : ObservableObject
         GridLinesVisibilities = new ObservableCollection<GridLinesVisibilityDisplay>(GridLinesVisibilityDisplay.GetAll());
         SelectedGridLinesVisibility = GridLinesVisibilities[0];
 
+        SubtitleGridTextDisplayModes = new ObservableCollection<SubtitleGridTextDisplayModeDisplay>(SubtitleGridTextDisplayModeDisplay.GetAll());
+        SelectedSubtitleGridTextDisplayMode = SubtitleGridTextDisplayModes[0];
+
         ErrorColor = Color.FromArgb(50, 255, 0, 0);
         ColorTextTooWideFontName = "Arial";
 
@@ -757,6 +762,7 @@ public partial class SettingsViewModel : ObservableObject
         ShowAssaLayer = appearance.ShowLayer;
         ShowHorizontalLineAboveToolbar = appearance.ShowHorizontalLineAboveToolbar;
         SelectedGridLinesVisibility = GridLinesVisibilities.FirstOrDefault(p => p.Type.ToString() == appearance.GridLinesAppearance) ?? GridLinesVisibilities[0];
+        SelectedSubtitleGridTextDisplayMode = SubtitleGridTextDisplayModes.FirstOrDefault(p => p.Mode.ToString() == appearance.SubtitleGridTextDisplay) ?? SubtitleGridTextDisplayModes[0];
         DarkModeBackgroundColor = appearance.DarkModeBackgroundColor.FromHexToColor();
         DarkModeForegroundColor = appearance.DarkModeForegroundColor.FromHexToColor();
         UseFocusedButtonBackgroundColor = appearance.UseFocusedButtonBackgroundColor;
@@ -1471,6 +1477,7 @@ public partial class SettingsViewModel : ObservableObject
         appearance.GridCompactMode = GridCompactMode;
         appearance.GridAlternatingRows = GridAlternatingRows;
         appearance.GridLinesAppearance = SelectedGridLinesVisibility.Type.ToString();
+        appearance.SubtitleGridTextDisplay = SelectedSubtitleGridTextDisplayMode.Mode.ToString();
         appearance.ShowLayer = ShowAssaLayer;
         appearance.ShowHorizontalLineAboveToolbar = ShowHorizontalLineAboveToolbar;
 

--- a/src/ui/Features/Options/Settings/SubtitleGridTextDisplayModeDisplay.cs
+++ b/src/ui/Features/Options/Settings/SubtitleGridTextDisplayModeDisplay.cs
@@ -1,0 +1,77 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Options.Settings;
+
+/// <summary>
+/// How the subtitle grid renders the Text / Original text columns so the visible text can
+/// adapt to the window size (feature request #11590).
+/// </summary>
+public enum SubtitleGridTextDisplayMode
+{
+    /// <summary>Current behaviour: text is not wrapped; long lines are clipped at the column edge.</summary>
+    Clip,
+
+    /// <summary>Text wraps within the column to the window width; rows grow to show the full text.</summary>
+    Wrap,
+
+    /// <summary>One line, truncated with an ellipsis that adapts to the column (window) width.</summary>
+    Ellipsis,
+}
+
+public class SubtitleGridTextDisplayModeDisplay
+{
+    public SubtitleGridTextDisplayMode Mode { get; }
+    public string DisplayName { get; }
+
+    public SubtitleGridTextDisplayModeDisplay(SubtitleGridTextDisplayMode mode, string displayName)
+    {
+        Mode = mode;
+        DisplayName = displayName;
+    }
+
+    public override string ToString() => DisplayName;
+
+    public static SubtitleGridTextDisplayModeDisplay[] GetAll()
+    {
+        return
+        [
+            new SubtitleGridTextDisplayModeDisplay(SubtitleGridTextDisplayMode.Clip, Se.Language.Options.Settings.SubtitleGridTextDisplayClip),
+            new SubtitleGridTextDisplayModeDisplay(SubtitleGridTextDisplayMode.Wrap, Se.Language.Options.Settings.SubtitleGridTextDisplayWrap),
+            new SubtitleGridTextDisplayModeDisplay(SubtitleGridTextDisplayMode.Ellipsis, Se.Language.Options.Settings.SubtitleGridTextDisplayEllipsis),
+        ];
+    }
+
+    /// <summary>Parse the persisted setting string into the mode, defaulting to <see cref="SubtitleGridTextDisplayMode.Clip"/>.</summary>
+    public static SubtitleGridTextDisplayMode FromSettings()
+    {
+        return Enum.TryParse<SubtitleGridTextDisplayMode>(Se.Settings.Appearance.SubtitleGridTextDisplay, out var mode)
+            ? mode
+            : SubtitleGridTextDisplayMode.Clip;
+    }
+
+    /// <summary>Apply the wrapping / max-lines / trimming that realises the mode on a grid text cell.</summary>
+    public static void ApplyTo(TextBlock textBlock, SubtitleGridTextDisplayMode mode)
+    {
+        switch (mode)
+        {
+            case SubtitleGridTextDisplayMode.Wrap:
+                textBlock.TextWrapping = TextWrapping.Wrap;
+                textBlock.MaxLines = 0; // unlimited - row grows to fit
+                textBlock.TextTrimming = TextTrimming.None;
+                break;
+            case SubtitleGridTextDisplayMode.Ellipsis:
+                textBlock.TextWrapping = TextWrapping.NoWrap;
+                textBlock.MaxLines = 1; // force a single visual line even for multi-line text
+                textBlock.TextTrimming = TextTrimming.CharacterEllipsis;
+                break;
+            default: // Clip
+                textBlock.TextWrapping = TextWrapping.NoWrap;
+                textBlock.MaxLines = 0;
+                textBlock.TextTrimming = TextTrimming.None;
+                break;
+        }
+    }
+}

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -75,6 +75,10 @@ public class LanguageSettings
     public string SubtitleGridFontSize { get; set; }
     public string SubtitleGridTextSingleLine { get; set; }
     public string SubtitleGridTextSingleLineSeparator { get; set; }
+    public string SubtitleGridTextDisplay { get; set; }
+    public string SubtitleGridTextDisplayClip { get; set; }
+    public string SubtitleGridTextDisplayWrap { get; set; }
+    public string SubtitleGridTextDisplayEllipsis { get; set; }
     public string SubtitleGridLiveSpellCheck { get; set; }
     public string SubtitleGridShowFormatting { get; set; }
     public string ShowUpDownStartTime { get; set; }
@@ -391,6 +395,10 @@ public class LanguageSettings
         SubtitleGridFontSize = "Font size in subtitle grid";
         SubtitleGridTextSingleLine = "Show subtitle text as single line in grid";
         SubtitleGridTextSingleLineSeparator = "Single line separator (e.g. <br />)";
+        SubtitleGridTextDisplay = "Subtitle text fit in grid";
+        SubtitleGridTextDisplayClip = "Clip (single line)";
+        SubtitleGridTextDisplayWrap = "Wrap to fit window";
+        SubtitleGridTextDisplayEllipsis = "Single line with ellipsis";
         SubtitleGridLiveSpellCheck = "Live spell check in subtitle grid";
         SubtitleGridShowFormatting = "Show formatted (HTML/ASSA) text in subtitle grid";
         ShowUpDownStartTime = "Show up/down control for \"Show\"";

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -19,6 +19,13 @@ public class SeAppearance
     public double SubtitleGridFontSize { get; set; }
     public bool SubtitleGridTextSingleLine { get; set; }
     public string SubtitleGridTextSingleLineSeparator { get; set; }
+
+    /// <summary>
+    /// How the subtitle grid Text/Original columns render so the visible text adapts to the
+    /// window size: "Clip" (default, current behaviour), "Wrap" or "Ellipsis". Stored as the
+    /// <see cref="Features.Options.Settings.SubtitleGridTextDisplayMode"/> name.
+    /// </summary>
+    public string SubtitleGridTextDisplay { get; set; }
     public double SubtitleTextBoxFontSize { get; set; }
     public string SubtitleTextBoxAndGridFontName { get; set; }
     public bool SubtitleTextBoxFontBold { get; set; }
@@ -89,6 +96,7 @@ public class SeAppearance
         SubtitleTextBoxAndGridFontName = "Default";
         SubtitleGridFontSize = 13d;
         SubtitleGridTextSingleLineSeparator = " ⏎ "; // "<br />";
+        SubtitleGridTextDisplay = nameof(Features.Options.Settings.SubtitleGridTextDisplayMode.Clip);
         SubtitleTextBoxFontSize = 15d;
         SubtitleTextBoxFontBold = true;
         SubtitleTextBoxColorTags = true;


### PR DESCRIPTION
Implements #11590 - an auto-fit setting for the subtitle grid so the visible text adapts to the window size.

## Background

The grid Text and Original columns were hardcoded to `TextWrapping.NoWrap`, so long lines are clipped at the column edge (you can't see the rest without widening) and multi-line subtitles produce very tall rows.

## Change

Adds an appearance setting **"Subtitle text fit in grid"** (Settings -> Appearance) with three modes:

- **Clip (single line)** - default, unchanged: `NoWrap`, long lines clipped at the edge.
- **Wrap to fit window** - `TextWrapping.Wrap`; text reflows to the column width and rows grow to show the full text (this is what the screenshot in the issue shows).
- **Single line with ellipsis** - `NoWrap` + `MaxLines=1` + `CharacterEllipsis`; one compact line, truncated with an ellipsis that adapts to the column (window) width.

It is modelled on the existing grid-lines-visibility dropdown: a `SubtitleGridTextDisplayMode` enum + display list, persisted in `SeAppearance.SubtitleGridTextDisplay` (stored as the mode name, default `Clip`). The mode is applied where the Text/Original cell templates are built, so it takes effect when the grid is rebuilt on Settings OK - the same path `GridCompactMode` / grid-lines use. It composes with the existing `SubtitleGridTextSingleLine` join setting.

## Notes

- Default `Clip` preserves current behaviour exactly; no migration needed (missing/old setting parses to `Clip`).
- English strings added in `LanguageSettings.cs`; other language JSONs fall back to those until translated.
- Builds clean (0 warnings / 0 errors).
- I don't have a Windows/macOS GUI here to judge the look, so I also produced portable Windows and macOS test builds from this branch so the feel of each mode (especially row growth in Wrap) can be confirmed. Happy to adjust defaults, naming, or where the setting lives.