### PR TITLE
Fix Change frame rate dialog: Browse, switch, and video auto-detect interactions

### DIFF
--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
@@ -24,6 +24,9 @@ public partial class ChangeFrameRateViewModel : ObservableObject
 
     private static readonly List<double> StandardFrameRates = new List<double> { 23.976, 24, 25, 29.97, 30, 50, 59.94, 60 };
 
+    private double _autoFromRate = double.NaN;
+    private double _autoToRate = double.NaN;
+
     private IFileHelper _fileHelper;
 
     public Window? Window { get; set; }
@@ -34,11 +37,14 @@ public partial class ChangeFrameRateViewModel : ObservableObject
     {
         _fileHelper = fileHelper;
 
-        FromFrameRates = new ObservableCollection<double>(StandardFrameRates);
-        ToFrameRates = new ObservableCollection<double>(StandardFrameRates);
+        var savedFrom = Se.Settings.Synchronization.ChangeFrameRateFrom;
+        var savedTo = Se.Settings.Synchronization.ChangeFrameRateTo;
 
-        SelectedFromFrameRate = GetClosestFrameRate(FromFrameRates, Se.Settings.Synchronization.ChangeFrameRateFrom);
-        SelectedToFrameRate = GetClosestFrameRate(ToFrameRates, Se.Settings.Synchronization.ChangeFrameRateTo);
+        FromFrameRates = new ObservableCollection<double>(StandardFrameRates.Append(savedFrom).Distinct().OrderBy(r => r));
+        ToFrameRates = new ObservableCollection<double>(StandardFrameRates.Append(savedTo).Distinct().OrderBy(r => r));
+
+        SelectedFromFrameRate = GetClosestFrameRate(FromFrameRates, savedFrom);
+        SelectedToFrameRate = GetClosestFrameRate(ToFrameRates, savedTo);
     }
 
     public void Initialize(string? videoFileName, FfmpegMediaInfo2? mediaInfo)
@@ -49,23 +55,24 @@ public partial class ChangeFrameRateViewModel : ObservableObject
         }
 
         var detectedRate = (double)mediaInfo.FramesRate;
-        var ratesWithDetected = StandardFrameRates.Append(detectedRate).Distinct().OrderBy(r => r).ToArray();
 
-        FromFrameRates = new ObservableCollection<double>(ratesWithDetected);
-        ToFrameRates = new ObservableCollection<double>(ratesWithDetected);
+        FromFrameRates = new ObservableCollection<double>(FromFrameRates.Append(detectedRate).Distinct().OrderBy(r => r));
+        ToFrameRates = new ObservableCollection<double>(ToFrameRates.Append(detectedRate).Distinct().OrderBy(r => r));
 
         SelectedToFrameRate = GetClosestFrameRate(ToFrameRates, detectedRate);
 
         var preferredFromRate = Math.Abs(SelectedToFrameRate - 25.0) < 0.01 ? 23.976 : 25.0;
         SelectedFromFrameRate = GetClosestFrameRate(FromFrameRates, preferredFromRate);
+
+        _autoToRate = SelectedToFrameRate;
+        _autoFromRate = SelectedFromFrameRate;
     }
 
     [RelayCommand]
     private void SwitchFrameRates()
     {
-        var temp = SelectedFromFrameRate;
-        SelectedFromFrameRate = SelectedToFrameRate;
-        SelectedToFrameRate = temp;
+        (FromFrameRates, ToFrameRates) = (ToFrameRates, FromFrameRates);
+        (SelectedFromFrameRate, SelectedToFrameRate) = (SelectedToFrameRate, SelectedFromFrameRate);
     }
 
     [RelayCommand]
@@ -123,8 +130,10 @@ public partial class ChangeFrameRateViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        Se.Settings.Synchronization.ChangeFrameRateFrom = SelectedFromFrameRate;
-        Se.Settings.Synchronization.ChangeFrameRateTo = SelectedToFrameRate;
+        if (double.IsNaN(_autoFromRate) || Math.Abs(SelectedFromFrameRate - _autoFromRate) > 0.001)
+            Se.Settings.Synchronization.ChangeFrameRateFrom = SelectedFromFrameRate;
+        if (double.IsNaN(_autoToRate) || Math.Abs(SelectedToFrameRate - _autoToRate) > 0.001)
+            Se.Settings.Synchronization.ChangeFrameRateTo = SelectedToFrameRate;
         Se.SaveSettings();
 
         OkPressed = true;

