### PR TITLE
Improve "Open video from URL" UX

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -344,6 +344,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<DownloadSpeechToTextEngineViewModel>();
         collection.AddTransient<DownloadSpeechToTextModelsViewModel>();
         collection.AddTransient<DownloadYtDlpViewModel>();
+        collection.AddTransient<PleaseWaitViewModel>();
         collection.AddTransient<EditCategoryViewModel>();
         collection.AddTransient<EditCustomTextFormatViewModel>();
         collection.AddTransient<EditEmbeddedTrackViewModel>();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5862,12 +5862,18 @@ public partial class MainViewModel :
         }
 
         // Now that the user has committed to a URL, see whether the background
-        // version check came back "outdated" — and only then interrupt with the
-        // upgrade prompt. The check is almost always finished by this point, but
-        // we await it to be safe.
+        // version check came back "outdated". It has almost always finished by this
+        // point, but if not, show a brief "Please wait..." so the app doesn't look
+        // frozen while `yt-dlp --version` is still running.
+        var isOutdated = false;
         if (outdatedCheckTask is not null)
         {
-            bool isOutdated;
+            PleaseWaitViewModel? pleaseWaitVm = null;
+            if (!outdatedCheckTask.IsCompleted)
+            {
+                pleaseWaitVm = _windowService.ShowWindow<PleaseWaitWindow, PleaseWaitViewModel>(Window!);
+            }
+
             try
             {
                 isOutdated = await outdatedCheckTask;
@@ -5878,12 +5884,18 @@ public partial class MainViewModel :
                 // its own error on the next yt-dlp invocation.
                 isOutdated = false;
             }
-
-            if (isOutdated &&
-                !await PromptToDownloadYtDlp(Se.Language.Main.YoutubeDlOutdatedDownloadNow))
+            finally
             {
-                return;
+                pleaseWaitVm?.Close();
             }
+        }
+
+        // If a newer yt-dlp is available, offer the upgrade — but open the video
+        // regardless of the user's choice. The installed binary still works, so a
+        // declined or failed update must not abort the open.
+        if (isOutdated)
+        {
+            await PromptToDownloadYtDlp(Se.Language.Main.YoutubeDlOutdatedDownloadNow);
         }
 
         switch (result.SelectedMode.Value)
@@ -5944,6 +5956,19 @@ public partial class MainViewModel :
     /// </summary>
     private async Task ShowPickerAndLoadAsync(IReadOnlyList<DownloadedSubtitleInfo> subtitles)
     {
+        if (subtitles.Count == 0)
+        {
+            return;
+        }
+
+        // With a single track there's nothing to choose — load it directly instead
+        // of making the user confirm a one-row picker.
+        if (subtitles.Count == 1)
+        {
+            await SubtitleOpen(subtitles[0].FilePath, skipLoadVideo: true);
+            return;
+        }
+
         var pickerResult = await ShowDialogAsync<PickOnlineSubtitleWindow, PickOnlineSubtitleViewModel>(
             vm => { vm.Initialize(subtitles); });
 

--- a/src/ui/Features/Shared/PleaseWaitViewModel.cs
+++ b/src/ui/Features/Shared/PleaseWaitViewModel.cs
@@ -1,0 +1,30 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Shared;
+
+/// <summary>
+/// Tiny non-modal "Please wait..." window shown while a short background
+/// operation runs (e.g. probing the installed yt-dlp version). The caller owns
+/// the lifetime: show it via the window service and call <see cref="Close"/>
+/// once the work is done.
+/// </summary>
+public partial class PleaseWaitViewModel : ObservableObject
+{
+    [ObservableProperty] private string _statusText;
+
+    public Window? Window { get; set; }
+
+    public PleaseWaitViewModel()
+    {
+        _statusText = Se.Language.General.PleaseWait;
+    }
+
+    public void Close()
+    {
+        Dispatcher.UIThread.Post(() => Window?.Close());
+    }
+}

--- a/src/ui/Features/Shared/PleaseWaitWindow.cs
+++ b/src/ui/Features/Shared/PleaseWaitWindow.cs
@@ -1,13 +1,14 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
-using Nikse.SubtitleEdit.Logic.Config;
 
-namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
+namespace Nikse.SubtitleEdit.Features.Shared;
 
-public class GeneratingAudioWindow : Window
+public class PleaseWaitWindow : Window
 {
-    public GeneratingAudioWindow(GeneratingAudioViewModel vm)
+    public PleaseWaitWindow(PleaseWaitViewModel vm)
     {
         vm.Window = this;
         UiUtil.InitializeWindow(this, GetType().Name);
@@ -19,27 +20,27 @@ public class GeneratingAudioWindow : Window
         Width = 360;
         SizeToContent = SizeToContent.Height;
         CanResize = false;
+        ShowInTaskbar = false;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
 
         DataContext = vm;
 
         var titleText = new TextBlock
         {
-            Text = Se.Language.General.PleaseWait,
             FontSize = 18,
             HorizontalAlignment = HorizontalAlignment.Center,
-            Margin = new Avalonia.Thickness(0, 0, 0, 8),
+            TextAlignment = Avalonia.Media.TextAlignment.Center,
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            Margin = new Thickness(0, 0, 0, 8),
         };
+        titleText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusText)));
 
         var progressBar = new ProgressBar
         {
             IsIndeterminate = true,
-            MinWidth = 300,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
             Height = 8,
         };
-
-        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var buttonBar = UiUtil.MakeButtonBar(buttonCancel);
 
         Content = new StackPanel
         {
@@ -49,13 +50,7 @@ public class GeneratingAudioWindow : Window
             {
                 titleText,
                 progressBar,
-                buttonBar,
             }
-        };
-
-        Loaded += delegate
-        {
-            buttonCancel.Focus();
         };
     }
 }


### PR DESCRIPTION
Several UX improvements to the **Video → Open video from URL** flow, plus a macOS window-sizing fix.

## Changes

1. **"Please wait…" feedback during the version check** — After submitting a URL, the app awaits a background `yt-dlp --version` check (slow on macOS first-run), which made it look frozen for 3-4 seconds with no feedback. Now a brief non-modal `PleaseWaitWindow` (indeterminate progress) shows until the check completes — only if it hasn't already finished.

2. **Skip the subtitle picker for a single track** — When only one subtitle is available, it loads directly instead of showing a one-row chooser. Applies to both the streaming ("Open online") and "Download & open" paths.

3. **Update available → continue instead of exit** — Previously, if yt-dlp was outdated and the user declined (or the download failed), the whole open was aborted. Now the upgrade is offered but the video opens regardless — the installed binary still works.

4. **Fix TTS "Please wait" window too wide on macOS** — `GeneratingAudioWindow` used `SizeToContent.WidthAndHeight`, which renders far too wide on macOS. Switched to an explicit `Width` + `SizeToContent.Height` (the established pattern in the repo). The new reusable `PleaseWaitWindow` uses the same approach.

## New files
- `src/ui/Features/Shared/PleaseWaitWindow.cs`
- `src/ui/Features/Shared/PleaseWaitViewModel.cs` (registered in DI)

## Notes
- The PleaseWaitWindow is non-modal, mirroring the existing `GeneratingAudioWindow`, so the main window stays responsive.
- Not yet manually verified in-app — worth a quick check of the Open-from-URL flow, especially the single-subtitle and outdated-yt-dlp cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)