### PR TITLE
Fix Qwen3 ASR CPP failing on unescaped control chars in JSON output (issue #11717)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -823,13 +823,14 @@ public partial class SpeechToTextViewModel : ObservableObject
             return;
         }
 
+        var rawJson = string.Empty;
         try
         {
-            var jsonText = File.ReadAllText(jsonPath);
+            rawJson = File.ReadAllText(jsonPath);
             // qwen3-asr-cli can write raw control chars (e.g. a literal newline) inside JSON
             // string values, which strict System.Text.Json rejects ("'0x0A' is invalid within a
             // JSON string"). Escape those so a result is still produced (issue #11717).
-            jsonText = JsonRepair.EscapeControlCharsInStrings(jsonText);
+            var jsonText = JsonRepair.EscapeControlCharsInStrings(rawJson);
             var jsonDoc = JsonDocument.Parse(jsonText);
             var words = jsonDoc.RootElement.GetProperty("words");
 
@@ -900,6 +901,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         catch (Exception ex)
         {
             Se.LogError(ex, $"Failed to read Qwen3 ASR CPP output JSON '{jsonPath}'");
+            // Persist the offending output so the failure is diagnosable — the temp .json is
+            // deleted below, so logging its raw content here is the only record (issue #11717).
+            Se.WriteToolsLog($"Qwen3 ASR CPP output JSON failed to parse ({ex.Message}):{Environment.NewLine}{rawJson}");
             Dispatcher.UIThread.Invoke<Task>(async () =>
             {
                 LogToConsole($"Speech to text ({settings.WhisperChoice}) failed: {ex.Message}{Environment.NewLine}");

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -826,6 +826,10 @@ public partial class SpeechToTextViewModel : ObservableObject
         try
         {
             var jsonText = File.ReadAllText(jsonPath);
+            // qwen3-asr-cli can write raw control chars (e.g. a literal newline) inside JSON
+            // string values, which strict System.Text.Json rejects ("'0x0A' is invalid within a
+            // JSON string"). Escape those so a result is still produced (issue #11717).
+            jsonText = JsonRepair.EscapeControlCharsInStrings(jsonText);
             var jsonDoc = JsonDocument.Parse(jsonText);
             var words = jsonDoc.RootElement.GetProperty("words");
 
@@ -895,9 +899,14 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            Se.LogError(ex, $"Failed to read Qwen3 ASR CPP output JSON '{jsonPath}'");
             Dispatcher.UIThread.Invoke<Task>(async () =>
             {
                 LogToConsole($"Speech to text ({settings.WhisperChoice}) failed: {ex.Message}{Environment.NewLine}");
+                if (ex is JsonException)
+                {
+                    LogToConsole($"The Qwen3 ASR engine produced output that could not be read. This is usually a problem with the engine or the chosen forced aligner (e.g. with some non-Latin scripts). Try re-running, a different model/aligner, or report it at {new Qwen3AsrCppEngine().Url}{Environment.NewLine}");
+                }
                 ProgressValue = 100;
                 IsTranscribeEnabled = true;
                 await Task.CompletedTask;

--- a/src/ui/Logic/JsonRepair.cs
+++ b/src/ui/Logic/JsonRepair.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Best-effort repair of slightly-malformed JSON emitted by external command-line tools so the
+/// strict <see cref="System.Text.Json"/> parser can read it.
+/// </summary>
+public static class JsonRepair
+{
+    /// <summary>
+    /// Escapes raw control characters (&lt; U+0020) that appear inside JSON string literals.
+    /// Strict JSON requires these to be escaped (e.g. a literal newline must be <c>\n</c>); some
+    /// tools — e.g. qwen3-asr-cli — write the raw character, which makes
+    /// <c>System.Text.Json</c> throw "'0x0A' is invalid within a JSON string". Characters outside
+    /// string literals (structural whitespace) are left untouched, so valid JSON is returned
+    /// unchanged.
+    /// </summary>
+    public static string EscapeControlCharsInStrings(string json)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            return json;
+        }
+
+        var sb = new StringBuilder(json.Length + 16);
+        var inString = false;
+        var escaped = false;
+
+        foreach (var c in json)
+        {
+            if (!inString)
+            {
+                sb.Append(c);
+                if (c == '"')
+                {
+                    inString = true;
+                }
+
+                continue;
+            }
+
+            if (escaped)
+            {
+                // Previous char was a backslash; this char is part of an escape sequence — emit verbatim.
+                sb.Append(c);
+                escaped = false;
+                continue;
+            }
+
+            switch (c)
+            {
+                case '\\':
+                    sb.Append(c);
+                    escaped = true;
+                    break;
+                case '"':
+                    sb.Append(c);
+                    inString = false;
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                case '\b':
+                    sb.Append("\\b");
+                    break;
+                case '\f':
+                    sb.Append("\\f");
+                    break;
+                default:
+                    if (c < 0x20)
+                    {
+                        sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/UI/Logic/JsonRepairTests.cs
+++ b/tests/UI/Logic/JsonRepairTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Nikse.SubtitleEdit.Logic;
+using Xunit;
+
+namespace UITests.Logic;
+
+public class JsonRepairTests
+{
+    [Fact]
+    public void EscapesRawNewlineInsideString_SoItParses()
+    {
+        // Mirrors the qwen3-asr-cli output from issue #11717: a literal newline inside a string value.
+        var bad = "{\n  \"text\": \"line one\nline two\",\n  \"words\": []\n}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(bad);
+
+        using var doc = JsonDocument.Parse(repaired); // would throw before the repair
+        Assert.Equal("line one\nline two", doc.RootElement.GetProperty("text").GetString());
+    }
+
+    [Theory]
+    [InlineData("\t", "\\t")]
+    [InlineData("\r", "\\r")]
+    [InlineData("\b", "\\b")]
+    [InlineData("\f", "\\f")]
+    [InlineData("", "\\u0001")]
+    public void EscapesEachRawControlCharInsideString(string raw, string expectedEscape)
+    {
+        var bad = "{\"a\":\"x" + raw + "y\"}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(bad);
+
+        Assert.Contains("\"x" + expectedEscape + "y\"", repaired);
+        using var doc = JsonDocument.Parse(repaired);
+        Assert.Equal("x" + raw + "y", doc.RootElement.GetProperty("a").GetString());
+    }
+
+    [Fact]
+    public void LeavesAlreadyEscapedSequencesUntouched()
+    {
+        // The backslash-n here is two characters (already escaped) and must not become \\n.
+        var ok = "{\"a\":\"already\\nescaped\"}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(ok);
+
+        Assert.Equal(ok, repaired);
+        using var doc = JsonDocument.Parse(repaired);
+        Assert.Equal("already\nescaped", doc.RootElement.GetProperty("a").GetString());
+    }
+
+    [Fact]
+    public void LeavesStructuralWhitespaceUntouched()
+    {
+        // Newlines/tabs BETWEEN tokens are valid JSON whitespace and must not be escaped.
+        var pretty = "{\n\t\"a\": 1,\n\t\"b\": 2\n}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(pretty);
+
+        Assert.Equal(pretty, repaired);
+    }
+
+    [Fact]
+    public void DoesNotTreatEscapedQuoteAsStringEnd()
+    {
+        // The \" is an escaped quote; the real string continues, so the raw newline after it
+        // must still be escaped.
+        var bad = "{\"a\":\"say \\\"hi\\\"\nthere\"}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(bad);
+
+        using var doc = JsonDocument.Parse(repaired);
+        Assert.Equal("say \"hi\"\nthere", doc.RootElement.GetProperty("a").GetString());
+    }
+}


### PR DESCRIPTION
Fixes #11717.

## Problem
On Linux, Qwen3 ASR CPP transcribes the audio but no subtitle is produced. The console ends with:

```
Output written to: /tmp/qwen3_asr_....json
Speech to text (Qwen3 ASR CPP) failed: '0x0A' is invalid within a JSON string. The string should be correctly escaped. LineNumber: 2 | BytePositionInLine: 257.
```

## Root cause
`qwen3-asr-cli` writes a **raw control character (a literal newline, `0x0A`) inside a JSON string value**, which is invalid per the JSON spec. `SpeechToTextViewModel.ProcessQwen3AsrCppTranscription` parses the output with `JsonDocument.Parse`, and strict `System.Text.Json` rejects it — so the whole transcription is discarded despite the engine having produced text. (Reproduced with a Chinese transcript; the aligner emitted a single "word" whose text carried the raw newline.)

`System.Text.Json` has no option to tolerate unescaped control characters, so the fix is to repair the input.

## Fix
- New `JsonRepair.EscapeControlCharsInStrings(json)` — a single forward pass that escapes raw control chars (`< U+0020`) **only when inside a string literal** (tracking `\`-escapes and quotes), leaving structural whitespace and already-valid JSON untouched. The engine output is run through it before `JsonDocument.Parse`.
- Better failure handling: the catch now logs the exception via `Se.LogError`, and on a `JsonException` prints an actionable note (likely an engine/forced-aligner issue — try another model/aligner or report upstream) instead of only the raw parser message.

## Tests
`JsonRepairTests` (9 cases): the exact issue scenario (raw newline → parses), every control char (`\t \r \b \f `), already-escaped sequences left intact, structural whitespace untouched, and escaped quotes inside strings handled correctly.

## Note
The malformed JSON is ultimately an upstream bug in `woct0rdho/qwen3-asr.cpp`; this change makes SE robust to it regardless of the engine version. Happy to file an upstream issue too if wanted.

## Verification
`dotnet build src/ui/UI.csproj` succeeds (one pre-existing unrelated warning); new tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)