### PR TITLE
Change default Auto-break shortcut from Ctrl+R to Ctrl+Alt+B

### DIFF
--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -836,7 +836,7 @@ public static class ShortcutsMain
             new(nameof(vm.WaveformSetEndAndGoToNextCommand), [nameof(Avalonia.Input.Key.F10)], ShortcutCategory.General),
             new(nameof(vm.InsertLineAfterCommand), ["Alt", nameof(Avalonia.Input.Key.Insert)], ShortcutCategory.General),
             new(nameof(vm.InsertLineBeforeCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.Insert)], ShortcutCategory.General),
-            new(nameof(vm.AutoBreakCommand), [cmd, nameof(Avalonia.Input.Key.R)], ShortcutCategory.General),
+            new(nameof(vm.AutoBreakCommand), [cmd, "Alt", nameof(Avalonia.Input.Key.B)], ShortcutCategory.General),
             new(nameof(vm.PlaySelectedLinesWithoutLoopCommand), [nameof(Avalonia.Input.Key.F5)], ShortcutCategory.General),
             new(nameof(vm.ExtendSelectedToNextCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.E)], ShortcutCategory.General),
             new(nameof(vm.ToggleTranslationModeCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.O)], ShortcutCategory.General),


### PR DESCRIPTION
## Problem
Ctrl+R was assigned twice as a default: **General: Replace** and **General: Auto-break text**.

The Auto-break = Ctrl+R default was added in 6a0a75eb3 ("Add more built-in default shortcuts from SE4"). That commit notes the keys "do not conflict with the current SE5 defaults" — true against SE5 (where Replace ships as Ctrl+H) — but **SE4 used Ctrl+R for Replace**, so anyone importing SE4 shortcuts (or on an older config with Replace=Ctrl+R) ends up with Ctrl+R bound to both Replace and Auto-break.

Ctrl+R is also mnemonic for "Replace", not "break".

## Fix
Change the Auto-break default to **Ctrl+Alt+B** — mnemonic for "break", and free across all defaults (Ctrl+B is Batch convert, Ctrl+Shift+B is Bookmark).

One line in `ShortcutsMain.cs`. Verified Ctrl+Alt+B isn't used by any other default; build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)