### PR TITLE
ASSA Set position: robust frame grab, add rotation, fix blank preview (#11457)

### DIFF
--- a/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -14,7 +15,9 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Media;
 using SkiaSharp;
 using System;
+using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Assa.AssaSetPosition;
@@ -36,6 +39,11 @@ public partial class AssaSetPositionViewModel : ObservableObject
     [ObservableProperty] private Bitmap _screenshotOverlayText;
     [ObservableProperty] private Bitmap _screenshot;
     [ObservableProperty] private string _screenshotOverlayPosiion;
+    [ObservableProperty] private decimal _rotation;
+
+    private static readonly Regex FrzRegex = new(@"\\frz\(?(-?\d+(\.\d+)?)\)?", RegexOptions.Compiled);
+
+    public decimal ResultRotation => Rotation;
 
     private Subtitle _subtitle = new();
     private bool _isLeftAligned = false;
@@ -110,9 +118,23 @@ public partial class AssaSetPositionViewModel : ObservableObject
         }
     }
 
+    partial void OnRotationChanged(decimal value)
+    {
+        if (VideoGrid != null && ScreenshotOverlayImage != null && ScreenshotImage != null)
+        {
+            UpdateOverlayPosition();
+        }
+    }
+
     public void Initialize(Subtitle subtitle, SubtitleLineViewModel line, string? videoFileName, int? videoWidth, int? videoHeight)
     {
         _subtitle = new Subtitle(subtitle, false);
+
+        var frzMatch = FrzRegex.Match(line.Text ?? string.Empty);
+        if (frzMatch.Success && decimal.TryParse(frzMatch.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var frz))
+        {
+            Rotation = frz;
+        }
 
         var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header);
         var style = styles.FirstOrDefault(s => s.Name.Equals(line.Style, StringComparison.OrdinalIgnoreCase));
@@ -186,7 +208,7 @@ public partial class AssaSetPositionViewModel : ObservableObject
 
         if (string.IsNullOrEmpty(videoFileName))
         {
-            Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetHeight, TargetHeight);
+            Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetWidth, TargetHeight);
             return;
         }
 
@@ -199,12 +221,12 @@ public partial class AssaSetPositionViewModel : ObservableObject
             }
             catch
             {
-                Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetHeight, TargetHeight);
+                Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetWidth, TargetHeight);
             }
         }
         else
         {
-            Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetHeight, TargetHeight);
+            Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetWidth, TargetHeight);
         }
     }
 
@@ -299,6 +321,12 @@ public partial class AssaSetPositionViewModel : ObservableObject
             0,
             0);
 
-        ScreenshotOverlayPosiion = $"X: {ScreenshotX}, Y: {ScreenshotY}";
+        // ASSA \frz rotates counter-clockwise; Avalonia RotateTransform is clockwise, so negate.
+        ScreenshotOverlayImage.RenderTransformOrigin = RelativePoint.Center;
+        ScreenshotOverlayImage.RenderTransform = new RotateTransform(-(double)Rotation);
+
+        ScreenshotOverlayPosiion = Rotation == 0
+            ? $"X: {ScreenshotX}, Y: {ScreenshotY}"
+            : $"X: {ScreenshotX}, Y: {ScreenshotY}, {Rotation}°";
     }
 }

--- a/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionWindow.cs
+++ b/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionWindow.cs
@@ -147,7 +147,25 @@ public class AssaSetPositionWindow : Window
         // Position buttons
         var buttonCenterHorizontally = UiUtil.MakeButton(Se.Language.General.CenterHorizontally, vm.CenterHorizontallyCommand);
         var buttonCenterVertically = UiUtil.MakeButton(Se.Language.General.CenterVertically, vm.CenterVerticallyCommand);
-        var panelPositionButtons = UiUtil.MakeButtonBar(buttonCenterHorizontally, buttonCenterVertically).WithAlignmentLeft();
+
+        var labelRotation = UiUtil.MakeLabel(Se.Language.Assa.Rotation);
+        var numericRotation = new NumericUpDown
+        {
+            Width = 110,
+            Minimum = -360,
+            Maximum = 360,
+            Increment = 1,
+            FormatString = "F0",
+            VerticalAlignment = VerticalAlignment.Center,
+            DataContext = vm,
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.Rotation)) { Mode = BindingMode.TwoWay },
+        };
+
+        var panelPositionButtons = UiUtil.MakeButtonBar(
+            buttonCenterHorizontally,
+            buttonCenterVertically,
+            labelRotation,
+            numericRotation).WithAlignmentLeft();
 
         // Buttons
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1535,14 +1535,21 @@ public partial class MainViewModel :
 
         var x = result.ResultX;
         var y = result.ResultY;
