### PR TITLE
Spell check: continue-from-current-line, wrap-around, and replace-all confirm (#11770)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5574,7 +5574,12 @@ public partial class MainViewModel :
         if (result.OkPressed)
         {
             _currentSpellCheckDictionary = result.SelectedDictionary;
+        }
 
+        // Show the summary when the run finished or when the user closed early after making
+        // changes/skips, so the "X changed, Y skipped" result is never silently lost.
+        if (result.OkPressed || result.TotalChangedWords > 0 || result.TotalSkippedWords > 0)
+        {
             var msg = string.Format(
                 Se.Language.Main.SpellCheckResult,
                 result.TotalChangedWords,

--- a/src/ui/Features/SpellCheck/ISpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/ISpellCheckManager.cs
@@ -9,7 +9,7 @@ public interface ISpellCheckManager
     event SpellCheckManager.SpellCheckWordChangedHandler? OnWordChanged;
     bool IsWordCorrect(string word);
     bool IsWordCorrect(SpellCheckWord word, string allText);
-    List<SpellCheckResult> CheckSpelling(ObservableCollection<SubtitleLineViewModel> subtitles, SpellCheckResult? startFrom = null);
+    List<SpellCheckResult> CheckSpelling(ObservableCollection<SubtitleLineViewModel> subtitles, SpellCheckResult? startFrom = null, int? stopBeforeLineIndex = null);
     int NoOfChangedWords { get; set; }
     int NoOfSkippedWords { get; set; }
     bool Initialize(string dictionaryFile, string twoLetterLanguageCode);

--- a/src/ui/Features/SpellCheck/SpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckManager.cs
@@ -113,7 +113,7 @@ public class SpellCheckManager : ISpellCheckManager, IDoSpell
         return true;
     }
 
-    public List<SpellCheckResult> CheckSpelling(ObservableCollection<SubtitleLineViewModel> subtitles, SpellCheckResult? startFrom = null)
+    public List<SpellCheckResult> CheckSpelling(ObservableCollection<SubtitleLineViewModel> subtitles, SpellCheckResult? startFrom = null, int? stopBeforeLineIndex = null)
     {
         var results = new List<SpellCheckResult>();
 
@@ -124,7 +124,12 @@ public class SpellCheckManager : ISpellCheckManager, IDoSpell
             startWordIndex++;
         }
 
-        for (var lineIndex = startLineIndex; lineIndex < subtitles.Count; lineIndex++)
+        // When wrapping back to the top, scan only the lines above where this run started.
+        var endLineIndex = stopBeforeLineIndex.HasValue
+            ? Math.Min(stopBeforeLineIndex.Value, subtitles.Count)
+            : subtitles.Count;
+
+        for (var lineIndex = startLineIndex; lineIndex < endLineIndex; lineIndex++)
         {
             var p = subtitles[lineIndex];
             var words = SpellCheckWordLists.Split(p.Text);

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.SpellCheck.EditWholeText;
 using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 using Nikse.SubtitleEdit.Logic;
@@ -63,6 +64,14 @@ public partial class SpellCheckViewModel : ObservableObject
     private SpellCheckResult? _lastSpellCheckResult;
     private System.Timers.Timer? _statusTimer;
     private readonly List<SpellCheckUndoItem> _undoList = new();
+
+    // Where this run started scanning (0 = top). When the user chooses to start at the
+    // current line, the scan runs to the end and then offers to wrap back to the top;
+    // _stopBeforeLineIndex bounds that wrapped pass to the lines above the start so it
+    // does not re-check the part already covered. _hasWrapped guards against re-prompting.
+    private int _scanStartLineIndex;
+    private int? _stopBeforeLineIndex;
+    private bool _hasWrapped;
 
     public SpellCheckViewModel(ISpellCheckManager spellCheckManager, IWindowService windowService)
     {
@@ -232,7 +241,61 @@ public partial class SpellCheckViewModel : ObservableObject
         Paragraphs.Clear();
         Paragraphs.AddRange(paragraphs);
         SetLanguage(dictionaryFileName);
-        Dispatcher.UIThread.Post(DoSpellCheck, DispatcherPriority.Background);
+
+        // Posted to run after the window exists (Window is assigned in the window ctor),
+        // so the "continue from current line?" prompt and the close hook have an owner.
+        Dispatcher.UIThread.Post(() => _ = StartSpellCheckAsync(selectedSubtitleIndex), DispatcherPriority.Background);
+    }
+
+    /// <summary>
+    /// Decides where the scan begins. When a line other than the first is selected, the user
+    /// is asked whether to continue from that line or start from the top (SE4 parity); Cancel
+    /// closes the dialog without checking. The chosen start line is remembered so the scan can
+    /// later offer to wrap back to the top.
+    /// </summary>
+    private async Task StartSpellCheckAsync(int? selectedSubtitleIndex)
+    {
+        // Make sure a summary of changes is reported even when the user closes early (Esc / X),
+        // not only when the run completes or "Done" is pressed.
+        if (Window != null)
+        {
+            Window.Closing += (_, _) => CaptureTotals();
+        }
+
+        var startLine = 0;
+        if (Window != null && selectedSubtitleIndex is int idx && idx > 0 && idx < Paragraphs.Count)
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                Se.Language.SpellCheck.SpellCheck,
+                Se.Language.SpellCheck.ContinueFromCurrentLine,
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (answer == MessageBoxResult.Cancel || answer == MessageBoxResult.None)
+            {
+                Dispatcher.UIThread.Invoke(() => Window?.Close());
+                return;
+            }
+
+            if (answer == MessageBoxResult.Yes)
+            {
+                startLine = idx;
+            }
+        }
+
+        _scanStartLineIndex = startLine;
+        _lastSpellCheckResult = startLine > 0
+            ? new SpellCheckResult { LineIndex = startLine, WordIndex = -1 }
+            : null;
+
+        DoSpellCheck();
+    }
+
+    private void CaptureTotals()
+    {
+        TotalChangedWords = _spellCheckManager.NoOfChangedWords;
+        TotalSkippedWords = _spellCheckManager.NoOfSkippedWords;
     }
 
     private void SetLanguage(string? dictionaryFileName)
@@ -370,13 +433,28 @@ public partial class SpellCheckViewModel : ObservableObject
     }
 
     [RelayCommand(CanExecute = nameof(CanChangeWord))]
-    private void ChangeWordAll()
+    private async Task ChangeWordAll()
     {
         var selectedParagraph = SelectedParagraph;
         if (selectedParagraph == null)
         {
             Dispatcher.UIThread.Invoke(() => { TextBoxWordNotFound.Focus(); });
             return;
+        }
+
+        if (Window != null)
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                Se.Language.SpellCheck.SpellCheck,
+                string.Format(Se.Language.SpellCheck.ChangeAllConfirmX, WordNotFoundOriginal, CurrentWord),
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
         }
 
         var status = string.Format(Se.Language.SpellCheck.ChangeAllWordsFromXToY, WordNotFoundOriginal, CurrentWord);
@@ -614,7 +692,7 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
-        var results = _spellCheckManager.CheckSpelling(Paragraphs, _lastSpellCheckResult);
+        var results = _spellCheckManager.CheckSpelling(Paragraphs, _lastSpellCheckResult, _stopBeforeLineIndex);
         if (results.Count > 0)
         {
             WordNotFoundOriginal = results[0].Word.Text;
@@ -642,6 +720,33 @@ public partial class SpellCheckViewModel : ObservableObject
             LineText = string.Format(Se.Language.SpellCheck.LineXofY, lineIndex, Paragraphs.Count);
 
             _focusSubtitleLine?.GoToAndFocusLine(SelectedParagraph);
+        }
+        else if (_scanStartLineIndex > 0 && !_hasWrapped)
+        {
+            // Reached the end after starting mid-list: offer to wrap back and check the top part.
+            Dispatcher.UIThread.Post(async () =>
+            {
+                var answer = Window == null
+                    ? MessageBoxResult.No
+                    : await MessageBox.Show(
+                        Window,
+                        Se.Language.SpellCheck.SpellCheck,
+                        Se.Language.SpellCheck.ContinueFromTop,
+                        MessageBoxButtons.YesNo,
+                        MessageBoxIcon.Question);
+
+                if (answer == MessageBoxResult.Yes)
+                {
+                    _hasWrapped = true;
+                    _stopBeforeLineIndex = _scanStartLineIndex;
+                    _lastSpellCheckResult = null;
+                    DoSpellCheck();
+                }
+                else
+                {
+                    Ok();
+                }
+            }, DispatcherPriority.Background);
         }
         else
         {

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -433,28 +433,13 @@ public partial class SpellCheckViewModel : ObservableObject
     }
 
     [RelayCommand(CanExecute = nameof(CanChangeWord))]
-    private async Task ChangeWordAll()
+    private void ChangeWordAll()
     {
         var selectedParagraph = SelectedParagraph;
         if (selectedParagraph == null)
         {
             Dispatcher.UIThread.Invoke(() => { TextBoxWordNotFound.Focus(); });
             return;
-        }
-
-        if (Window != null)
-        {
-            var answer = await MessageBox.Show(
-                Window,
-                Se.Language.SpellCheck.SpellCheck,
-                string.Format(Se.Language.SpellCheck.ChangeAllConfirmX, WordNotFoundOriginal, CurrentWord),
-                MessageBoxButtons.YesNo,
-                MessageBoxIcon.Question);
-
-            if (answer != MessageBoxResult.Yes)
-            {
-                return;
-            }
         }
 
         var status = string.Format(Se.Language.SpellCheck.ChangeAllWordsFromXToY, WordNotFoundOriginal, CurrentWord);

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -35,7 +35,6 @@ public class LanguageSpellCheck
     public string EditWholeText { get; set; }
     public string ContinueFromCurrentLine { get; set; }
     public string ContinueFromTop { get; set; }
-    public string ChangeAllConfirmX { get; set; }
 
     public LanguageSpellCheck()
     {
@@ -70,6 +69,5 @@ public class LanguageSpellCheck
         EditWholeText = "Edit whole text";
         ContinueFromCurrentLine = "Continue spell check from the current line?\n\nYes = continue from the current line\nNo = start from the beginning";
         ContinueFromTop = "Spell check reached the end of the subtitle.\n\nContinue from the top?";
-        ChangeAllConfirmX = "Change all occurrences of '{0}' to '{1}'?";
     }
 }

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -33,6 +33,9 @@ public class LanguageSpellCheck
     public string PickLiveSpellCheckDictionary { get; set; }
     public string UndoX { get; set; }
     public string EditWholeText { get; set; }
+    public string ContinueFromCurrentLine { get; set; }
+    public string ContinueFromTop { get; set; }
+    public string ChangeAllConfirmX { get; set; }
 
     public LanguageSpellCheck()
     {
@@ -65,5 +68,8 @@ public class LanguageSpellCheck
         PickLiveSpellCheckDictionary = "Pick live spell check dictionary";
         UndoX = "Undo: {0}";
         EditWholeText = "Edit whole text";
+        ContinueFromCurrentLine = "Continue spell check from the current line?\n\nYes = continue from the current line\nNo = start from the beginning";
+        ContinueFromTop = "Spell check reached the end of the subtitle.\n\nContinue from the top?";
+        ChangeAllConfirmX = "Change all occurrences of '{0}' to '{1}'?";
     }
 }


