### PR TITLE
docs: add "Set up like Subtitle Edit 4" shortcut and fix review findings

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -95,13 +95,13 @@ See [Speech to Text](features/speech-to-text.md) for details.
 ## Synchronization
 
 ### How do I fix subtitle timing that is off by a constant amount?
-Use **Sync → Adjust all times...** and enter the offset in milliseconds.
+Use **Synchronization → Adjust all times...** and enter the offset in milliseconds.
 
 ### How do I sync subtitles that drift over time?
-Use **Sync → Visual sync...** or **Sync → Point sync...** to synchronize at multiple points.
+Use **Synchronization → Visual sync...** or **Synchronization → Point sync...** to synchronize at multiple points.
 
 ### How do I convert subtitles between different frame rates?
-Use **Sync → Change frame rate...** and select the source and target frame rates.
+Use **Synchronization → Change frame rate...** and select the source and target frame rates.
 
 ---
 
@@ -141,7 +141,7 @@ During spell check, click **Add to dictionary** to add a word. You can also mana
 ASSA (Advanced SubStation Alpha) is a subtitle format that supports rich styling including fonts, colors, positioning, animations, and more. It is widely used in anime fansubbing and professional workflows.
 
 ### How do I edit ASSA styles?
-Go to **ASSA → Styles...** to create and edit subtitle styles with fonts, colors, borders, shadows, and alignment.
+Go to **ASSA tools → Styles...** to create and edit subtitle styles with fonts, colors, borders, shadows, and alignment.
 
 ---
 

--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -111,7 +111,7 @@ Double-clicking a rule also opens the **Edit rule** dialog.
 | `Escape` | Close the window |
 | `F1` | Open help |
 
-The expand/collapse buttons (`+` / `−`) above the tree expand or collapse all categories at once (`Ctrl++` / `Ctrl+-`).
+The expand/collapse buttons (`+` / `−`) above the tree expand or collapse all categories at once (`Ctrl+Shift++` / `Ctrl+Shift+-`).
 
 ### Import / Export
 

--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -89,8 +89,8 @@ Local OCR engine.
 |----------|--------|
 | Escape | Cancel OCR / Close window |
 | Ctrl+G | Go to line number |
-| Ctrl+ | Zoom in (images in grid) |
-| Ctrl- | Zoom out (images in grid) |
+| Ctrl++ | Zoom in (images in grid) |
+| Ctrl+- | Zoom out (images in grid) |
 | F1 | Show help |
 
 ### Subtitle Grid

--- a/docs/features/point-sync-via-other.md
+++ b/docs/features/point-sync-via-other.md
@@ -2,7 +2,7 @@
 
 Synchronize a subtitle file using another subtitle file as reference.
 
-- **Menu:** Sync → Point sync via other subtitle...
+- **Menu:** Synchronization → Point sync via other subtitle...
 
 <!-- Screenshot: Point sync via other window -->
 ![Point Sync Via Other](../screenshots/point-sync-via-other.png)

--- a/docs/features/point-sync.md
+++ b/docs/features/point-sync.md
@@ -2,7 +2,7 @@
 
 Synchronize subtitles using multiple reference points.
 
-- **Menu:** Sync → Point sync...
+- **Menu:** Synchronization → Point sync...
 
 <!-- Screenshot: Point sync window -->
 ![Point Sync](../screenshots/point-sync.png)

--- a/docs/features/shortcuts.md
+++ b/docs/features/shortcuts.md
@@ -76,5 +76,3 @@ This is useful for sharing shortcut configurations between machines or team memb
 |-----|--------|
 | Escape | Close shortcuts window |
 | F1 | Open help |
-
-Double-clicking a command opens the key capture dialog, allowing you to press the desired key combination directly.

--- a/docs/features/shortcuts.md
+++ b/docs/features/shortcuts.md
@@ -31,7 +31,7 @@ Shortcuts are organized into the following categories:
 2. Check the desired modifier keys: **Ctrl**, **Alt**, **Shift**, **Win**
 3. Select the key from the dropdown
 4. The shortcut is applied immediately in the list
