### PR TITLE
Add auto-save of the open subtitle file (Options > General)

### DIFF
--- a/src/ui/Features/Main/AutoSaveDebounce.cs
+++ b/src/ui/Features/Main/AutoSaveDebounce.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Main;
+
+/// <summary>
+/// Pure decision logic for the debounced auto-save in <see cref="MainViewModel"/>.
+/// Kept side-effect free so it can be unit tested without spinning up the view model.
+/// </summary>
+public static class AutoSaveDebounce
+{
+    public enum Action
+    {
+        /// <summary>Nothing to do this tick (no changes, or still waiting for the idle window).</summary>
+        Skip,
+
+        /// <summary>Content just changed - (re)start the idle window and remember the new content hash.</summary>
+        Arm,
+
+        /// <summary>Content has been idle long enough - write the file(s) now.</summary>
+        Save,
+    }
+
+    /// <summary>
+    /// Decides what auto-save should do this tick.
+    /// </summary>
+    /// <param name="mainDirty">Main subtitle has unsaved changes.</param>
+    /// <param name="originalDirty">Original/translation subtitle has unsaved changes.</param>
+    /// <param name="settleHash">Combined content hash for the current tick.</param>
+    /// <param name="previousSettleHash">Content hash recorded when the idle window was last armed.</param>
+    /// <param name="lastChangeUtc">When the idle window was last armed.</param>
+    /// <param name="nowUtc">Current time.</param>
+    /// <param name="idleSeconds">How long content must be unchanged before saving.</param>
+    public static Action Decide(
+        bool mainDirty,
+        bool originalDirty,
+        int settleHash,
+        int previousSettleHash,
+        DateTime lastChangeUtc,
+        DateTime nowUtc,
+        double idleSeconds)
+    {
+        if (!mainDirty && !originalDirty)
+        {
+            return Action.Skip;
+        }
+
+        // Content changed since we last looked - restart the idle window.
+        if (settleHash != previousSettleHash)
+        {
+            return Action.Arm;
+        }
+
+        // Same content as last tick, but not idle long enough yet.
+        if ((nowUtc - lastChangeUtc).TotalSeconds < idleSeconds)
+        {
+            return Action.Skip;
+        }
+
+        return Action.Save;
+    }
+}

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15203,22 +15203,38 @@ public partial class MainViewModel :
         return true;
     }
 
-    private async Task<bool> SaveSubtitle()
+    private async Task<bool> SaveSubtitle(bool isAutoSave = false)
     {
         if (Subtitles == null || !Subtitles.Any())
         {
-            ShowStatus(Se.Language.Main.NothingToSave);
+            if (!isAutoSave)
+            {
+                ShowStatus(Se.Language.Main.NothingToSave);
+            }
+
             return false;
         }
 
         if (string.IsNullOrEmpty(_subtitleFileName) || _converted)
         {
+            // Auto-save must never pop a "Save as" dialog - silently skip until the user picks a file.
+            if (isAutoSave)
+            {
+                return false;
+            }
+
             var result = await SaveSubtitleAs();
             return result;
         }
 
         if (_lastOpenSaveFormat == null || _lastOpenSaveFormat.Name != SelectedSubtitleFormat.Name)
         {
+            // Saving in a different format goes through "Save as"; do not trigger that automatically.
+            if (isAutoSave)
+            {
+                return false;
+            }
+
             var result = await SaveSubtitleAs();
             return result;
         }
@@ -15257,6 +15273,13 @@ public partial class MainViewModel :
         catch (Exception ex)
         {
             var message = string.Format(Se.Language.General.CouldNotSaveFileXErrorY, _subtitleFileName, ex.Message);
+            if (isAutoSave)
+            {
+                // Don't spam modal error dialogs on a timer; surface it in the status bar instead.
+                ShowStatus(message);
+                return false;
+            }
+
             await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK,
                 MessageBoxIcon.Error);
             return false;
@@ -15270,16 +15293,25 @@ public partial class MainViewModel :
         return true;
     }
 
