### PR TITLE
Qwen3 ASR: CPU/GPU (Vulkan) download picker + use niksedk v0.1.2 binaries

### DIFF
--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -40,6 +40,12 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
     /// </summary>
     public string CrispAsrWindowsVariant { get; set; } = "vulkan";
 
+    /// <summary>
+    /// When true, download the Vulkan (GPU) build of Qwen3 ASR CPP instead of the CPU build.
+    /// Only honoured on platforms that have a Vulkan build (win64, linux-x64).
+    /// </summary>
+    public bool Qwen3AsrUseVulkan { get; set; }
+
     private readonly IWhisperDownloadService _whisperDownloadService;
     private readonly IChatLlmDownloadService _chatLlmDownloadService;
     private readonly IQwen3AsrCppDownloadService _qwen3AsrCppDownloadService;
@@ -465,7 +471,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
         else if (Engine is Qwen3AsrCppEngine)
         {
             var dir = Engine.GetAndCreateWhisperFolder();
-            _downloadTask = _qwen3AsrCppDownloadService.DownloadEngine(_downloadStream, downloadProgress, _cancellationTokenSource.Token);
+            _downloadTask = _qwen3AsrCppDownloadService.DownloadEngine(_downloadStream, downloadProgress, _cancellationTokenSource.Token, Qwen3AsrUseVulkan);
         }
         else if (Engine is ICrispAsrEngine)
         {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2102,15 +2102,73 @@ public partial class SpeechToTextViewModel : ObservableObject
             crispVariant = linuxAnswer;
         }
 
+        var qwen3UseVulkan = false;
+        if (engine is Qwen3AsrCppEngine && Qwen3AsrCppDownloadService.IsVulkanBuildAvailable())
+        {
+            var pick = await PromptQwen3AsrGpuAsync(engine.Name);
+            if (pick == null)
+            {
+                return;
+            }
+
+            qwen3UseVulkan = pick.Value;
+        }
+
         await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
             Window, viewModel =>
             {
                 viewModel.Engine = engine;
                 viewModel.CrispAsrWindowsVariant = crispVariant;
+                viewModel.Qwen3AsrUseVulkan = qwen3UseVulkan;
                 viewModel.StartDownload();
             });
 
         RefreshEngineCombo?.Invoke();
+    }
+
+    /// <summary>
+    /// Qwen3 ASR build prompt (win64 / linux-x64, where a Vulkan build exists): CPU vs GPU (Vulkan).
+    /// Returns true for the Vulkan build, false for CPU, or null when the user cancels.
+    /// </summary>
+    private async Task<bool?> PromptQwen3AsrGpuAsync(string engineName)
+    {
+        var answer = await MessageBox.Show(
+            Window!,
+            $"Download {engineName}?",
+            $"{Environment.NewLine}\"{engineName}\" requires downloading the engine.{Environment.NewLine}{Environment.NewLine}Select a version to download:",
+            MessageBoxButtons.Cancel,
+            MessageBoxIcon.Question,
+            "CPU",
+            "GPU (Vulkan)");
+
+        if (answer == MessageBoxResult.None || answer == MessageBoxResult.Cancel)
+        {
+            return null;
+        }
+
+        var useVulkan = answer == MessageBoxResult.Custom2;
+        if (useVulkan && !VulkanHelper.IsInstalled())
+        {
+            var vulkanAnswer = await MessageBox.Show(
+                Window!,
+                "Vulkan may be required",
+                $"The GPU (Vulkan) build needs a Vulkan-capable GPU and runtime.{Environment.NewLine}{Environment.NewLine}You can get the Vulkan SDK from:{Environment.NewLine}https://vulkan.lunarg.com/sdk/home{Environment.NewLine}{Environment.NewLine}Continue with the GPU download?",
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (vulkanAnswer == MessageBoxResult.No)
+            {
+                UiUtil.OpenUrl("https://vulkan.lunarg.com/sdk/home");
+                return null;
+            }
+
+            if (vulkanAnswer != MessageBoxResult.Yes)
+            {
+                return null;
+            }
+        }
+
+        return useVulkan;
     }
 
     /// <summary>
@@ -2551,22 +2609,38 @@ public partial class SpeechToTextViewModel : ObservableObject
                 }
                 else
                 {
-                    var answer = await MessageBox.Show(
-                        Window!,
-                        $"Download {engine.Name}?",
-                        $"Download and use {engine.Name}?",
-                        MessageBoxButtons.YesNoCancel,
-                        MessageBoxIcon.Question);
-
-                    if (answer != MessageBoxResult.Yes)
+                    var qwen3UseVulkan = false;
+                    if (engine is Qwen3AsrCppEngine && Qwen3AsrCppDownloadService.IsVulkanBuildAvailable())
                     {
-                        return;
+                        // Qwen3 ASR has a Vulkan (GPU) build on win64/linux-x64 — let the user choose.
+                        var pick = await PromptQwen3AsrGpuAsync(engine.Name);
+                        if (pick == null)
+                        {
+                            return;
+                        }
+
+                        qwen3UseVulkan = pick.Value;
+                    }
+                    else
+                    {
+                        var answer = await MessageBox.Show(
+                            Window!,
+                            $"Download {engine.Name}?",
+                            $"Download and use {engine.Name}?",
+                            MessageBoxButtons.YesNoCancel,
+                            MessageBoxIcon.Question);
+
+                        if (answer != MessageBoxResult.Yes)
+                        {
+                            return;
+                        }
                     }
 
                     var vm = await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
                         Window!, viewModel =>
                         {
                             viewModel.Engine = engine;
+                            viewModel.Qwen3AsrUseVulkan = qwen3UseVulkan;
                             viewModel.StartDownload();
                         });
 

