### PR TITLE
Improve Find/Replace keyboard UX flow

### DIFF
--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -23,6 +24,7 @@ public partial class FindViewModel : ObservableObject
     public partial FindMode FindMode { get; set; }
 
     public Window? Window { get; set; }
+    public Action? FocusSearchBox { get; set; }
 
     public bool FindNextPressed { get; private set; }
     public bool FindPreviousPressed { get; private set; }

--- a/src/ui/Features/Edit/Find/FindWindow.cs
+++ b/src/ui/Features/Edit/Find/FindWindow.cs
@@ -153,16 +153,15 @@ public class FindWindow : Window
 
         Content = grid;
 
-        Opened += delegate
+        vm.FocusSearchBox = () => Avalonia.Threading.Dispatcher.UIThread.Post(() =>
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-            {
-                textBoxFind.GetVisualDescendants()
-                           .OfType<TextBox>()
-                           .FirstOrDefault()?
-                           .Focus();
-            });
-        };
+            textBoxFind.GetVisualDescendants()
+                       .OfType<TextBox>()
+                       .FirstOrDefault()?
+                       .Focus();
+        });
+
+        Opened += delegate { vm.FocusSearchBox(); };
         AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);
         Closing += (_, _) => vm.SaveSettings();
     }

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -27,6 +27,7 @@ public partial class ReplaceViewModel : ObservableObject
     
     public Window? Window { get; set; }
 
+    public bool FocusReplaceOnOpen { get; set; }
     public bool FindNextPressed { get; private set; }
     public bool ReplacePressed { get; private set; }
     public bool ReplaceAllPressed { get; private set; }

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -7,6 +7,7 @@ using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -26,6 +27,7 @@ public partial class ReplaceViewModel : ObservableObject
     public partial FindMode FindMode { get; set; }
     
     public Window? Window { get; set; }
+    public Action? FocusSearchBox { get; set; }
 
     public bool FocusReplaceOnOpen { get; set; }
     public bool FindNextPressed { get; private set; }

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -215,7 +215,10 @@ public class ReplaceWindow : Window
                 }
                 else
                 {
-                    vm.FocusSearchBox();
+                    textBoxFind.GetVisualDescendants()
+                               .OfType<TextBox>()
+                               .FirstOrDefault()?
+                               .Focus();
                 }
             });
         };

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -197,6 +197,14 @@ public class ReplaceWindow : Window
 
         Content = grid;
 
+        vm.FocusSearchBox = () => Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            textBoxFind.GetVisualDescendants()
+                       .OfType<TextBox>()
+                       .FirstOrDefault()?
+                       .Focus();
+        });
+
         Opened += delegate
         {
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
@@ -207,10 +215,7 @@ public class ReplaceWindow : Window
                 }
                 else
                 {
-                    textBoxFind.GetVisualDescendants()
-                               .OfType<TextBox>()
-                               .FirstOrDefault()?
-                               .Focus();
+                    vm.FocusSearchBox();
                 }
             });
         };

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -201,10 +201,17 @@ public class ReplaceWindow : Window
         {
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
-                textBoxFind.GetVisualDescendants()
-                           .OfType<TextBox>()
-                           .FirstOrDefault()?
-                           .Focus();
+                if (vm.FocusReplaceOnOpen)
+                {
+                    textBoxReplace.Focus();
+                }
+                else
+                {
+                    textBoxFind.GetVisualDescendants()
+                               .OfType<TextBox>()
+                               .FirstOrDefault()?
+                               .Focus();
+                }
             });
         };
         AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9555,6 +9555,7 @@ public partial class MainViewModel :
             _findPreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
             _findViewModel.ResultFound = false;
             _findViewModel.Window.Activate();
+            _findViewModel.FocusSearchBox?.Invoke();
             return;
         }
 
@@ -9585,7 +9586,13 @@ public partial class MainViewModel :
                 var cmd = _shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
                 if (ReferenceEquals(cmd, ShowReplaceCommand))
                 {
+                    e.Handled = true;
                     ShowReplace();
+                }
+                else if (ReferenceEquals(cmd, ShowFindCommand))
+                {
+                    e.Handled = true;
+                    vm.FocusSearchBox?.Invoke();
                 }
             };
             window.Closed += (_, _) =>
@@ -9881,6 +9888,7 @@ public partial class MainViewModel :
             _replacePreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
             _replaceViewModel.ResultFound = false;
             _replaceViewModel.Window.Activate();
+            _replaceViewModel.FocusSearchBox?.Invoke();
             return;
         }
 
@@ -9914,8 +9922,20 @@ public partial class MainViewModel :
                 vm.FindMode = findMode.Value;
                 vm.WholeWord = findWholeWord!.Value;
             }
