### PR TITLE
Fix crash on subtitle grid cut by re-selecting a line

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12629,8 +12629,30 @@ public partial class MainViewModel :
             return;
         }
 
+        // Remember where the first cut line was so we can re-select a row afterwards.
+        // Leaving the grid with a dangling/empty selection crashes for some users.
+        var idx = Subtitles.IndexOf(selectedItems[0]);
+
         await SubtitleGridCopyPasteHelper.Cut(Window, Subtitles, selectedItems, SelectedSubtitleFormat, _subtitle);
         Renumber();
+
+        if (Subtitles.Count == 0)
+        {
+            // Everything was cut: clear the stale selection so the grid and the
+            // waveform highlight don't keep pointing at the removed lines.
+            SubtitleGrid.SelectedItem = null;
+            SubtitleGridSelectionChanged();
+        }
+        else
+        {
+            if (idx >= Subtitles.Count)
+            {
+                idx = Subtitles.Count - 1;
+            }
+
+            SelectAndScrollToRow(idx);
+        }
+
         _updateAudioVisualizer = true;
         _shortcutManager.ClearKeys();
     }


### PR DESCRIPTION
## Problem

Cutting one or more lines in the subtitle grid (`SubtitleGridCut` in `MainViewModel`) removed the selected lines but never re-selected a row afterwards. This left the grid with a dangling/empty selection, which crashed for some users. It also left the waveform's selection highlight painted over the now-removed paragraphs (since `_selectedSubtitles` was never refreshed).

Every other line-removal path (e.g. `DeleteSelectedItems`) re-selects a row after removal — cut was the odd one out.

## Fix

- Capture the index of the first cut line before removal, then re-select a row at that index (clamped to the new list size) via `SelectAndScrollToRow`, mirroring the Delete pattern.
- Re-selecting triggers `SubtitleGridSelectionChanged()`, which refreshes `_selectedSubtitles` and flags the audio visualizer, so the waveform highlight moves to the new line instead of lingering on the cut paragraphs.
- When **all** lines are cut, there's no row to select, so the selection is cleared explicitly (`SubtitleGrid.SelectedItem = null` + `SubtitleGridSelectionChanged()`) to clear both the grid selection and the waveform highlight.

## Testing

- `dotnet build src/ui/UI.csproj` succeeds (only a pre-existing unrelated nullable warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)