### PR TITLE
Replace/Find: Count no longer corrupts the last-found position

### DIFF
--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -103,9 +103,18 @@ public partial class FindViewModel : ObservableObject
             return;
         }
 
-        _findService.Initialize(_subs, 0, WholeWord, FindMode);
+        // Preserve the last-found position so it survives the Initialize/ResetSearchState
+        // call below (relevant when the Find dialog is open alongside a Replace dialog).
+        var savedLine  = _findService.CurrentLineNumber;
+        var savedIndex = _findService.CurrentTextIndex;
+        var savedText  = _findService.CurrentTextFound;
 
+        _findService.Initialize(_subs, 0, WholeWord, FindMode);
         var count = _findService.Count(SearchText);
+
+        _findService.CurrentLineNumber = savedLine;
+        _findService.CurrentTextIndex  = savedIndex;
+        _findService.CurrentTextFound  = savedText;
 
         if (count <= 0)
         {

--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -103,18 +103,7 @@ public partial class FindViewModel : ObservableObject
             return;
         }
 
-        // Preserve the last-found position so it survives the Initialize/ResetSearchState
-        // call below (relevant when the Find dialog is open alongside a Replace dialog).
-        var savedLine  = _findService.CurrentLineNumber;
-        var savedIndex = _findService.CurrentTextIndex;
-        var savedText  = _findService.CurrentTextFound;
-
-        _findService.Initialize(_subs, 0, WholeWord, FindMode);
-        var count = _findService.Count(SearchText);
-
-        _findService.CurrentLineNumber = savedLine;
-        _findService.CurrentTextIndex  = savedIndex;
-        _findService.CurrentTextFound  = savedText;
+        var count = _findService.Count(SearchText, _subs, WholeWord, FindMode);
 
         if (count <= 0)
         {

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -111,9 +111,18 @@ public partial class ReplaceViewModel : ObservableObject
             return;
         }
 
-        _findService.Initialize(_subs, 0, WholeWord, FindMode);
+        // Preserve the last-found position so a Replace pressed after Count still
+        // knows which occurrence to replace (Initialize wipes it via ResetSearchState).
+        var savedLine  = _findService.CurrentLineNumber;
+        var savedIndex = _findService.CurrentTextIndex;
+        var savedText  = _findService.CurrentTextFound;
 
+        _findService.Initialize(_subs, 0, WholeWord, FindMode);
         var count = _findService.Count(SearchText);
+
+        _findService.CurrentLineNumber = savedLine;
+        _findService.CurrentTextIndex  = savedIndex;
+        _findService.CurrentTextFound  = savedText;
 
         if (count <= 0)
         {

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -111,18 +111,7 @@ public partial class ReplaceViewModel : ObservableObject
             return;
         }
 
-        // Preserve the last-found position so a Replace pressed after Count still
-        // knows which occurrence to replace (Initialize wipes it via ResetSearchState).
-        var savedLine  = _findService.CurrentLineNumber;
-        var savedIndex = _findService.CurrentTextIndex;
-        var savedText  = _findService.CurrentTextFound;
-
-        _findService.Initialize(_subs, 0, WholeWord, FindMode);
-        var count = _findService.Count(SearchText);
-
-        _findService.CurrentLineNumber = savedLine;
-        _findService.CurrentTextIndex  = savedIndex;
-        _findService.CurrentTextFound  = savedText;
+        var count = _findService.Count(SearchText, _subs, WholeWord, FindMode);
 
         if (count <= 0)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10034,12 +10034,22 @@ public partial class MainViewModel :
             }
         }
 
-        // Verify the matched slice is still at the recorded position before
-        // mutating — the line may have been edited since the find ran.
-        var actualAtMatch = line.Substring(matchIndex, matchText.Length);
         var comparison = result.FindMode == FindMode.CaseSensitive
             ? StringComparison.Ordinal
             : StringComparison.OrdinalIgnoreCase;
+
+        // Bail if the search text changed since the last Find — the saved match
+        // no longer corresponds to the current query (mirrors the regex path above,
+        // which re-runs the regex against the current SearchText and bails on mismatch).
+        if (!string.Equals(matchText, result.SearchText, comparison))
+        {
+            newLine = line;
+            return null;
+        }
+
+        // Verify the matched slice is still at the recorded position before
+        // mutating — the line may have been edited since the find ran.
+        var actualAtMatch = line.Substring(matchIndex, matchText.Length);
         if (!string.Equals(actualAtMatch, matchText, comparison))
         {
             newLine = line;

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -140,18 +140,7 @@ public partial class FindService : IFindService
 
     public int Count(string searchText)
     {
-        if (string.IsNullOrEmpty(searchText) || _textLines.Count == 0)
-        {
-            return 0;
-        }
-
-        int count = 0;
-        for (int i = 0; i < _textLines.Count; i++)
-        {
-            count += CountMatchesInLine(_textLines[i], searchText, WholeWord, CurrentFindMode);
-        }
-
-        return count;
+        return Count(searchText, _textLines, WholeWord, CurrentFindMode);
     }
 
     public int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode)
