### PR TITLE
Smooth out waveform/video playback cursor (lag, stutter, seek delay)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1958,13 +1958,38 @@ public class AudioVisualizer : Control
             waveformHeight = renderCtx.WaveformHeight;
         }
 
-        if (WaveformDrawStyle == WaveformDrawStyle.Classic)
+        // Rebuild the cached geometry only when the view actually changed; otherwise (e.g. the
+        // cursor moved) just replay the existing draw ops. See _waveformCacheDraws.
+        var key = BuildWaveformCacheKey(waveformHeight, ref renderCtx);
+        if (!_waveformCacheValid || !ReferenceEquals(_waveformCachePeaks, WavePeaks) || !key.Equals(_waveformCacheKey))
         {
-            DrawWaveFormClassic(context, waveformHeight, ref renderCtx);
+            _waveformCacheDraws.Clear();
+            if (WaveformDrawStyle == WaveformDrawStyle.Classic)
+            {
+                BuildWaveFormClassic(waveformHeight, ref renderCtx);
+            }
+            else
+            {
+                BuildWaveFormFancy(waveformHeight, ref renderCtx);
+            }
+
+            _waveformCacheKey = key;
+            _waveformCachePeaks = WavePeaks;
+            _waveformCacheValid = true;
         }
-        else
+
+        // The fancy style draws a center line; it depends only on width/height (already in the
+        // key) so it's cheap to draw live each render rather than caching it.
+        if (WaveformDrawStyle != WaveformDrawStyle.Classic)
         {
-            DrawWaveFormFancy(context, waveformHeight, ref renderCtx);
+            var halfWaveformHeight = waveformHeight / 2;
+            context.DrawLine(_centerLinePen, new Point(0, halfWaveformHeight), new Point(renderCtx.Width, halfWaveformHeight));
+        }
+
+        for (var i = 0; i < _waveformCacheDraws.Count; i++)
+        {
+            var draw = _waveformCacheDraws[i];
+            context.DrawGeometry(null, draw.Pen, draw.Geometry);
         }
     }
 
@@ -2025,7 +2050,7 @@ public class AudioVisualizer : Control
     private readonly Dictionary<int, FancyBatch> _fancyBatches = new(64);
     private readonly List<int> _fancyBatchKeysInUse = new(64);
 
-    private void DrawWaveFormFancy(DrawingContext context, double waveformHeight, ref RenderContext renderCtx)
+    private void BuildWaveFormFancy(double waveformHeight, ref RenderContext renderCtx)
     {
         _isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate);
         var isSelectedHelper = _isSelectedHelper;
@@ -2042,9 +2067,6 @@ public class AudioVisualizer : Control
         var peaks = WavePeaks.AsSpan();
         var peaksCount = peaks.Length;
         var highestPeak = renderCtx.HighestPeak;
-
-        // Draw center line first
-        context.DrawLine(_centerLinePen, new Point(0, halfWaveformHeight), new Point(renderCtx.Width, halfWaveformHeight));
 
         // Calculate the threshold for color transitions (as a fraction of the highest peak)
         var lowThreshold = highestPeak * 0.3;
@@ -2169,35 +2191,18 @@ public class AudioVisualizer : Control
             }
         }
 
-        // One DrawGeometry per pen, instead of two DrawLines per column.
+        // One cached geometry per pen, instead of two DrawLines per column.
         // The gradient brush bounds become the entire waveform area instead of each
         // individual line, so the gradient fades across the waveform vertically rather
         // than per column.
         for (var i = 0; i < keysInUse.Count; i++)
         {
             var batch = batches[keysInUse[i]];
-            var lines = batch.Lines;
-            if (lines.Count == 0)
-            {
-                continue;
-            }
-
-            var geom = new StreamGeometry();
-            using (var gctx = geom.Open())
-            {
-                for (var j = 0; j < lines.Count; j++)
-                {
-                    var l = lines[j];
-                    gctx.BeginFigure(new Point(l.X, l.YMax), false);
-                    gctx.LineTo(new Point(l.X, l.YMin));
-                    gctx.EndFigure(false);
-                }
-            }
-            context.DrawGeometry(null, batch.Pen, geom);
+            AddLineBatchToCache(batch.Pen, batch.Lines);
         }
     }
 
-    private void DrawWaveFormClassic(DrawingContext context, double waveformHeight, ref RenderContext renderCtx)
+    private void BuildWaveFormClassic(double waveformHeight, ref RenderContext renderCtx)
     {
         _isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate);
         var isSelectedHelper = _isSelectedHelper;
@@ -2262,13 +2267,137 @@ public class AudioVisualizer : Control
             }
         }
 
-        DrawVerticalLineBatch(context, _paintWaveform, unselectedLines);
-        DrawVerticalLineBatch(context, _paintPenSelected, selectedLines);
+        AddLineBatchToCache(_paintWaveform, unselectedLines);
+        AddLineBatchToCache(_paintPenSelected, selectedLines);
     }
 
     // Pooled buffers for the classic waveform's two pens.
     private readonly List<FancyLine> _classicUnselectedLines = new(2048);
     private readonly List<FancyLine> _classicSelectedLines = new(2048);
