### PR TITLE
Dutch casing: 's/'t contractions + IJ digraph (#11747)

### DIFF
--- a/src/libse/Common/DutchCasing.cs
+++ b/src/libse/Common/DutchCasing.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Dutch-specific capitalization rules:
+    ///  - The "IJ" digraph is capitalized as two letters: "ijsland" -> "IJsland" (not "Ijsland").
+    ///  - Sentence-initial contractions ('s, 't, 'n, 'k, 'm, 'r) keep their lowercase letter and the
+    ///    following word takes the capital instead: "'s morgens" -> "'s Morgens".
+    /// Callers must gate on <see cref="IsDutch"/>; the methods themselves do not check the language.
+    /// </summary>
+    public static class DutchCasing
+    {
+        public const string LanguageCode = "nl";
+
+        private static readonly char[] Apostrophes = { '\'', '’' }; // straight + typographic
+        private const string ContractionLetters = "stnkmr"; // 's 't 'n 'k 'm 'r
+
+        public static bool IsDutch(string language)
+            => string.Equals(language, LanguageCode, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Capitalizes the first letter of <paramref name="word"/> (which must begin with the letter
+        /// to capitalize), applying the Dutch IJ-digraph rule. Idempotent and safe on empty input.
+        /// </summary>
+        public static string CapitalizeFirstLetter(string word)
+        {
+            if (string.IsNullOrEmpty(word))
+            {
+                return word;
+            }
+
+            // Word-initial "ij" is the IJ digraph - capitalize both letters. Skip when already "IJ".
+            if (word.Length >= 2 &&
+                (word[0] == 'i' || word[0] == 'I') &&
+                (word[1] == 'j' || word[1] == 'J') &&
+                !(word[0] == 'I' && word[1] == 'J'))
+            {
+                return "IJ" + word.Substring(2);
+            }
+
+            return char.ToUpper(word[0]) + word.Substring(1);
+        }
+
+        /// <summary>
+        /// Applies Dutch sentence-start casing to <paramref name="text"/>, which must begin at the
+        /// first character to consider (a leading apostrophe contraction is allowed; leading tags and
+        /// other punctuation must already be stripped by the caller). Handles 's/'t/etc. contractions
+        /// (the contraction stays lowercase and the next word is capitalized) and the IJ digraph for
+        /// the word that ends up capitalized. Returns the input unchanged when nothing applies.
+        /// </summary>
+        public static string FixSentenceStart(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            // "'s morgens" / "'S morgens" -> "'s Morgens": keep the contraction lowercase and move
+            // the capital to the following word. A leading apostrophe that is NOT one of these
+            // contractions (e.g. an opening quote) falls through to normal capitalization.
+            if (text.Length > 3 &&
+                Array.IndexOf(Apostrophes, text[0]) >= 0 &&
+                ContractionLetters.IndexOf(char.ToLowerInvariant(text[1])) >= 0 &&
+                text[2] == ' ')
+            {
+                var contraction = text[0] + char.ToLowerInvariant(text[1]).ToString();
+                return contraction + " " + CapitalizeFirstLetter(text.Substring(3));
+            }
+
+            return CapitalizeFirstLetter(text);
+        }
+    }
+}

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraph.cs
@@ -95,10 +95,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     isPrevEndOfLine = true;
                 }
 
-                if ((!text.StartsWith("www.", StringComparison.Ordinal) && !text.StartsWith("http:", StringComparison.Ordinal) && !text.StartsWith("https:", StringComparison.Ordinal)) &&
-                    (char.IsLower(firstLetter) || Helper.IsTurkishLittleI(firstLetter, encoding, language)) &&
-                    !char.IsDigit(firstLetter) &&
-                    isPrevEndOfLine)
+                var isUrl = text.StartsWith("www.", StringComparison.Ordinal) || text.StartsWith("http:", StringComparison.Ordinal) || text.StartsWith("https:", StringComparison.Ordinal);
+                // Dutch additionally acts on a leading apostrophe contraction ('s morgens), where
+                // 'firstLetter' is an apostrophe rather than a lowercase letter.
+                if (!isUrl && !char.IsDigit(firstLetter) && isPrevEndOfLine &&
+                    (char.IsLower(firstLetter) || Helper.IsTurkishLittleI(firstLetter, encoding, language) || DutchCasing.IsDutch(language)))
                 {
                     bool isMatchInKnowAbbreviations = language == "en" &&
                         (prevText.EndsWith(" o.r.", StringComparison.Ordinal) ||
@@ -107,7 +108,12 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                     if (!isMatchInKnowAbbreviations)
                     {
-                        if (Helper.IsTurkishLittleI(firstLetter, encoding, language))
+                        if (DutchCasing.IsDutch(language))
+                        {
+                            // Handles 's/'t/etc. contractions (capitalize the next word) and the IJ digraph.
+                            p.Text = pre + DutchCasing.FixSentenceStart(text);
+                        }
+                        else if (Helper.IsTurkishLittleI(firstLetter, encoding, language))
                         {
                             p.Text = pre + Helper.GetTurkishUppercaseLetter(firstLetter, encoding) + text.Substring(1);
                         }
@@ -174,10 +180,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     char firstLetter = text[0];
                     string prevText = HtmlUtil.RemoveHtmlTags(arr[0]);
                     bool isPrevEndOfLine = Helper.IsPreviousTextEndOfParagraph(prevText);
-                    if ((!text.StartsWith("www.", StringComparison.Ordinal) && !text.StartsWith("http:", StringComparison.Ordinal) && !text.StartsWith("https:", StringComparison.Ordinal)) &&
-                        (char.IsLower(firstLetter) || Helper.IsTurkishLittleI(firstLetter, encoding, language)) &&
+                    var isUrl = text.StartsWith("www.", StringComparison.Ordinal) || text.StartsWith("http:", StringComparison.Ordinal) || text.StartsWith("https:", StringComparison.Ordinal);
+                    if (!isUrl &&
                         !prevText.EndsWith("...", StringComparison.Ordinal) &&
-                        isPrevEndOfLine)
+                        isPrevEndOfLine &&
+                        (char.IsLower(firstLetter) || Helper.IsTurkishLittleI(firstLetter, encoding, language) || DutchCasing.IsDutch(language)))
                     {
                         bool isMatchInKnowAbbreviations = language == "en" &&
                             (prevText.EndsWith(" o.r.", StringComparison.Ordinal) ||
@@ -186,7 +193,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                         if (!isMatchInKnowAbbreviations)
                         {
-                            if (Helper.IsTurkishLittleI(firstLetter, encoding, language))
+                            if (DutchCasing.IsDutch(language))
+                            {
+                                text = pre + DutchCasing.FixSentenceStart(text);
+                            }
+                            else if (Helper.IsTurkishLittleI(firstLetter, encoding, language))
                             {
                                 text = pre + Helper.GetTurkishUppercaseLetter(firstLetter, encoding) + text.Substring(1);
                             }
@@ -302,7 +313,12 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     }
                     else if (st.StrippedText.Length > 0 && st.StrippedText[0] != char.ToUpper(st.StrippedText[0]) && !st.Pre.EndsWith('[') && !st.Pre.Contains("..."))
                     {
-                        text = st.Pre + char.ToUpper(st.StrippedText[0]) + st.StrippedText.Substring(1) + st.Post;
+                        // DutchCasing.CapitalizeFirstLetter applies the IJ digraph rule for "nl"; for
+                        // other languages it is equivalent to char.ToUpper on the first letter.
+                        var capitalized = DutchCasing.IsDutch(language)
+                            ? DutchCasing.CapitalizeFirstLetter(st.StrippedText)
+                            : char.ToUpper(st.StrippedText[0]) + st.StrippedText.Substring(1);
+                        text = st.Pre + capitalized + st.Post;
                         p.Text = p.Text.Remove(indexOfNewLine + len).Insert(indexOfNewLine + len, text);
                     }
                 }

--- a/tests/libse/Core/DutchCasingTest.cs
+++ b/tests/libse/Core/DutchCasingTest.cs
@@ -1,0 +1,65 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Core;
+
+public class DutchCasingTest
+{
+    // --- IJ digraph (CapitalizeFirstLetter) ---
+
+    [Theory]
+    [InlineData("ijsland", "IJsland")]
+    [InlineData("ijs", "IJs")]
+    [InlineData("ijzer", "IJzer")]
+    [InlineData("Ijsland", "IJsland")]   // wrongly single-capitalized -> corrected
+    [InlineData("IJsland", "IJsland")]   // already correct -> idempotent
+    [InlineData("morgens", "Morgens")]   // ordinary word
+    [InlineData("a", "A")]
+    [InlineData("", "")]
+    public void CapitalizeFirstLetter_HandlesIjDigraph(string input, string expected)
+    {
+        Assert.Equal(expected, DutchCasing.CapitalizeFirstLetter(input));
+    }
+
+    // --- Sentence start: apostrophe contractions + IJ (FixSentenceStart) ---
+
+    [Theory]
+    [InlineData("'s morgens is te laat", "'s Morgens is te laat")] // the issue's "Not Good" case
+    [InlineData("'S morgens is te laat", "'s Morgens is te laat")] // the issue's "WRONG" case
+    [InlineData("'s Morgens is te laat", "'s Morgens is te laat")] // the issue's "Good" case -> unchanged
+    [InlineData("'t kind", "'t Kind")]
+    [InlineData("'n appel", "'n Appel")]
+    [InlineData("'k weet het", "'k Weet het")]
+    [InlineData("'m geven", "'m Geven")]
+    [InlineData("'t ijs smelt", "'t IJs smelt")]  // contraction + IJ digraph on next word
+    public void FixSentenceStart_HandlesContractions(string input, string expected)
+    {
+        Assert.Equal(expected, DutchCasing.FixSentenceStart(input));
+    }
+
+    [Theory]
+    [InlineData("ijsland is koud", "IJsland is koud")] // plain sentence start with IJ
+    [InlineData("morgen is het laat", "Morgen is het laat")]
+    public void FixSentenceStart_CapitalizesFirstWord(string input, string expected)
+    {
+        Assert.Equal(expected, DutchCasing.FixSentenceStart(input));
+    }
+
+    [Fact]
+    public void FixSentenceStart_LeavesNonContractionApostropheAlone()
+    {
+        // A leading apostrophe that is not a Dutch contraction (e.g. an opening quote) must not be
+        // treated as one - we don't move/force casing there (the quote/contraction ambiguity).
+        Assert.Equal("'Hallo,' zei hij", DutchCasing.FixSentenceStart("'Hallo,' zei hij"));
+    }
+
+    [Theory]
+    [InlineData("nl", true)]
+    [InlineData("NL", true)]
+    [InlineData("en", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsDutch(string? language, bool expected)
+    {
+        Assert.Equal(expected, DutchCasing.IsDutch(language!));
+    }
+}


### PR DESCRIPTION
## Summary
Adds two Dutch-specific capitalization rules to the **"Fix first letter to uppercase after paragraph"** rule (the "capitalize" function from #11747), gated to `language == "nl"`:

1. **Apostrophe contractions** — sentence-initial `'s 't 'n 'k 'm 'r` keep their lowercase letter and the **following** word is capitalized:
   - `'s morgens is te laat` → `'s Morgens is te laat`
   - `'S morgens …` → `'s Morgens …` (also corrects the wrongly upper-cased form)
   - `'s Morgens …` → unchanged (idempotent)
2. **IJ digraph** — capitalizes as two letters: `ijsland` → `IJsland` (was `Ijsland`), `'t ijs` → `'t IJs`.

## Design
- New pure helper `DutchCasing` (`CapitalizeFirstLetter` = IJ-aware; `FixSentenceStart` = contraction + IJ). All logic lives here and is unit-tested.
- Wired into `FixStartWithUppercaseLetterAfterParagraph` (single-line, second-line, and the dash/newline `StrippableText` path). Non-Dutch languages are completely unchanged — English `'Tis`/`'Twas` is unaffected.
- A leading apostrophe that is **not** one of the listed contractions (e.g. an opening quote `'Hallo,'`) is intentionally left alone — the quote-vs-contraction ambiguity (which the reporter also flagged) can't be resolved reliably, so we avoid producing wrong output.

## Scope / follow-ups
- Covers the Fix Common Errors "uppercase after paragraph" rule. The **Change Casing** tool and the **OCR fix engine** reuse separate capitalize paths and are not wired yet — natural follow-ups using the same helper.

## Tests
`DutchCasingTest` — 24 cases: the issue's four `'s morgens` outcomes, each contraction, IJ digraph (incl. idempotency and `Ijsland`→`IJsland` correction), plain sentence starts, and the quote case proving quotes aren't broken.

## Verification
- `dotnet build src/libse` + `src/ui` → 0 errors.
- `dotnet test --filter DutchCasing` → 24 passed.
- Not runtime-tested in the UI; logic is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)