### PR TITLE
Pin OmniVoice TTS to omnivoice-2026-06-18 (portable AVX2 build)

### DIFF
--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -611,37 +611,43 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [OmniVoice.WindowsCpu] = new[]
             {
-                "4af38bcb264ef34d7d39a7c76af00993e32f731a17253b7e82a9b8a6140a736b", // omnivoice-2026-05-22 (current download URL)
+                "ba1606c39987ea541e55db53f8925ed3c4f8301447e4f590aca800ccd52cef52", // omnivoice-2026-06-18 (current download URL — portable AVX2 baseline, GGML_NATIVE=OFF)
+                "4af38bcb264ef34d7d39a7c76af00993e32f731a17253b7e82a9b8a6140a736b", // omnivoice-2026-05-22
                 "ea1f0c6032f5a0333103ccffa7d7478c5ee00a35867776c277d717512587766c", // omnivoice-2026-05-17
             },
             [OmniVoice.WindowsVulkan] = new[]
             {
-                "ff90f8eb8c36ea64d46bd1d245e109ef80cadf234417bdc2c78b7420ab8f9a43", // omnivoice-2026-05-22 (current download URL)
+                "0f1e33fe67c78835991ccd787da68d265142f07e95f17b1c0b89e4d0c1fc6811", // omnivoice-2026-06-18 (current download URL — portable AVX2 baseline, GGML_NATIVE=OFF)
+                "ff90f8eb8c36ea64d46bd1d245e109ef80cadf234417bdc2c78b7420ab8f9a43", // omnivoice-2026-05-22
                 "b461b8535892b3e6979aec79eff4d6a0109a31184008b778b6848d7d36ea9901", // omnivoice-2026-05-17
             },
             [OmniVoice.WindowsCuda] = new[]
             {
-                "735d5672507b3796138cecabcde6512e6a1e60bc9e6e86efd0fa6ce13a361fa1", // omnivoice-2026-05-22 (current download URL)
+                "1d3109d67e4a3e3e83bce83791fa4af5c825f2fd60806593fda0539091bf49e6", // omnivoice-2026-06-18 (current download URL — portable AVX2 baseline, GGML_NATIVE=OFF; fixes #11677 illegal-instruction crash)
+                "735d5672507b3796138cecabcde6512e6a1e60bc9e6e86efd0fa6ce13a361fa1", // omnivoice-2026-05-22
                 "79308e79bb47df9f2bd2d31c6a60fe5672b74f43c3caf9b0a09566408894789e", // omnivoice-2026-05-17
             },
             [OmniVoice.MacOs] = new[]
             {
-                "d5ce6807adc50e6e1f1f92235828bad7c139c50042090a5361d0506e069ad1ba", // omnivoice-2026-05-22 (current download URL — RPATH fix)
+                "1063bf7f481bf1ecd296ba480a5655c68d12f392794504916fa542a2792da903", // omnivoice-2026-06-18 (current download URL)
+                "d5ce6807adc50e6e1f1f92235828bad7c139c50042090a5361d0506e069ad1ba", // omnivoice-2026-05-22 (RPATH fix)
                 "bbe354cdf8995641074c46d02d7f8b9353fa4803452cb45a762de10e899aca8e", // omnivoice-2026-05-17
             },
             [OmniVoice.LinuxX64] = new[]
             {
-                "c8eec5e66b362ddd3504658021a890a8acd4d2c092ba51a847fce1e80f4807e9", // omnivoice-2026-05-22 (current download URL — RPATH fix)
+                "698156714d03fadc503e4ebe01e47295b47c64df6d6496df48ed6c4128147214", // omnivoice-2026-06-18 (current download URL — portable AVX2 baseline, GGML_NATIVE=OFF)
+                "c8eec5e66b362ddd3504658021a890a8acd4d2c092ba51a847fce1e80f4807e9", // omnivoice-2026-05-22 (RPATH fix)
                 "198046721ebcbe49ded959fd832ec4a091d899be49e2a26b549723e32b82daba", // omnivoice-2026-05-17
             },
             [OmniVoice.LinuxArm64] = new[]
             {
-                "a46029c360398fc8775d6a4d703df158fa6f3ee6576e6efd3be0b7be424e5276", // omnivoice-2026-05-22 (current download URL — RPATH fix)
+                "7ad6a7ca9484b14b4b1ec25fdec4e67b2750d7a27b86d5937676f143aa95eaeb", // omnivoice-2026-06-18 (current download URL)
+                "a46029c360398fc8775d6a4d703df158fa6f3ee6576e6efd3be0b7be424e5276", // omnivoice-2026-05-22 (RPATH fix)
                 "3802d4136a6ffdc37cce72b286ab7c17422d55964fec13d4e3eb36f26e6ae1fe", // omnivoice-2026-05-17
             },
             [OmniVoice.Voices] = new[]
             {
-                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-05-22 (current download URL — unchanged from -05-17, identical to support-files/omnivoice-26-06 copy)
+                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-06-18 (current download URL — unchanged; identical to support-files/omnivoice-26-06 copy)
             },
 
             // Qwen3 TTS — https://github.com/niksedk/qwen3-tts.cpp/releases

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -32,7 +32,7 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
     // omnivoice.cpp release pin. Bump in lockstep with the hashes in DownloadHashManager.OmniVoice
     // (each new release: prepend the new SHA-256 at index 0, keep the previous one for "update available").
