### PR TITLE
Apply French space-before-punctuation during OCR (issue #11702)

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -25,6 +25,34 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         public static readonly char[] NewLineChars = { '\r', '\n' };
 
+        /// <summary>
+        /// French typography puts a space before <c>! ? : ;</c>. Inserts that space where a
+        /// letter is immediately followed by one of those marks (e.g. <c>"Quoi?"</c> -> <c>"Quoi ?"</c>).
+        /// A non-letter before the mark (digit, existing space, etc.) is left untouched, so
+        /// time codes like <c>12:30</c> are not changed.
+        /// </summary>
+        public static string AddSpaceBeforeFrenchPunctuation(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            var newText = text;
+            var j = 1;
+            while (j < newText.Length)
+            {
+                if ("!?:;".Contains(newText[j]) && char.IsLetter(newText[j - 1]))
+                {
+                    newText = newText.Insert(j++, " ");
+                }
+
+                j++;
+            }
+
+            return newText;
+        }
+
         private static readonly Regex NumberSeparatorNumberRegEx = new Regex(@"\b\d+[\.:;] \d+\b", RegexOptions.Compiled);
         private static readonly Regex RegexIsNumber = new Regex("^\\d+$", RegexOptions.Compiled);
         private static readonly Regex RegexIsEpisodeNumber = new Regex("^\\d+x\\d+$", RegexOptions.Compiled);

--- a/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
@@ -371,16 +371,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                 if (callbacks.Language == "fr") // special rules for French
                 {
-                    var newText = p.Text;
-                    var j = 1;
-                    while (j < newText.Length)
-                    {
-                        if (@"!?:;".Contains(newText[j]) && char.IsLetter(newText[j - 1]))
-                        {
-                            newText = newText.Insert(j++, " ");
-                        }
-                        j++;
-                    }
+                    var newText = Utilities.AddSpaceBeforeFrenchPunctuation(p.Text);
                     if (newText != p.Text && callbacks.AllowFix(p, fixAction))
                     {
                         missingSpaces++;

--- a/src/ui/Features/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/ui/Features/Ocr/FixEngine/OcrFixEngine.cs
@@ -32,6 +32,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
     private string[] _wordSplitList;
     private SpellCheckWordLists _spellCheckWordLists;
     private string _threeLetterIsoLanguageName;
+    private string _twoLetterIsoLanguageName = string.Empty;
     private Subtitle _subtitle;
     private List<OcrSubtitleItem> _subtitles;
     private HashSet<string> _wordSkipList = new HashSet<string>();
@@ -58,6 +59,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
     {
         _isLoaded = true;
         var twoLetterIsoLanguageName = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(threeLetterIsoLanguageName);
+        _twoLetterIsoLanguageName = twoLetterIsoLanguageName;
         _spellCheckManager.Initialize(spellCheckDictionary.DictionaryFileName, twoLetterIsoLanguageName);
 
         _fiveLetterName = Path.GetFileNameWithoutExtension(spellCheckDictionary.DictionaryFileName);
@@ -120,6 +122,15 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
     {
         var spelledOK = IsSpelledCorrect(item.Text);
         var replacedLine = _ocrFixReplaceList.FixOcrErrorViaLineReplaceList(item.Text, _subtitle, index, _spellCheckManager, wordsToIgnore, spelledOK);
+
+        // French typography wants a space before ! ? : ; — Tesseract often returns it glued to the
+        // word ("Quoi?"). Apply the same normalization Fix-Common-Errors uses, so OCR output is
+        // French-correct without a separate pass (issue #11702).
+        if (_twoLetterIsoLanguageName == "fr")
+        {
+            replacedLine = Utilities.AddSpaceBeforeFrenchPunctuation(replacedLine);
+        }
+
         return replacedLine;
     }
 

--- a/tests/libse/Common/UtilitiesTest.cs
+++ b/tests/libse/Common/UtilitiesTest.cs
@@ -75,4 +75,28 @@ public class UtilitiesTest
 
         Assert.Equal(new SKColor(255, 0, 0), result);
     }
+
+    // French typography: a space before ! ? : ; — applied to French OCR output (issue #11702).
+    [Theory]
+    [InlineData("Quoi?", "Quoi ?")]
+    [InlineData("Bonjour!", "Bonjour !")]
+    [InlineData("Paul:", "Paul :")]
+    [InlineData("fin;", "fin ;")]
+    [InlineData("J'arrive. Tu viens?", "J'arrive. Tu viens ?")]
+    [InlineData("Quoi? Vraiment?", "Quoi ? Vraiment ?")]
+    public void AddSpaceBeforeFrenchPunctuation_InsertsSpace(string input, string expected)
+    {
+        Assert.Equal(expected, Utilities.AddSpaceBeforeFrenchPunctuation(input));
+    }
+
+    [Theory]
+    [InlineData("Déjà vu ?")]        // already spaced
+    [InlineData("12:30")]            // digit before colon (time code) — untouched
+    [InlineData("Vraiment ?!")]      // mark after a mark, not a letter — untouched
+    [InlineData("")]
+    [InlineData("Hello")]
+    public void AddSpaceBeforeFrenchPunctuation_LeavesOthersUnchanged(string input)
+    {
+        Assert.Equal(input, Utilities.AddSpaceBeforeFrenchPunctuation(input));
+    }
 }


### PR DESCRIPTION
Addresses part of #11702 — French OCR output in SE5 has `?`/`!`/`:`/`;` glued to the word (`Quoi?`), whereas SE4 produced the French-correct `Quoi ?`.

## Where SE4 added it (confirmed via `se4-legacy`)
The space-before-`! ? : ;` rule lives in exactly one place — **`FixMissingSpaces.cs`, the `Language == "fr"` branch** (Fix Common Errors). It's identical in SE4 and SE5 (shared `libse`). SE4's OCR fix engine itself only does the `J'`/♪ apostrophe fix (`FixFrenchLApostrophe`), **not** the spacing — so SE4 users got `Quoi ?` by running Fix Common Errors. SE5 has the same rule but its **OCR flow never invokes it**, so raw OCR output keeps `Quoi?`.

## Fix
- Extract the rule into **`Utilities.AddSpaceBeforeFrenchPunctuation`** (one source of truth).
- Apply it in **`OcrFixEngine`** when the OCR language is French, so OCR output is French-correct without a separate Fix-Common-Errors pass (the space is inserted before `SplitLine`, so it survives reassembly via `GetText()`).
- **`FixMissingSpaces`** now calls the same helper — behaviour unchanged (Fix-Common-Errors runner tests still green).
- A non-letter before the mark (digit, existing space) is left untouched, so time codes like `12:30` and already-spaced `Déjà ?` are safe.

## Tests
- `UtilitiesTest`: 11 cases (`Quoi?`→`Quoi ?`, `Paul:`→`Paul :`, multi-mark lines; and unchanged: `12:30`, already-spaced, `?!`, empty). All pass.
- `FixCommonErrorsRunner` tests still pass (refactor is behaviour-preserving).
- `dotnet build` succeeds.

## Scope note
This fixes the concrete, reproducible part of #11702 (the `?`-spacing the reporter quantified with Notepad++). The rest of that issue — Tesseract hallucinations, *missing* `?`, `J'`→`♪` — are OCR read-quality / config matters (and partly confounded by the reporter's mixed SE4/SE5 environment), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)