### PR TITLE
Open from URL: marshal download timer tick to UI thread

### DIFF
--- a/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
@@ -220,6 +220,15 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
 
     private void OnTimerElapsed(object? sender, ElapsedEventArgs e)
     {
+        // System.Timers.Timer raises Elapsed on a thread-pool thread, but this handler
+        // writes observable properties bound to the UI (StatusText/Error) and closes the
+        // window. Touching those off the UI thread can throw "call from invalid thread" or
+        // leave the UI in an inconsistent state, so marshal the whole tick to the UI thread.
+        Dispatcher.UIThread.Post(HandleTimerTick);
+    }
+
+    private void HandleTimerTick()
+    {
         lock (_lockObj)
         {
             if (_done || _downloadTask is null)
@@ -305,15 +314,13 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
 
     private void Close()
     {
-        Dispatcher.UIThread.Post(() =>
+        // Always invoked on the UI thread (HandleTimerTick / CommandCancel).
+        if (!string.IsNullOrEmpty(Error))
         {
-            if (!string.IsNullOrEmpty(Error))
-            {
-                return; // keep window open so the user can read the error
-            }
+            return; // keep window open so the user can read the error
+        }
 
-            Window?.Close();
-        });
+        Window?.Close();
     }
 
     internal void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION
## What

`DownloadVideoFromUrlViewModel` polls the background download task with a `System.Timers.Timer`. The `Elapsed` handler fires on a **thread-pool thread** but writes `[ObservableProperty]` values bound to the UI (`StatusText`, `Error`) and closes the window. Touching bound state off the UI thread can throw `"Call from invalid thread"` or leave the UI in an inconsistent state.

This wraps the tick in `Dispatcher.UIThread.Post(...)` so all of it runs on the UI thread. Since `Close()` is now always called on the UI thread, its own inner `Post` is removed.

## Why

Tightens a real thread-affinity smell in the "Open video from URL → Download and open" flow. Surfaced while investigating #11644 (freeze after opening a video from a URL with subtitles). This is **not** confirmed to be the cause of that report — the leading hypothesis there is the embedded video player rendering a specific container/codec — but the cross-thread property writes are a genuine latent bug worth fixing regardless.

## Testing

- `dotnet build UI.csproj` succeeds with 0 warnings / 0 errors.
- Behavior unchanged on the happy path; the timer tick now always executes on the UI thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)