### PR TITLE
Add "Treat words ending in 'in'' as 'ing'" spell-check setting (#11697)

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -602,6 +602,7 @@ public class SettingsPage : UserControl
                     Mode = BindingMode.TwoWay,
                 }
             }),
+            MakeCheckboxSetting(Se.Language.Options.Settings.SpellCheckEnglishTreatInApostropheAsIng, nameof(_vm.SpellCheckEnglishTreatInApostropheAsIng)),
             MakeCheckboxSetting(Se.Language.Options.Settings.OcrUseWordSplitList, nameof(_vm.OcrUseWordSplitList)),
             MakeCheckboxSetting(Se.Language.Options.Settings.SpeechToTextSelectedLinesPromptFirstTimeOnly, nameof(_vm.SpeechToTextSelectedLinesPromptFistTimeOnly)),
             MakeCheckboxSetting(Se.Language.Options.Settings.MultipleReplaceShowDotDotDotButtons, nameof(_vm.MultipleReplaceShowDotDotDotButtons)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -313,6 +313,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _isMpvChosen;
 
     [ObservableProperty] private bool _existsErrorLogFile;
+    [ObservableProperty] private bool _spellCheckEnglishTreatInApostropheAsIng;
     [ObservableProperty] private bool _existsToolsLogFile;
     [ObservableProperty] private bool _existsSettingsFile;
     [ObservableProperty] private bool _writeToolsLog;
@@ -668,6 +669,7 @@ public partial class SettingsViewModel : ObservableObject
         }
 
         AllowSingleLetterShortcutsInTextbox = Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox;
+        SpellCheckEnglishTreatInApostropheAsIng = Se.Settings.Tools.SpellCheckEnglishTreatInApostropheAsIng;
         GoToLineNumberAlsoSetVideoPosition = Se.Settings.Tools.GoToLineNumberAlsoSetVideoPosition;
         AdjustAllTimesRememberLineSelectionChoice = Se.Settings.Synchronization.AdjustAllTimesRememberLineSelectionChoice;
         SelectedSplitOddNumberOfLinesAction = MapFromSplitOddActionToLanguageCode(Se.Settings.Tools.SplitOddLinesAction);
@@ -1351,6 +1353,7 @@ public partial class SettingsViewModel : ObservableObject
         general.FavoriteSubtitleFormats = sbFavorites.ToString().TrimEnd(';');
 
         Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox = AllowSingleLetterShortcutsInTextbox;
+        Se.Settings.Tools.SpellCheckEnglishTreatInApostropheAsIng = SpellCheckEnglishTreatInApostropheAsIng;
         Se.Settings.Tools.GoToLineNumberAlsoSetVideoPosition = GoToLineNumberAlsoSetVideoPosition;
         Se.Settings.Synchronization.AdjustAllTimesRememberLineSelectionChoice = AdjustAllTimesRememberLineSelectionChoice;
         Se.Settings.Tools.SplitOddLinesAction = MapFromSplitOddActionTranslationToCode(SelectedSplitOddNumberOfLinesAction);

--- a/src/ui/Features/SpellCheck/SpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckManager.cs
@@ -33,6 +33,7 @@ public class SpellCheckManager : ISpellCheckManager, IDoSpell
     private SpellCheckWordLists? _spellCheckWordLists;
     private readonly List<string> _skipAllList;
     private readonly Dictionary<string, string> _changeAllDictionary;