+
+    // Cached waveform draw ops. Building the waveform is a per-pixel CPU loop that allocates
+    // geometry every render; doing it on every cursor tick (CurrentVideoPositionSeconds has
+    // AffectsRender) made playback stutter, worst over loud audio (extra glow geometry). We
+    // build the geometry once per view-state and just replay the draw calls while only the
+    // cursor moves. The key captures everything that changes the waveform pixels, so any real
+    // change (scroll, zoom, resize, selection, peaks, colors, style) rebuilds automatically.
+    private readonly List<(IPen Pen, Geometry Geometry)> _waveformCacheDraws = new(64);
+    private WaveformCacheKey _waveformCacheKey;
+    private bool _waveformCacheValid;
+    private object? _waveformCachePeaks;
+
+    private readonly struct WaveformCacheKey : IEquatable<WaveformCacheKey>
+    {
+        public readonly int Width;
+        public readonly double Height;
+        public readonly double WaveformHeight;
+        public readonly double StartPositionSeconds;
+        public readonly double ZoomFactor;
+        public readonly double VerticalZoomFactor;
+        public readonly double HighestPeak;
+        public readonly int SampleRate;
+        public readonly int DisplayMode;
+        public readonly int DrawStyle;
+        public readonly uint ColorMain;
+        public readonly uint ColorSelected;
+        public readonly uint ColorHigh;
+        public readonly int SelectionCount;
+        public readonly long SelectionHash;
+
+        public WaveformCacheKey(int width, double height, double waveformHeight, double startPositionSeconds,
+            double zoomFactor, double verticalZoomFactor, double highestPeak, int sampleRate, int displayMode,
+            int drawStyle, uint colorMain, uint colorSelected, uint colorHigh, int selectionCount, long selectionHash)
+        {
+            Width = width;
+            Height = height;
+            WaveformHeight = waveformHeight;
+            StartPositionSeconds = startPositionSeconds;
+            ZoomFactor = zoomFactor;
+            VerticalZoomFactor = verticalZoomFactor;
+            HighestPeak = highestPeak;
+            SampleRate = sampleRate;
+            DisplayMode = displayMode;
+            DrawStyle = drawStyle;
+            ColorMain = colorMain;
+            ColorSelected = colorSelected;
+            ColorHigh = colorHigh;
+            SelectionCount = selectionCount;
+            SelectionHash = selectionHash;
+        }
+
+        public bool Equals(WaveformCacheKey other) =>
+            Width == other.Width &&
+            Height.Equals(other.Height) &&
+            WaveformHeight.Equals(other.WaveformHeight) &&
+            StartPositionSeconds.Equals(other.StartPositionSeconds) &&
+            ZoomFactor.Equals(other.ZoomFactor) &&
+            VerticalZoomFactor.Equals(other.VerticalZoomFactor) &&
+            HighestPeak.Equals(other.HighestPeak) &&
+            SampleRate == other.SampleRate &&
+            DisplayMode == other.DisplayMode &&
+            DrawStyle == other.DrawStyle &&
+            ColorMain == other.ColorMain &&
+            ColorSelected == other.ColorSelected &&
+            ColorHigh == other.ColorHigh &&
+            SelectionCount == other.SelectionCount &&
+            SelectionHash == other.SelectionHash;
+
+        public override bool Equals(object? obj) => obj is WaveformCacheKey other && Equals(other);
+        public override int GetHashCode() => 0; // unused; cache does an exact Equals comparison
+    }
+
+    private static uint ToKeyColor(Color c) => ((uint)c.A << 24) | ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
+
+    private WaveformCacheKey BuildWaveformCacheKey(double waveformHeight, ref RenderContext renderCtx)
+    {
+        long selectionHash = 17;
+        var selection = AllSelectedParagraphs;
+        for (var i = 0; i < selection.Count; i++)
+        {
+            var p = selection[i];
+            selectionHash = selectionHash * 31 + p.StartTime.Ticks;
+            selectionHash = selectionHash * 31 + p.EndTime.Ticks;
+        }
+
+        return new WaveformCacheKey(
+            (int)Math.Ceiling(renderCtx.Width),
+            renderCtx.Height,
+            waveformHeight,
+            renderCtx.StartPositionSeconds,
+            renderCtx.ZoomFactor,
+            renderCtx.VerticalZoomFactor,
+            renderCtx.HighestPeak,
+            renderCtx.SampleRate,
+            (int)_displayMode,
+            (int)WaveformDrawStyle,
+            ToKeyColor(WaveformColor),
+            ToKeyColor(WaveformSelectedColor),
+            ToKeyColor(WaveformFancyHighColor),
+            selection.Count,
+            selectionHash);
+    }
+
+    private void AddLineBatchToCache(IPen pen, List<FancyLine> lines)
+    {
+        if (lines.Count == 0)
+        {
+            return;
+        }
+
+        var geom = new StreamGeometry();
+        using (var gctx = geom.Open())
+        {
+            for (var i = 0; i < lines.Count; i++)
+            {
+                var l = lines[i];
+                gctx.BeginFigure(new Point(l.X, l.YMax), false);
+                gctx.LineTo(new Point(l.X, l.YMin));
+                gctx.EndFigure(false);
+            }
+        }
+
+        _waveformCacheDraws.Add((pen, geom));
+    }
 
     private static void DrawVerticalLineBatch(DrawingContext context, IPen pen, List<FancyLine> lines)
     {
@@ -2306,6 +2435,56 @@ public class AudioVisualizer : Control
         }
     }
 
