### PR TITLE
Batch convert: pluralize remove-file confirmation for multi-select

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1644,10 +1644,14 @@ public partial class BatchConvertViewModel : ObservableObject
 
         if (Se.Settings.General.PromptBeforeDelete)
         {
+            var message = selectedItems.Count > 1
+                ? string.Format(Se.Language.General.RemoveSelectedFilesX, selectedItems.Count)
+                : Se.Language.General.RemoveSelectedFile;
+
             var result = await MessageBox.Show(
                 Window,
                 Se.Language.General.Remove,
-                Se.Language.General.RemoveSelectedFile,
+                message,
                 MessageBoxButtons.YesNo,
                 MessageBoxIcon.Question);
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -444,6 +444,7 @@ public class LanguageGeneral
     public string RemoveItalic { get; set; }
     public string RemoveRightToLeftUnicodeTags { get; set; }
     public string RemoveSelectedFile { get; set; }
+    public string RemoveSelectedFilesX { get; set; }
     public string RemoveStyling { get; set; }
     public string RemoveTextForHearingImpaired { get; set; }
     public string RemoveUnderline { get; set; }
@@ -1174,6 +1175,7 @@ public class LanguageGeneral
         RemoveItalic = "Remove italic";
         RemoveRightToLeftUnicodeTags = "Remove RTL Unicode tags";
         RemoveSelectedFile = "Remove selected file?";
+        RemoveSelectedFilesX = "Remove {0} selected files?";
         RemoveStyling = "Remove styling";
         RemoveTextForHearingImpaired = "Remove text for hearing impaired";
         RemoveUnderline = "Remove underline";


### PR DESCRIPTION
## Summary
The Batch Convert "remove selected file(s)" confirmation always showed the singular *"Remove selected file?"*, even when multiple files were selected.

## Changes
- Added `RemoveSelectedFilesX = "Remove {0} selected files?"` to `LanguageGeneral`.
- `RemoveSelectedFiles()` now uses the pluralized string (formatted with the selected count) when more than one file is selected, and keeps the existing singular string for a single file.

## Verification
- `dotnet build src/ui/UI.csproj` → 0 errors (the lone `CS8604` warning is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)