### PR TITLE
Honor configurable new-subtitle duration when inserting lines

### DIFF
--- a/src/ui/Logic/InsertService.cs
+++ b/src/ui/Logic/InsertService.cs
@@ -42,7 +42,7 @@ public class InsertService : IInsertService
         if (prev != null && next != null)
         {
             newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - addMilliseconds);
-            newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(newParagraph.EndTime.TotalMilliseconds - 2000));
+            newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(newParagraph.EndTime.TotalMilliseconds - Se.Settings.General.NewEmptyDefaultMs));
             if (newParagraph.StartTime.TotalMilliseconds <= prev.EndTime.TotalMilliseconds)
             {
                 newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(prev.EndTime.TotalMilliseconds + 1));
@@ -81,7 +81,7 @@ public class InsertService : IInsertService
         }
         else if (next != null)
         {
-            newParagraph.StartTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - (2000 + minGapBetweenLines));
+            newParagraph.StartTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - (Se.Settings.General.NewEmptyDefaultMs + minGapBetweenLines));
             newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - minGapBetweenLines);
 
             if (next.StartTime.IsMaxTime())
@@ -180,7 +180,7 @@ public class InsertService : IInsertService
         }
         else if (next != null)
         {
-            newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - 2000));
+            newParagraph.SetStartTimeOnly(TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.NewEmptyDefaultMs));
             newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - addMilliseconds);
         }
         else


### PR DESCRIPTION
## Summary
Replaces the three remaining hardcoded `2000` ms durations in `InsertService` with the existing `General.NewEmptyDefaultMs` setting (Settings > "Default new subtitle duration (ms)").

This matches how the rest of `InsertService` (e.g. the `InsertBefore`/`InsertAfter` end-time branches) and the other insert paths across the app already behave, so a user's configured default duration is respected consistently.

## Scope
This is the duration-only half of #11610. It deliberately leaves out that PR's waveform-selection insert change (the `TryInsertWaveformSelection` logic in `MainViewModel`), which can be considered separately.

**Supersedes #11610** — that PR can be closed in favor of this one.

Credit to @muaz978 for the original change in #11610.

## Test
Build clean (0 warnings / 0 errors). One file changed, 3 lines.