### PR TITLE
Add MLX Whisper Mac speech-to-text engine (Apple GPU / Neural Engine)

### DIFF
--- a/src/libse/AudioToText/WhisperChoice.cs
+++ b/src/libse/AudioToText/WhisperChoice.cs
@@ -10,6 +10,7 @@
         public const string WhisperX = "WhisperX";
         public const string ConstMe = "Const-me";
         public const string CTranslate2 = "CTranslate2";
+        public const string MlxWhisperMac = "MLX Whisper Mac";
         public const string StableTs = "stable-ts";
         public const string PurfviewFasterWhisperXxl = "Purfview's Faster-Whisper-XXL";
         public const string ChatLlm = "Chat LLM";

--- a/src/ui/Assets/SpeechToText/MlxWhisperMac.txt
+++ b/src/ui/Assets/SpeechToText/MlxWhisperMac.txt
@@ -1,0 +1,22 @@
+MLX Whisper Mac runs Apple's "mlx-whisper" Python library via python3.
+
+Requirements
+- An Apple Silicon Mac (M1 or newer).
+- Install once:  pip3 install mlx-whisper
+
+Why use it
+MLX runs Whisper on the Apple GPU and Neural Engine via Apple's MLX framework,
+so on M-series Macs it is typically much faster than the CPU-only
+"Faster Whisper Mac" engine, at the same accuracy.
+
+Models
+tiny, base, small, medium, large-v2, large-v3, large-v3-turbo. These are
+MLX-format Whisper weights hosted on Hugging Face (the mlx-community org) and are
+downloaded automatically on first use.
+
+Tip: large-v3-turbo is multilingual and the best speed/quality pick.
+
+Advanced
+The "command line parameters" box is passed through to the helper script. You can
+also type a full Hugging Face repo id as the model (anything containing "/") to use
+a custom MLX Whisper model.

