### PR TITLE
Fix Tesseract OCR blanking coloured subtitle text, and surface errors

### DIFF
--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -189,6 +189,26 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
+        /// <summary>
+        /// Binarizes the image for OCR: bright, sufficiently opaque pixels (the subtitle text)
+        /// become black, everything else becomes white. Keys on overall brightness (the max of the
+        /// R/G/B channels) rather than a single channel, so coloured text such as yellow or red is
+        /// kept instead of being dropped — unlike <see cref="MakeOneColor"/>, which only looks at
+        /// the blue channel and blanks low-blue text.
+        /// </summary>
+        public void MakeBlackAndWhiteForOcr(int brightnessThreshold = 90, int alphaThreshold = 100)
+        {
+            var black = new byte[] { 0, 0, 0, 255 };
+            var white = new byte[] { 255, 255, 255, 255 };
+            for (int i = 0; i < _bitmapData.Length; i += 4)
+            {
+                // _bitmapData is BGRA: [i]=blue, [i+1]=green, [i+2]=red, [i+3]=alpha.
+                var brightness = Math.Max(_bitmapData[i], Math.Max(_bitmapData[i + 1], _bitmapData[i + 2]));
+                var isText = _bitmapData[i + 3] >= alphaThreshold && brightness >= brightnessThreshold;
+                Buffer.BlockCopy(isText ? black : white, 0, _bitmapData, i, 4);
+            }
+        }
+
         private static SKColor GetOutlineColor(SKColor borderColor)
         {
             if (borderColor.Red + borderColor.Green + borderColor.Blue < 30)

--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -102,7 +102,18 @@ public class TesseractOcr
 
 #pragma warning disable CA1416 // Validate platform compatibility
             using var process = new Process { StartInfo = psi };
-            process.Start();
+            try
+            {
+                process.Start();
+            }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                Error = $"Could not start Tesseract at \"{_executablePath}\": {ex.Message}." +
+                        (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                            ? string.Empty
+                            : " Make sure Tesseract is installed (e.g. \"brew install tesseract\" on macOS, \"apt install tesseract-ocr\" on Linux).");
+                return string.Empty;
+            }
 #pragma warning restore CA1416 // Validate platform compatibility
 
             var stderrTask = process.StandardError.ReadToEndAsync(CancellationToken.None);

--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -62,10 +62,10 @@ public class TesseractOcr
             _executablePath = GetExecutablePath();
         }
 
-        // Preprocess image: make black and white (black text on white background)
+        // Preprocess image: binarize to black text on white. Keys on brightness so coloured text
+        // (e.g. yellow) is kept rather than blanked the way the blue-only MakeOneColor did.
         var nbmp = new NikseBitmap(bitmap);
-        nbmp.MakeOneColor(SKColors.Black);
-        nbmp.ReplaceTransparentWith(SKColors.White);
+        nbmp.MakeBlackAndWhiteForOcr();
         using var oneColorBitmap = nbmp.GetBitmap();
 
         var tempImage = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.png");
@@ -80,7 +80,8 @@ public class TesseractOcr
             Se.WriteToolsLog($"Tesseract OCR: input {oneColorBitmap.Width}x{oneColorBitmap.Height}, ink={inkPercent:0.0}% (0% = preprocessing blanked the text), lang={language}, oem={engineMode}");
             try
             {
-                var debugCopy = Path.Combine(Path.GetDirectoryName(Se.GetToolsLogFilePath()) ?? Path.GetTempPath(), "tesseract-input.png");
+                var logDir = Path.GetDirectoryName(Se.GetToolsLogFilePath()) ?? Path.GetTempPath();
+                var debugCopy = Path.Combine(logDir, "tesseract-input.png");
                 await File.WriteAllBytesAsync(debugCopy, oneColorBitmap.ToPngArray(), cancellationToken);
                 Se.WriteToolsLog($"Tesseract OCR: saved preprocessed image to {debugCopy}");
             }

--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -71,6 +71,25 @@ public class TesseractOcr
         var tempImage = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.png");
         var tempTextFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
+        // When the tools log is on, record what Tesseract is actually fed: how much "ink" survived
+        // the black/white preprocessing (0% means the text was blanked, e.g. coloured subtitles) and
+        // a copy of the exact image, so blank output can be diagnosed without guessing.
+        if (Se.Settings.Tools.WriteToolsLog)
+        {
+            var inkPercent = GetInkPercent(nbmp);
+            Se.WriteToolsLog($"Tesseract OCR: input {oneColorBitmap.Width}x{oneColorBitmap.Height}, ink={inkPercent:0.0}% (0% = preprocessing blanked the text), lang={language}, oem={engineMode}");
+            try
+            {
+                var debugCopy = Path.Combine(Path.GetDirectoryName(Se.GetToolsLogFilePath()) ?? Path.GetTempPath(), "tesseract-input.png");
+                await File.WriteAllBytesAsync(debugCopy, oneColorBitmap.ToPngArray(), cancellationToken);
+                Se.WriteToolsLog($"Tesseract OCR: saved preprocessed image to {debugCopy}");
+            }
+            catch
+            {
+                // ignore debug-save failures
+            }
+        }
+
         try
         {
             await File.WriteAllBytesAsync(tempImage, oneColorBitmap.ToPngArray(), cancellationToken);
@@ -128,9 +147,17 @@ public class TesseractOcr
             }
 
             var stderr = await stderrTask;
