### PR TITLE
Remove subtitle from mpv when all lines are deleted

### DIFF
--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -29,6 +29,26 @@ public class MpvReloader : IMpvReloader
     {
         if (subtitle.Paragraphs.Count == 0 && subtitleSecondary == null)
         {
+            // All subtitles were deleted - remove any previously loaded subtitle from mpv,
+            // otherwise the last shown lines stay visible on the video.
+            if (!string.IsNullOrEmpty(_mpvTextFileName) || !string.IsNullOrEmpty(_mpvTextOld))
+            {
+                try
+                {
+                    mpvContext.SubRemove();
+                }
+                catch (Exception exception)
+                {
+                    Se.LogError(exception);
+                }
+
+                DeleteTempMpvFileName();
+                _mpvTextFileName = null;
+                _mpvTextOld = string.Empty;
+                _mpvSubOldHash = -1;
+                _subtitlePrev = null;
+            }
+
             return;
         }
 


### PR DESCRIPTION
## Problem

Fixes #11658.

When the user deletes **all** subtitle lines, the deleted subtitles still appear burned on the video (mpv player).

## Root cause

`MpvReloader.RefreshMpv` returned early when the subtitle had zero paragraphs:

```csharp
if (subtitle.Paragraphs.Count == 0 && subtitleSecondary == null)
{
    return;
}
```

Deleting all lines correctly marks the preview dirty and the timer calls `RefreshMpv`, but this early return means mpv is never told to drop the previously loaded subtitle file — so the last-shown lines stay visible.

(Deleting *some* lines already worked, because the non-empty path regenerated and reloaded the subtitle file.)

## Fix

Before returning on an empty subtitle, if a subtitle was previously loaded into mpv, call `SubRemove()` to clear it from the video and reset the cached state (temp file, hash, old text, prev subtitle). The guard ensures `SubRemove()` only runs when something was actually loaded, so it doesn't fire on every 400 ms timer tick when nothing is present.

## Testing

- `dotnet build src/ui/UI.csproj` — 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)