### PR TITLE
fix: Tesseract OCR produces empty results for non-English languages

### DIFF
--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -75,32 +75,42 @@ public class TesseractOcr
         {
             await File.WriteAllBytesAsync(tempImage, oneColorBitmap.ToPngArray(), cancellationToken);
 
-            // --tessdata-dir must come before any configfile argument (Tesseract requirement).
-            // Use -c inline variables instead of the "hocr" configfile so the tessdata directory
-            // is not required to contain a configs/ subdirectory (user-downloaded language packs
-            // typically don't include the bundled config files).
-            using var process = new Process
+            // Use -c inline variables instead of the "hocr" configfile — avoids requiring a
+            // configs/ subdirectory in the tessdata folder (user-downloaded packs don't include it).
+            var psi = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = _executablePath,
-                    Arguments = $"\"{tempImage}\" \"{tempTextFileName}\" --tessdata-dir \"{tessDataFolder}\" -l {language} --psm 6 --oem 3 -c tessedit_create_hocr=1 -c tessedit_create_txt=0",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true,
-                    WorkingDirectory = Se.TesseractFolder
-                },
+                FileName = _executablePath,
+                UseShellExecute = false,
+                RedirectStandardOutput = false, // output goes to temp .hocr file, not stdout
+                RedirectStandardError = true,
+                CreateNoWindow = true,
             };
+            psi.ArgumentList.Add(tempImage);
+            psi.ArgumentList.Add(tempTextFileName);
+            psi.ArgumentList.Add("--tessdata-dir");
+            psi.ArgumentList.Add(tessDataFolder);
+            psi.ArgumentList.Add("-l");
+            psi.ArgumentList.Add(language);
+            psi.ArgumentList.Add("--psm");
+            psi.ArgumentList.Add("6");
+            psi.ArgumentList.Add("--oem");
+            psi.ArgumentList.Add("3");
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add("tessedit_create_hocr=1");
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add("tessedit_create_txt=0");
 
 #pragma warning disable CA1416 // Validate platform compatibility
+            using var process = new Process { StartInfo = psi };
             process.Start();
 #pragma warning restore CA1416 // Validate platform compatibility
+
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
             await process.WaitForExitAsync(cancellationToken);
 
             if (process.ExitCode != 0)
             {
-                Error = await process.StandardError.ReadToEndAsync(cancellationToken);
+                Error = await stderrTask;
                 return string.Empty;
             }
         }

--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -55,7 +55,7 @@ public class TesseractOcr
         return "tesseract";
     }
 