### PR DESCRIPTION
Fixes #11770.

In SE5 the spell-check dialog always started scanning from the top. `SpellCheckViewModel.Initialize` received `selectedSubtitleIndex` from the main view model but never used it, so `_lastSpellCheckResult` stayed `null` and `CheckSpelling` began at line 0. This restores the SE4 behaviour the issue asks for.

## Changes

- **Start from the current line** — when a line other than the first is selected, the dialog now asks **"Continue spell check from the current line?"** (Yes / No / Cancel). Yes seeds the scan at that line (from its first word), No starts at the top, Cancel closes without checking.
- **Wrap back to the top** — once a mid-list run reaches the end, it offers **"Reached the end. Continue from the top?"** and then re-scans only the lines above where the run started. `ISpellCheckManager.CheckSpelling` gained an optional `stopBeforeLineIndex` to bound that wrapped pass; it will not re-prompt.
- **End-of-run summary on early close** — the changed/skipped totals are captured on window close (via a `Closing` hook), and the main view model now shows the "X changed, Y skipped" summary whenever any change/skip happened, not only when the run completes via **Done**. Previously closing with Esc/X discarded the counts.

## Notes

- New language strings added to `LanguageSpellCheck` (English defaults): `ContinueFromCurrentLine`, `ContinueFromTop`.
- The issue also mentioned a "replace all confirmation"; that is not included here (a confirm-before-Change-all prompt was added and then removed at the maintainer's request). If it was meant for **Find & Replace -> Replace All**, that is a separate feature and can be addressed separately.

## Testing

- Compile-only build of `UI.csproj` succeeds with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)