+    private string _twoLetterLanguageCode = string.Empty;
 
     public SpellCheckManager()
     {
@@ -79,6 +80,7 @@ public class SpellCheckManager : ISpellCheckManager, IDoSpell
     public bool Initialize(string dictionaryFile, string twoLetterLanguageCode)
     {
         _skipAllList.Clear();
+        _twoLetterLanguageCode = twoLetterLanguageCode ?? string.Empty;
 
         if (!File.Exists(dictionaryFile))
         {
@@ -319,10 +321,45 @@ public class SpellCheckManager : ISpellCheckManager, IDoSpell
 
         if (WordSpellChecker != null)
         {
-            return WordSpellChecker.DoSpell(word);
+            if (WordSpellChecker.DoSpell(word))
+            {
+                return true;
+            }
+        }
+        else if (_hunspellWeCantSpell != null && _hunspellWeCantSpell.Check(word))
+        {
+            return true;
         }
 
-        return _hunspellWeCantSpell != null && _hunspellWeCantSpell.Check(word);
+        return IsEnglishInApostropheActuallyIng(word);
+    }
+
+    /// <summary>
+    /// English-only convenience rule: words spelled with a dropped "g" such as
+    /// "runnin'" or "doin'" are accepted as if they ended in "ing" ("running", "doing").
+    /// Controlled by the Tools setting "Treat words ending in 'in'' as 'ing'".
+    /// </summary>
+    private bool IsEnglishInApostropheActuallyIng(string word)
+    {
+        if (!Se.Settings.Tools.SpellCheckEnglishTreatInApostropheAsIng)
+        {
+            return false;
+        }
+
+        if (!_twoLetterLanguageCode.StartsWith("en", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (word.Length > 3 &&
+            word.EndsWith("in'", StringComparison.OrdinalIgnoreCase) &&
+            char.IsLetter(word[word.Length - 4]))
+        {
+            // drop the trailing apostrophe and append "g": "runnin'" -> "running"
+            return DoSpell(word.Substring(0, word.Length - 1) + "g");
+        }
+
+        return false;
     }
 
     public bool IsWordCorrect(SpellCheckWord spellCheckWord, string text)
@@ -417,7 +454,7 @@ public class SpellCheckManager : ISpellCheckManager, IDoSpell
             return true;
         }
 
-        var isCorrect = DoSpell(word);
+        var isCorrect = DoSpell(word) || IsEnglishInApostropheActuallyIng(word);
 
         if (_changeAllDictionary.ContainsKey(word) && NotSameSpecialEnding(words[wordIndex], _changeAllDictionary[word], text))
         {

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -193,6 +193,7 @@ public class LanguageSettings
     public string DownloadMpv { get; set; }
     public string DownloadVlc { get; set; }
     public string AllowSingleLetterShortcutsInTextbox { get; set; }
+    public string SpellCheckEnglishTreatInApostropheAsIng { get; set; }
     public string GoToLineNumberSetsVideoPosition { get; set; }
     public string AdjustAllTimesRememberLineSelectionChoice { get; set; }
     public string FilesAndLogs { get; set; }
@@ -501,6 +502,7 @@ public class LanguageSettings
         DownloadMpv = "Download mpv";
         DownloadVlc = "Download VLC";
         AllowSingleLetterShortcutsInTextbox = "Allow single-letter shortcuts in text box";
+        SpellCheckEnglishTreatInApostropheAsIng = "Spell check: Treat words ending in 'in'' as 'ing' (English only)";
         GoToLineNumberSetsVideoPosition = "Go-to-line-number also sets video position";
         AdjustAllTimesRememberLineSelectionChoice = "Adjust all times, remember line selection choice";
         DefaultFormat = "Default format";

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -124,6 +124,7 @@ public class SeTools
 
     public List<string> FindHistory { get; set; } = new List<string>();
     public bool AllowSingleLetterShortcutsInTextbox { get; set; }
+    public bool SpellCheckEnglishTreatInApostropheAsIng { get; set; } = true;
     public bool WriteToolsLog { get; set; } = false;
 
     public SeTools()


### PR DESCRIPTION
Fixes #11697

The classic SubtitleEdit had an English-only spell-check option, "Treat words ending in 'in'' as 'ing'", that was missing from the new cross-platform UI. This restores it.

When enabled (and an English dictionary is active), words spelled with a dropped "g" — e.g. `runnin'`, `doin'`, `nothin'` — are accepted as if they ended in "ing" (`running`, `doing`, `nothing`).

## Changes
- **`SeTools.cs`** — new setting `SpellCheckEnglishTreatInApostropheAsIng` (default **on**, matching classic SE).
- **`LanguageSettings.cs`** — label "Spell check: Treat words ending in 'in'' as 'ing' (English only)".
- **`SettingsViewModel.cs`** — observable property + load/save.
- **`SettingsPage.cs`** — checkbox in **Settings → Tools**, next to the spell-check engine.
- **`SpellCheckManager.cs`** — stores the dictionary language code; `IsEnglishInApostropheActuallyIng()` applies the rule in both the live-underline path and the spell-check dialog path, gated on an English dictionary and on the setting.

The rule only fires for English dictionaries and ignores short/edge tokens (`word.Length > 3`, must be letter + `in'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)