### PR TITLE
Add plain text output options to seconv

### DIFF
--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -74,6 +74,18 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Path to a Subtitle Edit custom-format XML file (used with --format customtext)")]
         public string? CustomFormat { get; init; }
 
+        [CommandOption("--plaintext-merge|--plaintextmerge")]
+        [Description("Plain text output: merge all subtitles into one space-separated block (no blank lines)")]
+        public bool PlainTextMerge { get; init; }
+
+        [CommandOption("--plaintext-unbreak|--plaintextunbreak")]
+        [Description("Plain text output: unbreak each subtitle, joining its lines into one")]
+        public bool PlainTextUnbreak { get; init; }
+
+        [CommandOption("--plaintext-no-blank-line|--plaintextnoblankline")]
+        [Description("Plain text output: do not put a blank line between subtitles (default keeps it)")]
+        public bool PlainTextNoBlankLine { get; init; }
+
         [CommandOption("--ocr-engine|--ocrengine")]
         [Description("OCR engine: tesseract | nocr | binaryocr | ollama | paddle (default: tesseract)")]
         public string? OcrEngine { get; init; }
@@ -448,6 +460,9 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 EbuHeaderFile = settings.EbuHeaderFile,
                 MultipleReplaceFile = settings.MultipleReplace,
                 CustomFormatFile = settings.CustomFormat,
+                PlainTextMerge = settings.PlainTextMerge,
+                PlainTextUnbreak = settings.PlainTextUnbreak,
+                PlainTextLineBetweenSubtitles = !settings.PlainTextNoBlankLine,
                 TrackNumbers = ParseTrackNumbers(settings.TrackNumber),
                 ForcedOnly = settings.ForcedOnly,
                 OcrEngine = string.IsNullOrWhiteSpace(settings.OcrEngine) ? "tesseract" : settings.OcrEngine,

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -310,7 +310,7 @@ internal static class LibSEIntegration
             return;
         }
 
-        // Plain text output — strip HTML, one paragraph per group separated by blank lines
+        // Plain text output — strip HTML; optional merge/unbreak and blank-line control
         if (formatName.Replace(" ", "").Equals("PlainText", StringComparison.OrdinalIgnoreCase))
         {
             var outputDirPlain = Path.GetDirectoryName(filePath);
@@ -318,18 +318,43 @@ internal static class LibSEIntegration
             {
                 Directory.CreateDirectory(outputDirPlain);
             }
-            var sb = new StringBuilder();
-            foreach (var p in subtitle.Paragraphs)
-            {
-                if (sb.Length > 0)
-                {
-                    sb.AppendLine();
-                }
-                sb.AppendLine(HtmlUtil.RemoveHtmlTags(p.Text, true));
-            }
+
             var plainEncoding = string.IsNullOrWhiteSpace(encodingName)
                 ? new UTF8Encoding(true)
                 : GetEncoding(encodingName);
+
+            // Merge: collapse every paragraph into a single space-separated block.
+            if (options?.PlainTextMerge == true)
+            {
+                var parts = new List<string>();
+                foreach (var p in subtitle.Paragraphs)
+                {
+                    var text = HtmlUtil.RemoveHtmlTags(p.Text, true).Replace(Environment.NewLine, " ").Trim();
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        parts.Add(text);
+                    }
+                }
+                File.WriteAllText(filePath, string.Join(" ", parts), plainEncoding);
+                return;
+            }
+
+            var unbreak = options?.PlainTextUnbreak == true;
+            var blankLineBetween = options?.PlainTextLineBetweenSubtitles ?? true;
+            var sb = new StringBuilder();
+            foreach (var p in subtitle.Paragraphs)
+            {
+                var text = HtmlUtil.RemoveHtmlTags(p.Text, true);
+                if (unbreak)
+                {
+                    text = Utilities.UnbreakLine(text.Replace(Environment.NewLine, " "));
+                }
+                if (sb.Length > 0 && blankLineBetween)
+                {
+                    sb.AppendLine();
+                }
+                sb.AppendLine(text);
+            }
             File.WriteAllText(filePath, sb.ToString(), plainEncoding);
             return;
         }

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -867,6 +867,15 @@ internal record class ConversionOptions
     public bool SkipTeletext { get; init; }
     public int? TeletextOnlyPage { get; init; }
 
+    /// <summary>Plain text output: merge every paragraph into one space-separated block (no blank lines).</summary>
+    public bool PlainTextMerge { get; init; }
+
+    /// <summary>Plain text output: unbreak each paragraph, joining its lines into one.</summary>
+    public bool PlainTextUnbreak { get; init; }
+
+    /// <summary>Plain text output: emit a blank line between consecutive paragraphs. Default true (legacy behaviour).</summary>
+    public bool PlainTextLineBetweenSubtitles { get; init; } = true;
+
     public bool Quiet { get; init; }
     public bool Verbose { get; init; }
 }

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -222,6 +222,23 @@ seconv movie.ts fcpimage                                       # DVB-sub → FCP
 >
 > The full list of supported keys lives in `src/seconv/Core/SeConvSettings.cs`.
 
+### Plain text output (`--format plaintext`)
+| Option | Description |
+|---|---|
+| `--plaintext-merge` | Merge all subtitles into one space-separated block (no blank lines) |
+| `--plaintext-unbreak` | Unbreak each subtitle, joining its lines into one |
+| `--plaintext-no-blank-line` | Do not put a blank line between subtitles (default keeps it) |
+
+HTML/styling tags are always stripped. `--plaintext-merge` takes precedence over
+`--plaintext-unbreak` and `--plaintext-no-blank-line`.
+
+```bash
+seconv movie.srt plaintext                              # one entry per blank-line-separated block
+seconv movie.srt plaintext --plaintext-no-blank-line    # one entry per line, no blank lines
+seconv movie.srt plaintext --plaintext-unbreak          # collapse multi-line entries
+seconv movie.srt plaintext --plaintext-merge            # everything on a single line
+```
+
 ### Verbosity
 | Option | Description |
 |---|---|


### PR DESCRIPTION
## Summary

The seconv plain-text writer (`--format plaintext`) previously only stripped HTML and inserted a blank line between entries, with no way to control the output. This adds three CLI options, mirroring the desktop UI's **Export plain text** dialog:

| Flag | Effect |
|---|---|
| `--plaintext-merge` | Merge all subtitles into one space-separated block (no blank lines) |
| `--plaintext-unbreak` | Join each subtitle's lines into one |
| `--plaintext-no-blank-line` | Suppress the blank line between subtitles |

HTML/styling tags are still always stripped. `--plaintext-merge` takes precedence over the other two. **The default output is unchanged when no new flag is passed.**

## Changes

- **`SubtitleConverter.cs`** — added `PlainTextMerge`, `PlainTextUnbreak`, `PlainTextLineBetweenSubtitles` (defaults `true`) to `ConversionOptions`.
- **`ConvertCommand.cs`** — three `[CommandOption]`s + mapping into `ConversionOptions` (`PlainTextLineBetweenSubtitles = !PlainTextNoBlankLine` keeps the legacy default).
- **`LibSEIntegration.cs`** — reworked the plain-text writer to honour merge/unbreak/blank-line.
- **`README.md`** — new "Plain text output" subsection with examples.

## Testing

Build is clean (0 warnings/errors). Verified all four modes against a sample `.srt`:

- **default** — HTML stripped, blank line between entries (byte-for-byte identical to before)
- **`--plaintext-no-blank-line`** — no blank lines between entries
- **`--plaintext-unbreak`** — each entry's lines joined into one
- **`--plaintext-merge`** — everything on a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)