### PR TITLE
Fix Change frame rate using raw 23.976 instead of exact 24000/1001

### DIFF
--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -164,7 +165,7 @@ public partial class ChangeFrameRateViewModel : ObservableObject
     /// </summary>
     internal static double GetFrameRateRatio(double fromFrameRate, double toFrameRate)
     {
-        return fromFrameRate / toFrameRate;
+        return SubtitleFormat.GetFrameForCalculation(fromFrameRate) / SubtitleFormat.GetFrameForCalculation(toFrameRate);
     }
 
     internal static void ChangeFrameRate(ObservableCollection<SubtitleLineViewModel> subtitles, double fromFrameRate, double toFrameRate)

--- a/tests/UI/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModelTests.cs
+++ b/tests/UI/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModelTests.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Sync.ChangeFrameRate;
 using System.Collections.ObjectModel;
@@ -17,7 +18,8 @@ public class ChangeFrameRateViewModelTests
         // libse Subtitle.ChangeFrameRate, which scales by oldFrameRate / newFrameRate.
         var ratio = ChangeFrameRateViewModel.GetFrameRateRatio(from, to);
 
-        Assert.Equal(from / to, ratio);
+        var expected = SubtitleFormat.GetFrameForCalculation(from) / SubtitleFormat.GetFrameForCalculation(to);
+        Assert.Equal(expected, ratio);
     }
 
     [Fact]


### PR DESCRIPTION
  ## Problem

  The Change Frame Rate dialog computed the scaling ratio by dividing the display values directly (e.g. `23.976 / 25.0`). The correct value for 23.976 fps is the rational `24000/1001`, not the truncated decimal. The same applies to 29.97 (`30000/1001`) and 59.94 (`60000/1001`).

  This produced a systematic error of ~7 ms on the last subtitle of a 2-hour file when converting 23.976 → 25 fps. The error accumulates linearly with duration.

  The bug affected both the main window Change Frame Rate dialog and the image-based subtitle editor (BDN/PGS), which share the same `GetFrameRateRatio()` helper.

  ## Root cause

  `ChangeFrameRateViewModel.GetFrameRateRatio()` divided the raw `double` frame rate values directly. LibSE's `Subtitle.ChangeFrameRate()` and the batch convert path already handled this correctly via `SubtitleFormat.GetFrameForCalculation()`, which maps the three non-integer NTSC rates to their exact rational equivalents.

  ## Fix

  Route `GetFrameRateRatio()` through `SubtitleFormat.GetFrameForCalculation()` for both operands, matching the existing LibSE and SE4 behaviour:

  ```csharp
  internal static double GetFrameRateRatio(double fromFrameRate, double toFrameRate)
  {
      return SubtitleFormat.GetFrameForCalculation(fromFrameRate) / SubtitleFormat.GetFrameForCalculation(toFrameRate);
  }
