### PR TITLE
Fix Split tool dropping the last part; default output to source folder

### DIFF
--- a/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
@@ -88,6 +88,19 @@ public partial class SplitSubtitleViewModel : ObservableObject
         PartsMax = subtitle.Paragraphs.Count;
         _subtitleFileName = fileName;
         _subtitle = subtitle;
+
+        // Default the output to the source subtitle's own folder - that's where users splitting a
+        // file for translation expect the parts to land. Falls back to the loaded/Desktop folder
+        // for untitled subtitles.
+        if (!string.IsNullOrEmpty(fileName))
+        {
+            var folder = Path.GetDirectoryName(fileName);
+            if (!string.IsNullOrEmpty(folder) && Directory.Exists(folder))
+            {
+                OutputFolder = folder;
+            }
+        }
+
         _timerUpdatePreview.Start();
         SetDirty();
     }
@@ -173,12 +186,11 @@ public partial class SplitSubtitleViewModel : ObservableObject
 
         SaveSettings();
 
-        // Save parts
-        foreach (var part in _parts)
+        // Save parts. _parts and SplitItems are built together in UpdateSplit, so they stay aligned.
+        for (var i = 0; i < _parts.Count; i++)
         {
-            var text = part.ToText(SelectedSubtitleFormat);
-            var splitItem = SplitItems[_parts.IndexOf(part)];
-            var fileName = Path.Combine(OutputFolder, splitItem.FileName);
+            var text = _parts[i].ToText(SelectedSubtitleFormat);
+            var fileName = Path.Combine(OutputFolder, SplitItems[i].FileName);
             await File.WriteAllTextAsync(fileName, text, SelectedEncoding.Encoding ?? Encoding.UTF8);
         }
 
@@ -247,129 +259,34 @@ public partial class SplitSubtitleViewModel : ObservableObject
             NumberOfEqualParts = 1;
         }
 
