### PR TITLE
Fix Qwen3 TTS (CrispASR) empty-audio failure from 22 kHz voice prompts

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -584,9 +584,10 @@ public partial class DownloadTtsViewModel : ObservableObject
                     ProgressValue = percentage;
                     ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
                 });
-                // Same voices.zip as qwen3-tts.cpp (24 kHz mono WAV + .txt sidecars,
-                // identical format). Reuse the Qwen3 TTS .cpp download service rather
-                // than adding a second copy of the URL/hash.
+                // Same voices.zip as qwen3-tts.cpp (22.05 kHz WAV + .txt sidecars). Reuse
+                // the Qwen3 TTS .cpp download service rather than adding a second copy of the
+                // URL/hash; the WAVs are resampled to 24 kHz after extraction below since the
+                // CrispASR qwen3-tts backend rejects any other rate.
                 _downloadTaskQwen3TtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamQwen3TtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
                 _timer.Start();
@@ -618,6 +619,10 @@ public partial class DownloadTtsViewModel : ObservableObject
                     {
                         _downloadStreamQwen3TtsCrispAsrVoices.Position = 0;
                         _zipUnpacker.UnpackZipStream(_downloadStreamQwen3TtsCrispAsrVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        // The pack ships 22.05 kHz WAVs but the qwen3-tts backend strictly
+                        // requires 24 kHz (otherwise it drops the voice prompt and returns
+                        // empty audio), so bring every reference WAV up to 24 kHz mono.
+                        ResampleVoicesTo24kHz(voicesFolder);
                         // The pack ships attribution-blurb .txt files, not spoken transcriptions.
                         // Drop those (the Base backend would load them as ref-text → off-voice
                         // output) and fill real transcripts from the OmniVoice pack where it has

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -260,11 +260,13 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         }
 
         SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        NormalizeVoiceSampleRatesOnce(voicesFolder);
         NormalizeVoiceTranscriptsOnce(voicesFolder);
         return voicesFolder;
     }
 
     private static bool _voiceSeedAttempted;
+    private static bool _voiceSampleRatesNormalized;
     private static bool _voiceTranscriptsNormalized;
 
     /// <summary>
@@ -336,6 +338,116 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         }
         _voiceTranscriptsNormalized = true;
         NormalizeVoiceTranscripts(voicesFolder);
