### PR TITLE
Open video/audio when clicking the empty waveform

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -19645,6 +19645,14 @@ public partial class MainViewModel :
 
     internal void AudioVisualizerOnPrimarySingleClicked(object sender, ParagraphNullableEventArgs e)
     {
+        // No media loaded yet: clicking the empty waveform offers to open a video or audio file,
+        // restoring the older behaviour where the empty waveform was an entry point for opening media.
+        if (string.IsNullOrEmpty(_videoFileName))
+        {
+            _ = CommandVideoOpen();
+            return;
+        }
+
         var vp = GetVideoPlayerControl();
         if (vp == null || string.IsNullOrEmpty(_videoFileName) || AudioVisualizer == null)
         {


### PR DESCRIPTION
Fixes #11606

When no media was loaded, the waveform single-click handler returned early, so clicking the empty waveform did nothing.

- A click on the empty waveform now opens the standard video/audio picker (`CommandVideoOpen`, whose filter already lists both video and audio), restoring the older behaviour.

Builds clean (0/0).