### PR TITLE
Add "Toggle translation mode" command/shortcut (SE4 parity)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1753,6 +1753,36 @@ public partial class MainViewModel :
         _shortcutManager.ClearKeys();
     }
 
+    // SE4 parity (GeneralToggleTranslationMode): toggle the side-by-side original/translation view.
+    // Off -> hide the original column; on with an original already loaded -> re-show it without
+    // re-prompting; on with nothing loaded -> open an original subtitle file.
+    [RelayCommand]
+    private async Task ToggleTranslationMode()
+    {
+        if (Subtitles.Count == 0)
+        {
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        if (ShowColumnOriginalText)
+        {
+            ShowColumnOriginalText = false;
+            AutoFitColumns();
+        }
+        else if (_subtitleOriginal != null && _subtitleOriginal.Paragraphs.Count > 0)
+        {
+            ShowColumnOriginalText = true;
+            AutoFitColumns();
+        }
+        else
+        {
+            await FileOpenOriginal();
+        }
+
+        _shortcutManager.ClearKeys();
+    }
+
     [RelayCommand]
     private async Task FileCloseTranslation()
     {

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -313,6 +313,7 @@ public static class Se4ShortcutsImporter
         ["GeneralMergeSelectedLinesAndUnbreakNoSpace"] = nameof(MainViewModel.MergeSelectedLinesAndUnbreakCjkCommand),
         ["GeneralMergeSelectedLinesBilingual"] = nameof(MainViewModel.MergeSelectedLinesBilingualCommand),
         ["GeneralMergeOriginalAndTranslation"] = nameof(MainViewModel.MergeOriginalIntoTranslationSelectedLinesCommand),
+        ["GeneralToggleTranslationMode"] = nameof(MainViewModel.ToggleTranslationModeCommand),
         ["GeneralMergeWithNext"] = nameof(MainViewModel.MergeWithLineAfterCommand),
         ["GeneralMergeWithPrevious"] = nameof(MainViewModel.MergeWithLineBeforeCommand),
         ["GeneralApplyAssaOverrideTags"] = nameof(MainViewModel.ShowAssaApplyCustomOverrideTagsCommand),

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -104,6 +104,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.CommandFileOpenKeepVideoCommand), Se.Language.Options.Shortcuts.FileOpenKeepVideo },
         { nameof(MainViewModel.FileOpenOriginalCommand), Se.Language.Options.Shortcuts.FileOpenOriginal },
         { nameof(MainViewModel.FileCloseOriginalCommand), Se.Language.Options.Shortcuts.FileCloseOriginal },
+        { nameof(MainViewModel.ToggleTranslationModeCommand), Se.Language.Options.Shortcuts.GeneralToggleTranslationMode },
         { nameof(MainViewModel.FileCloseTranslationCommand), Se.Language.Options.Shortcuts.FileCloseTranslation },
         { nameof(MainViewModel.CommandExitCommand), Se.Language.Options.Shortcuts.FileExit },
         { nameof(MainViewModel.CommandFileNewCommand), Se.Language.Options.Shortcuts.FileNew },
@@ -465,6 +466,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.CommandFileOpenKeepVideoCommand, nameof(vm.CommandFileOpenKeepVideoCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.FileOpenOriginalCommand, nameof(vm.FileOpenOriginalCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.FileCloseOriginalCommand, nameof(vm.FileCloseOriginalCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ToggleTranslationModeCommand, nameof(vm.ToggleTranslationModeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.FileCloseTranslationCommand, nameof(vm.FileCloseTranslationCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ExportBluRaySupCommand, nameof(vm.ExportBluRaySupCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowExportCustomTextFormatCommand, nameof(vm.ShowExportCustomTextFormatCommand), ShortcutCategory.General);
@@ -829,6 +831,7 @@ public static class ShortcutsMain
             new(nameof(vm.AutoBreakCommand), [cmd, nameof(Avalonia.Input.Key.R)], ShortcutCategory.General),
             new(nameof(vm.PlaySelectedLinesWithoutLoopCommand), [nameof(Avalonia.Input.Key.F5)], ShortcutCategory.General),
             new(nameof(vm.ExtendSelectedToNextCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.E)], ShortcutCategory.General),
+            new(nameof(vm.ToggleTranslationModeCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.O)], ShortcutCategory.General),
             new(nameof(vm.ExtendSelectedToPreviousCommand), ["Alt", "Shift", nameof(Avalonia.Input.Key.E)], ShortcutCategory.General),
 
             // Text casing / split (V4 defaults)


### PR DESCRIPTION
SE4 had `GeneralToggleTranslationMode` (default **Ctrl+Shift+O**) to toggle the side-by-side original/translation view. SE5 had no equivalent command (only separate `FileOpenOriginal`/`FileCloseOriginal`). This adds it.

### Behavior
`ToggleTranslationMode`:
- **On → off:** hide the original column (`ShowColumnOriginalText = false`).
- **Off, original already loaded:** re-show the column without re-prompting (non-destructive, unlike SE4 which removed it).
- **Off, nothing loaded:** open an original subtitle file (`FileOpenOriginal`).
- No-op when the subtitle is empty.

### Wiring
- New `ToggleTranslationMode` `[RelayCommand]` in `MainViewModel`.
- Registered in `ShortcutsMain` (General category) with the SE4 default **Ctrl+Shift+O** (verified unused in SE5), reusing the existing `GeneralToggleTranslationMode` = "Toggle translation mode" string.
- Bridged in `Se4ShortcutsImporter` (`GeneralToggleTranslationMode` → `ToggleTranslationModeCommand`).

Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)