### PR TITLE
Fix SurroundWith to place symbols after formatting tags, add spacing for music symbols

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9744,23 +9744,13 @@ public partial class MainViewModel :
         }
 
         var first = selectedItems.First();
-        var haveSurround = first.Text.StartsWith(surroundLeft) && first.Text.EndsWith(surroundRight);
+        first.Text = Utilities.ToggleSymbols(surroundLeft, first.Text, surroundRight, out var added);
 
-        // add toggle functionality
-        foreach (var item in selectedItems)
+        foreach (var item in selectedItems.Skip(1))
         {
-            if (haveSurround)
-            {
-                if (item.Text.StartsWith(surroundLeft) && item.Text.EndsWith(surroundRight))
-                {
-                    item.Text = item.Text.Substring(surroundLeft.Length,
-                        item.Text.Length - surroundLeft.Length - surroundRight.Length);
-                }
-            }
-            else
-            {
-                item.Text = surroundLeft + item.Text + surroundRight;
-            }
+            item.Text = added
+                ? Utilities.AddSymbols(surroundLeft, item.Text, surroundRight)
+                : Utilities.RemoveSymbols(surroundLeft, item.Text, surroundRight);
         }
 
         _updateAudioVisualizer = true;


### PR DESCRIPTION
  ## Problem

  The "Surround with..." context menu feature used simple string concatenation to wrap subtitle text, which placed the symbol *before* any leading formatting tags:

  - Input: `{\an8}Hello` → Result: `♪{\an8}Hello♪`

  This breaks subtitle rendering since `{\an8}` must appear at the very start of the line.
  The same issue affects `<i>`, `<b>`, `<u>`, and `<font>` tags. Trailing closing tags (`</i>` etc.) had the same problem in reverse.

  Additionally, no spacing was added around music symbols: SE4 produced `♪ Hello ♪` but SE5 produced `♪Hello♪`.

  ## Fix

  Replace the naive concatenation with calls to the existing `Utilities.ToggleSymbols`, `Utilities.AddSymbols`, and `Utilities.RemoveSymbols` helpers (already present in `Utilities.cs`). These methods use `SplitStartTags`/`SplitEndTags` to extract leading/trailing formatting tags before inserting the symbol, then reassemble as `{tags}{symbol}{text}{symbol}{closing tags}`.

  **After:**
  - `{\an8}Hello` → `{\an8}♪ Hello ♪`
  - `<i>Hello</i>` → `<i>[Hello]</i>`
  - Toggle off correctly detects and removes symbols even when tags are present
  - Multi-line selection: first line determines add/remove direction, rest follow

## Summary of regressions in SE5

  | Behavior | SE4 | SE5 |
  |---|---|---|
  | `{\an8}` stays before symbol | ✅ Yes (pre extraction) | ❌ No, ends up inside |
  | `<i>` stays before symbol | ✅ Yes | ❌ No |
  | Closing tags (`</i>`) stay after symbol | ✅ Yes | ❌ No |
  | Space after opening music symbol | ✅ `♪ text ♪` | ❌ `♪text♪` |
