### PR TITLE
Burn-in: "Match source video size" target-size mode + enable in batch (#11802)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1861,6 +1861,7 @@
       "targetFileName": "Target file name: {0}",
       "targetFileSize": "Target file size (requires 2 pass encoding)",
       "fileSizeMb": "File size in MB",
+      "matchSourceVideoSize": "Match source video size",
       "passX": "Pass {0}",
       "encoding": "Encoding",
       "bitRate": "Bit rate",

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -87,6 +87,7 @@ public partial class BurnInViewModel : ObservableObject
     [ObservableProperty] private TimeSpan _cutTo;
     [ObservableProperty] private bool _useTargetFileSize;
     [ObservableProperty] private int? _targetFileSize;
+    [ObservableProperty] private bool _matchSourceVideoSize;
     [ObservableProperty] private string _progressText;
     [ObservableProperty] private double _progressValue;
     [ObservableProperty] private ObservableCollection<BurnInJobItem> _jobItems;
@@ -265,12 +266,7 @@ public partial class BurnInViewModel : ObservableObject
         if (fileExists)
         {
             SingleMode();
-            var fileLengthInBytes = new FileInfo(videoFileName).Length;
-            VideoFileSize = Utilities.FormatBytesToDisplayFileSize(fileLengthInBytes);
-
-            // Default the target file size to the original file's size, so enabling
-            // "use target file size" roughly preserves the source size by default.
-            TargetFileSize = Math.Max(1, (int)Math.Round(fileLengthInBytes / (1024.0 * 1024.0)));
+            VideoFileSize = Utilities.FormatBytesToDisplayFileSize(new FileInfo(videoFileName).Length);
             _ = Task.Run(() =>
             {
                 _mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
@@ -492,7 +488,12 @@ public partial class BurnInViewModel : ObservableObject
             }
         }
         jobItem.UseTargetFileSize = UseTargetFileSize;
-        jobItem.TargetFileSize = UseTargetFileSize ? TargetFileSize ?? 0 : 0;
+        // Resolve the per-file target (MB): "match source" derives it from each input file's own
+        // size (so a batch of differently-sized videos keeps each output near its source), otherwise
+        // the fixed value from the UI is used for every file.
+        jobItem.TargetFileSize = UseTargetFileSize
+            ? (MatchSourceVideoSize ? GetSourceFileSizeInMb(jobItem.InputVideoFileName) : TargetFileSize ?? 0)
+            : 0;
         jobItem.AssaSubtitleFileName = MakeAssa(jobItem.SubtitleFileName);
         jobItem.Status = Se.Language.General.Generating;
         if (IsBatchMode)
@@ -564,9 +565,23 @@ public partial class BurnInViewModel : ObservableObject
         return true;
     }
 
+    // Source file size in whole MB (>= 1), used when "match source video size" is enabled.
+    private static long GetSourceFileSizeInMb(string videoFileName)
+    {
+        try
+        {
+            var bytes = new FileInfo(videoFileName).Length;
+            return Math.Max(1, (long)Math.Round(bytes / (1024.0 * 1024.0)));
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
     private int GetVideoBitRate(BurnInJobItem item)
     {
-        if (TargetFileSize == null)
+        if (item.TargetFileSize < 1)
         {
             return 0;
         }
@@ -578,7 +593,7 @@ public partial class BurnInViewModel : ObservableObject
         }
 
         // (MiB * 8192 [converts MiB to kBit]) / video seconds = kBit/s total bitrate
-        var bitRate = (int)Math.Round(((double)TargetFileSize - audioMb) * 8192.0 / item.TotalSeconds);
+        var bitRate = (int)Math.Round(((double)item.TargetFileSize - audioMb) * 8192.0 / item.TotalSeconds);
         if (SelectedAudioEncoding != "copy" && !string.IsNullOrWhiteSpace(SelectedAudioBitRate))
         {
             var audioBitRate = int.Parse(SelectedAudioBitRate.RemoveChar('k').TrimEnd());
@@ -1311,6 +1326,7 @@ public partial class BurnInViewModel : ObservableObject
 
         UseTargetFileSize = settings.TargetFileSize;
         TargetFileSize = settings.TargetFileSizeMb;
+        MatchSourceVideoSize = settings.TargetFileSizeMatchSource;
         PromptForFfmpegParameters = settings.PromptFfmpegParameters;
 
         var effectsAsStringArray = settings.Effects?.Split(',') ?? [];
@@ -1351,6 +1367,7 @@ public partial class BurnInViewModel : ObservableObject
 
         settings.TargetFileSize = UseTargetFileSize;
         settings.TargetFileSizeMb = TargetFileSize ?? 0;
+        settings.TargetFileSizeMatchSource = MatchSourceVideoSize;
         settings.PromptFfmpegParameters = PromptForFfmpegParameters;
 
         settings.Effects = string.Join(",", _selectedEffects.Select(p => p.Name).Distinct());
@@ -1963,7 +1980,9 @@ public partial class BurnInViewModel : ObservableObject
 
     private int GetVideoBitRate()
     {
-        if (TargetFileSize == null || TargetFileSize < 1)
+        // In "match source" mode the preview uses the loaded file's own size; otherwise the fixed MB.
+        var targetMb = MatchSourceVideoSize ? GetSourceFileSizeInMb(VideoFileName) : TargetFileSize ?? 0;
+        if (targetMb < 1)
         {
             return 0;
         }
@@ -1980,7 +1999,7 @@ public partial class BurnInViewModel : ObservableObject
         }
 
         // (MiB * 8192 [converts MiB to kBit]) / video seconds = kBit/s total bitrate
-        var bitRate = (int)Math.Round(((double)TargetFileSize - audioMb) * 8192.0 / _mediaInfo.Duration.TotalSeconds);
+        var bitRate = (int)Math.Round(((double)targetMb - audioMb) * 8192.0 / _mediaInfo.Duration.TotalSeconds);
         if (SelectedAudioEncoding != "copy" && !string.IsNullOrWhiteSpace(SelectedAudioBitRate))
         {
             var audioBitRate = int.Parse(SelectedAudioBitRate.RemoveChar('k').TrimEnd());
@@ -1995,7 +2014,8 @@ public partial class BurnInViewModel : ObservableObject
     {
         TargetVideoBitRateInfo = string.Empty;
 
-        if (!UseTargetFileSize || _mediaInfo == null || TargetFileSize == null || TargetFileSize < 1)
+        if (!UseTargetFileSize || _mediaInfo == null ||
+            (!MatchSourceVideoSize && (TargetFileSize == null || TargetFileSize < 1)))
         {
             return;
         }
@@ -2039,6 +2059,11 @@ public partial class BurnInViewModel : ObservableObject
     }
 
     internal void CheckBoxTargetFileChanged()
+    {
+        CalculateTargetFileBitRate();
+    }
+
+    partial void OnMatchSourceVideoSizeChanged(bool value)
     {
         CalculateTargetFileBitRate();
     }

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -840,7 +840,9 @@ public class BurnInWindow : Window
         grid.Add(panelTargetFileSize, 2, 1);
 
         // Visible in batch mode too, so each file can target its own source size (issue #11802).
+        // MarginBottom(5) matches every other settings box so the borders line up across columns.
         return UiUtil.MakeBorderForControl(grid)
+            .WithMarginBottom(5)
             .WithMarginRight(5);
     }
 
@@ -876,6 +878,7 @@ public class BurnInWindow : Window
 
         return UiUtil.MakeBorderForControl(grid)
             .WithBindIsVisible(nameof(vm.IsBatchMode), new InverseBooleanConverter())
+            .WithMarginBottom(5)
             .WithMarginRight(5);
     }
 

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -793,9 +793,10 @@ public class BurnInWindow : Window
 
         // "Match source video size" derives the target from each input file's own size (works per-file
         // in batch mode); when on, the fixed-MB field is irrelevant and is disabled.
-        var checkBoxMatchSource = UiUtil.MakeCheckBox(Se.Language.Video.BurnIn.MatchSourceVideoSize, vm, nameof(vm.MatchSourceVideoSize));
+        var checkBoxMatchSource = UiUtil.MakeCheckBox(Se.Language.Video.BurnIn.MatchSourceVideoSize, vm, nameof(vm.MatchSourceVideoSize))
+            .WithMarginLeft(10);
 
-        var labelTargetFileSize = UiUtil.MakeLabel(Se.Language.Video.BurnIn.FileSizeMb);
+        var labelTargetFileSize = UiUtil.MakeLabel(Se.Language.Video.BurnIn.FileSizeMb).WithMarginLeft(10);
         var numericUpDownTargetFileSize = UiUtil.MakeNumericUpDownInt(1, 1000_000_000, 0, 150, vm, nameof(vm.TargetFileSize));
         numericUpDownTargetFileSize.ValueChanged += vm.NumericUpDownTargetFileSizeChanged;
         numericUpDownTargetFileSize.Bind(NumericUpDown.IsEnabledProperty, new Binding(nameof(vm.MatchSourceVideoSize)) { Converter = new InverseBooleanConverter() });

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -791,9 +791,14 @@ public class BurnInWindow : Window
         var checkBoxUseTargetFileSize = UiUtil.MakeCheckBox(Se.Language.Video.BurnIn.TargetFileSize, vm, nameof(vm.UseTargetFileSize));
         checkBoxUseTargetFileSize.IsCheckedChanged += (_, _) => vm.CheckBoxTargetFileChanged();
 
+        // "Match source video size" derives the target from each input file's own size (works per-file
+        // in batch mode); when on, the fixed-MB field is irrelevant and is disabled.
+        var checkBoxMatchSource = UiUtil.MakeCheckBox(Se.Language.Video.BurnIn.MatchSourceVideoSize, vm, nameof(vm.MatchSourceVideoSize));
+
         var labelTargetFileSize = UiUtil.MakeLabel(Se.Language.Video.BurnIn.FileSizeMb);
         var numericUpDownTargetFileSize = UiUtil.MakeNumericUpDownInt(1, 1000_000_000, 0, 150, vm, nameof(vm.TargetFileSize));
         numericUpDownTargetFileSize.ValueChanged += vm.NumericUpDownTargetFileSizeChanged;
+        numericUpDownTargetFileSize.Bind(NumericUpDown.IsEnabledProperty, new Binding(nameof(vm.MatchSourceVideoSize)) { Converter = new InverseBooleanConverter() });
         var labelVideoBitRate = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.TargetVideoBitRateInfo));
         labelVideoBitRate.FontSize = 10;
         labelVideoBitRate.Opacity = 0.7;
@@ -815,6 +820,7 @@ public class BurnInWindow : Window
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -828,11 +834,12 @@ public class BurnInWindow : Window
         };
 
         grid.Add(checkBoxUseTargetFileSize, 0, 0, 1, 2);
