### PR TITLE
Ensure found/selected subtitle-grid row is fully visible (#11723)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13459,8 +13459,82 @@ public partial class MainViewModel :
                 {
                     CenterSelectedRowInSubtitleGrid(itemToScroll);
                 }
+                else
+                {
+                    EnsureRowFullyVisibleInSubtitleGrid(itemToScroll);
+                }
             }
         });
+    }
+
+    // Avalonia's DataGrid.ScrollIntoView often leaves the target only partially visible -
+    // clipped at the bottom edge, or a row or two below the fold - because its viewport
+    // estimate is wrong with the variable-height subtitle rows (issue #11723). After the
+    // built-in scroll (which realizes the target row), measure that row against the actual
+    // rows-presenter viewport and nudge the vertical scrollbar by exactly how far it pokes
+    // out, so it ends up fully on screen. This is the non-centering counterpart to
+    // CenterSelectedRowInSubtitleGrid and uses the same deterministic scrollbar approach.
+    private void EnsureRowFullyVisibleInSubtitleGrid(SubtitleLineViewModel item)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            var row = SubtitleGrid.GetVisualDescendants().OfType<DataGridRow>()
+                .FirstOrDefault(r => ReferenceEquals(r.DataContext, item));
+            if (row == null || row.Bounds.Height <= 0)
+            {
+                return;
+            }
+
+            var rowsPresenter = SubtitleGrid.GetVisualDescendants().OfType<DataGridRowsPresenter>().FirstOrDefault();
+            if (rowsPresenter == null || rowsPresenter.Bounds.Height <= 0)
+            {
+                return;
+            }
+
+            var verticalScrollBar = SubtitleGrid.GetVisualDescendants().OfType<ScrollBar>()
+                .FirstOrDefault(sb => sb.Orientation == Orientation.Vertical);
+            if (verticalScrollBar == null)
+            {
+                return;
+            }
+
+            // row.Bounds is relative to the rows presenter, so these are viewport coordinates.
+            var rowTop = row.Bounds.Y;
+            var rowBottom = row.Bounds.Y + row.Bounds.Height;
+            double delta;
+            if (rowBottom > rowsPresenter.Bounds.Height)
+            {
+                delta = rowBottom - rowsPresenter.Bounds.Height; // pokes out the bottom -> scroll down
+            }
+            else if (rowTop < 0)
+            {
+                delta = rowTop; // pokes out the top -> scroll up (negative)
+            }
+            else
+            {
+                return; // already fully visible
+            }
+
+            if (Math.Abs(delta) < 1)
+            {
+                return;
+            }
+
+            var newValue = Math.Max(0, Math.Min(verticalScrollBar.Value + delta, verticalScrollBar.Maximum));
+            if (Math.Abs(newValue - verticalScrollBar.Value) < 0.5)
+            {
+                return;
+            }
+
+            verticalScrollBar.Value = newValue;
+
+            // Avalonia's DataGrid hooks the scrollbar's Scroll event (not ValueChanged) to
+            // update the visible rows; invoke the internal handler via reflection.
+            var processVerticalScroll = typeof(DataGrid).GetMethod(
+                "ProcessVerticalScroll",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            processVerticalScroll?.Invoke(SubtitleGrid, new object[] { ScrollEventType.EndScroll });
+        }, DispatcherPriority.Loaded);
     }
 
     private void CenterSelectedRowInSubtitleGrid(SubtitleLineViewModel itemToCenter)


### PR DESCRIPTION
Fixes #11723

### Problem
After **Find** (and other grid navigation), the target row often lands clipped at the bottom or 1-3 rows below the last fully-visible row. Cause: Avalonia `DataGrid.ScrollIntoView` mis-estimates the viewport with the subtitle grid''s **variable-height rows** (1- vs 2-line subtitles), so it only scrolls the target *approximately* into view.

The **centered** path already avoided this by positioning the row deterministically via the vertical scrollbar (`CenterSelectedRowInSubtitleGrid`), but `SubtitleGridCenterSelectedRow` defaults to **false**, so the default path trusted `ScrollIntoView` with no correction.

### Fix
Add `EnsureRowFullyVisibleInSubtitleGrid` - the non-centering counterpart - called from `SelectAndScrollToRow` when centering is off. After `ScrollIntoView` realizes the target row, on a `Loaded`-priority pass it:
1. measures the target `DataGridRow.Bounds` against the real `DataGridRowsPresenter` viewport,
2. computes how far the row pokes out (bottom or top),
3. nudges the vertical scrollbar by that delta and invokes the DataGrid''s internal `ProcessVerticalScroll` (same mechanism the centering path already uses).

The row is now placed deterministically fully inside the viewport instead of trusting Avalonia''s estimate. Fixes Find and every other `SelectAndScrollToRow` caller; no change when centering is enabled.

Single-file change; builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)