### PR TITLE
libmpv: allow volume boost up to 130% (fix volume clamped at 100)

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1155,8 +1155,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 return;
             }
 
-            // Clamp volume between 0 and 100
-            var clampedVolume = Math.Max(0, Math.Min(100, value));
+            // Clamp volume between 0 and the player maximum. mpv's default
+            // volume-max is 130, matching MaxVolume, so values above 100 boost
+            // (amplify) the audio. Clamping to 100 here meant the upper part of
+            // the volume slider (100..130) did nothing.
+            var clampedVolume = Math.Max(0, Math.Min(MaxVolume, value));
             var err = DoMpvCommand("set", "volume", clampedVolume.ToString(CultureInfo.InvariantCulture));
             //if (err < 0)
             //{


### PR DESCRIPTION
## Problem

The volume slider and `LibMpvDynamicPlayer.VolumeMaximum`/`MaxVolume` advertise a maximum of **130**, but the `Volume` setter clamped the value to **100** before handing it to mpv:

```csharp
// Clamp volume between 0 and 100
var clampedVolume = Math.Max(0, Math.Min(100, value));
```

So the upper part of the slider (100..130) was a no-op — mpv never received anything above unity gain, and users could not amplify audio above the source's natural level. (The `LibVlcDynamicPlayer` path already scales correctly to its 130 max; only the mpv path was wrong.)

## Fix

Clamp to `MaxVolume` instead of the hardcoded 100. mpv's default `volume-max` is 130 (== `MaxVolume`), so values above 100 boost (amplify) the audio as intended.

## Context

Relates to #11647 (RC4 / Fedora: audio extremely low). This is not a full fix for that report — the underlying "extremely low" baseline there is most likely environmental (PipeWire per-app stream level / multichannel downmix, and embedded libmpv not loading the user's `mpv.conf`). But the clamp meant SubtitleEdit users had **no** way to compensate above unity gain even though the UI offered it. This restores the intended boost headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)