### PR TITLE
Replace dialog: focus search box on cold open if not opened via shortcut from Find dialog

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9913,9 +9913,10 @@ public partial class MainViewModel :
             return;
         }
 
-        var findSearchText = _findViewModel?.SearchText;
-        var findMode = _findViewModel?.FindMode;
-        var findWholeWord = _findViewModel?.WholeWord;
+        var activeFindVm = _findViewModel?.Window?.IsVisible == true ? _findViewModel : null;
+        var findSearchText = activeFindVm?.SearchText;
+        var findMode = activeFindVm?.FindMode;
+        var findWholeWord = activeFindVm?.WholeWord;
 
         if (_findViewModel != null)
         {


### PR DESCRIPTION
This PR is a minor focus tweak some usability testing brought up. It fixes the Replace dialog focus so that it goes to the search box when opening it directly, instead of incorrectly landing on the replace box due to stale state from a previously closed Find dialog.

- **Cold open (Replace launched directly)**: Focus on the **Find field, always** — even if there's a remembered search term. The remembered term is a convenience, not a signal that the user has already decided what to search for.
- **Opened from Find dialog**: Focus on the **Replace field**. The user just confirmed their search term; they're ready to type the replacement.

  Why not always focus Replace when a term is remembered?

  A remembered term from a past session could be:
- Something the user wants to continue with (Replace focus would be right)
- Something totally irrelevant to today's task (they need to change it first)

  There's no way to distinguish these, so defaulting to Find field is safer — the user can Tab to Replace if the term is fine. The reverse (being dropped into Replace when you wanted to change the search term first) is more disruptive.

  ## Root cause

  `_findViewModel` is not cleared when the user manually closes the Find window. As a result, `ShowReplace()` would read a non-empty `SearchText` from the stale view model and incorrectly set `FocusReplaceOnOpen = true`, even though no Find→Replace navigation had taken place.

  ## Fix

  Guard the `findSearchText` capture with a window visibility check, so carried-over state (search text, find mode, whole word) and Replace-box focus are only applied when the Find window is actually open at the time Replace is opened.

  ## Behavior

  | How Replace is opened | Search box | Focus |
  |---|---|---|
  | Directly (cold open) | Prefilled with last search term | **Search box** (text selected) |
  | Via shortcut from open Find | Carried over from Find | **Replace box** |


A video exercising all options: Find cold open, Find -> Replace transition, Replace cold open. Shortcuts in use: CMD+F for Find and OPTION+CMD+F for Replace:


https://github.com/user-attachments/assets/6be83a07-dbe8-4bea-83cc-ac5e3ad48423

