### PR TITLE
Refine Chatterbox Turbo message after upstream CrispASR#181 fix

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -558,12 +558,12 @@ public class ChatterboxTtsCpp : ITtsEngine
                     if (LooksLikeChatterboxTurboTokenizerMismatch(tail))
                     {
                         throw new InvalidOperationException(
-                            "Chatterbox TTS \"Turbo\" is not compatible with this version of CrispASR. "
-                            + "The upstream chatterbox-turbo model embeds a 50257-token tokenizer but "
-                            + "declares a text vocab size of 50276, and CrispASR 0.8.0+ rejects the "
-                            + "mismatch. Switch to the \"Base\" Chatterbox model, which works. Fixing "
-                            + "Turbo needs an upstream re-converted GGUF — see "
-                            + "https://github.com/CrispStrobe/CrispASR/issues."
+                            "Chatterbox TTS \"Turbo\" does not load with CrispASR 0.8.0. The turbo model "
+                            + "is fine — 0.8.0's tokenizer/vocab check was overly strict and rejected its "
+                            + "benign embedding superset (50257-token tokenizer, text vocab size 50276). "
+                            + "This is fixed upstream (CrispStrobe/CrispASR#181): a newer CrispASR loads "
+                            + "Turbo normally, with no re-download. Until then, switch to the \"Base\" "
+                            + "Chatterbox model, which works."
                             + Environment.NewLine + Environment.NewLine + tail
                             + LaunchCmdSuffix(exitedLaunchCommand));
                     }
@@ -635,15 +635,17 @@ public class ChatterboxTtsCpp : ITtsEngine
 
     private static bool LooksLikeChatterboxTurboTokenizerMismatch(string output)
     {
-        // CrispASR 0.8.0 added a strict tokenizer/vocab consistency check. The upstream
-        // chatterbox-turbo GGUF (cstr/chatterbox-turbo-GGUF) embeds a 50257-token GPT-2
-        // tokenizer but declares text_vocab_size=50276, so 0.8.0 refuses to load it:
+        // CrispASR 0.8.0 added a tokenizer/vocab consistency check that was overly strict —
+        // it rejected the upstream chatterbox-turbo GGUF (cstr/chatterbox-turbo-GGUF), which
+        // embeds a 50257-token GPT-2 tokenizer but declares text_vocab_size=50276:
         //   chatterbox: tokenizer/model vocab mismatch: tokenizer has 50257 tokens,
         //               T3 text_vocab_size=50276. Re-convert with the tokenizer paired ...
         //   crispasr[chatterbox]: failed to load T3 model '...-turbo-t3-...gguf'
-        // 0.7.x didn't validate this, so the same file loaded (silently mismatched). The
-        // Base model is internally consistent (704 == 704) and is unaffected, so this is
-        // always a "use Base" situation until the turbo GGUF is re-converted upstream.
+        // The mismatch is benign (embedding superset — the extra rows are reserved/unused), so
+        // upstream made the check directional (CrispStrobe/CrispASR#181): tokenizer < vocab now
+        // warns and loads. A CrispASR newer than 0.8.0 loads Turbo with no re-download. This
+        // detector therefore only fires on 0.8.0, where the model can't load at all and the Base
+        // model (internally consistent, 704 == 704) is the workaround. 0.7.x never validated this.
         return output.Contains("tokenizer/model vocab mismatch", StringComparison.Ordinal)
             || (output.Contains("text_vocab_size", StringComparison.Ordinal)
                 && output.Contains("Re-convert with the tokenizer", StringComparison.Ordinal));


### PR DESCRIPTION
Follow-up to #11730 based on the upstream maintainer's response on [CrispStrobe/CrispASR#181](https://github.com/CrispStrobe/CrispASR/issues/181).

## What changed upstream
CrispStrobe confirmed the turbo tokenizer/vocab "mismatch" is **benign** — an embedding superset where the extra rows (50276 − 50257 = 19) are reserved/unused. CrispASR 0.8.0's check was simply **too strict** (it rejected any inequality). They made it **directional**:
- `tokenizer > text_vocab_size` → hard error (real out-of-bounds risk)
- `tokenizer < text_vocab_size` → warn and load (benign superset, the turbo case)

The fix is on upstream `main` and ships in the next CrispASR release, so **the turbo files already on disk load again with no re-download** — just a one-line note at load.

## What this PR fixes
The message and code comment added in #11730 were written before that clarification and are now inaccurate — they imply the model is broken and needs a re-converted GGUF. Updated to reflect reality:
- The turbo model is **fine**; it's a CrispASR-**0.8.0-only** over-strict check, fixed upstream.
- A **newer CrispASR loads Turbo with no re-download**; use **Base** in the meantime.
- Links the specific issue (`CrispStrobe/CrispASR#181`) instead of the issues index.

The detector itself is unchanged (it still correctly catches the 0.8.0 failure SE currently pins).

## Verification
`dotnet build src/ui/UI.csproj` succeeds (one pre-existing unrelated warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)