### PR TITLE
Burn-in: default target file size to the source video size

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -265,7 +265,12 @@ public partial class BurnInViewModel : ObservableObject
         if (fileExists)
         {
             SingleMode();
-            VideoFileSize = Utilities.FormatBytesToDisplayFileSize(new FileInfo(videoFileName).Length);
+            var fileLengthInBytes = new FileInfo(videoFileName).Length;
+            VideoFileSize = Utilities.FormatBytesToDisplayFileSize(fileLengthInBytes);
+
+            // Default the target file size to the original file's size, so enabling
+            // "use target file size" roughly preserves the source size by default.
+            TargetFileSize = Math.Max(1, (int)Math.Round(fileLengthInBytes / (1024.0 * 1024.0)));
             _ = Task.Run(() =>
             {
                 _mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);


### PR DESCRIPTION
## Summary
In Video → Burn-in, the target file size defaulted to a fixed **100 MB**. This changes the default so that when a single source video is loaded, the target file size (MB) is initialized to the **original file''s size**, so enabling "use target file size" roughly preserves the source size by default.

## Changes
- In `BurnInViewModel.Initialize`, when the input file exists, set `TargetFileSize` to the source file length converted to MB (`Math.Max(1, round(bytes / 1024²))`).
- Reuses the already-read `FileInfo` length (also used for the displayed `VideoFileSize`).

The user can still override the value, and this runs after settings are applied so it takes effect as the sensible default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)