### PR TITLE
fix: bundle Tesseract in Flatpak so OCR works in the sandbox

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -16,18 +16,23 @@ jobs:
   # because the flatpak container image does not ship the .NET SDK.
   regenerate-nuget-sources:
     runs-on: ubuntu-latest
+    env:
+      # The runtime version the flatpak org.freedesktop.Sdk.Extension.dotnet10//24.08
+      # extension ships. generate-nuget-sources.sh pins the pre-fetched shared-framework
+      # packs to this exact version; otherwise a self-contained restore rolls them forward
+      # to the newest patch on nuget.org, which mismatches the older runtime the flatpak SDK
+      # pins and breaks the offline restore inside the sandbox (NU1102). Bump this to match
+      # whenever the flathub dotnet10 extension updates its runtime.
+      DOTNET_RUNTIME_VERSION: '10.0.8'
     steps:
       - uses: actions/checkout@v5
 
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          # Must match the runtime the flatpak org.freedesktop.Sdk.Extension.dotnet10//24.08
-          # extension ships. A floating '10.0.x' resolves to the newest patch on the runner
-          # (e.g. SDK 10.0.109 → runtime 10.0.9), which then mismatches the older runtime
-          # packs the flatpak SDK pins, breaking the offline restore (NU1102). SDK 10.0.108
-          # provides runtime 10.0.8. Bump this when the flathub extension updates.
-          dotnet-version: '10.0.108'
+          # Any .NET 10 SDK can perform the restore; the exact runtime pack version is
+          # forced via DOTNET_RUNTIME_VERSION above, not by the SDK selection.
+          dotnet-version: '10.0.x'
 
       - name: Regenerate nuget-sources.json
         run: bash installer/flatpak/generate-nuget-sources.sh

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -22,7 +22,12 @@ jobs:
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          # Must match the runtime the flatpak org.freedesktop.Sdk.Extension.dotnet10//24.08
+          # extension ships. A floating '10.0.x' resolves to the newest patch on the runner
+          # (e.g. SDK 10.0.109 → runtime 10.0.9), which then mismatches the older runtime
+          # packs the flatpak SDK pins, breaking the offline restore (NU1102). SDK 10.0.108
+          # provides runtime 10.0.8. Bump this when the flathub extension updates.
+          dotnet-version: '10.0.108'
 
       - name: Regenerate nuget-sources.json
         run: bash installer/flatpak/generate-nuget-sources.sh

--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -278,6 +278,7 @@ modules:
 
   - name: leptonica
     buildsystem: cmake-ninja
+    builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_SHARED_LIBS=ON
@@ -293,6 +294,7 @@ modules:
 
   - name: tesseract
     buildsystem: cmake-ninja
+    builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_SHARED_LIBS=ON

--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -29,6 +29,8 @@ finish-args:
   - --socket=pulseaudio
   # .NET single-file bundle extraction directory (persistent cache)
   - --env=DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/cache/.net
+  # Where the bundled Tesseract finds its language models (issue #11646)
+  - --env=TESSDATA_PREFIX=/app/share/tessdata
 
 cleanup:
   - '*.la'
@@ -265,6 +267,56 @@ modules:
         url: https://github.com/mpv-player/mpv.git
         tag: v0.41.0
         commit: 41f6a645068483470267271e1d09966ca3b9f413
+
+  # --- Tesseract OCR (bundled into the sandbox; see issue #11646) ---
+  #
+  # The sandbox has its own /usr, so a Tesseract installed on the host
+  # (e.g. `apt install tesseract-ocr`) is invisible to the Flatpak. We build
+  # Leptonica + Tesseract into /app/bin/tesseract — the path that
+  # TesseractOcr.GetExecutablePath() already probes — and ship the English
+  # language model so OCR works out of the box.
+
+  - name: leptonica
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_PROG=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/DanBloomberg/leptonica/releases/download/1.85.0/leptonica-1.85.0.tar.gz
+        sha256: 3745ae3bf271a6801a2292eead83ac926e3a9bc1bf622e9cd4dd0f3786e17205
+
+  - name: tesseract
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_TRAINING_TOOLS=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/tesseract-ocr/tesseract/archive/refs/tags/5.5.1.tar.gz
+        sha256: a7a3f2a7420cb6a6a94d80c24163e183cf1d2f1bed2df3bbc397c81808a57237
+
+  # English language model, pre-downloaded so OCR works out of the box.
+  # The standard tessdata model is used (not tessdata_fast/best) because SE runs
+  # Tesseract with `--oem 3`, which needs both the legacy and LSTM data.
+  - name: tessdata-eng
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 eng.traineddata /app/share/tessdata/eng.traineddata
+    sources:
+      - type: file
+        url: https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata
+        sha256: daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
 
   # --- SubtitleEdit application ---
 