-    private async Task<bool> SaveSubtitleOriginal()
+    private async Task<bool> SaveSubtitleOriginal(bool isAutoSave = false)
     {
         if (Subtitles == null || !Subtitles.Any())
         {
-            ShowStatus(Se.Language.Main.NothingToSaveOriginal);
+            if (!isAutoSave)
+            {
+                ShowStatus(Se.Language.Main.NothingToSaveOriginal);
+            }
+
             return false;
         }
 
         if (string.IsNullOrEmpty(_subtitleFileNameOriginal))
         {
+            if (isAutoSave)
+            {
+                return false;
+            }
+
             return await SaveSubtitleOriginalAs();
         }
 
@@ -15304,6 +15336,12 @@ public partial class MainViewModel :
         catch (Exception ex)
         {
             var message = string.Format(Se.Language.General.CouldNotSaveFileXErrorY, _subtitleFileNameOriginal, ex.Message);
+            if (isAutoSave)
+            {
+                ShowStatus(message);
+                return false;
+            }
+
             await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK,
                 MessageBoxIcon.Error);
             return false;
@@ -18824,6 +18862,7 @@ public partial class MainViewModel :
         {
             UpdateTitleStatus();
             UpdateGaps();
+            AutoSaveTick();
 
             var vp = GetVideoPlayerControl();
             if (!_mpvPreviewDirty || vp == null)
@@ -18861,6 +18900,86 @@ public partial class MainViewModel :
             }
         };
         _slowTimer.Start();
+    }
+
+    // Auto-save (saves the actual open file) state. Debounced: we only write once edits have
+    // settled so we don't hammer the disk while the user is typing.
+    private int _autoSaveSettleHash = -1;
+    private DateTime _autoSaveLastChangeUtc = DateTime.MinValue;
+    private bool _autoSaveInProgress;
+    private const double AutoSaveIdleSeconds = 1.5;
+
+    private async void AutoSaveTick()
+    {
+        if (!Se.Settings.General.AutoSave || _autoSaveInProgress)
+        {
+            return;
+        }
+
+        // Only auto-save real, already-named files in their current format. Anything that would
+        // open a "Save as" dialog (untitled, converted, format change) is left to the user.
+        if (IsEmpty ||
+            string.IsNullOrEmpty(_subtitleFileName) ||
+            _converted ||
+            _lastOpenSaveFormat == null ||
+            _lastOpenSaveFormat.Name != SelectedSubtitleFormat.Name)
+        {
+            return;
+        }
+
+        var currentHash = GetFastHash();
+        var originalHash = ShowColumnOriginalText ? GetFastHashOriginal() : 0;
+        var originalDirty = ShowColumnOriginalText &&
+                            !string.IsNullOrEmpty(_subtitleFileNameOriginal) &&
+                            _changeSubtitleHashOriginal != originalHash;
+        var mainDirty = currentHash != _changeSubtitleHash;
+
+        if (!mainDirty && !originalDirty)
+        {
+            return;
+        }
+
+        // Debounce: restart the idle window whenever either column keeps changing.
+        var settleHash = HashCode.Combine(currentHash, originalHash);
+        if (settleHash != _autoSaveSettleHash)
+        {
+            _autoSaveSettleHash = settleHash;
+            _autoSaveLastChangeUtc = DateTime.UtcNow;
+            return;
+        }
+
+        if ((DateTime.UtcNow - _autoSaveLastChangeUtc).TotalSeconds < AutoSaveIdleSeconds)
+        {
+            return;
+        }
+
+        _autoSaveInProgress = true;
+        try
+        {
+            var saved = false;
+            if (mainDirty)
+            {
+                saved |= await SaveSubtitle(isAutoSave: true);
+            }
+
+            if (originalDirty)
+            {
+                saved |= await SaveSubtitleOriginal(isAutoSave: true);
+            }
+
+            if (saved && !string.IsNullOrEmpty(_subtitleFileName))
+            {
+                ShowStatus(string.Format(Se.Language.General.SavedChangesToX, _subtitleFileName));
+            }
+        }
+        catch
+        {
+            // Auto-save runs on a timer; never let a failure bubble up as an unhandled async-void exception.
+        }
+        finally
+        {
+            _autoSaveInProgress = false;
+        }
     }
 
     private void UpdateTitleStatus()

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15239,7 +15239,12 @@ public partial class MainViewModel :
             return result;
         }
 
-        AutoTrimWhiteSpaces();
+        // Auto-save writes exactly what is on screen. AutoTrimWhiteSpaces() mutates the grid text,
+        // which is fine for an explicit Ctrl+S but surprising for a background timer save - so skip it.
+        if (!isAutoSave)
+        {
+            AutoTrimWhiteSpaces();
+        }
 
         var text = GetUpdateSubtitle(true).ToText(SelectedSubtitleFormat);
 
