### PR TITLE
Add output container choice (mkv/mp4/mov) to burn-in window

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -62,6 +62,8 @@ public partial class BurnInViewModel : ObservableObject
     [ObservableProperty] private VideoEncodingItem _selectedVideoEncoding;
     [ObservableProperty] private ObservableCollection<PixelFormatItem> _videoPixelFormats;
     [ObservableProperty] private PixelFormatItem? _selectedVideoPixelFormat;
+    [ObservableProperty] private ObservableCollection<string> _videoExtensions;
+    [ObservableProperty] private string _selectedVideoExtension;
     [ObservableProperty] private ObservableCollection<string> _videoPresets;
     [ObservableProperty] private string? _selectedVideoPreset;
     [ObservableProperty] private string _videoPresetText;
@@ -207,6 +209,14 @@ public partial class BurnInViewModel : ObservableObject
         SelectedVideoEncoding = VideoEncodings[0];
 
         VideoCrf = new ObservableCollection<string>();
+
+        VideoExtensions = new ObservableCollection<string>
+        {
+            ".mkv",
+            ".mp4",
+            ".mov",
+        };
+        SelectedVideoExtension = VideoExtensions[0];
 
         JobItems = new ObservableCollection<BurnInJobItem>();
 
@@ -849,14 +859,10 @@ public partial class BurnInViewModel : ObservableObject
             "PlayResY: " + height.ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
     }
 
-    private static string MakeOutputFileName(string videoFileName)
+    private string MakeOutputFileName(string videoFileName)
     {
         var nameNoExt = Path.GetFileNameWithoutExtension(videoFileName);
-        var ext = Path.GetExtension(videoFileName).ToLowerInvariant();
-        if (ext != ".mp4" && ext != ".mkv")
-        {
-            ext = ".mkv";
-        }
+        var ext = VideoExtensions.Contains(SelectedVideoExtension) ? SelectedVideoExtension : ".mkv";
 
         var suffix = Se.Settings.Video.BurnIn.BurnInSuffix;
         var fileName = Path.Combine(Path.GetDirectoryName(videoFileName)!, nameNoExt + suffix + ext);
@@ -1180,11 +1186,7 @@ public partial class BurnInViewModel : ObservableObject
         {
             var nameNoExt = Path.GetFileNameWithoutExtension(VideoFileName);
             var path = Path.GetDirectoryName(VideoFileName) ?? string.Empty;
-            var ext = Path.GetExtension(VideoFileName).ToLowerInvariant();
-            if (ext != ".mp4" && ext != ".mkv")
-            {
-                ext = ".mkv";
-            }
+            var ext = VideoExtensions.Contains(SelectedVideoExtension) ? SelectedVideoExtension : ".mkv";
 
             var suggestedFileName = Path.Combine(path, nameNoExt + ext);
             var i = 2;
@@ -1194,7 +1196,13 @@ public partial class BurnInViewModel : ObservableObject
                 i++;
             }
 
-            var outputVideoFileName = await _fileHelper.PickSaveFile(Window!, ext, suggestedFileName, Se.Language.General.SaveVideoAsVideoTitle);
+            // Offer all supported containers in the "Save as type" dropdown, with the selected one first (the default).
+            var fileTypes = VideoExtensions
+                .OrderByDescending(p => p == ext)
+                .Select(p => (p.TrimStart('.'), p))
+                .ToList();
+
+            var outputVideoFileName = await _fileHelper.PickSaveFile(Window!, fileTypes, suggestedFileName, Se.Language.General.SaveVideoAsVideoTitle);
             if (string.IsNullOrEmpty(outputVideoFileName))
             {
                 return;
@@ -1294,6 +1302,8 @@ public partial class BurnInViewModel : ObservableObject
         SelectedAudioSampleRate = AudioSampleRates.FirstOrDefault(p => p.Replace("Hz", string.Empty).Trim() == settings.AudioSampleRate) ?? AudioSampleRates[1];
         SelectedAudioBitRate = AudioBitRates.Contains(settings.AudioBitRate) ? settings.AudioBitRate : AudioBitRates[2];
 
+        SelectedVideoExtension = VideoExtensions.Contains(settings.OutputExtension) ? settings.OutputExtension : VideoExtensions[0];
+
         UseTargetFileSize = settings.TargetFileSize;
         TargetFileSize = settings.TargetFileSizeMb;
         PromptForFfmpegParameters = settings.PromptFfmpegParameters;
@@ -1331,6 +1341,8 @@ public partial class BurnInViewModel : ObservableObject
         settings.AudioForceStereo = AudioIsStereo;
         settings.AudioSampleRate = SelectedAudioSampleRate.Replace("Hz", string.Empty).Trim();
         settings.AudioBitRate = SelectedAudioBitRate;
+
+        settings.OutputExtension = SelectedVideoExtension;
 
         settings.TargetFileSize = UseTargetFileSize;
         settings.TargetFileSizeMb = TargetFileSize ?? 0;

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -393,14 +393,13 @@ public class BurnInWindow : Window
         var labelPixelFormat = UiUtil.MakeLabel(Se.Language.Video.BurnIn.PixelFormat);
         var comboBoxPixelFormat = UiUtil.MakeComboBox(vm.VideoPixelFormats, vm, nameof(vm.SelectedVideoPixelFormat));
 
+        var labelVideoExtension = UiUtil.MakeLabel(Se.Language.General.VideoExtension);
+        var comboBoxVideoExtension = UiUtil.MakeComboBox(vm.VideoExtensions, vm, nameof(vm.SelectedVideoExtension));
+
         var grid = new Grid
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -434,6 +433,9 @@ public class BurnInWindow : Window
 
         grid.Add(labelPixelFormat, 4, 0);
         grid.Add(comboBoxPixelFormat, 4, 1);
+
+        grid.Add(labelVideoExtension, 5, 0);
+        grid.Add(comboBoxVideoExtension, 5, 1);
 
         return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);
     }