+            window.AddHandler(InputElement.KeyDownEvent, _shortcutManager.OnKeyPressed, RoutingStrategies.Tunnel);
+            window.AddHandler(InputElement.KeyUpEvent, _shortcutManager.OnKeyReleased, RoutingStrategies.Bubble);
+            window.KeyDown += (_, e) =>
+            {
+                var cmd = _shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
+                if (ReferenceEquals(cmd, ShowReplaceCommand))
+                {
+                    e.Handled = true;
+                    vm.FocusSearchBox?.Invoke();
+                }
+            };
             window.Closed += (_, _) =>
             {
+                _shortcutManager.ClearKeys();
                 if (_replaceClosingProgrammatically)
                 {
                     _replaceClosingProgrammatically = false;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9907,6 +9907,7 @@ public partial class MainViewModel :
             if (!string.IsNullOrEmpty(findSearchText))
             {
                 vm.SearchText = findSearchText;
+                vm.FocusReplaceOnOpen = true;
             }
             if (findMode.HasValue)
             {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -9577,8 +9578,19 @@ public partial class MainViewModel :
             }
 
             vm.InitializeFindData(_findService, subs, selectedText, this);
+            window.AddHandler(InputElement.KeyDownEvent, _shortcutManager.OnKeyPressed, RoutingStrategies.Tunnel);
+            window.AddHandler(InputElement.KeyUpEvent, _shortcutManager.OnKeyReleased, RoutingStrategies.Bubble);
+            window.KeyDown += (_, e) =>
+            {
+                var cmd = _shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
+                if (ReferenceEquals(cmd, ShowReplaceCommand))
+                {
+                    ShowReplace();
+                }
+            };
             window.Closed += (_, _) =>
             {
+                _shortcutManager.ClearKeys();
                 if (_findClosingProgrammatically)
                 {
                     _findClosingProgrammatically = false;
@@ -9853,6 +9865,10 @@ public partial class MainViewModel :
             return;
         }
 
+        var findSearchText = _findViewModel?.SearchText;
+        var findMode = _findViewModel?.FindMode;
+        var findWholeWord = _findViewModel?.WholeWord;
+
         if (_findViewModel != null)
         {
             _findClosingProgrammatically = true;
@@ -9888,6 +9904,15 @@ public partial class MainViewModel :
             }
 
             vm.InitializeFindData(_findService, subs, selectedText, this);
+            if (!string.IsNullOrEmpty(findSearchText))
+            {
+                vm.SearchText = findSearchText;
+            }
+            if (findMode.HasValue)
+            {
+                vm.FindMode = findMode.Value;
+                vm.WholeWord = findWholeWord!.Value;
+            }
             window.Closed += (_, _) =>
             {
                 if (_replaceClosingProgrammatically)


### PR DESCRIPTION
  ## Summary

  Related UX improvements to the Find and Replace dialogs:

  - **Find → Replace switching**: pressing the Replace shortcut while the Find dialog is open now closes Find and opens Replace with the search text, find mode, and whole-word option transferred from the live Find UI state. The replace field receives focus since the search term is already set. When Replace opens cold (no Find transition), focus goes to the search field as before.

  - **Shortcut re-focus**: pressing the Find shortcut while Find is already open, or the Replace shortcut while Replace is already open, returns focus to the search box with the search text selected. Useful after clicking a radio button or button with the mouse when starting a new search.

  ## Notes

  - The Find and Replace windows are separate OS windows so the main window's shortcut handler is not active when they have focus. Key tracking (`IShortcutManager.OnKeyPressed/Released`) is hooked onto each dialog window to enable shortcut detection within them.
  - State transfer reads live ViewModel properties rather than persisted settings, since `SaveSettings()` only runs on Find Next/Count — not on radio button or checkbox changes.


  ## Rationale / UX assessment

  **Find → Replace switching**

  When the Find dialog is open and the user presses the Replace shortcut, nothing happens — the shortcut fires on the main window, which is not focused. The user has to manually close Find, open Replace, and re-type the search term.

  The fix: pressing the Replace shortcut while Find is open closes Find and opens Replace with the same search text, FindMode, and WholeWord transferred from the live Find UI state.

  This is a well-established pattern — VS Code, IntelliJ, Notepad++, and Sublime Text all behave this way. The workflow "find something to locate it → realize you need to replace it → press Replace shortcut" is natural and common.

  **Focus lands on the replace field**

  When from Find to Replace via shortcut, the user is already committed to the search term. The signal is "I know what I'm searching for; now I need to type what to replace it with." The next required input is the replacement — so that's where focus lands.

  Focusing the search box instead would force a Tab or click to reach the empty replace field. That's the right default when opening Replace cold, but wrong here. VS Code follows the same logic: expanding Find → Find+Replace with a term already set moves focus to the replace field.

  **Shortcut re-focuses the search box when the dialog is already open**

  After clicking a button, checkbox, or radio button, the user's hands return to the keyboard. Re-pressing the shortcut is the natural way to get back to the search box without reaching for the mouse or tabbing through controls.

  The search text is also selected on re-focus, so the user can immediately type a new term to replace it.

  For Replace, re-pressing the Replace shortcut focuses the search box (not the replace field) — the user is signaling they want to change what they're searching for.