+    // Subtitle text is otherwise re-shaped on every frame. At 60 fps the FormattedText shaping
+    // plus RemoveHtmlTags (regex) and SplitToLines for each visible paragraph churns enough
+    // short-lived garbage to trigger GC pauses, which show up as the cursor briefly freezing and
+    // then jumping. Cache the prepared text and the shaped FormattedText; both are cleared in
+    // ResetCache() when the waveform font/colors change.
+    private readonly Dictionary<string, FormattedText> _paragraphFormattedTextCache = new(512);
+    private readonly Dictionary<string, (List<string> Lines, string Unwrapped)> _paragraphTextCache = new(512);
+
+    private FormattedText GetCachedParagraphText(string text)
+    {
+        if (!_paragraphFormattedTextCache.TryGetValue(text, out var formatted))
+        {
+            if (_paragraphFormattedTextCache.Count > 8000)
+            {
+                _paragraphFormattedTextCache.Clear();
+            }
+
+            formatted = new FormattedText(text, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
+                _typeface, _fontSize, _paintText);
+            _paragraphFormattedTextCache[text] = formatted;
+        }
+
+        return formatted;
+    }
+
+    private (List<string> Lines, string Unwrapped) GetPreparedParagraphText(string rawText)
+    {
+        if (!_paragraphTextCache.TryGetValue(rawText, out var prepared))
+        {
+            var text = HtmlUtil.RemoveHtmlTags(rawText, true);
+            if (text.Length > 200)
+            {
+                text = text.Substring(0, 100).TrimEnd() + "...";
+            }
+
+            var lines = text.SplitToLines();
+            var unwrapped = string.Join("  ", lines);
+            prepared = (lines, unwrapped);
+
+            if (_paragraphTextCache.Count > 8000)
+            {
+                _paragraphTextCache.Clear();
+            }
+
+            _paragraphTextCache[rawText] = prepared;
+        }
+
+        return prepared;
+    }
+
     private void DrawParagraph(SubtitleLineViewModel paragraph, DrawingContext context, ref RenderContext renderCtx)
     {
         var currentRegionLeft = SecondsToXPositionOptimized(paragraph.StartTime.TotalSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
@@ -2327,32 +2506,24 @@ public class AudioVisualizer : Control
         context.DrawLine(_paintLeft, new Point(currentRegionLeft, 0), new Point(currentRegionLeft, height));
         context.DrawLine(_paintRight, new Point(currentRegionRight - 1, 0), new Point(currentRegionRight - 1, height));
 
-        // Draw clipped text
-        var text = HtmlUtil.RemoveHtmlTags(paragraph.Text, true);
-        if (text.Length > 200)
-        {
-            text = text.Substring(0, 100).TrimEnd() + "...";
-        }
+        // Draw clipped text (prepared text + shaped FormattedText are cached; see GetCachedParagraphText)
+        var prepared = GetPreparedParagraphText(paragraph.Text);
 
         var textBounds = new Rect(currentRegionLeft + 1, 0, currentRegionWidth - 3, height);
 
         using (context.PushClip(textBounds))
         {
-            var arr = text.SplitToLines();
             if (Se.Settings.Waveform.WaveformUnwrapText)
             {
-                text = string.Join("  ", arr);
-                var formattedText = new FormattedText(text, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
-                    _typeface, _fontSize, _paintText);
+                var formattedText = GetCachedParagraphText(prepared.Unwrapped);
                 context.DrawText(formattedText, new Point(currentRegionLeft + 3, 14));
             }
             else
             {
                 double addY = 0;
-                foreach (var line in arr)
+                foreach (var line in prepared.Lines)
                 {
-                    var formattedText = new FormattedText(line, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
-                        _typeface, _fontSize, _paintText);
+                    var formattedText = GetCachedParagraphText(line);
                     context.DrawText(formattedText, new Point(currentRegionLeft + 3, 14 + addY));
                     addY += formattedText.Height;
                 }
@@ -2405,8 +2576,7 @@ public class AudioVisualizer : Control
                 // the frame form ("00:00:02:12") without an explicit branch here.
                 var durationText = new TimeCode(paragraph.Duration.TotalMilliseconds).ToShortDisplayString();
                 var withDuration = $"#{paragraph.Number}  {durationText}";
-                var probe = new FormattedText(withDuration, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
-                    _typeface, _fontSize, _paintText);
+                var probe = GetCachedParagraphText(withDuration);
 
                 baseLine = probe.Width >= availableWidth
                     ? $"#{paragraph.Number}"
@@ -2431,22 +2601,19 @@ public class AudioVisualizer : Control
 
         if (baseLine != null)
         {
-            var baseText = new FormattedText(baseLine, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
-                _typeface, _fontSize, _paintText);
+            var baseText = GetCachedParagraphText(baseLine);
             var baseY = bottomY - baseText.Height;
             context.DrawText(baseText, new Point(x, baseY));
 
             if (cpsLine != null)
             {
-                var cpsText = new FormattedText(cpsLine, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
-                    _typeface, _fontSize, _paintText);
+                var cpsText = GetCachedParagraphText(cpsLine);
                 context.DrawText(cpsText, new Point(x, baseY - cpsText.Height));
             }
         }
         else if (cpsLine != null)
         {
-            var cpsText = new FormattedText(cpsLine, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
-                _typeface, _fontSize, _paintText);
+            var cpsText = GetCachedParagraphText(cpsLine);
             context.DrawText(cpsText, new Point(x, bottomY - cpsText.Height));
         }
     }
@@ -3173,6 +3340,9 @@ public class AudioVisualizer : Control
         _fancyWaveformGlowPenCache.Clear();
         _fancyWaveformGradientCache.Clear();
         _timeLineTextCache.Clear();
+        _paragraphFormattedTextCache.Clear();
+        _paragraphTextCache.Clear();
+        _waveformCacheValid = false;
 
         _paintText = new SolidColorBrush(Se.Settings.Waveform.WaveformTextColor.FromHexToColor());
         _typeface = new Typeface(UiUtil.GetDefaultFontName(), FontStyle.Normal, Se.Settings.Waveform.WaveformTextFontBold ? FontWeight.Bold : FontWeight.Normal);

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -2214,7 +2214,7 @@ public class AudioVisualizer : Control
             return;
         }
 
-        // See DrawWaveFormFancy: skip IList<T> interface dispatch in the per-pixel loop.
+        // See BuildWaveFormFancy: skip IList<T> interface dispatch in the per-pixel loop.
         var peaks = WavePeaks.AsSpan();
         var peaksCount = peaks.Length;
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18427,10 +18427,15 @@ public partial class MainViewModel :
                 return;
             }
 
+            // Always advance the estimate: the 50 ms _positionTimer reads _playheadEstimateSeconds as
+            // its source of truth (SelectCurrentSubtitleWhilePlaying, play-selection end detection, the
+            // auto-scroll branches), and some layouts have a video player but no waveform. Only the
+            // visual updates below need the AudioVisualizer.
+            var est = UpdatePlayheadEstimate(vp);
+
             var av = AudioVisualizer;
             if (av != null)
             {
-                var est = UpdatePlayheadEstimate(vp);
                 av.CurrentVideoPositionSeconds = est;
 
                 // In "center waveform on current position" mode the waveform scrolls to keep the cursor

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -338,8 +338,11 @@ public partial class MainViewModel :
     private const double PlayheadSeekArriveToleranceSeconds = 0.15;
     private const double PlayheadSeekPinTimeoutMs = 600;
     private const double PlayheadResyncThresholdSeconds = 0.5; // drift beyond this = real discontinuity -> snap
-    private const double PlayheadDriftCorrection = 0.1; // gentle pull toward mpv when its clock is live
+    private const double PlayheadDriftCorrection = 0.05; // gentle pull toward mpv when its clock is live
+    private const double PlayheadMaxCorrectionFraction = 0.2; // cap catch-up to ~1.2x speed (vs the forward step)
     private const double PlayheadMaxForwardStepSeconds = 0.05; // cap one tick's advance so a starved tick can't lurch
+    private const double PlayheadFreezeHoldSeconds = 0.12; // if mpv's clock hasn't moved this long, it's frozen: hold
+    private long _playheadLastRawChangeTs; // when mpv's reported position last changed
     private CancellationTokenSource _videoOpenTokenSource;
     private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _waveformsBeingGeneratedLock = new();
@@ -18177,21 +18180,41 @@ public partial class MainViewModel :
                 speed = 1.0;
             }
 
-            var forwardStep = elapsedSeconds * speed;
-            _playheadEstimateSeconds += forwardStep;
+            var rawChanged = Math.Abs(rawPosition - _playheadLastRealSeconds) > 0.0005;
+            if (rawChanged)
+            {
+                _playheadLastRawChangeTs = nowTimestamp;
+            }
+
+            var rawFrozenSeconds = (nowTimestamp - _playheadLastRawChangeTs) / (double)Stopwatch.Frequency;
+
+            // Only extrapolate while mpv's clock is actually advancing. After a paused seek mpv's
+            // time-pos (and the video) freezes for ~400 ms while it re-primes, then resumes at 1x from
+            // the same spot. Extrapolating through that freeze races the cursor ahead of the still-frozen
+            // frame and then forces a visible sub-1x crawl to resync. Holding while frozen and gliding
+            // once mpv resumes is seamless, since it resumes from where the cursor is held.
+            if (rawFrozenSeconds < PlayheadFreezeHoldSeconds)
+            {
+                _playheadEstimateSeconds += elapsedSeconds * speed;
+            }
 
             var drift = rawPosition - _playheadEstimateSeconds;
             if (Math.Abs(drift) > PlayheadResyncThresholdSeconds)
             {
                 _playheadEstimateSeconds = rawPosition;
             }
-            else if (rawPosition > _playheadLastRealSeconds + 0.0005)
+            else if (rawChanged && drift > 0)
             {
-                // Correct a fraction of the drift, but never by more than the forward step so the
-                // cursor can't visibly reverse or jump while chasing mpv's chunky updates.
+                // Only ever nudge forward to close a lag (e.g. after a starved tick); never pull the
+                // cursor backward, which is what showed up as the sub-1x "slow" after the rush. Cap the
+                // per-tick correction so the catch-up tops out around ~1.2x.
                 var correction = drift * PlayheadDriftCorrection;
-                var maxCorrection = forwardStep * 0.5;
-                correction = Math.Clamp(correction, -maxCorrection, maxCorrection);
+                var maxCorrection = elapsedSeconds * speed * PlayheadMaxCorrectionFraction;
+                if (correction > maxCorrection)
+                {
+                    correction = maxCorrection;
+                }
+
                 _playheadEstimateSeconds += correction;
             }
         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18412,9 +18412,12 @@ public partial class MainViewModel :
         // is what makes the line glide smoothly instead of stepping at 20 fps.
         // Priority matters: the mpv video control posts its frame requests at DispatcherPriority.Render,
         // and a DispatcherTimer defaults to the much lower Background priority. While the video pipeline
-        // is busy (e.g. the decode burst right after a seek) those high-priority posts starved the cursor
-        // timer for 100-800 ms, which is the stutter. Run the cursor timer at Render so it competes fairly.
-        _cursorTimer = new DispatcherTimer(DispatcherPriority.Render) { Interval = TimeSpan.FromMilliseconds(16) };
+        // is busy (e.g. the decode burst right after pressing play) those posts starved the cursor timer
+        // for 100-800 ms (a stutter), and merely matching Render still let a burst delay it via FIFO,
+        // leaving the play-start lag-then-rush. Running at Normal (above Render) keeps the cursor timer
+        // firing on time through the burst so the line glides smoothly. Its per-tick work is ~0.2 ms, so
+        // it doesn't disturb video rendering.
+        _cursorTimer = new DispatcherTimer(DispatcherPriority.Normal) { Interval = TimeSpan.FromMilliseconds(16) };
         _cursorTimer.Tick += (s, e) =>
         {
             var vp = GetVideoPlayerControl();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18299,11 +18299,12 @@ public partial class MainViewModel :
 
                 if (WaveformCenter && isPlaying)
                 {
-                    // calculate the center position based on the waveform width
+                    // The center-mode scroll position is driven smoothly by the 60 fps cursor timer (see
+                    // the _cursorTimer tick); here we only refresh the paragraph list. Pass the current
+                    // start/position so this 50 ms tick doesn't fight the cursor timer's scroll.
                     if (av != null)
                     {
-                        var waveformHalfSeconds = (av.EndPositionSeconds - av.StartPositionSeconds) / 2.0;
-                        av.SetPosition(Math.Max(0, mediaPlayerSeconds - waveformHalfSeconds), subtitle, mediaPlayerSeconds,
+                        av.SetPosition(av.StartPositionSeconds, subtitle, av.CurrentVideoPositionSeconds,
                             firstSelectedIndex, _selectedSubtitles ?? []);
                     }
                 }
@@ -18429,7 +18430,17 @@ public partial class MainViewModel :
             var av = AudioVisualizer;
             if (av != null)
             {
-                av.CurrentVideoPositionSeconds = UpdatePlayheadEstimate(vp);
+                var est = UpdatePlayheadEstimate(vp);
+                av.CurrentVideoPositionSeconds = est;
+
+                // In "center waveform on current position" mode the waveform scrolls to keep the cursor
+                // centered. Drive that scroll here at ~60 fps, in lockstep with the cursor, so it glides
+                // smoothly instead of jumping in 20 fps steps from the heavy 50 ms timer.
+                if (WaveformCenter && vp.IsPlaying && av.WavePeaks != null)
+                {
+                    var halfSeconds = (av.EndPositionSeconds - av.StartPositionSeconds) / 2.0;
+                    av.StartPositionSeconds = Math.Max(0, est - halfSeconds);
+                }
             }
         };
         _cursorTimer.Start();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -322,6 +322,19 @@ public partial class MainViewModel :
     private readonly List<SubtitleLineViewModel> _waveformSubtitleBuffer = new();
     private DispatcherTimer _positionTimer = new();
     private DispatcherTimer _slowTimer = new();
+    private DispatcherTimer _cursorTimer = new(); // ~60 fps; drives only the waveform/video playhead cursor
+
+    // Playhead interpolation state. When mpv resumes after a paused seek its time-pos stalls
+    // for ~one audio-buffer interval (~200 ms) and then resyncs forward, which makes the
+    // waveform/video cursor freeze and then jump. While playing we advance the cursor on a
+    // wall clock and continuously reconcile it with mpv's real position so motion starts
+    // immediately and stays smooth. See _positionTimer.Tick.
+    private double _playheadEstimateSeconds;
+    private double _playheadLastRealSeconds = -1;
+    private long _playheadLastTimestamp; // Stopwatch ticks; high-resolution so per-tick advance is even
+    private bool _playheadValid;
+    private const double PlayheadResyncThresholdSeconds = 0.5; // drift beyond this = real discontinuity -> snap
+    private const double PlayheadDriftCorrection = 0.1; // gentle pull toward mpv when its clock is live
     private CancellationTokenSource _videoOpenTokenSource;
     private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _waveformsBeingGeneratedLock = new();
@@ -15381,6 +15394,7 @@ public partial class MainViewModel :
     private void CleanUp()
     {
         _positionTimer.Stop();
+        _cursorTimer.Stop();
         _slowTimer.Stop();
 
         if (_findViewModel != null)
@@ -18090,6 +18104,67 @@ public partial class MainViewModel :
         }
     }
 
+    // Advances the interpolated playhead toward the player's real position and returns it.
+    // Called from the high-frequency _cursorTimer so the cursor moves at ~60 fps. mpv's time-pos
+    // stalls (and then jumps forward) for ~200 ms after resuming from a paused seek; rather than
+    // drive the cursor straight off it we advance on a high-resolution wall clock at the current
+    // playback speed and reconcile: snap on a large discontinuity (user seek / loop / EOF), gently
+    // correct small drift only while mpv's clock is actually moving, and otherwise trust the wall
+    // clock so the line keeps gliding through the resume gap. Elapsed time uses Stopwatch
+    // (sub-microsecond) not Environment.TickCount64 (~15 ms on Windows), whose coarse steps would
+    // make the cursor advance unevenly.
+    private double UpdatePlayheadEstimate(VideoPlayerControl vp)
+    {
+        var rawPosition = vp.VideoPlayer.Position;
+        if (IsSmpteTimingEnabled)
+        {
+            rawPosition = rawPosition * 1000.0 / 1001.0;
+        }
+
+        var nowTimestamp = Stopwatch.GetTimestamp();
+        if (vp.IsPlaying && _playheadValid && _playheadLastRealSeconds >= 0)
+        {
+            var elapsedSeconds = (nowTimestamp - _playheadLastTimestamp) / (double)Stopwatch.Frequency;
+            if (elapsedSeconds < 0 || elapsedSeconds > 1.0)
+            {
+                elapsedSeconds = 0; // clock glitch / app was suspended: don't lurch forward
+            }
+
+            var speed = vp.VideoPlayer.Speed;
+            if (speed <= 0)
+            {
+                speed = 1.0;
+            }
+
+            var forwardStep = elapsedSeconds * speed;
+            _playheadEstimateSeconds += forwardStep;
+
+            var drift = rawPosition - _playheadEstimateSeconds;
+            if (Math.Abs(drift) > PlayheadResyncThresholdSeconds)
+            {
+                _playheadEstimateSeconds = rawPosition;
+            }
+            else if (rawPosition > _playheadLastRealSeconds + 0.0005)
+            {
+                // Correct a fraction of the drift, but never by more than the forward step so the
+                // cursor can't visibly reverse or jump while chasing mpv's chunky updates.
+                var correction = drift * PlayheadDriftCorrection;
+                var maxCorrection = forwardStep * 0.5;
+                correction = Math.Clamp(correction, -maxCorrection, maxCorrection);
+                _playheadEstimateSeconds += correction;
+            }
+        }
+        else
+        {
+            _playheadEstimateSeconds = rawPosition;
+            _playheadValid = true;
+        }
+
+        _playheadLastRealSeconds = rawPosition;
+        _playheadLastTimestamp = nowTimestamp;
+        return _playheadEstimateSeconds;
+    }
+
     private void StartTimers()
     {
         Subtitles.CollectionChanged += OnSubtitlesCollectionChangedForMpv;
@@ -18149,16 +18224,16 @@ public partial class MainViewModel :
                 }
                 subtitle.Sort((a, b) => a.StartTime.Ticks.CompareTo(b.StartTime.Ticks));
 
-                var mediaPlayerSeconds = vp.Position;
+                // The playhead cursor is interpolated and applied by the dedicated high-frequency
+                // _cursorTimer (see UpdatePlayheadEstimate) so it moves at ~60 fps instead of this
+                // heavy 50 ms timer's rate. Here we just read the latest estimate for the centering /
+                // selection / play-selection logic below; we don't advance it or set the cursor.
+                var mediaPlayerSeconds = _playheadEstimateSeconds;
+
                 var startPos = mediaPlayerSeconds - 0.01;
                 if (startPos < 0)
                 {
                     startPos = 0;
-                }
-
-                if (av != null)
-                {
-                    av.CurrentVideoPositionSeconds = vp.Position;
                 }
 
                 var isPlaying = vp.IsPlaying;
@@ -18271,6 +18346,32 @@ public partial class MainViewModel :
             }
         };
         _positionTimer.Start();
