### PR TITLE
Merge continuation lines: treat CJK like English (#11806)

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -3155,9 +3155,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                         return true;
                     }
 
+                    var lastChar = s[s.Length - 1];
                     var isLineContinuation = s.EndsWith("...", StringComparison.Ordinal) ||
                                               (AllLetters + "…,-$%").Contains(s.Substring(s.Length - 1)) ||
-                                              CalcCjk.IsCjk(s[s.Length - 1]);
+                                              (CalcCjk.IsCjk(lastChar) && !IsCjkSentenceEnding(lastChar));
 
                     if (s.EndsWith('♪') || nextText.StartsWith('♪'))
                     {
@@ -3178,6 +3179,27 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
             return false;
+        }
+
+        /// <summary>
+        /// CJK sentence-final punctuation. A line ending in one of these is a complete
+        /// sentence rather than a continuation, e.g. the ideographic full stop "。".
+        /// Needed because <see cref="CalcCjk.IsCjk"/> treats CJK punctuation as CJK,
+        /// which would otherwise make every "。"-terminated line look like a continuation.
+        /// </summary>
+        private static bool IsCjkSentenceEnding(char c)
+        {
+            switch (c)
+            {
+                case '。': // U+3002 ideographic full stop
+                case '．': // U+FF0E fullwidth full stop
+                case '｡': // U+FF61 halfwidth ideographic full stop
+                case '！': // U+FF01 fullwidth exclamation mark
+                case '？': // U+FF1F fullwidth question mark
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         public static string GetPathAndFileNameWithoutExtension(string fileName)

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelper.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelper.cs
@@ -1,5 +1,4 @@
 using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
 using Nikse.SubtitleEdit.Features.Main;
 using System;
 using System.Collections.Generic;
@@ -8,18 +7,6 @@ namespace Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
 
 public static class MergeContinuationLinesHelper
 {
-    // Languages where sentence-final punctuation is routinely absent;
-    // QualifiesForMerge(onlyContinuationLines:true) would generate noise on these.
-    private static readonly HashSet<string> SkipLanguages = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "zh", "ja", "th", "lo", "my", "km", "ko", "bo",
-    };
-
-    public static bool IsLanguageSkipped(string? language)
-    {
-        return !string.IsNullOrEmpty(language) && SkipLanguages.Contains(language!);
-    }
-
     public static List<MergeContinuationLinesCandidate> Detect(
         IReadOnlyList<SubtitleLineViewModel> subtitles,
         string? language,
@@ -42,16 +29,6 @@ public static class MergeContinuationLinesHelper
             var nextP = next.ToParagraph();
 
             if (!Utilities.QualifiesForMerge(p, nextP, maxGapMs, maxTotalLength, onlyContinuationLines: true))
-            {
-                continue;
-            }
-
-            // Detect CJK per line rather than skipping the whole file by its overall
-            // detected language (issue #11267): a file can mix scripts (e.g. a few
-            // Japanese lines over an English body). In CJK the absence of sentence-final
-            // punctuation makes QualifiesForMerge treat almost every line as a
-            // continuation, so skip only those lines that actually end in CJK.
-            if (EndsWithCjk(current.Text))
             {
                 continue;
             }
@@ -113,19 +90,6 @@ public static class MergeContinuationLinesHelper
         }
 
         return result;
-    }
-
-    // Mirrors the CJK check inside Utilities.QualifiesForMerge: sanitize tags/whitespace
-    // the same way and test the last visible character.
-    private static bool EndsWithCjk(string? text)
-    {
-        if (string.IsNullOrEmpty(text))
-        {
-            return false;
-        }
-
-        var sanitized = HtmlUtil.RemoveHtmlTags(text!.Trim(), true);
-        return sanitized.Length > 0 && CalcCjk.IsCjk(sanitized[sanitized.Length - 1]);
     }
 
     private static bool StartsWithDashSpeaker(string? text)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -891,10 +891,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         var language = LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitle);
-        if (MergeContinuationLinesHelper.IsLanguageSkipped(language))
-        {
-            return;
-        }
 
         var format = _subtitle.OriginalFormat ?? new SubRip();
         var viewModels = _subtitle.Paragraphs

