### PR TITLE
Add go-to / copy current video position to the player slider

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -366,6 +366,15 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 Margin = new Thickness(2, 0, 0, 0),
                 [AutomationProperties.NameProperty] = Se.Language.General.VideoPosition,
             };
+
+            // Right-click the position slider to jump to / copy the current video position
+            // (SE4 parity for the old "Video position" control).
+            var goToPositionItem = new Avalonia.Controls.MenuItem { Header = Se.Language.Options.Shortcuts.GeneralGoToVideoPosition };
+            goToPositionItem.Click += (_, _) => GoToPositionRequested?.Invoke();
+            var copyPositionItem = new Avalonia.Controls.MenuItem { Header = Se.Language.General.Copy };
+            copyPositionItem.Click += (_, _) => CopyPositionRequested?.Invoke();
+            sliderPosition.ContextFlyout = new MenuFlyout { Items = { goToPositionItem, copyPositionItem } };
+
             if (Se.Settings.Appearance.ShowHints)
             {
                 ToolTip.SetTip(sliderPosition, Se.Language.General.VideoPosition);
@@ -685,6 +694,8 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         public event Action<double>? UserSeeked;
         public event Action<double>? VolumeChanged;
         public event Action? ToggleDisplayProgressTextModeRequested;
+        public event Action? GoToPositionRequested;
+        public event Action? CopyPositionRequested;
         public event Action<PointerPressedEventArgs>? VideoFileNamePointerPressed;
 
         public void SetPlayPauseIcon(bool isPlaying)

--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -79,6 +79,8 @@ public static class InitVideoPlayer
         control.VideoFileNamePointerPressed += vm.VideoPlayerControlPointerPressed;
         control.SurfacePointerPressed += (_, _) => vm.VideoPlayerAreaPointerPressed();
         control.UserSeeked += vm.OnVideoPlayerUserSeeked;
+        control.GoToPositionRequested += () => vm.ShowGoToVideoPositionCommand.Execute(null);
+        control.CopyPositionRequested += () => vm.CopyVideoPositionCommand.Execute(null);
 
         Grid.SetRow(control, 0);
         mainGrid.Children.Add(control);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5632,6 +5632,21 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task CopyVideoPosition()
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp == null || Window == null || string.IsNullOrEmpty(_videoFileName))
+        {
+            return;
+        }
+
+        // Copy the current position as a timecode, applying the same video offset the player
+        // shows. SE4 parity: the old "Video position" control let you copy the current position.
+        var seconds = vp.Position + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0;
+        await ClipboardHelper.SetTextAsync(Window, TimeCode.FromSeconds(seconds).ToDisplayString());
+    }
+
+    [RelayCommand]
     private void ToggleIsWaveformToolbarVisible()
     {
         IsWaveformToolbarVisible = !IsWaveformToolbarVisible;


### PR DESCRIPTION
Adds go-to / copy of the current video position, addressing the follow-up on #11598 (@OmrSi: "a way to go to a video position and copy the current video position", which SE4 had on the Video position control).

Right-click the **video position slider**:
- **Go to video position** - opens the existing go-to dialog (previously only reachable via shortcut).
- **Copy** - copies the current position as a timecode, applying the configured video offset.

New `CopyVideoPosition` command; `VideoPlayerControl` raises `GoToPositionRequested`/`CopyPositionRequested` from a context menu on the slider, wired to the view-model in `InitVideoPlayer`. Reuses existing language strings (no new tags). Builds clean (0/0).

Couldn't GUI-test here; a Windows/macOS test build can be provided to confirm the menu and copy if useful.