### PR TITLE
Use system PATH ffmpeg (v7+) when download failed (#11760)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -737,7 +737,16 @@ public partial class MainViewModel :
         var ffmpegFileName = DownloadFfmpegViewModel.GetFfmpegFileName();
         if (!string.IsNullOrEmpty(ffmpegFileName) && File.Exists(ffmpegFileName))
         {
-            Se.Settings.General.FfmpegPath = DownloadFfmpegViewModel.GetFfmpegFileName();
+            FfmpegHelper.SetFfmpegPath(ffmpegFileName);
+            return;
+        }
+
+        // Fall back to an ffmpeg already on the system PATH (e.g. after a failed download), so SE
+        // does not get stuck on actions that need ffmpeg on the next start - issue #11760.
+        var systemFfmpeg = FfmpegHelper.GetSystemFfmpegPath();
+        if (!string.IsNullOrEmpty(systemFfmpeg))
+        {
+            FfmpegHelper.SetFfmpegPath(systemFfmpeg);
         }
     }
 
@@ -13030,13 +13039,21 @@ public partial class MainViewModel :
 
         if (File.Exists(DownloadFfmpegViewModel.GetFfmpegFileName()))
         {
-            Se.Settings.General.FfmpegPath = DownloadFfmpegViewModel.GetFfmpegFileName();
+            FfmpegHelper.SetFfmpegPath(DownloadFfmpegViewModel.GetFfmpegFileName());
+            return true;
+        }
+
+        // Use an ffmpeg on the system PATH before prompting to (re)download - issue #11760.
+        var systemFfmpeg = FfmpegHelper.GetSystemFfmpegPath();
+        if (!string.IsNullOrEmpty(systemFfmpeg))
+        {
+            FfmpegHelper.SetFfmpegPath(systemFfmpeg);
             return true;
         }
 
         if (!OperatingSystem.IsWindows() && File.Exists("/usr/local/bin/ffmpeg"))
         {
-            Se.Settings.General.FfmpegPath = "/usr/local/bin/ffmpeg";
+            FfmpegHelper.SetFfmpegPath("/usr/local/bin/ffmpeg");
             return true;
         }
 
@@ -13057,7 +13074,7 @@ public partial class MainViewModel :
             var result = await ShowDialogAsync<DownloadFfmpegWindow, DownloadFfmpegViewModel>();
             if (!string.IsNullOrEmpty(result.FfmpegFileName))
             {
-                Se.Settings.General.FfmpegPath = result.FfmpegFileName;
+                FfmpegHelper.SetFfmpegPath(result.FfmpegFileName);
                 ShowStatus(string.Format(Se.Language.Main.FfmpegDownloadedAndInstalledToX, result.FfmpegFileName));
                 return true;
             }

