### PR TITLE
Fix ASSA Title field not being saved in properties dialog

### DIFF
--- a/src/ui/Features/Assa/AssaPropertiesViewModel.cs
+++ b/src/ui/Features/Assa/AssaPropertiesViewModel.cs
@@ -78,6 +78,7 @@ public partial class AssaPropertiesViewModel : ObservableObject
 
     private void UpdateHeader()
     {
+        UpdateTag("Title", ScriptTitle, string.IsNullOrWhiteSpace(ScriptTitle));
         UpdateTag("Original Script", OriginalScript, string.IsNullOrWhiteSpace(OriginalScript));
         UpdateTag("Original Translation", Translation, string.IsNullOrWhiteSpace(Translation));
         UpdateTag("Original Editing", Editing, string.IsNullOrWhiteSpace(Editing));


### PR DESCRIPTION
## Problem

Reported in #11634: in the ASSA (Advanced SubStation Alpha) **Properties** dialog, the `Title` field is shown and editable, but the edited value is not saved.

## Cause

`AssaPropertiesViewModel.LoadFromHeader()` reads `Title:` from the `[Script Info]` header into `ScriptTitle`, but `UpdateHeader()` (run on OK) wrote back every other Script Info property *except* `Title`, so the value was silently discarded.

The format layer (`AdvancedSubStationAlpha.cs`) round-trips `Title:` correctly — it writes `subtitle.Header` verbatim — so the value just never made it back into the header from the UI.

## Fix

Add the missing call in `UpdateHeader()`:

```csharp
UpdateTag("Title", ScriptTitle, string.IsNullOrWhiteSpace(ScriptTitle));
```

This matches the SSA properties dialog (`SsaPropertiesViewModel.cs`), which already has this line and works correctly. No change is needed for SSA.

## Notes

- Only the ASSA dialog was affected; SSA already handled Title.
- The unrelated IME/input-method issue also mentioned in #11634 is a separate problem and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)