### PR TITLE
Wire F1 help in windows missing it; fix Netflix-check help target

### DIFF
--- a/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundViewModel.cs
@@ -647,6 +647,11 @@ public partial class AssSetBackgroundViewModel : ObservableObject
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assa-set-background");
+        }
     }
 
     private void StartPreviewTimer()

--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
+using Nikse.SubtitleEdit.Logic;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -846,6 +847,11 @@ public partial class CompareViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/compare");
         }
     }
 

--- a/src/ui/Features/Files/Statistics/StatisticsViewModel.cs
+++ b/src/ui/Features/Files/Statistics/StatisticsViewModel.cs
@@ -701,5 +701,10 @@ https://github.com/SubtitleEdit/subtitleedit
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/statistics");
+        }
     }
 }

--- a/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesViewModel.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesViewModel.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -45,6 +46,11 @@ public partial class FindDoubleLinesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/find-double-lines");
         }
     }
 

--- a/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsViewModel.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsViewModel.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -46,6 +47,11 @@ public partial class FindDoubleWordsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/find-double-words");
         }
     }
 

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
@@ -243,6 +243,11 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/apply-duration-limits");
+        }
     }
 
     public void Initialize(List<SubtitleLineViewModel> toList, List<double> shotChanges)

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -635,6 +635,11 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
             e.Handled = true;
             Cancel();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/beautify-time-codes");
+        }
     }
 
     public void Dispose()

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsViewModel.cs
@@ -312,7 +312,7 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
         else if (UiUtil.IsHelp(e))
         {
             e.Handled = true;
-            UiUtil.ShowHelp("features/fix-common-errors");
+            UiUtil.ShowHelp("features/netflix-errors");
         }
     }
 

--- a/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesViewModel.cs
+++ b/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesViewModel.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -429,6 +430,11 @@ public partial class JoinSubtitlesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/join-subtitles");
         }
     }
 

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
+using Nikse.SubtitleEdit.Logic;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -148,6 +149,11 @@ public partial class MergeShortLinesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/merge-short-lines");
         }
     }
 

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
+using Nikse.SubtitleEdit.Logic;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -596,6 +597,11 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/split-break-long-lines");
         }
     }
 

--- a/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
@@ -386,5 +386,10 @@ public partial class SplitSubtitleViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/split-subtitle");
+        }
     }
 }

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1957,6 +1957,11 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             Cancel();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/auto-translate");
+        }
     }
 
     internal void OnLoaded()

--- a/src/ui/Features/Translate/CopyPasteTranslateViewModel.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateViewModel.cs
@@ -185,5 +185,10 @@ public partial class CopyPasteTranslateViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/copy-paste-translate");
+        }
     }
 }

--- a/tests/UI/Logic/HelpLinksResolveTests.cs
+++ b/tests/UI/Logic/HelpLinksResolveTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Guards that every <c>UiUtil.ShowHelp("name")</c> in the UI maps to a real help page under
+/// <c>docs/</c> (GitHub Pages serves <c>docs/name.md</c> as <c>name.html</c>). Catches typos /
+/// renamed docs that would make F1 open a 404.
+/// </summary>
+public class HelpLinksResolveTests
+{
+    private static readonly Regex ShowHelpRegex =
+        new("ShowHelp\\(\"(?<name>[^\"]+)\"", RegexOptions.Compiled);
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "SubtitleEdit.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    [Fact]
+    public void EveryShowHelpTargetHasADocsPage()
+    {
+        var root = FindRepoRoot();
+        var uiDir = Path.Combine(root, "src", "ui");
+        var docsDir = Path.Combine(root, "docs");
+
+        var missing = new List<string>();
+        var found = 0;
+
+        foreach (var file in Directory.EnumerateFiles(uiDir, "*.cs", SearchOption.AllDirectories))
+        {
+            foreach (Match m in ShowHelpRegex.Matches(File.ReadAllText(file)))
+            {
+                var name = m.Groups["name"].Value; // e.g. "features/spell-check" or "index"
+                var mdPath = Path.Combine(docsDir, name.Replace('/', Path.DirectorySeparatorChar) + ".md");
+                if (File.Exists(mdPath))
+                {
+                    found++;
+                }
+                else
+                {
+                    missing.Add($"{name} (in {Path.GetFileName(file)}) -> {mdPath}");
+                }
+            }
+        }
+
+        Assert.True(found > 0, "No ShowHelp(...) calls found — test wiring is broken.");
+        Assert.True(missing.Count == 0, "ShowHelp targets without a docs page:\n" + string.Join("\n", missing));
+    }
+}


### PR DESCRIPTION
## What
Audited every window against the help pages under `docs/` and made **F1 (the help key) open the corresponding page** wherever it was missing or wrong.

`F1 → UiUtil.IsHelp → UiUtil.ShowHelp("features/x") → subtitleedit.github.io/subtitleedit/features/x.html`.

## Findings
- **13 dialogs had a help page but no F1 handler** — their key handler only handled Escape, so F1 did nothing. Added the standard `else if (UiUtil.IsHelp(e)) { ShowHelp("features/…"); }` branch to each:
  `apply-duration-limits`, `assa-set-background`, `auto-translate`, `beautify-time-codes`, `compare`, `copy-paste-translate`, `find-double-lines`, `find-double-words`, `join-subtitles`, `merge-short-lines`, `split-break-long-lines`, `split-subtitle`, `statistics`.
- **Wrong target:** the Netflix quality-check window (`FixNetflixErrors`) opened `features/fix-common-errors` instead of its own **`features/netflix-errors`** page. Fixed. (Same window from #11720.)
- **Verified OK:** all pre-existing `ShowHelp` calls resolve to a real doc; spot-checked semantically (e.g. the "Change speed" dialog is internally `ManualSync` → `features/change-speed`, which is correct).
- **Intentionally left:** pages that aren't standalone dialogs — `main-window`/`file`/`subtitle-grid`/`text-editor`/`video-player`/`audio-visualizer` (main-window areas; main window F1 opens the docs `index`), `seconv` (CLI), `whats-new-in-se5`, `assa-override-tags` (reference), and `empty-translation` (a menu action with no window).

## Test
`HelpLinksResolveTests` scans every `UiUtil.ShowHelp("name")` in `src/ui` and asserts a matching `docs/name.md` exists — so a future typo or renamed doc that would make F1 open a 404 fails the build. Passes (and confirms the netflix retarget resolves).

## Verification
`dotnet build src/ui/UI.csproj` succeeds (one pre-existing unrelated warning); new test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)