### PR TITLE
Add CJK font fallbacks on Linux

### DIFF
--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -2,6 +2,8 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
 using Avalonia.Threading;
@@ -82,7 +84,24 @@ namespace Nikse.SubtitleEdit
                 // system fonts with proper fallback, so let them use the system default there.
                 if (OperatingSystem.IsLinux())
                 {
-                    appBuilder = appBuilder.WithInterFont();
+                    // Inter is the default here, but it has no CJK glyphs and Avalonia does not fall
+                    // back to system fonts from a forced embedded default - so name the common Linux
+                    // CJK families explicitly. fontconfig resolves whichever of these is installed
+                    // (normal desktops ship Noto Sans CJK); minimal installs have no CJK font at all,
+                    // so CJK can't render there regardless.
+                    appBuilder = appBuilder
+                        .WithInterFont()
+                        .With(new FontManagerOptions
+                        {
+                            FontFallbacks = new[]
+                            {
+                                new FontFallback { FontFamily = new FontFamily("Noto Sans CJK SC") },
+                                new FontFallback { FontFamily = new FontFamily("Noto Sans CJK KR") },
+                                new FontFallback { FontFamily = new FontFamily("Noto Sans CJK JP") },
+                                new FontFallback { FontFamily = new FontFamily("Noto Sans CJK TC") },
+                                new FontFallback { FontFamily = new FontFamily("WenQuanYi Zen Hei") },
+                            }
+                        });
                 }
 
                 appBuilder = appBuilder


### PR DESCRIPTION
Follow-up to #11831, which fixed CJK UI rendering on **macOS/Windows** by no longer forcing the embedded Inter font as the default there (so the OS provides system CJK fallback).

**Linux still needs Inter as the default** — it's the whole reason it's registered (the #11355 startup crash on minimal installs with no fontconfig-discoverable fonts). And Avalonia 12 does **not** fall back to system fonts from a forced embedded default, so Korean/Japanese/Chinese UI text would still render as boxes on Linux.

## Fix
On the Linux path, add explicit `FontManagerOptions.FontFallbacks` naming the common Linux CJK families (Noto Sans CJK SC/KR/JP/TC, WenQuanYi Zen Hei). fontconfig resolves whichever is installed, so installed CJK fonts now render the UI.

## Caveats
- Works only if a CJK font is installed. Normal desktops ship Noto Sans CJK; the *minimal* installs that triggered #11355 have no CJK font at all, so CJK can't render there regardless — that's an OS-level "install fonts" matter, not something SE can embed (full Noto CJK is tens of MB).
- macOS/Windows are unchanged (system fallback already covers them).
- Reasoned from Avalonia's named-fallback resolution; I couldn't visually verify on a Linux box with a CJK locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)