+
+        // Dedicated high-frequency cursor timer (~60 fps). It only advances the interpolated
+        // playhead and updates the waveform/video cursor position, which is cheap now that the
+        // waveform geometry is cached. The heavy per-tick work (subtitle buffer, centering,
+        // selection, paragraph reload) stays on the 50 ms _positionTimer above. Splitting them
+        // is what makes the line glide smoothly instead of stepping at 20 fps.
+        // Priority matters: the mpv video control posts its frame requests at DispatcherPriority.Render,
+        // and a DispatcherTimer defaults to the much lower Background priority. While the video pipeline
+        // is busy (e.g. the decode burst right after a seek) those high-priority posts starved the cursor
+        // timer for 100-800 ms, which is the stutter. Run the cursor timer at Render so it competes fairly.
+        _cursorTimer = new DispatcherTimer(DispatcherPriority.Render) { Interval = TimeSpan.FromMilliseconds(16) };
+        _cursorTimer.Tick += (s, e) =>
+        {
+            var vp = GetVideoPlayerControl();
+            if (vp == null || string.IsNullOrEmpty(_videoFileName))
+            {
+                return;
+            }
+
+            var av = AudioVisualizer;
+            if (av != null)
+            {
+                av.CurrentVideoPositionSeconds = UpdatePlayheadEstimate(vp);
+            }
+        };
+        _cursorTimer.Start();
 
         _slowTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };
         _slowTimer.Tick += (s, e) =>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -333,8 +333,13 @@ public partial class MainViewModel :
     private double _playheadLastRealSeconds = -1;
     private long _playheadLastTimestamp; // Stopwatch ticks; high-resolution so per-tick advance is even
     private bool _playheadValid;
