### PR TITLE
Apply Dutch contraction casing after colon and mid-paragraph period (#11747)

### DIFF
--- a/src/libse/Common/DutchCasing.cs
+++ b/src/libse/Common/DutchCasing.cs
@@ -43,6 +43,20 @@ namespace Nikse.SubtitleEdit.Core.Common
         }
 
         /// <summary>
+        /// Returns true when <paramref name="text"/> begins with a Dutch apostrophe contraction
+        /// ('s, 't, 'n, 'k, 'm, 'r) followed by a space - i.e. a sentence-initial contraction whose
+        /// apostrophe-letter must stay lowercase while the next word takes the capital.
+        /// </summary>
+        public static bool StartsWithContraction(string text)
+        {
+            return text != null &&
+                   text.Length > 3 &&
+                   Array.IndexOf(Apostrophes, text[0]) >= 0 &&
+                   ContractionLetters.IndexOf(char.ToLowerInvariant(text[1])) >= 0 &&
+                   text[2] == ' ';
+        }
+
+        /// <summary>
         /// Applies Dutch sentence-start casing to <paramref name="text"/>, which must begin at the
         /// first character to consider (a leading apostrophe contraction is allowed; leading tags and
         /// other punctuation must already be stripped by the caller). Handles 's/'t/etc. contractions
@@ -59,10 +73,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             // "'s morgens" / "'S morgens" -> "'s Morgens": keep the contraction lowercase and move
             // the capital to the following word. A leading apostrophe that is NOT one of these
             // contractions (e.g. an opening quote) falls through to normal capitalization.
