### PR TITLE
Fix video offset with "Keep existing time codes" modifying the file (#11637)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6087,6 +6087,8 @@ public partial class MainViewModel :
             return;
         }
 
+        var oldOffsetMs = Se.Settings.General.CurrentVideoOffsetInMs;
+
         var result = await ShowDialogAsync<SetVideoOffsetWindow, SetVideoOffsetViewModel>();
 
         if (result.ResetPressed)
@@ -6111,14 +6113,23 @@ public partial class MainViewModel :
                 offset = offset - TimeSpan.FromSeconds(vp.Position);
             }
 
-            Se.Settings.General.CurrentVideoOffsetInMs = (int)Math.Round(offset.TotalMilliseconds, MidpointRounding.AwayFromZero);
+            Se.Settings.General.CurrentVideoOffsetInMs = (long)Math.Round(offset.TotalMilliseconds, MidpointRounding.AwayFromZero);
         }
 
-        if (result.KeepTimeCodes)
+        // The video offset is a non-destructive display offset (see TimeSpanToDisplayFullConverter):
+        // the listview shows "time code + offset" while the underlying time codes stay untouched.
+        // "Keep existing time codes" therefore leaves the time codes alone. When it is NOT checked,
+        // we bake the offset change into the time codes so the displayed values stay the same.
+        if (!result.KeepTimeCodes)
         {
-            foreach (var s in Subtitles)
+            var delta = TimeSpan.FromMilliseconds(Se.Settings.General.CurrentVideoOffsetInMs - oldOffsetMs);
+            if (delta != TimeSpan.Zero)
             {
-                s.StartTime = s.StartTime - offset;
+                foreach (var s in Subtitles)
+                {
+                    s.StartTime -= delta;
+                    s.EndTime -= delta;
+                }
             }
         }
 

--- a/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetViewModel.cs
+++ b/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetViewModel.cs
@@ -42,7 +42,7 @@ public partial class SetVideoOffsetViewModel : ObservableObject
             return;
         }
 
-        Se.Settings.General.CurrentVideoOffsetInMs = (int)Math.Round(TimeOffset.Value.TotalMilliseconds, MidpointRounding.AwayFromZero);
+        Se.Settings.General.CurrentVideoOffsetInMs = (long)Math.Round(TimeOffset.Value.TotalMilliseconds, MidpointRounding.AwayFromZero);
         OkPressed = true;
         Window?.Close();
     }


### PR DESCRIPTION
Fixes #11637

## Problem

Using **Set video offset** with **Keep existing time codes** modified the subtitle's time codes instead of leaving them alone:

1. The time codes were altered and the file was marked as changed.
2. Saving wrote the offset into the file.
3. Reopening double-applied the offset (e.g. a file starting at `01:00:00:00` reopened at `02:00:00:00` when unsaved, or `00:00:00:00` when saved).

## Cause

In the new Avalonia UI the video offset is a **non-destructive display offset** — `TimeSpanToDisplayFullConverter` renders `time code + offset` while the stored time codes stay untouched. The handler in `MainViewModel.ShowVideoSetOffset` had the logic inverted: checking *Keep existing time codes* was the branch that subtracted the offset from the paragraphs (and only `StartTime`, corrupting durations) and dirtied the file.

This is backwards from the legacy `Main.cs`, where `DoNotaddVideoOffsetToTimeCodes` (the checked state) is the path that resets the change-hash so the file is **not** marked dirty.

## Fix

- **Checked** → leave the time codes alone; only set the display offset. File is not modified and there is no double-apply on reopen.
- **Unchecked** → bake the offset *delta* (`new − old`) into both `StartTime` and `EndTime`, so the displayed values stay put while the underlying codes change (and the file is correctly marked as modified). Using the delta makes re-running the dialog with an existing offset correct.
- Cast the rounded offset to `long` to match the `long CurrentVideoOffsetInMs` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)