-    public const string ReleaseTag = "omnivoice-2026-05-22";
+    public const string ReleaseTag = "omnivoice-2026-06-18";
     private const string ReleaseUrlBase = "https://github.com/niksedk/omnivoice.cpp/releases/download/" + ReleaseTag + "/";
 
     private const string WindowsCpuUrl = ReleaseUrlBase + "omnivoice-win64-cpu.zip";


### PR DESCRIPTION
Fixes #11677

## What

Bumps the OmniVoice TTS engine to release **`omnivoice-2026-06-18`** and refreshes the archive SHA-256 hashes:

- `ReleaseTag` in `OmniVoiceDownloadService.cs` → `omnivoice-2026-06-18`
- New SHA-256 prepended at index 0 for all 6 binary archives in `DownloadHashManager.cs` (previous releases kept for "update available" detection)
- Voices archive **unchanged** (the new release re-publishes the identical `OmniVoices.zip`, same hash)

## Why

The previous release crashed with an **illegal instruction** (`0xC000001D` / `STATUS_ILLEGAL_INSTRUCTION`) on AVX2-only CPUs such as Intel Alder Lake (i5-12400), even with a fully supported GPU — see #11677. The omnivoice.cpp release binaries were built `GGML_NATIVE=ON` on GitHub's AVX-512-capable Xeon runners, so ggml's CPU backend (which runs even in the CUDA build, for tokenizer/codec/fallback ops) used AVX-512 the user's CPU lacks.

The new release ([niksedk/omnivoice.cpp#2](https://github.com/niksedk/omnivoice.cpp/pull/2)) builds with `GGML_NATIVE=OFF`, producing a portable AVX2+FMA+F16C baseline with no AVX-512.

## New hashes (verified against the published release assets)

| Asset | SHA-256 |
|---|---|
| omnivoice-win64-cpu.zip | `ba1606c3…cef52` |
| omnivoice-win64-vulkan.zip | `0f1e33fe…c6811` |
| omnivoice-win64-cuda.zip | `1d3109d6…49e6` |
| omnivoice-macos-universal-cpu-metal.zip | `1063bf7f…da903` |
| omnivoice-linux-x64-cpu.zip | `69815671…147214` |
| omnivoice-linux-arm64-cpu.zip | `7ad6a7ca…95eaeb` |
| OmniVoices.zip | `5d252eb7…d0c773` (unchanged) |

## Testing

- Hashes computed directly from the downloaded release assets (`gh release download` → `sha256sum`).
- `dotnet build src/ui/UI.csproj` succeeds (only a pre-existing unrelated nullable warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)