+    private double? _playheadSeekTarget; // pin the cursor here until mpv's reported position arrives
+    private long _playheadSeekTargetTs;
+    private const double PlayheadSeekArriveToleranceSeconds = 0.15;
+    private const double PlayheadSeekPinTimeoutMs = 600;
     private const double PlayheadResyncThresholdSeconds = 0.5; // drift beyond this = real discontinuity -> snap
     private const double PlayheadDriftCorrection = 0.1; // gentle pull toward mpv when its clock is live
+    private const double PlayheadMaxForwardStepSeconds = 0.05; // cap one tick's advance so a starved tick can't lurch
     private CancellationTokenSource _videoOpenTokenSource;
     private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _waveformsBeingGeneratedLock = new();
@@ -18122,12 +18127,48 @@ public partial class MainViewModel :
         }
 
         var nowTimestamp = Stopwatch.GetTimestamp();
+
+        // A fresh user seek (e.g. clicking the waveform) is pinned to the clicked position: mpv
+        // applies the pause+seek asynchronously, so for ~100-200 ms vp.VideoPlayer.Position still
+        // reports the old spot. Hold the target until mpv's reported position actually arrives (or a
+        // short timeout), so the cursor jumps to the click instantly instead of lagging then snapping.
+        if (_playheadSeekTarget.HasValue)
+        {
+            var target = _playheadSeekTarget.Value;
+            var arrived = Math.Abs(rawPosition - target) < PlayheadSeekArriveToleranceSeconds;
+            var timedOut = (nowTimestamp - _playheadSeekTargetTs) * 1000.0 / Stopwatch.Frequency > PlayheadSeekPinTimeoutMs;
+            if (!arrived && !timedOut)
+            {
+                _playheadLastRealSeconds = rawPosition;
+                _playheadLastTimestamp = nowTimestamp;
+                _playheadEstimateSeconds = target;
+                return target;
+            }
+
+            // mpv has arrived (or we gave up waiting): resume normal tracking from the real position.
+            _playheadSeekTarget = null;
+            _playheadEstimateSeconds = rawPosition;
+            _playheadValid = true;
+            _playheadLastRealSeconds = rawPosition;
+            _playheadLastTimestamp = nowTimestamp;
+            return rawPosition;
+        }
+
         if (vp.IsPlaying && _playheadValid && _playheadLastRealSeconds >= 0)
         {
             var elapsedSeconds = (nowTimestamp - _playheadLastTimestamp) / (double)Stopwatch.Frequency;
-            if (elapsedSeconds < 0 || elapsedSeconds > 1.0)
+            if (elapsedSeconds < 0)
             {
-                elapsedSeconds = 0; // clock glitch / app was suspended: don't lurch forward
+                elapsedSeconds = 0; // clock glitch
+            }
+            else if (elapsedSeconds > PlayheadMaxForwardStepSeconds)
+            {
+                // The cursor timer was starved (e.g. the mpv decode burst right after pressing play) or
+                // the app was suspended. Advancing by the whole missed span would make the cursor visibly
+                // rush forward and overshoot, since mpv hasn't actually played that far yet. Cap the step
+                // so the cursor keeps gliding smoothly; drift correction (or a snap, for a big gap)
+                // reconciles with mpv's real clock over the next few frames.
+                elapsedSeconds = PlayheadMaxForwardStepSeconds;
             }
 
             var speed = vp.VideoPlayer.Speed;
@@ -18163,6 +18204,23 @@ public partial class MainViewModel :
         _playheadLastRealSeconds = rawPosition;
         _playheadLastTimestamp = nowTimestamp;
         return _playheadEstimateSeconds;
+    }
+
+    // Called when the user seeks via the waveform: show the clicked position on the cursor
+    // immediately and pin it there until mpv's clock catches up (see UpdatePlayheadEstimate).
+    private void PinPlayheadTo(double targetSeconds)
+    {
+        _playheadSeekTarget = targetSeconds;
+        _playheadSeekTargetTs = Stopwatch.GetTimestamp();
+        _playheadEstimateSeconds = targetSeconds;
+        _playheadValid = true;
+        _playheadLastRealSeconds = targetSeconds;
+        _playheadLastTimestamp = _playheadSeekTargetTs;
+
+        if (AudioVisualizer != null)
+        {
+            AudioVisualizer.CurrentVideoPositionSeconds = targetSeconds;
+        }
     }
 
     private void StartTimers()
