### PR TITLE
Prep Flathub submission: git-source manifest + refresh metainfo releases

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
+++ b/installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
@@ -74,6 +74,12 @@
   </screenshots>
 
   <releases>
+    <release version="5.0.0" date="2026-06-22">
+      <url>https://github.com/SubtitleEdit/subtitleedit/releases/tag/v5.0.0</url>
+      <description>
+        <p>First stable cross-platform release of Subtitle Edit 5, based on Avalonia UI.</p>
+      </description>
+    </release>
     <release version="5.0.0-beta9" date="2026-03-19">
       <description>
         <p>Initial cross-platform release based on Avalonia UI.</p>

--- a/installer/flatpak/flathub/README.md
+++ b/installer/flatpak/flathub/README.md
@@ -1,0 +1,51 @@
+# Flathub submission
+
+This folder holds the **Flathub-ready** variant of the Flatpak manifest. It differs from the
+CI manifest (`../dk.nikse.subtitleedit.yaml`, which builds from a local `type: dir` checkout)
+only in the app source: Flathub builds from the public repository at a pinned release tag +
+commit.
+
+Everything else (bundled mpv/ffmpeg/tesseract+eng, offline NuGet restore, desktop/metainfo/icon/
+license install) is identical and already validated in CI by `.github/workflows/build-flatpak.yml`.
+
+## Files
+- `dk.nikse.subtitleedit.yaml` — the manifest to submit (git source, pinned to a tag + commit).
+- `nuget-sources.json` — offline NuGet packages. **Must be regenerated for the pinned commit.**
+
+The `.desktop`, `.metainfo.xml` and icon are installed from the git checkout during the build, so
+they do not need to be copied here.
+
+## Before submitting
+1. **Pin the release.** Set `tag:` and `commit:` in the manifest to the release you want to ship
+   (currently `v5.0.0` / `a44ffa7025b59f424aa8a5a7ee250ea85c4c1361`).
+2. **Regenerate `nuget-sources.json`** for that exact commit:
+   ```sh
+   git checkout v5.0.0
+   installer/flatpak/generate-nuget-sources.sh
+   cp installer/flatpak/nuget-sources.json installer/flatpak/flathub/nuget-sources.json
+   ```
+3. **Validate** (on Linux, or rely on the Flathub bot):
+   ```sh
+   appstreamcli validate installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
+   flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest \
+     installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+   ```
+
+## Submitting
+1. Fork `https://github.com/flathub/flathub`.
+2. Create a branch **named exactly `dk.nikse.subtitleedit`**.
+3. Add `dk.nikse.subtitleedit.yaml` and `nuget-sources.json` at the repo root of that branch.
+4. Open a PR against the **`new-pr`** branch of `flathub/flathub`. A bot builds it; reviewers review.
+5. On acceptance, Flathub creates the `flathub/dk.nikse.subtitleedit` repo (you maintain it there).
+   Push updates / let the auto-update bot PR on new GitHub releases.
+6. Verify the app on flathub.org (prove ownership of `nikse.dk` or the GitHub org).
+
+## Likely review questions (be ready)
+- **Runtime downloads of executables** (whisper.cpp, CrispASR, TTS/STT). Core editing, OCR (bundled
+  Tesseract) and video (bundled mpv/ffmpeg) work offline; the optional AI engines fetch executables
+  at runtime, which Flathub scrutinizes. Justify as optional + user-initiated into the app data dir,
+  or expect to limit/disable those under the sandbox.
+- **`--filesystem=home` + `--share=network`** — broad but standard for an editor with online services.
+- **App-id `dk.nikse.subtitleedit`** — fine if `nikse.dk` is verified later on flathub.org;
+  `io.github.SubtitleEdit.subtitleedit` is the easier-to-verify alternative (but renaming the app-id
+  touches the desktop/metainfo/icon filenames and the settings directory).

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -1,0 +1,375 @@
+app-id: dk.nikse.subtitleedit
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.dotnet10
+command: SubtitleEdit
+
+# Make the dotnet10 SDK tools available to every module at build time
+build-options:
+  append-path: /usr/lib/sdk/dotnet10/bin
+  append-ld-library-path: /app/lib:/usr/lib/sdk/dotnet10/lib
+  no-debuginfo: true
+  env:
+    PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
+
+finish-args:
+  # Display
+  - --share=ipc
+  - --socket=wayland
+  - --socket=x11
+  # Hardware acceleration
+  - --device=dri
+  # File access (subtitle files are typically in the home directory)
+  - --filesystem=home
+  # Network (optional online services: translation, TTS, speech-to-text, etc.)
+  - --share=network
+  # Audio (video playback via mpv)
+  - --socket=pulseaudio
+  # .NET single-file bundle extraction directory (persistent cache)
+  - --env=DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/cache/.net
+
+cleanup:
+  - '*.la'
+  - '*.a'
+
+modules:
+  # --- libmpv dependencies ---
+
+  - name: harfbuzz
+    buildsystem: meson
+    config-opts:
+      - -Ddocs=disabled
+      - -Dtests=disabled
+      - -Dintrospection=disabled
+      - -Dutilities=disabled
+      - -Dfreetype=enabled
+      - -Dglib=disabled
+      - -Dgobject=disabled
+      - -Dcairo=disabled
+      - -Dicu=disabled
+      - -Dgraphite2=disabled
+      - -Dc_link_args=-lstdc++
+    cleanup:
+      - /bin
+      - /include
+      - /lib/cmake
+      - /lib/libharfbuzz-subset.so*
+      - /lib/pkgconfig/harfbuzz-subset.pc
+      - /share
+    sources:
+      - type: git
+        url: https://github.com/harfbuzz/harfbuzz.git
+        tag: 8.3.1
+        commit: 985366b8b2a4e7e07413af918612334d6764a287
+
+  - name: libass
+    config-opts:
+      - --disable-static
+      - --enable-asm
+      - --enable-fontconfig
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/libass/libass.git
+        tag: 0.17.4
+        commit: bbb3c7f1570a4a021e52683f3fbdf74fe492ae84
+
+  - name: uchardet
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_STATIC=0
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: archive
+        url: https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz
+        sha256: e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0
+
+  - name: libplacebo
+    buildsystem: meson
+    config-opts:
+      - -Dvulkan=enabled
+      - -Dshaderc=enabled
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/haasn/libplacebo.git
+        tag: v7.360.1
+        commit: cee9b076f2c63104ccfd497fa79c39a867293ec4
+
+  - name: rubberband
+    buildsystem: meson
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/breakfastquay/rubberband.git
+        tag: v4.0.0
+        commit: 1d95888bec3ae0a17c0c4af791810d5a63f6bc35
+
+  - name: mujs
+    no-autogen: true
+    make-args:
+      - release
+    make-install-args:
+      - prefix=/app
+      - install-shared
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://codeberg.org/ccxvii/mujs.git
+        tag: 1.3.8
+        commit: 307f18c4216420f2f56e22d8e7040baa39a6304a
+      - type: file
+        url: https://www.unicode.org/Public/16.0.0/ucd/UnicodeData.txt
+        sha256: ff58e5823bd095166564a006e47d111130813dcf8bf234ef79fa51a870edb48f
+      - type: file
+        url: https://www.unicode.org/Public/16.0.0/ucd/SpecialCasing.txt
+        sha256: 8d5de354eef79f2395a54c9c7dcebbaf3d30fc962d0f85611ea97aa973a0c451
+
+  # --- x264 encoder (needed for burn-in, blank video generation) ---
+
+  - name: x264
+    config-opts:
+      - --disable-cli
+      - --enable-shared
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://code.videolan.org/videolan/x264.git
+        commit: 0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee
+
+  # --- ffmpeg with rubberband + x264 + libass (overrides platform ffmpeg) ---
+
+  - name: ffmpeg
+    config-opts:
+      - --disable-debug
+      - --disable-doc
+      - --disable-static
+      - --enable-shared
+      - --enable-gnutls
+      - --enable-gpl
+      - --enable-version3
+      - --enable-libass
+      - --enable-libdav1d
+      - --enable-libfreetype
+      - --enable-libmp3lame
+      - --enable-libopus
+      - --enable-librubberband
+      - --enable-libtheora
+      - --enable-libv4l2
+      - --enable-libvorbis
+      - --enable-libvpx
+      - --enable-libwebp
+      - --enable-libx264
+      - --enable-libxml2
+      - --enable-vulkan
+      - --enable-encoder=png
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/ffmpeg/examples
+    sources:
+      - type: git
+        url: https://github.com/FFmpeg/FFmpeg.git
+        tag: n7.1.2
+        commit: 7003a8c4544b780eb0ab5c02ac4ad89d2132f2a2
+
+  - name: libXpresent
+    buildsystem: autotools
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/xorg/lib/libxpresent.git
+        tag: libXpresent-1.0.2
+        commit: 4d92149372461bf575e8a09b1064a2884c38c3aa
+
+  - name: hwdata
+    buildsystem: autotools
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v0.394.tar.gz
+        sha256: b7c3fd7214a3b7c49d2661db127a712dc11cffd1799f793947aa1cb20aaf3298
+
+  - name: libdisplay-info
+    buildsystem: meson
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/0.2.0/libdisplay-info-0.2.0.tar.gz
+        sha256: f7331fcaf5527251b84c8fb84238d06cd2f458422ce950c80e86c72927aa8c2b
+
+  # --- libmpv (video player library, no standalone player binary needed) ---
+
+  - name: libmpv
+    buildsystem: meson
+    config-opts:
+      - -Dlibmpv=true
+      - -Dcplayer=false
+      - -Dbuild-date=false
+      - -Dmanpage-build=disabled
+      - -Dalsa=disabled
+      - -Djavascript=enabled
+      - -Dlua=disabled
+      - -Dpulse=enabled
+      - -Duchardet=enabled
+      - -Dvulkan=enabled
+      - -Dwayland=enabled
+      - -Dx11=enabled
+      - -Ddrm=enabled
+      - -Degl=enabled
+      - -Degl-drm=enabled
+      - -Degl-wayland=enabled
+      - -Degl-x11=enabled
+      - -Dgl=enabled
+      - -Dgl-x11=enabled
+      - -Dplain-gl=enabled
+      - -Dvaapi=enabled
+      - -Dvdpau=enabled
+      - -Drubberband=enabled
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/applications
+      - /share/bash-completion
+      - /share/doc
+      - /share/icons
+      - /share/man
+      - /share/zsh
+    sources:
+      - type: git
+        url: https://github.com/mpv-player/mpv.git
+        tag: v0.41.0
+        commit: 41f6a645068483470267271e1d09966ca3b9f413
+
+  # --- Tesseract OCR (bundled into the sandbox; see issue #11646) ---
+  #
+  # The sandbox has its own /usr, so a Tesseract installed on the host
+  # (e.g. `apt install tesseract-ocr`) is invisible to the Flatpak. We build
+  # Leptonica + Tesseract into /app/bin/tesseract — the path that
+  # TesseractOcr.GetExecutablePath() already probes — and ship the English
+  # language model so OCR works out of the box.
+
+  - name: leptonica
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_PROG=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/DanBloomberg/leptonica/releases/download/1.85.0/leptonica-1.85.0.tar.gz
+        sha256: 3745ae3bf271a6801a2292eead83ac926e3a9bc1bf622e9cd4dd0f3786e17205
+
+  - name: tesseract
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_TRAINING_TOOLS=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/tesseract-ocr/tesseract/archive/refs/tags/5.5.1.tar.gz
+        sha256: a7a3f2a7420cb6a6a94d80c24163e183cf1d2f1bed2df3bbc397c81808a57237
+
+  # English language model, pre-downloaded so OCR works out of the box.
+  # The standard tessdata model is used (not tessdata_fast/best) because SE runs
+  # Tesseract with `--oem 3`, which needs both the legacy and LSTM data.
+  - name: tessdata-eng
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 eng.traineddata /app/share/tessdata/eng.traineddata
+    sources:
+      - type: file
+        url: https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata
+        sha256: daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
+
+  # --- SubtitleEdit application ---
+
+  - name: subtitleedit
+    buildsystem: simple
+    # Select the correct RID per host architecture
+    build-options:
+      arch:
+        x86_64:
+          env:
+            RUNTIME: linux-x64
+        aarch64:
+          env:
+            RUNTIME: linux-arm64
+    build-commands:
+      # Build and publish from source using the pre-fetched NuGet packages.
+      # --source points to the directory where flatpak-builder staged the .nupkg
+      # files from nuget-sources.json (dest: nuget-sources by default).
+      - |
+        . /usr/lib/sdk/dotnet10/enable.sh
+        dotnet publish src/ui/UI.csproj \
+          --configuration Release \
+          --runtime "$RUNTIME" \
+          --self-contained true \
+          -p:PublishSingleFile=true \
+          -p:RestoreLockedMode=false \
+          -p:DebugSymbols=false \
+          -p:DebugType=none \
+          --source /run/build/subtitleedit/nuget-sources \
+          -o /app/bin
+
+      # Desktop entry
+      - install -Dm644 installer/flatpak/dk.nikse.subtitleedit.desktop /app/share/applications/dk.nikse.subtitleedit.desktop
+
+      # AppStream metainfo
+      - install -Dm644 installer/flatpak/dk.nikse.subtitleedit.metainfo.xml /app/share/metainfo/dk.nikse.subtitleedit.metainfo.xml
+
+      # Icon (256x256 PNG from the source tree)
+      - install -Dm644 src/ui/Assets/SE.png /app/share/icons/hicolor/256x256/apps/dk.nikse.subtitleedit.png
+
+      # MIT license — distribute the project's terms alongside the app (issue #11278).
+      - install -Dm644 LICENSE /app/share/licenses/dk.nikse.subtitleedit/LICENSE
+
+    sources:
+      # Flathub builds from the public repository at a pinned release tag + commit
+      # (not a local checkout). Bump tag + commit on every release, and regenerate
+      # nuget-sources.json for that commit (installer/flatpak/generate-nuget-sources.sh).
+      - type: git
+        url: https://github.com/SubtitleEdit/subtitleedit.git
+        tag: v5.0.0
+        commit: a44ffa7025b59f424aa8a5a7ee250ea85c4c1361
+
+      # NuGet packages pre-fetched for the offline build. flatpak-builder expands this
+      # JSON array and downloads every package into the nuget-sources/ directory before
+      # the build starts. MUST be regenerated for the pinned commit above.
+      - nuget-sources.json