+        var mode = SplitByCharacters
+            ? SubtitleSplitter.SplitMode.Characters
+            : SplitByTime
+                ? SubtitleSplitter.SplitMode.Time
+                : SubtitleSplitter.SplitMode.Lines;
+
+        // Build the parts and the preview rows from the same source, so the displayed part count
+        // always matches the number of files written on OK.
+        _parts = SubtitleSplitter.Split(_subtitle, NumberOfEqualParts, mode);
+
         Dispatcher.UIThread.Post(() =>
         {
             SplitItems.Clear();
-            var startNumber = 0;
-            if (SplitByLines)
+            for (var i = 0; i < _parts.Count; i++)
             {
-                var partSize = (int)(_subtitle.Paragraphs.Count / NumberOfEqualParts);
-                for (var i = 0; i < NumberOfEqualParts; i++)
+                var part = _parts[i];
+                var size = 0;
+                foreach (var p in part.Paragraphs)
                 {
-                    var noOfLines = partSize;
-                    if (i == NumberOfEqualParts - 1)
-                    {
-                        noOfLines = (int)(_subtitle.Paragraphs.Count - (NumberOfEqualParts - 1) * partSize);
-                    }
-
-                    var temp = new Subtitle { Header = _subtitle.Header };
-                    var size = 0;
-                    for (var number = 0; number < noOfLines; number++)
-                    {
-                        var p = _subtitle.Paragraphs[startNumber + number];
-                        temp.Paragraphs.Add(new Paragraph(p));
-                        size += HtmlUtil.RemoveHtmlTags(p.Text, true).Length;
-                    }
-                    startNumber += noOfLines;
-                    _parts.Add(temp);
-
-                    var item = new SplitDisplayItem()
-                    {
-                        Lines = noOfLines,
-                        Characters = size,
-                        FileName = fileNameNoExt + ".Part" + (i + 1) + format.Extension
-                    };
-                    SplitItems.Add(item);
-                }
-            }
-            else if (SplitByCharacters)
-            {
-                var totalNumberOfCharacters = 0;
-                foreach (var p in _subtitle.Paragraphs)
-                {
-                    totalNumberOfCharacters += HtmlUtil.RemoveHtmlTags(p.Text, true).Length;
+                    size += HtmlUtil.RemoveHtmlTags(p.Text, true).Length;
                 }
 
-                var partSize = (int)(totalNumberOfCharacters / NumberOfEqualParts);
-                var nextLimit = partSize;
-                var currentSize = 0;
-                var temp = new Subtitle { Header = _subtitle.Header };
-                for (var i = 0; i < _subtitle.Paragraphs.Count; i++)
+                SplitItems.Add(new SplitDisplayItem()
                 {
-                    var p = _subtitle.Paragraphs[i];
-                    var size = HtmlUtil.RemoveHtmlTags(p.Text, true).Length;
-                    if (currentSize + size > nextLimit + 4 && _parts.Count < NumberOfEqualParts - 1)
-                    {
-                        _parts.Add(temp);
-
-                        var item = new SplitDisplayItem()
-                        {
-                            Lines = temp.Paragraphs.Count,
-                            Characters = currentSize,
-                            FileName = fileNameNoExt + ".Part" + (SplitItems.Count + 1) + format.Extension
-                        };
-                        SplitItems.Add(item);
-
-                        currentSize = size;
-                        temp = new Subtitle { Header = _subtitle.Header };
-                        temp.Paragraphs.Add(new Paragraph(p));
-                    }
-                    else
-                    {
-                        currentSize += size;
-                        temp.Paragraphs.Add(new Paragraph(p));
-                    }
-                }
-
-                var lastItem = new SplitDisplayItem()
-                {
-                    Lines = temp.Paragraphs.Count,
-                    Characters = currentSize,
-                    FileName = fileNameNoExt + ".Part" + (SplitItems.Count + 1) + format.Extension
-                };
-                SplitItems.Add(lastItem);
-            }
-            else if (SplitByTime)
-            {
-                var startMs = _subtitle.Paragraphs[0].StartTime.TotalMilliseconds;
-                var endMs = _subtitle.Paragraphs[_subtitle.Paragraphs.Count - 1].EndTime.TotalMilliseconds;
-                var partSize = (endMs - startMs) / (double)NumberOfEqualParts;
-                var nextLimit = startMs + partSize;
-                var currentSize = 0;
-                var temp = new Subtitle { Header = _subtitle.Header };
-                for (var i = 0; i < _subtitle.Paragraphs.Count; i++)
-                {
-                    var p = _subtitle.Paragraphs[i];
-                    var size = HtmlUtil.RemoveHtmlTags(p.Text, true).Replace("\r\n", "\n").Length;
-                    if (p.StartTime.TotalMilliseconds > nextLimit - 10 && _parts.Count < NumberOfEqualParts - 1)
-                    {
-                        _parts.Add(temp);
-                        var item = new SplitDisplayItem()
-                        {
-                            Lines = temp.Paragraphs.Count,
-                            Characters = currentSize,
-                            FileName = fileNameNoExt + ".Part" + (SplitItems.Count + 1) + format.Extension
-                        };
-                        SplitItems.Add(item);
-                        temp = new Subtitle { Header = _subtitle.Header };
-                        temp.Paragraphs.Add(new Paragraph(p));
-                        nextLimit += partSize;
-                        currentSize = 0;
-                    }
-                    else
-                    {
-                        currentSize += size;
-                        temp.Paragraphs.Add(new Paragraph(p));
-                    }
-                }
-
-                var lastItem = new SplitDisplayItem()
-                {
-                    Lines = temp.Paragraphs.Count,
-                    Characters = currentSize,
-                    FileName = fileNameNoExt + ".Part" + (SplitItems.Count + 1) + format.Extension
-                };
-                SplitItems.Add(lastItem);
+                    Lines = part.Paragraphs.Count,
+                    Characters = size,
+                    FileName = fileNameNoExt + ".Part" + (i + 1) + format.Extension
+                });
             }
         });
     }

