### PR TITLE
Fix three bugs: ripple-delete anchor, mpv/vlc temp-file leak, WebVTT cue drop

### DIFF
--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -17,6 +17,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static readonly Regex RegexTimeCodes = new Regex(@"^-?\d+:-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexTimeCodesMiddle = new Regex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexTimeCodesShort = new Regex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
+        private static readonly Regex RegexShortArrow = new Regex(@"-->\s*", RegexOptions.Compiled);
 
         public static readonly Dictionary<string, SKColor> DefaultColorClasses = new Dictionary<string, SKColor>
         {
@@ -257,7 +258,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 if (isTimeCode && RegexTimeCodesShort.IsMatch(s))
                 {
-                    s = "00:" + s.Replace("--> ", "--> 00:");
+                    // Both sides lack the hour part. Prefix the end time via the arrow
+                    // (regardless of spacing) and the start time via concatenation.
+                    s = "00:" + RegexShortArrow.Replace(s, "--> 00:", 1);
                 }
 
                 if (isNextTimeCode && Utilities.IsNumber(s) && p?.Text.Length > 0)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16605,13 +16605,16 @@ public partial class MainViewModel :
         }
 
         _subtitleGridSelectionChangedSkip = true;
-        var idx = Subtitles.IndexOf(selectedItems.First());
         _undoRedoManager.StopChangeDetection();
 
         var sortedIndices = selectedItems
             .Select(item => Subtitles.IndexOf(item))
             .OrderBy(i => i)
             .ToList();
+
+        // Anchor on the lowest selected index, not selectedItems.First() (which is the
+        // first-clicked row and can differ from row order on an out-of-order selection).
+        var idx = sortedIndices.FirstOrDefault();
 
         var firstLine = Subtitles.GetOrNull(sortedIndices.FirstOrDefault());
 

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -246,6 +246,7 @@ public class MpvReloader : IMpvReloader
 
     public void Reset()
     {
+        DeleteTempMpvFileName();
         _mpvTextFileName = null;
         _mpvTextFileExtension = null;
         _mpvTextOld = string.Empty;

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -248,6 +248,7 @@ public class VlcReloader : IVlcReloader
 
     public void Reset()
     {
+        DeleteTempMpvFileName();
         _mpvTextFileName = null;
         _mpvTextFileExtension = null;
         _mpvTextOld = string.Empty;


### PR DESCRIPTION
Three independent bug fixes found during a code review.

## 1. Ripple Delete uses the wrong anchor on out-of-order multi-select

`MainViewModel.RippleDeleteSelectedItems` computed `firstLine` from the **lowest** selected index (`sortedIndices[0]`) but derived `idx` (used for the ripple time-shift anchor and the post-delete selection) from `selectedItems.First()` — the **first-clicked** row. Avalonia's `DataGrid.SelectedItems` is ordered by click order, not row order, so selecting a consecutive block bottom-up (e.g. click row 5, ctrl-click 4, then 3) made `nextLine = Subtitles[idx + count]` point past the real block. The gap was then closed against the wrong line and a wrong time shift applied to every following subtitle.

**Fix:** anchor `idx` on the lowest selected index (`sortedIndices.FirstOrDefault()`).

## 2. `MpvReloader.Reset()` / `VlcReloader.Reset()` leak the temp subtitle file

`Reset()` set `_mpvTextFileName = null` without deleting the temp `.ass` file first (every other path calls `DeleteTempMpvFileName()`). Since `Reset()` runs on essentially every video/subtitle load, each load orphaned a temp file for the process lifetime.

**Fix:** call `DeleteTempMpvFileName()` at the top of `Reset()` in both reloaders.

## 3. WebVTT cue silently dropped when there's no space after `-->`

`RegexTimeCodesShort` matches short time-codes with `\s*` around `-->` (zero spaces allowed), but the hour-prefix normalization relied on the literal `"--> "` (with a trailing space) to prefix `00:` onto the end time. A cue like `01:02.500 -->05:06.700` therefore had its end time left without the hour part, failed the full `RegexTimeCodes` match, and was silently lost.

**Fix:** inject the hour prefix via a regex on the arrow (`-->\s*`) so spacing no longer matters. The start time is still prefixed by concatenation. Normal (spaced) cues are unchanged.

## Testing

- `dotnet build src/ui/UI.csproj` — 0 warnings / 0 errors.
- `dotnet test tests/libse` WebVTT suite — 24/24 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)