-        grid.Add(labelTargetFileSize, 1, 0);
-        grid.Add(panelTargetFileSize, 1, 1);
+        grid.Add(checkBoxMatchSource, 1, 0, 1, 2);
+        grid.Add(labelTargetFileSize, 2, 0);
+        grid.Add(panelTargetFileSize, 2, 1);
 
+        // Visible in batch mode too, so each file can target its own source size (issue #11802).
         return UiUtil.MakeBorderForControl(grid)
-            .WithBindIsVisible(nameof(vm.IsBatchMode), new InverseBooleanConverter())
             .WithMarginRight(5);
     }
 

--- a/src/ui/Logic/Config/Language/Video/LanguageBurnIn.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageBurnIn.cs
@@ -15,6 +15,7 @@ public class LanguageBurnIn
     public string TargetFileName { get; set; }
     public string TargetFileSize { get; set; }
     public string FileSizeMb { get; set; }
+    public string MatchSourceVideoSize { get; set; }
     public string PassX { get; set; }
     public string Encoding { get; set; }
     public string BitRate { get; set; }
@@ -61,6 +62,7 @@ public class LanguageBurnIn
         TargetFileName = "Target file name: {0}";
         TargetFileSize = "Target file size (requires 2 pass encoding)";
         FileSizeMb = "File size in MB";