--- a/src/ui/Features/Tools/SplitSubtitle/SubtitleSplitter.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SubtitleSplitter.cs
@@ -1,0 +1,140 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
+
+/// <summary>
+/// Pure split logic for the Split Subtitle tool. Kept side-effect free (no UI, no settings) so it
+/// can be unit tested. The number of returned parts always equals <paramref name="numberOfParts"/>
+/// (clamped to at least 1 and at most the paragraph count) - this is what guarantees the dialog
+/// preview and the files written to disk can never disagree.
+/// </summary>
+public static class SubtitleSplitter
+{
+    public enum SplitMode
+    {
+        Lines,
+        Characters,
+        Time,
+    }
+
+    public static List<Subtitle> Split(Subtitle subtitle, int numberOfParts, SplitMode mode)
+    {
+        var parts = new List<Subtitle>();
+        if (subtitle == null || subtitle.Paragraphs.Count == 0)
+        {
+            return parts;
+        }
+
+        if (numberOfParts < 1)
+        {
+            numberOfParts = 1;
+        }
+
+        if (numberOfParts > subtitle.Paragraphs.Count)
+        {
+            numberOfParts = subtitle.Paragraphs.Count;
+        }
+
+        return mode switch
+        {
+            SplitMode.Characters => SplitByCharacters(subtitle, numberOfParts),
+            SplitMode.Time => SplitByTime(subtitle, numberOfParts),
+            _ => SplitByLines(subtitle, numberOfParts),
+        };
+    }
+
+    private static List<Subtitle> SplitByLines(Subtitle subtitle, int numberOfParts)
+    {
+        var parts = new List<Subtitle>();
+        var partSize = subtitle.Paragraphs.Count / numberOfParts;
+        var startNumber = 0;
+        for (var i = 0; i < numberOfParts; i++)
+        {
+            var noOfLines = partSize;
+            if (i == numberOfParts - 1)
+            {
+                noOfLines = subtitle.Paragraphs.Count - (numberOfParts - 1) * partSize;
+            }
+
+            var temp = new Subtitle { Header = subtitle.Header };
+            for (var number = 0; number < noOfLines; number++)
+            {
+                temp.Paragraphs.Add(new Paragraph(subtitle.Paragraphs[startNumber + number]));
+            }
+
+            startNumber += noOfLines;
+            parts.Add(temp);
+        }
+
+        return parts;
+    }
+
+    private static List<Subtitle> SplitByCharacters(Subtitle subtitle, int numberOfParts)
+    {
+        var parts = new List<Subtitle>();
+        var totalNumberOfCharacters = 0;
+        foreach (var p in subtitle.Paragraphs)
+        {
+            totalNumberOfCharacters += HtmlUtil.RemoveHtmlTags(p.Text, true).Length;
+        }
+
+        var partSize = totalNumberOfCharacters / numberOfParts;
+        var nextLimit = partSize;
+        var currentSize = 0;
+        var temp = new Subtitle { Header = subtitle.Header };
+        for (var i = 0; i < subtitle.Paragraphs.Count; i++)
+        {
+            var p = subtitle.Paragraphs[i];
+            var size = HtmlUtil.RemoveHtmlTags(p.Text, true).Length;
+            if (currentSize + size > nextLimit + 4 && parts.Count < numberOfParts - 1)
+            {
+                parts.Add(temp);
+                currentSize = size;
+                temp = new Subtitle { Header = subtitle.Header };
+                temp.Paragraphs.Add(new Paragraph(p));
+            }
+            else
+            {
+                currentSize += size;
+                temp.Paragraphs.Add(new Paragraph(p));
+            }
+        }
+
+        // The trailing part must be added too, otherwise the dialog shows N parts but only N-1
+        // files are written (the reported "6 parts shown, 5 files generated" bug).
+        parts.Add(temp);
+
+        return parts;
+    }
+
+    private static List<Subtitle> SplitByTime(Subtitle subtitle, int numberOfParts)
+    {
+        var parts = new List<Subtitle>();
+        var startMs = subtitle.Paragraphs[0].StartTime.TotalMilliseconds;
+        var endMs = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].EndTime.TotalMilliseconds;
+        var partSize = (endMs - startMs) / numberOfParts;
+        var nextLimit = startMs + partSize;
+        var temp = new Subtitle { Header = subtitle.Header };
+        for (var i = 0; i < subtitle.Paragraphs.Count; i++)
+        {
+            var p = subtitle.Paragraphs[i];
+            if (p.StartTime.TotalMilliseconds > nextLimit - 10 && parts.Count < numberOfParts - 1)
+            {
+                parts.Add(temp);
+                temp = new Subtitle { Header = subtitle.Header };
+                temp.Paragraphs.Add(new Paragraph(p));
+                nextLimit += partSize;
+            }
+            else
+            {
+                temp.Paragraphs.Add(new Paragraph(p));
+            }
+        }
+
+        // See note in SplitByCharacters - the final part must be added as well.
+        parts.Add(temp);
+
+        return parts;
+    }
+}