@@ -18860,9 +18865,14 @@ public partial class MainViewModel :
         _slowTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };
         _slowTimer.Tick += (s, e) =>
         {
-            UpdateTitleStatus();
+            // GetFastHash()/GetFastHashOriginal() are O(n) over all lines. Compute them once per tick
+            // and share with both the title dirty-star and auto-save so auto-save adds no extra passes.
+            var mainHash = GetFastHash();
+            var originalHash = ShowColumnOriginalText ? GetFastHashOriginal() : 0;
+
+            UpdateTitleStatus(mainHash, originalHash);
             UpdateGaps();
-            AutoSaveTick();
+            AutoSaveTick(mainHash, originalHash);
 
             var vp = GetVideoPlayerControl();
             if (!_mpvPreviewDirty || vp == null)
@@ -18904,12 +18914,17 @@ public partial class MainViewModel :
 
     // Auto-save (saves the actual open file) state. Debounced: we only write once edits have
     // settled so we don't hammer the disk while the user is typing.
+    //
+    // Deliberate trade-off: when enabled this writes straight back to the open file(s) on disk, so
+    // edits are persisted without an explicit Ctrl+S and there is no "discard changes?" prompt on
+    // close - the same data-loss model SE4's auto-save had. It is off by default and only ever
+    // overwrites the already-open file in its current format (never a Save-as).
     private int _autoSaveSettleHash = -1;
     private DateTime _autoSaveLastChangeUtc = DateTime.MinValue;
     private bool _autoSaveInProgress;
     private const double AutoSaveIdleSeconds = 1.5;
 
-    private async void AutoSaveTick()
+    private async void AutoSaveTick(int mainHash, int originalHash)
     {
         if (!Se.Settings.General.AutoSave || _autoSaveInProgress)
         {
@@ -18927,28 +18942,25 @@ public partial class MainViewModel :
             return;
         }
 
-        var currentHash = GetFastHash();
-        var originalHash = ShowColumnOriginalText ? GetFastHashOriginal() : 0;
         var originalDirty = ShowColumnOriginalText &&
                             !string.IsNullOrEmpty(_subtitleFileNameOriginal) &&
                             _changeSubtitleHashOriginal != originalHash;
-        var mainDirty = currentHash != _changeSubtitleHash;
+        var mainDirty = mainHash != _changeSubtitleHash;
 
-        if (!mainDirty && !originalDirty)
-        {
-            return;
-        }
+        var now = DateTime.UtcNow;
+        var settleHash = HashCode.Combine(mainHash, originalHash);
+        var action = AutoSaveDebounce.Decide(
+            mainDirty, originalDirty, settleHash, _autoSaveSettleHash, _autoSaveLastChangeUtc, now, AutoSaveIdleSeconds);
 
-        // Debounce: restart the idle window whenever either column keeps changing.
-        var settleHash = HashCode.Combine(currentHash, originalHash);
-        if (settleHash != _autoSaveSettleHash)
+        if (action == AutoSaveDebounce.Action.Arm)
         {
+            // Edits are still landing - restart the idle window and wait for things to settle.
             _autoSaveSettleHash = settleHash;
-            _autoSaveLastChangeUtc = DateTime.UtcNow;
+            _autoSaveLastChangeUtc = now;
             return;
         }
 
-        if ((DateTime.UtcNow - _autoSaveLastChangeUtc).TotalSeconds < AutoSaveIdleSeconds)
+        if (action != AutoSaveDebounce.Action.Save)
         {
             return;
         }
@@ -18956,20 +18968,21 @@ public partial class MainViewModel :
         _autoSaveInProgress = true;
         try
         {
-            var saved = false;
-            if (mainDirty)
-            {
-                saved |= await SaveSubtitle(isAutoSave: true);
-            }
+            var mainSaved = mainDirty && await SaveSubtitle(isAutoSave: true);
+            var originalSaved = originalDirty && await SaveSubtitleOriginal(isAutoSave: true);
 
-            if (originalDirty)
+            // Report the file(s) actually written, not always the main file name.
+            if (mainSaved && originalSaved)
             {
-                saved |= await SaveSubtitleOriginal(isAutoSave: true);
+                ShowStatus(string.Format(Se.Language.General.SavedChangesToXAndY, _subtitleFileName, _subtitleFileNameOriginal));
             }
-
-            if (saved && !string.IsNullOrEmpty(_subtitleFileName))
+            else if (mainSaved)
             {
                 ShowStatus(string.Format(Se.Language.General.SavedChangesToX, _subtitleFileName));
+            }
+            else if (originalSaved)
+            {
+                ShowStatus(string.Format(Se.Language.General.SavedChangesToX, _subtitleFileNameOriginal));
             }
         }
         catch
@@ -18982,7 +18995,7 @@ public partial class MainViewModel :
         }
     }
 
