### PR TITLE
Cache Matroska subtitle tracks across track switches

### DIFF
--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -18,8 +18,9 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         private double _frameRate;
         private string _videoCodecId;
 
-        private int _subtitleRipTrackNumber;
-        private readonly List<MatroskaSubtitle> _subtitleRip = new List<MatroskaSubtitle>();
+        private readonly Dictionary<int, List<MatroskaSubtitle>> _subtitleRipByTrackNumber = new Dictionary<int, List<MatroskaSubtitle>>();
+        private HashSet<int> _subtitleTrackNumbers;
+        private bool _subtitleRipLoaded;
         private List<MatroskaTrackInfo> _tracks;
         private List<MatroskaChapter> _chapters;
 
@@ -558,11 +559,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
                         ReadBlockGroupElement(element, clusterTimeCode);
                         break;
                     case ElementId.SimpleBlock:
-                        var subtitle = ReadSubtitleBlock(element, clusterTimeCode);
-                        if (subtitle != null)
-                        {
-                            _subtitleRip.Add(subtitle);
-                        }
+                        AddSubtitleBlock(ReadSubtitleBlock(element, clusterTimeCode));
                         break;
                     default:
                         _stream.Seek(element.DataSize, SeekOrigin.Current);
@@ -581,12 +578,9 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
                 switch (element.Id)
                 {
                     case ElementId.Block:
-                        subtitle = ReadSubtitleBlock(element, clusterTimeCode);
-                        if (subtitle == null)
-                        {
-                            return;
-                        }
-                        _subtitleRip.Add(subtitle);
+                        var subtitleBlock = ReadSubtitleBlock(element, clusterTimeCode);
+                        subtitle = subtitleBlock?.Subtitle;
+                        AddSubtitleBlock(subtitleBlock);
                         break;
                     case ElementId.BlockDuration:
                         var duration = ReadUIntAsLong(element.DataSize);
@@ -602,10 +596,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
             }
         }
 
-        private MatroskaSubtitle ReadSubtitleBlock(Element blockElement, long clusterTimeCode)
+        private MatroskaSubtitleBlock ReadSubtitleBlock(Element blockElement, long clusterTimeCode)
         {
             var trackNumber = (int)ReadVariableLengthUInt();
-            if (trackNumber != _subtitleRipTrackNumber)
+            if (!IsSubtitleTrackNumber(trackNumber))
             {
                 _stream.Seek(blockElement.EndPosition, SeekOrigin.Begin);
                 return null;
@@ -644,22 +638,68 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
             var data = new byte[dataLength];
             _stream.Read(data, 0, dataLength);
 
-            return new MatroskaSubtitle(data, (long)Math.Round(GetTimeScaledToMilliseconds(clusterTimeCode + timeCode)));
+            var subtitle = new MatroskaSubtitle(data, (long)Math.Round(GetTimeScaledToMilliseconds(clusterTimeCode + timeCode)));
+            return new MatroskaSubtitleBlock(trackNumber, subtitle);
         }
 
         public List<MatroskaSubtitle> GetSubtitle(int trackNumber, LoadMatroskaCallback progressCallback)
         {
-            // Cache: GetSubtitle is called multiple times per UI flow (preview, OCR).
-            // Reuse the previously parsed list when the track matches.
-            if (_subtitleRipTrackNumber == trackNumber && _subtitleRip.Count > 0)
+            if (!_subtitleRipLoaded)
             {
-                return _subtitleRip;
+                EnsureSubtitleTrackNumbers();
+                _subtitleRipByTrackNumber.Clear();
+                ReadSegmentCluster(progressCallback);
+                _subtitleRipLoaded = true;
             }
 
-            _subtitleRip.Clear();
-            _subtitleRipTrackNumber = trackNumber;
-            ReadSegmentCluster(progressCallback);
-            return _subtitleRip;
+            return _subtitleRipByTrackNumber.TryGetValue(trackNumber, out var subtitles)
+                ? subtitles
+                : new List<MatroskaSubtitle>();
+        }
+
+        private bool IsSubtitleTrackNumber(int trackNumber)
+        {
+            EnsureSubtitleTrackNumbers();
+            return _subtitleTrackNumbers.Contains(trackNumber);
+        }
+
+        private void EnsureSubtitleTrackNumbers()
+        {
+            if (_subtitleTrackNumbers == null)
+            {
+                ReadSegmentInfoAndTracks();
+                _subtitleTrackNumbers = new HashSet<int>(
+                    _tracks?.Where(p => p.IsSubtitle).Select(p => p.TrackNumber) ?? Enumerable.Empty<int>());
+            }
+        }
+
+        private void AddSubtitleBlock(MatroskaSubtitleBlock subtitleBlock)
+        {
+            if (subtitleBlock == null)
+            {
+                return;
+            }
+
+            if (!_subtitleRipByTrackNumber.TryGetValue(subtitleBlock.TrackNumber, out var subtitles))
+            {
+                subtitles = new List<MatroskaSubtitle>();
+                _subtitleRipByTrackNumber.Add(subtitleBlock.TrackNumber, subtitles);
+            }
+
+            subtitles.Add(subtitleBlock.Subtitle);
+        }
+
+        private sealed class MatroskaSubtitleBlock
+        {
+            public MatroskaSubtitleBlock(int trackNumber, MatroskaSubtitle subtitle)
+            {
+                TrackNumber = trackNumber;
+                Subtitle = subtitle;
+            }
+
+            public int TrackNumber { get; }
+
+            public MatroskaSubtitle Subtitle { get; }
         }
 
         public void Dispose() => Dispose(true);

--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -154,9 +154,8 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         else if (trackInfo.CodecId == MatroskaTrackType.TextSt && subtitles != null && _matroskaFile != null)
         {
             var subtitle = new Subtitle();
-            var sub = _matroskaFile.GetSubtitle(trackInfo.TrackNumber, null);
-            Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, sub, subtitle);
-            Utilities.ParseMatroskaTextSt(trackInfo, sub, subtitle);
+            Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, subtitles, subtitle);
+            Utilities.ParseMatroskaTextSt(trackInfo, subtitles, subtitle);
             await WriteTextSubtitleFile(Window, trackInfo, subtitles, new SubRip());
         }
         else
