### PR TITLE
Show clear message when Chatterbox Turbo is incompatible with CrispASR 0.8.0

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -555,6 +555,18 @@ public class ChatterboxTtsCpp : ITtsEngine
                             + "Delete them and try again so they re-download. Original output: " + tail
                             + LaunchCmdSuffix(exitedLaunchCommand));
                     }
+                    if (LooksLikeChatterboxTurboTokenizerMismatch(tail))
+                    {
+                        throw new InvalidOperationException(
+                            "Chatterbox TTS \"Turbo\" is not compatible with this version of CrispASR. "
+                            + "The upstream chatterbox-turbo model embeds a 50257-token tokenizer but "
+                            + "declares a text vocab size of 50276, and CrispASR 0.8.0+ rejects the "
+                            + "mismatch. Switch to the \"Base\" Chatterbox model, which works. Fixing "
+                            + "Turbo needs an upstream re-converted GGUF — see "
+                            + "https://github.com/CrispStrobe/CrispASR/issues."
+                            + Environment.NewLine + Environment.NewLine + tail
+                            + LaunchCmdSuffix(exitedLaunchCommand));
+                    }
                     if (LooksLikeChatterboxTurboStartupCrash(modelKey, tail))
                     {
                         throw new InvalidOperationException(
@@ -619,6 +631,22 @@ public class ChatterboxTtsCpp : ITtsEngine
         return output.Contains("required tensor", StringComparison.Ordinal)
             || output.Contains("failed to bind", StringComparison.Ordinal)
             || output.Contains("ggml_uncaught_exception", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeChatterboxTurboTokenizerMismatch(string output)
+    {
+        // CrispASR 0.8.0 added a strict tokenizer/vocab consistency check. The upstream
+        // chatterbox-turbo GGUF (cstr/chatterbox-turbo-GGUF) embeds a 50257-token GPT-2
+        // tokenizer but declares text_vocab_size=50276, so 0.8.0 refuses to load it:
+        //   chatterbox: tokenizer/model vocab mismatch: tokenizer has 50257 tokens,
+        //               T3 text_vocab_size=50276. Re-convert with the tokenizer paired ...
+        //   crispasr[chatterbox]: failed to load T3 model '...-turbo-t3-...gguf'
+        // 0.7.x didn't validate this, so the same file loaded (silently mismatched). The
+        // Base model is internally consistent (704 == 704) and is unaffected, so this is
+        // always a "use Base" situation until the turbo GGUF is re-converted upstream.
+        return output.Contains("tokenizer/model vocab mismatch", StringComparison.Ordinal)
+            || (output.Contains("text_vocab_size", StringComparison.Ordinal)
+                && output.Contains("Re-convert with the tokenizer", StringComparison.Ordinal));
     }
 
     private static bool LooksLikeChatterboxTurboStartupCrash(string modelKey, string output)


### PR DESCRIPTION
## Problem
After updating to CrispASR v0.8.0, selecting Chatterbox **Turbo** fails with a raw, opaque error:

```
crispasr (chatterbox) exited during startup (code 1). Output:
...
chatterbox: tokenizer/model vocab mismatch: tokenizer has 50257 tokens, T3 text_vocab_size=50276.
            Re-convert with the tokenizer paired to this T3 checkpoint.
crispasr-server: failed to init backend 'chatterbox-turbo'
```

## Root cause (upstream, not fixable in SE)
CrispASR 0.8.0 added a strict tokenizer/vocab consistency check. The upstream chatterbox-turbo GGUF (`cstr/chatterbox-turbo-GGUF`) embeds a **50257**-token GPT-2 tokenizer but declares `text_vocab_size = 50276` — confirmed by parsing the GGUF metadata directly. 0.7.x didn't validate this, so the same file loaded (silently mismatched); 0.8.0 rejects it.

- The user already has the latest upstream turbo file (local SHA-256 matches the current HF LFS oid), and the turbo HF repo hasn't been re-converted, so **re-downloading does not help**.
- The **Base** model is internally consistent (`text_vocab_size = 704` == tokenizer 704 tokens) and its HF repo was refreshed alongside v0.8.0, so Base works.

A re-converted turbo GGUF is needed upstream — reported at **CrispStrobe/CrispASR#181**.

## Fix
Detect this specific failure (`tokenizer/model vocab mismatch`, or `text_vocab_size` + `Re-convert with the tokenizer`) and replace the raw "exited code 1" with an actionable message: switch to the **Base** Chatterbox model, with a pointer to the upstream issue tracker. Mirrors the existing `LooksLikeChatterboxTurboStartupCrash` / `LooksLikeStaleModelCache` detectors.

## Verification
- GGUF metadata parsed from the actual installed files confirms turbo 50276-vs-50257 mismatch and base 704-vs-704 consistency.
- `dotnet build src/ui/UI.csproj` succeeds (one pre-existing unrelated warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)