### PR TITLE
Fix truncated ♫ mojibake in default MusicSymbolReplace

### DIFF
--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -346,7 +346,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             FixShortDisplayTimesAllowMoveStartTime = false;
             RemoveEmptyLinesBetweenText = true;
             MusicSymbol = "♪";
-            MusicSymbolReplace = "â™ª,â™," + // ♪ + ♫ in UTF-8 opened as ANSI
+            MusicSymbolReplace = "â™ª,â™«," + // ♪ + ♫ in UTF-8 opened as ANSI
                                  "<s M/>,<s m/>," + // music symbols by subtitle creator
                                  "#,*,¶"; // common music symbols
             UnicodeSymbolsToInsert = "♪;♫;—;…;°;☺;☹;♥;©;☮;☯;Σ;∞;≡;⇒;π";

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -163,7 +163,7 @@ public class SeTools
         SplitOddLinesAction = nameof(SplitOddLinesActionType.Smart);
         UnicodeSymbolsToInsert = "♪;♫;—;…;°;∙;©;®;☺;☹;♥;☮;☯;Σ;∞;≡;⇒;π";
         MusicSymbol = "♪";
-        MusicSymbolReplace = "â™ª,â™," + // ♪ + ♫ in UTF-8 opened as ANSI
+        MusicSymbolReplace = "â™ª,â™«," + // ♪ + ♫ in UTF-8 opened as ANSI
                              "<s M/>,<s m/>," + // music symbols by subtitle creator
                              "#,*,¶"; // common music symbols
 


### PR DESCRIPTION
## Problem

Reported in discussion #11628 — the default **Music symbol replace** list has a truncated/corrupted second entry.

`MusicSymbolReplace` lists strings that get detected and converted back to a real music symbol (♪). The first two entries are deliberately *mojibake*: ♪/♫ saved as **UTF-8** but later opened as **ANSI (Windows-1252)**.

The correct mojibake forms are:

| Symbol | UTF-8 bytes | As Windows-1252 |
|--------|-------------|-----------------|
| ♪ U+266A | `E2 99 AA` | `â™ª` ✓ |
| ♫ U+266B | `E2 99 AB` | `â™«` |

The default had `"â™ª,â™,"` — the second entry was `â™` (2 chars), **missing the trailing `«` (byte `0xAB` → U+00AB)**. So ♫ mangled by a UTF-8↔ANSI mismatch was never repaired.

## Fix

Corrects the default in both:
- `src/ui/Logic/Config/SeTools.cs`
- `src/libse/Settings/ToolsSettings.cs`

Note: only the **default** changes — existing users keep their saved value unless they reset to defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)