### PR TITLE
Easy perf optimizations in Utilities.cs

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -29,6 +29,12 @@ namespace Nikse.SubtitleEdit.Core.Common
         private static readonly Regex RegexIsNumber = new Regex("^\\d+$", RegexOptions.Compiled);
         private static readonly Regex RegexIsEpisodeNumber = new Regex("^\\d+x\\d+$", RegexOptions.Compiled);
         private static readonly Regex RegexNumberSpacePeriod = new Regex(@"(\d) (\.)", RegexOptions.Compiled);
+        private static readonly Regex RegexOrdinalSt = new Regex(@"(1) (st)\b", RegexOptions.Compiled);
+        private static readonly Regex RegexOrdinalNd = new Regex(@"(2) (nd)\b", RegexOptions.Compiled);
+        private static readonly Regex RegexOrdinalRd = new Regex(@"(3) (rd)\b", RegexOptions.Compiled);
+        private static readonly Regex RegexOrdinalTh = new Regex(@"([0456789]) (th)\b", RegexOptions.Compiled);
+        private static readonly Regex RegexArabicWawSpace = new Regex(@"\bو ", RegexOptions.Compiled);
+        private static readonly Regex RegexLetterSpacePeriodSpaceLetter = new Regex(@"[a-z] \. [A-Z]", RegexOptions.Compiled);
 
         public static string[] VideoFileExtensions { get; } = { ".avi", ".mkv", ".wmv", ".mpg", ".mpeg", ".divx", ".mp4", ".asf", ".flv", ".mov", ".m4v", ".vob", ".ogv", ".webm", ".ts", ".tts", ".m2ts", ".mts", ".avs", ".mxf" };
         public static string[] AudioFileExtensions { get; } = { ".mp3", ".wav", ".wma", ".ogg", ".mpa", ".m4a", ".ape", ".aiff", ".flac", ".aac", ".ac3", ".eac3", ".mka", ".opus", ".adts", ".m4b" };
