### PR TITLE
Add missing window title to ASSA/SSA style picker

### DIFF
--- a/src/ui/Features/Assa/AssaStylePickerViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylePickerViewModel.cs
@@ -52,10 +52,11 @@ public partial class AssaStylePickerViewModel : ObservableObject
         });
     }
 
-    public void Initialize(List<StyleDisplay> styles, string buttonAcceptText, bool showUsageCount)
+    public void Initialize(string title, List<StyleDisplay> styles, string buttonAcceptText, bool showUsageCount)
     {
+        Title = title;
         Styles.AddRange(styles);
-        
+
         if (Styles.Count > 0)
         {
             SelectedStyle = Styles[0];

--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -142,7 +142,7 @@ public partial class AssaStylesViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
-            vm.Initialize(ssaStyles.Select(p => new StyleDisplay(p) { IsSelected = true, Name = MakeUniqueName(p.Name, FileStyles) }).ToList(), Se.Language.General.Import, false);
+            vm.Initialize(Se.Language.General.Import, ssaStyles.Select(p => new StyleDisplay(p) { IsSelected = true, Name = MakeUniqueName(p.Name, FileStyles) }).ToList(), Se.Language.General.Import, false);
         });
 
         var selectedStyles = result.Styles.Where(p => p.IsSelected).ToList();
@@ -359,7 +359,7 @@ public partial class AssaStylesViewModel : ObservableObject
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
             var styles = ssaStyles.Select(p => new StyleDisplay(p)).ToList();
-            vm.Initialize(styles, Se.Language.General.Ok, true);
+            vm.Initialize(Se.Language.Assa.TakeUsagesFromDotDotDot, styles, Se.Language.General.Ok, true);
         });
 
         var selectedStyles = result.Styles.Where(p => p.IsSelected).ToList();
@@ -399,7 +399,7 @@ public partial class AssaStylesViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
-            vm.Initialize(ssaStyles.Select(p => new StyleDisplay(p) { IsSelected = true, Name = MakeUniqueName(p.Name, StorageStyles) }).ToList(), Se.Language.General.Import, false);
+            vm.Initialize(Se.Language.General.Import, ssaStyles.Select(p => new StyleDisplay(p) { IsSelected = true, Name = MakeUniqueName(p.Name, StorageStyles) }).ToList(), Se.Language.General.Import, false);
         });
 
         var selectedStyles = result.Styles.Where(p => p.IsSelected).ToList();

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -145,7 +145,7 @@ public partial class SsaStylesViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
-            vm.Initialize(ssaStyles.Select(p => StripAlpha(new StyleDisplay(p) { IsSelected = true, Name = MakeUniqueName(p.Name, FileStyles) })).ToList(), Se.Language.General.Import, false);
+            vm.Initialize(Se.Language.General.Import, ssaStyles.Select(p => StripAlpha(new StyleDisplay(p) { IsSelected = true, Name = MakeUniqueName(p.Name, FileStyles) })).ToList(), Se.Language.General.Import, false);
         });
 
         var selectedStyles = result.Styles.Where(p => p.IsSelected).ToList();
@@ -314,7 +314,7 @@ public partial class SsaStylesViewModel : ObservableObject
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
             var styles = ssaStyles.Select(p => StripAlpha(new StyleDisplay(p))).ToList();
-            vm.Initialize(styles, Se.Language.General.Ok, true);
+            vm.Initialize(Se.Language.Assa.TakeUsagesFromDotDotDot, styles, Se.Language.General.Ok, true);
         });
 
         var selectedStyles = result.Styles.Where(p => p.IsSelected).ToList();
@@ -355,7 +355,7 @@ public partial class SsaStylesViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
-            vm.Initialize(ssaStyles.Select(p => StripAlpha(new StyleDisplay(p) { IsSelected = true, Name = MakeUniqueName(p.Name, StorageStyles) })).ToList(), Se.Language.General.Import, false);
+            vm.Initialize(Se.Language.General.Import, ssaStyles.Select(p => StripAlpha(new StyleDisplay(p) { IsSelected = true, Name = MakeUniqueName(p.Name, StorageStyles) })).ToList(), Se.Language.General.Import, false);
         });
 
         var selectedStyles = result.Styles.Where(p => p.IsSelected).ToList();

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1248,7 +1248,7 @@ public partial class BatchConvertViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
-            vm.Initialize(ssaStyles.Select(p => new StyleDisplay(p)).ToList(), Se.Language.General.Ok, false);
+            vm.Initialize(Se.Language.General.Styles, ssaStyles.Select(p => new StyleDisplay(p)).ToList(), Se.Language.General.Ok, false);
         });
 
         if (!result.OkPressed || result.SelectedStyle == null)


### PR DESCRIPTION
## Summary
`AssaStylePickerWindow` binds its title to `AssaStylePickerViewModel.Title`, but `Initialize` never set it — so every reuse of the picker opened with a **blank title**, including the "Take usages from..." window (reported).

## Changes
- Added a `title` parameter to `AssaStylePickerViewModel.Initialize` and set `Title`.
- Passed a meaningful title at all 7 call sites:
  - **Take usages from...** (`SsaStylesViewModel`, `AssaStylesViewModel`) → `Se.Language.Assa.TakeUsagesFromDotDotDot`
  - **Import** (file + storage style import, both view models) → `Se.Language.General.Import`
  - **Pick style** (Batch Convert) → `Se.Language.General.Styles`
- Reused existing language strings, so no new translation keys are required.

## Verification
- `dotnet build src/ui/UI.csproj` → 0 errors (the lone `CS8604` warning is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)