+    }
+
+    /// <summary>
+    /// One-time, per-session pass that resamples any reference WAV in <paramref name="voicesFolder"/>
+    /// that is not already 24 kHz to 24 kHz mono in place. The qwen3-tts backend strictly rejects a
+    /// voice prompt at any other rate (logs "voice prompt must be 24kHz, got NNNNN Hz") and then
+    /// returns empty audio, so a voice pack at another rate — the shared voices.zip ships 22.05 kHz
+    /// clips — must be brought up to 24 kHz before the server reads it from --voice-dir. Files that
+    /// are already 24 kHz (or whose header we cannot parse) are left untouched so we never re-encode
+    /// on every launch. Best-effort per file: an ffmpeg failure leaves the original in place.
+    /// </summary>
+    private static void NormalizeVoiceSampleRatesOnce(string voicesFolder)
+    {
+        if (_voiceSampleRatesNormalized)
+        {
+            return;
+        }
+        _voiceSampleRatesNormalized = true;
+
+        if (!Directory.Exists(voicesFolder))
+        {
+            return;
+        }
+
+        foreach (var wav in Directory.GetFiles(voicesFolder, "*.wav"))
+        {
+            if (TryGetWavSampleRate(wav) is null or 24000)
+            {
+                continue; // unparseable header (leave for synth-time handling) or already correct
+            }
+
+            var temp = wav + ".24k.wav";
+            var consumed = false;
+            try
+            {
+                var process = FfmpegGenerator.ConvertToMono24kHzWav(wav, temp);
+                if (!process.Start())
+                {
+                    continue;
+                }
+
+                process.WaitForExit();
+                if (File.Exists(temp) && new FileInfo(temp).Length > 0)
+                {
+                    File.Delete(wav);
+                    File.Move(temp, wav);
+                    consumed = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Se.LogError(ex, $"Qwen3 TTS (CrispASR): failed to resample voice '{wav}' to 24 kHz");
+            }
+            finally
+            {
+                if (!consumed && File.Exists(temp))
+                {
+                    try { File.Delete(temp); } catch { /* leave it; not worth retrying */ }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the sample rate (Hz) from a PCM WAV header by walking RIFF chunks to the <c>fmt </c>
+    /// chunk, or null if the file is not a WAV we can parse. Cheap header-only read — no decode.
+    /// </summary>
+    private static int? TryGetWavSampleRate(string fileName)
+    {
+        try
+        {
+            using var fs = File.OpenRead(fileName);
+            using var br = new BinaryReader(fs);
+            if (fs.Length < 12 ||
+                Encoding.ASCII.GetString(br.ReadBytes(4)) != "RIFF")
+            {
+                return null;
+            }
+
+            br.ReadInt32(); // overall RIFF size
+            if (Encoding.ASCII.GetString(br.ReadBytes(4)) != "WAVE")
+            {
+                return null;
+            }
+
+            while (fs.Position + 8 <= fs.Length)
+            {
+                var chunkId = Encoding.ASCII.GetString(br.ReadBytes(4));
+                var chunkSize = br.ReadInt32();
+                if (chunkId == "fmt ")
+                {
+                    br.ReadInt16(); // audio format
+                    br.ReadInt16(); // channels
+                    return br.ReadInt32(); // sample rate (little-endian)
+                }
+
+                if (chunkSize < 0 || fs.Position + chunkSize > fs.Length)
+                {
+                    return null;
+                }
+
+                fs.Position += chunkSize + (chunkSize & 1); // chunks are word-aligned
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem
Qwen3 TTS (CrispASR) synthesis fails with:

```
Qwen3 TTS (CrispASR) synthesis failed (500): synthesis failed (backend returned empty audio)
```

The server log shows the real cause:

```
qwen3_tts: voice prompt must be 24kHz, got 22050 Hz
crispasr[qwen3-tts]: failed to set voice prompt from '.../voices/female_06.wav'
```

The CrispASR `qwen3-tts` backend strictly requires a **24 kHz** voice prompt. The shared `voices.zip` ships **22.05 kHz** reference WAVs, so the backend drops the prompt and returns empty audio → HTTP 500.

## Root cause
Every other CrispASR TTS engine (VibeVoice, IndexTTS, Zonos, F5-TTS, VoxCPM2) calls `ResampleVoicesTo24kHz(voicesFolder)` right after extracting `voices.zip`. The **Qwen3 (CrispASR)** download flow was the only one missing that call, so its reference WAVs stayed at 22.05 kHz. (The download-flow comment even mislabeled the pack as "24 kHz mono"; it is actually 22.05 kHz — verified by downloading the pack.)

## Fix
- **`DownloadTtsViewModel.cs`** — resample the Qwen3 (CrispASR) voices to 24 kHz mono after extraction, matching the sibling engines; corrected the misleading comment.
- **`Qwen3TtsCrispAsr.cs`** — added a one-time, per-session normalization in `GetSetVoicesFolder()` that resamples any non-24 kHz reference WAV **in place**, so users who already have a 22.05 kHz pack installed are fixed on next launch **without re-downloading**. A cheap WAV-header read (`TryGetWavSampleRate`) skips files already at 24 kHz so nothing is re-encoded needlessly.

## Verification
- Confirmed `voices.zip` (`qwen3-tts-cpp-2026-5`) ships 22.05 kHz WAVs (`female_06.wav` header → 22050 Hz).
- Confirmed the WAV-header parse offset against the real file and that `ffmpeg -ar 24000 -ac 1` produces a 24 kHz mono WAV.
- `dotnet build src/ui/UI.csproj` succeeds (one pre-existing unrelated warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)