### PR TITLE
Make text box italic/bold/underline toggle intelligent like SE4 (#11711)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13492,8 +13492,12 @@ public partial class MainViewModel :
 
             tb.Text = text;
 
-            // Keep the caret next to where it was; tag length is 3 for <i>/<b>/<u>.
-            var newCaret = textLen > text.Length ? Math.Max(selectionStart - 3, 0) : selectionStart + 3;
+            // Keep the caret next to where it was, shifting by the length of the opening
+            // tag inserted before it: "<i>" (3) for HTML, "{\i1}" (5) for ASSA.
+            var openTagLength = isAssa ? tag.Length + 4 : tag.Length + 2;
+            var newCaret = textLen > text.Length
+                ? Math.Max(selectionStart - openTagLength, 0)
+                : selectionStart + openTagLength;
             Dispatcher.UIThread.Post(() =>
             {
                 tb.Focus();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11360,7 +11360,7 @@ public partial class MainViewModel :
     private void TextBoxBold()
     {
         var tb = EditTextBox;
-        ToggleTextBoxTag(tb, "b", "b1", "b0");
+        ToggleTextBoxTag(tb, "b");
         _updateAudioVisualizer = true;
     }
 
@@ -11368,7 +11368,7 @@ public partial class MainViewModel :
     private void TextBoxItalic()
     {
         var tb = EditTextBox;
-        ToggleTextBoxTag(tb, "i", "i1", "i0");
+        ToggleTextBoxTag(tb, "i");
         _updateAudioVisualizer = true;
     }
 
@@ -11376,7 +11376,7 @@ public partial class MainViewModel :
     private void TextBoxUnderline()
     {
         var tb = EditTextBox;
-        ToggleTextBoxTag(tb, "u", "u1", "u0");
+        ToggleTextBoxTag(tb, "u");
         _updateAudioVisualizer = true;
     }
 
@@ -13443,71 +13443,100 @@ public partial class MainViewModel :
         }, DispatcherPriority.Background);
     }
 
