### PR TITLE
Preserve all paragraph fields in SubtitleLineViewModel round-trip

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -58,6 +58,13 @@ public partial class SubtitleLineViewModel : ObservableObject
     public string Extra { get; set; }
     public string Language { get; set; }
     public string Region { get; set; }
+    public string Effect { get; set; }
+    public bool IsComment { get; set; }
+    public string MarginL { get; set; }
+    public string MarginR { get; set; }
+    public string MarginV { get; set; }
+    public bool NewSection { get; set; }
+    public bool Forced { get; set; }
     public Guid Id { get; set; }
     public bool IsCpsColumnVisible { get; set; } = true;
     public bool IsDefault => Text == string.Empty && Number == 0 && Duration == TimeSpan.Zero && StartTime == TimeSpan.Zero;
@@ -84,6 +91,10 @@ public partial class SubtitleLineViewModel : ObservableObject
         Extra = string.Empty;
         Language = string.Empty;
         Region = string.Empty;
+        Effect = string.Empty;
+        MarginL = string.Empty;
+        MarginR = string.Empty;
+        MarginV = string.Empty;
         Style = string.Empty;
         Actor = string.Empty;
         Layer = 0;
@@ -104,6 +115,13 @@ public partial class SubtitleLineViewModel : ObservableObject
         Layer = p.Layer;
         Number = p.Number;
         Extra = p.Extra;
+        Effect = p.Effect;
+        IsComment = p.IsComment;
+        MarginL = p.MarginL;
+        MarginR = p.MarginR;
+        MarginV = p.MarginV;
+        NewSection = p.NewSection;
+        Forced = p.Forced;
         Bookmark = p.Bookmark;
 
         Id = generateNewId ? Guid.NewGuid() : p.Id;
@@ -121,6 +139,13 @@ public partial class SubtitleLineViewModel : ObservableObject
         Extra = paragraph.Extra;
         Language = paragraph.Language;
         Region = paragraph.Region;
+        Effect = paragraph.Effect;
+        IsComment = paragraph.IsComment;
+        MarginL = paragraph.MarginL;
+        MarginR = paragraph.MarginR;
+        MarginV = paragraph.MarginV;
+        NewSection = paragraph.NewSection;
+        Forced = paragraph.Forced;
         Style = paragraph.Style;
         Actor = paragraph.Actor;
         Layer = paragraph.Layer;
@@ -150,6 +175,13 @@ public partial class SubtitleLineViewModel : ObservableObject
             Style = Style,
             Language = Language,
             Region = Region,
+            Effect = Effect,
+            IsComment = IsComment,
+            MarginL = MarginL,
+            MarginR = MarginR,
+            MarginV = MarginV,
+            NewSection = NewSection,
+            Forced = Forced,
             Layer = Layer,
             Bookmark = Bookmark,
         };
@@ -174,6 +206,13 @@ public partial class SubtitleLineViewModel : ObservableObject
             Style = Style,
             Language = Language,
             Region = Region,
+            Effect = Effect,
+            IsComment = IsComment,
+            MarginL = MarginL,
+            MarginR = MarginR,
+            MarginV = MarginV,
+            NewSection = NewSection,
+            Forced = Forced,
             Layer = Layer,
             Bookmark = Bookmark,
         };
@@ -592,6 +631,16 @@ public partial class SubtitleLineViewModel : ObservableObject
         Style = p.Style;
         Layer = p.Layer;
         Extra = p.Extra;
+        Language = p.Language;
+        Region = p.Region;
+        Effect = p.Effect;
+        IsComment = p.IsComment;
+        MarginL = p.MarginL;
+        MarginR = p.MarginR;
+        MarginV = p.MarginV;
+        NewSection = p.NewSection;
+        Forced = p.Forced;
+        Bookmark = p.Bookmark;
         if (subtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
         {
             Style = p.Extra;
@@ -615,6 +664,16 @@ public partial class SubtitleLineViewModel : ObservableObject
         Style = src.Style;
         Layer = src.Layer;
         Extra = src.Extra;
+        Language = src.Language;
+        Region = src.Region;
+        Effect = src.Effect;
+        IsComment = src.IsComment;
+        MarginL = src.MarginL;
+        MarginR = src.MarginR;
+        MarginV = src.MarginV;
+        NewSection = src.NewSection;
+        Forced = src.Forced;
+        Bookmark = src.Bookmark;
         _skipUpdate = true;
         StartTime = src.StartTime;
         EndTime = src.EndTime;


### PR DESCRIPTION
## Problem

`SubtitleLineViewModel` (the subtitle grid's view model in the new `src/ui`) only carried a **subset** of `Paragraph`'s fields. Any field it didn't carry was silently dropped whenever the grid was serialized back to a `Paragraph` — which happens on **every save** (`SaveSubtitle` → `GetUpdateSubtitle()` → `ToParagraph()`) and whenever a tool rebuilds the list.

This is the same class of bug as the lost bookmarks fixed in #11667, which patched only the `Bookmark` field. The view model was still missing several others.

## Fields that were being lost

| Field | Used by |
|---|---|
| `Effect` | ASSA/SSA |
| `IsComment` | ASSA/SSA (`Comment:` lines) |
| `MarginL` / `MarginR` / `MarginV` | ASSA/SSA per-line margin overrides |
| `NewSection` | TimedText10 / TimedTextNoNs |
| `Forced` | EBU STL, PAC, image formats |

The original data survived in the retained `.Paragraph` reference, but `ToParagraph()` builds a fresh `Paragraph` and ignored it — so the loss was invisible until save or a tool round-trip.

## Fix

Add the missing fields to `SubtitleLineViewModel` and route them through **every** mapping site so the conversion is exhaustive in all directions:

- `Paragraph` constructor and copy constructor
- `ToParagraph()` / `ToParagraphOriginal()`
- both `UpdateFrom(...)` overloads

Also closed a secondary gap: `UpdateFrom(Paragraph, …)` now refreshes `Language`, `Region`, and `Bookmark` from the source too (it previously copied only a subset), keeping the inbound mapping consistent across all sites.

The existing ASSA `Style ⇄ Extra` special-casing is unchanged.

## Test

`dotnet build src/ui/UI.csproj` — 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