--- a/src/ui/Assets/SpeechToText/mlx_whisper_transcribe.py
+++ b/src/ui/Assets/SpeechToText/mlx_whisper_transcribe.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Subtitle Edit - MLX Whisper Mac helper.
+
+Transcribes an audio file with Apple's MLX implementation of Whisper
+(the `mlx-whisper` pip package) and writes a subtitle file (SRT or VTT)
+into the output directory, named <audio-basename>.<ext>, which Subtitle Edit
+then loads.
+
+Unlike CTranslate2 (faster-whisper), MLX runs on the Apple Silicon GPU and
+Neural Engine via Apple's MLX framework, so on M-series Macs it is typically
+much faster than the CPU-only faster-whisper path. Models are MLX-format
+Whisper weights hosted on Hugging Face (e.g. mlx-community/whisper-large-v3-turbo)
+and are downloaded automatically on first use.
+
+Each segment is printed as `[MM:SS.mmm --> MM:SS.mmm] text` so the host can show
+live progress and, if needed, recover the transcript from stdout.
+"""
+import argparse
+import os
+import sys
+
+
+def fmt_timestamp(seconds, sep):
+    if seconds < 0:
+        seconds = 0.0
+    total_ms = int(round(seconds * 1000))
+    hours, total_ms = divmod(total_ms, 3600000)
+    minutes, total_ms = divmod(total_ms, 60000)
+    secs, millis = divmod(total_ms, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}{sep}{millis:03d}"
+
+
+def fmt_short(seconds):
+    if seconds < 0:
+        seconds = 0.0
+    total_ms = int(round(seconds * 1000))
+    minutes, total_ms = divmod(total_ms, 60000)
+    secs, millis = divmod(total_ms, 1000)
+    return f"{minutes:02d}:{secs:02d}.{millis:03d}"
+
+
+def load_wav_as_array(path):
+    """Read a PCM WAV directly into a 16 kHz mono float32 array.
+
+    mlx-whisper's own loader shells out to the `ffmpeg` binary, which may be
+    missing or not executable in the host's environment. Subtitle Edit always
+    feeds a 16 kHz mono PCM WAV, so we decode it here with the standard library
+    and hand mlx-whisper the waveform directly, avoiding ffmpeg entirely.
+    Returns a float32 numpy array, or None if the file is not a WAV we can read.
+    """
+    import wave
+    import numpy as np
+
+    with wave.open(path, "rb") as w:
+        channels = w.getnchannels()
+        sample_width = w.getsampwidth()
+        framerate = w.getframerate()
+        frames = w.readframes(w.getnframes())
+
+    if sample_width == 2:
+        data = np.frombuffer(frames, dtype="<i2").astype(np.float32) / 32768.0
+    elif sample_width == 4:
+        data = np.frombuffer(frames, dtype="<i4").astype(np.float32) / 2147483648.0
+    elif sample_width == 1:
+        data = (np.frombuffer(frames, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+    else:
+        return None  # unusual width - let mlx-whisper handle it via ffmpeg
+
+    if channels > 1:
+        data = data.reshape(-1, channels).mean(axis=1)
+
+    if framerate != 16000 and len(data) > 0:
+        target_len = int(round(len(data) * 16000 / framerate))
+        if target_len > 0:
+            old_idx = np.linspace(0.0, 1.0, num=len(data), endpoint=False)
+            new_idx = np.linspace(0.0, 1.0, num=target_len, endpoint=False)
+            data = np.interp(new_idx, old_idx, data).astype(np.float32)
+
+    return np.ascontiguousarray(data, dtype=np.float32)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="mlx-whisper transcription helper for Subtitle Edit")
+    parser.add_argument("--audio", required=True, help="Path to the input audio file")
+    parser.add_argument("--model", default="mlx-community/whisper-large-v3-turbo",
+                        help="MLX Whisper model (Hugging Face repo id)")
+    parser.add_argument("--language", default=None, help="Language code, or omit/auto to auto-detect")
+    parser.add_argument("--output-dir", default=None, help="Directory for the subtitle file (default: audio's folder)")
+    parser.add_argument("--output-format", default="srt", choices=["srt", "vtt"])
+    parser.add_argument("--task", default="transcribe", choices=["transcribe", "translate"])
+    args = parser.parse_args()
+
+    try:
+        import mlx_whisper
+    except ImportError:
+        print("error: mlx-whisper not found - install it with: pip3 install mlx-whisper",
+              file=sys.stderr)
+        return 3
+
+    if not os.path.isfile(args.audio):
+        print(f"error: audio file not found: {args.audio}", file=sys.stderr)
+        return 2
+
+    language = args.language
+    if language in (None, "", "auto"):
+        language = None
+
+    out_dir = args.output_dir or os.path.dirname(os.path.abspath(args.audio))
+    os.makedirs(out_dir, exist_ok=True)
+    base = os.path.splitext(os.path.basename(args.audio))[0]
+    ext = args.output_format
+    out_path = os.path.join(out_dir, base + "." + ext)
+
+    # Prefer decoding the WAV ourselves so we never depend on a system ffmpeg binary
+    # (mlx-whisper's path loader calls `ffmpeg`, which may be missing/non-executable).
+    audio_input = args.audio
+    if os.path.splitext(args.audio)[1].lower() == ".wav":
+        try:
+            arr = load_wav_as_array(args.audio)
+            if arr is not None:
+                audio_input = arr
+        except Exception as e:
+            print(f"warning: direct WAV load failed ({e}); falling back to ffmpeg path",
+                  file=sys.stderr, flush=True)
+
+    print(f"Loading MLX Whisper model '{args.model}' (Apple GPU/Neural Engine)...", flush=True)
+    result = mlx_whisper.transcribe(
+        audio_input,
+        path_or_hf_repo=args.model,
+        language=language,
+        task=args.task,
+        verbose=False,
+    )
+
+    detected = result.get("language", language or "?")
+    print(f"Detected language: {detected}", flush=True)
+
+    collected = []
+    for seg in result.get("segments", []):
+        text = (seg.get("text") or "").strip()
+        start = float(seg.get("start", 0.0))
+        end = float(seg.get("end", 0.0))
+        # Progress line; matches the host's short-timestamp parser for a stdout fallback.
+        print(f"[{fmt_short(start)} --> {fmt_short(end)}] {text}", flush=True)
+        collected.append((start, end, text))
+
+    sep = "," if ext == "srt" else "."
+    with open(out_path, "w", encoding="utf-8") as f:
+        if ext == "vtt":
+            f.write("WEBVTT\n\n")
+        for index, (start, end, text) in enumerate(collected, 1):
+            if ext == "srt":
+                f.write(f"{index}\n")
+            f.write(f"{fmt_timestamp(start, sep)} --> {fmt_timestamp(end, sep)}\n{text}\n\n")
+
+    print(f"Wrote {len(collected)} subtitle(s) to {out_path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Avalonia.Platform;
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// Speech-to-text engine for Apple Silicon Macs that drives the pip-installed "mlx-whisper"
+/// Python package. Unlike CTranslate2 / faster-whisper (CPU-only on macOS), MLX runs Whisper on
+/// the Apple GPU and Neural Engine via Apple's MLX framework, so on M-series Macs it is typically
+/// much faster. Because the pip package ships a library rather than a console tool, transcription
+/// runs a small bundled helper script (<c>mlx_whisper_transcribe.py</c>) via <c>python3</c>, which
+/// writes an SRT next to the input audio. Installation is detected by importing the package
+/// (<c>python3 -c "import mlx_whisper"</c>); MLX-format models are downloaded automatically from
+/// Hugging Face (the <c>mlx-community</c> org) on first use.
+/// </summary>
+public class MlxWhisperMac : ISpeechToTextEngine
+{
+    public static string StaticName => "MLX Whisper Mac";
+    public string Name => StaticName;
+    public string Choice => WhisperChoice.MlxWhisperMac;
+    public string Url => "https://github.com/ml-explore/mlx-examples/tree/main/whisper";
+
+    private const string TranscribeScriptName = "mlx_whisper_transcribe.py";
+
+    // Friendly model name -> MLX-format Hugging Face repo (mlx-community).
+    private static readonly Dictionary<string, string> ModelRepos = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["tiny"] = "mlx-community/whisper-tiny-mlx",
+        ["base"] = "mlx-community/whisper-base-mlx",
+        ["small"] = "mlx-community/whisper-small-mlx",
+        ["medium"] = "mlx-community/whisper-medium-mlx",
+        ["large-v2"] = "mlx-community/whisper-large-v2-mlx",
+        ["large-v3"] = "mlx-community/whisper-large-v3-mlx",
+        ["large-v3-turbo"] = "mlx-community/whisper-large-v3-turbo",
+    };
+
+    private static bool? _isMlxWhisperInstalled;
+
+    public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
+
+    // Built explicitly (not filtered from the CTranslate2 list, which has no turbo entry). large-v3-turbo
+    // is multilingual and the best speed/quality pick; on the Apple GPU it is very fast. Sizes are the
+    // approximate MLX download sizes. Models download from Hugging Face automatically on first use.
+    public List<WhisperModel> Models => new List<WhisperModel>
+    {
+        new WhisperModel { Name = "large-v3-turbo", Size = "1.6 GB" },
+        new WhisperModel { Name = "large-v3", Size = "2.9 GB" },
+        new WhisperModel { Name = "large-v2", Size = "2.9 GB" },
+        new WhisperModel { Name = "medium", Size = "1.5 GB" },
+        new WhisperModel { Name = "small", Size = "483 MB" },
+        new WhisperModel { Name = "base", Size = "145 MB" },
+        new WhisperModel { Name = "tiny", Size = "75 MB" },
+    };
+
+    public string Extension => string.Empty;
+    public string UnpackSkipFolder => string.Empty;
+
+    public string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterMlxWhisperMac;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterMlxWhisperMac = value;
+    }
+
+    public bool IsEngineInstalled()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return false;
+        }
+
+        if (_isMlxWhisperInstalled.HasValue)
+        {
+            return _isMlxWhisperInstalled.Value;
+        }
+
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo(GetExecutable(), "-c \"import mlx_whisper\"")
+                {
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                }
+            };
+
+#pragma warning disable CA1416
+            process.Start();
+            if (!process.WaitForExit(10_000))
+            {
+                process.Kill(true);
+                _isMlxWhisperInstalled = false;
+                return false;
+            }
+#pragma warning restore CA1416
+
+            _isMlxWhisperInstalled = process.ExitCode == 0;
+        }
+        catch
+        {
+            _isMlxWhisperInstalled = false;
+        }
+
+        return _isMlxWhisperInstalled.Value;
+    }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+
+    public string GetAndCreateWhisperFolder()
+    {
+        var baseFolder = Se.SpeechToTextFolder;
+        if (!Directory.Exists(baseFolder))
+        {
+            Directory.CreateDirectory(baseFolder);
+        }
+
+        var folder = Path.Combine(baseFolder, "MlxWhisperMac");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        // mlx-whisper downloads models itself into the Hugging Face cache.
+        return new WhisperCTranslate2Model().ModelFolder;
+    }
+
+    public string GetExecutable()
+    {
+        // The engine drives the mlx-whisper *library* through python3 (see the class summary),
+        // so the executable is the Python interpreter. Probe the usual macOS install locations
+        // (Homebrew on Apple Silicon, Homebrew/python.org on Intel, the system Python) and fall
+        // back to PATH resolution.
+        var candidates = new[]
+        {
+            "/opt/homebrew/bin/python3",
+            "/usr/local/bin/python3",
+            "/usr/bin/python3",
+        };
+
+        foreach (var candidate in candidates)
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return "python3"; // resolved via PATH
+    }
+
+    /// <summary>
+    /// Extracts the bundled transcription helper script to the engine folder and returns its path.
+    /// The script is rewritten on every call so it always matches the running build.
+    /// </summary>
+    public string GetTranscribeScript()
+    {
+        var scriptPath = Path.Combine(GetAndCreateWhisperFolder(), TranscribeScriptName);
+
+        var uri = new Uri($"avares://SubtitleEdit/Assets/SpeechToText/{TranscribeScriptName}");
+        using var stream = AssetLoader.Open(uri);
+        using var fileStream = File.Create(scriptPath);
+        stream.CopyTo(fileStream);
+
+        return scriptPath;
+    }
+
+    public bool IsModelInstalled(WhisperModel model)
+    {
+        // mlx-whisper resolves models by Hugging Face repo and downloads them on first use,
+        // so any of the supported models can be used right away.
+        return true;
+    }
+
+    public string GetModelForCmdLine(string modelName)
+    {
+        if (string.IsNullOrWhiteSpace(modelName))
+        {
+            return ModelRepos["large-v3-turbo"];
+        }
+
+        // Allow passing a full Hugging Face repo id directly.
+        if (modelName.Contains('/'))
+        {
+            return modelName;
+        }
+
+        return ModelRepos.TryGetValue(modelName, out var repo) ? repo : modelName;
+    }
+
+    public async Task<string> GetHelpText()
+    {
+        var assetName = $"{StaticName.Replace(" ", string.Empty)}.txt";
+        var uri = new Uri($"avares://SubtitleEdit/Assets/SpeechToText/{assetName}");
+
+        try
+        {
+            await using var stream = AssetLoader.Open(uri);
+            using var reader = new StreamReader(stream);
+            var contents = await reader.ReadToEndAsync();
+            return contents;
+        }
+        catch
+        {
+            return "MLX Whisper Mac runs Apple's \"mlx-whisper\" Python library via python3.\n\n" +
+                   "Install it with: pip3 install mlx-whisper\n\n" +
+                   "Requires an Apple Silicon Mac. MLX runs Whisper on the GPU / Neural Engine, so it is\n" +
+                   "typically much faster than the CPU-only Faster Whisper Mac engine.\n\n" +
+                   "Models (tiny, base, small, medium, large-v2, large-v3, large-v3-turbo) are MLX-format\n" +
+                   "weights downloaded from Hugging Face (mlx-community) on first use.\n" +
+                   "Tip: large-v3-turbo is multilingual and the best speed/quality pick.";
+        }
+    }
+
+    public string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        return string.Empty;
+    }
+
+    public bool CanBeDownloaded()
+    {
+        return false;
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
@@ -42,6 +42,11 @@ public static class WhisperEngineFactory
             return new WhisperEnginePurfviewFasterWhisperXxl();
         }
 
+        if (staticName == MlxWhisperMac.StaticName)
+        {
+            return new MlxWhisperMac();
+        }
+
         if (staticName == Qwen3AsrCppEngine.StaticName)
         {
             return new Qwen3AsrCppEngine();

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -198,6 +198,14 @@ public partial class SpeechToTextViewModel : ObservableObject
             Engines.Add(new WhisperEngineCTranslate2());
         }
 
+        // MLX Whisper runs Whisper on the Apple GPU / Neural Engine and is arm64-only, so offer it
+        // only on Apple Silicon.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+            RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        {
+            Engines.Add(new MlxWhisperMac());
+        }
+
         Engines.Add(new WhisperEngineOpenAi());
 
         // Add OpenAI Compatible STT engine (available on all platforms)
@@ -2440,6 +2448,16 @@ public partial class SpeechToTextViewModel : ObservableObject
 
             if (!engine.IsEngineInstalled())
             {
+                if (engine is MlxWhisperMac)
+                {
+                    // pip-managed engine - Subtitle Edit cannot download it.
+                    await MessageBox.Show(
+                        Window!,
+                        $"{engine.Name} not found",
+                        "mlx-whisper not found - install it with: pip3 install mlx-whisper");
+                    return;
+                }
+
                 if (engine is ICrispAsrEngine && Configuration.IsRunningOnWindows)
                 {
                     var answer = await MessageBox.Show(
@@ -3212,6 +3230,71 @@ public partial class SpeechToTextViewModel : ObservableObject
             return p;
         }
 
+        if (engine is MlxWhisperMac mlxWhisperMac)
+        {
+            // mlx-whisper is a library, not a CLI, so we run a bundled helper script via python3.
+            // It writes "<audio-basename>.srt" into the audio's folder, which GetResultFromSrt then
+            // picks up. MLX runs Whisper on the Apple GPU / Neural Engine.
+            var python = mlxWhisperMac.GetExecutable();
+            var scriptPath = mlxWhisperMac.GetTranscribeScript();
+            var outputDir = Path.GetDirectoryName(waveFileName) ?? string.Empty;
+
+            var mlxLanguage = language;
+            if (mlxLanguage.Equals("english", StringComparison.OrdinalIgnoreCase))
+            {
+                mlxLanguage = "en";
+            }
+
+            var languagePart = !string.IsNullOrWhiteSpace(mlxLanguage) &&
+                               !mlxLanguage.Equals("auto", StringComparison.OrdinalIgnoreCase)
+                ? $" --language {mlxLanguage}"
+                : string.Empty;
+            var taskPart = translate ? " --task translate" : string.Empty;
+            var mlxExtraArgs = engine.CommandLineParameter;
+            var extraPart = string.IsNullOrWhiteSpace(mlxExtraArgs) ? string.Empty : " " + mlxExtraArgs.Trim();
+
+            var mlxParameters =
+                $"\"{scriptPath}\" --audio \"{waveFileName}\" --model {mlxWhisperMac.GetModelForCmdLine(model)} " +
+                $"--output-format srt --output-dir \"{outputDir}\"{languagePart}{taskPart}{extraPart}";
+
+            Se.WriteToolsLog($"{python} {mlxParameters}");
+
+            var mlxProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo(python, mlxParameters)
+                {
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                }
+            };
+
+            mlxProcess.StartInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
+            mlxProcess.StartInfo.EnvironmentVariables["PYTHONUTF8"] = "1";
+
+            if (dataReceivedHandler != null)
+            {
+                mlxProcess.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+                mlxProcess.StartInfo.StandardErrorEncoding = Encoding.UTF8;
+                mlxProcess.StartInfo.RedirectStandardOutput = true;
+                mlxProcess.StartInfo.RedirectStandardError = true;
+                mlxProcess.OutputDataReceived += dataReceivedHandler;
+                mlxProcess.ErrorDataReceived += dataReceivedHandler;
+            }
+
+#pragma warning disable CA1416
+            mlxProcess.Start();
+#pragma warning restore CA1416
+
+            if (dataReceivedHandler != null)
+            {
+                mlxProcess.BeginOutputReadLine();
+                mlxProcess.BeginErrorReadLine();
+            }
+
+            return mlxProcess;
+        }
+
         var settings = Se.Settings.Tools.AudioToText;
         var args = engine.CommandLineParameter;
         var cppVulkanDevice = string.Empty;
@@ -3786,6 +3869,14 @@ public partial class SpeechToTextViewModel : ObservableObject
         // It opens a dialog with the installed backend, status and Re-download — which is
         // also the answer to issue #11022 (switch backend after the initial install).
         IsEngineSettingsButtonVisible = canDownload && isInstalled && IsSettingsCapable(engine);
+
+        if (engine is MlxWhisperMac && !isInstalled)
+        {
+            // pip-managed engine - Subtitle Edit cannot download it, so show install help instead.
+            EngineDownloadHint = "mlx-whisper not found - install it with: pip3 install mlx-whisper";
+            IsEngineDownloadButtonVisible = false;
+            return;
+        }
 
         if (!canDownload || isInstalled)
         {

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -38,6 +38,7 @@ public class SeAudioToText
     public string CommandLineParameterCppVulkan { get; set; } = string.Empty;
     public string CommandLineParameterConstMe { get; set; } = string.Empty;
     public string CommandLineParameterCTranslate2 { get; set; } = "--vad_filter True";
+    public string CommandLineParameterMlxWhisperMac { get; set; } = string.Empty;
     public string CommandLineParameterPurfviewFasterWhisperXxl { get; set; } = "--standard";
     public string CommandLineParameterOpenAi { get; set; } = string.Empty;
     public string CommandLineParameterQwen3AsrCpp { get; set; } = string.Empty;

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -220,6 +220,10 @@
 		<AvaloniaResource Include="Assets\about3.png" />
 		<None Remove="Assets\SpeechToText\WhisperCTranslate2.txt" />
 		<AvaloniaResource Include="Assets\SpeechToText\WhisperCTranslate2.txt" />
+		<None Remove="Assets\SpeechToText\MlxWhisperMac.txt" />
+		<AvaloniaResource Include="Assets\SpeechToText\MlxWhisperMac.txt" />
+		<None Remove="Assets\SpeechToText\mlx_whisper_transcribe.py" />
+		<AvaloniaResource Include="Assets\SpeechToText\mlx_whisper_transcribe.py" />
 		<None Remove="Assets\Languages\Korean.json" />
 		<AvaloniaResource Include="Assets\Languages\Korean.json" />
 		<None Remove="Assets\Languages\Finnish.json" />


### PR DESCRIPTION
## What

Adds a macOS speech-to-text engine, **MLX Whisper Mac**, that runs Whisper on the Apple Silicon **GPU / Neural Engine** via Apple's [`mlx-whisper`](https://github.com/ml-explore/mlx-examples/tree/main/whisper) package.

## Why

On macOS the existing CTranslate2 path is **CPU-only** (no Metal/CUDA on Apple Silicon), so large models run near real-time regardless of how powerful the Mac is. MLX uses the GPU, giving a large speedup at the **same accuracy** (same Whisper weights).

## How

- New engine **MLX Whisper Mac**, offered only on macOS **arm64** (where MLX runs).
- Driven through a bundled helper script (`mlx_whisper_transcribe.py`) run via `python3`, the same library-via-script pattern used elsewhere; it writes an SRT that Subtitle Edit loads.
- Models `tiny`..`large-v3` plus **`large-v3-turbo`**, mapped to `mlx-community` Hugging Face repos and downloaded automatically on first use. A full repo id can be passed as the model for custom MLX models.
- The helper decodes Subtitle Edit's 16 kHz mono WAV with the Python standard library, so it does **not** depend on a system `ffmpeg` binary (mlx-whisper's own loader shells out to `ffmpeg`, which may be missing/non-executable).
- Install detection via `python3 -c "import mlx_whisper"`; a pip-install hint is shown when missing (Subtitle Edit cannot download a pip package). One-time setup: `pip3 install mlx-whisper`.

## Notes

- Apple-Silicon only by design (MLX is arm64). Intel Macs are unaffected (engine not listed).
- Verified end-to-end on an Apple M5 (macOS 26) via a local build — see the test report in the comments.