-            if (text.Length > 3 &&
-                Array.IndexOf(Apostrophes, text[0]) >= 0 &&
-                ContractionLetters.IndexOf(char.ToLowerInvariant(text[1])) >= 0 &&
-                text[2] == ' ')
+            if (StartsWithContraction(text))
             {
                 var contraction = text[0] + char.ToLowerInvariant(text[1]).ToString();
                 return contraction + " " + CapitalizeFirstLetter(text.Substring(3));

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
@@ -60,8 +60,14 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         {
                             // slice from k index
                             var textFromK = text.Substring(k);
-                            
-                            if (CanCapitalize(textFromK, callbacks) && !isTurkish)
+
+                            if (DutchCasing.IsDutch(callbacks.Language) && DutchCasing.StartsWithContraction(textFromK))
+                            {
+                                // "Hij zei: 's morgens" -> "'s Morgens": keep the contraction lowercase
+                                // and capitalize the following word instead of the apostrophe letter.
+                                text = text.Substring(0, k) + DutchCasing.FixSentenceStart(textFromK);
+                            }
+                            else if (CanCapitalize(textFromK, callbacks) && !isTurkish)
                             {
                                 text = text.Substring(0, k) + textFromK.CapitalizeFirstLetter();
                             }

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
@@ -72,8 +72,21 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         if (start + 3 < text.Length && (text[start + 1] == ' ') && !IsAbbreviation(text, start, callbacks))
                         {
                             var textBefore = text.Substring(0, start + 1);
-                            var subText = new StrippableText(text.Substring(start + 2));
-                            text = text.Substring(0, start + 2) + subText.CombineWithPrePost(ToUpperFirstLetter(textBefore, subText.StrippedText, callbacks));
+                            var afterText = text.Substring(start + 2);
+                            if (DutchCasing.IsDutch(callbacks.Language) &&
+                                DutchCasing.StartsWithContraction(afterText) &&
+                                !textBefore.EndsWith("...", System.StringComparison.Ordinal))
+                            {
+                                // "Het regelt. 's morgens..." -> keep "'s" lowercase and capitalize the next
+                                // word. Handle it before StrippableText strips the leading apostrophe into Pre
+                                // (which would otherwise uppercase the contraction letter: "'S morgens").
+                                text = text.Substring(0, start + 2) + DutchCasing.FixSentenceStart(afterText);
+                            }
+                            else
+                            {
+                                var subText = new StrippableText(afterText);
+                                text = text.Substring(0, start + 2) + subText.CombineWithPrePost(ToUpperFirstLetter(textBefore, subText.StrippedText, callbacks));
+                            }
                         }
 
                         start += 3;

--- a/tests/libse/Core/DutchCasingTest.cs
+++ b/tests/libse/Core/DutchCasingTest.cs
@@ -62,4 +62,26 @@ public class DutchCasingTest
     {
         Assert.Equal(expected, DutchCasing.IsDutch(language!));
     }
+
+    // --- StartsWithContraction ---
+
+    [Theory]
+    [InlineData("'s morgens", true)]
+    [InlineData("'S morgens", true)]   // wrongly capitalized contraction is still a contraction
+    [InlineData("'t kind", true)]
+    [InlineData("'n appel", true)]
+    [InlineData("'k weet", true)]
+    [InlineData("'m geven", true)]
+    [InlineData("'r naam", true)]
+    [InlineData("'x morgens", false)]  // not a contraction letter
+    [InlineData("'smorgens", false)]   // no space after the contraction
+    [InlineData("'Hallo' zei hij", false)] // opening quote, not a contraction
+    [InlineData("morgens", false)]
+    [InlineData("'s", false)]          // too short
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void StartsWithContraction(string? input, bool expected)
+    {
+        Assert.Equal(expected, DutchCasing.StartsWithContraction(input!));
+    }
 }

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColonTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColonTest.cs
@@ -1,0 +1,34 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+
+namespace LibSETests.Forms.FixCommonErrors;
+
+public class FixStartWithUppercaseLetterAfterColonTest
+{
+    private static string Fix(string input, string language)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(input, 0, 2000));
+        subtitle.Renumber();
+        new FixStartWithUppercaseLetterAfterColon().Fix(subtitle, new EmptyFixCallback { Language = language });
+        return subtitle.Paragraphs[0].Text;
+    }
+
+    // Dutch contraction after a colon: keep "'s" lowercase, capitalize the next word.
+    [Theory]
+    [InlineData("Hij zei: 's morgens.", "Hij zei: 's Morgens.")]
+    [InlineData("Hij zei: 'S morgens.", "Hij zei: 's Morgens.")] // also fixes wrongly capitalized contraction
+    public void Dutch_KeepsContractionLowercaseAndCapitalizesNextWord(string input, string expected)
+    {
+        Assert.Equal(expected, Fix(input, "nl"));
+    }
+
+    // Regular capitalization after a colon must still happen for Dutch and English.
+    [Theory]
+    [InlineData("Hij zei: hallo.", "Hij zei: Hallo.", "nl")]
+    [InlineData("He said: hello.", "He said: Hello.", "en")]
+    public void CapitalizesNormalWordAfterColon(string input, string expected, string language)
+    {
+        Assert.Equal(expected, Fix(input, language));
+    }
+}

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest.cs
@@ -1,0 +1,40 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+
+namespace LibSETests.Forms.FixCommonErrors;
+
+public class FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest
+{
+    private static string Fix(string input, string language)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(input, 0, 2000));
+        subtitle.Renumber();
+        new FixStartWithUppercaseLetterAfterPeriodInsideParagraph().Fix(subtitle, new EmptyFixCallback { Language = language });
+        return subtitle.Paragraphs[0].Text;
+    }
+
+    // Dutch contraction after a mid-paragraph period: keep "'s" lowercase, capitalize the next word.
+    [Theory]
+    [InlineData("Het regelt. 's morgens werkt hij.", "Het regelt. 's Morgens werkt hij.")]
+    [InlineData("Het regelt. 'S morgens werkt hij.", "Het regelt. 's Morgens werkt hij.")] // also fixes wrongly capitalized contraction
+    [InlineData("Het regelt. 't kind speelt.", "Het regelt. 't Kind speelt.")]
+    public void Dutch_KeepsContractionLowercaseAndCapitalizesNextWord(string input, string expected)
+    {
+        Assert.Equal(expected, Fix(input, "nl"));
+    }
+
+    // Regular Dutch capitalization after a period must still happen.
+    [Fact]
+    public void Dutch_CapitalizesNormalWordAfterPeriod()
+    {
+        Assert.Equal("Het is laat. Morgen kom ik.", Fix("Het is laat. morgen kom ik.", "nl"));
+    }
+
+    // The contraction must not be touched after an ellipsis (we don't force casing after "...").
+    [Fact]
+    public void Dutch_LeavesContractionAfterEllipsis()
+    {
+        Assert.Equal("Het regelt... 's morgens werkt hij.", Fix("Het regelt... 's morgens werkt hij.", "nl"));
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #11747 / commit `3b1af61d`, which added `DutchCasing` and wired it into the **"start with uppercase after paragraph"** fix. The other two uppercase fixes were not Dutch-aware:

- **`FixStartWithUppercaseLetterAfterPeriodInsideParagraph`** actively **corrupted** contractions: `Het regelt. 's morgens werkt hij.` → `Het regelt. 'S morgens werkt hij.` This happens because `StrippableText` strips the leading apostrophe into `Pre`, so the contraction letter (`s`) gets uppercased.
- **`FixStartWithUppercaseLetterAfterColon`** left contractions untouched (`Hij zei: 's morgens` stayed lowercase) instead of applying the Dutch rule.

In Dutch, sentence-initial apostrophe contractions (`'s`, `'t`, `'n`, `'k`, `'m`, `'r`) keep their lowercase letter and the **next word** takes the capital: `'s Morgens`.

## Changes
- `DutchCasing`: add public `StartsWithContraction(string)` predicate (reused internally by `FixSentenceStart`, keeping one source of truth).
- `FixStartWithUppercaseLetterAfterPeriodInsideParagraph`: when the language is `nl` and the segment after the period starts with a contraction, route it through `DutchCasing.FixSentenceStart` **before** `StrippableText` strips the apostrophe. The existing ellipsis (`...`) guard is preserved.
- `FixStartWithUppercaseLetterAfterColon`: same contraction handling after a colon/semicolon; normal capitalization (Dutch and English) is unchanged.
- Tests: unit tests for `StartsWithContraction`, plus integration tests for both fixes (contraction kept lowercase + next word capitalized, wrongly-capitalized `'S` corrected, normal capitalization still works, ellipsis left alone).

## Why native rather than `nld_OCRFixReplaceList.xml`
The corruption is a casing transformation applied to any text/SRT, while the OCR replace list only runs during image OCR / "Fix OCR errors". A native rule generalizes to every contraction × following-word instead of enumerating each pair, and it prevents the corruption rather than patching it afterward.

All 453 libse tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)