### PR TITLE
Bold shortcut: bold only the selected words when text box is focused (#11814)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9414,6 +9414,24 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void ToggleLinesBoldOrSelectedText()
+    {
+        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        if (selectedItems.Count == 1 && EditTextBox.SelectedText.Length > 0)
+        {
+            TextBoxBold();
+            return;
+        }
+
+        ToggleBold();
+    }
+
+    [RelayCommand]
     private async Task ShowAlignmentPicker()
     {
         var selected = SelectedSubtitle;

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -138,7 +138,7 @@ public static class Se4ShortcutsImporter
 
         // List view
         ["MainListViewItalic"] = nameof(MainViewModel.ToggleLinesItalicOrSelectedTextCommand),
-        ["MainListViewBold"] = nameof(MainViewModel.ToggleLinesBoldCommand),
+        ["MainListViewBold"] = nameof(MainViewModel.ToggleLinesBoldOrSelectedTextCommand),
         ["MainListViewAlignment"] = nameof(MainViewModel.ShowAlignmentPickerCommand),
         ["MainListViewAlignmentN1"] = nameof(MainViewModel.DoAlignmentAn1Command),
         ["MainListViewAlignmentN2"] = nameof(MainViewModel.DoAlignmentAn2Command),

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -197,7 +197,7 @@ public static class ShortcutsMain
 
         { nameof(MainViewModel.ShowGoToVideoPositionCommand), Se.Language.Options.Shortcuts.GeneralGoToVideoPosition },
         { nameof(MainViewModel.ToggleLinesItalicOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleItalic },
-        { nameof(MainViewModel.ToggleLinesBoldCommand), Se.Language.Options.Shortcuts.GeneralToggleBold },
+        { nameof(MainViewModel.ToggleLinesBoldOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleBold },
 
         { nameof(MainViewModel.PlayCommand), Se.Language.General.Play },
         { nameof(MainViewModel.PlayNextCommand), Se.Language.General.PlayNext },
@@ -492,7 +492,7 @@ public static class ShortcutsMain
 
         AddShortcut(shortcuts, vm.ShowGoToVideoPositionCommand, nameof(vm.ShowGoToVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ToggleLinesItalicOrSelectedTextCommand, nameof(vm.ToggleLinesItalicOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
-        AddShortcut(shortcuts, vm.ToggleLinesBoldCommand, nameof(vm.ToggleLinesBoldCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.ToggleLinesBoldOrSelectedTextCommand, nameof(vm.ToggleLinesBoldOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
 
         AddShortcut(shortcuts, vm.PlayCommand, nameof(vm.PlayCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.PlayNextCommand, nameof(vm.PlayNextCommand), ShortcutCategory.General);


### PR DESCRIPTION
Fixes #11814

The **bold** shortcut always wrapped the entire line, even when words were selected in the text box — unlike **italic**, which correctly wraps just the selection. The cause: italic's shortcut is bound to `ToggleLinesItalicOrSelectedTextCommand` (which routes to `TextBoxItalic` when there's a selection), while bold's shortcut went straight to `ToggleLinesBoldCommand` (whole line).

## Fix
- Added `ToggleLinesBoldOrSelectedText`, mirroring `ToggleLinesItalicOrSelectedText`: when exactly one line is selected and the edit text box has a non-empty selection, it bolds just the selected words (`<b>…</b>`) via `TextBoxBold`; otherwise it toggles the whole line(s) as before.
- Rebound the bold **shortcut** (main shortcuts + the SE4 importer mapping) to the new command.
- The subtitle-grid context menu and image-based export keep the whole-line `ToggleLinesBold`, matching how italic is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)