--- a/src/ui/Logic/Config/SeVideoBurnIn.cs
+++ b/src/ui/Logic/Config/SeVideoBurnIn.cs
@@ -43,6 +43,7 @@ public class SeVideoBurnIn
     public string OutputFolder { get; set; }
     public string BurnInSuffix { get; set; }
     public bool UseSourceResolution { get; set; }
+    public string OutputExtension { get; set; }
     public string Effects { get; set; }
 
     public SeVideoBurnIn()
@@ -73,6 +74,7 @@ public class SeVideoBurnIn
         EmbedOutputReplace = "embed" + Environment.NewLine + "SoftSub" + Environment.NewLine + "SoftSubbed";
         BurnInSuffix = "_new";
         GenTransparentVideoExtension = ".mkv";
+        OutputExtension = ".mkv";
         NonAssaAlignment = "2";
         Effects = string.Empty;
     }


### PR DESCRIPTION
## Summary
Fixes #11611. The burn-in / generate-video window forced the output container to follow the input video (mp4/mkv only), so users couldn't choose a different container — notably MP4 was unavailable when the source was MKV.

This adds a **"Video file extension"** dropdown (`.mkv`, `.mp4`, `.mov`) to the window, consistent with the Cut and Re-encode video windows.

## Changes
- **`SeVideoBurnIn`**: new persisted `OutputExtension` setting (defaults to `.mkv`).
- **`BurnInViewModel`**: `VideoExtensions` collection + `SelectedVideoExtension`; load/save wiring; single-mode generate and batch-mode `MakeOutputFileName` now honor the selected extension (the latter changed from `static` to an instance method).
- **`BurnInWindow`**: dropdown added to the video-settings grid (reusing the existing `VideoExtension` localization string); surplus grid rows trimmed so there's no empty space below the new control.
- The single-mode **Save-as dialog** now lists all supported containers in its "Save as type" filter, with the selected one first.

## Notes on container choice
The ffmpeg container is inferred from the output filename extension, and nothing validates codec/container compatibility, so the list is kept conservative:
- `.mkv` — accepts every encoder offered (default)
- `.mp4` — the requested addition; pairs with H.264/H.265
- `.mov` — pairs with H.264/H.265 and is the native container for the ProRes encoder this window already offers

`.webm` is intentionally left out because it only works with VP9 and would fail with the default H.264 encoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)