### PR TITLE
Fix three latent bugs in Utilities.cs

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -505,7 +505,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                             }
                         }
                     }
-                    if (sanitizedLines[0].StartsWith('♪') && sanitizedLines[0].EndsWith('♪') || sanitizedLines[1].StartsWith('♪') && sanitizedLines[0].EndsWith('♪'))
+                    if (sanitizedLines[0].StartsWith('♪') && sanitizedLines[0].EndsWith('♪') || sanitizedLines[1].StartsWith('♪') && sanitizedLines[1].EndsWith('♪'))
                     {
                         return input;
                     }

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -111,7 +111,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 if (double.TryParse(displayFileSize.Replace("bytes", string.Empty).Trim(), NumberStyles.AllowDecimalPoint, CultureInfo.CurrentCulture, out var n))
                 {
-                    return (int)Math.Round(n);
+                    return (long)Math.Round(n);
                 }
             }
 
@@ -119,7 +119,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 if (double.TryParse(displayFileSize.Replace("kb", string.Empty).Trim(), NumberStyles.AllowDecimalPoint, CultureInfo.CurrentCulture, out var n))
                 {
-                    return (int)Math.Round(n * 1024);
+                    return (long)Math.Round(n * 1024);
                 }
             }
 
@@ -127,7 +127,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 if (double.TryParse(displayFileSize.Replace("mb", string.Empty).Trim(), NumberStyles.AllowDecimalPoint, CultureInfo.CurrentCulture, out var n))
                 {
-                    return (int)Math.Round(n * 1024 * 1024);
+                    return (long)Math.Round(n * 1024 * 1024);
                 }
             }
 
@@ -135,7 +135,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 if (double.TryParse(displayFileSize.Replace("gb", string.Empty).Trim(), NumberStyles.AllowDecimalPoint, CultureInfo.CurrentCulture, out var n))
                 {
-                    return (int)Math.Round(n * 1024 * 1024 * 1024);
+                    return (long)Math.Round(n * 1024.0 * 1024.0 * 1024.0);
                 }
             }
 

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1998,7 +1998,8 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 return defaultColor;
             }
-            var colorStart = f.IndexOf(" color=", StringComparison.OrdinalIgnoreCase);
+            // f starts at 'start' within s, so offset f-relative index back into s
+            var colorStart = start + f.IndexOf(" color=", StringComparison.OrdinalIgnoreCase);
             if (s.IndexOf('"', colorStart + " color=".Length + 1) > 0)
             {
                 end = s.IndexOf('"', colorStart + " color=".Length + 1);


### PR DESCRIPTION
## Summary
Three independent bug fixes in `src/libse/Common/Utilities.cs`:

- **`DisplayFileSizeToBytes` integer overflow** — the method returns `long` but cast each result to `int`, so any value ≥ 2 GB (and large `mb` inputs) overflowed to a negative/garbage value. Now casts to `long`, with the `gb` multiplication kept in double space.
- **`AutoBreakLinePrivate` music-symbol check** — a copy/paste error tested whether line 1 *starts* with the music symbol but whether line 0 (not line 1) *ends* with it, so a fully ♪-wrapped second line was never detected. Now checks line 1's ending.
- **`GetColorFromFontString` wrong index base** — `colorStart` was measured relative to the extracted font-tag substring `f` but then used to index/substring the full string `s`. When the `<font>` tag wasn't at the start of the line this read the wrong region and returned a wrong color (or the default). `colorStart` is now offset by `start` so it indexes `s` correctly.

## Test plan
- [ ] `dotnet build src/libse/LibSE.csproj` succeeds with no warnings/errors
- [ ] `DisplayFileSizeToBytes("3.0 gb")` returns `3221225472` (not a negative number)
- [ ] `DisplayFileSizeToBytes` round-trips with `FormatBytesToDisplayFileSize` for kb/mb/gb sizes
- [ ] A subtitle whose second line is fully wrapped in ♪ (e.g. `♪ la la ♪`) is not auto-broken
- [ ] `GetColorFromFontString` returns the correct color for input with leading text before the tag, e.g. `Hi <font color="red">x</font>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)