-    private void UpdateTitleStatus()
+    private void UpdateTitleStatus(int mainHash, int originalHash)
     {
         var text = Se.Language.General.Untitled;
         if (!string.IsNullOrEmpty(_subtitleFileName))
@@ -18996,7 +19009,7 @@ public partial class MainViewModel :
         {
             text += " + ";
 
-            if (_changeSubtitleHashOriginal != GetFastHashOriginal())
+            if (_changeSubtitleHashOriginal != originalHash)
             {
                 text += "*";
             }
@@ -19014,7 +19027,7 @@ public partial class MainViewModel :
         }
 
         text = text + " - " + Se.Language.Title + " " + Se.Version;
-        if (_changeSubtitleHash != GetFastHash())
+        if (_changeSubtitleHash != mainHash)
         {
             text = "*" + text;
         }

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -313,6 +313,7 @@ public class SettingsPage : UserControl
             }),
 
             MakeSeparator(),
+            MakeCheckboxSetting(Se.Language.Options.Settings.AutoSave, nameof(_vm.AutoSave)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoBackupOn, nameof(_vm.AutoBackupOn)),
             MakeNumericSettingInt(Se.Language.Options.Settings.AutoBackupIntervalMinutes, nameof(_vm.AutoBackupIntervalMinutes), 1),
             MakeNumericSettingInt(Se.Language.Options.Settings.AutoBackupDeleteAfterDays, nameof(_vm.AutoBackupDeleteAfterDays), 1),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -108,6 +108,7 @@ public partial class SettingsViewModel : ObservableObject
         ? Se.Language.Options.Settings.MinGapFrames
         : Se.Language.Options.Settings.MinGapMs;
     [ObservableProperty] private bool _textBoxLimitNewLines;
+    [ObservableProperty] private bool _autoSave;
     [ObservableProperty] private bool _autoBackupOn;
     [ObservableProperty] private int? _autoBackupIntervalMinutes;
     [ObservableProperty] private int? _autoBackupDeleteAfterDays;
@@ -620,6 +621,7 @@ public partial class SettingsViewModel : ObservableObject
         LockTimeCodes = general.LockTimeCodes;
         RememberPositionAndSize = general.RememberPositionAndSize;
         OpenLastFileOnStart = Se.Settings.File.OpenLastFileOnStart;
+        AutoSave = general.AutoSave;
         AutoBackupOn = general.AutoBackupOn;
         AutoBackupIntervalMinutes = general.AutoBackupIntervalMinutes;
         AutoBackupDeleteAfterDays = general.AutoBackupDeleteAfterDays;
@@ -1311,6 +1313,7 @@ public partial class SettingsViewModel : ObservableObject
         general.LockTimeCodes = LockTimeCodes;
         general.RememberPositionAndSize = RememberPositionAndSize;
         Se.Settings.File.OpenLastFileOnStart = OpenLastFileOnStart;
+        general.AutoSave = AutoSave;
         general.AutoBackupOn = AutoBackupOn;
         general.AutoBackupIntervalMinutes = AutoBackupIntervalMinutes ?? general.AutoBackupIntervalMinutes;
         general.AutoBackupDeleteAfterDays = AutoBackupDeleteAfterDays ?? general.AutoBackupDeleteAfterDays;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -106,6 +106,7 @@ public class LanguageSettings
     public string PromptBeforeDelete { get; set; }
     public string RememberPositionAndSize { get; set; }
     public string OpenLastFileOnStart { get; set; }
+    public string AutoSave { get; set; }
     public string AutoBackupOn { get; set; }
     public string AutoBackupIntervalMinutes { get; set; }
     public string AutoBackupDeleteAfterDays { get; set; }
@@ -413,6 +414,7 @@ public class LanguageSettings
         PromptBeforeDelete = "Prompt before delete";
         RememberPositionAndSize = "Remember window position and size";
         OpenLastFileOnStart = "Open last recent file on start";
