### PR TITLE
Fix Change frame rate / Change speed producing zero-length subtitles in binary editor

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1438,8 +1438,10 @@ public partial class BinaryEditViewModel : ObservableObject
                 foreach (var idx in selectedIndices)
                 {
                     var s = Subtitles[idx];
-                    s.StartTime = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * ratio);
-                    s.EndTime = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * ratio);
+                    var newStart = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * ratio);
+                    var newEnd = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * ratio);
+                    s.StartTime = newStart;
+                    s.EndTime = newEnd;
                 }
 
                 appliedToSelected = true;
@@ -1451,8 +1453,10 @@ public partial class BinaryEditViewModel : ObservableObject
             // Apply to all subtitles
             foreach (var s in Subtitles)
             {
-                s.StartTime = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * ratio);
-                s.EndTime = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * ratio);
+                var newStart = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * ratio);
+                var newEnd = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * ratio);
+                s.StartTime = newStart;
+                s.EndTime = newEnd;
             }
         }
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1435,29 +1435,14 @@ public partial class BinaryEditViewModel : ObservableObject
 
             if (selectedIndices.Count > 0)
             {
-                foreach (var idx in selectedIndices)
-                {
-                    var s = Subtitles[idx];
-                    var newStart = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * ratio);
-                    var newEnd = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * ratio);
-                    s.StartTime = newStart;
-                    s.EndTime = newEnd;
-                }
-
+                ScaleBinarySubtitleTimes(selectedIndices.Select(i => Subtitles[i]), ratio);
                 appliedToSelected = true;
             }
         }
 
         if (!appliedToSelected)
         {
-            // Apply to all subtitles
-            foreach (var s in Subtitles)
-            {
-                var newStart = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * ratio);
-                var newEnd = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * ratio);
-                s.StartTime = newStart;
-                s.EndTime = newEnd;
-            }
+            ScaleBinarySubtitleTimes(Subtitles, ratio);
         }
     }
 
@@ -1497,24 +1482,14 @@ public partial class BinaryEditViewModel : ObservableObject
 
             if (selectedIndices.Count > 0)
             {
-                foreach (var idx in selectedIndices)
-                {
-                    var s = Subtitles[idx];
-                    s.StartTime = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * factor);
-                    s.EndTime = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * factor);
-                }
-
+                ScaleBinarySubtitleTimes(selectedIndices.Select(i => Subtitles[i]), factor);
                 appliedToSelected = true;
             }
         }
 
         if (!appliedToSelected)
         {
-            foreach (var s in Subtitles)
-            {
-                s.StartTime = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * factor);
-                s.EndTime = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * factor);
-            }
+            ScaleBinarySubtitleTimes(Subtitles, factor);
         }
     }
 
@@ -2026,6 +2001,17 @@ public partial class BinaryEditViewModel : ObservableObject
     internal static bool ShouldOpenVideoPickerOnSurfaceClick(string? videoFileName)
     {
         return string.IsNullOrEmpty(videoFileName);
+    }
+
+    internal static void ScaleBinarySubtitleTimes(IEnumerable<BinarySubtitleItem> subtitles, double factor)
+    {
+        foreach (var s in subtitles)
+        {
+            var newStart = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * factor);
+            var newEnd = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * factor);
+            s.StartTime = newStart;
+            s.EndTime = newEnd;
+        }
     }
 
     private void SelectAndScrollToRow(int index)

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+using Nikse.SubtitleEdit.Features.Sync.ChangeFrameRate;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
 
@@ -59,5 +60,36 @@ public class BinaryEditViewModelTests
         var settings = new SeTools();
 
         Assert.False(settings.BinEditSelectCurrentSubtitleWhilePlaying);
+    }
+
+    [Fact]
+    public void ScaleBinarySubtitleTimes_ChangeFrameRate_ShortSubtitleAtHighOffset_PreservesPositiveDuration()
+    {
+        // A short subtitle (200ms) at a high start offset (10000ms) with ratio < 1 (24→25fps)
+        // exposed the bug: the old code read s.EndTime after OnStartTimeChanged had already
+        // rewritten it to newStart + oldDuration, so the scaled EndTime fell below StartTime.
+        var item = new BinarySubtitleItem(TimeSpan.FromMilliseconds(10000), TimeSpan.FromMilliseconds(10200));
+        var ratio = ChangeFrameRateViewModel.GetFrameRateRatio(24.0, 25.0); // 0.96
+
+        BinaryEditViewModel.ScaleBinarySubtitleTimes([item], ratio);
+
+        Assert.Equal(9600, item.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(9792, item.EndTime.TotalMilliseconds, 3);
+        Assert.True(item.Duration > TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void ScaleBinarySubtitleTimes_ChangeSpeed_ShortSubtitleAtHighOffset_PreservesPositiveDuration()
+    {
+        // Same callback-corruption bug in ChangeSpeed: speeding up (factor < 1) a short subtitle
+        // at a high offset produced EndTime < StartTime with the old sequential assignment.
+        var item = new BinarySubtitleItem(TimeSpan.FromMilliseconds(10000), TimeSpan.FromMilliseconds(10200));
+        var factor = 100.0 / 110.0; // 110% speed → factor ≈ 0.909
+
+        BinaryEditViewModel.ScaleBinarySubtitleTimes([item], factor);
+
+        Assert.Equal(9090.909, item.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(9272.727, item.EndTime.TotalMilliseconds, 3);
+        Assert.True(item.Duration > TimeSpan.Zero);
     }
 }


### PR DESCRIPTION
## Problem

In the binary subtitle editor (image-based formats), the **Change frame rate** and **Change speed** commands could produce zero-duration or negative-duration subtitles.

`BinarySubtitleItem` uses CommunityToolkit.Mvvm observable properties with linked callbacks:

- Setting `StartTime` immediately fires `OnStartTimeChanged`, which rewrites `EndTime` to `newStart + oldDuration` to maintain the duration.
- Setting `EndTime` fires `OnEndTimeChanged`, which updates `Duration`.

The original code set `StartTime` and then read `s.EndTime` on the next line — but by that point the callback had already overwritten `EndTime`. The second assignment scaled the wrong value instead of the original end time.

The failure is most visible with a short subtitle (e.g. 200 ms) at a high start offset (e.g. 10 000 ms) when the scale factor is less than 1 (converting to a higher frame rate, or speeding up). In that case the corrupted `EndTime` ends up below `StartTime`, producing a zero or negative duration.

## Fix

Pre-capture both scaled values from the original properties before any assignment:

```csharp
var newStart = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * factor);
var newEnd   = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * factor);
s.StartTime = newStart;
s.EndTime   = newEnd;
```

This is extracted into a shared ScaleBinarySubtitleTimes static helper (mirroring the ChangeFrameRateViewModel.ChangeFrameRate and ChangeSpeedViewModel.ChangeSpe helpers that already exist for text subtitles), and called from both commands.

## Tests

Two regression tests added to BinaryEditViewModelTests: a short subtitle at a high start offset scaled with a factor < 1 for each command path, asserting correct time and positive duration.