### PR TITLE
Fix all build warnings after SkiaSharp package update

### DIFF
--- a/src/libse/BluRaySup/BluRaySupParser.cs
+++ b/src/libse/BluRaySup/BluRaySupParser.cs
@@ -348,7 +348,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                             var offset = new BluRayPoint(PcsObjects[ioIndex].Origin.X - r.Location.X, PcsObjects[ioIndex].Origin.Y - r.Location.Y);
                             using (var singleBmp = SupDecoder.DecodeImage(PcsObjects[ioIndex], BitmapObjects[ioIndex], PaletteInfos))
                             {
-                                canvas.DrawBitmap(singleBmp, offset.X, offset.Y);
+                                canvas.DrawBitmap(singleBmp, offset.X, offset.Y, SKSamplingOptions.Default);
                             }
                         }
                     }

--- a/src/libse/BluRaySup/SkiaExt.cs
+++ b/src/libse/BluRaySup/SkiaExt.cs
@@ -137,7 +137,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             using (SKCanvas canvas = new SKCanvas(newBitmap))
             {
                 canvas.Clear(SKColors.Transparent); // Fill the new bitmap with transparent color
-                canvas.DrawBitmap(bitmap, marginLeft, marginTop); // Draw the original bitmap at the correct position
+                canvas.DrawBitmap(bitmap, marginLeft, marginTop, SKSamplingOptions.Default); // Draw the original bitmap at the correct position
             }
 
             return newBitmap;
@@ -225,7 +225,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             {
                 SKRect sourceRect = new SKRect(left, top, right + 1, bottom + 1);
                 SKRect destRect = new SKRect(0, 0, newWidth, newHeight);
-                canvas.DrawBitmap(bitmap, sourceRect, destRect);
+                canvas.DrawBitmap(bitmap, sourceRect, destRect, SKSamplingOptions.Default);
             }
 
             return new TrimResult

--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -62,7 +62,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var newBitmap = new SKBitmap(info);
                 using (var canvas = new SKCanvas(newBitmap))
                 {
-                    canvas.DrawBitmap(inputBitmap, 0, 0);
+                    canvas.DrawBitmap(inputBitmap, 0, 0, SKSamplingOptions.Default);
                 }
                 inputBitmap = newBitmap;
                 createdNewBitmap = true;

--- a/src/libse/ContainerFormats/TransportStream/DvbSubPes.cs
+++ b/src/libse/ContainerFormats/TransportStream/DvbSubPes.cs
@@ -471,7 +471,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                     if (odsImage != null)
                     {
                         var odsPoint = GetImagePosition(ods); // Assuming this returns an SKPoint or similar
-                        canvas.DrawBitmap(odsImage, odsPoint.X, odsPoint.Y);
+                        canvas.DrawBitmap(odsImage, odsPoint.X, odsPoint.Y, SKSamplingOptions.Default);
                     }
                 }
             }

--- a/src/libse/VobSub/SubPicture.cs
+++ b/src/libse/VobSub/SubPicture.cs
@@ -415,7 +415,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             var target = new SKBitmap(rect.Width, rect.Height, source.ColorType, source.AlphaType);
             using (var canvas = new SKCanvas(target))
             {
-                canvas.DrawBitmap(source, rect, new SKRect(0, 0, rect.Width, rect.Height));
+                canvas.DrawBitmap(source, rect, new SKRect(0, 0, rect.Width, rect.Height), SKSamplingOptions.Default);
             }
 
             return target;

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -208,7 +208,7 @@ public static class ImageRenderer
         }
 
         // Draw the already-rendered text bitmap on top of the boxes, offset by padding
-        canvas.DrawBitmap(textBitmap, padLeft, padTop);
+        canvas.DrawBitmap(textBitmap, padLeft, padTop, SKSamplingOptions.Default);
         return result;
     }
 

--- a/src/libuilogic/Ocr/ImageTextSplitter.cs
+++ b/src/libuilogic/Ocr/ImageTextSplitter.cs
@@ -66,7 +66,7 @@ public class TextSplitter
                 var lineBitmap = new SKBitmap(image.Width, lineHeight);
                 using (var canvas = new SKCanvas(lineBitmap))
                 {
-                    canvas.DrawBitmap(image, new SKRect(0, lineStart, image.Width, y), new SKRect(0, 0, image.Width, lineHeight));
+                    canvas.DrawBitmap(image, new SKRect(0, lineStart, image.Width, y), new SKRect(0, 0, image.Width, lineHeight), SKSamplingOptions.Default);
                 }
                 lines.Add(lineBitmap);
             }
