### PR TITLE
Show subtitle count below the right grid in track pickers

### DIFF
--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -28,6 +28,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<MatroskaTrackInfoDisplay> _tracks;
     [ObservableProperty] private MatroskaTrackInfoDisplay? _selectedTrack;
     [ObservableProperty] private ObservableCollection<MatroskaSubtitleCueDisplay> _rows;
+    [ObservableProperty] private string _subtitleCountText;
 
     public Window? Window { get; set; }
     public DataGrid TracksGrid { get; set; }
@@ -49,6 +50,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         Tracks = new ObservableCollection<MatroskaTrackInfoDisplay>();
         TracksGrid = new DataGrid();
         WindowTitle = string.Empty;
+        SubtitleCountText = string.Empty;
         Rows = new ObservableCollection<MatroskaSubtitleCueDisplay>();
         _matroskaTracks = new List<MatroskaTrackInfo>();
         _fileName = string.Empty;
@@ -219,31 +221,34 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         var selectedTrack = SelectedTrack;
         if (selectedTrack == null || selectedTrack.MatroskaTrackInfo == null)
         {
+            SubtitleCountText = string.Empty;
             return false;
         }
 
         Rows.Clear();
+        var count = 0;
         var trackInfo = selectedTrack.MatroskaTrackInfo!;
         var subtitles = _matroskaFile?.GetSubtitle(trackInfo.TrackNumber, null);
         if (trackInfo.CodecId == MatroskaTrackType.SubRip && subtitles != null)
         {
-            AddTextContent(trackInfo, subtitles, new SubRip());
+            count = AddTextContent(trackInfo, subtitles, new SubRip());
         }
         else if (trackInfo.CodecId is MatroskaTrackType.SubStationAlpha or MatroskaTrackType.SubStationAlpha2 && subtitles != null)
         {
-            AddTextContent(trackInfo, subtitles, new SubStationAlpha());
+            count = AddTextContent(trackInfo, subtitles, new SubStationAlpha());
         }
         else if (trackInfo.CodecId is MatroskaTrackType.AdvancedSubStationAlpha or MatroskaTrackType.AdvancedSubStationAlpha2 && subtitles != null)
         {
-            AddTextContent(trackInfo, subtitles, new AdvancedSubStationAlpha());
+            count = AddTextContent(trackInfo, subtitles, new AdvancedSubStationAlpha());
         }
         else if (trackInfo.CodecId is MatroskaTrackType.WebVTT or MatroskaTrackType.WebVTT2 && subtitles != null)
         {
-            AddTextContent(trackInfo, subtitles, new WebVTT());
+            count = AddTextContent(trackInfo, subtitles, new WebVTT());
         }
         else if (trackInfo.CodecId == MatroskaTrackType.BluRay && subtitles != null && _matroskaFile != null)
         {
             var pcsData = BluRaySupParser.ParseBluRaySupFromMatroska(trackInfo, _matroskaFile);
+            count = pcsData.Count;
             for (var i = 0; i < 20 && i < pcsData.Count; i++)
             {
                 var item = pcsData[i];
@@ -265,6 +270,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
             Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, sub, subtitle);
             Utilities.ParseMatroskaTextSt(trackInfo, sub, subtitle);
 
+            count = subtitle.Paragraphs.Count;
             for (var i = 0; i < 20 && i < subtitle.Paragraphs.Count; i++)
             {
                 var item = subtitle.Paragraphs[i];
@@ -279,10 +285,11 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
             }
         }
 
+        SubtitleCountText = string.Format(Se.Language.File.Import.NumberOfSubtitlesX, count);
         return true;
     }
 
-    private void AddTextContent(MatroskaTrackInfo trackInfo, List<MatroskaSubtitle> subtitles, SubtitleFormat format)
+    private int AddTextContent(MatroskaTrackInfo trackInfo, List<MatroskaSubtitle> subtitles, SubtitleFormat format)
     {
         var sub = new Subtitle();
         Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, subtitles, sub);
@@ -299,6 +306,8 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
             };
             Rows.Add(cue);
         }
+
+        return sub.Paragraphs.Count;
     }
 
     internal void SelectAndScrollToRow(int index)

--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackWindow.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackWindow.cs
@@ -33,11 +33,14 @@ public class PickMatroskaTrackWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonExport, buttonOk, buttonCancel);
 
+        var labelSubtitleCount = UiUtil.MakeLabel(new Binding(nameof(vm.SubtitleCountText)));
+
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -53,7 +56,8 @@ public class PickMatroskaTrackWindow : Window
 
         grid.Add(tracksView, 0);
         grid.Add(subtitleView, 0, 1);
-        grid.Add(panelButtons, 1, 0, 1, 2);
+        grid.Add(labelSubtitleCount, 1, 1);
+        grid.Add(panelButtons, 2, 0, 1, 2);
 
         Content = grid;
 

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -17,6 +18,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<Mp4TrackInfoDisplay> _tracks;
     [ObservableProperty] private Mp4TrackInfoDisplay? _selectedTrack;
     [ObservableProperty] private ObservableCollection<Mp4SubtitleCueDisplay> _rows;
+    [ObservableProperty] private string _subtitleCountText;
 
     public Window? Window { get; set; }
     public DataGrid TracksGrid { get; set; }
@@ -31,6 +33,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
         Tracks = new ObservableCollection<Mp4TrackInfoDisplay>();
         TracksGrid = new DataGrid();
         WindowTitle = string.Empty;
