### PR TITLE
AudioVisualizer: two micro-opts in the per-frame time ruler

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1750,43 +1750,49 @@ public class AudioVisualizer : Control
             return;
         }
 
-        var seconds = Math.Ceiling(renderCtx.StartPositionSeconds) - renderCtx.StartPositionSeconds;
-        var position = SecondsToXPositionOptimized(seconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+        // Hoist loop-invariants: renderCtx is a ref struct, and n (pixels per second) was being
+        // recomputed every iteration. With sampleRate != 0 guaranteed above, SecondsToXPositionOptimized
+        // reduces to Math.Round(seconds * n), so inline it.
+        var startPosSeconds = renderCtx.StartPositionSeconds;
+        var n = renderCtx.ZoomFactor * renderCtx.SampleRate;
         var imageHeight = renderCtx.Height;
         var width = renderCtx.Width;
+
+        var seconds = Math.Ceiling(startPosSeconds) - startPosSeconds;
+        var position = (int)Math.Round(seconds * n, MidpointRounding.AwayFromZero);
 
         var majorTicks = _timeLineMajorTicks;
         var minorTicks = _timeLineMinorTicks;
         majorTicks.Clear();
         minorTicks.Clear();
 
+        var drawMinor = n > 64;
+
         // Collect ticks first; draw text directly with cached FormattedText (single
         // DrawText call per label is fine — the per-frame cost was the FormattedText
         // allocation, not the DrawText call).
         while (position < width)
         {
-            var n = renderCtx.ZoomFactor * renderCtx.SampleRate;
-
-            if (n > 38 || (int)Math.Round(renderCtx.StartPositionSeconds + seconds) % 5 == 0)
+            if (n > 38 || (int)Math.Round(startPosSeconds + seconds) % 5 == 0)
             {
                 majorTicks.Add(new FancyLine(position, imageHeight - 10, imageHeight));
 
-                var timeText = GetDisplayTime(renderCtx.StartPositionSeconds + seconds);
+                var timeText = GetDisplayTime(startPosSeconds + seconds);
                 var formattedText = GetCachedTimeLineText(timeText);
                 var textY = Math.Max(0, imageHeight - formattedText.Height - 2);
                 context.DrawText(formattedText, new Point(position + 2, textY));
             }
 
             seconds += 0.5;
-            position = SecondsToXPositionOptimized(seconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+            position = (int)Math.Round(seconds * n, MidpointRounding.AwayFromZero);
 
-            if (n > 64)
+            if (drawMinor)
             {
                 minorTicks.Add(new FancyLine(position, imageHeight - 5, imageHeight));
             }
 
             seconds += 0.5;
-            position = SecondsToXPositionOptimized(seconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+            position = (int)Math.Round(seconds * n, MidpointRounding.AwayFromZero);
         }
 
         DrawVerticalLineBatch(context, _paintTimeLine, majorTicks);
@@ -1824,11 +1830,17 @@ public class AudioVisualizer : Control
             startFrame = 0;
         }
 
+        // The x position is linear in the frame index: x = absFrame * pixelsPerFrame -
+        // startPixelOffset. Precompute the invariants so each tick is a multiply-subtract instead of
+        // a per-tick division + SecondsToXPositionOptimized call (which re-reads the ref-struct
+        // renderCtx fields). invFps is only needed for the visible labels' time value.
+        var startPixelOffset = renderCtx.StartPositionSeconds * renderCtx.SampleRate * renderCtx.ZoomFactor;
+        var invFps = 1.0 / fps;
+
         var firstAbsFrame = startFrame - startFrame % majorStepFrames;
         for (var absFrame = firstAbsFrame; ; absFrame += majorStepFrames)
         {
-            var relSeconds = absFrame / fps - renderCtx.StartPositionSeconds;
-            var xPosition = SecondsToXPositionOptimized(relSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+            var xPosition = (int)Math.Round(absFrame * pixelsPerFrame - startPixelOffset, MidpointRounding.AwayFromZero);
             if (xPosition >= width)
             {
                 break;
@@ -1838,7 +1850,7 @@ public class AudioVisualizer : Control
             {
                 majorTicks.Add(new FancyLine(xPosition, imageHeight - 10, imageHeight));
 
-                var timeText = GetFrameDisplayTime(absFrame / fps);
+                var timeText = GetFrameDisplayTime(absFrame * invFps);
                 var formattedText = GetCachedTimeLineText(timeText);
                 var textY = Math.Max(0, imageHeight - formattedText.Height - 2);
                 context.DrawText(formattedText, new Point(xPosition + 2, textY));
@@ -1846,8 +1858,7 @@ public class AudioVisualizer : Control
 
             if (minorStepFrames > 0)
             {
-                var minorRelSeconds = (absFrame + minorStepFrames) / fps - renderCtx.StartPositionSeconds;
-                var minorX = SecondsToXPositionOptimized(minorRelSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+                var minorX = (int)Math.Round((absFrame + minorStepFrames) * pixelsPerFrame - startPixelOffset, MidpointRounding.AwayFromZero);
                 if (minorX >= 0 && minorX < width)
                 {
                     minorTicks.Add(new FancyLine(minorX, imageHeight - 5, imageHeight));


### PR DESCRIPTION
Two more micro-opts, this time in the time-ruler builders, which run on **every render** (unlike the now-cached waveform).

### 1. Time-based ruler (`BuildTimeLine`)
`n = renderCtx.ZoomFactor * renderCtx.SampleRate` was recomputed **every loop iteration** despite being loop-invariant. Hoisted it (and the ref-struct field reads), and since `sampleRate != 0` is already guaranteed, inlined `SecondsToXPositionOptimized` to `Math.Round(seconds * n)`. The `n > 64` minor-tick test is also constant, so lifted out of the loop.

### 2. Frame-aligned ruler (`DrawFrameAlignedTimeLine`)
Each tick computed `SecondsToXPositionOptimized(absFrame / fps - startPos, ...)` — a division plus a call that re-reads `renderCtx` per tick. The x position is linear in the frame index, so use the already-computed `pixelsPerFrame`:
```csharp
x = absFrame * pixelsPerFrame - startPixelOffset;   // multiply-subtract, no division/call
```

Both behaviour-preserving (same `AwayFromZero` rounding; `sampleRate == 0` is guarded upstream).

### Scope / honesty note
These are **smaller** than the per-pixel waveform loop wins (#11833/#11834): the ruler loops run only ~tens of ticks per frame, and the real per-frame cost there is text layout (already cached), not this arithmetic. I didn't benchmark them in isolation because the arithmetic is a negligible fraction of the ruler's cost — the value is removing redundant per-iteration work (notably the invariant `n` recompute) on the render path. If you'd prefer to stop here rather than chase further diminishing returns in this file, that's reasonable — the impactful hot loop is already done.