--- a/src/ui/Logic/Media/FfmpegHelper.cs
+++ b/src/ui/Logic/Media/FfmpegHelper.cs
@@ -1,12 +1,24 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Logic.Media;
 
 public static class FfmpegHelper
 {
+    // SE bundles/downloads ffmpeg 7/8 and is verified against it, so require a system/PATH ffmpeg
+    // to be at least this major version. Older builds are ignored (SE offers to download instead)
+    // rather than used and failing later.
+    internal const int MinimumFfmpegMajorVersion = 7;
+
+    // "ffmpeg version 6.1.1", "ffmpeg version n7.0", "ffmpeg version 4.4.2-0ubuntu0.22.04.1".
+    private static readonly Regex FfmpegVersionRegex =
+        new(@"ffmpeg version n?(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     public static bool IsFfmpegInstalled()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -14,7 +26,137 @@ public static class FfmpegHelper
             return true;
         }
 
-        Configuration.Settings.General.UseFFmpegForWaveExtraction = true;        
-        return File.Exists(Se.Settings.General.FfmpegPath);
+        Configuration.Settings.General.UseFFmpegForWaveExtraction = true;
+
+        if (File.Exists(Se.Settings.General.FfmpegPath))
+        {
+            return true;
+        }
+
+        // ffmpeg may already be installed and on the system PATH (e.g. the bundled download
+        // failed but the user has ffmpeg). Use it instead of hanging or forcing another
+        // download - issue #11760.
+        var systemFfmpeg = GetSystemFfmpegPath();
+        if (!string.IsNullOrEmpty(systemFfmpeg))
+        {
+            SetFfmpegPath(systemFfmpeg);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Sets the ffmpeg path everywhere it is read from: the SE 5 setting and the libse
+    /// <see cref="Configuration"/> mirror that the ffmpeg process launchers use. Keeping the two in
+    /// sync avoids the case where ffmpeg is resolved but the launcher still sees the old/empty path.
+    /// </summary>
+    public static void SetFfmpegPath(string path)
+    {
+        Se.Settings.General.FfmpegPath = path;
+        Configuration.Settings.General.FFmpegLocation = path;
+    }
+
+    /// <summary>
+    /// Returns the full path of a usable "ffmpeg" / "ffmpeg.exe" found on the system PATH, or an
+    /// empty string. Scans the PATH variable directly (never spawns a process to find candidates,
+    /// so the scan cannot hang) and accepts a candidate only if its version meets the minimum.
+    /// </summary>
+    public static string GetSystemFfmpegPath()
+    {
+        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg";
+        var pathValue = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathValue))
+        {
+            return string.Empty;
+        }
+
+        foreach (var dir in pathValue.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(dir))
+            {
+                continue;
+            }
+
+            try
+            {
+                var candidate = Path.Combine(dir.Trim(), exeName);
+                if (File.Exists(candidate) && IsSupportedVersion(candidate))
+                {
+                    return candidate;
+                }
+            }
+            catch
+            {
+                // Ignore malformed PATH entries (illegal path characters, etc.).
+            }
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Runs "&lt;ffmpeg&gt; -version" and returns true unless we positively detect a major version
+    /// below <see cref="MinimumFfmpegMajorVersion"/>. If the probe fails or the version can't be
+    /// parsed (e.g. a nightly "N-..." build or custom banner) we assume it's usable rather than
+    /// reject a working ffmpeg. The probe is bounded by a timeout and kills the process on overrun,
+    /// so it cannot hang.
+    /// </summary>
+    public static bool IsSupportedVersion(string ffmpegPath)
+    {
+        var major = GetMajorVersion(ffmpegPath);
+        return major == null || major.Value >= MinimumFfmpegMajorVersion;
+    }
+
+    private static int? GetMajorVersion(string ffmpegPath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = ffmpegPath,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            psi.ArgumentList.Add("-version");
+
+            using var process = Process.Start(psi);
+            if (process == null)
+            {
+                return null;
+            }
+
+            // "-version" prints a short banner and exits immediately; 4 s is generous.
+            if (!process.WaitForExit(4000))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                return null;
+            }
+
+            var combined = process.StandardOutput.ReadToEnd() + "\n" + process.StandardError.ReadToEnd();
+            return ParseMajorVersion(combined);
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"FfmpegHelper: failed to probe ffmpeg version at '{ffmpegPath}'");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses the ffmpeg major version out of an "ffmpeg -version" banner, or null if it cannot be
+    /// determined (nightly "N-..." builds, custom banners). Pure - exposed for testing.
+    /// </summary>
+    internal static int? ParseMajorVersion(string versionOutput)
+    {
+        if (string.IsNullOrEmpty(versionOutput))
+        {
+            return null;
+        }
+
+        var match = FfmpegVersionRegex.Match(versionOutput);
+        return match.Success && int.TryParse(match.Groups[1].Value, out var major) ? major : null;
     }
 }