+            if (Se.Settings.Tools.WriteToolsLog)
+            {
+                Se.WriteToolsLog($"Tesseract OCR: exit={process.ExitCode}" +
+                                 (string.IsNullOrWhiteSpace(stderr) ? string.Empty : " stderr=" + stderr.Trim()));
+            }
+
             if (process.ExitCode != 0)
             {
-                Error = stderr;
+                Error = string.IsNullOrWhiteSpace(stderr)
+                    ? $"Tesseract exited with code {process.ExitCode}."
+                    : stderr.Trim();
                 return string.Empty;
             }
         }
@@ -176,6 +203,32 @@ public class TesseractOcr
                 // Ignore cleanup errors
             }
         }
+    }
+
+    // Percentage of dark "ink" pixels in the preprocessed (black-on-white) image. ~0% means the
+    // black/white conversion blanked the text (e.g. coloured subtitles), which yields empty OCR.
+    private static double GetInkPercent(NikseBitmap nbmp)
+    {
+        long total = (long)nbmp.Width * nbmp.Height;
+        if (total == 0)
+        {
+            return 0;
+        }
+
+        long ink = 0;
+        for (var y = 0; y < nbmp.Height; y++)
+        {
+            for (var x = 0; x < nbmp.Width; x++)
+            {
+                var c = nbmp.GetPixel(x, y);
+                if (c.Alpha > 0 && c.Red < 128 && c.Green < 128 && c.Blue < 128)
+                {
+                    ink++;
+                }
+            }
+        }
+
+        return ink * 100.0 / total;
     }
 
     private static string ParseHOcr(string html)

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3575,12 +3575,14 @@ public partial class OcrViewModel : ObservableObject
 
                 // Tesseract exited cleanly but every line came back empty — that is almost never the
                 // intent, so tell the user instead of leaving a grid full of blank lines.
-                if (processedCount > 1 && !producedAnyText && !cancellationToken.IsCancellationRequested)
+                if (processedCount >= 1 && !producedAnyText && !cancellationToken.IsCancellationRequested)
                 {
                     await ShowTesseractErrorAsync(
-                        "Tesseract returned no text for any of the " + processedCount + " lines." + Environment.NewLine +
+                        "Tesseract returned no text for " +
+                        (processedCount == 1 ? "the line." : "any of the " + processedCount + " lines.") + Environment.NewLine +
                         "The subtitle images may not suit Tesseract (e.g. coloured text), or the selected language (" +
-                        language + ") may be wrong. Try another OCR engine or language.");
+                        language + ") may be wrong. Try another OCR engine or language." + Environment.NewLine +
+                        "Enable Options > Tools > write tools log for details.");
                 }
             }
             catch (OperationCanceledException)

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3527,36 +3527,92 @@ public partial class OcrViewModel : ObservableObject
 
         _ = Task.Run(async () =>
         {
-            for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
+            var processedCount = 0;
+            var producedAnyText = false;
+            try
             {
-                var i = selectedIndices[processedIndex];
-                if (cancellationToken.IsCancellationRequested)
+                for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
                 {
-                    return;
-                }
-
-                UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
-
-                var item = OcrSubtitleItems[i];
-                var bitmap = item.GetSkBitmap();
-
-                var text = await tesseractOcr.Ocr(bitmap, language, tessDataFolder, cancellationToken, engineMode);
-                item.Text = text;
-
-                var unknownWords = OcrFixLineAndSetText(i, item);
-
-                if (DoPromptForUnknownWords && unknownWords.Count > 0)
-                {
-                    var keepRunning = await PromptForUnknownWordsAsync(i, item);
-                    if (!keepRunning)
+                    var i = selectedIndices[processedIndex];
+                    if (cancellationToken.IsCancellationRequested)
                     {
                         return;
                     }
+
+                    UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
+
+                    var item = OcrSubtitleItems[i];
+                    var bitmap = item.GetSkBitmap();
+
+                    var text = await tesseractOcr.Ocr(bitmap, language, tessDataFolder, cancellationToken, engineMode);
+
+                    // Surface a real Tesseract failure instead of silently filling the grid with blank lines.
+                    if (string.IsNullOrEmpty(text) && !string.IsNullOrEmpty(tesseractOcr.Error))
+                    {
+                        await ShowTesseractErrorAsync(tesseractOcr.Error);
+                        return;
+                    }
+
+                    processedCount++;
+                    if (!string.IsNullOrWhiteSpace(text))
+                    {
+                        producedAnyText = true;
+                    }
+
+                    item.Text = text;
+
+                    var unknownWords = OcrFixLineAndSetText(i, item);
+
+                    if (DoPromptForUnknownWords && unknownWords.Count > 0)
+                    {
+                        var keepRunning = await PromptForUnknownWordsAsync(i, item);
+                        if (!keepRunning)
+                        {
+                            return;
+                        }
+                    }
+                }
+
+                // Tesseract exited cleanly but every line came back empty — that is almost never the
+                // intent, so tell the user instead of leaving a grid full of blank lines.
+                if (processedCount > 1 && !producedAnyText && !cancellationToken.IsCancellationRequested)
+                {
+                    await ShowTesseractErrorAsync(
+                        "Tesseract returned no text for any of the " + processedCount + " lines." + Environment.NewLine +
+                        "The subtitle images may not suit Tesseract (e.g. coloured text), or the selected language (" +
+                        language + ") may be wrong. Try another OCR engine or language.");
                 }
             }
-
-            PauseOcr();
+            catch (OperationCanceledException)
+            {
+                // Cancelled by the user.
+            }
+            catch (Exception ex)
+            {
+                SeLogger.Error(ex, "Error running Tesseract OCR");
+                await ShowTesseractErrorAsync(tesseractOcr.Error is { Length: > 0 } e ? e : ex.Message);
+            }
+            finally
+            {
+                PauseOcr();
+            }
         });
