### PR TITLE
Add remote/external llama.cpp server (URL) option to translate (#11584)

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -92,6 +92,8 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
     [ObservableProperty] private bool _llamaCppModelComboIsVisible;
     [ObservableProperty] private bool _llamaCppButtonsAreVisible;
+    [ObservableProperty] private bool _llamaCppRemoteToggleIsVisible;
+    [ObservableProperty] private bool _llamaCppUseRemoteServer;
     [ObservableProperty] private string _llamaCppServerButtonText = "Start server";
     [ObservableProperty] private string _llamaCppDownloadButtonText = string.Empty;
     [ObservableProperty] private string _crispAsrDownloadButtonText = string.Empty;
@@ -107,6 +109,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     private Subtitle _subtitle = new Subtitle();
     private int _translationProgressIndex;
     private bool _llamaCppUpdatePromptShown;
+    private bool _suppressLlamaCppRemoteToggle;
     private readonly IWindowService _windowService;
     private readonly IFolderHelper _folderHelper;
 
@@ -318,8 +321,18 @@ public partial class AutoTranslateViewModel : ObservableObject
             Configuration.Settings.Tools.LmStudioModel = apiModel.Trim();
         }
 
-        // llama.cpp is server-managed: the API URL is set by LlamaCppServerManager and the
-        // model is persisted via OnSelectedLlamaCppModelChanged, so nothing to save here.
+        if (engineType == typeof(LlamaCppTranslate))
+        {
+            Se.Settings.AutoTranslate.LlamaCppUseRemoteServer = LlamaCppUseRemoteServer;
+            if (LlamaCppUseRemoteServer)
+            {
+                // Remote mode: persist the user-entered endpoint.
+                Configuration.Settings.Tools.LlamaCppApiUrl = apiUrl.Trim();
+                Se.Settings.AutoTranslate.LlamaCppApiUrl = apiUrl.Trim();
+            }
+            // Local mode stays server-managed: the API URL is set by LlamaCppServerManager and the
+            // model is persisted via OnSelectedLlamaCppModelChanged, so nothing else to save here.
+        }
 
         if (engineType == typeof(OllamaTranslate))
         {
@@ -1164,10 +1177,18 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         _cancellationTokenSource = new CancellationTokenSource();
 
-        if (engineType == typeof(LlamaCppTranslate) && !await EnsureLlamaCppReady())
+        if (engineType == typeof(LlamaCppTranslate))
         {
-            IsProgressEnabled = false;
-            return false;
+            if (Se.Settings.AutoTranslate.LlamaCppUseRemoteServer)
+            {
+                // Remote server: use the configured endpoint directly, skip local server management.
+                Configuration.Settings.Tools.LlamaCppApiUrl = (ApiUrlText ?? string.Empty).Trim();
+            }
+            else if (!await EnsureLlamaCppReady())
+            {
+                IsProgressEnabled = false;
+                return false;
+            }
         }
 
         _translationInProgress = true;
@@ -1456,6 +1477,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         SelectedCrispAsrModel = null;
         LlamaCppModelComboIsVisible = false;
         LlamaCppButtonsAreVisible = false;
+        LlamaCppRemoteToggleIsVisible = false;
         LlamaCppModels.Clear();
         SelectedLlamaCppModel = null;
         ModelText = string.Empty;
@@ -1629,6 +1651,30 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         if (engineType == typeof(LlamaCppTranslate))
         {
+            // The remote toggle is always available for llama.cpp; its current value decides
+            // whether we show the local model/server controls or a plain API URL field (#11584).
+            LlamaCppRemoteToggleIsVisible = true;
+            _suppressLlamaCppRemoteToggle = true;
+            LlamaCppUseRemoteServer = Se.Settings.AutoTranslate.LlamaCppUseRemoteServer;
+            _suppressLlamaCppRemoteToggle = false;
+
+            if (LlamaCppUseRemoteServer)
+            {
+                // Remote/external server: just edit the URL (the llama.cpp server is OpenAI-compatible,
+                // same as the LM Studio engine). No local download or server management.
+                if (string.IsNullOrEmpty(Se.Settings.AutoTranslate.LlamaCppApiUrl))
+                {
+                    Se.Settings.AutoTranslate.LlamaCppApiUrl = "http://localhost:8080/v1/chat/completions";
+                }
+
+                FillUrls(new List<string>
+                {
+                    Se.Settings.AutoTranslate.LlamaCppApiUrl.TrimEnd('/'),
+                });
+
+                return;
+            }
+
             LlamaCppModelComboIsVisible = true;
             LlamaCppButtonsAreVisible = true;
             var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
@@ -1830,6 +1876,23 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         throw new Exception($"Engine {translator.Name} not handled!");
+    }
+
+    partial void OnLlamaCppUseRemoteServerChanged(bool value)
+    {
+        // Ignore the programmatic assignment made while SetAutoTranslatorEngine builds the panel.
+        if (_suppressLlamaCppRemoteToggle)
+        {
+            return;
+        }
+
+        Se.Settings.AutoTranslate.LlamaCppUseRemoteServer = value;
+
+        // Swap the llama.cpp panel between the local model/server controls and the remote URL field.
+        if (SelectedAutoTranslator is LlamaCppTranslate)
+        {
+            SetAutoTranslatorEngine(SelectedAutoTranslator);
+        }
     }
 
     private void FillUrls(List<string> urls)

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -304,6 +304,10 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.ApiKey, vm, null, nameof(vm.ApiKeyIsVisible)).WithMarginRight(5));
         settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiKeyText), nameof(vm.ApiKeyIsVisible)).WithMarginRight(15));
 
