### PR TITLE
Fix EBU STL export writing a blank Display Standard Code

### DIFF
--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
@@ -311,11 +311,11 @@ public partial class ExportEbuStlViewModel : ObservableObject
         {
             _header.DisplayStandardCode = "0";
         }
-        if (SelectedDisplayStandardCode != null && SelectedDisplayStandardCode.StartsWith("1"))
+        else if (SelectedDisplayStandardCode != null && SelectedDisplayStandardCode.StartsWith("1"))
         {
             _header.DisplayStandardCode = "1";
         }
-        if (SelectedDisplayStandardCode != null && SelectedDisplayStandardCode.StartsWith("2"))
+        else if (SelectedDisplayStandardCode != null && SelectedDisplayStandardCode.StartsWith("2"))
         {
             _header.DisplayStandardCode = "2";
         }


### PR DESCRIPTION
Reported by email (Guido Venditti): EBU STL exports fail to import in Premiere Pro because the **Display Standard Code** (GSI byte 11) is always blank, regardless of the option chosen.

## Cause
In `ExportEbuStlViewModel`, the DSC was set with three **separate** `if` statements where only the third had an `else`:

```csharp
if (...StartsWith("0")) { _header.DisplayStandardCode = "0"; }
if (...StartsWith("1")) { _header.DisplayStandardCode = "1"; }
if (...StartsWith("2")) { _header.DisplayStandardCode = "2"; }
else                    { _header.DisplayStandardCode = " "; }   // ran for "0" and "1" too
```

The dangling `else` belongs only to the `"2"` check, so it fired for any non-"2" selection and overwrote the value back to a blank space:

| Selected | Result |
|---|---|
| **0 Open subtitling** | blank ❌ |
| **1 Level-1 teletext** | blank ❌ |
| 2 Level-2 teletext | "2" ✅ |
| Undefined | blank (intended) |

The GSI serializer itself was fine.

## Fix
Make the branches mutually exclusive (`else if`) so the selected code is preserved. Repro/verify: export with **"0 Open subtitling"** selected — byte 11 of the GSI header is now `0` instead of a space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)