### PR TITLE
Fix profile dialog CPS/WPM fields showing & saving wrong values (#11815)

### DIFF
--- a/src/ui/Features/Options/Settings/ProfilesWindow.cs
+++ b/src/ui/Features/Options/Settings/ProfilesWindow.cs
@@ -179,13 +179,13 @@ public class ProfilesWindow : Window
         var numericUpDownSingleLineMaxLength = UiUtil.MakeNumericUpDownInt(0, 1000, 43, 150, vm, nameof(vm.SelectedProfile) + "." + nameof(ProfileDisplay.SingleLineMaxLength));
 
         var labelOptimalCharsPerSec = UiUtil.MakeLabel(Se.Language.Options.Settings.OptimalCharsPerSec);
-        var numericUpDownOptimalCharsPerSec = UiUtil.MakeNumericUpDownInt(0, 1000, 43, 150, vm, nameof(vm.SelectedProfile) + "." + nameof(ProfileDisplay.OptimalCharsPerSec));
+        var numericUpDownOptimalCharsPerSec = UiUtil.MakeNumericUpDownDouble(0, 1000, 43, 150, vm, nameof(vm.SelectedProfile) + "." + nameof(ProfileDisplay.OptimalCharsPerSec));
 
         var labelMaxCharsPerSec = UiUtil.MakeLabel(Se.Language.General.MaxCharactersPerSecond);
-        var numericUpDownMaxCharsPerSec = UiUtil.MakeNumericUpDownInt(0, 1000, 43, 150, vm, nameof(vm.SelectedProfile) + "." + nameof(ProfileDisplay.MaxCharsPerSec));
+        var numericUpDownMaxCharsPerSec = UiUtil.MakeNumericUpDownDouble(0, 1000, 43, 150, vm, nameof(vm.SelectedProfile) + "." + nameof(ProfileDisplay.MaxCharsPerSec));
 
         var labelMaxWordsPerMin = UiUtil.MakeLabel(Se.Language.Options.Settings.MaxWordsPerMin);
-        var numericUpDownMaxWordsPerMin = UiUtil.MakeNumericUpDownInt(0, 1000, 43, 150, vm, nameof(vm.SelectedProfile) + "." + nameof(ProfileDisplay.MaxWordsPerMin));
+        var numericUpDownMaxWordsPerMin = UiUtil.MakeNumericUpDownDouble(0, 1000, 43, 150, vm, nameof(vm.SelectedProfile) + "." + nameof(ProfileDisplay.MaxWordsPerMin));
 
         var labelMinDurationMs = UiUtil.MakeLabel(Se.Language.Options.Settings.MinDurationMs);
         var numericUpDownMinDurationMs = UiUtil.MakeNumericUpDownInt(0, 10000, 43, 150, vm, nameof(vm.SelectedProfile) + "." + nameof(ProfileDisplay.MinDurationMs));

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2032,6 +2032,57 @@ public static class UiUtil
         return control;
     }
 
+    // Like MakeNumericUpDownInt but for double-typed (double?) view-model properties.
+    // Uses NullableDoubleConverter so the actual value round-trips; NullableIntConverter
+    // would fall back to its DefaultValue whenever the source is a double (not an int).
+    public static NumericUpDown MakeNumericUpDownDouble(int min, int max, double defaultValue, double width, object viewModel,
+        string? propertyValuePath = null, string? propertyIsVisiblePath = null)
+    {
+        var control = new NumericUpDown
+        {
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            DataContext = viewModel,
+            Minimum = min,
+            Maximum = max,
+            Width = width,
+            Increment = 1,
+            FormatString = "F0",
+            Foreground = GetTextColor(),
+        };
+
+        if (propertyValuePath != null)
+        {
+            control.Bind(NumericUpDown.ValueProperty, new Binding
+            {
+                Path = propertyValuePath,
+                Mode = BindingMode.TwoWay,
+                Converter = new NullableDoubleConverter { DefaultValue = defaultValue },
+            });
+        }
+
+        if (propertyIsVisiblePath != null)
+        {
+            control.Bind(NumericUpDown.IsVisibleProperty, new Binding
+            {
+                Path = propertyIsVisiblePath,
+                Mode = BindingMode.TwoWay,
+            });
+        }
+
+        control.AddHandler(InputElement.PointerWheelChangedEvent, (s, e) =>
+        {
+            control.Value = Math.Clamp((control.Value ?? 0) + (e.Delta.Y > 0 ? control.Increment : -control.Increment),
+                                        control.Minimum,
+                                        control.Maximum);
+            e.Handled = true;
+        });
+
+        ForwardAutomationNameToInnerTextBox(control);
+
+        return control;
+    }
+
     public static NumericUpDown MakeNumericUpDownTwoDecimals(decimal min, decimal max, double width, object viewModel,
         string? propertyValuePath = null, string? propertyIsVisiblePath = null, decimal defaultValue = 0)
     {


### PR DESCRIPTION
Re: #11815

## What I found
The overall profile save path is actually sound (which is why the full "nothing saves" report is hard to reproduce), but there is a concrete binding bug in the **Profiles** dialog.

Three `ProfileDisplay` fields are `double?`: **Optimal chars/sec**, **Max chars/sec**, **Max words/min**. The dialog bound them with `UiUtil.MakeNumericUpDownInt`, which uses `NullableIntConverter`:

```csharp
public object? Convert(object? value, ...)
{
    if (value is int intValue) { return intValue; }
    return DefaultValue;   // <-- a double source never matches `is int`
}
```

Because the source is a `double`, `value is int` is always false, so the control displayed the **hard-coded default** instead of the profile's real value, and wrote the value back as an `int` to a `double?` property. The main settings *Rules* section binds the same three properties as decimals, so it was correct there — only the dialog was wrong.

## Fix
- Added `UiUtil.MakeNumericUpDownDouble` — same whole-number display as the int helper but using `NullableDoubleConverter`, so `double?` values round-trip correctly.
- Pointed the three double fields in `ProfilesWindow` at it.

The int-typed fields (single line max length, durations, gap, max lines, unbreak-shorter-than) were already correct and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)