### PR TITLE
Add "Set end, add new and go to new" shortcuts (#9788)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12239,6 +12239,66 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
+    [RelayCommand]
+    private void WaveformSetEndAddNewAndGoToNew()
+    {
+        SetEndAddNewAndGoToNew(focusTextBox: true);
+    }
+
+    [RelayCommand]
+    private void WaveformSetEndAddNewAndGoToNewNoFocusTextBox()
+    {
+        SetEndAddNewAndGoToNew(focusTextBox: false);
+    }
+
+    // Sets the end of the current subtitle to the playhead, inserts a new empty subtitle just after
+    // it, and selects that new subtitle (issue #9788). The "no focus" variant leaves keyboard focus
+    // where it is instead of jumping into the text box, for waveform/keyboard-driven workflows.
+    private void SetEndAddNewAndGoToNew(bool focusTextBox)
+    {
+        var s = SelectedSubtitle;
+        var vp = GetVideoPlayerControl();
+        if (s == null || vp == null || AudioVisualizer == null || LockTimeCodes)
+        {
+            return;
+        }
+
+        var videoPositionSeconds = vp.Position;
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        if (videoPositionSeconds < s.StartTime.TotalSeconds + gapMs / 1000.0)
+        {
+            return;
+        }
+
+        s.EndTime = TimeSpan.FromSeconds(videoPositionSeconds);
+
+        var startMs = videoPositionSeconds * 1000.0 + gapMs;
+        var endMs = startMs + Se.Settings.General.NewEmptyDefaultMs;
+        var newParagraph = new SubtitleLineViewModel(new Paragraph(string.Empty, startMs, endMs), SelectedSubtitleFormat);
+
+        RunWithoutChangeDetection(() =>
+        {
+            var idx = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+            var next = Subtitles.GetOrNull(idx + 1);
+            if (next != null &&
+                next.StartTime.TotalMilliseconds < endMs &&
+                next.StartTime.TotalMilliseconds > newParagraph.StartTime.TotalMilliseconds + 200)
+            {
+                newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - gapMs);
+            }
+        });
+
+        AudioVisualizer.NewSelectionParagraph = null;
+        SelectAndScrollToSubtitle(newParagraph);
+        Renumber();
+        if (focusTextBox)
+        {
+            FocusEditTextBox();
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
 
     [RelayCommand]
     private void WaveformSetEndAndStartOfNextAfterGap()

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -216,6 +216,7 @@ public static class Se4ShortcutsImporter
         ["MainCreateSetStart"] = nameof(MainViewModel.WaveformSetStartCommand),
         ["MainCreateSetEnd"] = nameof(MainViewModel.WaveformSetEndCommand),
         ["MainCreateStartDownEndUp"] = nameof(MainViewModel.InsertSubtitleAtVideoPositionSetEndAtKeyUpCommand),
+        ["MainCreateSetEndAddNewAndGoToNew"] = nameof(MainViewModel.WaveformSetEndAddNewAndGoToNewCommand),
         ["MainAdjustSetStartAndOffsetTheRest"] = nameof(MainViewModel.WaveformSetStartAndOffsetTheRestCommand),
         ["MainAdjustSetStartAndOffsetTheRest2"] = nameof(MainViewModel.WaveformSetStartAndOffsetTheRestCommand),
         ["MainAdjustSetStartAndEndOfPrevious"] = nameof(MainViewModel.WaveformSetStartAndSetEndOfPreviousMinusGapCommand),

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -500,6 +500,8 @@ public class LanguageGeneral
     public string SessionKeyGenerate { get; set; }
     public string SetEnd { get; set; }
     public string SetEndAndGoToNext { get; set; }
+    public string SetEndAddNewAndGoToNew { get; set; }
+    public string SetEndAddNewAndGoToNewNoFocusTextBox { get; set; }
     public string SetEndAndOffsetTheRest { get; set; }
     public string SetFontDotDotDot { get; set; }
     public string SetInCueToClosestShotChangeLeftGreenZone { get; set; }
@@ -1237,6 +1239,8 @@ public class LanguageGeneral
         SessionKeyGenerate = "Generate new key";
         SetEnd = "Set end";
         SetEndAndGoToNext = "Set end and go to next";
+        SetEndAddNewAndGoToNew = "Set end, add new and go to new";
+        SetEndAddNewAndGoToNewNoFocusTextBox = "Set end, add new and go to new (no focus text box)";
         SetEndAndOffsetTheRest = "Set end and offset the rest";
         SetFontDotDotDot = "Set font...";
         SetInCueToClosestShotChangeLeftGreenZone = "Set in-cue to closest shot change (snap to left green zone)";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -254,6 +254,8 @@ public static class ShortcutsMain
         { nameof(MainViewModel.WaveformSetStartCommand),  Se.Language.General.SetStart },
         { nameof(MainViewModel.WaveformSetEndCommand),  Se.Language.General.SetEnd },
         { nameof(MainViewModel.WaveformSetEndAndGoToNextCommand),  Se.Language.General.SetEndAndGoToNext },
+        { nameof(MainViewModel.WaveformSetEndAddNewAndGoToNewCommand),  Se.Language.General.SetEndAddNewAndGoToNew },
+        { nameof(MainViewModel.WaveformSetEndAddNewAndGoToNewNoFocusTextBoxCommand),  Se.Language.General.SetEndAddNewAndGoToNewNoFocusTextBox },
         { nameof(MainViewModel.DoWaveformCenterCommand),  Se.Language.General.WaveformCenterOnVideoPosition },
         { nameof(MainViewModel.ToggleShotChangesAtVideoPositionCommand),  Se.Language.General.ToggleShotChangesAtVideoPosition },
         { nameof(MainViewModel.GoToPreviousShotChangeCommand),  Se.Language.General.GoToPreviousShotChange },
@@ -605,6 +607,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.WaveformSetStartCommand, nameof(vm.WaveformSetStartCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformSetEndCommand, nameof(vm.WaveformSetEndCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformSetEndAndGoToNextCommand, nameof(vm.WaveformSetEndAndGoToNextCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.WaveformSetEndAddNewAndGoToNewCommand, nameof(vm.WaveformSetEndAddNewAndGoToNewCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.WaveformSetEndAddNewAndGoToNewNoFocusTextBoxCommand, nameof(vm.WaveformSetEndAddNewAndGoToNewNoFocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.DoWaveformCenterCommand, nameof(vm.DoWaveformCenterCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformSetEndAndStartOfNextAfterGapCommand, nameof(vm.WaveformSetEndAndStartOfNextAfterGapCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformSetEndAndStartOfNextAfterGapAndGoToNextCommand, nameof(vm.WaveformSetEndAndStartOfNextAfterGapAndGoToNextCommand), ShortcutCategory.General);


### PR DESCRIPTION
Fixes #9788.

SE5 had "Set end and go to next" but not "Set end, **add new** and go to **new**". This adds it, plus the no-text-box-focus variant the issue asked for.

## What it does
Both new commands: set the current subtitle's **end** to the playhead, insert a **new empty** subtitle just after it (respecting the min-gap and clamping to the following line), then **select** that new subtitle.

- **"Set end, add new and go to new"** — focuses the text box afterwards (matches the SE4 feature).
- **"Set end, add new and go to new (no focus text box)"** — keeps keyboard focus where it is, for waveform/keyboard-driven workflows (the actual request).

## Implementation
Both call a shared `SetEndAddNewAndGoToNew(bool focusTextBox)` that reuses the existing insert-at-position logic (`WaveformInsertAtPositionAndFocusTextBox` / `…NoFocusTextBox`); the only difference between the two is the trailing `FocusEditTextBox()` call.

Wired into the assignable shortcut list (`ShortcutsMain`, display strings + registration) and mapped the base command from the SE4 importer (`MainCreateSetEndAddNewAndGoToNew`). No default key — users assign it.

Build is clean.

> Note: I mapped the SE4 key as `MainCreateSetEndAddNewAndGoToNew` (the conventional `MainCreate…` name); if classic SE used a different setting name, the import mapping just no-ops — easy to adjust.