### PR TITLE
Add grid context menu "insert subtitle after current line" on last line

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -753,6 +753,11 @@ public static partial class InitListViewAndEditBox
         insertLineMenuItem.Command = vm.InsertLineAtEndCommand;
         flyout.Items.Add(insertLineMenuItem);
 
+        var insertSubtitleFileAfterLineMenuItem = new MenuItem { Header = Se.Language.General.InsertSubtitleAfterCurrentLine, DataContext = vm };
+        insertSubtitleFileAfterLineMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsInsertSubtitleFileAfterLineVisible)));
+        insertSubtitleFileAfterLineMenuItem.Command = vm.InsertSubtitleFileAfterThisLineCommand;
+        flyout.Items.Add(insertSubtitleFileAfterLineMenuItem);
+
         var copyOriginal = new MenuItem { Header = Se.Language.Main.CopyTextFromOriginalToCurrent, Command = vm.ColumnCopyTextFromOriginalToCurrentCommand };
         copyOriginal.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowColumnOriginalText)));
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -220,6 +220,7 @@ public partial class MainViewModel :
     [ObservableProperty] private bool _isSubtitleGridDataMenuVisible;
     [ObservableProperty] private bool _isMergeWithNextOrPreviousVisible;
     [ObservableProperty] private bool _isInsertLineNoSelectionVisible;
+    [ObservableProperty] private bool _isInsertSubtitleFileAfterLineVisible;
     [ObservableProperty] private bool _showColumnOriginalText;
     [ObservableProperty] private bool _showColumnStartTime;
     [ObservableProperty] private bool _showColumnEndTime;
@@ -2990,6 +2991,47 @@ public partial class MainViewModel :
             var offset = p.StartTime.TotalMilliseconds - firstStartTime;
             newParagraph.SetStartTimeKeepDuration(TimeSpan.FromMilliseconds(videoPosition * 1000 + offset));
 
+            _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+        }
+
+        Renumber();
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
+    private async Task InsertSubtitleFileAfterThisLine()
+    {
+        var selectedItem = SelectedSubtitle;
+        if (Window == null || selectedItem == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenSubtitleFile(Window, Se.Language.General.OpenSubtitleFileTitle, false);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        var subtitle = Subtitle.Parse(fileName);
+        if (subtitle == null || subtitle.Paragraphs.Count <= 0)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.General.UnknownSubtitleFormat,
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        // Shift the inserted lines so the first one starts 1 second after the selected (last) line,
+        // mirroring the binary-edit "insert subtitle after current line" behaviour and avoiding overlap.
+        var oldLastTime = selectedItem.EndTime.TotalMilliseconds;
+        var newFirstTime = subtitle.Paragraphs[0].StartTime.TotalMilliseconds;
+        var timeOffset = oldLastTime - newFirstTime + 1000;
+        foreach (var p in subtitle.Paragraphs)
+        {
+            var newParagraph = new SubtitleLineViewModel(p, SelectedSubtitleFormat);
+            newParagraph.SetStartTimeKeepDuration(TimeSpan.FromMilliseconds(p.StartTime.TotalMilliseconds + timeOffset));
             _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
         }
 
@@ -17355,6 +17397,7 @@ public partial class MainViewModel :
             IsSubtitleGridDataMenuVisible = false;
             IsMergeWithNextOrPreviousVisible = false;
             IsInsertLineNoSelectionVisible = false;
+            IsInsertSubtitleFileAfterLineVisible = false;
             MenuItemExtendToLineBefore.IsVisible = false;
             MenuItemExtendToLineAfter.IsVisible = false;
         }
@@ -17363,12 +17406,15 @@ public partial class MainViewModel :
             IsSubtitleGridDataMenuVisible = false;
             IsMergeWithNextOrPreviousVisible = false;
             IsInsertLineNoSelectionVisible = true;
+            IsInsertSubtitleFileAfterLineVisible = false;
         }
         else
         {
             IsSubtitleGridDataMenuVisible = true;
             IsMergeWithNextOrPreviousVisible = SubtitleGrid.SelectedItems.Count == 1;
             IsInsertLineNoSelectionVisible = false;
+            // Only on the last line, single selection — like SE4's "insert subtitle file after this line".
+            IsInsertSubtitleFileAfterLineVisible = SubtitleGrid.SelectedItems.Count == 1 && idx == count - 1;
 
             if (IsFormatAssa || IsFormatSsa)
             {


### PR DESCRIPTION
Adds a subtitle-grid right-click item **"Insert subtitle after current line…"**, like SE4's "insert subtitle file after this line".

- Visible only when a **single row is selected and it is the last line**.
- Opens a file picker, parses the chosen subtitle, and appends its lines after the selected line — shifted so the first inserted line starts **1 second after** that line's end (mirrors the existing binary-edit "insert subtitle after current line" behaviour; avoids overlap).

### Implementation
- `MainViewModel`: new `IsInsertSubtitleFileAfterLineVisible` observable property; new `InsertSubtitleFileAfterThisLine` command (modeled on `InsertSubtitleFileAtVideoPosition` + the binary-edit offset logic); `SubtitleContextOpening` sets the flag for single-selection-on-last-line only.
- `InitListViewAndEditBox`: added the menu item to the grid flyout, bound to the new visibility flag.
- Reuses the existing localized `InsertSubtitleAfterCurrentLine` string — no new language entries.

Note: timecodes are auto-shifted (+1s after the last line). If preserving the imported file's original absolute times (e.g. appending a pre-timed "part 2") is preferred, that can be swapped in or offered as a prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)