### PR TITLE
Add assignable "Waveform insert new selection" shortcut (#11808)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2728,6 +2728,7 @@
       "showMediaInformation": "Show media information",
       "chooseSubtitleFormat": "Choose subtitle format",
       "trimWhitespaceSelectedLines": "Trim whitespace (selected lines)",
+      "waveformInsertNewSelection": "Waveform insert new selection",
       "waveformHorizontalZoomInCommand": "Waveform horizontal zoom in",
       "waveformHorizontalZoomOutCommand": "Waveform horizontal zoom out",
       "waveformVerticalZoomInCommand": "Waveform vertical zoom in",

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -252,6 +252,7 @@ public class LanguageSettingsShortcuts
     public string ShowMediaInformation { get; set; }
     public string ChooseSubtitleFormat { get; set; }
     public string TrimWhitespaceSelectedLines { get; set; }
+    public string WaveformInsertNewSelection { get; set; }
     public string WaveformHorizontalZoomInCommand { get; set; }
     public string WaveformHorizontalZoomOutCommand { get; set; }
     public string WaveformVerticalZoomInCommand { get; set; }
@@ -551,6 +552,7 @@ public class LanguageSettingsShortcuts
         ShowMediaInformation = "Show media information";
         ChooseSubtitleFormat = "Choose subtitle format";
         TrimWhitespaceSelectedLines = "Trim whitespace (selected lines)";
+        WaveformInsertNewSelection = "Waveform insert new selection";
         WaveformHorizontalZoomInCommand = "Waveform horizontal zoom in";
         WaveformHorizontalZoomOutCommand = "Waveform horizontal zoom out";
         WaveformVerticalZoomInCommand = "Waveform vertical zoom in";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -366,6 +366,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.RepeatNextLineCommand), Se.Language.Options.Shortcuts.RepeatNextLine },
         { nameof(MainViewModel.InsertLineBeforeCommand), Se.Language.General.InsertBefore },
         { nameof(MainViewModel.InsertLineAfterCommand), Se.Language.General.InsertAfter },
+        { nameof(MainViewModel.WaveformInsertNewSelectionCommand), Se.Language.Options.Shortcuts.WaveformInsertNewSelection },
         { nameof(MainViewModel.WaveformInsertAtPositionAndFocusTextBoxCommand), Se.Language.General.InsertAtPositionAndFocusTextBox },
         { nameof(MainViewModel.WaveformInsertAtPositionNoFocusTextBoxCommand), Se.Language.General.InsertAtPositionNoFocusTextBox },
         { nameof(MainViewModel.WaveformPasteFromClipboardCommand), Se.Language.General.WaveformPasteFromClipboard },
@@ -710,6 +711,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.RepeatNextLineCommand, nameof(vm.RepeatNextLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.InsertLineBeforeCommand, nameof(vm.InsertLineBeforeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.InsertLineAfterCommand, nameof(vm.InsertLineAfterCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.WaveformInsertNewSelectionCommand, nameof(vm.WaveformInsertNewSelectionCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformInsertAtPositionAndFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionAndFocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformInsertAtPositionNoFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionNoFocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformPasteFromClipboardCommand, nameof(vm.WaveformPasteFromClipboardCommand), ShortcutCategory.Waveform);


### PR DESCRIPTION
## Summary
Resolves the shortcut part of #11808. On the waveform, inserting a dragged "new selection" as a subtitle was only possible via the **hardcoded Enter key** (and the right-click menu) — there was no way to bind a custom key as in SE4.

This registers the existing `WaveformInsertNewSelectionCommand` as an **assignable shortcut** in the **Waveform** category (Options → Settings → Shortcuts), so users can bind their own key.

## Changes
- `ShortcutsMain.cs`: add the display-name mapping and the `AddShortcut(... ShortcutCategory.Waveform)` registration for `WaveformInsertNewSelectionCommand`.
- New localized string **"Waveform insert new selection"** (`English.json` + `LanguageSettingsShortcuts` default).

## Notes
- **Enter still works** as the built-in convenience key (handled in the `AudioVisualizer` control); the new shortcut has **no default key**, so the user assigns one — nothing changes for existing users.
- The command is the same one already used by the waveform right-click "Insert new selection" menu item, so it is a proven path; it inserts `AudioVisualizer.NewSelectionParagraph` and clears it. The action only does something while a new selection is active on the waveform.
- Other language files fall back to the English default until translated (standard).

The "Also, autosave" part of the issue is not addressed — SE5 already has auto-save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)