### PR TITLE
fix: load Matroska WebVTT tracks as WebVTT, not SubRip

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -2795,7 +2795,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             subtitle.Paragraphs.Clear();
 
             var isSsa = false;
+            var isVtt = false;
             SubtitleFormat format = new SubRip();
+            var codecId = matroskaSubtitleInfo.CodecId ?? string.Empty;
             var codecPrivate = matroskaSubtitleInfo.GetCodecPrivate();
             if (codecPrivate.Contains("[script info]", StringComparison.OrdinalIgnoreCase))
             {
@@ -2810,8 +2812,33 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 isSsa = true;
             }
+            else if (codecId.StartsWith("S_TEXT/WEBVTT", StringComparison.OrdinalIgnoreCase) ||
+                     codecId.StartsWith("D_WEBVTT", StringComparison.OrdinalIgnoreCase))
+            {
+                // Matroska stores WebVTT tracks as their own format - don't fall back to SubRip,
+                // which would parse the cue identifier/settings as part of the subtitle text.
+                format = new WebVTT();
+                isVtt = true;
+            }
 
-            if (isSsa)
+            if (isVtt)
+            {
+                // MakeMKV (codec id "D_WEBVTT/*") puts the cue identifier and the cue settings
+                // list in front of the payload inside each block. The standard "S_TEXT/WEBVTT"
+                // stores only the payload (identifier/settings live in block additions).
+                var hasCueHeader = codecId.StartsWith("D_WEBVTT", StringComparison.OrdinalIgnoreCase);
+                foreach (var p in sub)
+                {
+                    var text = p.GetText(matroskaSubtitleInfo);
+                    if (hasCueHeader)
+                    {
+                        text = RemoveMatroskaWebVttCueHeader(text);
+                    }
+
+                    subtitle.Paragraphs.Add(new Paragraph(text, p.Start, p.End));
+                }
+            }
+            else if (isSsa)
             {
                 foreach (var p in LoadMatroskaSSA(matroskaSubtitleInfo, matroska.Path, format, sub).Paragraphs)
                 {
@@ -2883,6 +2910,19 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             subtitle.Renumber();
             return format;
+        }
+
+        /// <summary>
+        /// MakeMKV stores each WebVTT cue block as
+        /// "&lt;cue identifier&gt;\n&lt;cue settings list&gt;\n&lt;payload&gt;".
+        /// Strip those two header lines so only the displayable text remains;
+        /// otherwise the identifier (e.g. "1") and the settings (e.g. "align:middle line:90%")
+        /// end up in the subtitle text.
+        /// </summary>
+        private static string RemoveMatroskaWebVttCueHeader(string text)
+        {
+            var lines = text.SplitToLines();
+            return lines.Count <= 2 ? string.Empty : string.Join(Environment.NewLine, lines.Skip(2));
         }
 
         public static void ParseMatroskaTextSt(MatroskaTrackInfo trackInfo, List<MatroskaSubtitle> subtitleLines, Subtitle subtitle)

--- a/tests/libse/Common/UtilitiesTest.cs
+++ b/tests/libse/Common/UtilitiesTest.cs
@@ -1,10 +1,34 @@
+using System.Text;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
 using SkiaSharp;
 
 namespace LibSETests.Common;
 
 public class UtilitiesTest
 {
+    // WebVTT tracks in a Matroska container must be loaded as WebVTT, not SubRip.
+    // MakeMKV (codec id "D_WEBVTT/*") prepends "<cue identifier>\n<cue settings>\n" to each
+    // block, which previously leaked into the subtitle text (issue #11680).
+    [Fact]
+    public void LoadMatroskaTextSubtitle_WebVtt_DetectsFormatAndStripsCueHeader()
+    {
+        var track = new MatroskaTrackInfo { CodecId = "D_WEBVTT/SUBTITLES", IsSubtitle = true };
+        var sub = new List<MatroskaSubtitle>
+        {
+            new MatroskaSubtitle(Encoding.UTF8.GetBytes("1\n\n[TENSE MUSIC]"), 160, 1000),
+            new MatroskaSubtitle(Encoding.UTF8.GetBytes("\nalign:middle line:90%\nHello there.\nSecond line."), 3320, 1680),
+        };
+        var subtitle = new Subtitle();
+
+        var format = Utilities.LoadMatroskaTextSubtitle(track, null, sub, subtitle);
+
+        Assert.Equal("WebVTT", format.Name);
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("[TENSE MUSIC]", subtitle.Paragraphs[0].Text);
+        Assert.Equal("Hello there." + Environment.NewLine + "Second line.", subtitle.Paragraphs[1].Text);
+    }
+
     // DisplayFileSizeToBytes used to cast each result to int, so any value >= 2 GB
     // (and large mb inputs) overflowed to a negative/garbage number. The method
     // returns long, so the result must survive past int.MaxValue.


### PR DESCRIPTION
Fixes #11680 (duplicate of #7755)

## Problem

A WebVTT subtitle track inside a Matroska / `.mks` container was loaded as **SubRip**. Because MakeMKV (codec id `D_WEBVTT/SUBTITLES`) stores each cue's block as:

```
<cue identifier>\n<cue settings list>\n<payload>
```

parsing it as SRT dumped the identifier and settings straight into the subtitle text — stray numbers, extra blank lines, and `align:middle line:90%` tags, exactly as the reporter showed.

## Fix

`Utilities.LoadMatroskaTextSubtitle` now:
- Detects the WebVTT codec ids (`S_TEXT/WEBVTT` and `D_WEBVTT/*`) and keeps the format as **WebVTT** instead of falling back to SubRip.
- For the MakeMKV `D_WEBVTT/*` layout, strips the `<identifier>\n<settings>\n` header so only the displayable payload remains.
- For the standard `S_TEXT/WEBVTT` layout (block = payload only), uses the payload directly.

Verified against both sample `.mks` files attached to the issue (513 and 1020 cues): the format is now detected as WebVTT and the text is clean and multi-line-correct.

Note: cue positioning settings (e.g. `align:middle line:90%`) are dropped rather than translated into WebVTT cue settings — that could be a follow-up, but it's out of scope for fixing the garbled text.

## Test

Added `LoadMatroskaTextSubtitle_WebVtt_DetectsFormatAndStripsCueHeader`. Full libse suite (395 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)