### PR TITLE
Add Play previous (and stop / and loop) commands

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -982,6 +982,82 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void PlayPrevious()
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp == null)
+        {
+            return;
+        }
+
+        var previous = Subtitles.LastOrDefault(s => s.StartTime.TotalSeconds < vp.Position);
+        if (previous == null)
+        {
+            return;
+        }
+
+        vp.Position = previous.StartTime.TotalSeconds;
+        PinPlayheadTo(previous.StartTime.TotalSeconds);
+        SelectAndScrollToSubtitle(previous);
+        vp.VideoPlayer.Play();
+    }
+
+    [RelayCommand]
+    private void PlayPreviousAndStop()
+    {
+        PlayPreviousParagraph(false);
+    }
+
+    [RelayCommand]
+    private void PlayPreviousAndLoop()
+    {
+        PlayPreviousParagraph(true);
+    }
+
+    // Plays the paragraph before the current selection (or before the video position when nothing is
+    // selected), selects it, and either stops at its end (loop=false) or repeats it (loop=true) via
+    // the _playSelectionItem handled in the player position-changed loop.
+    private void PlayPreviousParagraph(bool loop)
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp == null)
+        {
+            return;
+        }
+
+        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().OrderBy(p => p.StartTime).ToList();
+        SubtitleLineViewModel? previous;
+        if (selectedItems.Count > 0)
+        {
+            var currentIndex = Subtitles.IndexOf(selectedItems.First());
+            previous = currentIndex > 0
+                ? Subtitles[currentIndex - 1]
+                : null;
+        }
+        else
+        {
+            previous = Subtitles.LastOrDefault(s => s.StartTime.TotalSeconds < vp.Position);
+        }
+
+        if (previous == null)
+        {
+            return;
+        }
+
+        vp.VideoPlayer.Pause();
+        // Select synchronously rather than via SelectAndScrollToSubtitle (which posts the selection
+        // to the dispatcher): the grid's SelectionChanged handler calls ResetPlaySelection, so a
+        // deferred selection would null _playSelectionItem *after* we set it and break stop/loop.
+        // Mirror PlayNextParagraph — change selection first, then assign _playSelectionItem.
+        SubtitleGrid.SelectedItem = previous;
+        SubtitleGrid.ScrollIntoView(previous, null);
+        vp.Position = previous.StartTime.TotalSeconds;
+        PinPlayheadTo(previous.StartTime.TotalSeconds);
+        _playSelectionItem = new PlaySelectionItem(new List<SubtitleLineViewModel> { previous }, previous.EndTime, loop);
+        vp.VideoPlayer.Play();
+    }
+
+    [RelayCommand]
     private void Pause()
     {
         var vp = GetVideoPlayerControl();

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -406,6 +406,9 @@ public class LanguageGeneral
     public string PlayNext { get; set; }
     public string PlayNextAndStop { get; set; }
     public string PlayNextAndLoop { get; set; }
+    public string PlayPrevious { get; set; }
+    public string PlayPreviousAndStop { get; set; }
+    public string PlayPreviousAndLoop { get; set; }
     public string PlaySelectedLines { get; set; }
     public string PlaySelectedLinesWithLoop { get; set; }
     public string PlaySelectedLinesAndFocusWaveform { get; set; }
@@ -1140,6 +1143,9 @@ public class LanguageGeneral
         PlayNext = "Play next";
         PlayNextAndStop = "Play next (and stop)";
         PlayNextAndLoop = "Play next (and loop)";
+        PlayPrevious = "Play previous";
+        PlayPreviousAndStop = "Play previous (and stop)";
+        PlayPreviousAndLoop = "Play previous (and loop)";
         PlaySelectedLines = "Play selected lines";
         PlaySelectedLinesWithLoop = "Play selected lines with loop";
         PlaySelectedLinesAndFocusWaveform = "Play selected lines and focus waveform";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -203,6 +203,9 @@ public static class ShortcutsMain
         { nameof(MainViewModel.PlayNextCommand), Se.Language.General.PlayNext },
         { nameof(MainViewModel.PlayNextAndStopCommand), Se.Language.General.PlayNextAndStop },
         { nameof(MainViewModel.PlayNextAndLoopCommand), Se.Language.General.PlayNextAndLoop },
+        { nameof(MainViewModel.PlayPreviousCommand), Se.Language.General.PlayPrevious },
+        { nameof(MainViewModel.PlayPreviousAndStopCommand), Se.Language.General.PlayPreviousAndStop },
+        { nameof(MainViewModel.PlayPreviousAndLoopCommand), Se.Language.General.PlayPreviousAndLoop },
         { nameof(MainViewModel.PauseCommand), Se.Language.General.Pause },
         { nameof(MainViewModel.TogglePlayPauseCommand), Se.Language.Options.Shortcuts.TogglePlayPause },
         { nameof(MainViewModel.TogglePlayPause2Command), Se.Language.Options.Shortcuts.TogglePlayPause },
@@ -494,6 +497,9 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.PlayNextCommand, nameof(vm.PlayNextCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.PlayNextAndStopCommand, nameof(vm.PlayNextAndStopCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.PlayNextAndLoopCommand, nameof(vm.PlayNextAndLoopCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.PlayPreviousCommand, nameof(vm.PlayPreviousCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.PlayPreviousAndStopCommand, nameof(vm.PlayPreviousAndStopCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.PlayPreviousAndLoopCommand, nameof(vm.PlayPreviousAndLoopCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.PauseCommand, nameof(vm.PauseCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.TogglePlayPauseCommand, nameof(vm.TogglePlayPauseCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.TogglePlayPause2Command, nameof(vm.TogglePlayPause2Command), ShortcutCategory.General);


### PR DESCRIPTION
## Summary
Adds the previous-paragraph counterparts to the existing "Play next" command set:

- **Play previous** — jump to the previous subtitle and play
- **Play previous (and stop)** — play the previous paragraph, stop at its end
- **Play previous (and loop)** — play the previous paragraph, loop it

These mirror `PlayNext` / `PlayNextAndStop` / `PlayNextAndLoop`. They are registered as shortcut-only commands (no default key assigned), exactly like the next-and-stop/loop variants — users can bind them in Options → Shortcuts.

## Changes
- `src/ui/Features/Main/MainViewModel.cs` — `PlayPrevious`, `PlayPreviousAndStop`, `PlayPreviousAndLoop`, and the shared `PlayPreviousParagraph(bool loop)` helper.
- `src/ui/Logic/Config/Language/LanguageGeneral.cs` — new string properties + English defaults.
- `src/ui/Logic/ShortcutsMain.cs` — label mappings and shortcut registrations.

## Testing
- `dotnet build` succeeds (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)