### PR TITLE
Speed up large MKV reading and add open progress (#6772)

### DIFF
--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -34,7 +34,17 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         public MatroskaFile(string path)
         {
             Path = path;
-            _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 65536);
+
+            // Subtitle/track extraction walks the entire cluster structure but only reads a
+            // tiny fraction of a (potentially multi-GB) file: it reads each block's small header
+            // and then seeks past the large video/audio payloads. A big read buffer is
+            // counter-productive here - because the forward skips are usually smaller than the
+            // buffer, FileStream keeps refilling contiguously and ends up pulling almost the
+            // whole file off disk. A small 4 KB (one page) buffer makes the skips fall outside
+            // the buffer so the skipped payloads are never read, cutting cold-open disk I/O by
+            // ~4x (e.g. ~700 MB -> ~175 MB on a 1 GB file) and open time several-fold.
+            // Memory-mapping was measured to be slower here (synchronous page-fault stalls).
+            _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096);
 
             // read header
             var headerElement = ReadElement();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14653,12 +14653,12 @@ public partial class MainViewModel :
 
         if (matroskaSubtitleInfo.CodecId.Equals("S_HDMV/TEXTST", StringComparison.OrdinalIgnoreCase))
         {
-            return LoadTextSTFromMatroska(matroskaSubtitleInfo, matroska);
+            return await LoadTextSTFromMatroska(matroskaSubtitleInfo, matroska);
         }
 
         if (matroskaSubtitleInfo.CodecId.Equals("S_DVBSUB", StringComparison.OrdinalIgnoreCase))
         {
-            return LoadDvbFromMatroska(matroskaSubtitleInfo, matroska, fileName);
+            return await LoadDvbFromMatroska(matroskaSubtitleInfo, matroska, fileName);
         }
 
         if (matroskaSubtitleInfo.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase))
@@ -14666,7 +14666,7 @@ public partial class MainViewModel :
             return await LoadVobSubFromMatroska(matroskaSubtitleInfo, matroska, fileName);
         }
 
-        var sub = matroska.GetSubtitle(matroskaSubtitleInfo.TrackNumber, null);
+        var sub = await ExtractMatroskaSubtitleAsync(matroska, matroskaSubtitleInfo.TrackNumber);
         var subtitle = new Subtitle();
         var format = Utilities.LoadMatroskaTextSubtitle(matroskaSubtitleInfo, matroska, sub, subtitle);
         VideoCloseFile();
@@ -14684,10 +14684,10 @@ public partial class MainViewModel :
         track.CodecId.Equals("S_DVBSUB", StringComparison.OrdinalIgnoreCase) ||
         track.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase);
 
-    private bool LoadDvbFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska, string fileName)
+    private async Task<bool> LoadDvbFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska, string fileName)
     {
         ShowStatus(Se.Language.Main.ParsingMatroskaFile);
-        var sub = matroska.GetSubtitle(matroskaSubtitleInfo.TrackNumber, MatroskaProgress);
+        var sub = await ExtractMatroskaSubtitleAsync(matroska, matroskaSubtitleInfo.TrackNumber);
 
         _subtitle.Paragraphs.Clear();
         var subtitleImages = new List<DvbSubPes>();
@@ -14805,7 +14805,7 @@ public partial class MainViewModel :
             return false;
         }
 
-        var sub = matroska.GetSubtitle(matroskaSubtitleInfo.TrackNumber, MatroskaProgress);
+        var sub = await ExtractMatroskaSubtitleAsync(matroska, matroskaSubtitleInfo.TrackNumber);
         _subtitle.Paragraphs.Clear();
 
         List<VobSubMergedPack> mergedVobSubPacks = [];
@@ -14863,15 +14863,49 @@ public partial class MainViewModel :
         return false;
     }
 
-    private void MatroskaProgress(long position, long total)
+    // Files smaller than this parse fast enough that a progress window would only
+    // flash; above it the extraction can take long enough to warrant feedback.
+    private const long MatroskaProgressWindowMinFileSize = 25 * 1024 * 1024; // 25 MB
+
+    /// <summary>
+    /// Extracts a Matroska track's blocks on a background thread so the UI stays
+    /// responsive, showing a determinate "Please wait..." window with percentage
+    /// progress for large files. Must be called on the UI thread.
+    /// </summary>
+    private async Task<List<MatroskaSubtitle>> ExtractMatroskaSubtitleAsync(MatroskaFile matroska, int trackNumber)
     {
-        // UpdateProgress(position, total, _language.ParsingMatroskaFile);
+        PleaseWaitViewModel? pleaseWaitVm = null;
+        long fileSize = 0;
+        try
+        {
+            fileSize = new FileInfo(matroska.Path).Length;
+        }
+        catch
+        {
+            // ignore - just means no size-based gating
+        }
+
+        if (fileSize >= MatroskaProgressWindowMinFileSize)
+        {
+            pleaseWaitVm = _windowService.ShowWindow<PleaseWaitWindow, PleaseWaitViewModel>(Window!);
+            pleaseWaitVm.StatusText = Se.Language.Main.ParsingMatroskaFile;
+        }
+
+        try
+        {
+            var vm = pleaseWaitVm;
+            return await Task.Run(() => matroska.GetSubtitle(trackNumber, (pos, total) => vm?.ReportProgress(pos, total)));
+        }
+        finally
+        {
+            pleaseWaitVm?.Close();
+        }
     }
 
