### PR TITLE
Fix CJK UI rendering as boxes on macOS/Windows (only force Inter on Linux)

### DIFF
--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -71,14 +71,21 @@ namespace Nikse.SubtitleEdit
 
                 // Build and configure the app
                 var appBuilder = AppBuilder.Configure<Application>()
-                    .UsePlatformDetect()
-                    // Register the embedded Inter font as the default. Avalonia v12's font manager
-                    // throws "Could not create glyphTypeface. Font family: $Default" at startup on
-                    // minimal Linux installs that ship without fontconfig-discoverable fonts
-                    // (e.g. Debian 13 trixie base — issue #11355). With Inter registered, FontFamily.Default
-                    // resolves to the embedded font when no system font is available; healthy systems
-                    // still pick up their own fonts for explicit family names.
-                    .WithInterFont()
+                    .UsePlatformDetect();
+
+                // Register the embedded Inter font as the default ONLY on Linux. Avalonia v12's font
+                // manager throws "Could not create glyphTypeface. Font family: $Default" at startup on
+                // minimal Linux installs that ship without fontconfig-discoverable fonts
+                // (e.g. Debian 13 trixie base — issue #11355). Forcing Inter as the default on macOS and
+                // Windows, however, overrides the system font and its CJK fallback, so Korean/Japanese/
+                // Chinese UI text renders as boxes (Inter has no CJK glyphs). Those platforms always have
+                // system fonts with proper fallback, so let them use the system default there.
+                if (OperatingSystem.IsLinux())
+                {
+                    appBuilder = appBuilder.WithInterFont();
+                }
+
+                appBuilder = appBuilder
                     .With(new X11PlatformOptions
                     {
                         RenderingMode = new[] { X11RenderingMode.Glx, X11RenderingMode.Egl }


### PR DESCRIPTION
Reported by email: a Korean user on **macOS v5.0.0** sees the whole UI/menu as boxes (□) — the Korean translation loads, but no glyphs render. Same happens for any CJK (Korean/Japanese/Chinese) UI language on macOS and Windows.

## Cause
`Program.cs` called `.WithInterFont()`, which makes the embedded **Inter** font the app's *default* UI family (`FontFamily.Default`). Inter has **no CJK glyphs**, and there is **no `FontManagerOptions.FontFallbacks`** configured — so CJK text becomes tofu. macOS/Windows ship CJK fonts (Apple SD Gothic Neo / Malgun Gothic) that would render it, but forcing Inter as the default overrides the system font and its fallback.

Inter was only added to avoid a *startup crash* on minimal Linux installs without fontconfig-discoverable fonts (#11355: "Could not create glyphTypeface. Font family: $Default").

## Fix
Apply `.WithInterFont()` **only on Linux**. macOS and Windows always have system fonts with proper CJK fallback, so they now use the system default and render Korean/Japanese/Chinese correctly. The Linux crash fix is unchanged.

Trade-off: the UI font on macOS/Windows reverts from Inter to the native system font (San Francisco / Segoe UI) — a small, arguably more-native visual change.

## Notes / follow-up
- Linux CJK on minimal installs (where Inter is the only font) would still show boxes; that needs a Noto Sans CJK fallback and is a separate, smaller change.
- I couldn't reproduce a Korean locale visually here, but the mechanism is standard Avalonia behaviour (system font fallback applies once the default isn't pinned to Inter). Build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)