@@ -131,7 +131,7 @@ public class TextSplitter
                     var letterBitmap = new SKBitmap(letterWidth + whitespaceThreshold, lineBitmap.Height);
                     using (var canvas = new SKCanvas(letterBitmap))
                     {
-                        canvas.DrawBitmap(lineBitmap, new SKRect(letterStart - whitespaceThreshold, 0, x + whitespaceThreshold, lineBitmap.Height), new SKRect(0, 0, letterWidth + whitespaceThreshold, lineBitmap.Height));
+                        canvas.DrawBitmap(lineBitmap, new SKRect(letterStart - whitespaceThreshold, 0, x + whitespaceThreshold, lineBitmap.Height), new SKRect(0, 0, letterWidth + whitespaceThreshold, lineBitmap.Height), SKSamplingOptions.Default);
                     }
 
                     // Add the letter with its original coordinates
@@ -154,7 +154,7 @@ public class TextSplitter
             var letterBitmap = new SKBitmap(letterWidth + whitespaceThreshold, lineBitmap.Height);
             using (var canvas = new SKCanvas(letterBitmap))
             {
-                canvas.DrawBitmap(lineBitmap, new SKRect(letterStart - whitespaceThreshold, 0, lineBitmap.Width, lineBitmap.Height), new SKRect(0, 0, letterWidth + whitespaceThreshold, lineBitmap.Height));
+                canvas.DrawBitmap(lineBitmap, new SKRect(letterStart - whitespaceThreshold, 0, lineBitmap.Width, lineBitmap.Height), new SKRect(0, 0, letterWidth + whitespaceThreshold, lineBitmap.Height), SKSamplingOptions.Default);
             }
 
             letters.Add(new LetterBitmap

--- a/src/libuilogic/Ocr/NikseBitmap2.cs
+++ b/src/libuilogic/Ocr/NikseBitmap2.cs
@@ -93,7 +93,7 @@ public class NikseBitmap2
             convertedBitmap = new SKBitmap(inputBitmap.Width, inputBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
             using (var canvas = new SKCanvas(convertedBitmap))
             {
-                canvas.DrawBitmap(inputBitmap, 0, 0);
+                canvas.DrawBitmap(inputBitmap, 0, 0, SKSamplingOptions.Default);
             }
             inputBitmap = convertedBitmap;
             needsDisposal = true;

--- a/src/seconv/Core/OllamaOcrEngine.cs
+++ b/src/seconv/Core/OllamaOcrEngine.cs
@@ -84,7 +84,7 @@ internal sealed class OllamaOcrEngine : IOcrEngine
         canvas.Clear(SKColors.Black);
         var left = (side - source.Width) / 2f;
         var top = (side - source.Height) / 2f;
-        canvas.DrawBitmap(source, new SKRect(left, top, left + source.Width, top + source.Height));
+        canvas.DrawBitmap(source, new SKRect(left, top, left + source.Width, top + source.Height), SKSamplingOptions.Default);
         canvas.Flush();
         return square;
     }

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1647,7 +1647,7 @@ public class AudioVisualizer : Control
             // Draw part of the spectrogram image
             var sourceRect = new SKRect(x, 0, x + w, skBitmapCombined.Height);
             var destRect = new SKRect(offset, 0, offset + w, skBitmapCombined.Height);
-            skCanvas.DrawBitmap(_spectrogram.Images[imageIndex], sourceRect, destRect);
+            skCanvas.DrawBitmap(_spectrogram.Images[imageIndex], sourceRect, destRect, SKSamplingOptions.Default);
 
             offset += w;
             imageIndex++;

--- a/src/ui/Features/Assa/AssaAttachmentsViewModel.cs
+++ b/src/ui/Features/Assa/AssaAttachmentsViewModel.cs
@@ -460,7 +460,7 @@ public partial class AssaAttachmentsViewModel : ObservableObject
         {
             if (!string.IsNullOrEmpty(line))
             {
-                canvas.DrawText(line, 12, y, font, paint);
+                canvas.DrawText(line, 12, y, SKTextAlign.Left, font, paint);
             }
             y += font.Size + 5; // Line spacing using font.Size instead of paint.TextSize
         }

--- a/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewViewModel.cs
@@ -44,7 +44,7 @@ public partial class ImageBasedPreviewViewModel : ObservableObject
         using (var canvas = new SKCanvas(skBitmap))
         {
             UiUtil.DrawCheckerboardBackground(canvas, width, height);
-            canvas.DrawBitmap(bitmap, x, y);
+            canvas.DrawBitmap(bitmap, x, y, SKSamplingOptions.Default);
         }
 
         BitmapPreview = skBitmap.ToAvaloniaBitmap();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -19805,8 +19805,7 @@ public partial class MainViewModel :
             var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
             if (selectedItems.Count > 0)
             {
-                var first = selectedItems.MinBy(p => Subtitles.IndexOf(p));
-                var firstSelectedIndex = Subtitles.IndexOf(first);
+                var firstSelectedIndex = selectedItems.Min(p => Subtitles.IndexOf(p));
                 for (var i = firstSelectedIndex; i < Subtitles.Count; i++)
                 {
                     var p = Subtitles[i];

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddViewModel.cs
@@ -210,7 +210,7 @@ public partial class BinaryOcrCharacterAddViewModel : ObservableObject
         {
             var sourceRect = new SKRect(0, linesToRemove, original.Width, original.Height);
             var destRect = new SKRect(0, 0, original.Width, newHeight);
-            canvas.DrawBitmap(original, sourceRect, destRect);
+            canvas.DrawBitmap(original, sourceRect, destRect, SKSamplingOptions.Default);
         }
 
         return newBitmap;

--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -171,7 +171,7 @@ public partial class PaddleOcr
         if (workingBitmap != bitmap)
         {
             using var canvas = new SKCanvas(workingBitmap);
-            canvas.DrawBitmap(bitmap, 0, 0);
+            canvas.DrawBitmap(bitmap, 0, 0, SKSamplingOptions.Default);
         }
 
         // Get all pixels at once
@@ -770,7 +770,7 @@ public partial class PaddleOcr
             finalWidth - borderSize * 2, finalHeight - borderSize * 2, paint);
 
         // Draw original bitmap in center
-        canvas.DrawBitmap(source, totalBorder, totalBorder);
+        canvas.DrawBitmap(source, totalBorder, totalBorder, SKSamplingOptions.Default);
 
         return result;
     }
@@ -842,7 +842,7 @@ public partial class PaddleOcr
             canvas.Clear(borderColor);
 
             // Draw the original bitmap onto the canvas, offset by the border width
-            canvas.DrawBitmap(originalBitmap, borderWidth, borderWidth);
+            canvas.DrawBitmap(originalBitmap, borderWidth, borderWidth, SKSamplingOptions.Default);
         }
 
         return borderedBitmap;

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterAddViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterAddViewModel.cs
@@ -259,7 +259,7 @@ public partial class NOcrCharacterAddViewModel : ObservableObject
         {
             var sourceRect = new SKRect(0, linesToRemove, original.Width, original.Height);
             var destRect = new SKRect(0, 0, original.Width, newHeight);
-            canvas.DrawBitmap(original, sourceRect, destRect);
+            canvas.DrawBitmap(original, sourceRect, destRect, SKSamplingOptions.Default);
         }
 
         return newBitmap;

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBdn.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBdn.cs
@@ -137,7 +137,7 @@ public class OcrSubtitleBdn : IOcrSubtitle
                                 part = MakeTransparent(part);
                             }
 
