### PR TITLE
Reliably remember a subtitle's media across reopen (SE4 parity)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16078,6 +16078,15 @@ public partial class MainViewModel :
             }
         }
 
+        // Persist the media association as soon as the file opens so reopening this subtitle
+        // reloads the same video/audio even if the app is force-quit before OnClosing runs.
+        // Guarded by a known subtitle name so opening media without a subtitle doesn't create
+        // a blank recent entry. AddToRecentFiles itself no-ops while still loading.
+        if (!string.IsNullOrEmpty(_subtitleFileName))
+        {
+            AddToRecentFiles(false);
+        }
+
         var _ = Task.Run(() =>
         {
             Dispatcher.UIThread.Post(() => LoadWaveformAndSpectrogram(videoFileName));

--- a/src/ui/Logic/Config/SeFile.cs
+++ b/src/ui/Logic/Config/SeFile.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Features.Files.ExportCustomTextFormat;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -40,6 +41,23 @@ public class SeFile
 
     public void AddToRecentFiles(string subtitleFileName, string subtitleFileNameOriginal, string videoFileName, int selectedLine, string encoding, long VideoOffsetInMs, bool videoIsSmpte, int audioTrack)
     {
+        var existing = RecentFiles.FirstOrDefault(rf =>
+            rf.SubtitleFileName == subtitleFileName && rf.SubtitleFileNameOriginal == subtitleFileNameOriginal);
+
+        // Don't erase the media this subtitle was last opened with: if no video/audio is
+        // currently loaded, inherit the remembered one (and its track/offset) so reopening the
+        // subtitle reloads the same media, like SE4. A real media path always overwrites.
+        if (string.IsNullOrEmpty(videoFileName) && existing != null && !string.IsNullOrEmpty(existing.VideoFileName))
+        {
+            videoFileName = existing.VideoFileName;
+            VideoOffsetInMs = existing.VideoOffsetInMs;
+            videoIsSmpte = existing.VideoIsSmpte;
+            if (audioTrack < 0)
+            {
+                audioTrack = existing.AudioTrack;
+            }
+        }
+
         RecentFiles.RemoveAll(rf => rf.SubtitleFileName == subtitleFileName && rf.SubtitleFileNameOriginal == subtitleFileNameOriginal);
 
         RecentFiles.Insert(0, new RecentFile


### PR DESCRIPTION
## What
Makes a subtitle reliably reopen with the video/audio it was last worked on, like SE4.

## Why
The media association lives only in the recent-files entry, and persistence was brittle:
- `VideoOpenFile` never wrote the association - it was saved only at the end of `SubtitleOpen` and on a clean `OnClosing`, so a force-quit (or app quit that doesn't raise the window-closing event) lost it.
- `AddToRecentFiles` overwrote `VideoFileName` with the currently-open media, so re-adding a subtitle with no video loaded (auto-open off, or video manually closed) erased the remembered media.

## How
- Persist the media association immediately when a local video/audio opens (guarded by a known subtitle name so opening media alone doesn't create a blank entry).
- When `AddToRecentFiles` is given no media, inherit the previously remembered video/audio (plus its track / offset / SMPTE flag) instead of clearing it. A real media path still overwrites.

Builds on the existing restore path (#11616).

Note: developed on macOS; not yet runtime-tested by CI at time of opening.