### PR TITLE
Fix inverted frame rate ratio in BinaryEdit change frame rate

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1414,7 +1414,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var ratio = result.SelectedToFrameRate / result.SelectedFromFrameRate;
+        var ratio = result.SelectedFromFrameRate / result.SelectedToFrameRate;
 
         // If there are selected items in the grid, apply only to them
         var appliedToSelected = false;


### PR DESCRIPTION
  ## Bug

  When using **Sync → Change frame rate** on VobSub/PGS subtitles in BinaryEdit, the scaling ratio was computed as `to / from` instead of `from / to`, causing timestamps to move in the wrong direction.

  For example, a 25 fps → 30 fps conversion multiplied all timestamps by `30 / 25 = 1.2` (making them later), when it should scale by `25 / 30 ≈ 0.833` (making them earlier). This is the exact opposite of the intended behavior and the opposite of what the same dialog does for regular text subtitles.

  ## Fix

  Swap the operands in `BinaryEditViewModel.ChangeFrameRate()` to match `Subtitle.ChangeFrameRate()` (libse) and `ChangeFrameRateViewModel.ChangeFrameRate()` (main subtitle path), both of which correctly use `from / to`.

  **Before:**
  ```csharp
  var ratio = result.SelectedToFrameRate / result.SelectedFromFrameRate;
  ```

  After:
  ```csharp
  var ratio = result.SelectedFromFrameRate / result.SelectedToFrameRate;
  ```

  ## Testing

  Open a VobSub or PGS file in BinaryEdit, note a subtitle's start time (e.g. 1 000 ms), run Change frame rate 25 → 30, and verify the time becomes ≈ 833 ms.