@@ -618,7 +607,7 @@ public partial class FindService : IFindService
             case FindMode.RegularExpression:
                 try
                 {
-                    var searchLine = NormalizeLineEndingsForRegex(line, out _);
+                    var searchLine = NormalizeLineEndingsForRegex(line);
                     return Regex.Matches(searchLine, searchText).Count;
                 }
                 catch (ArgumentException)
@@ -706,6 +695,33 @@ public partial class FindService : IFindService
     private static int MapNormalizedIndex(List<int> indexMap, int normalizedIndex, int originalLength)
     {
         return normalizedIndex < indexMap.Count ? indexMap[normalizedIndex] : originalLength;
+    }
+
+    private static string NormalizeLineEndingsForRegex(string line)
+    {
+        if (!line.Contains('\r'))
+        {
+            return line;
+        }
+
+        var normalized = new StringBuilder(line.Length);
+        for (var i = 0; i < line.Length; i++)
+        {
+            if (line[i] == '\r')
+            {
+                normalized.Append('\n');
+                if (i + 1 < line.Length && line[i + 1] == '\n')
+                {
+                    i++;
+                }
+            }
+            else
+            {
+                normalized.Append(line[i]);
+            }
+        }
+
+        return normalized.ToString();
     }
 
     private static string NormalizeLineEndingsForRegex(string line, out List<int> indexMap)

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -138,11 +138,6 @@ public partial class FindService : IFindService
         return CurrentLineNumber;
     }
 
-    public int Count(string searchText)
-    {
-        return Count(searchText, _textLines, WholeWord, CurrentFindMode);
-    }
-
     public int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode)
     {
         if (string.IsNullOrEmpty(searchText) || textLines == null || textLines.Count == 0)

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -694,7 +694,7 @@ public partial class FindService : IFindService
                         }
 
                         matches.Add(new FindMatch(index, searchText));
-                        startIndex = index + 1;
+                        startIndex = index + Math.Max(1, searchText.Length);
                     }
                 }
                 break;

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -148,10 +148,26 @@ public partial class FindService : IFindService
         int count = 0;
         for (int i = 0; i < _textLines.Count; i++)
         {
-            count += CountMatchesInLine(_textLines[i], searchText);
+            count += CountMatchesInLine(_textLines[i], searchText, WholeWord, CurrentFindMode);
         }
 
         return count;
+    }
+
+    public int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode)
+    {
+        if (string.IsNullOrEmpty(searchText) || textLines == null || textLines.Count == 0)
+        {
+            return 0;
+        }
+
+        var total = 0;
+        foreach (var line in textLines)
+        {
+            total += CountMatchesInLine(line, searchText, wholeWord, findMode);
+        }
+
+        return total;
     }
 
     public List<(int LineIndex, int TextIndex, string FoundText)> FindAll(string searchText)
@@ -165,7 +181,7 @@ public partial class FindService : IFindService
 
         for (int lineIndex = 0; lineIndex < _textLines.Count; lineIndex++)
         {
-            var matches = GetAllMatchesInLine(_textLines[lineIndex], searchText);
+            var matches = GetAllMatchesInLine(_textLines[lineIndex], searchText, WholeWord, CurrentFindMode);
             foreach (var match in matches)
             {
                 results.Add((lineIndex, match.Index, match.Value));
@@ -590,14 +606,14 @@ public partial class FindService : IFindService
         return (false, -1, string.Empty);
     }
 
-    private int CountMatchesInLine(string line, string searchText)
+    private int CountMatchesInLine(string line, string searchText, bool wholeWord, FindMode findMode)
     {
         if (string.IsNullOrEmpty(line))
         {
             return 0;
         }
 
-        switch (CurrentFindMode)
+        switch (findMode)
         {
             case FindMode.RegularExpression:
                 try
@@ -611,12 +627,12 @@ public partial class FindService : IFindService
                 }
 
             default:
-                var matches = GetAllMatchesInLine(line, searchText);
+                var matches = GetAllMatchesInLine(line, searchText, wholeWord, findMode);
                 return matches.Count;
         }
     }
 
-    private List<FindMatch> GetAllMatchesInLine(string line, string searchText)
+    private List<FindMatch> GetAllMatchesInLine(string line, string searchText, bool wholeWord, FindMode findMode)
     {
         var matches = new List<FindMatch>();
 
@@ -625,7 +641,7 @@ public partial class FindService : IFindService
             return matches;
         }
 