+        MatchSourceVideoSize = "Match source video size";
         PassX = "Pass {0}";
         Encoding = "Encoding";
         BitRate = "Bit rate";

--- a/src/ui/Logic/Config/SeVideoBurnIn.cs
+++ b/src/ui/Logic/Config/SeVideoBurnIn.cs
@@ -21,6 +21,7 @@ public class SeVideoBurnIn
     public string AudioBitRate { get; set; }
     public bool TargetFileSize { get; set; }
     public int TargetFileSizeMb { get; set; }
+    public bool TargetFileSizeMatchSource { get; set; }
     public bool PromptFfmpegParameters { get; set; }
     public int NonAssaBoxType { get; set; }
     public bool NonAssaBox { get; set; }
@@ -62,6 +63,7 @@ public class SeVideoBurnIn
         AudioSampleRate = "48000";
         AudioBitRate = "128k";
         TargetFileSizeMb = 100;
+        TargetFileSizeMatchSource = true;
         FontBold = true;
         OutlineWidth = 6;
         ShadowWidth = 3;


### PR DESCRIPTION
## Summary
Resolves #11802. The burn-in **target file size** had two problems:
1. It defaulted to a fixed 100 MB; PR #11803 then *forced* the source size in single mode (not a choice).
2. It was **completely hidden in batch mode**, so batch outputs were re-encoded with no size target and grew significantly.

This adds a proper **"Match source video size"** mode that works in both single and batch.

## Changes
- **Setting:** `SeVideoBurnIn.TargetFileSizeMatchSource` (default **on**).
- **New "Match source video size" checkbox** in the target-size box. When on, the target is derived from each input file''s own size and the fixed-MB field is disabled; when off, the fixed MB is used.
- **Batch mode now shows the target-size box** (removed the `!IsBatchMode` visibility gate). Each batch file targets its **own** source size — so a 50 MB clip and a 2 GB movie no longer both aim at one fixed number.
- **Per-file resolution:** the target (MB) is computed in `InitAndStartJobItem` (runs for single and batch) from `MatchSourceVideoSize ? source-size : fixed-MB`.
- **Bug fix:** `GetVideoBitRate(item)` now uses the per-item `item.TargetFileSize` instead of the shared UI `TargetFileSize` (the old code applied one value to every batch file).
- Single-mode bitrate preview reflects the source size when match mode is on.
- Reverted PR #11803''s forced single-mode default (now driven by the mode toggle).

## How to test
- **Single:** open a video → Burn-in. "Use target file size" + "Match source video size" → bit-rate preview reflects the source size; MB field disabled. Uncheck match → fixed MB editable.
- **Batch:** switch to Batch mode → the target-size box is now visible; with match-source on, each output targets its own source size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)