### PR TITLE
Add Undo button to spell check (SE4 parity)

### DIFF
--- a/src/ui/Features/SpellCheck/ISpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/ISpellCheckManager.cs
@@ -18,6 +18,10 @@ public interface ISpellCheckManager
     void ChangeAllWord(string fromWord, string toWord, SpellCheckWord spellCheckWord, SubtitleLineViewModel p);
     void AddToNames(string currentWord);
     void AdToUserDictionary(string currentWord);
+    void RemoveIgnoreWord(string word);
+    void RemoveChangeAllWord(string fromWord);
+    void RemoveFromNames(string word);
+    void RemoveFromUserDictionary(string word);
     List<SpellCheckDictionaryDisplay> GetDictionaryLanguages(string dictionaryFolder);
     List<string> GetSuggestions(string word);
     WordSpellCheck? WordSpellChecker { get; set; }

--- a/src/ui/Features/SpellCheck/SpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckManager.cs
@@ -259,6 +259,47 @@ public class SpellCheckManager : ISpellCheckManager, IDoSpell
         _spellCheckWordLists?.AddUserWord(word);
     }
 
+    /// <summary>
+    /// Reverses <see cref="AddIgnoreWord"/> by removing the word and the case variants it added.
+    /// Used by spell-check Undo. Counters are restored separately from a snapshot.
+    /// </summary>
+    public void RemoveIgnoreWord(string word)
+    {
+        if (string.IsNullOrWhiteSpace(word))
+        {
+            return;
+        }
+
+        _skipAllList.Remove(word);
+        _skipAllList.Remove(word.ToLowerInvariant());
+        _skipAllList.Remove(word.ToUpperInvariant());
+        if (word.Length > 1)
+        {
+            _skipAllList.Remove(char.ToUpperInvariant(word[0]) + word[1..].ToLowerInvariant());
+        }
+    }
+
+    public void RemoveChangeAllWord(string fromWord)
+    {
+        if (string.IsNullOrEmpty(fromWord))
+        {
+            return;
+        }
+
+        _changeAllDictionary.Remove(fromWord);
+        _spellCheckWordLists?.UseAlwaysListRemove(fromWord);
+    }
+
+    public void RemoveFromNames(string word)
+    {
+        _spellCheckWordLists?.RemoveName(word);
+    }
+
+    public void RemoveFromUserDictionary(string word)
+    {
+        _spellCheckWordLists?.RemoveUserWord(word);
+    }
+
     private static readonly HashSet<string> _allowedTokens = new HashSet<string>
     {
         "&", "—", "–", "…"

--- a/src/ui/Features/SpellCheck/SpellCheckUndoItem.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckUndoItem.cs
@@ -1,0 +1,32 @@
+using Nikse.SubtitleEdit.Features.Main;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.SpellCheck;
+
+public enum SpellCheckUndoAction
+{
+    Change,
+    ChangeAll,
+    SkipOnce,
+    SkipAll,
+    AddToNames,
+    AddToDictionary,
+    ChangeWholeText,
+}
+
+/// <summary>
+/// A single undoable spell-check step. Captured before the action runs so it can be reverted:
+/// paragraph texts and counters are restored from the snapshot, and word-list/dictionary mutations
+/// are reversed via the action + word. <see cref="ResumeFrom"/> is the position to re-scan from so
+/// the word that was acted on is shown again.
+/// </summary>
+public class SpellCheckUndoItem
+{
+    public string Description { get; set; } = string.Empty;
+    public SpellCheckUndoAction Action { get; set; }
+    public string ActionWord { get; set; } = string.Empty;
+    public int NoOfChangedWords { get; set; }
+    public int NoOfSkippedWords { get; set; }
+    public List<(SubtitleLineViewModel Paragraph, string Text)> ParagraphTexts { get; set; } = new();
+    public SpellCheckResult? ResumeFrom { get; set; }
+}

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
@@ -43,6 +44,8 @@ public partial class SpellCheckViewModel : ObservableObject
     [ObservableProperty] private bool _isPrompting;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _paragraphs;
     [ObservableProperty] private SubtitleLineViewModel? _selectedParagraph;
+    [ObservableProperty] private bool _isUndoVisible;
+    [ObservableProperty] private string _undoText;
 
     public Window? Window { get; set; }
     public int TotalChangedWords { get; set; }
@@ -59,6 +62,7 @@ public partial class SpellCheckViewModel : ObservableObject
     private SpellCheckWord _currentSpellCheckWord;
     private SpellCheckResult? _lastSpellCheckResult;
     private System.Timers.Timer? _statusTimer;
+    private readonly List<SpellCheckUndoItem> _undoList = new();
 
     public SpellCheckViewModel(ISpellCheckManager spellCheckManager, IWindowService windowService)
     {
@@ -86,6 +90,7 @@ public partial class SpellCheckViewModel : ObservableObject
         PanelWholeText = new StackPanel();
         TextBoxWordNotFound = new TextBox();
         StatusText = string.Empty;
+        UndoText = string.Empty;
         Paragraphs = new ObservableCollection<SubtitleLineViewModel>();
         _currentSpellCheckWord = new SpellCheckWord();
 
@@ -341,6 +346,7 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
+        PushUndo(Se.Language.SpellCheck.EditWholeText, SpellCheckUndoAction.ChangeWholeText, string.Empty);
         selectedParagraph.Text = result.WholeText;
         DoSpellCheck();
     }
@@ -356,8 +362,10 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
+        var status = string.Format(Se.Language.SpellCheck.ChangeWordFromXToY, WordNotFoundOriginal, CurrentWord);
+        PushUndo(status, SpellCheckUndoAction.Change, WordNotFoundOriginal);
         _spellCheckManager.ChangeWord(WordNotFoundOriginal, CurrentWord, _currentSpellCheckWord, SelectedParagraph!);
-        ShowStatus(string.Format(Se.Language.SpellCheck.ChangeWordFromXToY, WordNotFoundOriginal, CurrentWord));
+        ShowStatus(status);
         DoSpellCheck();
     }
 