-                            canvas.DrawBitmap(part, 0, y);
+                            canvas.DrawBitmap(part, 0, y, SKSamplingOptions.Default);
                             y += part.Height + 7;
 
                             // Dispose the temporary bitmap if it was made transparent

--- a/src/ui/Features/Ocr/PreProcessingSettings.cs
+++ b/src/ui/Features/Ocr/PreProcessingSettings.cs
@@ -110,7 +110,7 @@ public class PreProcessingSettings
         {
             var srcRect = new SKRect(left, top, right + 1, bottom + 1);
             var destinationRect = new SKRect(0, 0, cropWidth, cropHeight);
-            canvas.DrawBitmap(bitmap, srcRect, destinationRect);
+            canvas.DrawBitmap(bitmap, srcRect, destinationRect, SKSamplingOptions.Default);
         }
 
         return cropped;
@@ -190,7 +190,7 @@ public class PreProcessingSettings
         {
             var srcRect = new SKRect(borderSize, borderSize, bitmap.Width - borderSize, bitmap.Height - borderSize);
             var destinationRect = new SKRect(0, 0, width, height);
-            canvas.DrawBitmap(bitmap, srcRect, destinationRect);
+            canvas.DrawBitmap(bitmap, srcRect, destinationRect, SKSamplingOptions.Default);
         }
 
         return cropped;

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -239,9 +239,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _isLibVlcDownloadVisible;
     [ObservableProperty] private string _ffmpegPath;
     [ObservableProperty] private string _ffmpegStatus;
