### PR TITLE
Add a couple of `Extend` shortcuts from SE4

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -172,6 +172,8 @@
     "extendSelectedLinesToPreviousShotChange": "Extend selected lines to previous shot change (or previous subtitle)",
     "extendSelectedToNext": "Extend selected to next",
     "extendSelectedToPrevious": "Extend selected to previous",
+    "extendPreviousEndToSelectedStart": "Extend previous line's end to selected's start",
+    "extendNextStartToSelectedEnd": "Extend next line's start to selected's end",
     "extractingAudioClips": "Extracting audio clips...",
     "exitFullScreen": "Exit full screen",
     "fade": "Fade",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12604,7 +12604,7 @@ public partial class MainViewModel :
             return;
         }
 
-        next.SetStartTimeOnly(TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds()));
+        next.StartTime = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
         _updateAudioVisualizer = true;
     }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12568,9 +12568,43 @@ public partial class MainViewModel :
             return;
         }
 
-        ;
         s.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds -
                                               Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
+    private void ExtendPreviousEndToSelectedStart()
+    {
+        var s = SelectedSubtitle;
+        var idx = SelectedSubtitleIndex;
+        if (s == null || idx == null || idx == 0 || LockTimeCodes)
+        {
+            return;
+        }
+
+        var prev = Subtitles[idx.Value - 1];
+        prev.EndTime = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
+    private void ExtendNextStartToSelectedEnd()
+    {
+        var s = SelectedSubtitle;
+        var idx = SelectedSubtitleIndex;
+        if (s == null || idx == null || idx >= Subtitles.Count - 1 || LockTimeCodes)
+        {
+            return;
+        }
+
+        var next = Subtitles.GetOrNull(idx.Value + 1);
+        if (next == null)
+        {
+            return;
+        }
+
+        next.SetStartTimeOnly(TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds()));
         _updateAudioVisualizer = true;
     }
 

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -225,6 +225,8 @@ public static class Se4ShortcutsImporter
         ["MainSetEndAndStartNextAfterGap"] = nameof(MainViewModel.WaveformSetEndAndStartOfNextAfterGapCommand),
         ["MainAdjustExtendToNextSubtitle"] = nameof(MainViewModel.ExtendSelectedToNextCommand),
         ["MainAdjustExtendToPreviousSubtitle"] = nameof(MainViewModel.ExtendSelectedToPreviousCommand),
+        ["MainAdjustExtendPreviousLineEndToCurrentStart"] = nameof(MainViewModel.ExtendPreviousEndToSelectedStartCommand),
+        ["MainAdjustExtendNextLineStartToCurrentEnd"] = nameof(MainViewModel.ExtendNextStartToSelectedEndCommand),
         ["MainAdjustExtendToNextShotChange"] = nameof(MainViewModel.ExtendSelectedLinesToNextShotChangeOrNextSubtitleCommand),
         ["MainAdjustExtendToPreviousShotChange"] = nameof(MainViewModel.ExtendSelectedLinesToPreviousShotChangeCommand),
         ["MainAdjustSelected100MsBack"] = nameof(MainViewModel.Video100MsBackCommand),

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -172,6 +172,8 @@ public class LanguageGeneral
     public string ExtendSelectedLinesToPreviousShotChange { get; set; }
     public string ExtendSelectedToNext { get; set; }
     public string ExtendSelectedToPrevious { get; set; }
+    public string ExtendPreviousEndToSelectedStart { get; set; }
+    public string ExtendNextStartToSelectedEnd { get; set; }
     public string ExtractingAudioClips { get; set; }
     public string ExitFullScreen { get; set; }
     public string Fade { get; set; }
@@ -898,6 +900,8 @@ public class LanguageGeneral
         ExtendSelectedLinesToPreviousShotChange = "Extend selected lines to previous shot change (or previous subtitle)";
         ExtendSelectedToNext = "Extend selected to next";
         ExtendSelectedToPrevious = "Extend selected to previous";
+        ExtendPreviousEndToSelectedStart = "Extend previous line's end to selected's start";
+        ExtendNextStartToSelectedEnd = "Extend next line's start to selected's end";
         ExtractingAudioClips = "Extracting audio clips...";
         ExitFullScreen = "Exit full screen";
         Fade = "Fade";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -276,6 +276,8 @@ public static class ShortcutsMain
         { nameof(MainViewModel.ResetWaveformZoomAndSpeedCommand),  Se.Language.Waveform.ResetWaveformZoomAndSpeed },
         { nameof(MainViewModel.ExtendSelectedToPreviousCommand),  Se.Language.General.ExtendSelectedToPrevious },
         { nameof(MainViewModel.ExtendSelectedToNextCommand),  Se.Language.General.ExtendSelectedToNext },
+        { nameof(MainViewModel.ExtendPreviousEndToSelectedStartCommand),  Se.Language.General.ExtendPreviousEndToSelectedStart },
+        { nameof(MainViewModel.ExtendNextStartToSelectedEndCommand),  Se.Language.General.ExtendNextStartToSelectedEnd },
         { nameof(MainViewModel.ToggleLockTimeCodesCommand), Se.Language.Options.Shortcuts.ToggleLockTimeCodes },
         { nameof(MainViewModel.ShowHelpCommand), Se.Language.General.Help },
         { nameof(MainViewModel.ShowSourceViewCommand), Se.Language.Options.Shortcuts.SourceView },
@@ -619,6 +621,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ResetWaveformZoomAndSpeedCommand, nameof(vm.ResetWaveformZoomAndSpeedCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ExtendSelectedToPreviousCommand, nameof(vm.ExtendSelectedToPreviousCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ExtendSelectedToNextCommand, nameof(vm.ExtendSelectedToNextCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ExtendPreviousEndToSelectedStartCommand, nameof(vm.ExtendPreviousEndToSelectedStartCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ExtendNextStartToSelectedEndCommand, nameof(vm.ExtendNextStartToSelectedEndCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ToggleLockTimeCodesCommand, nameof(vm.ToggleLockTimeCodesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowHelpCommand, nameof(vm.ShowHelpCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowSourceViewCommand, nameof(vm.ShowSourceViewCommand), ShortcutCategory.General);


### PR DESCRIPTION
Add two useful Extend shortcuts that were in SE4:
1. Extend previous line's end to selected's start
2. Extend next line's start to selected's end