-    private bool ToggleTextBoxTag(ITextBoxWrapper tb, string htmlTag, string assaOn, string assaOff)
+    private bool ToggleTextBoxTag(ITextBoxWrapper tb, string tag)
     {
         if (tb == null || tb.Text == null)
         {
             return false;
         }
 
+        var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
         var selectionStart = Math.Min(tb.SelectionStart, tb.SelectionEnd);
         var selectionEnd = Math.Max(tb.SelectionStart, tb.SelectionEnd);
         var selectionLength = selectionEnd - selectionStart;
 
-        var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
+        // No text selected - toggle the whole line (or just the current dialog line).
         if (selectionLength == 0)
         {
-            if (isAssa)
+            var text = tb.Text;
+            var lines = text.SplitToLines();
+
+            // Find the line where the caret is currently located (do not count wrapped lines).
+            var numberOfNewLines = 0;
+            for (var i = 0; i < selectionStart && i < text.Length; i++)
             {
-                if (tb.Text.Contains("{\\" + assaOn + "}"))
+                if (text[i] == '\n')
                 {
-                    tb.Text = tb.Text.Replace("{\\" + assaOn + "}", string.Empty)
-                        .Replace("{\\" + assaOff + "}", string.Empty);
+                    numberOfNewLines++;
                 }
-                else
-                {
-                    tb.Text = "{\\" + assaOn + "}" + tb.Text + "{\\" + assaOff + "}";
-                }
+            }
+
+            var selectedLineIdx = Math.Min(numberOfNewLines, lines.Count - 1);
+            var selectedLine = lines[selectedLineIdx];
+
+            // When the caret is on a dialog line ("- ..."), only toggle that line so the
+            // other speaker's line keeps its formatting.
+            var isDialog = selectedLine.StartsWith('-') ||
+                           selectedLine.StartsWith("<" + tag + ">-", StringComparison.OrdinalIgnoreCase);
+
+            var textLen = text.Length;
+            if (isDialog)
+            {
+                lines[selectedLineIdx] = HtmlUtil.ToggleTag(selectedLine, tag, false, isAssa);
+                text = string.Join(Environment.NewLine, lines);
             }
             else
             {
-                if (tb.Text.Contains("<" + htmlTag + ">"))
-                {
-                    tb.Text = HtmlUtil.RemoveOpenCloseTags(tb.Text, htmlTag);
-                }
-                else
-                {
-                    tb.Text = "<" + htmlTag + ">" + tb.Text + "</" + htmlTag + ">";
-                }
+                text = HtmlUtil.ToggleTag(text, tag, false, isAssa);
             }
+
+            tb.Text = text;
+
+            // Keep the caret next to where it was; tag length is 3 for <i>/<b>/<u>.
+            var newCaret = textLen > text.Length ? Math.Max(selectionStart - 3, 0) : selectionStart + 3;
+            Dispatcher.UIThread.Post(() =>
+            {
+                tb.Focus();
+                tb.SelectionStart = newCaret;
+                tb.SelectionEnd = newCaret;
+            });
         }
         else
         {
+            // Move leading/trailing white-space (spaces and new-lines) outside the tag so
+            // " 'word'" becomes " <i>'word'</i>" instead of "<i> 'word'</i>".
+            var pre = string.Empty;
+            var post = string.Empty;
             var selectedText = tb.Text.Substring(selectionStart, selectionLength);
+            while (selectedText.EndsWith(' ') || selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal) ||
+                   selectedText.StartsWith(' ') || selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                if (selectedText.EndsWith(' '))
+                {
+                    post = " " + post;
+                    selectedText = selectedText.Remove(selectedText.Length - 1);
+                }
 
-            if (isAssa)
-            {
-                if (selectedText.Contains("{\\" + assaOn + "}"))
+                if (selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal))
                 {
-                    selectedText = selectedText.Replace("{\\" + assaOn + "}", string.Empty)
-                        .Replace("{\\" + assaOff + "}", string.Empty);
+                    post = Environment.NewLine + post;
+                    selectedText = selectedText.Remove(selectedText.Length - Environment.NewLine.Length);
                 }
-                else
+
+                if (selectedText.StartsWith(' '))
                 {
-                    selectedText = "{\\" + assaOn + "}" + selectedText + "{\\" + assaOff + "}";
+                    pre += " ";
+                    selectedText = selectedText.Remove(0, 1);
                 }
-            }
-            else
-            {
-                if (selectedText.Contains("<" + htmlTag + ">"))
+
+                if (selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
                 {
-                    selectedText = HtmlUtil.RemoveOpenCloseTags(selectedText, htmlTag);
-                }
-                else
-                {
-                    selectedText = "<" + htmlTag + ">" + selectedText + "</" + htmlTag + ">";
+                    pre += Environment.NewLine;
+                    selectedText = selectedText.Remove(0, Environment.NewLine.Length);
                 }
             }
+
+            selectedText = pre + HtmlUtil.ToggleTag(selectedText, tag, false, isAssa) + post;
 
             tb.Text = tb.Text
                 .Remove(selectionStart, selectionLength)


### PR DESCRIPTION
Fixes #11711

## Problem

In SE4, pressing **Ctrl+I** on a selection that included surrounding white-space put that white-space *outside* the tags. SE5 wrapped exactly what was selected:

| Selected text | SE4 | SE5 (before) |
|---|---|---|
| `'' 'Hondenvoer'`'' (space before) | `Er staat <i>''Hondenvoer''</i> op.` | `Er staat<i> ''Hondenvoer''</i> op.` |

The `<i> ...</i>` form is also invalid styling (leading space inside the tag).

## Fix

`ToggleTextBoxTag` in `MainViewModel` is now a faithful port of SE4''s `TextBoxListViewToggleTag`, delegating the actual tag manipulation to the existing shared `HtmlUtil.ToggleTag`. This brings back SE4''s "intelligent" behavior:

- **White-space stays outside the tag** — leading/trailing spaces and new-lines are moved out, so `'' ''word''''` becomes `'' <i>''word''''</i>` rather than `<i> ''word''''</i>`.
- **Dialog-aware whole-line toggle** — with no selection, when the caret is on a dialog line (`- ...`) only that line is toggled, leaving the other speaker''s line untouched.
- **Smarter tag handling via `HtmlUtil.ToggleTag`** — case-insensitive detection of existing tags, and the opening tag is inserted *after* a leading ASSA override block (e.g. `{\pos(..)}`).

Applies to italic, bold and underline (they share the method) for both HTML and ASSA formats.

## Testing

- `dotnet build src/ui/UI.csproj` succeeds (only a pre-existing unrelated nullability warning).
- Verified the whitespace, dialog-line, and ASSA cases against the SE4 source behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)