### PR TITLE
Open original subtitle into an empty subtitle as a blank translation

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1701,6 +1701,14 @@ public partial class MainViewModel :
             }
         }
 
+        if (Subtitles.Count == 0 && subtitle.Paragraphs.Count > 0)
+        {
+            // Nothing loaded yet: scaffold a blank translation from the original so the user
+            // can start translating from scratch, instead of reporting a line-count mismatch.
+            ImportOriginalIntoEmptySubtitle(fileName, subtitle);
+            return true;
+        }
+
         if (subtitle.Paragraphs.Count == Subtitles.Count)
         {
             ImportOriginalSubtitle(selectedIndex, fileName, subtitle);
@@ -1743,6 +1751,25 @@ public partial class MainViewModel :
         AutoFitColumns();
         SelectAndScrollToRow(selectedIndex);
         AddToRecentFiles(true);
+    }
+
+    /// <summary>
+    /// Opening an original subtitle while nothing is loaded: scaffold a blank translation that
+    /// mirrors the original's timing/structure (one empty line per original line) and show the
+    /// original text in the side-by-side column, so the user can start translating from scratch.
+    /// </summary>
+    private void ImportOriginalIntoEmptySubtitle(string fileName, Subtitle original)
+    {
+        _subtitle = new Subtitle();
+        foreach (var p in original.Paragraphs)
+        {
+            _subtitle.Paragraphs.Add(new Paragraph(p) { Text = string.Empty });
+        }
+
+        SetSubtitles(_subtitle);
+        _changeSubtitleHash = GetFastHash();
+
+        ImportOriginalSubtitle(0, fileName, original);
     }
 
     [RelayCommand]


### PR DESCRIPTION
## What

`File > Open original subtitle` while nothing is loaded previously reported a line-count mismatch ("different number of subtitles", 0 vs N) and would not import. Now, when the current subtitle is empty, it imports the original directly as the starting point for a translation:

- Scaffolds a blank main subtitle that mirrors the original's timing/structure - one empty-text line per original line (cloned timings).
- Loads it as the main subtitle and shows the original text in the side-by-side original column.

This lets the user start translating from scratch against the original's timings.

## How

In `SubtitleOpenOriginal`, before the existing count check:
```csharp
if (Subtitles.Count == 0 && subtitle.Paragraphs.Count > 0)
{
    ImportOriginalIntoEmptySubtitle(fileName, subtitle);
    return true;
}
```
`ImportOriginalIntoEmptySubtitle` clones the original paragraphs with blank text into the main subtitle, calls `SetSubtitles`, then reuses the existing `ImportOriginalSubtitle` to populate the original column and show it.

## Testing

- Compile-only build of `UI.csproj` succeeds with 0 warnings / 0 errors.
- Manual UI pass recommended: with no subtitle loaded, `File > Open original subtitle`, confirm the grid fills with blank main lines at the original timings and the original column shows the original text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)