### PR TITLE
Fix SSA toolbar hints showing "Advanced Sub Station Alpha"

### DIFF
--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -337,8 +337,8 @@ public static class InitToolbar
             Content = MakeImage("AssaStyle"),
             Command = vm.ShowSsaStylesCommand,
             Background = Brushes.Transparent,
-            [AutomationProperties.NameProperty] = languageHints.AssaStylesHint,
-            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.AssaStylesHint, shortcuts, nameof(vm.ShowSsaStylesCommand)),
+            [AutomationProperties.NameProperty] = languageHints.SsaStylesHint,
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SsaStylesHint, shortcuts, nameof(vm.ShowSsaStylesCommand)),
             [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsFormatSsa))
             {
                 Source = vm,
@@ -350,8 +350,8 @@ public static class InitToolbar
             Content = MakeImage("AssaProperties"),
             Command = vm.ShowSsaPropertiesCommand,
             Background = Brushes.Transparent,
-            [AutomationProperties.NameProperty] = languageHints.AssaPropertiesHint,
-            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.AssaPropertiesHint, shortcuts, nameof(vm.ShowSsaPropertiesCommand)),
+            [AutomationProperties.NameProperty] = languageHints.SsaPropertiesHint,
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SsaPropertiesHint, shortcuts, nameof(vm.ShowSsaPropertiesCommand)),
             [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsFormatSsa))
             {
                 Source = vm,
@@ -363,8 +363,8 @@ public static class InitToolbar
             Content = MakeImage("AssaAttachments"),
             Command = vm.ShowSsaAttachmentsCommand,
             Background = Brushes.Transparent,
-            [AutomationProperties.NameProperty] = languageHints.AssaAttachmentsHint,
-            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.AssaAttachmentsHint, shortcuts, nameof(vm.ShowSsaAttachmentsCommand)),
+            [AutomationProperties.NameProperty] = languageHints.SsaAttachmentsHint,
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SsaAttachmentsHint, shortcuts, nameof(vm.ShowSsaAttachmentsCommand)),
             [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsFormatSsa))
             {
                 Source = vm,

--- a/src/ui/Logic/Config/Language/Main/LanguageMainToolbar.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainToolbar.cs
@@ -24,6 +24,9 @@ public class LanguageMainToolbar
     public string AssaPropertiesHint { get; set; }
     public string AssaAttachmentsHint { get; set; }
     public string AssaDrawHint { get; set; }
+    public string SsaStylesHint { get; set; }
+    public string SsaPropertiesHint { get; set; }
+    public string SsaAttachmentsHint { get; set; }
 
 
     public LanguageMainToolbar()
@@ -50,5 +53,8 @@ public class LanguageMainToolbar
         AssaPropertiesHint = "Advanced Sub Station Alpha properties";
         AssaAttachmentsHint = "Advanced Sub Station Alpha attachments";
         AssaDrawHint = "Advanced Sub Station Alpha draw shapes";
+        SsaStylesHint = "Sub Station Alpha styles";
+        SsaPropertiesHint = "Sub Station Alpha properties";
+        SsaAttachmentsHint = "Sub Station Alpha attachments";
     }
 }


### PR DESCRIPTION
## Summary
The main toolbar has parallel buttons for ASSA (Advanced SubStation Alpha) and SSA (SubStation Alpha) files. The **SSA** buttons (styles, properties, attachments) reused the **ASSA** hint strings, so for `.ssa` files their tooltips and accessibility names incorrectly read *"Advanced Sub Station Alpha …"*.

## Changes
- **`LanguageMainToolbar.cs`** — added `SsaStylesHint`, `SsaPropertiesHint`, `SsaAttachmentsHint` ("Sub Station Alpha styles/properties/attachments").
- **`InitToolbar.cs`** — wired the SSA toolbar buttons (`ShowSsaStylesCommand`, `ShowSsaPropertiesCommand`, `ShowSsaAttachmentsCommand`) to the new SSA hints for both tooltip and automation name. The ASSA buttons keep the "Advanced …" hints.

## Verification
- `dotnet build src/ui/UI.csproj` → 0 errors (the lone `CS8604` warning is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)