-    [ObservableProperty] private string _proxyAddress;
-    [ObservableProperty] private string _proxyUserName;
-    [ObservableProperty] private string _proxyPassword;
+    [ObservableProperty] private string _proxyAddress = string.Empty;
+    [ObservableProperty] private string _proxyUserName = string.Empty;
+    [ObservableProperty] private string _proxyPassword = string.Empty;
     [ObservableProperty] private int _waveformTextFontSize;
     [ObservableProperty] private bool _waveformTextFontBold;
     [ObservableProperty] private Color _waveformTextColor;

--- a/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
@@ -133,7 +133,7 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
         var metrics = skFont.Metrics;
         var textY = previewHeight / 2f - (metrics.Ascent + metrics.Descent) / 2f;
         using var textPaint = new SKPaint { Color = SKColors.White, IsAntialias = true };
-        canvas.DrawText(SampleText, textX, textY, skFont, textPaint);
+        canvas.DrawText(SampleText, textX, textY, SKTextAlign.Left, skFont, textPaint);
 
         // Green limit lines (left and right edges of safe area)
         if (greenLineX > 0)

--- a/src/ui/Features/Shared/BinaryEdit/SetText/SetTextViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/SetText/SetTextViewModel.cs
@@ -215,7 +215,7 @@ public partial class SetTextViewModel : ObservableObject
         using (var canvas = new SKCanvas(finalBitmap))
         {
             canvas.Clear(skBackgroundColor);
-            canvas.DrawBitmap(bitmapWithoutBox, 0, 0);
+            canvas.DrawBitmap(bitmapWithoutBox, 0, 0, SKSamplingOptions.Default);
         }
         bitmapWithoutBox.Dispose();
 

--- a/src/ui/Features/Shared/ColorPicker/ColorWheelControl.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorWheelControl.cs
@@ -247,7 +247,7 @@ public class ColorWheelControl : Control
             using var lease = leaseFeature.Lease();
             var canvas = lease.SkCanvas;
 
-            canvas.DrawBitmap(_bitmap, 0, 0);
+            canvas.DrawBitmap(_bitmap, 0, 0, SKSamplingOptions.Default);
 
             // Draw selection indicator
             var paint = new SKPaint

--- a/src/ui/Features/Shared/PickFontName/PickFontNameViewModel.cs
+++ b/src/ui/Features/Shared/PickFontName/PickFontNameViewModel.cs
@@ -142,7 +142,7 @@ public partial class PickFontNameViewModel : ObservableObject
         {
             if (!string.IsNullOrEmpty(line))
             {
-                canvas.DrawText(line, 12, y, font, paint);
+                canvas.DrawText(line, 12, y, SKTextAlign.Left, font, paint);
             }
             y += font.Size + 5; // Line spacing using font.Size instead of paint.TextSize
         }

--- a/src/ui/Features/Ssa/SsaAttachmentsViewModel.cs
+++ b/src/ui/Features/Ssa/SsaAttachmentsViewModel.cs
@@ -460,7 +460,7 @@ public partial class SsaAttachmentsViewModel : ObservableObject
         {
             if (!string.IsNullOrEmpty(line))
             {
-                canvas.DrawText(line, 12, y, font, paint);
+                canvas.DrawText(line, 12, y, SKTextAlign.Left, font, paint);
             }
             y += font.Size + 5; // Line spacing using font.Size instead of paint.TextSize
         }

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesViewModel.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesViewModel.cs
@@ -625,16 +625,16 @@ public partial class MergeTwoSubtitlesViewModel : ObservableObject
                 {
                     for (var s = 1; s <= (int)shadowWidth; s++)
                     {
-                        canvas.DrawText(line, x + s, y + s, font, shadowPaint);
+                        canvas.DrawText(line, x + s, y + s, SKTextAlign.Left, font, shadowPaint);
                     }
                 }
 
                 if (outlinePaint != null)
                 {
-                    canvas.DrawText(line, x, y, font, outlinePaint);
+                    canvas.DrawText(line, x, y, SKTextAlign.Left, font, outlinePaint);
                 }
 
-                canvas.DrawText(line, x, y, font, fillPaint);
+                canvas.DrawText(line, x, y, SKTextAlign.Left, font, fillPaint);
             }
         }
         finally

--- a/src/ui/Logic/ClipboardHelper.cs
+++ b/src/ui/Logic/ClipboardHelper.cs
@@ -195,7 +195,7 @@ public static class ClipboardHelper
                 // Ensure we have BGRA format
                 using var bgraBitmap = new SkiaSharp.SKBitmap(width, height, SkiaSharp.SKColorType.Bgra8888, SkiaSharp.SKAlphaType.Premul);
                 using var canvas = new SkiaSharp.SKCanvas(bgraBitmap);
