### PR TITLE
Fix Find Next/Previous shortcuts while Find/Replace windows are open

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9996,7 +9996,7 @@ public partial class MainViewModel :
             vm.InitializeFindData(_findService, subs, selectedText, this);
             window.AddHandler(InputElement.KeyDownEvent, _shortcutManager.OnKeyPressed, RoutingStrategies.Tunnel);
             window.AddHandler(InputElement.KeyUpEvent, _shortcutManager.OnKeyReleased, RoutingStrategies.Bubble);
-            window.KeyDown += (_, e) =>
+            window.KeyDown += async (_, e) =>
             {
                 var cmd = _shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
                 if (ReferenceEquals(cmd, ShowReplaceCommand))
@@ -10008,6 +10008,16 @@ public partial class MainViewModel :
                 {
                     e.Handled = true;
                     vm.FocusSearchBox?.Invoke();
+                }
+                else if (ReferenceEquals(cmd, FindNextCommand))
+                {
+                    e.Handled = true;
+                    await vm.FindNextCommand.ExecuteAsync(null);
+                }
+                else if (ReferenceEquals(cmd, FindPreviousCommand))
+                {
+                    e.Handled = true;
+                    await vm.FindPreviousCommand.ExecuteAsync(null);
                 }
             };
             window.Closed += (_, _) =>
@@ -10340,13 +10350,18 @@ public partial class MainViewModel :
             }
             window.AddHandler(InputElement.KeyDownEvent, _shortcutManager.OnKeyPressed, RoutingStrategies.Tunnel);
             window.AddHandler(InputElement.KeyUpEvent, _shortcutManager.OnKeyReleased, RoutingStrategies.Bubble);
-            window.KeyDown += (_, e) =>
+            window.KeyDown += async (_, e) =>
             {
                 var cmd = _shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
                 if (ReferenceEquals(cmd, ShowReplaceCommand))
                 {
                     e.Handled = true;
                     vm.FocusSearchBox?.Invoke();
+                }
+                else if (ReferenceEquals(cmd, FindNextCommand))
+                {
+                    e.Handled = true;
+                    await vm.FindNextCommand.ExecuteAsync(null);
                 }
             };
             window.Closed += (_, _) =>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10095,6 +10095,7 @@ public partial class MainViewModel :
                     ? Se.Language.General.SearchItemNotFoundContinueFromTop
                     : Se.Language.General.SearchItemNotFoundContinueFromBottom;
                 var answer = await ShowWrapAroundDialog(message);
+                _shortcutManager.ClearKeys();
                 if (answer != MessageBoxResult.Yes)
                 {
                     ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));
@@ -10532,6 +10533,7 @@ public partial class MainViewModel :
             if (idx < 0)
             {
                 var answer = await ShowWrapAroundDialog(Se.Language.General.SearchItemNotFoundContinueFromTop);
+                _shortcutManager.ClearKeys();
                 if (answer != MessageBoxResult.Yes)
                 {
                     ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));


### PR DESCRIPTION
  F3 (Find Next) and Shift+F3 (Find Previous) had no effect when the Find window was focused, and F3 had no effect in the Replace window.

  The root cause: when a child window has focus, the main window's `OnKeyDownHandler` never fires. The Find/Replace windows register the shortcut manager for key-state tracking, but their `window.KeyDown` dispatch handlers only handled `ShowFind`/`ShowReplace` — never `FindNext`/`FindPrevious`.

  **Fix:** extend the `window.KeyDown` handlers in `ShowFind()` and `ShowReplace()` to also dispatch `FindNextCommand` and `FindPreviousCommand` to the dialog's own ViewModel, so the behavior is identical to clicking the buttons.

  - Find window: F3 → Find Next, Shift+F3 → Find Previous
  - Replace window: F3 → Find Next