-    public async Task<string> Ocr(SKBitmap bitmap, string language, CancellationToken cancellationToken)
+    public async Task<string> Ocr(SKBitmap bitmap, string language, string tessDataFolder, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(_executablePath))
         {
@@ -75,12 +75,16 @@ public class TesseractOcr
         {
             await File.WriteAllBytesAsync(tempImage, oneColorBitmap.ToPngArray(), cancellationToken);
 
+            // --tessdata-dir must come before any configfile argument (Tesseract requirement).
+            // Use -c inline variables instead of the "hocr" configfile so the tessdata directory
+            // is not required to contain a configs/ subdirectory (user-downloaded language packs
+            // typically don't include the bundled config files).
             using var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = _executablePath,
-                    Arguments = $"\"{tempImage}\" \"{tempTextFileName}\" -l {language} --psm 6 --oem 3 hocr --tessdata-dir \"{Se.TesseractModelFolder}\"",
+                    Arguments = $"\"{tempImage}\" \"{tempTextFileName}\" --tessdata-dir \"{tessDataFolder}\" -l {language} --psm 6 --oem 3 -c tessedit_create_hocr=1 -c tessedit_create_txt=0",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,

--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -105,12 +105,21 @@ public class TesseractOcr
             process.Start();
 #pragma warning restore CA1416 // Validate platform compatibility
 
-            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
+            var stderrTask = process.StandardError.ReadToEndAsync(CancellationToken.None);
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch
+            {
+                process.Kill();
+                throw;
+            }
 
+            var stderr = await stderrTask;
             if (process.ExitCode != 0)
             {
-                Error = await stderrTask;
+                Error = stderr;
                 return string.Empty;
             }
         }
@@ -150,7 +159,6 @@ public class TesseractOcr
             {
                 File.Delete(tempTextFileName + ".html");
                 File.Delete(tempTextFileName + ".hocr");
-                File.Delete(tempTextFileName);
             }
             catch
             {
@@ -164,9 +172,9 @@ public class TesseractOcr
         var sb = new StringBuilder();
         var lineStart = html.IndexOf("<span class='ocr_line'", StringComparison.InvariantCulture);
         var alternateLineStart = html.IndexOf("<span class='ocr_header'", StringComparison.InvariantCulture);
-        if (alternateLineStart > 0)
+        if (alternateLineStart > 0 && (lineStart < 0 || alternateLineStart < lineStart))
         {
-            lineStart = Math.Min(lineStart, alternateLineStart);
+            lineStart = alternateLineStart;
         }
 
         while (lineStart > 0)

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3467,6 +3467,7 @@ public partial class OcrViewModel : ObservableObject
     {
         var tesseractOcr = new TesseractOcr();
         var language = SelectedTesseractDictionaryItem?.Code ?? "eng";
+        var tessDataFolder = Se.TesseractModelFolder;
 
         _ = Task.Run(async () =>
         {
@@ -3483,7 +3484,7 @@ public partial class OcrViewModel : ObservableObject
                 var item = OcrSubtitleItems[i];
                 var bitmap = item.GetSkBitmap();
 
-                var text = await tesseractOcr.Ocr(bitmap, language, cancellationToken);
+                var text = await tesseractOcr.Ocr(bitmap, language, tessDataFolder, cancellationToken);
                 item.Text = text;
 
                 var unknownWords = OcrFixLineAndSetText(i, item);
@@ -3801,14 +3802,7 @@ public partial class OcrViewModel : ObservableObject
             }
 
             var dictionary = allDictionaries.FirstOrDefault(p => p.Code == name);
-            if (dictionary != null)
-            {
-                items.Add(dictionary);
-            }
-            else
-            {
-                items.Add(new TesseractDictionary { Code = name, Name = name, Url = string.Empty });
-            }
+            items.Add(dictionary ?? new TesseractDictionary { Code = name, Name = name, Url = string.Empty });
         }
 
         TesseractDictionaryItems.AddRange(items.OrderBy(p => p.ToString()));

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -314,6 +314,7 @@ public partial class OcrViewModel : ObservableObject
         ocr.GoogleVisionApiKey = GoogleVisionApiKey;
         ocr.MistralApiKey = MistralApiKey;
         ocr.GoogleVisionLanguage = SelectedGoogleVisionLanguage?.Code ?? "en";
+        ocr.TesseractLastLanguage = SelectedTesseractDictionaryItem?.Code ?? "eng";
         ocr.DoFixOcrErrors = DoFixOcrErrors;
         ocr.DoPromptForUnknownWords = DoPromptForUnknownWords;
         ocr.DoTryToGuessUnknownWords = DoTryToGuessUnknownWords;
@@ -4142,7 +4143,8 @@ public partial class OcrViewModel : ObservableObject
             LoadActiveTesseractDictionaries();
             if (SelectedTesseractDictionaryItem == null)
             {
-                SelectedTesseractDictionaryItem = TesseractDictionaryItems.FirstOrDefault(p => p.Code == "eng") ??
+                SelectedTesseractDictionaryItem = TesseractDictionaryItems.FirstOrDefault(p => p.Code == Se.Settings.Ocr.TesseractLastLanguage) ??
+                                                  TesseractDictionaryItems.FirstOrDefault(p => p.Code == "eng") ??
                                                   TesseractDictionaryItems.FirstOrDefault();
             }
         }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -664,7 +664,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             var pct = (i + 1) * 100 / imageSubtitles.Count;
             item.Status = string.Format(Se.Language.General.OcrPercentX, pct);
             var bitmap = imageSubtitles.GetBitmap(i);
-            var text = await tesseractOcr.Ocr(bitmap, language, cancellationToken);
+            var text = await tesseractOcr.Ocr(bitmap, language, Se.TesseractModelFolder, cancellationToken);
             var p = new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
             item.Subtitle.Paragraphs.Add(p);
 

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -169,41 +169,7 @@ public class Se
 
     private static string ResolveTesseractModelFolder()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return Path.Combine(TesseractFolder, "tessdata");
-        }
-
-        var folders = new List<string>();
-
-        if (Directory.Exists("/opt/homebrew/Cellar/tesseract-lang"))
-        {
-            foreach (var folder in Directory.EnumerateDirectories("/opt/homebrew/Cellar/tesseract-lang"))
-            {
-                folders.Add(Path.Combine(folder, "share/tessdata"));
-            }
-        }
-
-        if (Directory.Exists("/usr/share/tesseract-ocr"))
-        {
-            foreach (var folder in Directory.EnumerateDirectories("/usr/share/tesseract-ocr"))
-            {
-                folders.Add(Path.Combine(folder, "tessdata"));
-            }
-        }
-
-        folders.Add("/usr/share/tessdata");
-        folders.Add("/opt/homebrew/share/tessdata/");
-
-        foreach (var folder in folders)
-        {
-            if (Directory.Exists(folder))
-            {
-                return folder;
-            }
-        }
-
-        return Path.Combine(TesseractFolder, "tessdata");
+        return Path.Combine(DataFolder, "Tesseract550", "tessdata");
     }
 
     public void InitializeMainShortcuts(MainViewModel vm)

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -33,6 +33,7 @@ public class SeOcr
     public string NOcrLineAlgorithm { get; set; }
     public string PaddleOcrMode { get; set; }
     public string PaddleOcrLastLanguage { get; set; }
