### PR TITLE
Honor snap settings in waveform: playhead snapping + shot-change toggle

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -204,7 +204,9 @@ public class AudioVisualizer : Control
     public double ShotChangeSnapSeconds { get; set; } = 0.05;
     public WaveformDrawStyle WaveformDrawStyle { get; set; } = WaveformDrawStyle.Classic;
 
-    public bool SnapToShotChanges { get; set; } = true;
+    // Reads the user setting directly (like SnapToFrames) so the "Snap to shot changes"
+    // checkbox actually takes effect, and does so live without re-wiring at every call site.
+    public bool SnapToShotChanges => Se.Settings.Waveform.SnapToShotChanges;
     public bool FocusOnMouseOver { get; set; } = true;
     public int WaveformHeightPercentage { get; set; } = 50;
     public Color WaveformFancyHighColor { get; set; } = Colors.Orange;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8952,6 +8952,28 @@ public partial class MainViewModel :
         return (int)Math.Round(frames * 1000.0 / frameRate, MidpointRounding.AwayFromZero);
     }
 
+    /// <summary>
+    /// Snaps a video position (in seconds) to the nearest frame boundary when "Snap to frames"
+    /// is enabled, so the playhead lands exactly on a frame. Returns the value unchanged when the
+    /// setting is off or no usable frame rate is available.
+    /// </summary>
+    private static double SnapSecondsToFrame(double seconds)
+    {
+        if (!Se.Settings.Waveform.SnapToFrames)
+        {
+            return seconds;
+        }
+
+        var frameRate = Se.Settings.General.CurrentFrameRate;
+        if (frameRate < 1)
+        {
+            return seconds;
+        }
+
+        var frameDur = 1.0 / frameRate;
+        return Math.Round(seconds / frameDur, MidpointRounding.AwayFromZero) * frameDur;
+    }
+
     [RelayCommand]
     private void MergeSelectedLines()
     {
@@ -12338,6 +12360,11 @@ public partial class MainViewModel :
     [RelayCommand]
     private void VideoOneFrameBack()
     {
+        if (TryStepVideoFrameSnapped(forward: false))
+        {
+            return;
+        }
+
         var vp = GetVideoPlayerControl();
         if (vp != null && vp.VideoPlayer is LibMpvDynamicPlayer mpv)
         {
@@ -12358,6 +12385,11 @@ public partial class MainViewModel :
     [RelayCommand]
     private void VideoOneFrameForward()
     {
+        if (TryStepVideoFrameSnapped(forward: true))
+        {
+            return;
+        }
+
         var vp = GetVideoPlayerControl();
         if (vp != null && vp.VideoPlayer is LibMpvDynamicPlayer mpv)
         {
@@ -12373,6 +12405,40 @@ public partial class MainViewModel :
         }
 
         MoveVideoPositionMs(40);
+    }
+
+    /// <summary>
+    /// When "Snap to frames" is on, steps the playhead to the previous/next frame boundary on the
+    /// project frame grid (so stepping stays frame-aligned even from an off-grid position). Returns
+    /// false when snapping is off or no usable frame rate is available, leaving the default
+    /// (player-native) frame step in charge.
+    /// </summary>
+    private bool TryStepVideoFrameSnapped(bool forward)
+    {
+        if (!Se.Settings.Waveform.SnapToFrames)
+        {
+            return false;
+        }
+
+        var fps = Se.Settings.General.CurrentFrameRate;
+        if (fps < 1)
+        {
+            return false;
+        }
+
+        var vp = GetVideoPlayerControl();
+        if (vp == null || string.IsNullOrEmpty(_videoFileName) || AudioVisualizer == null)
+        {
+            return false;
+        }
+
+        var frameDur = 1.0 / fps;
+        var currentFrame = vp.Position / frameDur;
+        var targetFrame = forward
+            ? Math.Floor(currentFrame + 1e-6) + 1
+            : Math.Ceiling(currentFrame - 1e-6) - 1;
+        SetVideoPositionSeconds(targetFrame * frameDur);
+        return true;
     }
 
     [RelayCommand]
@@ -12757,7 +12823,17 @@ public partial class MainViewModel :
             return;
         }
 
-        var newPosition = vp.Position + (ms / 1000.0);
+        SetVideoPositionSeconds(vp.Position + (ms / 1000.0));
+    }
+
+    private void SetVideoPositionSeconds(double newPosition)
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp == null || string.IsNullOrEmpty(_videoFileName) || AudioVisualizer == null)
+        {
+            return;
+        }
+
         if (newPosition < 0)
         {
             newPosition = 0;
@@ -19980,11 +20056,13 @@ public partial class MainViewModel :
 
         if (Enum.TryParse<WaveformSingleClickActionType>(Se.Settings.Waveform.SingleClickAction, out var action))
         {
+            // Land the playhead on a frame boundary when "Snap to frames" is on.
+            var seconds = SnapSecondsToFrame(e.Seconds);
             switch (action)
             {
                 case WaveformSingleClickActionType.SetVideoPositionAndPauseAndSelectSubtitle:
                     vp.VideoPlayer.Pause();
-                    vp.Position = e.Seconds;
+                    vp.Position = seconds;
                     if (e.Paragraph != null)
                     {
                         var p1 = Subtitles.FirstOrDefault(p => p.Id == e.Paragraph.Id);
@@ -19997,37 +20075,37 @@ public partial class MainViewModel :
                     break;
                 case WaveformSingleClickActionType.SetVideopositionAndPauseAndSelectSubtitleAndCenter:
                     vp.VideoPlayer.Pause();
-                    vp.Position = e.Seconds;
+                    vp.Position = seconds;
                     if (e.Paragraph != null)
                     {
                         var p2 = Subtitles.FirstOrDefault(p => p.Id == e.Paragraph.Id);
                         if (p2 != null)
                         {
                             SelectAndScrollToSubtitle(p2);
-                            AudioVisualizer.CenterOnPosition(e.Seconds);
+                            AudioVisualizer.CenterOnPosition(seconds);
                         }
                     }
 
                     break;
                 case WaveformSingleClickActionType.SetVideoPositionAndPause:
                     vp.VideoPlayer.Pause();
-                    vp.Position = e.Seconds;
+                    vp.Position = seconds;
                     break;
                 case WaveformSingleClickActionType.SetVideopositionAndPauseAndCenter:
                     vp.VideoPlayer.Pause();
-                    vp.Position = e.Seconds;
+                    vp.Position = seconds;
                     if (e.Paragraph != null)
                     {
-                        AudioVisualizer.CenterOnPosition(e.Seconds);
+                        AudioVisualizer.CenterOnPosition(seconds);
                     }
 
                     break;
                 case WaveformSingleClickActionType.SetVideoposition:
-                    vp.Position = e.Seconds;
+                    vp.Position = seconds;
                     break;
             }
 
-            PinPlayheadTo(e.Seconds);
+            PinPlayheadTo(seconds);
             _updateAudioVisualizer = true;
         }
     }


### PR DESCRIPTION
Two related waveform snapping fixes so the snap settings are actually honored for the video playhead.

## Snap to frames — waveform click & frame stepping
When **Snap to frames** is on, the playhead now lands on a frame boundary in two more places:

- **Waveform single-click** rounds the clicked position to the nearest frame before seeking/centering/pinning.
- **Next/previous frame** stepping seeks to the previous/next frame boundary on the project frame grid, so stepping stays frame-aligned even when the playhead started off-grid.

Both are gated on `Waveform.SnapToFrames` and a valid frame rate; when off (or fps unavailable), behavior is unchanged — including mpv's native frame step. Extracted `SetVideoPositionSeconds` from `MoveVideoPositionMs` so stepping can seek to a sub-millisecond-accurate frame boundary (matters for rates like 29.97 where a frame isn't a whole ms).

## Snap to shot changes — setting was ignored
`Waveform.SnapToShotChanges` was defined, shown in Settings, and saved/loaded, but **never read** by the waveform: `AudioVisualizer.SnapToShotChanges` was hardcoded to `true` and never assigned, so shot-change snapping was always on regardless of the checkbox. It now reads the setting directly (the same way `SnapToFrames` does), so the checkbox takes effect live. Shift-to-override is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)