--- a/tests/UI/Features/Tools/SplitSubtitle/SubtitleSplitterTests.cs
+++ b/tests/UI/Features/Tools/SplitSubtitle/SubtitleSplitterTests.cs
@@ -1,0 +1,106 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
+
+namespace UITests.Features.Tools.SplitSubtitle;
+
+public class SubtitleSplitterTests
+{
+    private static Subtitle MakeSubtitle(int paragraphCount, int textLength = 10)
+    {
+        var subtitle = new Subtitle();
+        var text = new string('a', textLength);
+        for (var i = 0; i < paragraphCount; i++)
+        {
+            var startMs = i * 1000;
+            subtitle.Paragraphs.Add(new Paragraph(text, startMs, startMs + 900));
+        }
+
+        return subtitle;
+    }
+
+    [Theory]
+    [InlineData(SubtitleSplitter.SplitMode.Lines)]
+    [InlineData(SubtitleSplitter.SplitMode.Characters)]
+    [InlineData(SubtitleSplitter.SplitMode.Time)]
+    public void Split_Into6Parts_ProducesExactly6Parts(SubtitleSplitter.SplitMode mode)
+    {
+        // Regression test for the reported bug: "split into 6 parts shows 6 but only 5 files generated".
+        var subtitle = MakeSubtitle(60);
+
+        var parts = SubtitleSplitter.Split(subtitle, 6, mode);
+
+        Assert.Equal(6, parts.Count);
+    }
+
+    [Theory]
+    [InlineData(SubtitleSplitter.SplitMode.Lines)]
+    [InlineData(SubtitleSplitter.SplitMode.Characters)]
+    [InlineData(SubtitleSplitter.SplitMode.Time)]
+    public void Split_KeepsEveryParagraph_AndDropsNone(SubtitleSplitter.SplitMode mode)
+    {
+        var subtitle = MakeSubtitle(60);
+
+        var parts = SubtitleSplitter.Split(subtitle, 6, mode);
+
+        // No paragraph may be lost or duplicated across the parts.
+        Assert.Equal(subtitle.Paragraphs.Count, parts.Sum(p => p.Paragraphs.Count));
+    }
+
+    [Theory]
+    [InlineData(2, SubtitleSplitter.SplitMode.Lines)]
+    [InlineData(3, SubtitleSplitter.SplitMode.Characters)]
+    [InlineData(5, SubtitleSplitter.SplitMode.Time)]
+    public void Split_IntoN_ProducesExactlyNParts(int parts, SubtitleSplitter.SplitMode mode)
+    {
+        var subtitle = MakeSubtitle(50);
+
+        var result = SubtitleSplitter.Split(subtitle, parts, mode);
+
+        Assert.Equal(parts, result.Count);
+    }
+
+    [Fact]
+    public void SplitByLines_DistributesEvenly_RemainderGoesToLastPart()
+    {
+        var subtitle = MakeSubtitle(11);
+
+        var parts = SubtitleSplitter.Split(subtitle, 3, SubtitleSplitter.SplitMode.Lines);
+
+        Assert.Equal(3, parts.Count);
+        Assert.Equal(3, parts[0].Paragraphs.Count);
+        Assert.Equal(3, parts[1].Paragraphs.Count);
+        Assert.Equal(5, parts[2].Paragraphs.Count); // 11 - 2*3 = 5
+    }
+
+    [Fact]
+    public void Split_ClampsPartsToParagraphCount()
+    {
+        var subtitle = MakeSubtitle(3);
+
+        var parts = SubtitleSplitter.Split(subtitle, 10, SubtitleSplitter.SplitMode.Lines);
+
+        Assert.Equal(3, parts.Count);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Split_WithOnePartOrFewer_ReturnsWholeSubtitleAsSinglePart(int requested)
+    {
+        var subtitle = MakeSubtitle(20);
+
+        var parts = SubtitleSplitter.Split(subtitle, requested, SubtitleSplitter.SplitMode.Lines);
+
+        Assert.Single(parts);
+        Assert.Equal(20, parts[0].Paragraphs.Count);
+    }
+
+    [Fact]
+    public void Split_EmptySubtitle_ReturnsNoParts()
+    {
+        var parts = SubtitleSplitter.Split(new Subtitle(), 6, SubtitleSplitter.SplitMode.Lines);
+
+        Assert.Empty(parts);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a reported bug: splitting a subtitle into N parts shows N parts in the dialog but writes only **N-1** files — the last part is missing. Reproducible in the **by-characters** and **by-time** modes (split **by lines** was unaffected).

### Root cause
`SplitSubtitleViewModel.UpdateSplit` built two parallel lists: `SplitItems` (the dialog preview) and `_parts` (the `Subtitle` objects written to disk on OK). In the by-characters and by-time branches, the trailing segment was added to `SplitItems` but the matching `_parts.Add(temp)` was missing, so the save loop (which iterates `_parts`) wrote one file too few.

### Changes
- **New `SubtitleSplitter` helper** — pure, side-effect-free split logic (no UI/settings). Always returns exactly the requested number of parts (clamped to `[1, paragraphCount]`) and includes the trailing part in every mode.
- **`UpdateSplit` now derives both `_parts` and `SplitItems` from the same `SubtitleSplitter.Split(...)` result**, so the displayed count and the written-file count can never diverge again (structural fix).
- **Simplified the OK save loop** — dropped the fragile `O(n²)` `_parts.IndexOf(part)` lookup for a plain index.
- **Feature request: default output folder** — the output folder now defaults to the source subtitle's own folder (falls back to the previous folder / Desktop for untitled subtitles).

### Tests
New `SubtitleSplitterTests` (14 cases):
- Regression: split into 6 → exactly 6 parts, for all three modes.
- No paragraph lost or duplicated (sum of part counts == total).
- N parts for various N; even line distribution with remainder on the last part.
- Clamping when requested parts > paragraph count.
- ≤1 part returns the whole subtitle; empty subtitle returns no parts.

## Verification
- `dotnet build src/ui/UI.csproj` → 0 errors (the lone `CS8604` warning is pre-existing and unrelated).
- `dotnet test --filter SubtitleSplitter` → 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)