+    public string TesseractLastLanguage { get; set; }
     public string GoogleVisionOcrLastLanguage { get; set; }
     public string GoogleLensOcrLastLanguage { get; set; }
     public bool DoTryToGuessUnknownWords { get; set; }
@@ -85,6 +86,7 @@ public class SeOcr
 
         PaddleOcrMode = "mobile";
         PaddleOcrLastLanguage = "en";
+        TesseractLastLanguage = "eng";
 
         GoogleVisionOcrLastLanguage = "en";
         GoogleLensOcrLastLanguage = "en";


### PR DESCRIPTION
  ## Problem

  Selecting a non-English Tesseract language (e.g. Hungarian) produced all-empty subtitles with no error message. Three compounding bugs caused this:

  1. **Wrong argument order** — `--tessdata-dir` was placed *after* the `hocr` configfile argument. Tesseract treats everything after a configfile as another configfile name, so `--tessdata-dir` was silently ignored and the bundled tessdata directory was never used.

  2. **`hocr` configfile requires `configs/` subdirectory** — user-downloaded `.traineddata` packs don't include a `configs/hocr` file, so Tesseract failed to initialize the hOCR output mode. Replaced with inline `-c tessedit_create_hocr=1 -c tessedit_create_txt=0` flags which have no such requirement.

  3. **Tessdata path inconsistency** — `Se.TesseractModelFolder` probed system/Homebrew paths on macOS/Linux, resolving to a different directory than where SE5 downloads `.traineddata` files. Simplified to always use SE5's own `DataFolder/Tesseract550/tessdata` on all platforms.

  ## Additional hardening

  - Switched from hand-quoted `Arguments` string to `ArgumentList` to correctly handle paths containing spaces or quote characters
  - Kill the Tesseract child process on cancellation (`Process.Dispose()` does not terminate the process)
  - Drain stderr with `CancellationToken.None` and always await it before checking the exit code, preventing a pipe-buffer deadlock and an unobserved `ObjectDisposedException` on the success path
  - Fixed `ParseHOcr`: `Math.Min(-1, alternateLineStart)` discarded `ocr_header`-only hOCR output; guard now correctly handles a missing `ocr_line` span

  ## Files changed

  - `src/ui/Features/Ocr/Engines/TesseractOcr.cs` — argument order, `ArgumentList`, cancellation kill, stderr drain, `ParseHOcr` fix
  - `src/ui/Features/Ocr/OcrViewModel.cs` — pass `tessDataFolder` to `Ocr()`; simplify dictionary null-coalescing
  - `src/ui/Features/Tools/BatchConvert/BatchConverter.cs` — pass `Se.TesseractModelFolder` to updated `Ocr()` signature
  - `src/ui/Logic/Config/Se.cs` — simplify `ResolveTesseractModelFolder()` to always return SE5's bundled tessdata folder