--- a/installer/flatpak/generate-nuget-sources.sh
+++ b/installer/flatpak/generate-nuget-sources.sh
@@ -90,26 +90,28 @@ else
     TMPDIR_PKGS="$(mktemp -d)"
     trap 'rm -rf "$TMPDIR_PKGS"' EXIT
 
-    # Pin the shared-framework packs (Microsoft.NETCore.App / AspNetCore.App /
-    # host) to the runtime version that matches the active SDK's feature band:
-    # SDK 10.0.1NN ships runtime 10.0.NN (e.g. 10.0.108 -> 10.0.8). Without this,
-    # a self-contained restore rolls the runtime packs forward to the newest patch
-    # on nuget.org, which then mismatches the (often older) runtime the flatpak
-    # dotnet10 extension pins. The offline restore inside the sandbox demands an
-    # exact match, so the drift breaks the build with NU1102. Deriving from the
-    # SDK keeps the runner and the flatpak build in lockstep via the workflow's
-    # setup-dotnet pin — bump that pin and this follows automatically.
-    SDK_VERSION="$(dotnet --version)"
-    SDK_PATCH="${SDK_VERSION##*.}"
-    RUNTIME_FRAMEWORK_VERSION="${SDK_VERSION%.*}.$((10#$SDK_PATCH % 100))"
-    echo "Pinning RuntimeFrameworkVersion=$RUNTIME_FRAMEWORK_VERSION (from SDK $SDK_VERSION)"
+    # Optionally pin the shared-framework packs (Microsoft.NETCore.App /
+    # AspNetCore.App / host) to an exact runtime version via DOTNET_RUNTIME_VERSION.
+    # Without it, a self-contained restore rolls the runtime packs forward to the
+    # newest patch on nuget.org, which then mismatches the (often older) runtime
+    # the flatpak dotnet10 extension pins; the offline restore inside the sandbox
+    # demands an exact match, so the drift breaks the build with NU1102. The CI
+    # workflow sets DOTNET_RUNTIME_VERSION to the extension's runtime so the two
+    # stay in lockstep. We pin via -p:RuntimeFrameworkVersion (not the SDK version)
+    # because the runner picks the newest installed SDK regardless of any pin, and
+    # RuntimeFrameworkVersion forces the pack version no matter which SDK restores.
+    RUNTIME_PIN=()
+    if [ -n "${DOTNET_RUNTIME_VERSION:-}" ]; then
+        echo "Pinning RuntimeFrameworkVersion=$DOTNET_RUNTIME_VERSION"
+        RUNTIME_PIN=(-p:RuntimeFrameworkVersion="$DOTNET_RUNTIME_VERSION")
+    fi
 
     echo "Restoring for linux-x64..."
     dotnet restore "$PROJECT_PATH" \
         --packages "$TMPDIR_PKGS" \
         --runtime linux-x64 \
         -p:SelfContained=true \
-        -p:RuntimeFrameworkVersion="$RUNTIME_FRAMEWORK_VERSION" \
+        "${RUNTIME_PIN[@]}" \
         --verbosity quiet
 
     echo "Restoring for linux-arm64..."
@@ -117,7 +119,7 @@ else
         --packages "$TMPDIR_PKGS" \
         --runtime linux-arm64 \
         -p:SelfContained=true \
-        -p:RuntimeFrameworkVersion="$RUNTIME_FRAMEWORK_VERSION" \
+        "${RUNTIME_PIN[@]}" \
         --verbosity quiet
 
     echo "Building $OUTPUT from restored packages..."

--- a/installer/flatpak/generate-nuget-sources.sh
+++ b/installer/flatpak/generate-nuget-sources.sh
@@ -90,11 +90,26 @@ else
     TMPDIR_PKGS="$(mktemp -d)"
     trap 'rm -rf "$TMPDIR_PKGS"' EXIT
 
+    # Pin the shared-framework packs (Microsoft.NETCore.App / AspNetCore.App /
+    # host) to the runtime version that matches the active SDK's feature band:
+    # SDK 10.0.1NN ships runtime 10.0.NN (e.g. 10.0.108 -> 10.0.8). Without this,
+    # a self-contained restore rolls the runtime packs forward to the newest patch
+    # on nuget.org, which then mismatches the (often older) runtime the flatpak
+    # dotnet10 extension pins. The offline restore inside the sandbox demands an
+    # exact match, so the drift breaks the build with NU1102. Deriving from the
+    # SDK keeps the runner and the flatpak build in lockstep via the workflow's
+    # setup-dotnet pin — bump that pin and this follows automatically.
+    SDK_VERSION="$(dotnet --version)"
+    SDK_PATCH="${SDK_VERSION##*.}"
+    RUNTIME_FRAMEWORK_VERSION="${SDK_VERSION%.*}.$((10#$SDK_PATCH % 100))"
+    echo "Pinning RuntimeFrameworkVersion=$RUNTIME_FRAMEWORK_VERSION (from SDK $SDK_VERSION)"
+
     echo "Restoring for linux-x64..."
     dotnet restore "$PROJECT_PATH" \
         --packages "$TMPDIR_PKGS" \
         --runtime linux-x64 \
         -p:SelfContained=true \
