### PR TITLE
Don't let Netflix check garble ASSA override tags (issue #11720)

### DIFF
--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
@@ -31,17 +31,17 @@ public class NetflixCheckTextForHiUseBrackets : INetflixQualityChecker
             {
                 newText = "[" + newText.Substring(1, newText.Length - 2) + "]";
             }
-            else if (newText.StartsWith("{", StringComparison.Ordinal) && newText.EndsWith("}", StringComparison.Ordinal))
+            else if (newText.StartsWith("{", StringComparison.Ordinal) && newText.EndsWith("}", StringComparison.Ordinal) && !IsAssaOverride(newText))
             {
                 newText = "[" + newText.Substring(1, newText.Length - 2) + "]";
             }
             else if (arr.Count == 2 && arr[0].StartsWith("-", StringComparison.Ordinal) && arr[1].StartsWith("-", StringComparison.Ordinal))
             {
-                if ((arr[0].StartsWith("-(", StringComparison.Ordinal) && arr[0].EndsWith(")", StringComparison.Ordinal)) || (arr[0].StartsWith("-{", StringComparison.Ordinal) && arr[0].EndsWith("}", StringComparison.Ordinal)))
+                if ((arr[0].StartsWith("-(", StringComparison.Ordinal) && arr[0].EndsWith(")", StringComparison.Ordinal)) || (arr[0].StartsWith("-{", StringComparison.Ordinal) && arr[0].EndsWith("}", StringComparison.Ordinal) && !IsAssaOverride(arr[0].Substring(1))))
                 {
                     arr[0] = "-[" + newText.Substring(2, newText.Length - 3) + "]";
                 }
-                if ((arr[1].StartsWith("-(", StringComparison.Ordinal) && arr[1].EndsWith(")", StringComparison.Ordinal)) || (arr[1].StartsWith("-{", StringComparison.Ordinal) && arr[1].EndsWith("}", StringComparison.Ordinal)))
+                if ((arr[1].StartsWith("-(", StringComparison.Ordinal) && arr[1].EndsWith(")", StringComparison.Ordinal)) || (arr[1].StartsWith("-{", StringComparison.Ordinal) && arr[1].EndsWith("}", StringComparison.Ordinal) && !IsAssaOverride(arr[1].Substring(1))))
                 {
                     arr[1] = "-[" + arr[1].Substring(2, arr[1].Length - 3) + "]";
                 }
@@ -57,4 +57,10 @@ public class NetflixCheckTextForHiUseBrackets : INetflixQualityChecker
         }
     }
 
+    /// <summary>
+    /// True when the braced text is an ASS/SSA override block (e.g. <c>{\i1\a6}...</c>) rather
+    /// than a hearing-impaired speaker ID / sound effect in braces. Converting such a block to
+    /// square brackets would corrupt the override codes (issue #11720), so it must be skipped.
+    /// </summary>
+    private static bool IsAssaOverride(string text) => text.StartsWith("{\\", StringComparison.Ordinal);
 }

--- a/tests/UI/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBracketsTests.cs
+++ b/tests/UI/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBracketsTests.cs
@@ -1,0 +1,67 @@
+using System;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.NetflixQualityCheck;
+using Xunit;
+
+namespace UITests.Logic.NetflixQualityCheck;
+
+public class NetflixCheckTextForHiUseBracketsTests
+{
+    private static string RunFix(string text)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 0, 1000));
+        var controller = new NetflixQualityController { Language = "en" };
+
+        new NetflixCheckTextForHiUseBrackets("test").Check(subtitle, controller);
+
+        // The checker records a fix only when it changes the text; otherwise the text is left as-is.
+        return controller.Records.Count > 0 && controller.Records[0].FixedParagraph != null
+            ? controller.Records[0].FixedParagraph!.Text
+            : text;
+    }
+
+    [Theory]
+    [InlineData("{SIGHING}", "[SIGHING]")]
+    [InlineData("(SIGHING)", "[SIGHING]")]
+    [InlineData("{DOOR CREAKS}", "[DOOR CREAKS]")]
+    public void ConvertsHiSpeakerIdsAndSoundEffectsToSquareBrackets(string input, string expected)
+    {
+        Assert.Equal(expected, RunFix(input));
+    }
+
+    // Issue #11720: ASS/SSA override tags also use { } braces and must NOT be turned into [ ].
+    [Fact]
+    public void DoesNotMangleAssaOverrideTags_IssueExample()
+    {
+        var input = "{\\i1\\a6}Shot on location in Singapore" + Environment.NewLine +
+                    "and all over the Korean peninsula. {\\i0}";
+
+        Assert.Equal(input, RunFix(input));
+    }
+
+    [Theory]
+    [InlineData("{\\i1}Hello{\\i0}")]
+    [InlineData("{\\i1\\a6}Have you ever worked with a director?{\\i0}")]
+    [InlineData("{\\an8}Top of screen{\\an8}")]
+    public void DoesNotMangleSingleLineAssaOverride(string input)
+    {
+        Assert.Equal(input, RunFix(input));
+    }
+
+    [Fact]
+    public void DoesNotMangleDashedAssaOverrideLines()
+    {
+        var input = "-{\\i1}foo{\\i0}" + Environment.NewLine + "-{\\i1}bar{\\i0}";
+
+        Assert.Equal(input, RunFix(input));
+    }
+
+    [Theory]
+    [InlineData("{\\a6}Please do NOT hardsub and/or stream")] // override tag, no trailing brace
+    [InlineData("Plain dialogue line.")]
+    public void LeavesNonBracketTextUnchanged(string input)
+    {
+        Assert.Equal(input, RunFix(input));
+    }
+}


### PR DESCRIPTION
Fixes #11720.

## Problem
Running **Netflix check and fix** corrupts ASS/SSA inline override tags. With the reporter's file, lines like:

```
{\i1\a6}Shot on location in Singapore
and all over the Korean peninsula. {\i0}
```

came out as:

```
[\i1\a6}Shot on location in Singapore
and all over the Korean peninsula. {\i0]
```

— the outer `{ }` were rewritten to `[ ]`, breaking the override codes.

## Root cause
`NetflixCheckTextForHiUseBrackets` enforces the Netflix rule "use `[ ]` for HI speaker IDs / sound effects". It converts any subtitle that *starts with `{` and ends with `}`* into `[...]`:

```csharp
else if (newText.StartsWith("{") && newText.EndsWith("}"))
{
    newText = "[" + newText.Substring(1, newText.Length - 2) + "]";
}
```

ASSA override blocks (`{\i1\a6}…{\i0}`) match that exact shape, so they were mangled. (A single-line tag without a trailing brace, e.g. `{\a6}Please…`, was already untouched because it doesn't end in `}`.)

## Fix
Skip the conversion when the braced block is an ASSA override tag — detected by the codebase's established convention that override tags start with `{\` (`HtmlUtil`, `DialogSplitMerge`). Applied to both the single-line `{…}` case and the dashed two-line `-{…}` case. Genuine HI brackets (`{SIGHING}`, `(SIGHING)`) still convert to `[SIGHING]`.

## Tests
New `NetflixCheckTextForHiUseBracketsTests` (10 cases): the issue example + single-line/dashed ASSA overrides are left untouched; `{SIGHING}` / `(SIGHING)` / `{DOOR CREAKS}` still convert; plain text unchanged. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)