### PR TITLE
Fix bookmarks lost when Fix Common Errors changes paragraph count

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -130,6 +130,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         UpdateDuration();
         Id = Guid.TryParse(paragraph.Id, out var guid) ? guid : Guid.NewGuid();
         Paragraph = paragraph;
+        Bookmark = paragraph.Bookmark;
 
         if (subtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
         {


### PR DESCRIPTION
  ## Problem

  Running Fix Common Errors on a subtitle that had bookmarks could silently delete the `.SE.bookmarks` sidecar file. This happened in two steps:

  1. Any fix rule that changes the paragraph count (e.g. **Remove empty lines** deleting an empty subtitle entry) causes `ApplyFixedSubtitle` to call `SetSubtitles`, which rebuilds all `SubtitleLineViewModel` rows from scratch. The `SubtitleLineViewModel(Paragraph, SubtitleFormat)` constructor copied most fields from the paragraph but omitted `Bookmark`, so every row was left with `Bookmark = null`.

  2. The next save called `BookmarkPersistence.Save()`, which found no bookmarks and deleted the sidecar file.

  Bookmarks that survived on paragraphs inside the fixed subtitle were simply never transferred to the view models.

  ## Fix

  Add `Bookmark = paragraph.Bookmark` to the `SubtitleLineViewModel(Paragraph, SubtitleFormat)` constructor so bookmarks are preserved when the row list is rebuilt.

  ## How to reproduce

  1. Create an SRT with three entries where entry #2 has empty text.
  2. Add a bookmark to entry #3.
  3. Run **Tools → Fix Common Errors** (default rules). The empty-line removal reduces the count from 3 → 2, triggering the affected code path.
  4. Save. The `.SE.bookmarks` file is deleted and the bookmark is gone.