--- a/tests/UI/Logic/Media/FfmpegVersionParseTests.cs
+++ b/tests/UI/Logic/Media/FfmpegVersionParseTests.cs
@@ -1,0 +1,44 @@
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic.Media;
+
+public class FfmpegVersionParseTests
+{
+    [Theory]
+    [InlineData("ffmpeg version 6.1.1 Copyright (c) 2000-2023 the FFmpeg developers", 6)]
+    [InlineData("ffmpeg version 8.1 Copyright (c) 2000-2025", 8)]
+    [InlineData("ffmpeg version n7.0 Copyright", 7)] // git/release "n" prefix
+    [InlineData("ffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright", 4)] // distro build
+    [InlineData("ffmpeg version 3.4.11-0+deb10u1 Copyright", 3)]
+    [InlineData("FFMPEG VERSION 5.0 COPYRIGHT", 5)] // case-insensitive
+    public void ParsesMajorVersion(string banner, int expected)
+    {
+        Assert.Equal(expected, FfmpegHelper.ParseMajorVersion(banner));
+    }
+
+    [Theory]
+    [InlineData("ffmpeg version N-109000-g1234567 Copyright")] // nightly build, no numeric major
+    [InlineData("some unrelated text")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ReturnsNullWhenVersionCannotBeDetermined(string? banner)
+    {
+        Assert.Null(FfmpegHelper.ParseMajorVersion(banner!));
+    }
+
+    [Theory]
+    [InlineData("ffmpeg version 8.1 Copyright", true)]
+    [InlineData("ffmpeg version 7.0 Copyright", true)] // exactly the minimum
+    [InlineData("ffmpeg version 6.1.1 Copyright", false)] // below minimum
+    [InlineData("ffmpeg version 4.4.2-0ubuntu Copyright", false)] // common distro build, below minimum
+    [InlineData("ffmpeg version N-109000-g1234567 Copyright", true)] // unknown -> assume usable
+    public void SupportedDecisionMatchesMajorVersion(string banner, bool expectedSupported)
+    {
+        var major = FfmpegHelper.ParseMajorVersion(banner);
+
+        // Mirror IsSupportedVersion's rule: unknown (null) is treated as usable.
+        var supported = major == null || major.Value >= FfmpegHelper.MinimumFfmpegMajorVersion;
+
+        Assert.Equal(expectedSupported, supported);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #11760: after a failed ffmpeg download on a fresh Windows install, SE 5 never used an ffmpeg already on `%PATH%` and could **hang** on actions that need ffmpeg (the path was empty), recoverable only via Task Manager.

## Root causes
1. **No PATH fallback** — `InitializeFfmpeg` (startup), `IsFfmpegInstalled`, and `RequireFfmpegOk` only looked at the configured path and the download location, never the system PATH.
2. **Sync gap** — some paths set `Se.Settings.General.FfmpegPath` but not the `Configuration.Settings.General.FFmpegLocation` mirror that the ffmpeg process launchers actually read.

## Changes
- **`FfmpegHelper.GetSystemFfmpegPath()`** — scans `%PATH%` for `ffmpeg`/`ffmpeg.exe`. Pure PATH scan (no process spawn), so it cannot hang.
- **Version gate** — a found PATH ffmpeg is accepted only if its major version is **>= 7** (matches the bundled ffmpeg 7/8). The probe runs `ffmpeg -version` with a 4 s timeout and **kills on overrun**, so it can't hang; an unparseable/nightly (`N-...`) banner is treated as usable.
- **`FfmpegHelper.SetFfmpegPath()`** — sets the SE setting and the libse `FFmpegLocation` mirror together.
- Wired the PATH fallback into **startup** (`InitializeFfmpeg`) and **`RequireFfmpegOk`** (before prompting to re-download). The existing download-retry prompt is unchanged.
- Unit tests for the version-banner parsing.

## Verification
- `dotnet build src/ui/UI.csproj` → 0 errors.
- `dotnet test --filter FfmpegVersionParse` → 15 passed.
- Not runtime-tested on Windows (developed on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)