-    private bool LoadTextSTFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska)
+    private async Task<bool> LoadTextSTFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska)
     {
         ShowStatus(Se.Language.Main.ParsingMatroskaFile);
-        var sub = matroska.GetSubtitle(matroskaSubtitleInfo.TrackNumber, MatroskaProgress);
+        var sub = await ExtractMatroskaSubtitleAsync(matroska, matroskaSubtitleInfo.TrackNumber);
 
         VideoCloseFile();
         _subtitle.Paragraphs.Clear();

--- a/src/ui/Features/Shared/PleaseWaitViewModel.cs
+++ b/src/ui/Features/Shared/PleaseWaitViewModel.cs
@@ -15,12 +15,55 @@ namespace Nikse.SubtitleEdit.Features.Shared;
 public partial class PleaseWaitViewModel : ObservableObject
 {
     [ObservableProperty] private string _statusText;
+    [ObservableProperty] private double _progressValue;
+    [ObservableProperty] private bool _isIndeterminate = true;
+
+    private int _lastPercent = -1;
 
     public Window? Window { get; set; }
 
     public PleaseWaitViewModel()
     {
         _statusText = Se.Language.General.PleaseWait;
+    }
+
+    /// <summary>
+    /// Switches the progress bar to determinate mode and updates it (0-100).
+    /// Safe to call from a background thread; updates are throttled to whole
+    /// percent changes so a tight progress callback does not flood the UI thread.
+    /// </summary>
+    public void ReportProgress(long position, long total, string? statusText = null)
+    {
+        if (total <= 0)
+        {
+            return;
+        }
+
+        var percent = (int)(position * 100 / total);
+        if (percent < 0)
+        {
+            percent = 0;
+        }
+        else if (percent > 100)
+        {
+            percent = 100;
+        }
+
+        if (percent == _lastPercent)
+        {
+            return;
+        }
+
+        _lastPercent = percent;
+        Dispatcher.UIThread.Post(() =>
+        {
+            IsIndeterminate = false;
+            ProgressValue = percent;
+            if (statusText != null)
+            {
+                StatusText = statusText;
+            }
+        });
     }
 
     public void Close()

--- a/src/ui/Features/Shared/PleaseWaitWindow.cs
+++ b/src/ui/Features/Shared/PleaseWaitWindow.cs
@@ -38,9 +38,13 @@ public class PleaseWaitWindow : Window
         var progressBar = new ProgressBar
         {
             IsIndeterminate = true,
+            Minimum = 0,
+            Maximum = 100,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             Height = 8,
         };
+        progressBar.Bind(ProgressBar.IsIndeterminateProperty, new Binding(nameof(vm.IsIndeterminate)));
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
 
         Content = new StackPanel
         {


### PR DESCRIPTION
Fixes the slow open + missing progress for large MKV files with embedded subtitles reported in #6772.

## Part 1 — Faster MKV reading

Subtitle/track extraction walks the entire cluster structure but only needs a tiny fraction of the data: it reads each block's small header and seeks past the large video/audio payloads. The 64 KB `FileStream` buffer was counter‑productive — the forward skips (~21 KB on the sample files) are usually smaller than the buffer, so `FileStream` kept refilling contiguously and ended up pulling **almost the whole file off disk** (~700 MB read to extract ~1.7 MB of subtitles from a 1 GB file).

Switching to a **4 KB (one page) read buffer** makes the skips fall outside the buffer, so the skipped payloads are never read.

Measured read volume per call on the 1 GB jpsdr samples (deterministic, via `GetProcessIoCounters.ReadTransferCount`):

| buffer | MB read |
|-------:|--------:|
| 64 KB (old) | ~700 |
| 16 KB | ~440 |
| 8 KB | ~330 |
| **4 KB (new)** | **~175** |

Cold‑open time dropped from ~2.4–5.9 s to ~0.35–0.68 s (~5–10x) with **identical cue counts**.

Note: memory‑mapping (the old SE4 approach) was measured to be the *slowest* cold option here (~3.5–4.8 s on NVMe) due to synchronous page‑fault stalls, so it was intentionally not reintroduced.

## Part 2 — Progress window when opening large MKV

`SubtitleOpen` → `ImportSubtitleFromMatroskaFile` runs on the UI thread, so `GetSubtitle` froze the UI on large files. Extraction now runs on a background thread (`ExtractMatroskaSubtitleAsync`) so the UI stays responsive, and a determinate **"Please wait…" window with percentage progress** is shown for files ≥ 25 MB (small files parse instantly, so no flashing). All four extraction paths (text, DVB, VobSub, TEXT‑ST) route through it.

`PleaseWaitViewModel` gained `ReportProgress`/`ProgressValue`/`IsIndeterminate` (throttled to whole‑percent, marshalled to the UI thread); it defaults to indeterminate so existing callers (e.g. the yt‑dlp probe) are unchanged.

## Testing

- libse + UI build clean; Matroska libse tests pass.
- Benchmarked the four jpsdr sample files (~850 MB–1 GB) — read volume and timing as above, cue counts unchanged.
- Manually verified in the running app: large MKV opens fast, the progress window appears with an advancing percentage and closes cleanly into the OCR dialog, no UI freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
