### PR TITLE
Small UI perf optimizations: avoid Substring allocations in OCR/casing parsing loops

### DIFF
--- a/src/ui/Features/Ocr/FixEngine/OcrFixReplaceList2.cs
+++ b/src/ui/Features/Ocr/FixEngine/OcrFixReplaceList2.cs
@@ -453,7 +453,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 var indexes = new List<int>();
                 for (var i = 0; i <= word.Length - letter.Length; i++)
                 {
-                    if (word.Substring(i).StartsWith(letter, StringComparison.Ordinal))
+                    if (word.AsSpan(i).StartsWith(letter, StringComparison.Ordinal))
                     {
                         if (i == word.Length - letter.Length && !_partialWordReplaceList[letter].Contains(' '))
                         {
@@ -767,8 +767,8 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 {
                     if (word[match.Index + 1] == 'I' || word[match.Index + 1] == '1')
                     {
-                        var doFix = word[match.Index + 1] != 'I' && match.Index >= 1 && word.Substring(match.Index - 1).StartsWith("Mc", StringComparison.Ordinal);
-                        if (word[match.Index + 1] == 'I' && match.Index >= 2 && word.Substring(match.Index - 2).StartsWith("Mac", StringComparison.Ordinal))
+                        var doFix = word[match.Index + 1] != 'I' && match.Index >= 1 && word.AsSpan(match.Index - 1).StartsWith("Mc", StringComparison.Ordinal);
+                        if (word[match.Index + 1] == 'I' && match.Index >= 2 && word.AsSpan(match.Index - 2).StartsWith("Mac", StringComparison.Ordinal))
                         {
                             doFix = false;
                         }

--- a/src/ui/Logic/CasingToggler.cs
+++ b/src/ui/Logic/CasingToggler.cs
@@ -91,10 +91,10 @@ namespace Nikse.SubtitleEdit.Logic
 
                 var ch = input[index];
 
-                if (!tagOn && isAssa && ch == '\\'
-                           && (input.Substring(index).StartsWith("\\N")
-                               || input.Substring(index).StartsWith("\\n")
-                               || input.Substring(index).StartsWith("\\h")))
+                if (!tagOn && isAssa && ch == '\\' && index + 1 < input.Length
+                           && (input[index + 1] == 'N'
+                               || input[index + 1] == 'n'
+                               || input[index + 1] == 'h'))
                 {
                     tags.Add(new KeyValuePair<int, string>(index, input.Substring(index, 2)));
                     skipNext = true;


### PR DESCRIPTION
Three small, behavior-preserving perf micro-optimizations in the `ui` project — all eliminate per-iteration `Substring` allocations in string-parsing loops.

**1. OcrFixReplaceList2 — partial-word replace (nested loop)**
`word.Substring(i).StartsWith(letter, StringComparison.Ordinal)` → `word.AsSpan(i).StartsWith(letter, StringComparison.Ordinal)`. Runs for every key × every position; `Ordinal` is preserved so matching is identical.

**2. OcrFixReplaceList2 — Mc/Mac `I`→`l` check (while-match loop)**
The two `word.Substring(match.Index - 1/-2).StartsWith("Mc"/"Mac", StringComparison.Ordinal)` calls become `word.AsSpan(...).StartsWith(..., StringComparison.Ordinal)`, avoiding two string allocations per match iteration.

**3. CasingToggler — ASS line-break tag detection**
The branch is already guarded by `ch == '\'`, so the three `input.Substring(index).StartsWith("\N"/"\n"/"\h")` calls reduce to direct char comparisons on `input[index + 1]` (with a bounds check), removing the substring allocations entirely.

No behavioral changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
