### PR TITLE
Use fixed Qwen3 ASR CPP binaries (niksedk build) + enable Linux ARM64 / Intel Mac

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -823,13 +823,14 @@ public partial class SpeechToTextViewModel : ObservableObject
             return;
         }
 
+        var rawJson = string.Empty;
         try
         {
-            var jsonText = File.ReadAllText(jsonPath);
+            rawJson = File.ReadAllText(jsonPath);
             // qwen3-asr-cli can write raw control chars (e.g. a literal newline) inside JSON
             // string values, which strict System.Text.Json rejects ("'0x0A' is invalid within a
             // JSON string"). Escape those so a result is still produced (issue #11717).
-            jsonText = JsonRepair.EscapeControlCharsInStrings(jsonText);
+            var jsonText = JsonRepair.EscapeControlCharsInStrings(rawJson);
             var jsonDoc = JsonDocument.Parse(jsonText);
             var words = jsonDoc.RootElement.GetProperty("words");
 
@@ -900,6 +901,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         catch (Exception ex)
         {
             Se.LogError(ex, $"Failed to read Qwen3 ASR CPP output JSON '{jsonPath}'");
+            // Persist the offending output so the failure is diagnosable — the temp .json is
+            // deleted below, so logging its raw content here is the only record (issue #11717).
+            Se.WriteToolsLog($"Qwen3 ASR CPP output JSON failed to parse ({ex.Message}):{Environment.NewLine}{rawJson}");
             Dispatcher.UIThread.Invoke<Task>(async () =>
             {
                 LogToConsole($"Speech to text ({settings.WhisperChoice}) failed: {ex.Message}{Environment.NewLine}");

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -826,6 +826,10 @@ public partial class SpeechToTextViewModel : ObservableObject
         try
         {
             var jsonText = File.ReadAllText(jsonPath);
+            // qwen3-asr-cli can write raw control chars (e.g. a literal newline) inside JSON
+            // string values, which strict System.Text.Json rejects ("'0x0A' is invalid within a
+            // JSON string"). Escape those so a result is still produced (issue #11717).
+            jsonText = JsonRepair.EscapeControlCharsInStrings(jsonText);
             var jsonDoc = JsonDocument.Parse(jsonText);
             var words = jsonDoc.RootElement.GetProperty("words");
 
@@ -895,9 +899,14 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            Se.LogError(ex, $"Failed to read Qwen3 ASR CPP output JSON '{jsonPath}'");
             Dispatcher.UIThread.Invoke<Task>(async () =>
             {
                 LogToConsole($"Speech to text ({settings.WhisperChoice}) failed: {ex.Message}{Environment.NewLine}");
+                if (ex is JsonException)
+                {
+                    LogToConsole($"The Qwen3 ASR engine produced output that could not be read. This is usually a problem with the engine or the chosen forced aligner (e.g. with some non-Latin scripts). Try re-running, a different model/aligner, or report it at {new Qwen3AsrCppEngine().Url}{Environment.NewLine}");
+                }
                 ProgressValue = 100;
                 IsTranscribeEnabled = true;
                 await Task.CompletedTask;

--- a/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
@@ -16,9 +16,14 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-asr-cpp-2026-3/qwen3-asr-cpp-win64.zip";
-    private const string MacArmUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-asr-cpp-2026-3/qwen3-asr-cpp-mac.zip";
-    private const string LinuxUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-asr-cpp-2026-3/qwen3-asr-cpp-linux.zip";
+    // Built by https://github.com/niksedk/qwen3-asr.cpp (.github/workflows/release.yml) — these
+    // are the binaries with the JSON word-truncation fix (issue #11717).
+    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.1/";
+    private const string WindowsUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64.zip";
+    private const string MacArmUrl = ReleaseUrlBase + "qwen3-asr-cpp-mac.zip";
+    private const string MacX64Url = ReleaseUrlBase + "qwen3-asr-cpp-mac-x64.zip";
+    private const string LinuxUrl = ReleaseUrlBase + "qwen3-asr-cpp-linux.zip";
+    private const string LinuxArm64Url = ReleaseUrlBase + "qwen3-asr-cpp-linux-arm64.zip";
 
     public Qwen3AsrCppDownloadService(HttpClient httpClient)
     {
@@ -39,17 +44,12 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-            {
-                throw new PlatformNotSupportedException("Qwen3 ASR is not available for Linux ARM64.");
-            }
-
-            return LinuxUrl;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArm64Url : LinuxUrl;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            return MacArmUrl;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? MacArmUrl : MacX64Url;
         }
 
         throw new PlatformNotSupportedException();

--- a/src/ui/Logic/JsonRepair.cs
+++ b/src/ui/Logic/JsonRepair.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Best-effort repair of slightly-malformed JSON emitted by external command-line tools so the
+/// strict <see cref="System.Text.Json"/> parser can read it.
+/// </summary>
+public static class JsonRepair
+{
+    /// <summary>
+    /// Escapes raw control characters (&lt; U+0020) that appear inside JSON string literals.
+    /// Strict JSON requires these to be escaped (e.g. a literal newline must be <c>\n</c>); some
+    /// tools — e.g. qwen3-asr-cli — write the raw character, which makes
+    /// <c>System.Text.Json</c> throw "'0x0A' is invalid within a JSON string". Characters outside
+    /// string literals (structural whitespace) are left untouched, so valid JSON is returned
+    /// unchanged.
+    /// </summary>
+    public static string EscapeControlCharsInStrings(string json)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            return json;
+        }
+
+        var sb = new StringBuilder(json.Length + 16);
+        var inString = false;
+        var escaped = false;
+
+        foreach (var c in json)
+        {
+            if (!inString)
+            {
+                sb.Append(c);
+                if (c == '"')
+                {
+                    inString = true;
+                }
+
+                continue;
+            }
+
+            if (escaped)
+            {
+                // Previous char was a backslash; this char is part of an escape sequence — emit verbatim.
+                sb.Append(c);
+                escaped = false;
+                continue;
+            }
+
+            switch (c)
+            {
+                case '\\':
+                    sb.Append(c);
+                    escaped = true;
+                    break;
+                case '"':
+                    sb.Append(c);
+                    inString = false;
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                case '\b':
+                    sb.Append("\\b");
+                    break;
+                case '\f':
+                    sb.Append("\\f");
+                    break;
+                default:
+                    if (c < 0x20)
+                    {
+                        sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/UI/Logic/JsonRepairTests.cs
+++ b/tests/UI/Logic/JsonRepairTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Nikse.SubtitleEdit.Logic;
+using Xunit;
+
+namespace UITests.Logic;
+
+public class JsonRepairTests
+{
+    [Fact]
+    public void EscapesRawNewlineInsideString_SoItParses()
+    {
+        // Mirrors the qwen3-asr-cli output from issue #11717: a literal newline inside a string value.
+        var bad = "{\n  \"text\": \"line one\nline two\",\n  \"words\": []\n}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(bad);
+
+        using var doc = JsonDocument.Parse(repaired); // would throw before the repair
+        Assert.Equal("line one\nline two", doc.RootElement.GetProperty("text").GetString());
+    }
+
+    [Theory]
+    [InlineData("\t", "\\t")]
+    [InlineData("\r", "\\r")]
+    [InlineData("\b", "\\b")]
+    [InlineData("\f", "\\f")]
+    [InlineData("", "\\u0001")]
+    public void EscapesEachRawControlCharInsideString(string raw, string expectedEscape)
+    {
+        var bad = "{\"a\":\"x" + raw + "y\"}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(bad);
+
+        Assert.Contains("\"x" + expectedEscape + "y\"", repaired);
+        using var doc = JsonDocument.Parse(repaired);
+        Assert.Equal("x" + raw + "y", doc.RootElement.GetProperty("a").GetString());
+    }
+
+    [Fact]
+    public void LeavesAlreadyEscapedSequencesUntouched()
+    {
+        // The backslash-n here is two characters (already escaped) and must not become \\n.
+        var ok = "{\"a\":\"already\\nescaped\"}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(ok);
+
+        Assert.Equal(ok, repaired);
+        using var doc = JsonDocument.Parse(repaired);
+        Assert.Equal("already\nescaped", doc.RootElement.GetProperty("a").GetString());
+    }
+
+    [Fact]
+    public void LeavesStructuralWhitespaceUntouched()
+    {
+        // Newlines/tabs BETWEEN tokens are valid JSON whitespace and must not be escaped.
+        var pretty = "{\n\t\"a\": 1,\n\t\"b\": 2\n}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(pretty);
+
+        Assert.Equal(pretty, repaired);
+    }
+
+    [Fact]
+    public void DoesNotTreatEscapedQuoteAsStringEnd()
+    {
+        // The \" is an escaped quote; the real string continues, so the raw newline after it
+        // must still be escaped.
+        var bad = "{\"a\":\"say \\\"hi\\\"\nthere\"}";
+
+        var repaired = JsonRepair.EscapeControlCharsInStrings(bad);
+
+        using var doc = JsonDocument.Parse(repaired);
+        Assert.Equal("say \"hi\"\nthere", doc.RootElement.GetProperty("a").GetString());
+    }
+}


### PR DESCRIPTION
Points the **Qwen3 ASR CPP** engine download at the [niksedk/qwen3-asr.cpp `v0.1.1`](https://github.com/niksedk/qwen3-asr.cpp/releases/tag/v0.1.1) release, which is built with the JSON word-truncation fix for #11717.

## Why
The CLI's `alignment_to_json` formatted each word into a fixed `char buf[256]`, so a long word was truncated — and for languages without word spacing (e.g. **Chinese**) the forced aligner returns the *whole transcript as one "word"*, leaving unterminated/unparseable JSON (`'0x0A' is invalid within a JSON string`). Fixed upstream in niksedk/qwen3-asr.cpp#1; the v0.1.1 release ships those fixed binaries. The old `SubtitleEdit/support-files` build did not have the fix.

## Changes
- Repoint `win64` / `linux` / `mac` (arm) downloads to the `v0.1.1` release.
- The release also ships **`linux-arm64`** and **`mac-x64`** binaries, so wire them up:
  - Linux ARM64 no longer throws `PlatformNotSupportedException` — it downloads the arm64 build.
  - Intel Macs now get the **x64** build instead of being served the arm64 one.

## Verification
- All 5 release asset URLs return HTTP 200.
- The engine expects `qwen3-asr-cli[.exe]` at the unpack root, which the new zips provide (CLI + shared libs at root, optional Korean dict under `assets/`). No `DownloadHashManager` entries exist for this engine, so nothing else to update.
- `dotnet build src/ui/UI.csproj` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)