### PR TITLE
Fix MLX Whisper Mac engine detection and model-download stall

### DIFF
--- a/src/ui/Assets/SpeechToText/MLXWhisper.txt
+++ b/src/ui/Assets/SpeechToText/MLXWhisper.txt
@@ -1,4 +1,4 @@
-MLX Whisper Mac runs Apple's "mlx-whisper" Python library via python3.
+MLX Whisper runs Apple's "mlx-whisper" Python library via python3.
 
 Requirements
 - An Apple Silicon Mac (M1 or newer).

--- a/src/ui/Assets/SpeechToText/mlx_whisper_transcribe.py
+++ b/src/ui/Assets/SpeechToText/mlx_whisper_transcribe.py
@@ -40,6 +40,73 @@ def fmt_short(seconds):
     return f"{minutes:02d}:{secs:02d}.{millis:03d}"
 
 
+def ensure_model_downloaded(repo):
+    """Pre-download the MLX model so the first run shows progress instead of looking frozen.
+
+    mlx-whisper downloads the model from Hugging Face on first use. Unauthenticated downloads
+    are throttled and the 1+ GB weights file can take minutes; the host only sees newline-
+    terminated stdout, while Hugging Face's tqdm bars update with carriage returns, so without
+    this step a first run looks stalled. We fetch the snapshot up front and print our own
+    percent-progress lines the host can display. A local model path needs no download.
+    """
+    if not repo or os.path.isdir(repo) or "/" not in repo:
+        return
+
+    try:
+        from huggingface_hub import snapshot_download
+    except Exception:
+        return  # mlx-whisper will handle the download itself.
+
+    try:
+        from tqdm.auto import tqdm as _base_tqdm
+    except Exception:
+        try:
+            from tqdm import tqdm as _base_tqdm
+        except Exception:
+            _base_tqdm = None
+
+    tqdm_class = None
+    if _base_tqdm is not None:
+        class _LineTqdm(_base_tqdm):
+            # Emit a newline-terminated "<file> NN%" line (only on percent change) so the host
+            # shows live download progress, while the base class keeps its normal stderr bar.
+            def __init__(self, *a, **k):
+                self._last_pct = -1
+                super().__init__(*a, **k)
+
+            def _emit(self):
+                total = self.total or 0
+                if total <= 0:
+                    return
+                pct = int(self.n * 100 / total)
+                if pct == self._last_pct:
+                    return
+                self._last_pct = pct
+                label = (self.desc or "Downloading model").strip().rstrip(":") or "Downloading model"
+                print(f"{label}: {pct}%", flush=True)
+
+            def update(self, n=1):
+                ret = super().update(n)
+                self._emit()
+                return ret
+
+            def close(self):
+                self._emit()
+                return super().close()
+
+        tqdm_class = _LineTqdm
+
+    print(f"Downloading model '{repo}' from Hugging Face (first use; this can take a while)...",
+          flush=True)
+    try:
+        snapshot_download(repo_id=repo, tqdm_class=tqdm_class)
+        print("Model download complete.", flush=True)
+    except Exception as e:
+        # Not fatal: fall through and let mlx-whisper try its own download path.
+        print(f"warning: model pre-download failed ({e}); letting mlx-whisper download it",
+              file=sys.stderr, flush=True)
+
+
 def load_wav_as_array(path):
     """Read a PCM WAV directly into a 16 kHz mono float32 array.
 
@@ -124,6 +191,8 @@ def main():
         except Exception as e:
             print(f"warning: direct WAV load failed ({e}); falling back to ffmpeg path",
                   file=sys.stderr, flush=True)
+
+    ensure_model_downloaded(args.model)
 
     print(f"Loading MLX Whisper model '{args.model}' (Apple GPU/Neural Engine)...", flush=True)
     result = mlx_whisper.transcribe(

--- a/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
@@ -44,6 +44,10 @@ public class MlxWhisperMac : ISpeechToTextEngine
 
     private static bool? _isMlxWhisperInstalled;
 
+    // The python3 interpreter that can actually "import mlx_whisper". Resolved during the install
+    // check and reused for transcription so both use the same Python (see GetExecutable).
+    private static string? _resolvedPython;
+
     public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
 
     // Built explicitly (not filtered from the CTranslate2 list, which has no turbo entry). large-v3-turbo
@@ -81,11 +85,30 @@ public class MlxWhisperMac : ISpeechToTextEngine
             return _isMlxWhisperInstalled.Value;
         }
 
+        // mlx-whisper is almost never installed into Homebrew's Python (it is "externally managed",
+        // PEP 668), so checking a single fixed interpreter wrongly reports "not installed". Probe each
+        // candidate and pick the first one that can import the package; remember it for transcription.
+        foreach (var python in GetPythonCandidates())
+        {
+            if (CanImportMlxWhisper(python))
+            {
+                _resolvedPython = python;
+                _isMlxWhisperInstalled = true;
+                return true;
+            }
+        }
+
+        _isMlxWhisperInstalled = false;
+        return false;
+    }
+
+    private static bool CanImportMlxWhisper(string python)
+    {
         try
         {
             using var process = new Process
             {
-                StartInfo = new ProcessStartInfo(GetExecutable(), "-c \"import mlx_whisper\"")
+                StartInfo = new ProcessStartInfo(python, "-c \"import mlx_whisper\"")
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
                     CreateNoWindow = true,
@@ -100,19 +123,57 @@ public class MlxWhisperMac : ISpeechToTextEngine
             if (!process.WaitForExit(10_000))
             {
                 process.Kill(true);
-                _isMlxWhisperInstalled = false;
                 return false;
             }
 #pragma warning restore CA1416
 
-            _isMlxWhisperInstalled = process.ExitCode == 0;
+            return process.ExitCode == 0;
         }
         catch
         {
-            _isMlxWhisperInstalled = false;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The python3 interpreters to probe for mlx-whisper, in priority order: Homebrew, python.org
+    /// framework builds (newest first), pyenv, the system Python, and finally PATH resolution.
+    /// </summary>
+    private static IEnumerable<string> GetPythonCandidates()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var candidates = new List<string>();
+
+        void Add(string path)
+        {
+            if (!string.IsNullOrEmpty(path) && seen.Add(path))
+            {
+                candidates.Add(path);
+            }
         }
 
-        return _isMlxWhisperInstalled.Value;
+        Add("/opt/homebrew/bin/python3");
+        Add("/usr/local/bin/python3");
+
+        const string frameworkDir = "/Library/Frameworks/Python.framework/Versions";
+        if (Directory.Exists(frameworkDir))
+        {
+            foreach (var versionDir in Directory.GetDirectories(frameworkDir).OrderByDescending(p => p))
+            {
+                Add(Path.Combine(versionDir, "bin", "python3"));
+            }
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(home))
+        {
+            Add(Path.Combine(home, ".pyenv", "shims", "python3"));
+        }
+
+        Add("/usr/bin/python3");
+        Add("python3"); // resolved via PATH
+
+        return candidates.Where(p => p == "python3" || File.Exists(p));
     }
 
     public override string ToString()
@@ -145,26 +206,23 @@ public class MlxWhisperMac : ISpeechToTextEngine
 
     public string GetExecutable()
     {
-        // The engine drives the mlx-whisper *library* through python3 (see the class summary),
-        // so the executable is the Python interpreter. Probe the usual macOS install locations
-        // (Homebrew on Apple Silicon, Homebrew/python.org on Intel, the system Python) and fall
-        // back to PATH resolution.
-        var candidates = new[]
+        // The engine drives the mlx-whisper *library* through python3 (see the class summary), so the
+        // executable is the Python interpreter. Prefer the interpreter that actually has mlx-whisper
+        // importable (resolved during the install check) so detection and transcription stay in sync.
+        if (_resolvedPython != null)
         {
-            "/opt/homebrew/bin/python3",
-            "/usr/local/bin/python3",
-            "/usr/bin/python3",
-        };
-
-        foreach (var candidate in candidates)
-        {
-            if (File.Exists(candidate))
-            {
-                return candidate;
-            }
+            return _resolvedPython;
         }
 
-        return "python3"; // resolved via PATH
+        IsEngineInstalled();
+        if (_resolvedPython != null)
+        {
+            return _resolvedPython;
+        }
+
+        // Not installed in any probed interpreter; return a sensible default so the "pip3 install
+        // mlx-whisper" guidance points at a real interpreter.
+        return GetPythonCandidates().FirstOrDefault() ?? "python3";
     }
 
     /// <summary>

--- a/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 /// </summary>
 public class MlxWhisperMac : ISpeechToTextEngine
 {
-    public static string StaticName => "MLX Whisper Mac";
+    public static string StaticName => "MLX Whisper";
     public string Name => StaticName;
     public string Choice => WhisperChoice.MlxWhisperMac;
     public string Url => "https://github.com/ml-explore/mlx-examples/tree/main/whisper";
@@ -278,7 +278,7 @@ public class MlxWhisperMac : ISpeechToTextEngine
         }
         catch
         {
-            return "MLX Whisper Mac runs Apple's \"mlx-whisper\" Python library via python3.\n\n" +
+            return "MLX Whisper runs Apple's \"mlx-whisper\" Python library via python3.\n\n" +
                    "Install it with: pip3 install mlx-whisper\n\n" +
                    "Requires an Apple Silicon Mac. MLX runs Whisper on the GPU / Neural Engine, so it is\n" +
                    "typically much faster than the CPU-only Faster Whisper Mac engine.\n\n" +

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -220,8 +220,8 @@
 		<AvaloniaResource Include="Assets\about3.png" />
 		<None Remove="Assets\SpeechToText\WhisperCTranslate2.txt" />
 		<AvaloniaResource Include="Assets\SpeechToText\WhisperCTranslate2.txt" />
-		<None Remove="Assets\SpeechToText\MlxWhisperMac.txt" />
-		<AvaloniaResource Include="Assets\SpeechToText\MlxWhisperMac.txt" />
+		<None Remove="Assets\SpeechToText\MLXWhisper.txt" />
+		<AvaloniaResource Include="Assets\SpeechToText\MLXWhisper.txt" />
 		<None Remove="Assets\SpeechToText\mlx_whisper_transcribe.py" />
 		<AvaloniaResource Include="Assets\SpeechToText\mlx_whisper_transcribe.py" />
 		<None Remove="Assets\Languages\Korean.json" />


### PR DESCRIPTION
Follow-up fixes for the MLX Whisper Mac engine added in #11724.

## Problem 1 — keeps asking to install `mlx-whisper` even when it's installed

`IsEngineInstalled()` checked for `import mlx_whisper` using whatever `GetExecutable()` returned, and `GetExecutable()` simply picked the **first python3 that exists on disk** — always `/opt/homebrew/bin/python3` on Apple Silicon.

But Homebrew's Python is "externally managed" (PEP 668), so `pip3 install mlx-whisper` against it is rejected. Users therefore install mlx-whisper into a **different** interpreter (a venv, pyenv, or python.org build). Detection looked at Homebrew's Python, didn't find the package, and reported "not installed" forever.

**Fix:** probe all candidate interpreters (Homebrew → python.org framework builds → pyenv → system → PATH) and pick the first that can actually `import mlx_whisper`. The resolved interpreter is remembered and reused by `GetExecutable()`, so detection and transcription use the same Python.

## Problem 2 — first transcription appears to stall on startup

It wasn't hung — `mlx_whisper.transcribe` was downloading the ~1.6 GB `large-v3-turbo` model from Hugging Face. Unauthenticated downloads are throttled (observed ~6m30s, dropping to ~1.4 MB/s), and the host saw no progress because Hugging Face's tqdm bars update with carriage returns rather than newlines.

**Fix:** add an explicit `ensure_model_downloaded()` step to `mlx_whisper_transcribe.py` that pre-fetches the model snapshot and emits newline-terminated `Downloading ...: NN%` progress lines plus a `Model download complete.` line the UI can display. Falls back gracefully if the pre-download fails (mlx-whisper then downloads as before).

## Testing

Verified on an Apple Silicon Mac:
- Detection now resolves to the interpreter that actually has the package (`/usr/local/bin/python3`).
- Progress lines emit at 0/10/41/.../100% during download, followed by transcription writing the SRT.

## Notes
- Detection result is cached for the app's lifetime, so installing mlx-whisper *while* Subtitle Edit is running still needs a restart (pre-existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)