### PR TITLE
Fix Qwen3 (CrispASR) voice cloning: bundled voices missing transcriptions

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -618,6 +618,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                     {
                         _downloadStreamQwen3TtsCrispAsrVoices.Position = 0;
                         _zipUnpacker.UnpackZipStream(_downloadStreamQwen3TtsCrispAsrVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        // The pack ships attribution-blurb .txt files, not spoken transcriptions.
+                        // Drop those (the Base backend would load them as ref-text → off-voice
+                        // output) and fill real transcripts from the OmniVoice pack where it has
+                        // the same voice. Runs here explicitly since the normalize-once pass in
+                        // GetSetVoicesFolder above fires before this extraction.
+                        Qwen3TtsCrispAsr.NormalizeVoiceTranscripts(voicesFolder);
                         WriteInstalledHashSidecar(voicesFolder, _downloadStreamQwen3TtsCrispAsrVoices, DownloadHashManager.Qwen3TtsCpp.Voices);
                     }
                     catch (Exception ex)

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -260,10 +260,12 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         }
 
         SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        NormalizeVoiceTranscriptsOnce(voicesFolder);
         return voicesFolder;
     }
 
     private static bool _voiceSeedAttempted;
+    private static bool _voiceTranscriptsNormalized;
 
     /// <summary>
     /// One-time best-effort seeding of reference voices from the existing qwen3-tts.cpp engine's
@@ -324,6 +326,154 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         {
             Se.LogError(ex, "Qwen3 TTS (CrispASR): voice seeding from qwen3-tts.cpp folder failed");
         }