-5. **Double-click** a command to open the key capture dialog, which lets you press the desired key combination directly
+5. Alternatively, **double-click a command in the list** to open the key capture dialog, then press the desired key combination directly
 
 ## Configurable Commands
 

--- a/docs/features/visual-sync.md
+++ b/docs/features/visual-sync.md
@@ -2,7 +2,7 @@
 
 Synchronize subtitles visually by matching two points in the video.
 
-- **Menu:** Sync → Visual sync...
+- **Menu:** Synchronization → Visual sync...
 
 <!-- Screenshot: Visual sync window -->
 ![Visual Sync](../screenshots/visual-sync.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [Join Subtitles](features/join-subtitles.md) — Join multiple subtitle files
 - [Sort By](features/sort-by.md) — Sort subtitles by various criteria
 - [Remove Text for Hearing Impaired](features/remove-text-hi.md) — Remove HI annotations
+- [Command Line (seconv)](features/seconv.md) — Headless converter for scripts and bulk conversion (see also the [full reference](reference/command-line.md))
 
 ### Synchronization
 - [Adjust All Times](features/adjust-all-times.md) — Shift all timings

--- a/docs/reference/assa-override-tags.md
+++ b/docs/reference/assa-override-tags.md
@@ -221,11 +221,11 @@ This is {\1c&HFF0000&}blue text
 - `&HCC&` — 80% transparent
 - `&HFF&` — Fully transparent (invisible)
 
-**Example:** `{\alpha&HCC\1a&H00}Transparent box with visible text`
+**Example:** `{\alpha&HCC&\1a&H00&}Transparent box with visible text`
 
 ![Alpha 1 example](../screenshots/assa/alpha-1.png)
 
-**Example:** `{\an7\alpha&HCC}Watermark`
+**Example:** `{\an7\alpha&HCC&}Watermark`
 
 ![Alpha 2 example](../screenshots/assa/alpha-2.png)
 
@@ -458,7 +458,7 @@ This is {\1c&HFF0000&}blue text
 ## Drawing Tags
 
 - `\p<level>` — Set drawing mode (0=text, 1-4=drawing with different precision levels)
-- Drawing commands use vector graphics: `m` (move), `l` (line), `b` (cubic Bézier curve), `s` (cubic B-spline), `c` (close spline), `n` (close B-spline)
+- Drawing commands use vector graphics: `m` (move), `l` (line), `b` (cubic Bézier curve), `s` (cubic B-spline), `c` (close spline)
 
 **Drawing precision levels:**
 - `\p0` — Text mode (normal)
@@ -600,15 +600,12 @@ This draws a square.
 ## Notes
 
 - Override tags are case-sensitive (`\B1` will not work, must be `\b1`)
-- Some tags only work with certain renderers
-- Complex animations and effects may impact playback performance
-- Always test with your target player to ensure compatibility
 - Unrecognized text within override blocks is silently ignored
 - Mixing comments and override tags in the same block is not recommended
 
 ## See Also
 
 - [ASSA Styles](../features/assa-styles.md) — Managing ASS/SSA styles
-- [ASSA Apply Custom Override Tags](../features/assa-override-tags.md) — Applying override tags in Subtitle Edit
+- [ASSA Apply Override Tags](../features/assa-override-tags.md) — Applying override tags in Subtitle Edit
 - [ASSA Draw](../features/assa-draw.md) — Vector drawing tool
 - [ASSA Set Position](../features/assa-set-position.md) — Positioning subtitles

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -20,6 +20,7 @@ See also: [Shortcuts Settings](../features/shortcuts.md)
 | Ctrl+Shift+R | Multiple replace |
 | Ctrl+G | Go to line number |
 | Ctrl+Shift+B | Add or edit bookmark |
+| Ctrl+4 | Set up like Subtitle Edit 4 (classic theme, icons, waveform, replace rules and shortcuts) |
 | Alt+Up | Go to previous line |
 | Alt+Down | Go to next line |
 | F1 | Show help |

--- a/docs/reference/supported-formats.md
+++ b/docs/reference/supported-formats.md
@@ -60,4 +60,4 @@ Subtitle Edit supports a wide range of subtitle formats for reading and writing.
 | MPEG | .mpeg |
 | Blu-ray Transport Stream | .m2ts |
 
-> **Note:** Subtitle Edit ships with parsers/writers for 380+ text-based formats, plus a handful of binary and image-based ones. The format is auto-detected when you open a file.
+> **Note:** Subtitle Edit ships with parsers/writers for 380+ subtitle formats, including text, binary, and image-based ones. The format is auto-detected when you open a file.

--- a/docs/reference/webvtt.md
+++ b/docs/reference/webvtt.md
@@ -4,7 +4,7 @@ WebVTT (file extension `.vtt`) is a modern subtitle format designed for HTML5 vi
 
 ## Overview
 
-WebVTT (Web Video Text Tracks) was developed by the W3C (World Wide Web Consortium) as the official subtitle format for HTML5 video. It's based on SubRip (SRT) but with significant enhancements for web-based video playback.
+WebVTT (Web Video Text Tracks) began at the WHATWG and was standardized by the W3C (World Wide Web Consortium) as the official subtitle format for HTML5 video. It's based on SubRip (SRT) but with significant enhancements for web-based video playback.
 
 **Key Features:**
 - Official W3C standard with [complete specification](https://www.w3.org/TR/webvtt1/)
@@ -178,7 +178,7 @@ Apply CSS classes for styling:
 
 **Predefined color classes:**
 - `white`, `lime`, `cyan`, `red`, `yellow`
-- `magenta`, `blue`, `black`, `green`
+- `magenta`, `blue`, `black`
 
 ### Ruby Text
 


### PR DESCRIPTION
## What

Documents the new **Ctrl+4 — "Set up like Subtitle Edit 4"** action (from #11670) in the keyboard shortcuts reference, and fixes a batch of issues found in a broader docs review.

## Changes

**New shortcut**
- `reference/keyboard-shortcuts.md` — add the `Ctrl+4` row under General (matches the `SetupLikeSe4Command` default `[cmd, "D4"]`).

**Link integrity**
- `index.md` — link the orphaned `features/seconv.md` page into the nav (it existed but was unreachable).

**Factual / contradiction fixes (verified against code or spec)**
- `features/ocr.md` — broken zoom shortcut cells → `Ctrl++` / `Ctrl+-`.
- `features/edit.md` — prose contradicted the table for collapse/expand; reconciled to `Ctrl+Shift++` / `Ctrl+Shift+-`, matching the code default in `MultipleReplaceViewModel`.
- `reference/supported-formats.md` — the "380+" count is the total catalog (text + binary + image), not text-only; reworded.
- `reference/assa-override-tags.md` — removed mislabeled `n (close B-spline)` drawing command; closed the alpha example values with a trailing `&`; removed duplicated bullets in the Notes section; fixed a "See Also" link title.
- `reference/webvtt.md` — clarified WHATWG origin / W3C standardization (Overview contradicted the Version History); dropped the non-standard `green` cue color class (`lime` is the green one).

**Consistency**
- `features/shortcuts.md` — removed a duplicated key-capture instruction.
- `faq.md`, `features/visual-sync.md`, `features/point-sync.md`, `features/point-sync-via-other.md` — standardized the menu name on **Synchronization** (the actual menu header) and **ASSA tools**, matching the rest of the docs and the UI.

## Notes / not done

A few lower-priority, judgment-call items were intentionally left for the maintainer:
- Unifying the metadata-line house style (ASSA docs use backtick/no-bullet; others use bullet style).
- `change-frame-rate.md` / `change-speed.md` lack the "How to Use" section most sibling tool docs have (needs new content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)