### PR TITLE
Let the focused main menu own its navigation keys (#11745)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18012,6 +18012,50 @@ public partial class MainViewModel :
         return false;
     }
 
+    /// <summary>
+    /// True when keyboard focus is on the main menu itself or one of its items (including items in
+    /// an open drop-down, which live in a popup). Used to let the menu own arrow/Enter/Escape keys
+    /// instead of the shortcut manager while it is being navigated (#11745).
+    /// </summary>
+    private bool IsMainMenuFocused()
+    {
+        if (Menu == null)
+        {
+            return false;
+        }
+
+        var focusedElement = Window?.FocusManager?.GetFocusedElement();
+        if (focusedElement == null)
+        {
+            return false;
+        }
+
+        // A focused MenuItem belongs to a menu/flyout being navigated; let it keep the keys.
+        // (Drop-down items are hosted in a popup, so a visual-parent walk to Menu would miss them.)
+        if (focusedElement is MenuItem)
+        {
+            return true;
+        }
+
+        if (ReferenceEquals(focusedElement, Menu))
+        {
+            return true;
+        }
+
+        var parent = (focusedElement as Avalonia.Visual)?.GetVisualParent();
+        while (parent != null)
+        {
+            if (ReferenceEquals(parent, Menu))
+            {
+                return true;
+            }
+
+            parent = parent.GetVisualParent();
+        }
+
+        return false;
+    }
+
     internal void OnKeyDownHandler(object? sender, KeyEventArgs keyEventArgs)
     {
         lock (_onKeyDownHandlerLock)
@@ -18049,6 +18093,15 @@ public partial class MainViewModel :
             if (k == Key.F10 && keyEventArgs.KeyModifiers == KeyModifiers.None && TryFocusMainMenu())
             {
                 keyEventArgs.Handled = true;
+                return;
+            }
+
+            // When the main menu has keyboard focus (opened via F10 or Alt), let it handle its own
+            // arrow/Enter/Escape navigation instead of consuming those keys as shortcuts. The window
+            // key handler tunnels (runs before the focused menu item), so without this the shortcut
+            // manager would eat Left/Right etc. and menu navigation would never work (#11745).
+            if (IsMainMenuFocused())
+            {
                 return;
             }
 


### PR DESCRIPTION
Follow-up to the F10 menu-focus work (#11759) for #11745.

## Problem
F10 moves keyboard focus into the main menu, but the window's key handler is registered with `RoutingStrategies.Tunnel` (`MainView.cs`), so it — and the shortcut manager it calls — run **before** the focused menu item. Any arrow/Enter/Escape key that matches a configured shortcut was therefore consumed as a shortcut and never reached the menu, so keyboard menu navigation (notably **Left/Right between top-level menus**, the most-requested improvement in the issue thread) didn't actually work even after F10.

## Fix
Add an `IsMainMenuFocused()` guard in `OnKeyDownHandler`: when focus is on the `Menu` or a `MenuItem`, return early (without marking the event handled) so the key tunnels on to the focused menu and Avalonia's built-in menu navigation takes over. Mirrors the existing `IsTextInputFocused` early-out.

Drop-down items live in a popup (outside the menu's visual subtree), so a focused `MenuItem` is detected directly rather than via a visual-parent walk; the walk remains as a fallback for the top-level bar.

## Scope
Main window only — that's the only window with a menu bar. No behavior change when the menu isn't focused (shortcuts work exactly as before). Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)