--- a/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -9,47 +9,69 @@ namespace Nikse.SubtitleEdit.Logic.Download;
 
 public interface IQwen3AsrCppDownloadService
 {
-    Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken, bool useVulkan = false);
 }
 
 public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-asr-cpp-2026-3/qwen3-asr-cpp-win64.zip";
-    private const string MacArmUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-asr-cpp-2026-3/qwen3-asr-cpp-mac.zip";
-    private const string LinuxUrl = "https://github.com/SubtitleEdit/support-files/releases/download/qwen3-asr-cpp-2026-3/qwen3-asr-cpp-linux.zip";
+    // Built by https://github.com/niksedk/qwen3-asr.cpp (.github/workflows/release.yml) — these
+    // are the binaries with the JSON word-truncation fix (issue #11717). CPU for every platform,
+    // plus Vulkan (GPU) for win64 and linux-x64.
+    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.2/";
+    private const string WindowsUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64.zip";
+    private const string WindowsVulkanUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64-vulkan.zip";
+    private const string MacArmUrl = ReleaseUrlBase + "qwen3-asr-cpp-mac.zip";
+    private const string MacX64Url = ReleaseUrlBase + "qwen3-asr-cpp-mac-x64.zip";
+    private const string LinuxUrl = ReleaseUrlBase + "qwen3-asr-cpp-linux.zip";
+    private const string LinuxVulkanUrl = ReleaseUrlBase + "qwen3-asr-cpp-linux-vulkan.zip";
+    private const string LinuxArm64Url = ReleaseUrlBase + "qwen3-asr-cpp-linux-arm64.zip";
 
     public Qwen3AsrCppDownloadService(HttpClient httpClient)
     {
         _httpClient = httpClient;
     }
 
-    public async Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    /// <summary>
+    /// True when a Vulkan (GPU) build exists for the current platform — win64 and linux-x64.
+    /// Used to decide whether to offer the user a CPU/GPU choice before downloading.
+    /// </summary>
+    public static bool IsVulkanBuildAvailable()
     {
-        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(), stream, progress, cancellationToken);
+        if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        {
+            return false;
+        }
+
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
     }
 
-    private static string GetUrl()
+    public async Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken, bool useVulkan = false)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(useVulkan), stream, progress, cancellationToken);
+    }
+
+    private static string GetUrl(bool useVulkan)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return WindowsUrl;
+            return useVulkan ? WindowsVulkanUrl : WindowsUrl;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
-                throw new PlatformNotSupportedException("Qwen3 ASR is not available for Linux ARM64.");
+                return LinuxArm64Url; // no Vulkan build for ARM64
             }
 
-            return LinuxUrl;
+            return useVulkan ? LinuxVulkanUrl : LinuxUrl;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            return MacArmUrl;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? MacArmUrl : MacX64Url;
         }
 
         throw new PlatformNotSupportedException();


### PR DESCRIPTION
Adds a **CPU vs GPU (Vulkan)** choice when downloading the Qwen3 ASR CPP engine, and points the download at the [niksedk/qwen3-asr.cpp](https://github.com/niksedk/qwen3-asr.cpp) `v0.1.2` release (which includes the #11717 JSON fix **and** the new Vulkan GPU builds).

## Changes
- **`Qwen3AsrCppDownloadService`** — point at `v0.1.2` (CPU + Vulkan assets), add a `useVulkan` parameter, and `IsVulkanBuildAvailable()` (true on win64 / linux-x64, where a Vulkan build exists). Linux ARM64 and Intel Mac get their respective CPU builds.
- **`DownloadSpeechToTextEngineViewModel`** — new `Qwen3AsrUseVulkan` flag threaded into the download.
- **`SpeechToTextViewModel`** — `PromptQwen3AsrGpuAsync` (CPU / GPU (Vulkan) / Cancel, with a Vulkan-runtime heads-up like CrispASR's), shown from both the **re-download** and the **download-before-transcribe** flows. On platforms without a Vulkan build the previous plain confirm is kept.

## Why
Qwen3 ASR is slow on CPU (the #11717 reporter saw ~115 s for one clip). One Vulkan build covers NVIDIA + AMD + Intel GPUs.

## Dependencies / merge order
1. Merge niksedk/qwen3-asr.cpp **#3** (Vulkan workflow) and tag **`v0.1.2`** → publishes all 7 assets (5 CPU + 2 Vulkan).
2. Then merge this PR. **It supersedes #11739** (which repointed to v0.1.1, CPU-only) — recommend closing #11739 in favor of this.

## Verification
`dotnet build src/ui/UI.csproj` succeeds (one pre-existing unrelated warning). No other implementors of the download-service interface (DI only). Asset URLs go live once `v0.1.2` is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)