### PR TITLE
Video player: fix time display jitter with tabular numerals

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -489,6 +489,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 HorizontalAlignment = HorizontalAlignment.Center,
                 FontSize = 12,
                 FontWeight = FontWeight.Bold,
+                FontFeatures = FontFeatureCollection.Parse("tnum"),
             };
             progressText.Bind(TextBlock.TextProperty, this.GetObservable(ProgressTextProperty));
             _gridProgress.Children.Add(progressText);
@@ -822,7 +823,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 else
                 {
                     ProgressText =
-                        $"{TimeCode.FromSeconds(pos + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString()} / {fullDuration}{postFix}";
+                        $" {TimeCode.FromSeconds(pos + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString()} / {fullDuration}{postFix}";
                 }
             };
             _positionTimer.Start();


### PR DESCRIPTION
  The elapsed/remaining time and the slash + total duration were shifting horizontally during playback. The cause is proportional font rendering: even though the time string is always a fixed 12 characters (`HH:MM:SS,mmm`), digits like `1` are narrower than `8` in the default system font, so the centered TextBlock drifts left and right as each millisecond ticks by.

  Enable the `tnum` (tabular numerals) OpenType feature on the time display TextBlock so all digits occupy the same width without changing the font family. Also pad the elapsed-mode string with a leading space to match the width of the remaining-mode string (which has a `"-"` prefix), preventing a jump when toggling between the two modes.


Before:

https://github.com/user-attachments/assets/3cb7e341-847c-46ab-88ef-05d4ba06c1e1


After:

https://github.com/user-attachments/assets/0f8926e8-38b1-4dec-9f83-f4a97928515e