@@ -371,23 +379,29 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
+        var status = string.Format(Se.Language.SpellCheck.ChangeAllWordsFromXToY, WordNotFoundOriginal, CurrentWord);
+        PushUndo(status, SpellCheckUndoAction.ChangeAll, WordNotFoundOriginal);
         _spellCheckManager.ChangeAllWord(WordNotFoundOriginal, CurrentWord, _currentSpellCheckWord, selectedParagraph);
-        ShowStatus(string.Format(Se.Language.SpellCheck.ChangeAllWordsFromXToY, WordNotFoundOriginal, CurrentWord));
+        ShowStatus(status);
         DoSpellCheck();
     }
 
     [RelayCommand]
     private void SkipWord()
     {
-        ShowStatus(string.Format(Se.Language.SpellCheck.IgnoreWordXOnce, WordNotFoundOriginal));
+        var status = string.Format(Se.Language.SpellCheck.IgnoreWordXOnce, WordNotFoundOriginal);
+        PushUndo(status, SpellCheckUndoAction.SkipOnce, WordNotFoundOriginal);
+        ShowStatus(status);
         DoSpellCheck();
     }
 
     [RelayCommand]
     private void SkipWordAll()
     {
+        var status = string.Format(Se.Language.SpellCheck.IgnoreWordXAlways, WordNotFoundOriginal);
+        PushUndo(status, SpellCheckUndoAction.SkipAll, WordNotFoundOriginal);
         _spellCheckManager.AddIgnoreWord(WordNotFoundOriginal);
-        ShowStatus(string.Format(Se.Language.SpellCheck.IgnoreWordXAlways, WordNotFoundOriginal));
+        ShowStatus(status);
         DoSpellCheck();
     }
 
@@ -400,8 +414,10 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
+        var status = string.Format(Se.Language.SpellCheck.WordXAddedToNamesList, CurrentWord);
+        PushUndo(status, SpellCheckUndoAction.AddToNames, CurrentWord);
         _spellCheckManager.AddToNames(CurrentWord);
-        ShowStatus(string.Format(Se.Language.SpellCheck.WordXAddedToNamesList, CurrentWord));
+        ShowStatus(status);
         DoSpellCheck();
     }
 
@@ -414,8 +430,10 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
+        var status = string.Format(Se.Language.SpellCheck.WordXAddedToUserDictionary, CurrentWord);
+        PushUndo(status, SpellCheckUndoAction.AddToDictionary, CurrentWord);
         _spellCheckManager.AdToUserDictionary(CurrentWord);