@@ -18781,6 +18839,7 @@ public partial class MainViewModel :
         newPosition = Math.Min(vp.Duration, newPosition);
 
         vp.Position = newPosition;
+        PinPlayheadTo(newPosition);
 
         _updateAudioVisualizer = true;
     }
@@ -19859,6 +19918,7 @@ public partial class MainViewModel :
                     break;
             }
 
+            PinPlayheadTo(e.Seconds);
             _updateAudioVisualizer = true;
         }
     }


### PR DESCRIPTION
## Problem

The waveform/video playback cursor (the vertical position line) had several issues during playback:

- Lagged ~100–200 ms behind playback.
- Froze and then jumped forward when resuming after a seek.
- Stuttered during steady playback (worse over loud audio).
- Clicking the waveform to seek took ~100–200 ms before the line moved to the new spot.
- Pressing play after placing the line caused the cursor to "rush" forward, then settle.
- In "center waveform on current position" mode the waveform scrolled in coarse 20 fps steps.

## Changes

**Interpolated playhead.** The cursor is advanced on a high-resolution wall clock at the current playback speed and reconciled with mpv's real position (snap on a large discontinuity, gently correct small drift, cap a single tick's advance). This hides mpv's chunky `time-pos` updates and its stall-then-jump when resuming after a paused seek.

