### PR TITLE
Make SE4 waveform selected paragraph background lighter

### DIFF
--- a/src/ui/Logic/Se4Setup/Se4SetupApplier.cs
+++ b/src/ui/Logic/Se4Setup/Se4SetupApplier.cs
@@ -168,10 +168,10 @@ public static class Se4SetupApplier
         w.WaveformParagraphRightColor = Color.FromArgb(180, 255, 0, 0).FromColorToHex();
         w.WaveformFancyHighColor = Colors.Orange.FromColorToHex();
 
-        // SE 4 did not tint the paragraph background differently when selected -
-        // keep the selected background identical to the normal one.
+        // SE 4 used a dark gray paragraph background; make the selected paragraph a
+        // little lighter so the active subtitle stands out.
         w.ParagraphBackground = Color.FromArgb(90, 70, 70, 70).FromColorToHex();
-        w.ParagraphSelectedBackground = Color.FromArgb(90, 70, 70, 70).FromColorToHex();
+        w.ParagraphSelectedBackground = Color.FromArgb(90, 100, 100, 100).FromColorToHex();
 
         // SE 4 drew classic (non-fancy) waveforms with vertical grid lines.
         w.DrawGridLines = true;


### PR DESCRIPTION
## Summary
When applying the SE4 setup (`Ctrl+4` / `SetupLikeSe4`), the waveform **selected** paragraph background was identical to the normal paragraph background (`ARGB 90,70,70,70`), so the active subtitle did not visually stand out in the waveform.

This lightens the selected paragraph background a little (`ARGB 90,100,100,100`, alpha unchanged) so the active subtitle stands out while staying in the same gray family as the SE4 theme.

## Changes
- `src/ui/Logic/Se4Setup/Se4SetupApplier.cs` — set `ParagraphSelectedBackground` to a slightly lighter gray than `ParagraphBackground`.

## Testing
- Built and launched the UI.
- Apply SE4 setup via `Ctrl+4`, open audio/video to show the waveform, and select a subtitle — the selected paragraph now renders a little lighter than the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)