### PR TITLE
Reuse last-opened media when opening a subtitle

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13691,6 +13691,13 @@ public partial class MainViewModel :
                 {
                     await VideoOpenFile(videoFileName, desiredAudioTrackId);
                 }
+                else if (TryGetRecentVideoFileName(fileName, out var recentVideoFileName))
+                {
+                    // Honor the media this subtitle was last opened with - e.g. an audio-only
+                    // project keeps its .wav instead of grabbing a later burned-in .mp4 of the
+                    // same name that FindVideoFileName would otherwise prefer (issue #11612).
+                    await VideoOpenFile(recentVideoFileName, desiredAudioTrackId);
+                }
                 else if (FindVideoFileName.TryFindVideoFileName(fileName, out videoFileName))
                 {
                     await VideoOpenFile(videoFileName, desiredAudioTrackId);
@@ -15186,6 +15193,28 @@ public partial class MainViewModel :
 
         AddToRecentFiles(true);
         return true;
+    }
+
+    // Looks up the media file this subtitle was last opened with from the recent-files list.
+    // Returns true only when a remembered video/audio file is recorded and still exists on disk.
+    private static bool TryGetRecentVideoFileName(string subtitleFileName, out string videoFileName)
+    {
+        videoFileName = string.Empty;
+        if (string.IsNullOrEmpty(subtitleFileName))
+        {
+            return false;
+        }
+
+        var recentFile = Se.Settings.File.RecentFiles
+            .FirstOrDefault(rf => string.Equals(rf.SubtitleFileName, subtitleFileName, StringComparison.OrdinalIgnoreCase));
+
+        if (recentFile != null && !string.IsNullOrEmpty(recentFile.VideoFileName) && File.Exists(recentFile.VideoFileName))
+        {
+            videoFileName = recentFile.VideoFileName;
+            return true;
+        }
+
+        return false;
     }
 
     private void AddToRecentFiles(bool updateMenu)


### PR DESCRIPTION
## Summary
Fixes #11612. When a subtitle is opened directly (File ▸ Open, double-click, drag-drop) with no remembered media, auto-open fell back to `FindVideoFileName`, which matches by name and searches **video extensions before audio**. For an audio-only project (`.wav` + `.ass`) that later had a video burned in, this grabbed the new same-named `.mp4` instead of the `.wav` the user was working with — layering subtitles over the burned-in video.

## Change
In `SubtitleOpen`'s auto-open block, insert a recent-files lookup **between** the explicit-video path and the name-matching fallback:

```csharp
if (!string.IsNullOrEmpty(videoFileName) && File.Exists(videoFileName))
{
    await VideoOpenFile(videoFileName, desiredAudioTrackId);          // remembered (e.g. recent-files reopen)
}
else if (TryGetRecentVideoFileName(fileName, out var recentVideoFileName))
{
    await VideoOpenFile(recentVideoFileName, desiredAudioTrackId);    // NEW: honor last-used media
}
else if (FindVideoFileName.TryFindVideoFileName(fileName, out videoFileName))
{
    await VideoOpenFile(videoFileName, desiredAudioTrackId);          // name-match fallback
}
```

The new `TryGetRecentVideoFileName` helper finds the recent-files entry whose `SubtitleFileName` matches the one being opened and returns its `VideoFileName` only if it's recorded and still exists on disk.

## Behavior
- **Plain open** of a subtitle now reuses the media it was last opened with → audio-only projects keep their `.wav` instead of grabbing a later burned-in `.mp4`.
- First-ever open (no recent entry) → unchanged, falls through to name matching.
- Remembered media deleted/moved → unchanged, falls through to name matching.
- Recent Files menu reopen → unchanged (already used the explicit path).

No new settings or UI; this just makes the existing recent-files memory authoritative for media selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)