### PR TITLE
Fix `CpsLineLengthStrategy` not getting changed in profile settings

### DIFF
--- a/src/ui/Forms/Options/SettingsProfile.Designer.cs
+++ b/src/ui/Forms/Options/SettingsProfile.Designer.cs
@@ -178,6 +178,7 @@
             this.comboBoxCpsLineLenCalc.Size = new System.Drawing.Size(174, 23);
             this.comboBoxCpsLineLenCalc.TabIndex = 197;
             this.comboBoxCpsLineLenCalc.UsePopupWindow = false;
+            this.comboBoxCpsLineLenCalc.SelectedIndexChanged += new System.EventHandler(this.UiElementChanged);
             // 
             // buttonEditCustomContinuationStyle
             // 


### PR DESCRIPTION
Changing the `CpsLineLengthStrategy` from the profile settings wasn't triggering an edit.