+    }
+
+    private async Task ShowTesseractErrorAsync(string error)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await Dispatcher.UIThread.InvokeAsync(async () =>
+            await MessageBox.Show(
+                Window!,
+                Se.Language.General.Error,
+                "Tesseract OCR failed:" + Environment.NewLine + Environment.NewLine + error,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error));
     }
 
     private void RunOllamaOcr(List<int> selectedIndices, CancellationToken cancellationToken)

--- a/tests/libse/Common/NikseBitmapOcrBinarizeTest.cs
+++ b/tests/libse/Common/NikseBitmapOcrBinarizeTest.cs
@@ -1,0 +1,34 @@
+using Nikse.SubtitleEdit.Core.Common;
+using SkiaSharp;
+
+namespace LibSETests.Common;
+
+public class NikseBitmapOcrBinarizeTest
+{
+    // Bright subtitle text of any colour (white, yellow, red, …) must survive the OCR binarization
+    // as black "ink"; the dark/transparent background must become white. The old MakeOneColor keyed
+    // only on the blue channel, so yellow/red text (blue ≈ 0) was blanked entirely.
+    [Fact]
+    public void MakeBlackAndWhiteForOcr_KeepsColouredTextAsBlack()
+    {
+        using var bmp = new SKBitmap(new SKImageInfo(5, 1, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+        bmp.SetPixel(0, 0, new SKColor(255, 255, 255)); // white text
+        bmp.SetPixel(1, 0, new SKColor(255, 255, 0));   // yellow text
+        bmp.SetPixel(2, 0, new SKColor(255, 0, 0));     // red text
+        bmp.SetPixel(3, 0, new SKColor(0, 0, 0));       // black background
+        bmp.SetPixel(4, 0, new SKColor(0, 0, 0, 0));    // transparent background
+
+        var nbmp = new NikseBitmap(bmp);
+        nbmp.MakeBlackAndWhiteForOcr();
+
+        Assert.True(IsBlack(nbmp.GetPixel(0, 0)), "white text should become black ink");
+        Assert.True(IsBlack(nbmp.GetPixel(1, 0)), "yellow text should become black ink");
+        Assert.True(IsBlack(nbmp.GetPixel(2, 0)), "red text should become black ink");
+        Assert.True(IsWhite(nbmp.GetPixel(3, 0)), "black background should become white");
+        Assert.True(IsWhite(nbmp.GetPixel(4, 0)), "transparent background should become white");
+    }
+
+    private static bool IsBlack(SKColor c) => c.Red < 64 && c.Green < 64 && c.Blue < 64;
+
+    private static bool IsWhite(SKColor c) => c.Red > 192 && c.Green > 192 && c.Blue > 192;
+}


### PR DESCRIPTION
Tesseract OCR failing produced **blank lines with no message**. `RunTesseractOcr` ignored `TesseractOcr.Error` and ran its work in a fire-and-forget `Task.Run` with no try/catch — so a failure (missing binary, bad tessdata/language, or any exception) silently filled the grid with empty lines, and a thrown exception even skipped `PauseOcr` (leaving it stuck).

## Changes
- **Show the actual Tesseract error** when it reports one, and wrap the run in `try/catch/finally` so exceptions are surfaced and `PauseOcr` always runs.
- **All-empty run hint**: when Tesseract exits cleanly but returns no text for every line, tell the user (likely coloured text or wrong language) instead of leaving blank lines.
- **Friendly "can't start" message** if the executable fails to launch (e.g. `brew install tesseract` on macOS).

## Notes on macOS
There's no Tesseract installer for macOS/Linux (only Windows has the in-app downloader) — they use the system install, which is probed across the usual paths and PATH. Verified locally: `tesseract 5.5.1` is installed and SE's exact OCR command produces correct hOCR, so the binary/data/parser are fine; this PR makes the *reason* for any blank output visible. A likely silent-blank cause for coloured subtitles is the blue-channel-keyed `NikseBitmap.MakeOneColor` preprocessing — to be addressed separately once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)