### PR TITLE
Update CrispASR to v0.7.2

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrVersion.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrVersion.cs
@@ -10,15 +10,19 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 /// <summary>
 /// Cached <c>crispasr --version</c> probe. Used by the speech-to-text engine settings
 /// dialog and by Chatterbox / Qwen3 (CrispASR) TTS settings to show the user which
-/// CrispASR runtime they have installed. <c>crispasr --version</c> on v0.6.12 prints
+/// CrispASR runtime they have installed. <c>crispasr --version</c> on v0.7.2 prints
 /// something like:
 ///
 ///   <c>=== build info ===</c>
-///   <c>  version       : 0.6.12</c>
-///   <c>  git sha       : 9dfb1490</c>
-///   <c>  git date      : 2026-05-26T23:28:31+02:00</c>
+///   <c>  version       : 0.7.1</c>
+///   <c>  git sha       : b50a8f33</c>
+///   <c>  git date      : 2026-06-15T04:26:48Z</c>
+///   <c>  build type    : Release</c>
+///   <c>  ggml backends : cpu,metal,blas</c>
 ///   <c>  ...</c>
 ///
+/// (Note: the embedded <c>version</c> field can lag the release tag — the v0.7.2
+/// archives still self-report 0.7.1 — so we parse whatever the binary prints.)
 /// Older releases printed a single banner line like
 /// <c>crispasr 0.6.7 (git ..., Release) [backends: ...]</c>; we accept either form.
 /// </summary>
@@ -31,8 +35,8 @@ public static class CrispAsrVersion
     private static DateTime _cachedExeMtimeUtc;
     private static string? _cachedVersion;
 
-    // Matches either `version : 0.6.12` (structured --version output) or
-    // `crispasr 0.6.12` (legacy single-line banner).
+    // Matches either `version : 0.7.1` (structured --version output) or
+    // `crispasr 0.7.1` (legacy single-line banner).
     private static readonly Regex VersionRegex = new(
         @"(?:^\s*version\s*:\s*|\bcrispasr\s+)([\w.\-+]+)",
         RegexOptions.IgnoreCase | RegexOptions.Multiline);

