### PR TITLE
Small UI perf optimizations: hoist invariant compute, MinBy/MaxBy over OrderBy().First()

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -19353,7 +19353,7 @@ public partial class MainViewModel :
             var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
             if (selectedItems.Count > 0)
             {
-                var first = selectedItems.OrderBy(p => Subtitles.IndexOf(p)).First();
+                var first = selectedItems.MinBy(p => Subtitles.IndexOf(p));
                 var firstSelectedIndex = Subtitles.IndexOf(first);
                 for (var i = firstSelectedIndex; i < Subtitles.Count; i++)
                 {

--- a/src/ui/Features/Translate/MergeAndSplitHelper.cs
+++ b/src/ui/Features/Translate/MergeAndSplitHelper.cs
@@ -819,8 +819,8 @@ public static partial class MergeAndSplitHelper
             candidate.Score = CalculateCandidateScore(candidate, maxCps, maxLineLength);
         }
 
-        // Return the candidate with the highest score
-        return candidates.OrderByDescending(c => c.Score).First();
+        // Return the candidate with the highest score (caller guarantees candidates is non-empty)
+        return candidates.MaxBy(c => c.Score)!;
     }
 
     private static double CalculateCandidateScore(SplitCandidate candidate, double maxCps, int maxLineLength)

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckShotChange.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckShotChange.cs
@@ -48,11 +48,16 @@ public class NetflixCheckShotChange : INetflixQualityChecker
             var fixedParagraph = new Paragraph(p, false);
             string comment = string.Empty;
 
-            List<double> previousStartShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) < SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds)).ToList();
-            List<double> nextStartShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) > SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds)).ToList();
-            List<double> previousEndShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) < SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds)).ToList();
-            List<double> nextEndShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) > SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds)).ToList();
-            var onShotChange = shotChanges.FirstOrDefault(x => SubtitleFormat.MillisecondsToFrames(x * 1000) == SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds));
+            // These frame values are invariant across all shot changes - compute once per paragraph
+            // instead of recomputing inside every Where/FirstOrDefault predicate.
+            var startFrame = SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds);
+            var endFrame = SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds);
+
+            List<double> previousStartShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) < startFrame).ToList();
+            List<double> nextStartShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) > startFrame).ToList();
+            List<double> previousEndShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) < endFrame).ToList();
+            List<double> nextEndShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) > endFrame).ToList();
+            var onShotChange = shotChanges.FirstOrDefault(x => SubtitleFormat.MillisecondsToFrames(x * 1000) == endFrame);
 
             if (previousStartShotChanges.Count > 0)
             {


### PR DESCRIPTION
Three small, low-risk perf micro-optimizations in the `ui` project. No behavioral changes.

**1. NetflixCheckShotChange — hoist invariant frame computation**
The frame value for the paragraph start/end is invariant across all shot changes, but was recomputed inside every `Where`/`FirstOrDefault` predicate (5 LINQ passes per paragraph). Now computed once per paragraph as `startFrame`/`endFrame`.

**2. MainViewModel (adjust-and-forward) — `OrderBy(...).First()` → `MinBy(...)`**
Avoids a full O(n log n) sort where each comparison also did an O(n) `Subtitles.IndexOf(p)`. Guarded by `Count > 0`, so behavior is unchanged.

**3. MergeAndSplitHelper.SelectBestCandidate — `OrderByDescending(c => c.Score).First()` → `MaxBy(...)`**
Avoids a full sort to pick the single best candidate; the caller already guarantees a non-empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