-        selectedItem.Text = $"{{\\pos({x},{y})}}" + RemovePositionTags(selectedItem.Text);
+        var tags = $"\\pos({x},{y})";
+        if (result.ResultRotation != 0)
+        {
+            tags += "\\frz" + result.ResultRotation.ToString(CultureInfo.InvariantCulture);
+        }
+
+        selectedItem.Text = "{" + tags + "}" + RemovePositionTags(selectedItem.Text);
         RefreshSubtitlePreview();
     }
 
     private static string RemovePositionTags(string text)
     {
-        string result = Regex.Replace(text, @"\\pos\(\d+,\d+\)", string.Empty).Replace("{}", string.Empty);
-        return result;
+        string result = Regex.Replace(text, @"\\pos\(\d+,\d+\)", string.Empty);
+        result = Regex.Replace(result, @"\\frz\(?-?\d+(\.\d+)?\)?", string.Empty);
+        return result.Replace("{}", string.Empty);
     }
 
     [RelayCommand]

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -117,6 +117,7 @@ public class LanguageAssa
     public string SpinIn { get; set; }
     public string PlayCurrent { get; set; }
     public string SetPosition { get; set; }
+    public string Rotation { get; set; }
     public string ImageColorPicker { get; set; }
     public string CopyColorAsHextoClipboard { get; set; }
     public string GeneratingBackgroundBoxXOfY { get; set; }
@@ -320,6 +321,7 @@ public class LanguageAssa
         SpinIn = "Spin in";
         PlayCurrent = "Play current";
         SetPosition = "Set position";
+        Rotation = "Rotation";
         ImageColorPicker = "Image color picker";
         CopyColorAsHextoClipboard = "Copy color as hex to clipboard";
         GeneratingBackgroundBoxXOfY = "Generating background box {0} of {1}...";

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Video.EmbeddedSubtitlesEdit;
+using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -320,14 +321,38 @@ public class FfmpegGenerator
             vfMatrix = $"-vf colormatrix={colorMatrix}";
         }
 
+        // Fast path: input seeking ("-ss" before "-i"). For some containers/codecs this can land
+        // between keyframes and produce no frame, so fall back to accurate output seeking.
+        var stderr = RunFfmpegScreenShot($"-y -ss {timeCode} -i \"{inputFileName}\" {vfMatrix} -frames:v 1 -c:v png \"{outputFileName}\"");
+        if (HasFrame(outputFileName))
+        {
+            return outputFileName;
+        }
+
+        var stderr2 = RunFfmpegScreenShot($"-y -i \"{inputFileName}\" -ss {timeCode} {vfMatrix} -frames:v 1 -c:v png \"{outputFileName}\"");
+        if (HasFrame(outputFileName))
+        {
+            return outputFileName;
+        }
+
+        Se.LogError("FfmpegGenerator.GetScreenShot: no frame extracted from \"" + inputFileName +
+                    "\" at " + timeCode + Environment.NewLine +
+                    "input-seek: " + stderr + Environment.NewLine +
+                    "output-seek: " + stderr2);
+        return outputFileName;
+    }
+
+    private static string RunFfmpegScreenShot(string arguments)
+    {
         var process = new Process
         {
             StartInfo =
             {
                 FileName = GetFfmpegLocation(),
-                Arguments = $"-ss {timeCode} -i \"{inputFileName}\" {vfMatrix} -frames:v 1 -c:v png \"{outputFileName}\"",
+                Arguments = arguments,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                RedirectStandardError = true,
             }
         };
 
@@ -335,8 +360,14 @@ public class FfmpegGenerator
         _ = process.Start();
 #pragma warning restore CA1416
 
+        var stderr = process.StandardError.ReadToEnd();
         process.WaitForExit();
-        return outputFileName;
+        return stderr;
+    }
+
+    private static bool HasFrame(string fileName)
+    {
+        return File.Exists(fileName) && new FileInfo(fileName).Length > 0;
     }
 
     internal static string? GetScreenShotWithSubtitle(Subtitle previewSubtitle, int width, int height)


### PR DESCRIPTION
Re: #11457 (the video-preview part — the style-order part is out of scope here)

## Problem
*ASSA tools → Set position* showed no video, so you couldn't see where you were placing the text. The dialog uses a single ffmpeg frame-grab as the background and **silently** fell back to a blank/checkered image whenever ffmpeg failed to extract a frame — with no error surfaced. It also lacked the rotation control from SE4.

## Changes
**1. Robust frame grab + surfaced failure** (`FfmpegGenerator.GetScreenShot`)
- Capture ffmpeg stderr and verify a non-empty PNG was actually produced.
- The fast path uses input seeking (`-ss` before `-i`), which for some containers/codecs lands between keyframes and produces no frame. If that yields nothing, retry with accurate output seeking (`-i` before `-ss`).
- Added `-y` so the retry can overwrite, and log ffmpeg output when both attempts fail (instead of a silent blank).

**3. Checkered fallback dimensions** — was `CreateCheckeredBackground(TargetHeight, TargetHeight)` (square); now uses `(TargetWidth, TargetHeight)`.

**Rotation (`\frz`)** — new control:
- Initialized from any existing `\frz` on the line.
- Rotates the subtitle overlay live in the preview (around its center — an approximation of `\frz`, good enough for placement).
- Written back as `\frz<angle>` alongside `\pos(x,y)` on OK; existing pos/rotation tags are stripped first.

## Notes / follow-ups
- The preview rotates the overlay around its center; true `\frz` rotates around the alignment origin. Fine as a positioning aid.
- This adds z-axis rotation only; X/Y-axis (`\frx`/`\fry`) would need a 3D preview and are left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)