@@ -69,9 +75,10 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static SubtitleFormat GetSubtitleFormatByFriendlyName(string friendlyName)
         {
-            if (friendlyName.IndexOf('(') > 0)
+            var parenIndex = friendlyName.IndexOf('(');
+            if (parenIndex > 0)
             {
-                friendlyName = friendlyName.Substring(0, friendlyName.IndexOf('(')).TrimEnd();
+                friendlyName = friendlyName.Substring(0, parenIndex).TrimEnd();
             }
 
             foreach (var format in SubtitleFormat.AllSubtitleFormats)
@@ -295,15 +302,19 @@ namespace Nikse.SubtitleEdit.Core.Common
             while (six < s.Length)
             {
                 var letter = s[six];
-                var tagFound = letter == '<' &&
-                               (s.Substring(six).StartsWith("<font", StringComparison.OrdinalIgnoreCase)
-                                || s.Substring(six).StartsWith("</font", StringComparison.OrdinalIgnoreCase)
-                                || s.Substring(six).StartsWith("<u", StringComparison.OrdinalIgnoreCase)
-                                || s.Substring(six).StartsWith("</u", StringComparison.OrdinalIgnoreCase)
-                                || s.Substring(six).StartsWith("<b", StringComparison.OrdinalIgnoreCase)
-                                || s.Substring(six).StartsWith("</b", StringComparison.OrdinalIgnoreCase)
-                                || s.Substring(six).StartsWith("<i", StringComparison.OrdinalIgnoreCase)
-                                || s.Substring(six).StartsWith("</i", StringComparison.OrdinalIgnoreCase));
+                var tagFound = false;
+                if (letter == '<')
+                {
+                    var span = s.AsSpan(six);
+                    tagFound = span.StartsWith("<font".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                               || span.StartsWith("</font".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                               || span.StartsWith("<u".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                               || span.StartsWith("</u".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                               || span.StartsWith("<b".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                               || span.StartsWith("</b".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                               || span.StartsWith("<i".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                               || span.StartsWith("</i".AsSpan(), StringComparison.OrdinalIgnoreCase);
+                }
                 int endIndex = -1;
                 if (tagFound)
                 {
@@ -556,15 +567,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var tagFound = false;
                 if (letter == '<')
                 {
-                    var tagString = s.Substring(six);
-                    tagFound = tagString.StartsWith("<font", StringComparison.OrdinalIgnoreCase)
-                            || tagString.StartsWith("</font", StringComparison.OrdinalIgnoreCase)
-                            || tagString.StartsWith("<u", StringComparison.OrdinalIgnoreCase)
-                            || tagString.StartsWith("</u", StringComparison.OrdinalIgnoreCase)
-                            || tagString.StartsWith("<b", StringComparison.OrdinalIgnoreCase)
-                            || tagString.StartsWith("</b", StringComparison.OrdinalIgnoreCase)
-                            || tagString.StartsWith("<i", StringComparison.OrdinalIgnoreCase)
-                            || tagString.StartsWith("</i", StringComparison.OrdinalIgnoreCase);
+                    var tagSpan = s.AsSpan(six);
+                    tagFound = tagSpan.StartsWith("<font".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                            || tagSpan.StartsWith("</font".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                            || tagSpan.StartsWith("<u".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                            || tagSpan.StartsWith("</u".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                            || tagSpan.StartsWith("<b".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                            || tagSpan.StartsWith("</b".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                            || tagSpan.StartsWith("<i".AsSpan(), StringComparison.OrdinalIgnoreCase)
+                            || tagSpan.StartsWith("</i".AsSpan(), StringComparison.OrdinalIgnoreCase);
                 }
                 else if (letter == '{' && s.Substring(six).StartsWith("{\\"))
                 {
@@ -2417,16 +2428,16 @@ namespace Nikse.SubtitleEdit.Core.Common
             if (language == "en" && text.ContainsNumber())
             {
                 // 1 st => 1st
-                text = new Regex(@"(1) (st)\b").Replace(text, "$1$2");
+                text = RegexOrdinalSt.Replace(text, "$1$2");
 
                 // 2 nd => 2nd
-                text = new Regex(@"(2) (nd)\b").Replace(text, "$1$2");
+                text = RegexOrdinalNd.Replace(text, "$1$2");
 
                 // 3 rd => 2rd
-                text = new Regex(@"(3) (rd)\b").Replace(text, "$1$2");
+                text = RegexOrdinalRd.Replace(text, "$1$2");
 
                 // 4 th => 4th
-                text = new Regex(@"([0456789]) (th)\b").Replace(text, "$1$2");
+                text = RegexOrdinalTh.Replace(text, "$1$2");
             }
 
             if (language != null && "en-da-es-sv-de-nb-cz".Contains(language) && text.ContainsNumber())
@@ -2459,7 +2470,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     text = text.Replace(" \u060C", "\u060C");
                 }
 
-                text = new Regex(@"\bو ").Replace(text, "و");
+                text = RegexArabicWawSpace.Replace(text, "و");
 
                 while (text.Contains("ـ "))
                 {
@@ -2469,12 +2480,11 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (text.Contains(" . "))
             {
-                var regex = new Regex(@"[a-z] \. [A-Z]");
-                var match = regex.Match(text);
+                var match = RegexLetterSpacePeriodSpaceLetter.Match(text);
                 while (match.Success)
                 {
                     text = text.Remove(match.Index + 1, 1);
-                    match = regex.Match(text);
+                    match = RegexLetterSpacePeriodSpaceLetter.Match(text);
                 }
             }
 
@@ -3257,7 +3267,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return false;
             }
 
-            var numbers = array.OrderBy(p => p).ToList();
+            var numbers = (int[])array.Clone();
+            Array.Sort(numbers);
             var current = numbers[0];
             foreach (var n in numbers)
             {


### PR DESCRIPTION
## Summary

A few low-risk, behavior-preserving performance cleanups in the hot-path `Utilities.cs`:

- **Cache 6 per-call `Regex` allocations** in `RemoveUnneededSpaces` as static compiled fields (ordinal suffixes `1 st`→`1st` etc., Arabic waw, and `[a-z] \. [A-Z]`). The last one was being rebuilt on every call *inside* a `while` loop.
- **`AutoBreakLineMoreThanTwoLines` / `AutoBreakLinePrivate`**: replace up to 8 `s.Substring(six)` allocations per `<` character with a single `s.AsSpan(six)` and span-based `StartsWith` (netstandard2.1 supports the `StringComparison` overload).
- **`HasNoGaps`**: replace `array.OrderBy(p => p).ToList()` (LINQ iterator + List allocation) with `Array.Sort` on a cloned array.
- **`GetSubtitleFormatByFriendlyName`**: cache `IndexOf('(')` instead of calling it twice.

## Testing

`dotnet build src/libse/libse.csproj -c Release` — succeeds, 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)