### PR TITLE
Apply dictionary change mid spell-check session (issue #11731)

### DIFF
--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -104,6 +104,11 @@ public partial class SpellCheckViewModel : ObservableObject
 
     internal void OnDictionaryChanged()
     {
+        if (SelectedDictionary == null)
+        {
+            return;
+        }
+
         if (_spellCheckManager.WordSpellChecker != null)
         {
             if (Dictionaries.Count > 0)
@@ -116,6 +121,48 @@ public partial class SpellCheckViewModel : ObservableObject
                 }
             }
         }
+        else if (!string.IsNullOrEmpty(SelectedDictionary.DictionaryFileName))
+        {
+            // Hunspell provider: actually load the newly selected dictionary so switching
+            // dialect (e.g. British -> American) mid-session takes effect immediately.
+            // Previously this branch did nothing for Hunspell, so the spell checker kept
+            // using the dictionary it started with until the next run (issue #11731).
+            _spellCheckManager.Initialize(
+                SelectedDictionary.DictionaryFileName,
+                SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(SelectedDictionary));
+        }
+
+        ReCheckCurrentWordAfterDictionaryChange();
+    }
+
+    /// <summary>
+    /// Re-evaluates the word currently shown after the dictionary is switched mid-session.
+    /// If the word is now valid in the new dictionary the check advances to the next
+    /// misspelling; otherwise the suggestion list is refreshed for the new dictionary.
+    /// No-op until a check is underway and a flagged word is on screen.
+    /// </summary>
+    private void ReCheckCurrentWordAfterDictionaryChange()
+    {
+        if (_lastSpellCheckResult == null || SelectedParagraph == null || string.IsNullOrEmpty(WordNotFoundOriginal))
+        {
+            return;
+        }
+
+        if (_spellCheckManager.IsWordCorrect(_currentSpellCheckWord, SelectedParagraph.Text))
+        {
+            DoSpellCheck();
+            return;
+        }
+
+        var suggestions = _spellCheckManager.GetSuggestions(WordNotFoundOriginal);
+        Suggestions.Clear();
+        foreach (var suggestion in suggestions)
+        {
+            Suggestions.Add(suggestion);
+        }
+
+        AreSuggestionsAvailable = true;
+        SelectedSuggestion = suggestions.Count > 0 ? suggestions[0] : string.Empty;
     }
 
     private void LoadDictionaries()


### PR DESCRIPTION
Fixes #11731.

## Problem
In the Spell Check window, changing the dictionary in the combo box **during a running check** had no effect with the default (Hunspell) provider. Starting a check in e.g. British English and switching to American mid-session left the user **halted on the same word** — it didn't switch dictionary until the check was restarted. (SE4 allowed switching language during a check.)

## Root cause
The combo's `SelectionChanged` calls `SpellCheckViewModel.OnDictionaryChanged()`, but that method only handled the **MS Word** provider:

```csharp
internal void OnDictionaryChanged()
{
    if (_spellCheckManager.WordSpellChecker != null)   // MS Word only
    {
        ... set CurrentLanguage ...
    }
    // Hunspell: nothing happened — Initialize() was never called for the new dictionary
}
```

For Hunspell it never called `_spellCheckManager.Initialize(newDictionaryFile, …)`, so the active `WordList` stayed on the dictionary the session started with.

## Fix
`OnDictionaryChanged()` now:
1. For Hunspell, loads the newly selected dictionary (`Initialize(SelectedDictionary.DictionaryFileName, …)`), mirroring the MS Word branch.
2. For **both** providers, re-evaluates the word currently on screen: if it's now valid in the new dictionary the check advances to the next misspelling; otherwise the suggestion list is refreshed for the new dictionary.

Guarded to be a no-op until a check is underway and a flagged word is shown, so it doesn't interfere with window-open initialization.

## Notes
- Switching dictionaries re-initializes the manager, which clears the in-session "skip all" list (a new `Initialize` resets it). That's an acceptable side effect of changing language mid-check; changed/skipped counts are preserved.
- No automated test added: there are no existing `SpellCheckViewModel` tests, no mocking framework in the test project, and `en_GB.dic` isn't bundled to drive a clean dialect-switch unit test. Verified by build + the (previously confirmed) fact that the Hunspell manager flips `neighborhood`/`neighbourhood` correctness when re-initialized with en_US vs en_GB.

## Verification
`dotnet build src/ui/UI.csproj` succeeds (one pre-existing unrelated warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)