### PR TITLE
Work on video player labels

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -802,6 +802,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
 
                 SetPositionDisplayOnly(pos);
 
+                var fullDuration = TimeCode.FromSeconds(Duration + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString();
                 if (VideoPlayerDisplayTimeLeft)
                 {
                     var left = Duration - pos;
@@ -809,18 +810,18 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                     if (left > 0.001)
                     {
                         ProgressText =
-                            $"-{TimeCode.FromSeconds(left).ToDisplayString()}{postFix}";
+                            $"-{TimeCode.FromSeconds(left).ToDisplayString()} / {fullDuration}{postFix}";
                     }
                     else
                     {
                         ProgressText =
-                            $"{TimeCode.FromSeconds(0).ToDisplayString()}{postFix}";
+                            $"{TimeCode.FromSeconds(0).ToDisplayString()} / {fullDuration}{postFix}";
                     }
                 }
                 else
                 {
                     ProgressText =
-                        $"{TimeCode.FromSeconds(pos + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString()} / {TimeCode.FromSeconds(Duration + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString()}{postFix}";
+                        $"{TimeCode.FromSeconds(pos + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString()} / {fullDuration}{postFix}";
                 }
             };
             _positionTimer.Start();

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -369,8 +369,8 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             {
                 ToolTip.SetTip(sliderPosition, Se.Language.General.VideoPosition);
 
-                // Show the hovered timestamp in the tooltip (frame/HH:MM:SS:FF vs ms format is
-                // already handled by ToShortDisplayString via UseTimeFormatHHMMSSFF).
+                // Show the hovered timestamp in the tooltip (frame/HH:MM:SS:FF vs ms format
+                // is already handled by ToDisplayString via UseTimeFormatHHMMSSFF).
                 // Avalonia's Slider centers the thumb on the value point, so the effective
                 // value-range track is narrower than the slider by one thumb width — we have
                 // to match that mapping or the hint reads later than the actual click target.
@@ -387,7 +387,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                     var ratio = Math.Clamp(x / available, 0.0, 1.0);
                     var hovered = sliderPosition.Minimum + ratio * (sliderPosition.Maximum - sliderPosition.Minimum);
                     var offsetSec = Se.Settings.General.CurrentVideoOffsetInMs / 1000.0;
-                    ToolTip.SetTip(sliderPosition, TimeCode.FromSeconds(hovered + offsetSec).ToShortDisplayString());
+                    ToolTip.SetTip(sliderPosition, TimeCode.FromSeconds(hovered + offsetSec).ToDisplayString());
                 });
             }
             sliderPosition.TemplateApplied += (s, e) =>
@@ -809,18 +809,18 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                     if (left > 0.001)
                     {
                         ProgressText =
-                            $"-{TimeCode.FromSeconds(left).ToShortDisplayString()}{postFix}";
+                            $"-{TimeCode.FromSeconds(left).ToDisplayString()}{postFix}";
                     }
                     else
                     {
                         ProgressText =
-                            $"{TimeCode.FromSeconds(0).ToShortDisplayString()}{postFix}";
+                            $"{TimeCode.FromSeconds(0).ToDisplayString()}{postFix}";
                     }
                 }
                 else
                 {
                     ProgressText =
-                        $"{TimeCode.FromSeconds(pos + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToShortDisplayString()} / {TimeCode.FromSeconds(Duration + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToShortDisplayString()}{postFix}";
+                        $"{TimeCode.FromSeconds(pos + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString()} / {TimeCode.FromSeconds(Duration + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString()}{postFix}";
                 }
             };
             _positionTimer.Start();

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -474,8 +474,9 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 _videoPlayerInstance.Volume = e.NewValue;
                 VolumeChanged?.Invoke(e.NewValue);
                 SetVolumeIcon(e.NewValue < 0.0001);
-            };
 
+                ToolTip.SetTip(sliderVolume, $"{Se.Language.General.Volume} {sliderVolume.Value:0}%");
+            };
 
             _gridProgress.Children.Add(sliderVolume);
             Grid.SetColumn(sliderVolume, 3);


### PR DESCRIPTION
Having the timecode on the video and the video slider as just a short string of the video is really confusing; it's typical in places like these to have the full timecode, not just a part of it.

I can't intuitively understand what I'm seeing while I'm trying to read the timecode at some random point in time.

Also, even when showing the remaining time only, it's typical to show the full duration. This is the case in most video players.
Plus, it looks weird and empty having one timecode under the slider.

In addition, the tooltip of the volume showing only the word "Volume" seemed weird, so I added the level to that.