### PR TITLE
F10 focuses the main menu for keyboard/screen-reader access (partial #11745)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17635,6 +17635,26 @@ public partial class MainViewModel :
         Key.F24,
     };
 
+    /// <summary>
+    /// Moves keyboard focus to the first top-level item of the main menu bar, so the menu can be
+    /// opened and navigated with the keyboard / a screen reader (F10, #11745). No-op on platforms
+    /// that use the native menu (macOS), where <see cref="Menu"/> has no items.
+    /// </summary>
+    private bool TryFocusMainMenu()
+    {
+        if (Menu == null || Menu.Items.Count == 0)
+        {
+            return false;
+        }
+
+        if (Menu.Items[0] is MenuItem firstItem)
+        {
+            return firstItem.Focus(NavigationMethod.Tab);
+        }
+
+        return false;
+    }
+
     internal void OnKeyDownHandler(object? sender, KeyEventArgs keyEventArgs)
     {
         lock (_onKeyDownHandlerLock)
@@ -17664,6 +17684,14 @@ public partial class MainViewModel :
             // This allows option backspace on mac to delete the previous word
             if (TryHandleMacOptionBackspace(keyEventArgs))
             {
+                return;
+            }
+
+            // F10 moves keyboard focus into the main menu bar (standard Windows behavior), so the
+            // menu can be reached and read with a screen reader without a mouse (#11745).
+            if (k == Key.F10 && keyEventArgs.KeyModifiers == KeyModifiers.None && TryFocusMainMenu())
+            {
+                keyEventArgs.Handled = true;
                 return;
             }
 


### PR DESCRIPTION
## Summary
Partial fix for #11745 (main menu inaccessible to screen readers). The menu is built with Avalonia's native `Menu`/`MenuItem` (which do expose automation peers), but it could not be **reached** without a mouse — F10 did nothing, so a screen-reader user could never land on it.

This adds an **F10** handler (no modifiers) that moves keyboard focus to the first top-level menu item. From there the arrow keys move across top-level menus and Enter/Down opens submenus, and the native `MenuItem` automation peers (named from their headers) are announced.

## Scope / what this does NOT do yet
- **Alt / access-key mnemonics** (Alt+F for File, etc.) are not added — that requires `_`-mnemonics on every header (and collision handling) and touches all localized strings. Follow-up.
- No change to the macOS native menu path (`Menu` has no items there, so `TryFocusMainMenu` is a no-op).
- Full UIA `MenuBar` review beyond what Avalonia provides out of the box.

## ⚠️ Verification needed
I could **not** verify this with a screen reader — it was developed and built on macOS, and the scenario is Windows 11 + NVDA/Narrator. **Please test on Windows before merging**: press F10 in the main window and confirm (a) focus lands on "File", (b) arrows move between top-level menus and open submenus, (c) NVDA announces the menu and item names. If F10 doesn't behave as expected in Avalonia 12, this may need adjustment (e.g. opening the submenu explicitly).

- `dotnet build src/ui/UI.csproj` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)