+        var checkBoxLlamaCppRemote = UiUtil.MakeCheckBox(Se.Language.General.LlamaCppUseRemoteServer, vm, nameof(vm.LlamaCppUseRemoteServer)).WithMarginRight(15);
+        checkBoxLlamaCppRemote.Bind(CheckBox.IsVisibleProperty, new Binding(nameof(vm.LlamaCppRemoteToggleIsVisible)));
+        settingsPanel.Children.Add(checkBoxLlamaCppRemote);
+
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Url, vm, null, nameof(vm.ApiUrlIsVisible)).WithMarginRight(5));
         settingsPanel.Children.Add(UiUtil.MakeTextBox(200, vm, nameof(vm.ApiUrlText), nameof(vm.ApiUrlIsVisible)).WithMarginRight(15));
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -391,6 +391,7 @@ public class LanguageGeneral
     public string Percent { get; set; }
     public string PickLayer { get; set; }
     public string PickOllamaModel { get; set; }
+    public string LlamaCppUseRemoteServer { get; set; }
     public string PickOutputFolder { get; set; }
     public string PickResolutionFromCurrentVideo { get; set; }
     public string PickResolutionFromVideoDotDotDot { get; set; }
@@ -1117,6 +1118,7 @@ public class LanguageGeneral
         Percent = "Percent";
         PickLayer = "Set layer";
         PickOllamaModel = "Pick Ollama model";
+        LlamaCppUseRemoteServer = "Use external server (URL)";
         PickOutputFolder = "Pick output folder";
         PickResolutionFromCurrentVideo = "Pick resolution from current video";
         PickResolutionFromVideoDotDotDot = "Pick resolution from video...";

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -22,6 +22,12 @@ public class SeAutoTranslate
     public string LlamaCppApiUrl { get; set; }
     public string LlamaCppModel { get; set; }
     public string LlamaCppPrompt { get; set; }
+
+    /// <summary>
+    /// When true, connect to an external/remote llama.cpp server at <see cref="LlamaCppApiUrl"/>
+    /// (e.g. a GPU box) instead of downloading a model and managing a local server (#11584).
+    /// </summary>
+    public bool LlamaCppUseRemoteServer { get; set; }
     public string GroqUrl { get; set; }
     public string GroqPrompt { get; set; }
     public string GroqApiKey { get; set; }


### PR DESCRIPTION
Implements #11584 - lets the llama.cpp translate engine connect to an external/remote server via URL (e.g. a GPU box), instead of only managing a local instance.

## Background

`LlamaCppTranslate` and `LmStudioTranslate` are functionally identical - both POST to an OpenAI-compatible `/v1/chat/completions` endpoint read from a settings URL. The translate core for llama.cpp already targets a configurable `LlamaCppApiUrl`; the engine just never exposed it, instead downloading a model and managing a local server pointed at localhost.

## Change

Adds a **"Use external server (URL)"** checkbox to the llama.cpp engine in Auto-translate:

- **off (default)** - unchanged: local model download + SE-managed server.
- **on** - shows an editable API URL field; translation posts directly to that endpoint and skips the local download / `EnsureServerRunningAsync` path.

New setting `AutoTranslate.LlamaCppUseRemoteServer` (default `false`, so existing behaviour is untouched). The toggle swaps the panel live (a small guard prevents the programmatic re-setup from recursing). Mirrors how the Ollama/LM Studio engines present a URL field.

## Notes

- Builds clean (0 warnings / 0 errors).
- Until this is merged, users can already do this today by selecting the **LM Studio (local LLM)** engine and pointing its URL at the remote llama.cpp server - same endpoint shape. This PR just makes it discoverable under llama.cpp.
- I don't have a Windows/macOS GUI here, so I also produced portable Windows and macOS test builds from this branch to verify the toggle and a real remote translation. Happy to adjust naming/placement.