### PR TITLE
Fix Save As to ASS using Arial instead of the configured default style (#11788)

### DIFF
--- a/src/ui/Features/Assa/AssaStyleStorageHelper.cs
+++ b/src/ui/Features/Assa/AssaStyleStorageHelper.cs
@@ -56,6 +56,32 @@ public static class AssaStyleStorageHelper
     }
 
     /// <summary>
+    /// Applies the default ASSA storage style when a subtitle is about to be saved/converted to a
+    /// target format, but only when the conversion would otherwise lose the user's default style:
+    /// the target must be Advanced SubStation Alpha and the subtitle must not already carry ASSA
+    /// styles (e.g. it came from SRT). Without this, a "Save as" to ASS from a style-less format
+    /// falls back to the hard-coded Arial default instead of the configured default style
+    /// (issue #11788). No-op for other target formats, for subtitles that already have a
+    /// [V4+ Styles] header, or when no default storage style is configured.
+    /// </summary>
+    /// <returns>True if the default storage style was applied; otherwise false.</returns>
+    public static bool ApplyDefaultStorageStyleForFormatConversion(Subtitle subtitle, SubtitleFormat format)
+    {
+        if (subtitle == null || format is not AdvancedSubStationAlpha)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(subtitle.Header) &&
+            subtitle.Header.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return ApplyDefaultStorageStyle(subtitle);
+    }
+
+    /// <summary>
     /// Applies the default ASSA storage style (if any) to a subtitle that is about to use the
     /// Advanced SubStation Alpha format - used when creating a new subtitle or converting to ASSA
     /// from a format without ASSA styles. The default storage style becomes the only style in the

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15767,6 +15767,12 @@ public partial class MainViewModel :
         _converted = false;
         _lastOpenSaveFormat = saveAsResult.SubtitleFormat;
         SetSubtitleFormat(saveAsResult.SubtitleFormat);
+
+        // SetSubtitleFormat changes the format programmatically, which bypasses the format-change
+        // handler that would inject the default ASSA style. Apply it here so a "Save as" to ASS
+        // from a style-less format (e.g. SRT) uses the configured default style, not Arial (#11788).
+        AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(_subtitle, saveAsResult.SubtitleFormat);
+
         var result = await SaveSubtitle();
         AddToRecentFiles(true);
         return result;