--- a/tests/UI/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelperTests.cs
+++ b/tests/UI/Features/Tools/MergeContinuationLines/MergeContinuationLinesHelperTests.cs
@@ -31,38 +31,31 @@ public class MergeContinuationLinesHelperTests
     }
 
     [Fact]
-    public void Detect_MixedScriptFileDetectedAsJapanese_StillMergesEnglishBody()
+    public void Detect_CjkContinuationLines_MergeLikeEnglish()
     {
-        // Regression for issue #11267: a few Japanese lines at the top make the
-        // whole-file language detection return "ja", which previously suppressed
-        // the entire feature ("No continuation candidates found"). CJK must be
-        // skipped per line so the English continuation lines still merge.
+        // Issue #11806: CJK lines must be treated just like English. A CJK line that
+        // does not end in sentence-final punctuation is an unfinished sentence and
+        // should merge with the next line.
         var subtitles = new List<SubtitleLineViewModel>
         {
-            MakeSubtitle("はよう", 0.62, 0.70),
-            MakeSubtitle("はな", 0.81, 0.98),
-            MakeSubtitle("an", 1.02, 1.13),
-            MakeSubtitle("illusion,", 1.16, 1.74),
-            MakeSubtitle("an", 1.80, 1.90),
-            MakeSubtitle("echo", 1.92, 2.10),
+            MakeSubtitle("これは", 0.62, 0.70),
+            MakeSubtitle("ペンです", 0.81, 0.98),
         };
 
         var candidates = MergeContinuationLinesHelper.Detect(subtitles, "ja", maxGapMs: 500, maxTotalLength: 200);
 
         Assert.NotEmpty(candidates);
-        // None of the produced candidates should start from a CJK (Japanese) line.
-        Assert.DoesNotContain(candidates, c => c.Text1.Contains("はよう") || c.Text1.Contains("はな"));
     }
 
     [Fact]
-    public void Detect_CjkLines_AreSkipped()
+    public void Detect_CjkSentenceEndingWithIdeographicFullStop_NotMerged()
     {
-        // Pure CJK continuation lines remain noise-free: ending in a CJK character
-        // is not treated as an English-style "unfinished sentence".
+        // The ideographic full stop "。" ends a sentence, so the line is not a
+        // continuation and must not be offered as a merge candidate.
         var subtitles = new List<SubtitleLineViewModel>
         {
-            MakeSubtitle("はよう", 0.62, 0.70),
-            MakeSubtitle("はな", 0.81, 0.98),
+            MakeSubtitle("これはペンです。", 0.62, 0.70),
+            MakeSubtitle("そうですか", 0.81, 0.98),
         };
 
         var candidates = MergeContinuationLinesHelper.Detect(subtitles, "ja", maxGapMs: 500, maxTotalLength: 200);


### PR DESCRIPTION
Fixes #11806

The fix for #11267 made *Merge continuation lines* ignore CJK entirely — whole languages were skipped and any line ending in a CJK character was dropped as a candidate — so the feature became unusable for Japanese/Chinese/etc. As requested in the issue, CJK should behave **just like English**, while still respecting CJK sentence-final punctuation.

## Changes
- **`Utilities.QualifiesForMerge`** — a line ending in a CJK character is still treated as a continuation, **except** when it ends in CJK sentence-ending punctuation (`。` `．` `｡` `！` `？`), which now correctly counts as a finished sentence. (`！`/`？` were already handled since they aren't in the CJK ranges; the key addition is the ideographic full stop `。` U+3002, which `CalcCjk.IsCjk` classifies as CJK.)
- **`MergeContinuationLinesHelper`** — removed the CJK special handling: the `SkipLanguages` list / `IsLanguageSkipped` and the per-line `EndsWithCjk` skip.
- **`TextToSpeechViewModel`** — removed the `IsLanguageSkipped` early-out so CJK gets the same merge prompt as everything else (still only when real candidates exist).

## Tests
- CJK continuation lines (no terminal punctuation) now merge like English.
- CJK lines ending in `。` are not offered as candidates.
- Existing English and libse merge tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)