+    }
+
+    private static void NormalizeVoiceTranscriptsOnce(string voicesFolder)
+    {
+        if (_voiceTranscriptsNormalized)
+        {
+            return;
+        }
+        _voiceTranscriptsNormalized = true;
+        NormalizeVoiceTranscripts(voicesFolder);
+    }
+
+    /// <summary>
+    /// Brings the ref-text sidecars in <paramref name="voicesFolder"/> into the shape the Base
+    /// backend needs. Two clean-ups, per reference WAV:
+    ///  - Drop attribution-blurb <c>.txt</c> files: the qwen3-tts.cpp / voices.zip pack ships
+    ///    Wikimedia/Creative-Commons blurbs next to its named clips, NOT spoken transcriptions.
+    ///    The backend would happily load such a blurb as ref-text and produce runaway, off-voice
+    ///    output, so a blurb is treated as "no transcript" and removed.
+    ///  - Fill in a missing transcription from the sibling OmniVoice pack when it ships the same
+    ///    generic reference WAV (female_06.wav, male_03.wav, …) WITH a real transcript — a correct
+    ///    ref-text for free, no Whisper, no prompt.
+    /// Voices still left without a transcript afterwards are handled lazily at voice-selection /
+    /// import / synth time. Best-effort: an IO error on one file is logged and skipped.
+    /// </summary>
+    public static void NormalizeVoiceTranscripts(string voicesFolder)
+    {
+        if (!Directory.Exists(voicesFolder))
+        {
+            return;
+        }
+
+        foreach (var wav in Directory.GetFiles(voicesFolder, "*.wav"))
+        {
+            try
+            {
+                var sidecar = Path.ChangeExtension(wav, ".txt");
+                if (File.Exists(sidecar))
+                {
+                    var text = File.ReadAllText(sidecar).Trim();
+                    if (!string.IsNullOrWhiteSpace(text) && !LooksLikeAttributionBlurb(text))
+                    {
+                        continue; // already carries a usable transcription
+                    }
+
+                    // Empty or an attribution blurb — remove so it is never used as ref-text.
+                    File.Delete(sidecar);
+                }
+
+                var reuse = FindReusableTranscript(wav);
+                if (!string.IsNullOrWhiteSpace(reuse))
+                {
+                    File.WriteAllText(sidecar, reuse);
+                }
+            }
+            catch (Exception ex)
+            {
+                Se.LogError(ex, $"Qwen3 TTS (CrispASR): failed to normalize transcript for '{wav}'");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Best-effort lookup of a real spoken transcription for a bundled reference voice from the
+    /// sibling OmniVoice voice pack, which ships the same generic reference WAVs WITH real
+    /// transcripts. Matched by file name; returns null when OmniVoice isn't installed or has no
+    /// matching usable transcript.
+    /// </summary>
+    public static string? FindReusableTranscript(string wavPath)
+    {
+        try
+        {
+            var omniVoicesFolder = OmniVoiceTtsCpp.GetSetVoicesFolder();
+            var candidate = Path.Combine(omniVoicesFolder, Path.GetFileName(wavPath));
+            return File.Exists(candidate) ? TryReadUsableTranscript(candidate) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns the usable spoken transcription stored in the <c>.txt</c> sidecar next to
+    /// <paramref name="wavPath"/>, or null when there is none — a missing file, whitespace, or an
+    /// attribution blurb (see <see cref="LooksLikeAttributionBlurb"/>) all count as "no transcript".
+    /// </summary>
+    public static string? TryReadUsableTranscript(string wavPath)
+    {
+        try
+        {
+            var sidecar = Path.ChangeExtension(wavPath, ".txt");
+            if (!File.Exists(sidecar))
+            {
+                return null;
+            }
+
+            var text = File.ReadAllText(sidecar).Trim();
+            return string.IsNullOrWhiteSpace(text) || LooksLikeAttributionBlurb(text) ? null : text;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes <paramref name="transcript"/> as the <c>.txt</c> ref-text sidecar next to a
+    /// reference WAV (the Base backend auto-loads it as ref-text). Mirrors the sibling clone
+    /// engines' <c>TryWriteRefTextSidecar</c> so the auto-fill flows can share one shape.
+    /// </summary>
+    public static bool TryWriteRefTextSidecar(string voiceWavPath, string transcript)
+    {
+        if (string.IsNullOrEmpty(voiceWavPath) || string.IsNullOrWhiteSpace(transcript))
+        {
+            return false;
+        }
+
+        try
+        {
+            var sidecar = Path.ChangeExtension(voiceWavPath, ".txt");
+            File.WriteAllText(sidecar, transcript.Trim());
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Qwen3 TTS (CrispASR): failed to write ref-text sidecar for '{voiceWavPath}'");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="text"/> looks like the Wikimedia / Creative-Commons attribution
+    /// blurb that ships in the qwen3-tts.cpp voice pack's <c>.txt</c> sidecars rather than an
+    /// actual spoken transcription. Feeding such a blurb as ref-text yields runaway, off-voice
+    /// output, so it is treated as "no transcript" wherever a real ref-text is required.
+    /// </summary>
+    public static bool LooksLikeAttributionBlurb(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        return text.Contains("commons.wikimedia.org", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("creativecommons.org", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("This file is licensed", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("Downsampled to", StringComparison.OrdinalIgnoreCase);
     }
 
     public static string GetTalkerPath(string? modelKey = null) =>
@@ -471,8 +621,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
                     + "then pick it in the voice combo.");
             }
 
-            var transcriptPath = Path.ChangeExtension(qwen3Voice.FilePath, ".txt");
-            if (!File.Exists(transcriptPath) || string.IsNullOrWhiteSpace(File.ReadAllText(transcriptPath)))
+            if (string.IsNullOrWhiteSpace(TryReadUsableTranscript(qwen3Voice.FilePath)))
             {
                 throw new InvalidOperationException(
                     $"Qwen3 TTS (CrispASR) voice cloning needs the spoken transcription of '{qwen3Voice.Voice}'. "

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -545,6 +545,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         string? wavPath = null;
         bool isCosyVoice3 = false;
         bool isVoxCPM2 = false;
+        bool isQwen3Clone = false;
         if (voice.EngineVoice is CosyVoice3Voice cosy && !string.IsNullOrEmpty(cosy.FilePath) && string.IsNullOrEmpty(cosy.RefText))
         {
             wavPath = cosy.FilePath;
@@ -567,6 +568,18 @@ public partial class TextToSpeechViewModel : ObservableObject
                 isVoxCPM2 = true;
             }
         }
+        else if (voice.EngineVoice is Voices.Qwen3TtsVoice qwen3 && !string.IsNullOrEmpty(qwen3.FilePath))
+        {
+            // Only the Voice clone (Base) model carries a FilePath; CustomVoice/VoiceDesign leave
+            // it empty, so this never fires for them. A usable transcript may already exist —
+            // imported by the user, or filled from the OmniVoice pack by NormalizeVoiceTranscripts.
+            var existing = Qwen3TtsCrispAsr.TryReadUsableTranscript(qwen3.FilePath);
+            if (string.IsNullOrEmpty(existing))
+            {
+                wavPath = qwen3.FilePath;
+                isQwen3Clone = true;
+            }
+        }
 
         if (string.IsNullOrEmpty(wavPath))
         {
@@ -577,11 +590,20 @@ public partial class TextToSpeechViewModel : ObservableObject
         try
         {
             var audioFileName = wavPath;
+            // Qwen3 (CrispASR) clone: auto-run Whisper first so the user rarely has to type the
+            // transcript (the sibling engines keep their type-or-click-STT prompt). The result is
+            // still shown for a quick review/correction since clone quality is sensitive to it.
+            var initialText = string.Empty;
+            if (isQwen3Clone)
+            {
+                initialText = await RunSpeechToTextForRefTextAsync(audioFileName) ?? string.Empty;
+            }
+
             var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window, vm =>
             {
                 vm.Initialize(
                     Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
-                    string.Empty,
+                    initialText,
                     500,
                     150);
                 vm.ConfigureExtraButton(
@@ -602,6 +624,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (isVoxCPM2)
             {
                 written = VoxCPM2CrispAsr.TryWriteRefTextSidecar(wavPath, result.Text);
+            }
+            else if (isQwen3Clone)
+            {
+                written = Qwen3TtsCrispAsr.TryWriteRefTextSidecar(wavPath, result.Text);
             }
             else
             {

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -162,15 +162,22 @@ public partial class VoiceSettingsViewModel : ObservableObject
         else if (_engine is Qwen3TtsCrispAsr qwenCrispEngine)
         {
             // The Qwen3 (CrispASR) "Voice clone" (Base) model needs the spoken transcription of
-            // the reference WAV — the backend loads it as ref-text and errors without it. Always
-            // prompt (matching CosyVoice3), autofilling from a sibling .txt, with the STT helper.
-            var transcript = TryReadSiblingTranscript(fileName) ?? string.Empty;
+            // the reference WAV — the backend loads it as ref-text and errors without it. Prefer a
+            // sibling .txt; otherwise auto-transcribe with Whisper so the user rarely has to type
+            // it. Either way show the result for a quick review/correction (clone quality is
+            // sensitive to ref-text accuracy), keeping the STT button to re-run if needed.
+            var transcript = TryReadSiblingTranscript(fileName);
+            if (string.IsNullOrWhiteSpace(transcript) || Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(transcript))
+            {
+                transcript = await RunSpeechToTextAsync(fileName) ?? string.Empty;
+            }
+
             var audioFileName = fileName;
             var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window!, vm =>
             {
                 vm.Initialize(
                     Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
-                    transcript,
+                    transcript ?? string.Empty,
                     500,
                     150);
                 vm.ConfigureExtraButton(

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -690,7 +690,8 @@ public static class DownloadHashManager
             },
             [Qwen3TtsCpp.Voices] = new[]
             {
-                "ace389f8326e23dc65c22c081d13efb28b9ee5a78e8586bc259d1148f7346e05", // qwen3-tts-cpp-2026-4 (current download URL)
+                "8935dcb18c71fe261e95c0e7c8e4f6cbca153c76109bb946ba4dfe1f115fcada", // qwen3-tts-cpp-2026-5 (current download URL) — voices.zip with real transcripts
+                "ace389f8326e23dc65c22c081d13efb28b9ee5a78e8586bc259d1148f7346e05", // qwen3-tts-cpp-2026-4
             },
 
             // Qwen3 TTS (CrispASR): CustomVoiceTalker is intentionally absent — its hash hasn't

--- a/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
@@ -49,7 +49,9 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
         ["qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf"] = "https://huggingface.co/cstr/qwen3-tts-1.7b-voicedesign-GGUF/resolve/main/qwen3-tts-12hz-1.7b-voicedesign-q8_0.gguf",
     };
 
-    private const string VoicesUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-tts-cpp-2026-4/voices.zip";
+    // -5 ships real spoken transcriptions (.txt ref-text) for every voice; -4 had only Wikimedia
+    // attribution blurbs, which the Qwen3 (CrispASR) Voice-clone backend can't use as ref-text.
+    private const string VoicesUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-tts-cpp-2026-5/voices.zip";
 
     public Qwen3TtsCppDownloadService(HttpClient httpClient)
     {


### PR DESCRIPTION
## Problem

Qwen3 (CrispASR) **Voice clone (Base)** fails for bundled voices with:

> Qwen3 TTS (CrispASR) voice cloning needs the spoken transcription of 'female 06'. Re-import the voice and enter the exact words spoken in the reference WAV.

The Base backend loads a `<name>.txt` sidecar next to the reference WAV as **ref-text** and errors without it. But the bundled voices never had usable transcriptions:

- The `voices.zip` / qwen3-tts.cpp pack ships **Wikimedia attribution blurbs**, not spoken transcriptions, and only for a few named voices.
- The seed-from-qwen3-tts.cpp path deliberately skipped even those.

So selecting a bundled voice like `female 06` — whose spoken words a user can't possibly know — dead-ended at that error. The direct-download path was the mirror bug: it *kept* the attribution blurbs and would feed them to the backend as ref-text → runaway, off-voice output.

## Fix (scoped to Qwen3 CrispASR)

- **`Qwen3TtsCrispAsr`** — `NormalizeVoiceTranscripts` drops attribution-blurb `.txt` files and fills missing transcripts from the sibling **OmniVoice** pack, which ships the *same* reference clips with real transcripts (durations match to the millisecond). No Whisper, no prompt. Runs on voices-folder access and after `voices.zip` extraction. New helpers `TryReadUsableTranscript` / `LooksLikeAttributionBlurb` / `TryWriteRefTextSidecar`; `Speak` now rejects blurbs, not just empty sidecars.
- **`VoiceSettingsViewModel`** — importing a Qwen3 voice auto-transcribes via Whisper and prefills the prompt for review (clone quality is sensitive to ref-text accuracy), instead of a blank box.
- **`TextToSpeechViewModel`** — wired Qwen3 into the existing `EnsureClonedVoiceRefTextAsync` hook already used by CosyVoice3/F5/VoxCPM2: picking a transcript-less clone voice auto-runs Whisper, then shows the result for a quick correction.
- **`voices.zip`** bumped to **`qwen3-tts-cpp-2026-5`**, which now ships real `.txt` transcripts for all 18 voices (WAVs **byte-identical** to `-4`). `VoicesUrl` + integrity hash updated; the old `-4` hash is retained in the list so already-released versions are unaffected.

## Notes

- New release asset is already uploaded: https://github.com/SubtitleEdit/support-files/releases/tag/qwen3-tts-cpp-2026-5 (SHA-256 `8935dcb1…`, verified).
- Existing installs self-heal at runtime (OmniVoice reuse + auto-transcribe) — re-downloading the pack isn't required. The new zip also benefits F5-TTS / CosyVoice3, which seed from the same pack.
- `dotnet build`: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)