### PR TITLE
Share frame-rate ratio formula across change-frame-rate paths

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1414,7 +1414,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var ratio = result.SelectedFromFrameRate / result.SelectedToFrameRate;
+        var ratio = ChangeFrameRateViewModel.GetFrameRateRatio(result.SelectedFromFrameRate, result.SelectedToFrameRate);
 
         // If there are selected items in the grid, apply only to them
         var appliedToSelected = false;

--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
@@ -156,9 +156,20 @@ public partial class ChangeFrameRateViewModel : ObservableObject
         return frameRates.MinBy(r => Math.Abs(r - target));
     }
 
+    /// <summary>
+    /// Scaling ratio applied to time codes when changing frame rate.
+    /// Always <c>from / to</c> - a higher target frame rate makes time codes earlier.
+    /// Shared so every change-frame-rate path (text and binary) stays consistent with
+    /// libse's <see cref="Nikse.SubtitleEdit.Core.Common.Subtitle.ChangeFrameRate"/>.
+    /// </summary>
+    internal static double GetFrameRateRatio(double fromFrameRate, double toFrameRate)
+    {
+        return fromFrameRate / toFrameRate;
+    }
+
     internal static void ChangeFrameRate(ObservableCollection<SubtitleLineViewModel> subtitles, double fromFrameRate, double toFrameRate)
     {
-        double ratio = fromFrameRate / toFrameRate;
+        double ratio = GetFrameRateRatio(fromFrameRate, toFrameRate);
         foreach (var line in subtitles)
         {
             line.SetTimes(

--- a/tests/UI/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModelTests.cs
+++ b/tests/UI/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModelTests.cs
@@ -1,0 +1,49 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Sync.ChangeFrameRate;
+using System.Collections.ObjectModel;
+
+namespace UITests.Features.Sync.ChangeFrameRate;
+
+public class ChangeFrameRateViewModelTests
+{
+    [Theory]
+    [InlineData(25.0, 30.0)]
+    [InlineData(23.976, 25.0)]
+    [InlineData(30.0, 25.0)]
+    [InlineData(60.0, 23.976)]
+    public void GetFrameRateRatio_IsFromOverTo(double from, double to)
+    {
+        // Guards against re-inverting the ratio (see PR #11665): must match
+        // libse Subtitle.ChangeFrameRate, which scales by oldFrameRate / newFrameRate.
+        var ratio = ChangeFrameRateViewModel.GetFrameRateRatio(from, to);
+
+        Assert.Equal(from / to, ratio);
+    }
+
+    [Fact]
+    public void GetFrameRateRatio_HigherTargetRate_MakesTimeCodesEarlier()
+    {
+        var ratio = ChangeFrameRateViewModel.GetFrameRateRatio(25.0, 30.0);
+
+        Assert.True(ratio < 1.0);
+        Assert.Equal(1000.0 * 25.0 / 30.0, 1000.0 * ratio, 6); // 1000 ms -> ~833 ms
+    }
+
+    [Fact]
+    public void ChangeFrameRate_ScalesStartAndEndByFromOverTo()
+    {
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new() { Text = "a", StartTime = TimeSpan.FromMilliseconds(1000), EndTime = TimeSpan.FromMilliseconds(3000) },
+            new() { Text = "b", StartTime = TimeSpan.FromMilliseconds(6000), EndTime = TimeSpan.FromMilliseconds(9000) },
+        };
+
+        ChangeFrameRateViewModel.ChangeFrameRate(subtitles, 25.0, 30.0);
+
+        var ratio = 25.0 / 30.0;
+        Assert.Equal(1000.0 * ratio, subtitles[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(3000.0 * ratio, subtitles[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal(6000.0 * ratio, subtitles[1].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(9000.0 * ratio, subtitles[1].EndTime.TotalMilliseconds, 3);
+    }
+}


### PR DESCRIPTION
## Background

Follow-up to #11665, which fixed an **inverted** frame-rate ratio in BinaryEdit's *Change frame rate* (it used `to / from` instead of `from / to`). That bug was possible only because each change-frame-rate path inlined its own copy of the ratio formula, so the two implementations could drift apart.

## Change

- Extract the scaling ratio into a single shared helper, `ChangeFrameRateViewModel.GetFrameRateRatio(from, to)`, documented as always `from / to` and consistent with libse's `Subtitle.ChangeFrameRate` (`oldFrameRate / newFrameRate`).
- Call it from both the text-subtitle path (`ChangeFrameRateViewModel.ChangeFrameRate`) and `BinaryEditViewModel.ChangeFrameRate`, so there is now one definition of the formula instead of two.

The two paths still apply the ratio with their own loops because they operate on different item types (`SubtitleLineViewModel` via `SetTimes` vs `BinarySubtitleItem`), but the drift-prone part — the formula direction — is no longer duplicated.

## Tests

Adds `ChangeFrameRateViewModelTests`:
- `GetFrameRateRatio_IsFromOverTo` — asserts the ratio is `from / to` across several rate pairs, guarding against re-inversion.
- `GetFrameRateRatio_HigherTargetRate_MakesTimeCodesEarlier` — 25 → 30 fps maps 1000 ms to ~833 ms.
- `ChangeFrameRate_ScalesStartAndEndByFromOverTo` — end-to-end scaling of start/end time codes.

All UI tests pass (`dotnet test tests/UI/UITests.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)