--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs
@@ -24,11 +24,11 @@ public class ChangeFrameRateWindow : Window
 
         var comboFromFrameRate = new ComboBox
         {
-            ItemsSource = vm.FromFrameRates,
-            SelectedValue = vm.SelectedFromFrameRate,
             VerticalAlignment = VerticalAlignment.Center,
             MinWidth = 90,
-        }.WithBindSelected(nameof(vm.SelectedFromFrameRate));
+        }
+        .WithBindItemsSource(nameof(vm.FromFrameRates))
+        .WithBindSelected(nameof(vm.SelectedFromFrameRate));
 
         var buttonFromFrameRate = UiUtil.MakeButtonBrowse(vm.BrowseFromFrameRateCommand);
 
@@ -42,11 +42,11 @@ public class ChangeFrameRateWindow : Window
 
         var comboToFrameRate = new ComboBox
         {
-            ItemsSource = vm.ToFrameRates,
-            SelectedValue = vm.SelectedToFrameRate,
             VerticalAlignment = VerticalAlignment.Center,
             MinWidth = 90,
-        }.WithBindSelected(nameof(vm.SelectedToFrameRate));
+        }
+        .WithBindItemsSource(nameof(vm.ToFrameRates))
+        .WithBindSelected(nameof(vm.SelectedToFrameRate));
 
         var buttonToFrameRate = UiUtil.MakeButtonBrowse(vm.BrowseToFrameRateCommand);
 

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1266,6 +1266,16 @@ public static class UiUtil
         return control;
     }
 
+    public static ComboBox WithBindItemsSource(this ComboBox control, string itemsSourcePropertyBinding)
+    {
+        control.Bind(ItemsControl.ItemsSourceProperty, new Binding
+        {
+            Path = itemsSourcePropertyBinding,
+        });
+
+        return control;
+    }
+
     public static TextBlock WithMargin(this TextBlock control, int margin)
     {
         control.Margin = new Thickness(margin);


### PR DESCRIPTION
  ## Problems fixed

  ### Browse button dropped non-standard rates from the dropdown
  The "..." Browse buttons each created a new `ObservableCollection` and assigned it to `FromFrameRates`/`ToFrameRates`, but the `ComboBox.ItemsSource` was set via a direct property assignment at construction time, so it never saw the new collection. Non-standard detected rates (e.g. 48 fps) would not appear in the dropdown and the selection went blank.

<img width="419" height="321" alt="Screenshot 2026-06-17 at 2 09 39 PM" src="https://github.com/user-attachments/assets/51e1e4cf-2e94-4dbe-85de-8a3fc8755949" />


  ### Switch button left one side with an invalid selection
  `SwitchFrameRates` only swapped the selected *values*, not the item lists. If one side had a custom rate that the other side's list didn't contain, the switched-to combo would show blank.

  ### Video auto-detection silently discarded saved custom rates
  `Initialize()` rebuilt `FromFrameRates`/`ToFrameRates` from scratch (`StandardFrameRates + detectedRate`), dropping any non-standard rate that the constructor had restored from saved settings (e.g. a previously used 48 fps entry).

  ### Clicking OK after video auto-detection overwrote manual preferences
  When a video was loaded, `Initialize()` set the selections to the video-detected rates. Clicking OK then saved those auto-detected values, permanently replacing the user's prior manually chosen rates even though the user never consciously selected them.

  ## Changes

  - `src/ui/Logic/UiUtil.cs` — add `WithBindItemsSource` extension that binds `ComboBox.ItemsSource` to a VM property so collection replacement is reflected in the UI
  - `src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs` — switch both `ComboBox` controls from direct `ItemsSource =` assignment to `WithBindItemsSource`
  - `src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs`:
    - Constructor includes the saved non-standard rate in the dropdown via `Append/Distinct/OrderBy`
    - `SwitchFrameRates` swaps item lists alongside selected values
    - `Initialize()` merges the detected rate into the *existing* collections rather than replacing them
    - `Initialize()` records which values it auto-selected (`_autoFromRate` / `_autoToRate`)
    - `Ok()` only persists a rate if the user changed it away from the auto-detected value
