### PR TITLE
Persist Change frame rate dialog selections between sessions

### DIFF
--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
@@ -37,8 +37,8 @@ public partial class ChangeFrameRateViewModel : ObservableObject
         FromFrameRates = new ObservableCollection<double>(StandardFrameRates);
         ToFrameRates = new ObservableCollection<double>(StandardFrameRates);
 
-        SelectedFromFrameRate = FromFrameRates[0];
-        SelectedToFrameRate = ToFrameRates[0];
+        SelectedFromFrameRate = GetClosestFrameRate(FromFrameRates, Se.Settings.Synchronization.ChangeFrameRateFrom);
+        SelectedToFrameRate = GetClosestFrameRate(ToFrameRates, Se.Settings.Synchronization.ChangeFrameRateTo);
     }
 
     public void Initialize(string? videoFileName, FfmpegMediaInfo2? mediaInfo)
@@ -123,6 +123,10 @@ public partial class ChangeFrameRateViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
+        Se.Settings.Synchronization.ChangeFrameRateFrom = SelectedFromFrameRate;
+        Se.Settings.Synchronization.ChangeFrameRateTo = SelectedToFrameRate;
+        Se.SaveSettings();
+
         OkPressed = true;
         Window?.Close();
     }

--- a/src/ui/Logic/Config/SeSync.cs
+++ b/src/ui/Logic/Config/SeSync.cs
@@ -6,6 +6,9 @@ public class SeSync
     public bool AdjustAllTimesRememberLineSelectionChoice { get; set; }
     public string AdjustAllTimesLineSelectionChoice { get; set; }
 
+    public double ChangeFrameRateFrom { get; set; } = 23.976;
+    public double ChangeFrameRateTo { get; set; } = 25.0;
+
     public SeSync()
     {
         AdjustAllTimesLineSelectionChoice = string.Empty;


### PR DESCRIPTION
  ## Problem

  The **Sync → Change frame rate** dialog reset its From/To frame rate selections every time it was opened — either to the auto-detected video frame rate (if a video was loaded) or to `23.976` / `23.976` (the first entry in the standard list). The user's previous choices were never remembered.

  ## Fix

  - Added `ChangeFrameRateFrom` (default `23.976`) and `ChangeFrameRateTo` (default `25.0`) to `SeSync`.
  - `ChangeFrameRateViewModel` now loads the saved values on construction (via the existing `GetClosestFrameRate()` helper) and writes them back to settings when the user presses **OK**.
  - Pressing **Cancel** still discards changes — nothing is saved.
  - Video auto-detection in `Initialize()` is unchanged and continues to take precedence over saved settings when a video is loaded.

  ## Files changed

  | File | Change |
  |------|--------|
  | `src/ui/Logic/Config/SeSync.cs` | Add `ChangeFrameRateFrom` / `ChangeFrameRateTo` properties |
  | `src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs` | Load on construction, save on OK |