-        ShowStatus(string.Format(Se.Language.SpellCheck.WordXAddedToUserDictionary, CurrentWord));
+        ShowStatus(status);
         DoSpellCheck();
     }
 
@@ -449,8 +467,10 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
+        var status = string.Format(Se.Language.SpellCheck.UseSuggestionX, SelectedSuggestion);
+        PushUndo(status, SpellCheckUndoAction.Change, WordNotFoundOriginal);
         _spellCheckManager.ChangeWord(WordNotFoundOriginal, SelectedSuggestion, _currentSpellCheckWord, SelectedParagraph);
-        ShowStatus(string.Format(Se.Language.SpellCheck.UseSuggestionX, SelectedSuggestion));
+        ShowStatus(status);
         DoSpellCheck();
     }
 
@@ -462,8 +482,10 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
+        var status = string.Format(Se.Language.SpellCheck.UseSuggestionXAlways, SelectedSuggestion);
+        PushUndo(status, SpellCheckUndoAction.ChangeAll, WordNotFoundOriginal);
         _spellCheckManager.ChangeAllWord(WordNotFoundOriginal, SelectedSuggestion, _currentSpellCheckWord, SelectedParagraph);
-        ShowStatus(string.Format(Se.Language.SpellCheck.UseSuggestionXAlways, SelectedSuggestion));
+        ShowStatus(status);
         DoSpellCheck();
     }
 
@@ -490,6 +512,88 @@ public partial class SpellCheckViewModel : ObservableObject
             e.Handled = true;
             UiUtil.ShowHelp("features/spell-check");
         }
+    }
+
+    private bool CanUndo() => _undoList.Count > 0;
+
+    private void PushUndo(string description, SpellCheckUndoAction action, string actionWord)
+    {
+        _undoList.Add(new SpellCheckUndoItem
+        {
+            Description = description,
+            Action = action,
+            ActionWord = actionWord,
+            NoOfChangedWords = _spellCheckManager.NoOfChangedWords,
+            NoOfSkippedWords = _spellCheckManager.NoOfSkippedWords,
+            ParagraphTexts = Paragraphs.Select(p => (p, p.Text)).ToList(),
+
+            // Re-scan from just before the acted-on word so it is shown again after undo.
+            ResumeFrom = _lastSpellCheckResult == null
+                ? null
+                : new SpellCheckResult
+                {
+                    LineIndex = _lastSpellCheckResult.LineIndex,
+                    WordIndex = _lastSpellCheckResult.WordIndex - 1,
+                },
+        });
+
+        UndoText = string.Format(Se.Language.SpellCheck.UndoX, description);
+        IsUndoVisible = true;
+        UndoCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanUndo))]
+    private void Undo()
+    {
+        if (_undoList.Count == 0)
+        {
+            return;
+        }
+
+        var item = _undoList[^1];
+        _undoList.RemoveAt(_undoList.Count - 1);
+
+        // Restore the text of every line as it was before the action (covers Change, ChangeAll and
+        // its silent cascade, and Edit-whole-text).
+        foreach (var (paragraph, text) in item.ParagraphTexts)
+        {
+            paragraph.Text = text;
+        }
+
+        // Reverse word-list / change-all dictionary mutations.
+        switch (item.Action)
+        {
+            case SpellCheckUndoAction.SkipAll:
+                _spellCheckManager.RemoveIgnoreWord(item.ActionWord);
+                break;
+            case SpellCheckUndoAction.ChangeAll:
+                _spellCheckManager.RemoveChangeAllWord(item.ActionWord);
+                break;
+            case SpellCheckUndoAction.AddToNames:
+                _spellCheckManager.RemoveFromNames(item.ActionWord);
+                break;
+            case SpellCheckUndoAction.AddToDictionary:
+                _spellCheckManager.RemoveFromUserDictionary(item.ActionWord);
+                break;
+        }
+
+        // Restore counters and the scan position, then re-check so the word reappears.
+        _spellCheckManager.NoOfChangedWords = item.NoOfChangedWords;
+        _spellCheckManager.NoOfSkippedWords = item.NoOfSkippedWords;
+        _lastSpellCheckResult = item.ResumeFrom;
+
+        if (_undoList.Count > 0)
+        {
+            UndoText = string.Format(Se.Language.SpellCheck.UndoX, _undoList[^1].Description);
+        }
+        else
+        {
+            IsUndoVisible = false;
+            UndoText = string.Empty;
+        }
+
+        UndoCommand.NotifyCanExecuteChanged();
+        DoSpellCheck();
     }
 
     private void DoSpellCheck()