--- a/tests/UI/Features/Assa/AssaStyleStorageHelperTests.cs
+++ b/tests/UI/Features/Assa/AssaStyleStorageHelperTests.cs
@@ -1,0 +1,178 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Regression tests for issue #11788: "Save as" to ASS from a style-less format (e.g. SRT)
+/// must use the user's configured default ASSA style, not the hard-coded Arial default.
+/// </summary>
+public class AssaStyleStorageHelperTests
+{
+    private static SeAssaStyle MakeStoredStyle(string name, string fontName, decimal fontSize, bool isDefault)
+    {
+        return new SeAssaStyle
+        {
+            Name = name,
+            FontName = fontName,
+            FontSize = fontSize,
+            IsDefault = isDefault,
+            ColorPrimary = "#FFFFFF",
+            ColorSecondary = "#FFFFFF",
+            ColorOutline = "#000000",
+            ColorShadow = "#000000",
+            Alignment = "2",
+        };
+    }
+
+    private static Subtitle MakeSrtSubtitle()
+    {
+        // SRT has no ASS header and the paragraphs carry no style (Extra).
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("World", 1500, 2500));
+        return subtitle;
+    }
+
+    [Fact]
+    public void SrtToAss_AppliesConfiguredDefaultStyle_NotArial()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Default", "Segoe UI", 90, isDefault: true));
+
+            var subtitle = MakeSrtSubtitle();
+
+            var applied = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.True(applied);
+            Assert.Contains("[V4+ Styles]", subtitle.Header);
+            Assert.Contains("Segoe UI", subtitle.Header);
+            Assert.DoesNotContain("Arial", subtitle.Header);
+
+            // The single header style must be the configured default.
+            var styles = AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header);
+            Assert.Equal(new[] { "Default" }, styles);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void SrtToAss_WrittenFileUsesDefaultStyle_EvenWhenParagraphsHaveNoStyle()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            // Style name intentionally not "Default" to prove the Dialogue lines follow the header style.
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("MyStyle", "Segoe UI", 90, isDefault: true));
+
+            var subtitle = MakeSrtSubtitle();
+            AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha());
+
+            // Mirror the save path: GetUpdateSubtitle rebuilds paragraphs from the grid, so they
+            // reach the writer with an empty Extra (style). The writer must then fall back to the
+            // header's first style - which is now the configured default - not Arial "Default".
+            foreach (var p in subtitle.Paragraphs)
+            {
+                p.Extra = string.Empty;
+            }
+
+            var text = new AdvancedSubStationAlpha().ToText(subtitle, string.Empty);
+
+            var styleLine = text.SplitToLines().First(l => l.StartsWith("Style: MyStyle,"));
+            Assert.Contains("Segoe UI", styleLine);
+            Assert.Contains("90", styleLine);
+
+            // Every Dialogue line must reference the configured default style (field index 3).
+            var dialogueLines = text.SplitToLines().Where(l => l.StartsWith("Dialogue:")).ToList();
+            Assert.NotEmpty(dialogueLines);
+            foreach (var line in dialogueLines)
+            {
+                var styleField = line.Split(',')[3];
+                Assert.Equal("MyStyle", styleField);
+            }
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void NonAssTarget_DoesNothing()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Default", "Segoe UI", 90, isDefault: true));
+
+            var subtitle = MakeSrtSubtitle();
+
+            var applied = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new SubRip());
+
+            Assert.False(applied);
+            Assert.True(string.IsNullOrEmpty(subtitle.Header));
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void AlreadyHasAssStyles_DoesNothing()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Default", "Segoe UI", 90, isDefault: true));
+
+            var subtitle = MakeSrtSubtitle();
+            var existingHeader = AdvancedSubStationAlpha.DefaultHeader; // already contains [V4+ Styles] with Arial
+            subtitle.Header = existingHeader;
+
+            var applied = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.False(applied);
+            Assert.Equal(existingHeader, subtitle.Header);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void NoDefaultStorageStyle_DoesNothing_PreservingArialFallback()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            // A stored style exists but none is marked default.
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Some", "Segoe UI", 90, isDefault: false));
+
+            var subtitle = MakeSrtSubtitle();
+
+            var applied = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.False(applied);
+            Assert.True(string.IsNullOrEmpty(subtitle.Header));
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #11788.

## Problem

With an SRT file open and **Default "Save as" format = ASS**, choosing *Save As* wrote the file using libse's hard-coded `Default` style (**Arial 20**) instead of the user's configured default ASSA style (e.g. **Segoe UI 90**). Regression from SE4; worked when the user manually switched the format combo, which is why it was hard to reproduce.

## Root cause

`SaveSubtitleAs` auto-selects the default save format (ASS) and applies it via `SetSubtitleFormat`, which sets `_changingFormatProgrammatically = true`. The format-change handler that injects the default ASSA style (`AssaStyleStorageHelper.ApplyDefaultStorageStyle`) is guarded by `!_changingFormatProgrammatically`, so it is skipped. The style-less SRT then reaches the ASS writer with an empty header and the writer falls back to the built-in Arial default.

## Fix

- New `AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, format)` encapsulates the decision: apply the default storage style only when the target is `AdvancedSubStationAlpha` **and** the subtitle has no `[V4+ Styles]` header. No-op otherwise; returns `false` (Arial fallback preserved) when no default storage style is configured.
- `SaveSubtitleAs` calls it right after `SetSubtitleFormat`.

No per-paragraph re-pointing is required: the ASS writer already maps style-less Dialogue lines to the header's first style (`AdvancedSubStationAlpha.ToText`, the `string.IsNullOrEmpty(p.Extra)` -> `styles[0]` branch), and the injected header contains exactly the one default style. `GetUpdateSubtitle` preserves `_subtitle.Header` (it only rebuilds paragraphs), so the injected header survives to the writer.

## Tests

`tests/UI/Features/Assa/AssaStyleStorageHelperTests.cs` (5 tests, all passing):
- SRT -> ASS applies the configured default style and not Arial.
- Written ASS file: the `Style:` line uses the configured font/size and every `Dialogue:` line references it, even when paragraphs carry no style (a custom-named default style is used to prove the Dialogue lines follow the header).
- No-op guards: non-ASS target, subtitle that already has ASS styles, and no default storage style configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)