### PR TITLE
Fix proxy settings not persisting in SE5 (Avalonia migration)

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -714,9 +714,9 @@ public class SettingsPage : UserControl
 
         sections.Add(new SettingsSection(Se.Language.Options.Settings.Network,
         [
-            new SettingsItem(Se.Language.Options.Settings.ProxyAddress, () => new TextBox { Width = 250 }),
-            new SettingsItem(Se.Language.Options.Settings.Username, () => new TextBox { Width = 250 }),
-            new SettingsItem(Se.Language.Options.Settings.Password, () => new TextBox { Width = 250 }),
+            new SettingsItem(Se.Language.Options.Settings.ProxyAddress, () => UiUtil.MakeTextBox(250, _vm, nameof(_vm.ProxyAddress))),
+            new SettingsItem(Se.Language.Options.Settings.Username, () => UiUtil.MakeTextBox(250, _vm, nameof(_vm.ProxyUserName))),
+            new SettingsItem(Se.Language.Options.Settings.Password, () => UiUtil.MakeTextBox(250, _vm, nameof(_vm.ProxyPassword))),
         ]));
 
         if (OperatingSystem.IsWindows())

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -239,6 +239,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _isLibVlcDownloadVisible;
     [ObservableProperty] private string _ffmpegPath;
     [ObservableProperty] private string _ffmpegStatus;
+    [ObservableProperty] private string _proxyAddress;
+    [ObservableProperty] private string _proxyUserName;
+    [ObservableProperty] private string _proxyPassword;
     [ObservableProperty] private int _waveformTextFontSize;
     [ObservableProperty] private bool _waveformTextFontBold;
     [ObservableProperty] private Color _waveformTextColor;
@@ -880,6 +883,9 @@ public partial class SettingsViewModel : ObservableObject
 
         FfmpegPath = Se.Settings.General.FfmpegPath;
         LibMpvPath = Se.Settings.General.LibMpvPath;
+        ProxyAddress = Se.Settings.General.ProxyAddress ?? string.Empty;
+        ProxyUserName = Se.Settings.General.ProxyUserName ?? string.Empty;
+        ProxyPassword = Se.Settings.General.ProxyPassword ?? string.Empty;
         SetFfmpegStatus();
         SetLibMpvStatus();
         SetLibVlcStatus();
@@ -1542,6 +1548,9 @@ public partial class SettingsViewModel : ObservableObject
 
         general.FfmpegPath = FfmpegPath;
         general.LibMpvPath = LibMpvPath;
+        general.ProxyAddress = ProxyAddress;
+        general.ProxyUserName = ProxyUserName;
+        general.ProxyPassword = ProxyPassword;
 
         general.CurrentProfile = SelectedProfile;
         general.Profiles.Clear();

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -464,6 +464,17 @@ public class Se
         Configuration.Settings.General.UseDarkTheme = Settings.Appearance.Theme == "Dark";
         Configuration.Settings.General.UseTimeFormatHHMMSSFF = Settings.General.UseFrameMode;
 
+        Configuration.Settings.Proxy.ProxyAddress = Settings.General.ProxyAddress ?? string.Empty;
+        Configuration.Settings.Proxy.UserName = Settings.General.ProxyUserName ?? string.Empty;
+        if (!string.IsNullOrEmpty(Settings.General.ProxyPassword))
+        {
+            Configuration.Settings.Proxy.EncodePassword(Settings.General.ProxyPassword);
+        }
+        else
+        {
+            Configuration.Settings.Proxy.Password = null;
+        }
+
         var stt = Settings.Tools.AudioToText;
         Configuration.Settings.Tools.WhisperChoice = stt.WhisperChoice;
         Configuration.Settings.Tools.WhisperIgnoreVersion = stt.WhisperIgnoreVersion;

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -85,6 +85,10 @@ public class SeGeneral
     public bool FfmpegUseCenterChannelOnly { get; set; }
     public string LibMpvPath { get; set; }
 
+    public string ProxyAddress { get; set; }
+    public string ProxyUserName { get; set; }
+    public string ProxyPassword { get; set; }
+
     public bool ShowColumnStartTime { get; set; }
     public bool ShowColumnEndTime { get; set; }
     public bool ShowColumnGap { get; set; }


### PR DESCRIPTION
## Root cause

During the SE5 (Avalonia) migration, the proxy settings were never ported from the old WinForms settings system to the new `Se` settings model. Three problems existed:

1. **No data binding** — The ProxyAddress/Username/Password TextBoxes in `SettingsPage.cs` were created as empty `new TextBox { Width = 250 }` with no binding to any ViewModel property.

2. **No storage** — `SeGeneral.cs` had no `ProxyAddress`, `ProxyUserName`, or `ProxyPassword` properties, so even if the UI were wired, the values would never be serialized to `Settings.json`.

3. **No sync to libse** — `UpdateLibSeSettings()` in `Se.cs` never copied proxy settings to `Configuration.Settings.Proxy`, which is what the HTTP client code (`HttpClientHandlerExtensions.cs`, `DownloaderFactory.cs`, `LegacyDownloader.cs`) reads when making network requests.

## Fix

- **`SeGeneral.cs`**: Added `ProxyAddress`, `ProxyUserName`, `ProxyPassword` string properties.
- **`SettingsViewModel.cs`**: Added `[ObservableProperty]` fields, load them in `LoadSettings()`, save them in `SaveSettings()`.
- **`SettingsPage.cs`**: Changed proxy TextBox factories from bare `new TextBox` to `UiUtil.MakeTextBox(250, _vm, nameof(...))` for proper two-way data binding.
- **`Se.cs`**: Added proxy sync in `UpdateLibSeSettings()` so `Configuration.Settings.Proxy` is populated from `Se.Settings.General.*`. Password is base64-encoded to match the existing `ProxySettings.EncodePassword()` convention.

Fixes #8504