--- a/installer/flatpak/flathub/nuget-sources.json
+++ b/installer/flatpak/flathub/nuget-sources.json
@@ -1,0 +1,1213 @@
+[
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/12.0.1/avalonia.12.0.1.nupkg",
+        "sha512": "8e40a2414278bf56ae920f9a31549e311a6c0778d7a05c270f52ea95b5037abf2e19bec9e7ed723006729e7f0aa6b04a053c45513f215c7e97f75fee2cf6b448",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.25547.20250602/avalonia.angle.windows.natives.2.1.25547.20250602.nupkg",
+        "sha512": "5cf4ba739c4fe0bf9e36ad2b4d481338239ea98216e6188f8c2f7af5efbdcb8926ce7d6af2df951071f8d9294d4d25ce1e52835f2bf4ac08c3dceba5e503ae60",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.angle.windows.natives.2.1.25547.20250602.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.avaloniaedit/12.0.0/avalonia.avaloniaedit.12.0.0.nupkg",
+        "sha512": "e0c7fadec0216f6ab0520b462c8733c7f13387009bd24d725555d7167f1b0425a21aa73e4ea6aeb16e7e166b70de01d527c682e2a3ac45b4efe8ceb244b7ed21",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.avaloniaedit.12.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.buildservices/11.3.2/avalonia.buildservices.11.3.2.nupkg",
+        "sha512": "233f868e74ab91e56818004ad0aa7d0bb6e978044ddcf0061e373ada06a1846b17a82e94c777ab907ba484c1873d2212b47d3539d2694e89a415f1af047c3045",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.buildservices.11.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.colorpicker/12.0.1/avalonia.controls.colorpicker.12.0.1.nupkg",
+        "sha512": "8d87fb42c0f9e1a5b111166af988a6e0d524444501642e44061d475464a7febb6ae5352f24276940bfb4c6c54acfdbfd013b8024e9ec69753e9e7f95983a0737",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.controls.colorpicker.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.datagrid/12.0.0/avalonia.controls.datagrid.12.0.0.nupkg",
+        "sha512": "ea81fff4bf1797c5e62d3087ca1c12ae7c9f936d61a7cfcb8d9fe7e2b2040a618fc6506ec9092e95d78af412bdacf6102711b778015063074c7fab65ba5295ce",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.controls.datagrid.12.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/12.0.1/avalonia.desktop.12.0.1.nupkg",
+        "sha512": "90ee291de78dcc3fe9352b6911aa8a89b94c07494f63dfa12ec0524866d8bfb9b62ce09b642ca27869be6d796ea8597723122793661e97f23bd39ab966be761c",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.desktop.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.fonts.inter/12.0.1/avalonia.fonts.inter.12.0.1.nupkg",
+        "sha512": "a66828c4b033bac6984653f216bdb6bd500f479b0c138a2c20b7742b93af4a925f91fa3ef71734a98397bb26ed7ac4e6e129d13169a6bc1c021fd2baa8b6c2d4",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.fonts.inter.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/12.0.1/avalonia.freedesktop.12.0.1.nupkg",
+        "sha512": "2724d21f8e5fd9d8b1e2ff4ddb5c40e8640c7fdc10e2f67e4fbeea475229fde441b3f65788583a6055d8f3d5b54d02225ecb54e4b6c6e58868c67d83b24c1ba2",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.freedesktop.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop.atspi/12.0.1/avalonia.freedesktop.atspi.12.0.1.nupkg",
+        "sha512": "37aa30d5ceb4c504ed399b16d26810fd43672b14077ab06f46507a42f0072c2ffb4311deba0d65dcf83ca4e68951caf2a35875da7727db556bd64cb6dbd75a60",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.freedesktop.atspi.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.harfbuzz/12.0.1/avalonia.harfbuzz.12.0.1.nupkg",
+        "sha512": "37429d50860337718264fd1eaf9134f7d372e334222e962002962064fd1f3831fb7ba0575a1699fb55adbceb7d709e24a25546e27066057b03c644c5778d67e7",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.harfbuzz.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.markup.declarative/12.0.1/avalonia.markup.declarative.12.0.1.nupkg",
+        "sha512": "363ce596cb49a33f5858c19069ff23059c4fc798f054c0b26dfcd2d6f1d3c00861fabb0d9034686abb209b934eab44d33e35057a205c42648265ee39466b6b69",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.markup.declarative.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/12.0.1/avalonia.native.12.0.1.nupkg",
+        "sha512": "2c2510cc94d8ada05d9085b97b6cd20be3e46654ed7bc40a52f8b138e7bd14c2d0fd74131d3d4d610271711ab1ed703e3ca8d6080b1b748a3b058da769b73f51",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.native.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/12.0.1/avalonia.remote.protocol.12.0.1.nupkg",
+        "sha512": "1ae9e1618f7a78349edcdd33ba141804013f2311bc62d9aec1d93e8cb6c68753c6a947c38346a0312179fe0b68e1ce1e5c060c0e2c6a902eabd8d8abc9baeeb1",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.remote.protocol.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/12.0.1/avalonia.skia.12.0.1.nupkg",
+        "sha512": "86187649cc33bc1dbc0615fe9e309bb837caf9ab636ce489d9a95071b8e3b052cd3d0f864098ccba26da90c170b227c976c4f11395555bf52826d4df9042de3a",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.skia.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.fluent/12.0.1/avalonia.themes.fluent.12.0.1.nupkg",
+        "sha512": "04a1ccfe74612c470770793a223cf499d0261851df22d1175a7be839778687347dad364a7d359dd8bf5737262dc4a355ca54661422c0706f63d0f4ccb9a3369d",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.themes.fluent.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/12.0.1/avalonia.win32.12.0.1.nupkg",
+        "sha512": "0e2288d10e7ebe26db77a753cea8b1c9f42db160cb0a57ea213702ef4c69ae4d3c268ab85e04739717c320a1ce91cd39617b38b1fc7534130a880f6cd8560bdd",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.win32.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/12.0.1/avalonia.x11.12.0.1.nupkg",
+        "sha512": "55c091f065a34497483afb9af7ef705e0a1711fa46813c271d124469d01961e257efba836763e0575edabfae5d6f2c36698a09fce068280e2e794c70531272c3",
+        "dest": "nuget-sources",
+        "dest-filename": "avalonia.x11.12.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avaloniaedit.textmate/12.0.0/avaloniaedit.textmate.12.0.0.nupkg",
+        "sha512": "00f182172e25d9cbf4a27865fc465f5d13223ca15c9109483909634752d64f0b4d1939bbe6ed811d6374d471f360d984fb8aaef3ef60f20678f4771b5b8685a7",
+        "dest": "nuget-sources",
+        "dest-filename": "avaloniaedit.textmate.12.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/avaloniaui.diagnosticssupport/2.2.1/avaloniaui.diagnosticssupport.2.2.1.nupkg",
+        "sha512": "564accf6dbdc3a6d322d90c9e912d0908821212294c7c3d97dfa68d5deba8cca860f693e778b0ecc5f24bbb8ad86bad994d80d5d554175a23143365227f1a776",
+        "dest": "nuget-sources",
+        "dest-filename": "avaloniaui.diagnosticssupport.2.2.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/communitytoolkit.mvvm/8.4.2/communitytoolkit.mvvm.8.4.2.nupkg",
+        "sha512": "45a30676f54742dfd748065a6952b4563bd9f8aa19877f592f9b54bd464bf34fadc982c4b3f1c7170d92fb34d59966d5bd05f6a7906abfae60a127eaa0edca53",
+        "dest": "nuget-sources",
+        "dest-filename": "communitytoolkit.mvvm.8.4.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.api.commonprotos/2.17.0/google.api.commonprotos.2.17.0.nupkg",
+        "sha512": "994c2c867a7cbe2ba6cf54ea9d0bb430dd03ee7f45fafde3d20674216189bc49708f46696ce9ce7ad76bf13c27d9a6918e81da008d1dafe9022cdc5d26d15747",
+        "dest": "nuget-sources",
+        "dest-filename": "google.api.commonprotos.2.17.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.api.gax/4.13.1/google.api.gax.4.13.1.nupkg",
+        "sha512": "5c91400d710162ee814792f0da7dc593e859b027107c1b8ab52e081fdb23b69ea4d9c3653bbc53452c933402661998251201f0e61ac82825d2da0ae6d9b8c3ce",
+        "dest": "nuget-sources",
+        "dest-filename": "google.api.gax.4.13.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.api.gax.grpc/4.12.1/google.api.gax.grpc.4.12.1.nupkg",
+        "sha512": "924e4b36302e907fffc92af70d9000f869b9420ea655cd9ae2bb3e92b1f83fae29696a73f66c3320ca1c8146357e934991923088c8b04335a72a8e3e23eac11f",
+        "dest": "nuget-sources",
+        "dest-filename": "google.api.gax.grpc.4.12.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.api.gax.grpc/4.13.1/google.api.gax.grpc.4.13.1.nupkg",
+        "sha512": "5f805c29250be41abf5e3f5f241ce61021b2d8ea20fa989a518572ea924d7fceada9a294da935c1ca03a048aabad0135121a2c8061f3e9e54cfa4f8499968ccc",
+        "dest": "nuget-sources",
+        "dest-filename": "google.api.gax.grpc.4.13.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.apis/1.73.0/google.apis.1.73.0.nupkg",
+        "sha512": "bd98d6bcd99351e7be1e9f221dec1589317ee7db2829d2d566192225f1df2fac4ab2b818e7152acef37035c6ca619450dc19aeb76c1c1c8b6d380724fb67b7d0",
+        "dest": "nuget-sources",
+        "dest-filename": "google.apis.1.73.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.apis.auth/1.69.0/google.apis.auth.1.69.0.nupkg",
+        "sha512": "a2ca73f248755a301fd8d0fb7cedffc1a691e22176cf6618893286aefac99046bab34bd00693079665dfbbfcfff8d851fc1fa94a1276dd54145c7c11a9658350",
+        "dest": "nuget-sources",
+        "dest-filename": "google.apis.auth.1.69.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.apis.auth/1.73.0/google.apis.auth.1.73.0.nupkg",
+        "sha512": "41eda5a9e69a247e7f963fb6e4050792f68f8e94aac350d6c0a6ce6d5141c483f87ff3d6082d52e01d8dfada4d83debd5e744a4bbdd37ed4e4c82e19cf2fa655",
+        "dest": "nuget-sources",
+        "dest-filename": "google.apis.auth.1.73.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.apis.core/1.73.0/google.apis.core.1.73.0.nupkg",
+        "sha512": "ed8cbd91964cb6fb6c314d4bde0ed8fa3152956c5342cf3ddb8d4bc05a1ad2fe9296aa9b5a43974de26289c00de95c6ea75e41f9832b9de73916eccda894589a",
+        "dest": "nuget-sources",
+        "dest-filename": "google.apis.core.1.73.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.cloud.texttospeech.v1/3.18.0/google.cloud.texttospeech.v1.3.18.0.nupkg",
+        "sha512": "636677ed6dbffb2e29f32a0e50dd30b2b08b472fa51461079dbff2c94760dec05b1130bdaa719df7a6f01c7022e542a26c8f772764f7a41218c27e71a93c0948",
+        "dest": "nuget-sources",
+        "dest-filename": "google.cloud.texttospeech.v1.3.18.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.longrunning/3.5.0/google.longrunning.3.5.0.nupkg",
+        "sha512": "9aac476f6aaa9122f757306c9f18897afc9142f2781f46abfc8ee8e71494fcfd54ac05f1dd3b13e72dcf1fd28cce2ffcbfc2d0f12e6a3dd1f882b98bcf475ebb",
+        "dest": "nuget-sources",
+        "dest-filename": "google.longrunning.3.5.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/google.protobuf/3.31.1/google.protobuf.3.31.1.nupkg",
+        "sha512": "f4793a4ed46dd46a7b4cc50b76c33c09b92bb65bf503a388686aeec03b8454dc802e2f6b2a5596b8e495f74bcf50a541bce702127c70f24bb90f8fde1a4d3a1b",
+        "dest": "nuget-sources",
+        "dest-filename": "google.protobuf.3.31.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/grpc.auth/2.71.0/grpc.auth.2.71.0.nupkg",
+        "sha512": "56cb5155e47fb590a83f23d14917eac80ceb4e60d631e93645389e470640d64c48a8adc4078e77798e3b464688a44bec8960b2f62b0e1133ef274820c1df9a81",
+        "dest": "nuget-sources",
+        "dest-filename": "grpc.auth.2.71.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/grpc.core.api/2.71.0/grpc.core.api.2.71.0.nupkg",
+        "sha512": "4ff7f0bb7d70fb535d71f5492fa576e3bed577feeed7ae2c4181fa62d9b66f29bfbccb94efbd9f4c954400d21c1593c959bcf12424d620ea6421cd986989b40f",
+        "dest": "nuget-sources",
+        "dest-filename": "grpc.core.api.2.71.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/grpc.net.client/2.71.0/grpc.net.client.2.71.0.nupkg",
+        "sha512": "009821890eed7de6a8a8b201b097c239a916e666797eb9253a352557d071109bc18ae6fc1634d235572d02cc47d7dc38bfad0a9d2e98808b116c6dcd25cf8aba",
+        "dest": "nuget-sources",
+        "dest-filename": "grpc.net.client.2.71.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/grpc.net.common/2.71.0/grpc.net.common.2.71.0.nupkg",
+        "sha512": "1fb4d67bc75d0f138f0a475f0cb26a475aa67b8770c5dc7b5a47fbc73d6e5bfb8c459fef4c629a476ce8cf16746cfb2872725113a243ec60764295a449d55f79",
+        "dest": "nuget-sources",
+        "dest-filename": "grpc.net.common.2.71.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/8.3.1.3/harfbuzzsharp.8.3.1.3.nupkg",
+        "sha512": "8493b36e88beedfc80e12f13e3b986fb1e5560c4c8df86e672c1cad24a623fa36adc9a1a82f566fda3784f7a2d58975d10273ea65b7bcb119afc126b11a452c8",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.8.3.1.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/8.3.1.4-preview.1.1/harfbuzzsharp.8.3.1.4-preview.1.1.nupkg",
+        "sha512": "7ff0d706c5378fb8b1a6b18871040c912a4040d244ee28cdd8dbc076a5447e6eeede92ce40670dafa7b5a82c108a23e7f331a3eca17f78e81737bdea493f8977",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.8.3.1.4-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/8.3.1.3/harfbuzzsharp.nativeassets.linux.8.3.1.3.nupkg",
+        "sha512": "c413a4244f1fcf0caddd8e039f7e96324cee45ec0970aae23fc324bf40a8808c5fcf9e2b386be5a920f95e37cc2ee03a68d3dd7092fb9091c155e52a729ac8d7",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.linux.8.3.1.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/8.3.1.4-preview.1.1/harfbuzzsharp.nativeassets.macos.8.3.1.4-preview.1.1.nupkg",
+        "sha512": "eab34e073dc7f28fe860b0fa8c45e97da8ecdfe624fb37fc80572b498b0249ef9be16ec2587706b00f93495903f0cde9d6fecd848473e08701fe7982cdc90ddd",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.8.3.1.4-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/8.3.1.3/harfbuzzsharp.nativeassets.webassembly.8.3.1.3.nupkg",
+        "sha512": "a7991dc993e42ef2e10785d41193cdd731c03c135e8db4c09cb493a3d364a634a07f47ab035cb63ada41e643ff089cd461f1ab5844402f4cd30eecd3ad68b200",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.8.3.1.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/8.3.1.4-preview.1.1/harfbuzzsharp.nativeassets.win32.8.3.1.4-preview.1.1.nupkg",
+        "sha512": "74c8ae942da49ba5c630739272b48a764f767e0629ff8b409fdae47f190a6df679e15225d555a83d6a3ac0865d497a91e49b8ce9ce3c601c34e68b86ab681f31",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.8.3.1.4-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microcom.runtime/0.11.4/microcom.runtime.0.11.4.nupkg",
+        "sha512": "75dcb5b0761f8a5607dbe9a73407fafb3f4258424227286c1e6113cf3b24cd51ab6bb85abc7df58675c89634f2d01cbef1b262d67a762adc711212d48425ad02",
+        "dest": "nuget-sources",
+        "dest-filename": "microcom.runtime.0.11.4.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/10.0.7/microsoft.aspnetcore.app.runtime.linux-arm64.10.0.7.nupkg",
+        "sha512": "cafc92236965c07dc2e5226eee730f5dd88cb7d23c984eb261eda8eee19198b8a861d6af2fc2162537b4cfe787a941c124d19339e72ee225f27b01720675d151",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.10.0.7.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/10.0.7/microsoft.aspnetcore.app.runtime.linux-x64.10.0.7.nupkg",
+        "sha512": "0188eda19b8bca9662d38b9f39ea371277f86ae0ae4e1fcefad7f795801c7fd77968af397881d7b5e39bb207f7f9bcd181557d43c66b359a86ce6a38113e91ac",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.10.0.7.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/6.0.0/microsoft.bcl.asyncinterfaces.6.0.0.nupkg",
+        "sha512": "221a05a0c910f7a87b620d8f3831ed392b4eb95d112bee274d35f27009ad2a26445de9d7cd235fe6fb4a03f2550874bda3be3dddd96edaf9c0852a9c23d7b099",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/11.0.0-preview.2.26159.112/microsoft.extensions.configuration.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "37822f22deabb14f3e22c3107098cfbbc54eace6375c8e54560d630cf1b89b7fdf9640329195b5d3c82d058ffe3e289e2e5e5de38683af68a8d871844d8be128",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.configuration.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/11.0.0-preview.2.26159.112/microsoft.extensions.configuration.abstractions.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "0c8c92db5f7f268d3adcd3596f1ec6fb3e84d5fdb4f75843dbe490afea2245ef7682fc75c57bd3d4f62c2dcbb26222f589b51964cebee9601d15aa27cfd93b7e",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.configuration.abstractions.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/11.0.0-preview.2.26159.112/microsoft.extensions.configuration.binder.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "f0293947858789fc091a4fbb7bcaf6668272bdfe71d027efb30bb89d74c80d6961269e2bd42fb0959601dd26012373a35c0c9e778fbe98f2c94e10a0800fd1f3",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.configuration.binder.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/11.0.0-preview.2.26159.112/microsoft.extensions.dependencyinjection.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "418e91664d97f12b78752124d15e6e0f37744d740f3fcec48db16c9d34f15da9b5e9f46dea144a7fe56288791e4bcf4afd99baf66ff408be2fb0cea3550f0108",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.dependencyinjection.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/11.0.0-preview.2.26159.112/microsoft.extensions.dependencyinjection.abstractions.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "bd2105394884a3921aa75af6710a6850f8b63f228bcb00bbd2af757507b5199ad8606f6685e15ff41cc782cc5f4cd3e9b7c67a0f16fe627a322fa38eb1219dfc",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics/11.0.0-preview.2.26159.112/microsoft.extensions.diagnostics.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "4e5349f53b819ce3ecf7cfb04b1785d7ed09590eab2586fcf1e1326c9495db24efb07782b3de04a3724e7daf8449937d1c327d49b8cfab84110e734bcb587ffe",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.diagnostics.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.abstractions/11.0.0-preview.2.26159.112/microsoft.extensions.diagnostics.abstractions.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "d72e60a3e0725b66e62ff8482e2eab39e7f44d0765a2aebba581f93b7312fb5050c6b3bf8e401dc389039ebd72acc08aa67c4caa5436189ad6e3dfd07039587d",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.diagnostics.abstractions.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/11.0.0-preview.2.26159.112/microsoft.extensions.http.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "d47656c8cc22f6628e9d90089370f0186dacd38cd879059e2cdcafffd42816c27cca58b922debb852425defb109a2184ceeeaba2072e82b3452275bf0936d6fa",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.http.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/11.0.0-preview.2.26159.112/microsoft.extensions.logging.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "49e6e914d3a6238022b686280043a40077d5a2dbd3ecc017fc2e27d71f8dd0cc9068e7156da8c0b4217c19f72e442b1c59022b6940a75a6d6b8ca2b7ec13654d",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.logging.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/11.0.0-preview.2.26159.112/microsoft.extensions.logging.abstractions.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "5b71ebff08e767581748b5002325d73ba13969306380888b09be8a7e31c0b7b77364aaed8d80f7a153b1559dc9287ef463a281ec60ae4a99c85d35f0a7e1909e",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.logging.abstractions.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/6.0.0/microsoft.extensions.logging.abstractions.6.0.0.nupkg",
+        "sha512": "bfb1b4b98242104803d1a65a1a051d0b8e481fbc987fa2f4b58a610ab459b4d24e8753c515c32a376dd2c6804d1ce2d39624b972a81c68e92481958e1a8a31df",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.logging.abstractions.6.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.0/microsoft.extensions.logging.abstractions.8.0.0.nupkg",
+        "sha512": "50a0add96d30d90580fb8e02a25cea0aa15f4d22744279b5acfe18cc8568b74402aa062d5db13cc5887a08bfd24e07cbc88b2fc10ee8eec2c37edf3bcda7f8a7",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.logging.abstractions.8.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/11.0.0-preview.2.26159.112/microsoft.extensions.options.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "64e770ae7e62dce5269ffdbda507a73de7688df4058c792cfa5d38c39d7683eb8081627c4e564b445119a798f0003db9ad700bdd017b3fe02091e93332e8456b",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.options.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options.configurationextensions/11.0.0-preview.2.26159.112/microsoft.extensions.options.configurationextensions.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "309b60dea83156e21a985ad06971ae41aaed12d9d552416efd04cb95b0567d2dccace461b636f16cfe71be900de9de49c19f8a88112d0bdf4305203e3cc158cc",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.options.configurationextensions.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/11.0.0-preview.2.26159.112/microsoft.extensions.primitives.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "a88b1347830da0a54dd6cbb1a76a61beabf85b69ec15658155b78d058df922bd4eebf76dba59d0e7ca327d279fdd086184d1cd81334371d2fb061feba05e72a3",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.primitives.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.io.recyclablememorystream/3.0.1/microsoft.io.recyclablememorystream.3.0.1.nupkg",
+        "sha512": "c5794ea27c908b5fb2442faa441e9f3f81ffa3dc29d41a313b542643923ae61070905b1c15c2ecad98092c6b9b2a3b423aca979e71ed979728bd572b69f20a46",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.io.recyclablememorystream.3.0.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/10.0.7/microsoft.net.illink.tasks.10.0.7.nupkg",
+        "sha512": "7aa7f83a78680c287d79c0558118df6cbb71f20154d809bc6059f8bc6f5f252f9bc2d983807d3fa36ab92a30d886709c383a07b431850f3fab8f1fbac0a81ffb",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.net.illink.tasks.10.0.7.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/10.0.7/microsoft.netcore.app.host.linux-arm64.10.0.7.nupkg",
+        "sha512": "099b4c68e65904536750ccd3b7edf6bc848f77712794bcb64ac7801bbafeca328c093a02f1102d77f35be5badfe491b1a8693a3b45d9822b3f18b11d612f2cdc",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.app.host.linux-arm64.10.0.7.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-x64/10.0.7/microsoft.netcore.app.host.linux-x64.10.0.7.nupkg",
+        "sha512": "71ec17300c0c931cbbb49b1660322cfbf53cf9eda4e22581d2bad6b5e9e0b0fea02eb44ba0cc4f10a7e0a9c3d46fcc6a10a99ad767d78e51d2b0d439c3ca37fc",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.app.host.linux-x64.10.0.7.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/10.0.7/microsoft.netcore.app.runtime.linux-arm64.10.0.7.nupkg",
+        "sha512": "97f334245cbe06a565d159a1ffb5d6fee4ad0b991c271b36d11417ac1f60b72d7fd7e8de30fb4d8cf3314215f897c2299efc492b11eb4304b87e61b17952dc93",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.10.0.7.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/10.0.7/microsoft.netcore.app.runtime.linux-x64.10.0.7.nupkg",
+        "sha512": "e8ce562c71206e4c11808ad54cd0a2c8a4591171ba35d4a930713a6b7132b5af5d7e7c0e46d4ee83fa8573f8b4947ccaa3b91c0ffa926b49fc6c8c2f562f1a94",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.10.0.7.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg",
+        "sha512": "6bf892c274596fe2c7164e3d8503b24e187f64d0b7bec6d9b05eb95f04086fceb7a85ea6b2685d42dc465c52f6f0e6f636c0b3fddac48f6f0125dfd83e92d106",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.platforms.1.1.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.1/microsoft.netcore.platforms.1.1.1.nupkg",
+        "sha512": "9835090f578b5c8ce6527582cd69663506460e9fdc5464fc2b287331c24d9369e57dd1543a865a8bd89d4fcfc569c26bf0dbfcce102675fdfd1479b9a9652819",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.platforms.1.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg",
+        "sha512": "1ef033a68688aab9997ec1c0378acb1638b4afb618e533fcaf749d93389737ba94f4a0a94481becdf701c7e988ae2fe390136a8eae225887ee60db45063490fe",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.netcore.targets.1.1.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg",
+        "sha512": "366f07a79d72f6d61c2b7c43eaa938dd68dfb6b83599d1f6e02089b136fa82bec74b6d54d6e03e08a3c612d51c5596e3535cbc2b29f39b97a827b3e7c79826f0",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.win32.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/5.0.0/microsoft.win32.registry.5.0.0.nupkg",
+        "sha512": "471e66567ce59cc86475aece7815d05261264ce114e0c1688ba2551dd51494901fa72dd7a8f74f8e8f0f3dba74af8595f177552f3c06abb4bfce76692197076e",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.win32.registry.5.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/netstandard.library.ref/2.1.0/netstandard.library.ref.2.1.0.nupkg",
+        "sha512": "26bd0eaa7aa4689246115ab7c3da0d42b204b5e0ffe1004d83760e87572f463c9dcf0a29d3bfb96968cefd27c462ee82c019fe75204a5e3f27884bd3372d9bac",
+        "dest": "nuget-sources",
+        "dest-filename": "netstandard.library.ref.2.1.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.4/newtonsoft.json.13.0.4.nupkg",
+        "sha512": "6d1faff84ff227a83b195dae5f0d8ead44a36187e32e438b0bc243e24092db79ac2daa672ad7493c1240ef97f01c7fbe12b21f7de22acd82132f102eaf82805c",
+        "dest": "nuget-sources",
+        "dest-filename": "newtonsoft.json.13.0.4.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/onigwrap/1.0.10/onigwrap.1.0.10.nupkg",
+        "sha512": "7d4a049d9654d47f9ac57aff45f9a67a9fac11d74a3ec8c1e73ad8b194243c857243119da6744308eb618f2a1204345d66648b19a5ff4e306d604d3f68601b11",
+        "dest": "nuget-sources",
+        "dest-filename": "onigwrap.1.0.10.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia/12.0.6/optris.icons.avalonia.12.0.6.nupkg",
+        "sha512": "a052b6f884fad0adfe7965883b07da4672578af81b5f88dcb2c2c267858ddc60b16173feffb284e9638f6985c0ff08fb06301faf8f5153afcbad1a3c5b95e412",
+        "dest": "nuget-sources",
+        "dest-filename": "optris.icons.avalonia.12.0.6.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia.fontawesome/12.0.6/optris.icons.avalonia.fontawesome.12.0.6.nupkg",
+        "sha512": "81f417c1396c5c0b589edc9cbc137c163759776751568932b8ed9ce741f304833056c4f5852bb9f14763e54393f55410861fdfd4f507ff5223d21aba18fb3ab9",
+        "dest": "nuget-sources",
+        "dest-filename": "optris.icons.avalonia.fontawesome.12.0.6.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/optris.icons.avalonia.materialdesign/12.0.6/optris.icons.avalonia.materialdesign.12.0.6.nupkg",
+        "sha512": "0998884fbbd9814ffec532cadf77d47f362db2e16321f17125f9468bf9fcc662722408ed7c9173c169d774a801d9a64331ccc300a68f52c52a5e0cacec439e41",
+        "dest": "nuget-sources",
+        "dest-filename": "optris.icons.avalonia.materialdesign.12.0.6.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.collections/4.3.0/runtime.any.system.collections.4.3.0.nupkg",
+        "sha512": "9f8833176c139b71a58694ae401c5aec209a63227be07c7ab559bef772082bd1f6cc38ba2949cb1c8e5c5514ad9f4ff51859838dc2f28191f8bb7ae611a50239",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.collections.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
+        "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
+        "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
+        "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.io/4.3.0/runtime.any.system.io.4.3.0.nupkg",
+        "sha512": "7e0d4a238322d434a19afc79ea988d3727c1687fdd5bcd1c4c39cb6201073caabb924cc201c70545d60acf8b94cde8b783d0c268743e040c357d100677e4c5ed",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.io.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection/4.3.0/runtime.any.system.reflection.4.3.0.nupkg",
+        "sha512": "293d3dd8be87e1c5cd76ece4ed64ebb5ae6b50be95a39bee401eeed64355e34641905f8c14392fbc3acf8609f5d6fca731f39ce7607962eb5951f09516480015",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.reflection.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.reflection.primitives/4.3.0/runtime.any.system.reflection.primitives.4.3.0.nupkg",
+        "sha512": "a2f374276290ad9b799d3e49cd8fe7839c07b52f22894bcd77b9470841564319fb2ebbd7503e76feef42db4e8a362af8648cf0842a1cb0b5d9a60a58ef8b205e",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.reflection.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.resources.resourcemanager/4.3.0/runtime.any.system.resources.resourcemanager.4.3.0.nupkg",
+        "sha512": "39fab03cbade2b3848d62e137313530c06b37216e24cd58c70ed6ae54bdaf9d9613a3b410375ee167c87ff935a558b1f8766ee016b8b244fde99c38fcf42a49b",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.resources.resourcemanager.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime/4.3.0/runtime.any.system.runtime.4.3.0.nupkg",
+        "sha512": "bfee3c68312296860e5459af5e770c2e9fcd4ac134361fd569a9ce1e6574b9ae3978aad403f89639a4b5bac8ee5bb0ee1b8edb819e9a60f13ca5bd1812889bbd",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.runtime.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.handles/4.3.0/runtime.any.system.runtime.handles.4.3.0.nupkg",
+        "sha512": "95cdae2867a2182535bd0f4d01dc3eff70319dff044b070ab7791fa2bf8688a69b00a279ed569b7f0c5f3e26bf705303dc344ecf7d1ea014c579436d8e7b7389",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.runtime.handles.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.runtime.interopservices/4.3.0/runtime.any.system.runtime.interopservices.4.3.0.nupkg",
+        "sha512": "70eeb2469726d092bb95568e51ba5cfdd1cc07a9e65077e2b6dd5b7c8b164d4b45c749ef4a52f45928f63a27e8accdb83b861ea73c9ad3d42dc38e6afdbd0e8c",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.runtime.interopservices.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding/4.3.0/runtime.any.system.text.encoding.4.3.0.nupkg",
+        "sha512": "cbe6df98acd50e2251d3343620c408af56cfe7c1979277a8ec65b5eef093e93ed93c05980902a7152ed83302d5a625d7058921baa7f446c5e67194fa4c06f20a",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.text.encoding.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
+        "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
+        "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "8f071552ee042f0cba39b1ba0a1205cf73de447d662995bae68f857a5946f7d154c029a79e37469081675687873c8bf2b9efe57f5cbd660c366b1ca51823f7f2",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "a135ca0f4f5a49319b5a52b7f4338f8a5fc4387edf26f29e6cbf63a3c3a37b2b5c51c9caf562ec41e470fba281060362465bc56915be782d6c75778aa6195e46",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "2f24e2cba88a96bb23848e1404878e4478a65642387b7b76aa4007587fe7c4d8208cbde53d3ed65f8d0d71cd688bfc16be66dc5f7bcf84c7b2ccf1b3c505b0b4",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg",
+        "sha512": "299c5a96fffdcaf1972e3e3d1c727837d18ac9e88cb79c09914f12ff1de7280dff10c9232a49a1c1d3ba7785a5cf76f28c9dce414f0a2a567688de7fd5331dc8",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
+        "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+        "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.0/runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "ee5d047908b99b776ff9bb54856454b24b09a0f9271b127239543b1f5faa3381a032d9eeb4d813d01b5a4b7d183b6a16250f159fdc450d5314a7eace1550bea3",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.2/runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "a34ad2dbe67efcae97fcbea57af386b30660a98ab8229a56c0dca241316e673cf7a26e19c6efb6b7117cc271fdf208741ba6f8447ae254c91acba3ddb7d2923a",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "ce0873e07000df98e640bd265e969d4a9236535cee2699c5363f3ab297557b0d756260557995f2ee163cff05fc2ba922d66ba0e4cb28521f841e7d546ab3b63e",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "bf754c1a66cd70dc1bd38d54fe675e9dd470417ebba62e2f79e278be8f06cc3496ff58ed90d30b5dd4d3efea9accbd09eb17cd87be882951c0fdfb833c371f70",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
+        "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "0a38f25e8773b58155b5d3f94f849b93353d0809da56228b8ebab5c976e6458ca50eb5a38acca4c8940678e6e9521fb57ae487337f7cbf2ea7893ae9e3f43935",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "2ae9db4b719b31fa7e40c60f52c70038fc8668e029cf4e1d120fde8c295631d6b08207d7018a22937b79546016c560c894e27dd6ebc01d5e0f677567e6b2c4f2",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "cd4b7ba744de80086521ab67cad2db3085d488388d3d9cb83d9946389f0f4c784539bf3a4ffb8d4f3347c5c7813aadef95b355fd2563e30c948a883c27b95287",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "d7fc28a9f600e471edce0989c01c485d4e2a7e99551f531413afa75039a4004d4e2c27e88976d65432635a321d86316a3c6cdaebc7b2fefa42141b64f4f10d66",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg",
+        "sha512": "5fe0e6a878eff59cfe24a8d57af51140576d8e0fec4988e4892c233c47b3a3eed27dec072a6c0d55dd615777cd9ce3fe545c5353b4a95289376ad0b9408ed4be",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
+        "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
+        "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
+        "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.0/runtime.unix.system.net.primitives.4.3.0.nupkg",
+        "sha512": "c2a0ecf5c72b226b4776eb6281f00267827d6086a0ad758ebf6e6c64a1c148d2056fe99c87ab4207add5fa67f1db73dd1ed3dca81141fc896be6b6e98795c97e",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.net.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.private.uri/4.3.0/runtime.unix.system.private.uri.4.3.0.nupkg",
+        "sha512": "203ebe272791d79ab0c40afe9d0543852ee91b9fb4ae5bc15524d97728bc8bc9d7e0cbcf65d1fab8cfb0aa7a4ae37e7938933eef127aa5ea46f60e57b6ad2d91",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.private.uri.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.runtime.extensions/4.3.0/runtime.unix.system.runtime.extensions.4.3.0.nupkg",
+        "sha512": "54b81784c08e934389c59e6e155af6b1855e4bbc41678b01a702c94e6daba87c6ddfd16fe9e2cb61f3097bfa4950dbc37781454d027ce5ba6c50a393cc91b888",
+        "dest": "nuget-sources",
+        "dest-filename": "runtime.unix.system.runtime.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/sharpcompress/0.47.4/sharpcompress.0.47.4.nupkg",
+        "sha512": "3ada5b9b2882baf2afb7df90671b80a331820f9518ac3ab6123193badbcb8c749a4e8191799a8aec6abbeffcf4a64bba8960ea24a2c507dacfd4eae7b5c1e363",
+        "dest": "nuget-sources",
+        "dest-filename": "sharpcompress.0.47.4.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/3.119.3-preview.1.1/skiasharp.3.119.3-preview.1.1.nupkg",
+        "sha512": "873b773e2179b1f0a16ed50790a98c6e3b38ed5a63c468ef334ce46155d230e2a92fc8adde014efb7233dae967207595a62c03b342945a602039e56f5916c011",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.3.119.3-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/3.119.3-preview.1.1/skiasharp.harfbuzz.3.119.3-preview.1.1.nupkg",
+        "sha512": "19835423ad70dc06654787fd3cac5bb6ab7713b433cc0f6a11e0312c451ba837b404fe3ceedf5de5e902bf87486ea14b42bebe2903473a035c02b38f34524916",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.harfbuzz.3.119.3-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/3.119.3-preview.1.1/skiasharp.nativeassets.linux.3.119.3-preview.1.1.nupkg",
+        "sha512": "bfca2fe3939f38a13bf14b4b41a9b505a2f4257942657f6cf57a98f2fb931609130c71cf15ffd9318500ac7c6c7d024ab2be37c409e036c11fb601a733502a93",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.nativeassets.linux.3.119.3-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/3.119.3-preview.1.1/skiasharp.nativeassets.macos.3.119.3-preview.1.1.nupkg",
+        "sha512": "7daa455b94202d96a84ae324e29bfc6bb05082b519e4f896463fd43c731f428ba44cf7e5ef308fe6dbe56c3fef7af0fa010ebcd4e6dd1b9d969288201f95383e",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.nativeassets.macos.3.119.3-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/3.119.3-preview.1.1/skiasharp.nativeassets.webassembly.3.119.3-preview.1.1.nupkg",
+        "sha512": "c2b84b8662d6b7c2df34ea0e6befea7a08dace7115fbe1ee9c725727a3bd630445274f74bdb967333a8b529093ad0f12c4ec9b4fa12bab336a2f6f49689beb46",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.nativeassets.webassembly.3.119.3-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/3.119.3-preview.1.1/skiasharp.nativeassets.win32.3.119.3-preview.1.1.nupkg",
+        "sha512": "362ca4f0dbb8ee7714305f964ae572b7036e4da6bd8b871cebabc5768fd099e11881072bcce74a61ba20d7f26b758df0a7629498c75da1befb072e8e906c7b0e",
+        "dest": "nuget-sources",
+        "dest-filename": "skiasharp.nativeassets.win32.3.119.3-preview.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
+        "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
+        "dest": "nuget-sources",
+        "dest-filename": "system.buffers.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.5.1/system.buffers.4.5.1.nupkg",
+        "sha512": "80da6158e55b9bcf7e0b5e6379b9cf45a632914f037b53c5bf5609576e3cd7821f7861956b73d74470d2d0c2e56dd235a5ef4ca6ffe7e192b820dc2d023aaff2",
+        "dest": "nuget-sources",
+        "dest-filename": "system.buffers.4.5.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.codedom/7.0.0/system.codedom.7.0.0.nupkg",
+        "sha512": "eb3d7dece2b09817d0e3606f8a2c0e0e94a0fc928f18ae5dd7d5c768606f01fe75c9d70d047c8f44f0ade90a133c77c00f9bce6cb88f09902a9d503ab2cbccc3",
+        "dest": "nuget-sources",
+        "dest-filename": "system.codedom.7.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg",
+        "sha512": "ca7b952d30da1487ca4e43aa522817b5ee26e7e10537062810112fc67a7512766c39d402f394bb0426d1108bbcf9bbb64e9ce1f5af736ef215a51a35e55f051b",
+        "dest": "nuget-sources",
+        "dest-filename": "system.collections.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
+        "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
+        "dest": "nuget-sources",
+        "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg",
+        "sha512": "6c58fe1e3618e7f87684c1cea7efc7d3b19bd7df8d2535f9e27b62c52f441f11b67b21225d6bcd62f409e02c2a16231c4db19be33b8fab5b9b0a5c8660ddab24",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.debug.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/11.0.0-preview.2.26159.112/system.diagnostics.diagnosticsource.11.0.0-preview.2.26159.112.nupkg",
+        "sha512": "8504c9e2a08418991fe0d49892e2766f1aea1a07123977ed4d9f7caf48ce34ec1ebc49df4bf6b9fb37fc769549248a636d84c5cc2a19432f82edccd6d5352492",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.diagnosticsource.11.0.0-preview.2.26159.112.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
+        "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
+        "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
+        "dest": "nuget-sources",
+        "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg",
+        "sha512": "823d2ba308cb073b40a3146ecccd0d9fd7b1615ac3fbefb16f73d873e411fd81c3bdc87df206d3dc7e2f14c9cd53aafca684a3570c25471280aada8de805ece2",
+        "dest": "nuget-sources",
+        "dest-filename": "system.globalization.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
+        "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
+        "dest": "nuget-sources",
+        "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
+        "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
+        "dest": "nuget-sources",
+        "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
+        "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
+        "dest": "nuget-sources",
+        "dest-filename": "system.io.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
+        "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
+        "dest": "nuget-sources",
+        "dest-filename": "system.io.filesystem.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg",
+        "sha512": "5885953d09582cffd973d23a21a929064d72f2bc9518af3732d671fffcc628a8b686f1d058a001ee6a114023b3e48b3fc0d0e4b22629a1c7f715e03795ee9ee5",
+        "dest": "nuget-sources",
+        "dest-filename": "system.io.filesystem.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg",
+        "sha512": "eacc7fe1ec526f405f5ba0e671f616d0e5be9c1828d543a9e2f8c65df4099d6b2ea4a9fa2cdae4f34b170dc37142f60e267e137ca39f350281ed70d2dc620458",
+        "dest": "nuget-sources",
+        "dest-filename": "system.linq.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.management/7.0.2/system.management.7.0.2.nupkg",
+        "sha512": "9e00c0030d7fa1858fc0211d47261b6387fd9481ef9674b218cc217048f94c1fb1bbe23e72e27280fcd1852b5847a0c2f351157920bbc6f72452ba0cd32fd18e",
+        "dest": "nuget-sources",
+        "dest-filename": "system.management.7.0.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.4/system.memory.4.5.4.nupkg",
+        "sha512": "8ece5491eb0fe332bc190f40cf76b3beee0c5f996325034861be221fdb0ff02fd59e4f7020b3c4a1f29a457f76ff76c4c95d46d38555e4f48c7a3bf172d87966",
+        "dest": "nuget-sources",
+        "dest-filename": "system.memory.4.5.4.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.4/system.net.http.4.3.4.nupkg",
+        "sha512": "163edeef734d1f0a1ff7b8053d326eabc82fe86f3de72c6466dd780d59d974487882f2a5f16ae4b02c0d8c8a7f25e617ff2bbfab133f88ebfd6a2f99637169ed",
+        "dest": "nuget-sources",
+        "dest-filename": "system.net.http.4.3.4.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
+        "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
+        "dest": "nuget-sources",
+        "dest-filename": "system.net.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.numerics.vectors/4.4.0/system.numerics.vectors.4.4.0.nupkg",
+        "sha512": "81d46b509b3546b8d6dc9079a7cda162303aef1a1e14bbe1d127522168d388df2a13195b16dfd1b57c1560d73906e909fdff4e2b34104ba81a9336c97874ea1e",
+        "dest": "nuget-sources",
+        "dest-filename": "system.numerics.vectors.4.4.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.private.uri/4.3.0/system.private.uri.4.3.0.nupkg",
+        "sha512": "5989a57ef273b689a663e961a0fe09d9b1d88438e5478358efc4b165de3b2674fa9579c301ce12d2d2fa5f33295f2acb42eceea2ebebf70c733da6364ceaf94d",
+        "dest": "nuget-sources",
+        "dest-filename": "system.private.uri.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg",
+        "sha512": "2325b67ed60dce0302807064f25422cbe1b7fb275b539b44fba3c4a8ce4926f21d78529a5c34b31c03d80d110f7bace9af9589d457266beac014220057af8333",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg",
+        "sha512": "d4b9cc905f5a5cab900206338e889068bf66c18ee863a29d68eff3cde2ccca734112a2a851f2e2e5388a21ec28005fa19317c64d9b23923b05d6344be2e49eaa",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg",
+        "sha512": "9067db28f1c48d08fc52ad40a608f88c14ad9112646741ddaf426fdfe68bed61ab01954b179461e61d187371600c1e6e5c36c788993f5a105a64f5702a6b81d4",
+        "dest": "nuget-sources",
+        "dest-filename": "system.resources.resourcemanager.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
+        "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.3/system.runtime.compilerservices.unsafe.4.5.3.nupkg",
+        "sha512": "765d87d36a7b7415dee5b6cbd3a08ead9762915fbfacfad8a205a78d4a187cec6677da2407f7f7c2d1b55fe9f8c0257925c9b0bc193d402972c323979678baab",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.compilerservices.unsafe.4.5.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.7.1/system.runtime.compilerservices.unsafe.4.7.1.nupkg",
+        "sha512": "c8d781feacf79f3effc1c231a84beb0fa1e869fbeaa1d94ba3e84db75afe915e045c39ce059331fe48956534dcebdcd54fd97ab199e6a090bddc5250e208ee52",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.compilerservices.unsafe.4.7.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg",
+        "sha512": "680a32b19c2bd5026f8687aa5382aea4f432b4f032f8bde299facb618c56d57369adef7f7cc8e60ad82ae3c12e5dd50772491363bf8044c778778628a6605bbc",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg",
+        "sha512": "0a5baf1dd554bf9e01bcb4ce082cb26ee82b783364feb47cba730faeecd70edc528efad0394dcce11f37d7f9507f8608f15629ebaf051906bfd3513e46af0f11",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.handles.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg",
+        "sha512": "650799c3e654efbb9ad67157c9c60ce46f288a81597be37ce2a0bf5d4835044065ef3f65b997328cbbbbfb81f4c89b8d7e7d61380880019deee6eb3f963f70d9",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.interopservices.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
+        "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/5.0.0/system.security.accesscontrol.5.0.0.nupkg",
+        "sha512": "ae6b03ad029d3eb6818a6c8bb56cf4904013fa535a67b8e621b783a029dd88aa2e471e002cbc7d720381ad8bc8c6b93111a08f6ce2d271af6d974bf4d02b6c81",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.accesscontrol.5.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
+        "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
+        "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
+        "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
+        "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
+        "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
+        "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
+        "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/5.0.0/system.security.principal.windows.5.0.0.nupkg",
+        "sha512": "44a920aaaf22b2172d41319bb57ab2b8e1a4531d5f02192a6f53a81d875125195b60ba0b5a44a45981d137fd7b0f3a65b12959b5fd97afc0578cd84ef27467cd",
+        "dest": "nuget-sources",
+        "dest-filename": "system.security.principal.windows.5.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg",
+        "sha512": "6ff7feec7313a7121f795ec7d376e4b8728c17294219fafdfd4ea078f9df1455b4685f0b3962c3810098e95d68594a8392c0b799d36ec8284cd6fcbd4cfe2c67",
+        "dest": "nuget-sources",
+        "dest-filename": "system.text.encoding.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/4.7.1/system.text.encoding.codepages.4.7.1.nupkg",
+        "sha512": "bc2a94794af9b16d1d3dba1aa132baab756722a3064ad850eb051ff86dc7ffa93a4f69daf34c235c6a539541f798c2f197fff5215f15cefa57b0775cefd372e7",
+        "dest": "nuget-sources",
+        "dest-filename": "system.text.encoding.codepages.4.7.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
+        "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
+        "dest": "nuget-sources",
+        "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.threading/4.3.0/system.threading.4.3.0.nupkg",
+        "sha512": "97a2751bdce69faaf9c54f834a9fd5c60c7a786faa52f420769828dbc9b5804c1f3721ba1ea945ea1d844835d909810f9e782c9a44d0faaecccb230c4cd95a88",
+        "dest": "nuget-sources",
+        "dest-filename": "system.threading.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg",
+        "sha512": "7d488ff82cb20a3b3cef6380f2dae5ea9f7baa66bf75ad711aade1e3301b25993ccf2694e33c847ea5b9bdb90ff34c46fcd8a6ba7d6f95605ba0c124ed7c5d13",
+        "dest": "nuget-sources",
+        "dest-filename": "system.threading.tasks.4.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/taglibsharp/2.3.0/taglibsharp.2.3.0.nupkg",
+        "sha512": "9be37f6431f6ead36babe78dc6527340d7b4b0fe444736aaeae5aef3651191d4e0421d9d671106aea544888695d7841000fb12f8a44aab1b5fe93fb7c90d983f",
+        "dest": "nuget-sources",
+        "dest-filename": "taglibsharp.2.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/textmatesharp/2.0.3/textmatesharp.2.0.3.nupkg",
+        "sha512": "8989d09d842f7f31864919d5d290ec09915a5ce420dd5904e12686ec44fa337bce35df86a74759300ce50eca43563ba07b990f4ff7a4243dd4a13fbb77732b2f",
+        "dest": "nuget-sources",
+        "dest-filename": "textmatesharp.2.0.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/textmatesharp.grammars/2.0.3/textmatesharp.grammars.2.0.3.nupkg",
+        "sha512": "ddbfb1affb1edaf0c3f1e2bb47997c77b3c84a9bdee08ad68f32fcd852b9bb874e38c56b91310936503775d461597d9e35efdb820e3d778a357aa599e3b0d0b8",
+        "dest": "nuget-sources",
+        "dest-filename": "textmatesharp.grammars.2.0.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus.protocol/0.92.0/tmds.dbus.protocol.0.92.0.nupkg",
+        "sha512": "450d6c0efa7798327892e10e935cfc027dbd9a612249247ba89bd25620d151282a9e69ad8adc779fddaefe66134a3edc6c3a504b3d93d5b3c2eb87b61674bbaf",
+        "dest": "nuget-sources",
+        "dest-filename": "tmds.dbus.protocol.0.92.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/utf.unknown/2.6.0/utf.unknown.2.6.0.nupkg",
+        "sha512": "26c162a2924e65af28e4a0aca5c103a5f2887a6576920ee34e9e38bd451b70c0e038313f5f85ecc25d33d49a0491deb5fba937336de8f0fb9b5cfc26bdd69612",
+        "dest": "nuget-sources",
+        "dest-filename": "utf.unknown.2.6.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/wecantspell.hunspell/7.0.1/wecantspell.hunspell.7.0.1.nupkg",
+        "sha512": "9690bb0a1fc01e3c946fd2304e74117bceb8aed774e00a59dbaea9b9f875f18946928959257186c6d55cbfc40542b8598cd6adb0a9cec0aa259ceeb065c27392",
+        "dest": "nuget-sources",
+        "dest-filename": "wecantspell.hunspell.7.0.1.nupkg"
+    }
+]


