### PR TITLE
Fix change frame rate/speed corrupting selected line duration (#11650)

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -595,6 +595,24 @@ public partial class SubtitleLineViewModel : ObservableObject
         UpdateDuration();
     }
 
+    /// <summary>
+    /// Sets start and end time together without ever publishing an invalid
+    /// intermediate state (e.g. start &gt; end / negative duration). Updating
+    /// the two times separately can briefly expose such a state to the live
+    /// editor controls bound to the selected line; the duration up/down clamps
+    /// the negative value and writes it back, corrupting the end time. Suppress
+    /// notifications while both values are assigned, then recompute duration once.
+    /// </summary>
+    internal void SetTimes(TimeSpan startTime, TimeSpan endTime)
+    {
+        _skipUpdate = true;
+        StartTime = startTime;
+        EndTime = endTime;
+        _skipUpdate = false;
+
+        UpdateDuration();
+    }
+
     internal void Adjust(double factor, double adjustmentInSeconds)
     {
         if (StartTime.IsMaxTime())

--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
@@ -157,8 +157,9 @@ public partial class ChangeFrameRateViewModel : ObservableObject
         double ratio = fromFrameRate / toFrameRate;
         foreach (var line in subtitles)
         {
-            line.SetStartTimeOnly(TimeSpan.FromMilliseconds(line.StartTime.TotalMilliseconds * ratio));
-            line.EndTime = TimeSpan.FromMilliseconds(line.EndTime.TotalMilliseconds * ratio);
+            line.SetTimes(
+                TimeSpan.FromMilliseconds(line.StartTime.TotalMilliseconds * ratio),
+                TimeSpan.FromMilliseconds(line.EndTime.TotalMilliseconds * ratio));
         }
     }
 }

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -86,8 +86,10 @@ public partial class ChangeSpeedViewModel : ObservableObject
     {
         foreach (var subtitle in subtitles)
         {
-            subtitle.SetStartTimeOnly(TimeSpan.FromMilliseconds(subtitle.StartTime.TotalMilliseconds * (100.0 / speedPercent)));
-            subtitle.EndTime = TimeSpan.FromMilliseconds(subtitle.EndTime.TotalMilliseconds * (100.0 / speedPercent));
+            var factor = 100.0 / speedPercent;
+            subtitle.SetTimes(
+                TimeSpan.FromMilliseconds(subtitle.StartTime.TotalMilliseconds * factor),
+                TimeSpan.FromMilliseconds(subtitle.EndTime.TotalMilliseconds * factor));
         }
     }
 }


### PR DESCRIPTION
Fixes #11650.

## Problem
When changing frame rate (e.g. 25 → 23.976), the **currently selected line** gets a corrupted end time / duration — sometimes by a few seconds, sometimes by minutes/hours. Every other line scales correctly.

In the reporter's screenshots, line 9 (selected) scales its start correctly (`01:05:48,320` → `01:08:36,950`) but its end jumps to `01:11:32,782`, giving a ~2m55s duration instead of ~1.9s.

## Root cause
`ChangeFrameRate` (and the identical `ChangeSpeed`) updated each line's times in two separate steps — start first, then end:

```csharp
line.SetStartTimeOnly(line.StartTime.TotalMilliseconds * ratio);
line.EndTime = line.EndTime.TotalMilliseconds * ratio;
```

When times grow (ratio > 1), step 1 moves the start **past the still-unscaled end**, momentarily producing `start > end` → a negative duration, which is published via change notification.

That transient is harmless for ordinary rows, but the **selected** row is live two-way-bound to the editor's time/duration up/down controls. The duration control (`SecondsUpDown`) coerces the negative value to zero and writes it back into the model, which fires `OnDurationChanged` and moves the end time. Interleaved with step 2, the selected line's end ends up scaled roughly twice (`4292.78 ≈ 3950.2 × ratio²`). Non-selected rows have no bound controls, so they are unaffected.

## Fix
Add `SubtitleLineViewModel.SetTimes(start, end)` which assigns both times with change notifications suppressed (the same idiom already used by the constructor and `UpdateFrom`) and recomputes duration once — so no invalid intermediate state is ever exposed to the bound controls. Use it from both `ChangeFrameRate` and `ChangeSpeed` (which had the identical latent bug).

## Testing
- `dotnet build src/ui/UI.csproj` succeeds with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)