### PR TITLE
Broaden Linux CJK font fallbacks for Korean/Chinese

### DIFF
--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -88,7 +88,9 @@ namespace Nikse.SubtitleEdit
                     // back to system fonts from a forced embedded default - so name the common Linux
                     // CJK families explicitly. fontconfig resolves whichever of these is installed
                     // (normal desktops ship Noto Sans CJK); minimal installs have no CJK font at all,
-                    // so CJK can't render there regardless.
+                    // so CJK can't render there regardless. The non-CJK-suffixed Noto families and the
+                    // Nanum/WenQuanYi entries cover distros that ship a region-specific Korean/Chinese
+                    // font instead of the full Noto Sans CJK pack.
                     appBuilder = appBuilder
                         .WithInterFont()
                         .With(new FontManagerOptions
@@ -99,7 +101,14 @@ namespace Nikse.SubtitleEdit
                                 new FontFallback { FontFamily = new FontFamily("Noto Sans CJK KR") },
                                 new FontFallback { FontFamily = new FontFamily("Noto Sans CJK JP") },
                                 new FontFallback { FontFamily = new FontFamily("Noto Sans CJK TC") },
+                                new FontFallback { FontFamily = new FontFamily("Noto Sans KR") },
+                                new FontFallback { FontFamily = new FontFamily("Noto Sans JP") },
+                                new FontFallback { FontFamily = new FontFamily("Noto Sans SC") },
+                                new FontFallback { FontFamily = new FontFamily("NanumGothic") },
+                                new FontFallback { FontFamily = new FontFamily("Nanum Gothic") },
+                                new FontFallback { FontFamily = new FontFamily("UnDotum") },
                                 new FontFallback { FontFamily = new FontFamily("WenQuanYi Zen Hei") },
+                                new FontFallback { FontFamily = new FontFamily("WenQuanYi Micro Hei") },
                             }
                         });
                 }


### PR DESCRIPTION
Follow-up to #11831.

A user on **Ubuntu Linux** (the screenshot was Mac-themed, but the system is Linux) reported the UI rendering as boxes for Korean. PR #11831 added Linux CJK fallbacks, but only named the full **Noto Sans CJK** pack. Some distros ship a region-specific font instead.

## Change
Broaden the Linux `FontManagerOptions.FontFallbacks` list with additional Korean/Chinese families:

- `Noto Sans KR` / `Noto Sans JP` / `Noto Sans SC` (non-CJK-suffixed Noto variants)
- `NanumGothic` / `Nanum Gothic` / `UnDotum` (common Korean fonts)
- `WenQuanYi Micro Hei` (Chinese)

fontconfig resolves whichever of these is installed, so the UI renders CJK glyphs on a wider range of Linux installs. macOS/Windows are unaffected (they use the system default font).

🤖 Generated with [Claude Code](https://claude.com/claude-code)