### PR DESCRIPTION
Groundwork for publishing on Flathub (#11800). The existing CI Flatpak (`installer/flatpak/`) already builds from source with bundled mpv/ffmpeg/Tesseract+eng and offline NuGet, and is green in `build-flatpak.yml` — so this is just the small adaptation needed to submit, not a new packaging effort.

## What's here
- **`installer/flatpak/flathub/dk.nikse.subtitleedit.yaml`** — identical to the CI manifest except the app source is a **pinned git tag + commit** (`v5.0.0` / `a44ffa70…`) instead of the local `type: dir` checkout. Flathub builds from the public repo, so this is the form it needs.
- **`installer/flatpak/flathub/nuget-sources.json`** — copy of the offline NuGet sources (must be regenerated for the pinned commit before submitting; noted in the README).
- **`installer/flatpak/flathub/README.md`** — submission steps (regenerate sources → validate → fork `flathub/flathub` → branch `dk.nikse.subtitleedit` → PR to `new-pr`), plus the likely reviewer questions.
- **metainfo**: added the `5.0.0` stable release (Flathub wants the latest release listed; it previously only had `5.0.0-beta9`).

## Not done here (needs a Linux box / the maintainer)
- Regenerating `nuget-sources.json` at the v5.0.0 commit (`generate-nuget-sources.sh`).
- Running `appstreamcli validate` + `flatpak-builder-lint` (no flatpak tooling on macOS; the metainfo is at least well-formed XML).
- The actual `flathub/flathub` PR and flathub.org verification.

## Heads-up for review
The main discussion point will be the **optional AI engines downloading executables at runtime** (whisper.cpp, CrispASR, TTS/STT). Core editing, OCR (bundled Tesseract) and video (bundled mpv/ffmpeg) all work offline, but Flathub scrutinizes runtime executable downloads — be ready to justify or limit those under the sandbox. (Details in the README.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)