### PR TITLE
OCR: fix light-mode contrast for word colors and subtitle images

### DIFF
--- a/src/ui/Features/Ocr/FixEngine/OcrFixLineResult.cs
+++ b/src/ui/Features/Ocr/FixEngine/OcrFixLineResult.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
 
@@ -41,8 +42,11 @@ public class OcrFixLineResult
             textBlock.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         }
 
-        var errorColor = errorBrush ?? Brushes.LightPink;
-        var normalColor = normalBrush ?? Brushes.LightGreen;
+        // LightPink/LightGreen read well on a dark grid but wash out on a light background,
+        // so use darker, higher-contrast variants in non-dark themes.
+        var isDark = UiTheme.IsDarkThemeEnabled();
+        var errorColor = errorBrush ?? (isDark ? Brushes.LightPink : new SolidColorBrush(Color.FromRgb(0xC0, 0x00, 0x00)));
+        var normalColor = normalBrush ?? (isDark ? Brushes.LightGreen : new SolidColorBrush(Color.FromRgb(0x00, 0x80, 0x00)));
 
         if (textBlock.Inlines != null)
         {

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -423,7 +423,17 @@ public class OcrWindow : Window
                             };
                             image.Bind(Image.MaxHeightProperty, new Binding(nameof(vm.ImageMaxHeight)) { Source = vm });
                             image.Bind(Image.MaxWidthProperty, new Binding(nameof(vm.ImageMaxWidth)) { Source = vm });
-                            stackPanel.Children.Add(image);
+
+                            // Subtitle bitmaps are usually light text on a transparent background, which
+                            // is invisible on a light grid - give them a dark backdrop so they show.
+                            var imageContainer = new Border
+                            {
+                                Background = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.FromRgb(0x2D, 0x2D, 0x30)),
+                                CornerRadius = new CornerRadius(3),
+                                Padding = new Thickness(3),
+                                Child = image,
+                            };
+                            stackPanel.Children.Add(imageContainer);
                         }
 
                         return stackPanel;


### PR DESCRIPTION
## Summary
In **light (non-dark) mode** the OCR window had poor contrast:
- Recognized/unknown words used `Brushes.LightGreen` / `Brushes.LightPink`, which wash out on a light grid.
- Subtitle thumbnail images (light text on a transparent background) were nearly invisible on the light grid.

## Changes
- **`OcrFixLineResult.GetFormattedText`**: pick word colors by theme via `UiTheme.IsDarkThemeEnabled()`.
  - Dark mode: unchanged (LightGreen / LightPink)
  - Non-dark: green `#008000` (spell-checked OK), red `#C00000` (unknown word)
- **OCR grid image column**: wrap each subtitle thumbnail in a `Border` with a dark backdrop (`#2D2D30`), so light subtitle text is visible in both themes.

## Notes
- Dark mode appearance is unchanged for the word colors; the image now always has a dark backdrop (helps consistency and selection states in both themes). Easy to make it light-mode-only if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)