### PR TITLE
Align CJK merge shortcut label with SE4 wording

### DIFF
--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -320,7 +320,7 @@ public class LanguageSettingsShortcuts
         GeneralMergeWithNextAndAutoBreak = "Merge with next and auto-break";
         GeneralMergeSelectedLinesAndAutoBreak = "Merge selected lines and auto-break";
         GeneralMergeSelectedLinesAndUnbreak = "Merge selected lines and unbreak";
-        GeneralMergeSelectedLinesAndUnbreakCjk = "Merge selected lines and unbreak CJK";
+        GeneralMergeSelectedLinesAndUnbreakCjk = "Merge selected lines and unbreak without space (CJK)";
         GeneralUnbreakNoSpaceCjk = "Unbreak without space (CJK)";
         GeneralMergeSelectedLinesOnlyFirstText = "Merge selected lines only first text";
         GeneralMergeSelectedLinesBilingual = "Merge selected lines bilingual";


### PR DESCRIPTION
## Summary
Both CJK shortcuts already exist in SE5 (added in `f7e5489f7`, shipped in v5.0.0):
- `UnbreakNoSpaceCommand` → "Unbreak without space (CJK)" (matches SE4)
- `MergeSelectedLinesAndUnbreakCjkCommand` → "Merge selected lines and unbreak CJK"

The second was labelled differently from SE4 ("...unbreak CJK" vs SE4's "...unbreak **without space** (CJK)"), which made it hard to find when searching the shortcut list for "without space (CJK)" — and gave the impression the shortcut was missing.

## Change
Rename the label to the SE4 wording: **"Merge selected lines and unbreak without space (CJK)"**. No behaviour change — the command, registration, and key handling were already present.

## Verification
- `dotnet build src/ui/UI.csproj` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)