@@ -261,9 +260,8 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         else if (trackInfo.CodecId == MatroskaTrackType.TextSt && subtitles != null && _matroskaFile != null)
         {
             var subtitle = new Subtitle();
-            var sub = _matroskaFile.GetSubtitle(trackInfo.TrackNumber, null);
-            Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, sub, subtitle);
-            Utilities.ParseMatroskaTextSt(trackInfo, sub, subtitle);
+            Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, subtitles, subtitle);
+            Utilities.ParseMatroskaTextSt(trackInfo, subtitles, subtitle);
 
             for (var i = 0; i < 20 && i < subtitle.Paragraphs.Count; i++)
             {

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbedTrackPreviewViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbedTrackPreviewViewModel.cs
@@ -167,9 +167,8 @@ public partial class EmbedTrackPreviewViewModel : ObservableObject
         else if (trackInfo.CodecId == MatroskaTrackType.TextSt && subtitles != null && _matroskaFile != null)
         {
             var subtitle = new Subtitle();
-            var sub = _matroskaFile.GetSubtitle(trackInfo.TrackNumber, null);
-            Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, sub, subtitle);
-            Utilities.ParseMatroskaTextSt(trackInfo, sub, subtitle);
+            Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, subtitles, subtitle);
+            Utilities.ParseMatroskaTextSt(trackInfo, subtitles, subtitle);
 
             for (var i = 0; i < 20 && i < subtitle.Paragraphs.Count; i++)
             {


### PR DESCRIPTION
## Summary

This PR reduces repeated reads of the same Matroska file when working with embedded subtitle tracks.

The main change is in `MatroskaFile.GetSubtitle(...)`: the first subtitle extraction now scans the Matroska clusters once and caches subtitle blocks for all subtitle tracks in memory, keyed by Matroska track number. Later requests for any subtitle track on the same `MatroskaFile` instance reuse that cache instead of scanning the file again.

## Why

The `Pick Matroska track` dialog previews subtitle tracks by calling `GetSubtitle(...)` when the selected row changes. Before this change, `MatroskaFile` only cached the most recently requested track. Selecting track A, then B, then A again caused another full scan of the MKV for A. The same repeated read also showed up when the selected track was loaded after previewing it.

This is especially noticeable with large `.mkv` files because every track switch can turn into another read through the container.

## What changed

- Replace the single-track Matroska subtitle cache with an in-memory cache for all subtitle tracks in the current `MatroskaFile` instance.
- Collect subtitle blocks for all subtitle tracks during the first cluster scan.
- Keep the public `GetSubtitle(int trackNumber, LoadMatroskaCallback progressCallback)` API unchanged.
- Remove duplicate `GetSubtitle(...)` calls for HDMV TextST preview/export paths where the subtitles list had already been loaded.

The cache remains scoped to the lifetime of a `MatroskaFile` instance and is released when that instance is disposed.

## Known remaining behavior

There is still another related scenario outside this PR: after selecting an image-based MKV track and opening the OCR window, pressing `Edit/Export` opens `Edit image-based subtitle`. That path currently passes both the source file name and the already extracted OCR subtitle data to `BinaryEditViewModel`, but `BinaryEditViewModel` reloads the file when a file name is present. For multi-track or large MKV files this can show `Pick Matroska track` again and trigger another Matroska read.

That behavior is significant for large files, but it is a separate handoff/lifetime issue between the OCR and BinaryEdit windows. This PR keeps the scope limited to improving repeated reads within a single `MatroskaFile` instance.

## Validation

Ran locally:

- `dotnet test tests\\libse\\LibSETests.csproj --no-restore`

Also checked on the newer upstream-based branch before preparing this fork-compatible PR branch:

- `dotnet test tests\\libse\\LibSETests.csproj --no-restore`
- `dotnet test tests\\libuilogic\\LibUiLogicTests.csproj --no-restore`
- `dotnet build src\\UI\\UI.csproj --configuration Release --no-restore`

On this older fork base, `tests/UI/UITests.csproj` and `src/UI/UI.csproj` hit existing package/project setup issues unrelated to this change (`xUnit v3 OutputType` and missing UI package references without refreshing the lock/restore state), so I did not include lockfile updates in this PR.
