### PR TITLE
Insert new line from the waveform selection; honor configurable duration

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8535,6 +8535,14 @@ public partial class MainViewModel :
     [RelayCommand]
     private void InsertLineBefore()
     {
+        // Prefer the exact range the user dragged on the waveform, so the new line follows the
+        // mouse selection instead of a fixed default duration (and stays decoupled from the
+        // moving playback cursor). Falls back to the normal grid insert when there's no selection.
+        if (TryInsertWaveformSelection())
+        {
+            return;
+        }
+
         RunWithoutChangeDetection(() =>
         {
             InsertBeforeSelectedItem();
@@ -8549,6 +8557,12 @@ public partial class MainViewModel :
     [RelayCommand]
     private void InsertLineAfter()
     {
+        // See InsertLineBefore: a waveform mouse selection wins over the default-duration insert.
+        if (TryInsertWaveformSelection())
+        {
+            return;
+        }
+
         RunWithoutChangeDetection(() =>
         {
             InsertAfterSelectedItem();
@@ -8558,6 +8572,37 @@ public partial class MainViewModel :
         {
             FocusEditTextBox();
         }
+    }
+
+    /// <summary>
+    /// If the user has dragged a new-subtitle selection on the waveform, insert a line spanning
+    /// exactly that selection and return true; otherwise return false so the caller does its
+    /// normal insert. This keeps line creation tied to the mouse selection rather than the
+    /// continuously-moving playback position.
+    /// </summary>
+    private bool TryInsertWaveformSelection()
+    {
+        var newParagraph = AudioVisualizer?.NewSelectionParagraph;
+        if (newParagraph == null)
+        {
+            return false;
+        }
+
+        RunWithoutChangeDetection(() =>
+        {
+            _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+            AudioVisualizer!.NewSelectionParagraph = null;
+            SelectAndScrollToSubtitle(newParagraph);
+            Renumber();
+            _updateAudioVisualizer = true;
+        });
+
+        if (Se.Settings.Tools.GridFocusTextboxAfterInsertNew)
+        {
+            FocusEditTextBox();
+        }
+
+        return true;
     }
 
     [RelayCommand]

--- a/src/ui/Logic/InsertService.cs
+++ b/src/ui/Logic/InsertService.cs
@@ -42,7 +42,7 @@ public class InsertService : IInsertService
         if (prev != null && next != null)
         {
             newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - addMilliseconds);
-            newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(newParagraph.EndTime.TotalMilliseconds - 2000));
+            newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(newParagraph.EndTime.TotalMilliseconds - Se.Settings.General.NewEmptyDefaultMs));
             if (newParagraph.StartTime.TotalMilliseconds <= prev.EndTime.TotalMilliseconds)
             {
                 newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(prev.EndTime.TotalMilliseconds + 1));
@@ -81,7 +81,7 @@ public class InsertService : IInsertService
         }
         else if (next != null)
         {
-            newParagraph.StartTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - (2000 + minGapBetweenLines));
+            newParagraph.StartTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - (Se.Settings.General.NewEmptyDefaultMs + minGapBetweenLines));
             newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - minGapBetweenLines);
 
             if (next.StartTime.IsMaxTime())
@@ -180,7 +180,7 @@ public class InsertService : IInsertService
         }
         else if (next != null)
         {
-            newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - 2000));
+            newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.NewEmptyDefaultMs));
             newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - addMilliseconds);
         }
         else


### PR DESCRIPTION
Fixes #11607

Inserting a line always produced a fixed ~2s line even when a waveform range was selected, and a few `InsertService` branches hardcoded the duration.

- `InsertLineBefore`/`InsertLineAfter` now prefer the waveform's new-selection range when present, inserting a line spanning exactly that selection (decoupled from the moving playback cursor); with no selection they fall back to the normal grid insert.
- The remaining hardcoded `2000` ms in `InsertService` now uses the existing `General.NewEmptyDefaultMs` setting (Settings > "Default new subtitle duration (ms)").

Builds clean (0/0). Test build provided to confirm the feel.