-        switch (CurrentFindMode)
+        switch (findMode)
         {
             case FindMode.RegularExpression:
                 try
@@ -644,14 +660,14 @@ public partial class FindService : IFindService
                 break;
 
             default:
-                var comparison = CurrentFindMode == FindMode.CaseSensitive
+                var comparison = findMode == FindMode.CaseSensitive
                     ? StringComparison.Ordinal
                     : StringComparison.OrdinalIgnoreCase;
 
-                if (WholeWord)
+                if (wholeWord)
                 {
                     var pattern = RegexUtils.BuildWholeWordPattern(searchText);
-                    var options = CurrentFindMode == FindMode.CaseInsensitive ? RegexOptions.IgnoreCase : RegexOptions.None;
+                    var options = findMode == FindMode.CaseInsensitive ? RegexOptions.IgnoreCase : RegexOptions.None;
 
                     try
                     {

--- a/src/ui/Logic/IFindService.cs
+++ b/src/ui/Logic/IFindService.cs
@@ -18,6 +18,7 @@ public interface IFindService
     int FindPrevious(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex);
     int ReplaceAll(string searchText, string replaceText);
     int Count(string searchText);
+    int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode);
     List<(int LineIndex, int TextIndex, string FoundText)> FindAll(string searchText);
     void Reset();
     void RemoveFromSearchHistory(string searchText);

--- a/src/ui/Logic/IFindService.cs
+++ b/src/ui/Logic/IFindService.cs
@@ -17,7 +17,6 @@ public interface IFindService
     int FindNext(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex);
     int FindPrevious(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex);
     int ReplaceAll(string searchText, string replaceText);
-    int Count(string searchText);
     int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode);
     List<(int LineIndex, int TextIndex, string FoundText)> FindAll(string searchText);
     void Reset();

--- a/tests/UI/Logic/FindServiceTests.cs
+++ b/tests/UI/Logic/FindServiceTests.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Logic;
+using System.Collections.Generic;
 
 namespace UITests.Logic;
 
@@ -11,7 +12,7 @@ public class FindServiceTests
         var service = new FindService();
         service.Initialize([text], 0, false, FindService.FindMode.RegularExpression);
 
-        Assert.Equal(2, service.Count(@"(?m)-$"));
+        Assert.Equal(2, service.Count(@"(?m)-$", [text], false, FindService.FindMode.RegularExpression));
 
         var matches = service.FindAll(@"(?m)-$");
         Assert.Equal(2, matches.Count);
@@ -69,5 +70,22 @@ public class FindServiceTests
         idx = service.FindPrevious(pattern, [text], 0, service.CurrentTextIndex - 1);
         Assert.Equal(0, idx);
         Assert.Equal(0, service.CurrentTextIndex);
+    }
+
+    [Fact]
+    public void Count_DoesNotResetFindPosition()
+    {
+        var lines = new List<string> { "hello world", "hello again" };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive);
+        service.FindNext("hello", lines, 0, 0);
+
+        var lineBeforeCount = service.CurrentLineNumber;
+        var indexBeforeCount = service.CurrentTextIndex;
+
+        service.Count("hello", lines, false, FindService.FindMode.CaseInsensitive);
+
+        Assert.Equal(lineBeforeCount, service.CurrentLineNumber);
+        Assert.Equal(indexBeforeCount, service.CurrentTextIndex);
     }
 }


### PR DESCRIPTION
  ## Problem

  The Count button in the Find and Replace dialogs called `FindService.Initialize()` before counting matches. `Initialize()` calls `ResetSearchState()` internally, which wipes `CurrentLineNumber`, `CurrentTextIndex`, and `CurrentTextFound` — the three fields tracking the last-found position. This caused a subsequent Replace (without pressing Find Next first) to lose track of which occurrence to replace.

This video demonstrates the bug:

https://github.com/user-attachments/assets/b5702642-e687-4d9a-89c0-3d0d214ed190

  ## Fix

  Add a stateless `Count(searchText, textLines, wholeWord, findMode)` overload to `IFindService`/`FindService` that accepts all configuration as parameters and never touches navigation state. Both ViewModels now call this overload directly, with no `Initialize()` call needed in the Count path.

  To follow the Boy Scout rule, I am leaving the campground a bit cleaner than I found it: tests added, interface cleaned up, and I did a micro-optimization, too.

  This PR includes an example of a method that has a bug caused by a side effect, specifically when FindService wipes its state upon Count. As we remove this side effect, we discover that it has been masking another issue: replacing the wrong search text during the first replacement.

 `Count` should be stateless by nature, and now it is.