**Dedicated cursor timer at the right priority.** The cursor is driven by its own ~60 fps `DispatcherTimer`. The mpv video control posts frame requests at `DispatcherPriority.Render`; a default (Background) timer was starved by them for 100–800 ms during decode bursts (the stutter), and even matching `Render` left a play-start rush, so the timer runs at `Normal` (above Render). The heavy per-tick work (subtitle buffer, centering, selection) stays on the existing 50 ms timer.

**Rendering caches.** The waveform geometry and per-paragraph shaped text are cached and replayed, so a cursor-only move no longer re-runs the per-pixel waveform loop or re-shapes `FormattedText` every frame (the latter caused GC pauses). Caches are keyed by view state and cleared in `ResetCache()`.

**Instant waveform seek.** A waveform click/drag pins the cursor to the clicked position immediately and holds it until mpv's reported position arrives, instead of lagging on the old spot while mpv applies the async pause+seek.

**Smooth center-mode scrolling.** In center mode the waveform scroll is driven by the 60 fps cursor timer in lockstep with the cursor instead of the 20 fps heavy timer.

## Notes

- All changes are in `MainViewModel` (timers/interpolation) and `AudioVisualizer` (render caches); no public API/behavior changes outside the waveform.
- The diagnosis was data-driven: temporary instrumentation confirmed the stutter was a `DispatcherPriority` inversion (mpv render posts starving the cursor timer), not GC or our rendering; that instrumentation has been removed.