-                canvas.DrawBitmap(skBitmap, 0, 0);
+                canvas.DrawBitmap(skBitmap, 0, 0, SkiaSharp.SKSamplingOptions.Default);
                 canvas.Flush();
 
                 var pixels = bgraBitmap.Bytes;

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -197,6 +197,10 @@ public class SeGeneral
         FfmpegPath = string.Empty;
         LibMpvPath = string.Empty;
 
+        ProxyAddress = string.Empty;
+        ProxyUserName = string.Empty;
+        ProxyPassword = string.Empty;
+
         ShowColumnStartTime = true;
         ShowColumnEndTime = true;
         ShowColumnGap = false;

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -852,7 +852,7 @@ public class FfmpegGenerator
             using (var canvas = new SKCanvas(skBitmap))
             {
                 UiUtil.DrawCheckerboardBackground(canvas, width, height);
-                canvas.DrawBitmap(skBitmap, 0, 0);
+                canvas.DrawBitmap(skBitmap, 0, 0, SKSamplingOptions.Default);
             }
 
             using (var resizedBitmap = ResizeBitmap(skBitmap, width, height))
@@ -887,7 +887,7 @@ public class FfmpegGenerator
             {
                 paint.IsAntialias = true;
                 var destRect = new SKRect(0, 0, width, height);
-                canvas.DrawBitmap(originalBitmap, destRect, paint);
+                canvas.DrawBitmap(originalBitmap, destRect, SKSamplingOptions.Default, paint);
             }
         }
 

--- a/src/ui/Logic/Media/TextToImageGenerator.cs
+++ b/src/ui/Logic/Media/TextToImageGenerator.cs
@@ -232,7 +232,7 @@ public static class TextToImageGenerator
         x = Math.Max(0, Math.Min(x, frameWidth - textBitmap.Width));
         yy = Math.Max(0, Math.Min(yy, frameHeight - textBitmap.Height));
 
-        canvas.DrawBitmap(textBitmap, x, yy);
+        canvas.DrawBitmap(textBitmap, x, yy, SKSamplingOptions.Default);
         return frame;
     }
 
@@ -292,7 +292,7 @@ public static class TextToImageGenerator
         }
 
         // Draw the original bitmap
-        canvas.DrawBitmap(originalBitmap, 0, 0);
+        canvas.DrawBitmap(originalBitmap, 0, 0, SKSamplingOptions.Default);
 
         // Create a new bitmap from the surface
         using (var image = surface.Snapshot())

--- a/src/ui/Logic/SkBitmapExtensions.cs
+++ b/src/ui/Logic/SkBitmapExtensions.cs
@@ -23,7 +23,7 @@ internal static class SkBitmapExtensions
 
         paint.ColorFilter = SKColorFilter.CreateColorMatrix(colorMatrix);
 
-        canvas.DrawBitmap(bitmap, 0, 0, paint);
+        canvas.DrawBitmap(bitmap, 0, 0, SKSamplingOptions.Default, paint);
 
         return bitmap;
     }
@@ -264,7 +264,7 @@ internal static class SkBitmapExtensions
         var skBitmap = new SKBitmap(image.Width, image.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
         using (var canvas = new SKCanvas(skBitmap))
         {
-            canvas.DrawImage(image, 0, 0);
+            canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
         }
 
         return skBitmap;


### PR DESCRIPTION
The SkiaSharp 4.148.0 bump deprecated several `SKCanvas` overloads, producing 86 build warnings. This migrates every call site to the new API and clears the remaining handful of unrelated warnings, so the full solution builds **0 errors / 0 warnings**.

### SkiaSharp deprecations (CS0618 ×85)
- `DrawBitmap(...)` / `DrawImage(...)` → pass `SKSamplingOptions.Default`.
- `DrawText(text, x, y, font, paint)` → pass explicit `SKTextAlign.Left`.

**Behaviour-preserving:** no code in the repo uses `SKPaint.FilterQuality`, so every old draw used the default nearest-neighbour sampling — which is exactly what `SKSamplingOptions.Default` (nearest / no mipmap) is. `SKTextAlign.Left` matches the old default and the existing `DrawShapedText`/`DrawText` calls already in the codebase. `ClipboardHelper.cs` (no `using SkiaSharp;`) uses the fully-qualified `SkiaSharp.SKSamplingOptions.Default`.

### Other warnings
- `CS8618` ×12 — initialize proxy strings (`SeGeneral` ctor, `SettingsViewModel` fields).
- `CS8604` ×2 — compute the first selected index via `Min(...)`, removing a nullable `IndexOf` argument.

30 files changed, all mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)