### PR TITLE
Fix faint caret in edit box after system dark-to-light theme switch (color tags)

### DIFF
--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -74,6 +74,15 @@ public static class UiTheme
             {
                 ApplyLighterDark();
             }
+            else
+            {
+                // When the OS switches dark→light, RequestedThemeVariant stays at Default so
+                // Avalonia's full theme re-evaluation is not triggered. AvaloniaEdit's TextArea
+                // caret renderer then falls into a stale state, retaining the bright brush from
+                // the now-removed dark style. Push an explicit black CaretBrush via a style so
+                // a clean property-changed notification fires and the caret renders correctly.
+                ApplyLightThemeCaretFix();
+            }
 
             // Subscribe to theme changes
             Application.Current.ActualThemeVariantChanged += OnActualThemeVariantChanged;
@@ -617,6 +626,21 @@ public static class UiTheme
             Application.Current!.Styles.Remove(_lighterDarkStyle);
             _lighterDarkStyle = null;
         }
+    }
+
+    private static void ApplyLightThemeCaretFix()
+    {
+        _lighterDarkStyle = new Styles
+        {
+            new Style(x => x.OfType<TextArea>())
+            {
+                Setters =
+                {
+                    new Setter(TextArea.CaretBrushProperty, new SolidColorBrush(Colors.Black)),
+                }
+            },
+        };
+        Application.Current!.Styles.Add(_lighterDarkStyle);
     }
 
     private static void ApplyWindowsClassicGray()

--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -16,7 +16,7 @@ namespace Nikse.SubtitleEdit.Logic;
 
 public static class UiTheme
 {
-    private static IStyle? _lighterDarkStyle;
+    private static IStyle? _themeOverrideStyle;
     private static IStyle? _layoutScaleMenuStyle;
     private static ResourceDictionary? _resourceOverrides;
     private static object? _themeChangeSubscription;
@@ -405,7 +405,7 @@ public static class UiTheme
         };
         Application.Current.Resources.MergedDictionaries.Add(_resourceOverrides);
 
-        _lighterDarkStyle = new Styles
+        _themeOverrideStyle = new Styles
         {
             // TextBox
             new Style(x => x.OfType<TextBox>())
@@ -610,7 +610,7 @@ public static class UiTheme
             },
         };
 
-        Application.Current.Styles.Add(_lighterDarkStyle);
+        Application.Current.Styles.Add(_themeOverrideStyle);
     }
 
     private static void RemoveLighterDark()
@@ -621,26 +621,26 @@ public static class UiTheme
             _resourceOverrides = null;
         }
 
-        if (_lighterDarkStyle != null)
+        if (_themeOverrideStyle != null)
         {
-            Application.Current!.Styles.Remove(_lighterDarkStyle);
-            _lighterDarkStyle = null;
+            Application.Current!.Styles.Remove(_themeOverrideStyle);
+            _themeOverrideStyle = null;
         }
     }
 
     private static void ApplyLightThemeCaretFix()
     {
-        _lighterDarkStyle = new Styles
+        _themeOverrideStyle = new Styles
         {
             new Style(x => x.OfType<TextArea>())
             {
                 Setters =
                 {
-                    new Setter(TextArea.CaretBrushProperty, new SolidColorBrush(Colors.Black)),
+                    new Setter(TextArea.CaretBrushProperty, Brushes.Black),
                 }
             },
         };
-        Application.Current!.Styles.Add(_lighterDarkStyle);
+        Application.Current!.Styles.Add(_themeOverrideStyle);
     }
 
     private static void ApplyWindowsClassicGray()
@@ -657,7 +657,7 @@ public static class UiTheme
         var headerColor = Color.FromRgb(192, 192, 192); // Classic silver header
         var inputColor = Color.FromRgb(255, 255, 250); // Slightly off-white (ivory) for input controls
 
-        _lighterDarkStyle = new Styles
+        _themeOverrideStyle = new Styles
         {
             // Window background
             new Style(x => x.OfType<Window>())
@@ -757,7 +757,7 @@ public static class UiTheme
             },
         };
 
-        Application.Current.Styles.Add(_lighterDarkStyle);
+        Application.Current.Styles.Add(_themeOverrideStyle);
     }
 
     private static void ApplyPastel()
@@ -775,7 +775,7 @@ public static class UiTheme
         var lightPurple = Color.FromRgb(245, 240, 255); // Lavender
         var borderColor = Color.FromRgb(200, 180, 200); // Soft lavender border
 
-        _lighterDarkStyle = new Styles
+        _themeOverrideStyle = new Styles
         {
             // Window background with soft lavender
             new Style(x => x.OfType<Window>())
@@ -871,7 +871,7 @@ public static class UiTheme
             },
         };
 
-        Application.Current.Styles.Add(_lighterDarkStyle);
+        Application.Current.Styles.Add(_themeOverrideStyle);
     }
 
     private static Color GetDarkThemeBackgroundColor()


### PR DESCRIPTION
## Problem

  When **Theme** is set to **System** and macOS switches from dark to light mode, the text cursor (caret) in the subtitle edit box remains faint, hardly visible. This only occurs when **color tags** are enabled in Settings, because that activates the AvaloniaEdit `TextEditor` instead of a plain `TextBox`.

  ## Root cause

  The system theme auto-switch and the Settings theme change follow different code paths and are not equivalent:

  | | Settings theme change | System auto-switch |
  |---|---|---|
  | `RequestedThemeVariant` | Changes (e.g. `Default` → `Light`) | Stays at `Default` |
  | Avalonia full style re-evaluation | ✅ triggered by property-change event | ❌ not triggered |
  | Layout rebuild (`SetLayout`) | ✅ recreates all controls fresh | ❌ existing controls reused |

  When the dark-mode style is removed by `RemoveLighterDark()`, `TextArea.CaretBrushProperty` drops from an explicitly-set white brush to `null` (unset). AvaloniaEdit's caret renderer retains a stale bright brush — it does not re-read the `Foreground` fallback cleanly when the property goes to `null` rather than to an explicit new value. Because `RequestedThemeVariant` does not change, Avalonia never fires the re-evaluation that would correct it.

  Note: the earlier toolbar icon fix I made is a different class of problem — toolbar icons are PNG files loaded from a theme-specific folder at construction time, so no amount of style re-evaluation helps; `RebuildToolbar()` is the correct fix for that.

  ## Fix

  Apply a minimal style via `ApplyLightThemeCaretFix()` that explicitly sets `TextArea.CaretBrushProperty = Black` when the system variant switches to light. This fires a clean `White → Black` property-changed notification that the caret renderer responds to. The style is stored in `_lighterDarkStyle` so `RemoveLighterDark()` removes it automatically on the next theme switch.

  ## Architectural note

  This is a targeted, per-component fix. If more components exhibit stale state after a system theme switch, the correct long-term solution is the **heavy approach**: hook `OnActualThemeVariantChanged` to also call `SetLayout()` after `SetCurrentTheme()`, mirroring what `ApplySettings()` does. This rebuilds the entire layout — DataGrid, TextEditors, toolbar — creating all controls fresh with the correct theme active. It eliminates the stale-state class of bug entirely, at the cost of a brief visual reconstruction on every OS theme switch. Further per-component patches should be avoided in favor of that approach if a third component turns up with the same problem.

  If you prefer to go straight for the heavy approach, let me know, we close this PR, and I'll submit one for the full layout rebuild to unify the Settings and System theme switch paths.