--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -21,14 +21,14 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.1/crispasr-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.1/crispasr-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.1/crispasr-windows-x86_64-cpu.zip";
-    private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.1/crispasr-windows-x86_64-cpu-legacy.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.1/crispasr-macos.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.1/crispasr-linux-x86_64.tar.gz";
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.1/crispasr-linux-x86_64-cuda.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.1/crispasr-linux-arm64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.2/crispasr-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.2/crispasr-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.2/crispasr-windows-x86_64-cpu.zip";
+    private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.2/crispasr-windows-x86_64-cpu-legacy.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.2/crispasr-macos.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.2/crispasr-linux-x86_64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.2/crispasr-linux-x86_64-cuda.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.7.2/crispasr-linux-arm64.tar.gz";
 
     public CrispAsrDownloadService(HttpClient httpClient)
     {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -232,7 +232,8 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispAsr.WindowsCuda] = new[]
             {
-                "348a90a71524ccebbb133e6751dd90c355a5d72e2fc9ef8f445097c7377cf863", // v0.7.1 (current download URL)
+                "ee8baa3230d699bf72cad7811fd7560c62e8d582b84eb85ec3fc9d0885fc4e76", // v0.7.2 (current download URL)
+                "348a90a71524ccebbb133e6751dd90c355a5d72e2fc9ef8f445097c7377cf863", // v0.7.1
                 "318f6722bfe34be6b2900902a95cc74e436872d37a6ea477c7841f550c441f8d", // v0.7.0
                 "49d05553b40bc714a687b183a1287692858ab4ed10fc133e74541e05d1f0838b", // v0.6.12
                 "59735edc57b3d1a6ea10a50a46040977514da03a26e48eafa2fa2103ecca206b", // v0.6.11
@@ -252,7 +253,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsVulkan] = new[]
             {
-                "6296cb678706803e0ef545f057284c6037e5473d0994b813091dd8bbf84ef269", // v0.7.1 (current download URL)
+                "5ff9a9efdad4bfcc50249d555583086f9c07b6fea21493896f44bcef5cfcc7b7", // v0.7.2 (current download URL)
+                "6296cb678706803e0ef545f057284c6037e5473d0994b813091dd8bbf84ef269", // v0.7.1
                 "65ca72fe06bdd93a58936f41ecd8c3c316a7853db6c3295e85b89b01b8c433c0", // v0.7.0
                 "3522ffa10bbe0d678fd1a0c51c67b9ecc7c31acb02bcb0f4b8d76fe6b9ce42fc", // v0.6.12
                 "7aeb3b823e747cdb89ff0a717d939c85467cabf90395481e2091d6cac678a98c", // v0.6.11
@@ -272,7 +274,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpu] = new[]
             {
-                "25b451ad3abbd868e8779b9ca40d69c7001081da4091826742080ca0f6718efb", // v0.7.1 (current download URL)
+                "1a9e52647ac353239048a215869faeb5f39ce9587ce1d9f262dc5fce96d8b82f", // v0.7.2 (current download URL)
+                "25b451ad3abbd868e8779b9ca40d69c7001081da4091826742080ca0f6718efb", // v0.7.1
                 "a8c317c03080086357441d98f659b816fc759bf14d60d942d14e1409d1a8d58d", // v0.7.0
                 "90b3d102c58a73ea7f436c2651028774694ff4d7054cfd064020f0addcc152da", // v0.6.12
                 "439f6dc567d43326a25fbbe982e4936c20230423bbfc3e57b2e9e6bb39f4f1bd", // v0.6.11
@@ -285,7 +288,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuLegacy] = new[]
             {
-                "1fb461f1b222a7ec50f31eab3f333fed8b91c6453a3ba00fccba0f5b43124026", // v0.7.1 (current download URL)
+                "f43855f75852d37db29488b257a4784f911644f0047a571bbf0d1cafb3584701", // v0.7.2 (current download URL)
+                "1fb461f1b222a7ec50f31eab3f333fed8b91c6453a3ba00fccba0f5b43124026", // v0.7.1
                 "310a7fa263c5e90af79d4c2bf87444d783f64db161aac816d5abd7cfc251a331", // v0.7.0
                 "c088088922bf1da60c5ec8b29f975b1f3b576a8a6c184b8485351421e50f973c", // v0.6.12
                 "3cdf426fe74d61f80aa5ce0e4e939fcfd6135c7a9d46ab1bdb82084df4741917", // v0.6.11
@@ -304,7 +308,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOs] = new[]
             {
-                "1dfd50979b8d5d2b940fad34460f0ab4a237fca4fb6d58d43723dcf311c6086b", // v0.7.1 (current download URL)
+                "658ba1a35eb42ab49a3242cf24b84999fa0ee0a4f35d7e8c5688f02893907c17", // v0.7.2 (current download URL)
+                "1dfd50979b8d5d2b940fad34460f0ab4a237fca4fb6d58d43723dcf311c6086b", // v0.7.1
                 "ac0bd6e583c5611a9f277ae5d2428505bd92976406f823ae04b9f07503834afb", // v0.7.0
                 "48a7652983a2a6f798f62ecdd3ef43708af2f0c9493c55dfb30474a23f24a41e", // v0.6.12
                 "242c0267525c5587e23591d43f60b480e9aff7bef80817ab51ddc882476f2020", // v0.6.11
@@ -324,7 +329,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.Linux] = new[]
             {
-                "b4b41823bd891dd5182c5d3c1d62196379ca0b08cfd1f4b19dc3dcac73348517", // v0.7.1 (current download URL)
+                "6d62f9c7ec4d0efae3e4c1b15c88ab1e765840576e13bb08717706c2789c8a83", // v0.7.2 (current download URL)
+                "b4b41823bd891dd5182c5d3c1d62196379ca0b08cfd1f4b19dc3dcac73348517", // v0.7.1
                 "66ba2cac1220e527f84b928c55d26fd4232b2b3708ffe656af60f547875b6758", // v0.7.0
                 "f196afbf8f38618d8b98001d43c43bbfe3c4c7f3a6c2bd5a3dac64e073c861f0", // v0.6.12
                 "1fdca9e9f239519be3f339b899b5bf390d6d25428fec55470f8932f7df10c92e", // v0.6.11
@@ -344,7 +350,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCuda] = new[]
             {
-                "865c9483862728385cb6604129c7124f1af51a1e92812a39052a46dba6a95043", // v0.7.1 (current download URL)
+                "546a8ef9ba5b556ba803c50029f7b783363e97ba07f85a988b4c25161cc74953", // v0.7.2 (current download URL)
+                "865c9483862728385cb6604129c7124f1af51a1e92812a39052a46dba6a95043", // v0.7.1
                 "472768e41e2183c795e9221a95024f5df56f6d66469d66772acb489b8d73df54", // v0.7.0
                 "ed9feb7a5f57083cccb9abb06c7cbecba84501c992e440a989ecb20858f5fe24", // v0.6.12
                 "b1b772fd5d17c6ab288830a7afc07cffc448951fd9b673f73f77686c563302b3", // v0.6.11
@@ -355,7 +362,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxArm] = new[]
             {
-                "7a595663c5401c77f8b3ca0b6ca984c1d1027d819dd4a15f5241b7fb4fe4c8a0", // v0.7.1 (current download URL)
+                "100168336d56de3f7870dd0c2694ba2effaba32082f76303efbb6d02cd4923e3", // v0.7.2 (current download URL)
+                "7a595663c5401c77f8b3ca0b6ca984c1d1027d819dd4a15f5241b7fb4fe4c8a0", // v0.7.1
                 "b9bf474ea9a5ae6ba829069742d7dd932ac639e872d878f99e618563a50e4773", // v0.7.0
                 "bb8f462fc6082a90c209e13405a38f9c08a7c9c216aaa51688a4b05b16e109da", // v0.6.12
                 "8a8edb05d25ba793bcba90c528332ae17ef9324d689aa3ffd7c9dda48262bdbb", // v0.6.11
@@ -366,12 +374,14 @@ public static class DownloadHashManager
             // SHA-256 of crispasr.exe / crispasr extracted from each archive above.
             [CrispAsr.WindowsCudaExecutable] = new[]
             {
-                "f48979a07eac3c0bc0698f0d01c0e5dd25436867afc99d314d3fbc5113587b52", // v0.7.1 (current download URL)
+                "ed703ebd0701cea53c0b64a57e78b2099304c026d625842bef6a5903b74d8b5a", // v0.7.2 (current download URL)
+                "f48979a07eac3c0bc0698f0d01c0e5dd25436867afc99d314d3fbc5113587b52", // v0.7.1
                 "d771396ed4d9fe66626a8be9f648af904798f39ec73549ed9d3ba795e2ef51f4", // v0.7.0
             },
             [CrispAsr.WindowsVulkanExecutable] = new[]
             {
-                "bc8095e5c5850583da843aeb708a5657f721112b4d86b3ba349ad45e4357da94", // v0.7.1 (current download URL)
+                "1ae46697a2f55e5963b5fe7eacbb702af13b2202e684f8f81cda461b3160538a", // v0.7.2 (current download URL)
+                "bc8095e5c5850583da843aeb708a5657f721112b4d86b3ba349ad45e4357da94", // v0.7.1
                 "89320815096407ab2efd9aee6ddc2cb2efc55b2e333cbd5cc063c9c8661fc092", // v0.7.0
                 "801f811fdc57c1ccf2d682831acd856ff0d9397c5de342965ce9cd9aba78a5fb", // v0.6.12
                 "ce5c6c0da86714aa7df28f5f78cb75c707fb891d7bf0a09d0c68ed1c30112564", // v0.6.11
@@ -391,7 +401,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuExecutable] = new[]
             {
-                "b43338c0b9bd3c5f756e991c1734486e8c25cb97ac7194f04cff2c5cc25d0ba9", // v0.7.1 (current download URL)
+                "af1deed7ff25f3042f26dfe235f40f192aeea88f4710d8f58a284f4f148c92b0", // v0.7.2 (current download URL)
+                "b43338c0b9bd3c5f756e991c1734486e8c25cb97ac7194f04cff2c5cc25d0ba9", // v0.7.1
                 "522988686e57cbf577998d4e695d9d3f64539b8a0fe1e84087c38f16f9f562ff", // v0.7.0
                 "82d1fc1d5812fc9606f9958df655d3761969d9c39da40dc299b374b222c81b0f", // v0.6.12
                 "3cacd6f6b1ca0de7c7420d33ffb5c0f162240a6278efcc81ae43f119f94314f0", // v0.6.11
@@ -404,7 +415,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuLegacyExecutable] = new[]
             {
-                "d1229103eb719fea3a941afcdbe6634503b440047c9f9ed31cc682a64d1d7a0c", // v0.7.1 (current download URL)
+                "54a16109c2e50f5b46749e5ca9fcaf1c79d78b3819c6329b57caed9a6e977812", // v0.7.2 (current download URL)
+                "d1229103eb719fea3a941afcdbe6634503b440047c9f9ed31cc682a64d1d7a0c", // v0.7.1
                 "c089502fb6e05dfe68c74b4b47cdcae459728b010ee53e31d5c5ace403dc9fa7", // v0.7.0
                 "c367916596b139868f1785e358ece9cc128ee4c8b264839a4e5a58ec8e56294d", // v0.6.12
                 "8cf5e71fcbc774a1c691989c5f1a8419104edf66455ff98f80b91589aac453e6", // v0.6.11
@@ -423,7 +435,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxExecutable] = new[]
             {
-                "310476dc9a9205d86b3d645a5a8597566e3638b4118b10ab6e6c43e58b8a5278", // v0.7.1 (current download URL)
+                "369f950fc2e2a1ea78f5d53bdd52f1f742e8bff2c1efe5d93a656ee2e772a9ea", // v0.7.2 (current download URL)
+                "310476dc9a9205d86b3d645a5a8597566e3638b4118b10ab6e6c43e58b8a5278", // v0.7.1
                 "5760a7ca0cb88c41ce934986a47541178c58e1ae0a5451b283bed8ea5c33dfec", // v0.7.0
                 "c266cdaaa19acae0efdd7db3c1cefec3013d3bc3d376080f2923ba28517605b2", // v0.6.12
                 "1ab580b274f2614c52462d2b5883ac62be11871db9926436d9915c1adbc99ed9", // v0.6.11
@@ -443,7 +456,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOsExecutable] = new[]
             {
-                "d73a7550a2df0ce246bc4422d0d86db53dc3acd690f06f6d20eac4435a707897", // v0.7.1 (current download URL)
+                "fbda96914c712a96799b5fcc451faaed3837f1ab6765e023bc74b8ddd9945762", // v0.7.2 (current download URL)
+                "d73a7550a2df0ce246bc4422d0d86db53dc3acd690f06f6d20eac4435a707897", // v0.7.1
                 "d33b29909b2401c7b55856b64afdab4eca71f98a4dd73cd3198f6d0b4acdc35a", // v0.7.0
                 "ebed4020d36539d78cc609bf414601e31cc9669a3fc00d509f597d0d4d1175e7", // v0.6.12
                 "16b5bea6f9a012dfb67d39009972c25ba5c408414feae4cf8a20b1018f52df67", // v0.6.11
@@ -463,7 +477,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCudaExecutable] = new[]
             {
-                "a58bb06cce6c20749c24fa32327a57a5966db6eb54711e2ba9b837a414ca489e", // v0.7.1 (current download URL)
+                "384546277f648d93bbc4d6c6af63416e6959944a067eed4d9c03e1ff02581a92", // v0.7.2 (current download URL)
+                "a58bb06cce6c20749c24fa32327a57a5966db6eb54711e2ba9b837a414ca489e", // v0.7.1
                 "9356a878cfb263084c46edfbd75837683a871177db87f44f5370eceac08db1b5", // v0.7.0
                 "59c3b50ae6ae5fa6f2cac4f7c7581c464a716d877a76f413cb913205e02ef74f", // v0.6.12
                 "f5e36703104feead8bc51953c29dae372e27848e135fff5d973c8c456a8cd31b", // v0.6.11
@@ -474,7 +489,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxArmExecutable] = new[]
             {
-                "3e11a09569f030bc087cef797423a0d812037e748bb99080a03eb0d1a483539e", // v0.7.1 (current download URL)
+                "30c792990ade65df166f428c18ca15579b99cbf9623c2ab854eb329f08b8be9d", // v0.7.2 (current download URL)
+                "3e11a09569f030bc087cef797423a0d812037e748bb99080a03eb0d1a483539e", // v0.7.1
                 "ffe4f2dd10e81e6208332bde9a3c8a9426ed73cea6ad137c98d303aff5345ef9", // v0.7.0
                 "b20341886758536748f1cda560b74245d1a262b6fe178a7b975276f8bcb65705", // v0.6.12
                 "051c3f6fa9ccabc8cd8d914d6a9504c6e559e7d4e6634bc93fc9bc1a51293538", // v0.6.11


### PR DESCRIPTION
## Summary
Updates the bundled CrispASR speech-to-text runtime from **v0.7.1** to **v0.7.2** (https://github.com/CrispStrobe/CrispASR/releases/tag/v0.7.2).

## Changes
- **`CrispAsrDownloadService.cs`** — bumped all 8 release download URLs to `v0.7.2`.
- **`DownloadHashManager.cs`** — prepended the new v0.7.2 SHA-256 at index 0 (the "current download URL" slot) for all 16 CrispASR keys: 8 release archives + 8 unpacked `crispasr`/`crispasr.exe` executables. The v0.7.1 entries are kept (demoted to plain history comments) so existing installs are still recognized as "update available".
- **`CrispAsrVersion.cs`** — refreshed the `crispasr --version` doc example to the current structured output (now includes `build type` / `ggml backends`), and noted that the embedded `version` field can lag the release tag — the v0.7.2 archives still self-report `0.7.1`, which is why the probe parses whatever the binary prints.

## How the hashes were obtained
Each v0.7.2 archive was downloaded from the release (size verified against the GitHub asset manifest), the archive SHA-256 computed, then the `crispasr`/`crispasr.exe` binary extracted from each and hashed.

## Testing
- `dotnet build src/ui/UI.csproj -c Release` → 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)