### PR TITLE
Fix Adjust duration corruption (use SetTimes) and EncodeNumeric surrogate-pair handling

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -363,13 +363,23 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             var encoded = new StringBuilder(source.Length);
-            foreach (var ch in source)
+            for (var i = 0; i < source.Length; i++)
             {
+                var ch = source[i];
                 if (ch == ' ')
                 {
                     encoded.Append("&#");
                     encoded.Append(160); // &nbsp;
                     encoded.Append(';');
+                }
+                else if (char.IsHighSurrogate(ch) && i + 1 < source.Length && char.IsLowSurrogate(source[i + 1]))
+                {
+                    // Emit the full code point, not the two surrogate halves separately
+                    // (a numeric reference to a lone surrogate is invalid and won't round-trip).
+                    encoded.Append("&#");
+                    encoded.Append(char.ConvertToUtf32(ch, source[i + 1]));
+                    encoded.Append(';');
+                    i++;
                 }
                 else if (ch > 127 || ch == '<' || ch == '>' || ch == '"' || ch == '&' || ch == '\'')
                 {

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -620,8 +620,12 @@ public partial class SubtitleLineViewModel : ObservableObject
             return;
         }
 
-        SetStartTimeOnly(TimeSpan.FromMilliseconds(StartTime.TotalMilliseconds * factor + adjustmentInSeconds * TimeCode.BaseUnit));
-        EndTime = TimeSpan.FromMilliseconds(EndTime.TotalMilliseconds * factor + adjustmentInSeconds * TimeCode.BaseUnit);
+        // Set both times atomically via SetTimes; updating start then end
+        // separately can briefly expose start > end to the bound editor
+        // controls, which clamp the negative duration and corrupt the end time.
+        var newStart = TimeSpan.FromMilliseconds(StartTime.TotalMilliseconds * factor + adjustmentInSeconds * TimeCode.BaseUnit);
+        var newEnd = TimeSpan.FromMilliseconds(EndTime.TotalMilliseconds * factor + adjustmentInSeconds * TimeCode.BaseUnit);
+        SetTimes(newStart, newEnd);
     }
 
     internal double GetCharactersPerSecond()

--- a/tests/UI/Features/Main/SubtitleLineViewModelAdjustTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelAdjustTests.cs
@@ -1,0 +1,60 @@
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Main;
+
+public class SubtitleLineViewModelAdjustTests
+{
+    [Fact]
+    public void Adjust_ScalesBothStartAndEnd()
+    {
+        var line = new SubtitleLineViewModel
+        {
+            Text = "Hello",
+            StartTime = TimeSpan.FromMilliseconds(1000),
+            EndTime = TimeSpan.FromMilliseconds(3000),
+        };
+
+        line.Adjust(2.0, 0.0);
+
+        Assert.Equal(2000, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(6000, line.EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void Adjust_AppliesOffsetInSeconds()
+    {
+        var line = new SubtitleLineViewModel
+        {
+            Text = "Hello",
+            StartTime = TimeSpan.FromMilliseconds(1000),
+            EndTime = TimeSpan.FromMilliseconds(3000),
+        };
+
+        line.Adjust(1.0, 1.5); // shift by 1.5 seconds
+
+        Assert.Equal(2500, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(4500, line.EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void Adjust_GrowingFactorKeepsDurationConsistentAndEndAfterStart()
+    {
+        // Growing the timeline pushes the new start past the old end. Updating start
+        // and end separately briefly exposed start > end to the bound editor, which
+        // clamped the negative duration and corrupted the end time. Verify the end
+        // stays correct (after start) and the duration matches end - start.
+        var line = new SubtitleLineViewModel
+        {
+            Text = "Hello",
+            StartTime = TimeSpan.FromMilliseconds(1000),
+            EndTime = TimeSpan.FromMilliseconds(1500),
+        };
+
+        line.Adjust(3.0, 0.0);
+
+        Assert.Equal(3000, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(4500, line.EndTime.TotalMilliseconds, 3);
+        Assert.True(line.EndTime > line.StartTime);
+        Assert.Equal((line.EndTime - line.StartTime).TotalMilliseconds, line.Duration.TotalMilliseconds, 3);
+    }
+}

--- a/tests/libse/Core/HtmlUtilTest.cs
+++ b/tests/libse/Core/HtmlUtilTest.cs
@@ -90,4 +90,24 @@ public class HtmlUtilTest
         Assert.Equal("<i>foobar?</i>" + Environment.NewLine + "<i>foobar?</i>", HtmlUtil.FixInvalidItalicTags(s));
     }
 
+    [Fact]
+    public void EncodeNumericEncodesNonAsciiBmpChar()
+    {
+        Assert.Equal("Hi&#229;", HtmlUtil.EncodeNumeric("Hiå")); // å
+    }
+
+    [Fact]
+    public void EncodeNumericLeavesAsciiUntouched()
+    {
+        Assert.Equal("abc", HtmlUtil.EncodeNumeric("abc"));
+    }
+
+    [Fact]
+    public void EncodeNumericEncodesSurrogatePairAsSingleCodePoint()
+    {
+        // U+1F600 (😀) is a surrogate pair in UTF-16; it must encode as one
+        // code point reference, not two lone-surrogate references.
+        Assert.Equal("&#128512;", HtmlUtil.EncodeNumeric("😀"));
+    }
+
 }


### PR DESCRIPTION
Two fixes plus unit tests.

## 1. `SubtitleLineViewModel.Adjust` corrupts the selected line's end time

`Adjust` (used by multi-point sync, `PointSyncer.Sync`) updated start and end separately:

```csharp
SetStartTimeOnly(... * factor + ...);
EndTime = ... * factor + ...;        // separate write
```

When the scale `factor > 1`, setting the start first pushes it past the still-unscaled end, briefly exposing `start > end` to the editor controls bound to the selected line. Those controls clamp the negative duration and write it back, corrupting the end time. This is the same class of bug already fixed for ChangeFrameRate/ChangeSpeed in `ee2403746` (#11650), which introduced `SetTimes(start, end)` for exactly this purpose.

**Fix / design note:** route both writes through the existing `SetTimes()`, which sets both fields with notifications suppressed and recomputes the duration once — no invalid intermediate state. This also makes `SetTimes` the single canonical multi-field time update, instead of hand-pairing `SetStartTimeOnly` + `EndTime` (the `StartTime` setter itself intentionally drags `EndTime` to preserve duration, which is the footgun behind this bug).

## 2. `HtmlUtil.EncodeNumeric` corrupts non-BMP characters

`EncodeNumeric` iterated UTF-16 code units (`foreach (var ch in source)`), so a character outside the BMP (e.g. emoji 😀 U+1F600) was emitted as two invalid lone-surrogate references `&#55357;&#56832;` instead of the correct single `&#128512;`. Lone-surrogate numeric references are invalid and don't round-trip, corrupting the character on SAMI export (`Sami.cs:197`).

**Fix:** detect a high+low surrogate pair and emit one `&#<codepoint>;` via `char.ConvertToUtf32`. BMP and ASCII behavior is unchanged.

## Tests

- `tests/libse/Core/HtmlUtilTest.cs`: `EncodeNumeric` for ASCII (untouched), BMP (`å` → `&#229;`), and surrogate pair (`😀` → `&#128512;`).
- `tests/UI/Features/Main/SubtitleLineViewModelAdjustTests.cs`: `Adjust` scaling, second-offset, and a growing-factor case asserting `end > start` and `duration == end - start`.

All passing (libse HtmlUtil: 15/15, UI Adjust: 3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)