### PR TITLE
Add accessible names to waveform toolbar controls (#11745)

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -675,6 +675,26 @@ public class InitWaveform
         };
         flyoutMore.Items.Add(menuItemHideControls);
 
+        // The waveform toolbar buttons only contain an icon, so their automation peer would
+        // otherwise expose the icon control's type name ("Optris...Icon") as the accessible name -
+        // useless to a screen reader. Give each one a real name, reusing the localized hint strings
+        // (same concise form ToolbarItemDisplay uses). The buttons are already keyboard-focusable.
+        void SetAccessibleName(Control control, string hint) =>
+            AutomationProperties.SetName(control, string.Format(hint, string.Empty).TrimEnd());
+
+        SetAccessibleName(buttonPlay, languageHints.PlayPauseHint);
+        SetAccessibleName(buttonPlaySelectedLines, languageHints.PlaySelectionHint);
+        SetAccessibleName(buttonPlaySelectedLinesRepeat, languageHints.PlaySelectedRepeatHint);
+        SetAccessibleName(buttonPlayNext, languageHints.PlayNextHint);
+        SetAccessibleName(buttonNew, languageHints.NewHint);
+        SetAccessibleName(buttonSetStartAndOffsetTheRest, languageHints.SetStartAndOffsetTheRestHint);
+        SetAccessibleName(buttonSetStart, languageHints.SetStartHint);
+        SetAccessibleName(buttonSetEnd, languageHints.SetEndHint);
+        SetAccessibleName(buttonRemoveBlankLines, languageHints.RemoveBlankLines);
+        SetAccessibleName(toggleButtonAutoSelectOnPlay, languageHints.SelectCurrentLineWhilePlayingHint);
+        SetAccessibleName(toggleButtonCenter, languageHints.CenterWaveformHint);
+        AutomationProperties.SetName(buttonMore, Se.Language.General.More);
+
         var sortableButtons = MakeCustomSortableButtons(
             settings,
             buttonPlay,

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
@@ -438,6 +439,8 @@ public class InitWaveform
             VerticalAlignment = VerticalAlignment.Center,
             Value = 1,
             [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.ZoomHorizontalHint, shortcuts),
+            // Accessible name for screen readers (the slider only has a visual icon/tooltip otherwise).
+            [AutomationProperties.NameProperty] = string.Format(languageHints.ZoomHorizontalHint, string.Empty).TrimEnd(),
         };
         sliderHorizontalZoom.TemplateApplied += (s, e) =>
         {
@@ -486,6 +489,7 @@ public class InitWaveform
             Margin = new Thickness(0, 0, 0, 0),
             Value = 1,
             [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.ZoomVerticalHint, shortcuts),
+            [AutomationProperties.NameProperty] = string.Format(languageHints.ZoomVerticalHint, string.Empty).TrimEnd(),
         };
         sliderVerticalZoom.TemplateApplied += (s, e) =>
         {
@@ -527,6 +531,7 @@ public class InitWaveform
             Margin = new Thickness(settingPosition.LeftMargin, 0, settingPosition.RightMargin, 0),
             Focusable = true,
             [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.VideoPosition, shortcuts),
+            [AutomationProperties.NameProperty] = Se.Language.General.VideoPosition,
         };
         sliderPosition.TemplateApplied += (s, e) =>
         {
@@ -598,6 +603,8 @@ public class InitWaveform
             Padding = new Thickness(2, 2, 0, 2),
             Background = Brushes.Transparent,
             BorderThickness = new Thickness(0),
+            // The adjacent "Speed" TextBlock is not auto-associated, so name the combo box explicitly.
+            [AutomationProperties.NameProperty] = Se.Language.General.PlaybackSpeed,
         };
         comboBoxSpeed.Bind(ItemsControl.ItemsSourceProperty, new Binding(nameof(vm.Speeds)));
         comboBoxSpeed.Bind(SelectingItemsControl.SelectedItemProperty, new Binding(nameof(vm.SelectedSpeed)) { Mode = BindingMode.TwoWay });


### PR DESCRIPTION
## Summary
Part of the screen-reader accessibility work for #11745 / #11553. After the menu (F10) and main-editor field work, I ran a **UI Automation audit of the whole main window** (the same API NVDA/Narrator consume) and fixed the remaining gaps in the waveform toolbar.

## Two problems found & fixed in `InitWaveform.cs`

**1. Focusable controls with no name** — announced as a bare "slider"/"combo box": horizontal-zoom slider, vertical-zoom slider, video-position slider, and the playback-speed combo box (its visible "Speed" text is a separate `TextBlock`, which Avalonia does not auto-associate).

**2. Icon buttons exposing a garbage name** — every icon-only toolbar button (play, play-selection, repeat, play-next, new, set-start/-end, set-start-and-offset, remove-blank-lines, the auto-select-on-play and center **toggle buttons**, and "more") is keyboard-focusable, but its automation peer derived the accessible name from the contained `Icon` control, exposing the literal type name **`Optris.Icons.Avalonia.Icon`** to screen readers.

All fixed by setting `AutomationProperties.Name`, reusing existing localized strings (hint strings via `string.Format(hint, "").TrimEnd()`, plus `General.VideoPosition` / `General.PlaybackSpeed` / `General.More`), so names are already translated.

## Verification (UIA, on the built binary)
Sliders/combo box now: `Zoom horizontal`, `Zoom vertical`, `Video position`, `Playback speed`.
Buttons (were all `Optris.Icons.Avalonia.Icon`) now: `Play / Pause`, `Set start of current subtitle`, `Set end of current subtitle`, `Insert new subtitle at video position`, `Select current subtitle while playing`, `Center waveform on current video position while playing`, `More`, ...

Every keyboard-focusable control in the waveform toolbar now has a meaningful, localized accessible name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)