### PR TITLE
Fix: whole-word search misses terms starting/ending with punctuation (regression from SE4)

### DIFF
--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -181,6 +181,14 @@ namespace Nikse.SubtitleEdit.Core.Common
             return new Regex(@"\b" + s + @"\b", RegexOptions.Compiled);
         }
 
+        public static string BuildWholeWordPattern(string searchText)
+        {
+            var escaped = Regex.Escape(searchText);
+            var prefix = searchText.Length > 0 && (char.IsLetterOrDigit(searchText[0]) || searchText[0] == '_') ? @"\b" : @"(?<!\w)";
+            var suffix = searchText.Length > 0 && (char.IsLetterOrDigit(searchText[searchText.Length - 1]) || searchText[searchText.Length - 1] == '_') ? @"\b" : @"(?!\w)";
+            return $"{prefix}{escaped}{suffix}";
+        }
+
         public static string GetRegExGroup(string pattern)
         {
             var start = pattern.IndexOf("(?<", StringComparison.Ordinal);

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3258,8 +3258,7 @@ public partial class OcrViewModel : ObservableObject
         else
         {
             // fallback, try to find the word in text using regex using word boundary 
-            var pattern = @"\b" + Regex.Escape(unknownWord.Word.FixedWord) + @"\b";
-            var regex = new Regex(pattern);
+            var regex = new Regex(RegexUtils.BuildWholeWordPattern(unknownWord.Word.FixedWord));
             var match = regex.Match(item.Text);
             if (match.Success)
             {

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -425,7 +425,7 @@ public partial class FindService : IFindService
 
     private (bool replaced, string newText, int replacementCount) ReplaceWholeWordWithStringComparison(string line, string searchText, string replaceText, int startIndex, int maxReplacements, StringComparison comparison)
     {
-        var pattern = $@"\b{Regex.Escape(searchText)}\b";
+        var pattern = BuildWholeWordPattern(searchText);
         var options = comparison == StringComparison.OrdinalIgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
         try
@@ -465,13 +465,21 @@ public partial class FindService : IFindService
         }
     }
 
+    private static string BuildWholeWordPattern(string searchText)
+    {
+        var escaped = Regex.Escape(searchText);
+        var prefix = searchText.Length > 0 && (char.IsLetterOrDigit(searchText[0]) || searchText[0] == '_') ? @"\b" : @"(?<!\w)";
+        var suffix = searchText.Length > 0 && (char.IsLetterOrDigit(searchText[searchText.Length - 1]) || searchText[searchText.Length - 1] == '_') ? @"\b" : @"(?!\w)";
+        return $"{prefix}{escaped}{suffix}";
+    }
+
     private (bool found, int index, string foundText) FindWithStringComparison(string line, string searchText, StringComparison comparison, int startIndex)
     {
         var searchLine = startIndex > 0 ? line.Substring(startIndex) : line;
 
         if (WholeWord)
         {
-            var pattern = $@"\b{Regex.Escape(searchText)}\b";
+            var pattern = BuildWholeWordPattern(searchText);
             var options = comparison == StringComparison.OrdinalIgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
             try
@@ -505,7 +513,7 @@ public partial class FindService : IFindService
 
         if (WholeWord)
         {
-            var pattern = $@"\b{Regex.Escape(searchText)}\b";
+            var pattern = BuildWholeWordPattern(searchText);
             var options = comparison == StringComparison.OrdinalIgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
             try
@@ -650,7 +658,7 @@ public partial class FindService : IFindService
 
                 if (WholeWord)
                 {
-                    var pattern = $@"\b{Regex.Escape(searchText)}\b";
+                    var pattern = BuildWholeWordPattern(searchText);
                     var options = CurrentFindMode == FindMode.CaseInsensitive ? RegexOptions.IgnoreCase : RegexOptions.None;
 
                     try

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -425,7 +425,7 @@ public partial class FindService : IFindService
 
     private (bool replaced, string newText, int replacementCount) ReplaceWholeWordWithStringComparison(string line, string searchText, string replaceText, int startIndex, int maxReplacements, StringComparison comparison)
     {
-        var pattern = BuildWholeWordPattern(searchText);
+        var pattern = RegexUtils.BuildWholeWordPattern(searchText);
         var options = comparison == StringComparison.OrdinalIgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
         try
@@ -465,21 +465,13 @@ public partial class FindService : IFindService
         }
     }
 
-    private static string BuildWholeWordPattern(string searchText)
-    {
-        var escaped = Regex.Escape(searchText);
-        var prefix = searchText.Length > 0 && (char.IsLetterOrDigit(searchText[0]) || searchText[0] == '_') ? @"\b" : @"(?<!\w)";
-        var suffix = searchText.Length > 0 && (char.IsLetterOrDigit(searchText[searchText.Length - 1]) || searchText[searchText.Length - 1] == '_') ? @"\b" : @"(?!\w)";
-        return $"{prefix}{escaped}{suffix}";
-    }
-
     private (bool found, int index, string foundText) FindWithStringComparison(string line, string searchText, StringComparison comparison, int startIndex)
     {
         var searchLine = startIndex > 0 ? line.Substring(startIndex) : line;
 
         if (WholeWord)
         {
-            var pattern = BuildWholeWordPattern(searchText);
+            var pattern = RegexUtils.BuildWholeWordPattern(searchText);
             var options = comparison == StringComparison.OrdinalIgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
             try
@@ -513,7 +505,7 @@ public partial class FindService : IFindService
 
         if (WholeWord)
         {
-            var pattern = BuildWholeWordPattern(searchText);
+            var pattern = RegexUtils.BuildWholeWordPattern(searchText);
             var options = comparison == StringComparison.OrdinalIgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
             try
@@ -658,7 +650,7 @@ public partial class FindService : IFindService
 
                 if (WholeWord)
                 {
-                    var pattern = BuildWholeWordPattern(searchText);
+                    var pattern = RegexUtils.BuildWholeWordPattern(searchText);
                     var options = CurrentFindMode == FindMode.CaseInsensitive ? RegexOptions.IgnoreCase : RegexOptions.None;
 
                     try


### PR DESCRIPTION
## Bug

Whole-word search in Find/Replace fails to match any term that starts or ends with a non-alphabetic character. For example, searching for `[man]` or `"Fine." or `'em` with **Whole Word** checked returns no results, even when the subtitle text contains the exact string surrounded by spaces or at a line boundary. The same applies to any term beginning or ending with brackets, parentheses, quotes, or other punctuation.

## Root cause

SE5's `FindService` builds the whole-word regex pattern as:

```csharp
var pattern = $@"\b{Regex.Escape(searchText)}\b";
```

The `\b` word-boundary anchor matches at a position where one side is a word character (`[a-zA-Z0-9_]`) and the other is not. When the search term starts with a non-word character such as `[`, the leading `\b` requires a word character immediately to the left — so the pattern never matches at line start or after a space. The trailing `\b` has the symmetric problem.

## How SE4 handled it

SE4's `FindReplaceDialogHelper` did not use `\b` at all. It maintained an explicit list of separator characters:

```csharp
private const string SeparatorChars = " #><-\"„""[]''`´¶(){}♪,.!?:;¿¡.…—،؟\r\n ";
```

and checked boundaries manually after each `IndexOf` hit:

```csharp
var startOk = idx == 0 || SeparatorChars.Contains(text[idx - 1]);
var endOk   = idx + FindText.Length == text.Length || SeparatorChars.Contains(text[idx + FindText.Length]);
```

Because `[` and `]` are in that list, `[man]` was correctly found as a whole word when surrounded by any listed separator.

## Fix

This PR adds a `BuildWholeWordPattern` helper to `RegexUtils` that selects the right boundary assertion based on whether the search term's first/last character is a word character:

- Word character boundary → `\b` (unchanged, correct for plain words like `man`)
- Non-word character boundary → `(?<!\w)` / `(?!\w)` lookaround, asserting "no word character adjacent here"

```csharp
public static string BuildWholeWordPattern(string searchText)
{
    var escaped = Regex.Escape(searchText);
    var prefix = searchText.Length > 0 && (char.IsLetterOrDigit(searchText[0]) || searchText[0] == '_')
        ? @"\b" : @"(?<!\w)";
    var suffix = searchText.Length > 0 && (char.IsLetterOrDigit(searchText[searchText.Length - 1]) || searchText[searchText.Length - 1] == '_')
        ? @"\b" : @"(?!\w)";
    return $"{prefix}{escaped}{suffix}";
}
```

For a plain word like `man` the result is `\bman\b` — identical to before.
For `[man]` the result is `(?<!\w)\[man\](?!\w)`, which matches correctly at line start, after a space, or next to other punctuation.

The helper lives in `RegexUtils` (libse) so it is available to all layers. It is used in all four whole-word paths in `FindService` (forward search, reverse search, replace, count/find-all), and also defensively in `OcrViewModel` where the same `\b` + `Regex.Escape` pattern existed as a fallback for word replacement. That fallback only fires when the OCR word index is off by more than one character — an uncommon condition — but when it does fire for a word starting with a non-word character (e.g. `|t` as a misread of `It`), the old pattern would silently fail. `RemoveInterjection` uses the same `\b` pattern but is not affected: interjections are always plain words by definition, so `\b` is correct there.

## Difference from SE4's approach

SE4's separator list is a closed whitelist; any character not on it was silently treated as a word character. The new approach uses .NET's `\w` definition, which covers all Unicode letters and digits. Results are equivalent for the ASCII punctuation that appears in subtitle content, and the new approach is more robust for non-ASCII text.