--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -181,6 +181,17 @@ public class SpellCheckWindow : Window
             Margin = new Thickness(0, 5, 0, 0),
         };
 
+        var buttonUndo = new Button
+        {
+            [!Button.ContentProperty] = new Binding(nameof(SpellCheckViewModel.UndoText)) { Mode = BindingMode.OneWay },
+            [!Button.CommandProperty] = new Binding(nameof(SpellCheckViewModel.UndoCommand)) { Mode = BindingMode.OneWay },
+            [!Visual.IsVisibleProperty] = new Binding(nameof(SpellCheckViewModel.IsUndoVisible)) { Mode = BindingMode.OneWay },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 5, 0, 0),
+        };
+
         var buttonGoogleSearch = new Button
         {
             Content = Se.Language.General.GoogleIt,
@@ -223,6 +234,7 @@ public class SpellCheckWindow : Window
         grid.Add(buttonSkipAll, 3, 1);
         grid.Add(buttonAddToNames, 4, 0, 1, 2);
         grid.Add(buttonAddToDictionary, 5, 0, 1, 2);
+        grid.Add(buttonUndo, 6, 0, 1, 2);
         grid.Add(buttonGoogleSearch, 7, 0, 1, 2);
 
         return grid;

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -31,6 +31,8 @@ public class LanguageSpellCheck
     public string PickSpellCheckDictionaryDotDotDot { get; set; }
     public string ChooseSpellCheckDictionary { get; set; }
     public string PickLiveSpellCheckDictionary { get; set; }
+    public string UndoX { get; set; }
+    public string EditWholeText { get; set; }
 
     public LanguageSpellCheck()
     {
@@ -61,5 +63,7 @@ public class LanguageSpellCheck
         PickSpellCheckDictionaryDotDotDot = "Choose spell check dictionary...";
         ChooseSpellCheckDictionary = "Choose spell check dictionary";
         PickLiveSpellCheckDictionary = "Pick live spell check dictionary";
+        UndoX = "Undo: {0}";
+        EditWholeText = "Edit whole text";
     }
 }


### PR DESCRIPTION
## Summary
SE4's spell check window had an **Undo** button (issue raised: it's missing in SE5). It reverts the last spell-check action and re-shows that word. The SE5 rewrite dropped it — this ports it back.

Reference: `src/ui/Forms/SpellCheck.cs` on the `se4-legacy` branch (`_undoList`, `PushUndo`, `buttonUndo_Click`).

## Changes
- **Manager** (`SpellCheckManager` / `ISpellCheckManager`): added reverse operations mirroring the legacy undo switch — `RemoveIgnoreWord`, `RemoveChangeAllWord`, `RemoveFromNames`, `RemoveFromUserDictionary`.
- **ViewModel** (`SpellCheckViewModel`): an undo stack with `IsUndoVisible` / `UndoText` and an `Undo` command. `PushUndo` snapshots all line texts, the changed/skipped counters, and a resume position **before** each mutating action (change, change-all, skip once, skip all, add to names, add to dictionary, use suggestion once/always, edit whole text). `Undo` restores texts + counters, reverses the word-list/dictionary mutation, restores the scan position, and re-checks so the word reappears. Sequential undo supported; the change-all cascade is reverted via the full-text snapshot.
- **Window** (`SpellCheckWindow`): added the Undo button (row 6, between "Add to dictionary" and "Google it"); visible only when there's something to undo, label reads e.g. *"Undo: Change word from 'teh' to 'the'"*.
- **Language** (`LanguageSpellCheck`): added `UndoX = "Undo: {0}"` and `EditWholeText = "Edit whole text"`.

## Verification
- `dotnet build src/ui/UI.csproj` → 0 errors (the lone `CS8604` warning is pre-existing and unrelated).
- Not runtime-tested — exercising spell check needs an installed dictionary + loaded subtitle. Suggest a manual smoke test (change → undo, change-all → undo, skip-all → undo) before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)