+        SubtitleCountText = string.Empty;
         Rows = new ObservableCollection<Mp4SubtitleCueDisplay>();
         _mp4Tracks = new List<Trak>();
     }
@@ -103,12 +106,14 @@ public partial class PickMp4TrackViewModel : ObservableObject
         var selectedTrack = SelectedTrack;
         if (selectedTrack == null || selectedTrack.Track == null)
         {
+            SubtitleCountText = string.Empty;
             return false;
         }
 
         Rows.Clear();
         var trackinfo = selectedTrack.Track!;
         var subtitles = trackinfo.Mdia.Minf.Stbl.GetParagraphs();
+        SubtitleCountText = string.Format(Se.Language.File.Import.NumberOfSubtitlesX, subtitles.Count);
         var i = 0;
         foreach (var item in subtitles)
         {

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackWindow.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackWindow.cs
@@ -36,11 +36,14 @@ public class PickMp4TrackWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonExport, buttonOk, buttonCancel);
 
+        var labelSubtitleCount = UiUtil.MakeLabel(new Binding(nameof(vm.SubtitleCountText)));
+
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -56,7 +59,8 @@ public class PickMp4TrackWindow : Window
 
         grid.Add(tracksView, 0, 0);
         grid.Add(subtitleView, 0, 1);
-        grid.Add(panelButtons, 1, 0, 1, 2);
+        grid.Add(labelSubtitleCount, 1, 1);
+        grid.Add(panelButtons, 2, 0, 1, 2);
 
 
         Content = grid;

--- a/src/ui/Features/Shared/PickTsTrack/PickTsTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickTsTrack/PickTsTrackViewModel.cs
@@ -7,6 +7,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -18,6 +19,7 @@ public partial class PickTsTrackViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<TsTrackInfoDisplay> _tracks;
     [ObservableProperty] private TsTrackInfoDisplay? _selectedTrack;
     [ObservableProperty] private ObservableCollection<TsSubtitleCueDisplay> _rows;
+    [ObservableProperty] private string _subtitleCountText;
 
     public Window? Window { get; set; }
     public DataGrid TracksGrid { get; set; }
@@ -33,6 +35,7 @@ public partial class PickTsTrackViewModel : ObservableObject
         Tracks = new ObservableCollection<TsTrackInfoDisplay>();
         TracksGrid = new DataGrid();
         WindowTitle = string.Empty;
+        SubtitleCountText = string.Empty;
         Rows = new ObservableCollection<TsSubtitleCueDisplay>();
         TeletextSubtitle = new Subtitle();
     }
@@ -130,6 +133,7 @@ public partial class PickTsTrackViewModel : ObservableObject
         var selectedTrack = SelectedTrack;
         if (selectedTrack == null || _tsParser == null)
         {
+            SubtitleCountText = string.Empty;
             return false;
         }
 
@@ -137,9 +141,10 @@ public partial class PickTsTrackViewModel : ObservableObject
 
         if (selectedTrack.IsTeletext)
         {
-           var subtitle = new Subtitle(selectedTrack.Teletext);          
+           var subtitle = new Subtitle(selectedTrack.Teletext);
             subtitle.Renumber();
             TeletextSubtitle = subtitle;
+            SubtitleCountText = string.Format(Se.Language.File.Import.NumberOfSubtitlesX, subtitle.Paragraphs.Count);
             foreach (var p in subtitle.Paragraphs.Take(20))
             {
                 var cue = new TsSubtitleCueDisplay()
@@ -157,6 +162,7 @@ public partial class PickTsTrackViewModel : ObservableObject
         }
 
         var subtitles = _tsParser.GetDvbSubtitles(selectedTrack.TrackNumber);
+        SubtitleCountText = string.Format(Se.Language.File.Import.NumberOfSubtitlesX, subtitles.Count);
         for (var i = 0; i < 20 && i < subtitles.Count; i++)
         {
             var item = subtitles[i];

--- a/src/ui/Features/Shared/PickTsTrack/PickTsTrackWindow.cs
+++ b/src/ui/Features/Shared/PickTsTrack/PickTsTrackWindow.cs
@@ -31,11 +31,14 @@ public class PickTsTrackWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonExport, buttonOk, buttonCancel);
 
+        var labelSubtitleCount = UiUtil.MakeLabel(new Binding(nameof(vm.SubtitleCountText)));
+
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -51,7 +54,8 @@ public class PickTsTrackWindow : Window
 
         grid.Add(tracksView, 0, 0);
         grid.Add(subtitleView, 0, 1);
-        grid.Add(panelButtons, 1, 0, 1, 2);
+        grid.Add(labelSubtitleCount, 1, 1);
+        grid.Add(panelButtons, 2, 0, 1, 2);
 
 
         Content = grid;


### PR DESCRIPTION
Adds a **"Number of subtitles: X"** label beneath the cue grid in the Matroska, MP4 and TS track picker windows.

## Changes
- Label sits in its own grid row so the left and right grids keep the **same height** (the count no longer steals height from the right grid).
- Reuses the existing localized string `Se.Language.File.Import.NumberOfSubtitlesX` ("Number of subtitles: {0}").
- For pickers that cap the preview at 20 rows (BluRay/TextSt in Matroska, Teletext/DVB in TS), the label reports the **true total**, not the displayed row count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)