+        -p:RuntimeFrameworkVersion="$RUNTIME_FRAMEWORK_VERSION" \
         --verbosity quiet
 
     echo "Restoring for linux-arm64..."
@@ -102,6 +117,7 @@ else
         --packages "$TMPDIR_PKGS" \
         --runtime linux-arm64 \
         -p:SelfContained=true \
+        -p:RuntimeFrameworkVersion="$RUNTIME_FRAMEWORK_VERSION" \
         --verbosity quiet
 
     echo "Building $OUTPUT from restored packages..."
@@ -209,6 +225,15 @@ for src in data:
         if entry:
             added.append(entry)
         break
+
+# netstandard2.1 reference assemblies (LibSE targets netstandard2.1). The system
+# SDK used by the fallback path resolves these from its bundled packs without
+# downloading, so they never get captured here — but the flatpak SDK needs them
+# from the offline feed, otherwise restore fails with NU1101. The version is tied
+# to the netstandard version (2.1.0), not the .NET runtime, so it is fixed.
+entry = nuget_entry("netstandard.library.ref", "2.1.0")
+if entry:
+    added.append(entry)
 
 if added:
     data.extend(added)

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -151,6 +151,7 @@ public class Se
         folders.Add("/usr/bin");
         folders.Add("/opt/homebrew/bin");
         folders.Add("/opt/local/bin");
+        folders.Add("/app/bin"); // bundled into the Flatpak sandbox (issue #11646)
 
         foreach (var folder in folders)
         {
@@ -175,6 +176,9 @@ public class Se
         }
 
         var folders = new List<string>();
+
+        // Bundled location inside the Flatpak sandbox (issue #11646); harmless elsewhere.
+        folders.Add("/app/share/tessdata");
 
         if (Directory.Exists("/opt/homebrew/Cellar/tesseract-lang"))
         {


### PR DESCRIPTION
Fixes #11646.

## Problem
The Flatpak build can't find Tesseract even when it's installed on the host (e.g. `apt install tesseract-ocr`), while the tarball build works fine. The Flatpak sandbox has its own `/usr`, so the host's `/usr/bin/tesseract` is not on the sandbox filesystem — and the manifest never bundled Tesseract into `/app`.

## Fix — bundle Tesseract in the Flatpak
- **leptonica 1.85.0** and **tesseract 5.5.1** built via `cmake-ninja` (with `builddir: true`, since both forbid in-source builds), installed to `/app` → `/app/bin/tesseract`, the path `TesseractOcr.GetExecutablePath()` already probes.
- **eng.traineddata** pre-downloaded to `/app/share/tessdata`. The *standard* tessdata model is used (not fast/best) because SE runs Tesseract with `--oem 3`, which needs both the legacy and LSTM data.
- `--env=TESSDATA_PREFIX=/app/share/tessdata` added to `finish-args`.

Runtime path resolution in `Se.cs`:
- `ResolveTesseractModelFolder()` lists `/app/share/tessdata` (passed as `--tessdata-dir`).
- `ResolveTesseractFolder()` lists `/app/bin` — needed because `TesseractOcr` sets `WorkingDirectory` to the Tesseract folder, which would otherwise fall back to a non-existent path and make `Process.Start` throw in the sandbox.

Both `/app` paths are harmless on non-Flatpak systems (the directories won't exist).

## Incidental CI fix — .NET runtime-pack pinning
While validating the build, the `build-flatpak` workflow was failing in the existing `subtitleedit` .NET publish step (independent of Tesseract), because the `regenerate-nuget-sources` step drifted from the flatpak `dotnet10` extension:
- A self-contained restore rolled the shared-framework packs forward to the newest patch on nuget.org (10.0.9) while the extension pins them at 10.0.8 → offline restore failed (`NU1102`). Now pinned via a new `DOTNET_RUNTIME_VERSION` env consumed by `generate-nuget-sources.sh` (`-p:RuntimeFrameworkVersion`), which forces the exact pack version regardless of which SDK the runner selects.
- The system SDK resolved `NETStandard.Library.Ref` (needed by `LibSE`, which targets netstandard2.1) from bundled packs without downloading it, so it never landed in `nuget-sources.json` → `NU1101`. Now added to the ensure-present step, mirroring the existing ILLink.Tasks handling.

## Testing
- **Build Flatpak** workflow is green on this branch: all new modules (leptonica, tesseract, tessdata-eng) build and the `SubtitleEdit-linux-x64-x86_64.flatpak` bundle (~101 MB) is produced.
- The regenerated `nuget-sources.json` was verified to contain the shared-framework packs at exactly 10.0.8 plus `netstandard.library.ref` 2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)