+        AutoSave = "Auto-save (save the open file while editing)";
         AutoBackupOn = "Auto-backup";
         AutoBackupIntervalMinutes = "Auto-backup interval (minutes)";
         AutoBackupDeleteAfterDays = "Auto-backup retention (days)";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -61,6 +61,7 @@ public class SeGeneral
     public bool RememberPositionAndSize { get; set; }
     public bool UndockVideoControls { get; set; }
     public List<SeWindowPosition> WindowPositions { get; set; } = new List<SeWindowPosition>();
+    public bool AutoSave { get; set; }
     public bool AutoBackupOn { get; set; }
     public int AutoBackupIntervalMinutes { get; set; }
     public int AutoBackupDeleteAfterDays { get; set; }

--- a/tests/UI/Features/Main/AutoSaveDebounceTests.cs
+++ b/tests/UI/Features/Main/AutoSaveDebounceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Main;
+
+public class AutoSaveDebounceTests
+{
+    private static readonly DateTime Now = new(2026, 6, 22, 12, 0, 0, DateTimeKind.Utc);
+    private const double Idle = 1.5;
+
+    [Fact]
+    public void NoChanges_Skips()
+    {
+        var action = AutoSaveDebounce.Decide(
+            mainDirty: false, originalDirty: false, settleHash: 123, previousSettleHash: 123,
+            lastChangeUtc: Now.AddSeconds(-10), nowUtc: Now, idleSeconds: Idle);
+
+        Assert.Equal(AutoSaveDebounce.Action.Skip, action);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void ContentChangedSinceLastTick_Arms(bool mainDirty, bool originalDirty)
+    {
+        var action = AutoSaveDebounce.Decide(
+            mainDirty, originalDirty, settleHash: 999, previousSettleHash: 123,
+            lastChangeUtc: Now.AddSeconds(-10), nowUtc: Now, idleSeconds: Idle);
+
+        Assert.Equal(AutoSaveDebounce.Action.Arm, action);
+    }
+
+    [Fact]
+    public void SameContentButNotIdleLongEnough_Skips()
+    {
+        var action = AutoSaveDebounce.Decide(
+            mainDirty: true, originalDirty: false, settleHash: 123, previousSettleHash: 123,
+            lastChangeUtc: Now.AddSeconds(-1.0), nowUtc: Now, idleSeconds: Idle);
+
+        Assert.Equal(AutoSaveDebounce.Action.Skip, action);
+    }
+
+    [Fact]
+    public void SameContentAndIdleLongEnough_Saves()
+    {
+        var action = AutoSaveDebounce.Decide(
+            mainDirty: true, originalDirty: false, settleHash: 123, previousSettleHash: 123,
+            lastChangeUtc: Now.AddSeconds(-Idle), nowUtc: Now, idleSeconds: Idle);
+
+        Assert.Equal(AutoSaveDebounce.Action.Save, action);
+    }
+
+    [Fact]
+    public void DirtyButUnchanged_DoesNotReArm_SoIdleWindowCanElapse()
+    {
+        // Regression guard: a dirty-but-stable buffer must keep waiting (Skip), not re-Arm forever,
+        // otherwise the idle window would never elapse and auto-save would never fire.
+        var action = AutoSaveDebounce.Decide(
+            mainDirty: true, originalDirty: true, settleHash: 42, previousSettleHash: 42,
+            lastChangeUtc: Now.AddSeconds(-0.5), nowUtc: Now, idleSeconds: Idle);
+
+        Assert.Equal(AutoSaveDebounce.Action.Skip, action);
+    }
+}


### PR DESCRIPTION
## What
Adds a real **Auto-save** that writes changes back to the currently open subtitle file, so the user no longer has to press Ctrl+S / use the toolbar.

## Why
`GeneralSettings.AutoSave` already existed but was dead code: read nowhere and with no UI. Users who expected auto-save (SE4 parity) found their file was never saved automatically.

## How
- New **Auto-save** checkbox in Options > General (next to Auto-backup).
- Debounced via the existing 400 ms slow timer: once the subtitle (main and/or original column) has been idle ~1.5 s with unsaved changes, it writes back to the already-open file.
- Auto-save never opens a Save-As dialog (skips untitled / converted / format-changed files) and never shows modal error dialogs on a timer - failures go to the status bar.
- The separate Auto-backup feature is untouched.

Note: developed on macOS; not yet runtime-tested by CI at time of opening.