### PR TITLE
Add "Add custom model" GUI for Whisper engines (#11842)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -10,11 +10,13 @@ using System.Threading.Tasks;
 using System.Timers;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
@@ -35,6 +37,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
     [ObservableProperty] private string _progressFileName;
     [ObservableProperty] private string _error;
     [ObservableProperty] bool _downloadIsEnabled;
+    [ObservableProperty] private bool _supportsCustomModels;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; internal set; }
@@ -76,6 +79,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
     public void SetModels(ObservableCollection<SpeechToTextModelDisplay> models, ISpeechToTextEngine whisperEngine, SpeechToTextModelDisplay? whisperModel)
     {
         _whisperEngine = whisperEngine;
+        SupportsCustomModels = whisperEngine.SupportsCustomModels;
 
         foreach (var model in models)
         {
@@ -235,6 +239,88 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
 
         var folder = _whisperEngine.GetAndCreateWhisperModelFolder(SelectedModel?.Model);
         await _folderHelper.OpenFolder(Window!, folder);
+    }
+
+    [RelayCommand]
+    private async Task AddCustomModel()
+    {
+        if (_whisperEngine is not { SupportsCustomModels: true } engine || Window == null)
+        {
+            return;
+        }
+
+        try
+        {
+            string? sourcePath;
+            if (engine.CustomModelIsFolder)
+            {
+                var folders = await Window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                {
+                    Title = Se.Language.Video.AudioToText.SelectModel,
+                    AllowMultiple = false,
+                });
+                sourcePath = folders.Count > 0 ? folders[0].Path.LocalPath : null;
+            }
+            else
+            {
+                var files = await Window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = Se.Language.Video.AudioToText.SelectModel,
+                    AllowMultiple = false,
+                    FileTypeFilter = new List<FilePickerFileType>
+                    {
+                        new FilePickerFileType("Whisper model (*.bin)")
+                        {
+                            Patterns = new List<string> { "*.bin" },
+                        },
+                    },
+                });
+                sourcePath = files.Count > 0 ? files[0].Path.LocalPath : null;
+            }
+
+            if (string.IsNullOrEmpty(sourcePath))
+            {
+                return;
+            }
+
+            var newName = engine.ImportCustomModel(sourcePath);
+            ReloadModels(newName);
+        }
+        catch (Exception ex)
+        {
+            Error = ex.Message;
+            await MessageBox.Show(Window, "Error", ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void ReloadModels(string? selectName)
+    {
+        if (_whisperEngine == null)
+        {
+            return;
+        }
+
+        Models.Clear();
+        SpeechToTextModelDisplay? toSelect = null;
+        foreach (var model in _whisperEngine.Models)
+        {
+            var display = new SpeechToTextModelDisplay
+            {
+                Model = model,
+                Engine = _whisperEngine,
+            };
+            Models.Add(display);
+
+            if (selectName != null && model.Name.Equals(selectName, StringComparison.OrdinalIgnoreCase))
+            {
+                toSelect = display;
+            }
+        }
+
+        if (toSelect != null)
+        {
+            SelectedModel = toSelect;
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Styling;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -43,6 +44,9 @@ public class DownloadSpeechToTextModelsWindow : Window
         };
         Attached.SetIcon(buttonOpenFolder, "fa-solid fa-folder-open");
 
+        var buttonAddCustomModel = UiUtil.MakeButton(Se.Language.Video.AudioToText.AddCustomModelDotDotDot, vm.AddCustomModelCommand);
+        buttonAddCustomModel.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.SupportsCustomModels)));
+
         var panelModelButtons = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -51,9 +55,21 @@ public class DownloadSpeechToTextModelsWindow : Window
             Children =
             {
                 buttonDownload,
-                buttonOpenFolder
+                buttonOpenFolder,
+                buttonAddCustomModel
             }
         };
+
+        var labelCustomModelHelp = new TextBlock
+        {
+            Text = Se.Language.Video.AudioToText.CustomModelHelp,
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.6,
+            MaxWidth = 460,
+            Margin = new Thickness(0, 6, 0, 0),
+            HorizontalAlignment = HorizontalAlignment.Left,
+        };
+        labelCustomModelHelp.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.SupportsCustomModels)));
 
 
         var progressBar = UiUtil.MakeProgressBar();
@@ -94,7 +110,7 @@ public class DownloadSpeechToTextModelsWindow : Window
         var grid = new Grid
         {
             ColumnDefinitions = new ColumnDefinitions("Auto, *"),
-            RowDefinitions = new RowDefinitions("Auto, Auto, Auto, Auto"),
+            RowDefinitions = new RowDefinitions("Auto, Auto, Auto, Auto, Auto"),
             Margin = UiUtil.MakeWindowMargin(),
         };
 
@@ -112,6 +128,12 @@ public class DownloadSpeechToTextModelsWindow : Window
         grid.Children.Add(panelModelButtons);
         Grid.SetRow(panelModelButtons, row);
         Grid.SetColumn(panelModelButtons, 1);
+        row++;
+
+        grid.Children.Add(labelCustomModelHelp);
+        Grid.SetColumnSpan(labelCustomModelHelp, 2);
+        Grid.SetRow(labelCustomModelHelp, row);
+        Grid.SetColumn(labelCustomModelHelp, 0);
         row++;
 
         grid.Children.Add(panelStatus);

--- a/src/ui/Features/Video/SpeechToText/Engines/ISpeechToTextEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ISpeechToTextEngine.cs
@@ -30,6 +30,27 @@ public interface ISpeechToTextEngine
     string GetExecutable();
     string GetExecutableFileName() => Path.GetFileName(GetExecutable());
     bool IsModelInstalled(WhisperModel model);
+
+    /// <summary>
+    /// True when the user can add their own model to this engine's model folder and have
+    /// it picked up automatically (whisper.cpp, Purfview Faster-Whisper-XXL, CTranslate2).
+    /// </summary>
+    bool SupportsCustomModels => false;
+
+    /// <summary>
+    /// True when a custom model is a folder (containing model.bin), false when it is a
+    /// single file (e.g. a whisper.cpp ggml .bin). Controls whether the UI shows a folder
+    /// or a file picker. Only meaningful when <see cref="SupportsCustomModels"/> is true.
+    /// </summary>
+    bool CustomModelIsFolder => false;
+
+    /// <summary>
+    /// Copies a user-provided custom model (a file or a folder, per <see cref="CustomModelIsFolder"/>)
+    /// into this engine's model folder, validating it, and returns the resulting model display
+    /// name. Throws with a user-facing message when the source is not a valid model.
+    /// </summary>
+    string ImportCustomModel(string sourcePath) => throw new System.NotSupportedException();
+
     string GetModelForCmdLine(string modelName);
     Task<string> GetHelpText();
     string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url);

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
@@ -94,6 +94,16 @@ public class WhisperEngineCTranslate2 : ISpeechToTextEngine
         return modelFileName;
     }
 
+    public bool SupportsCustomModels => true;
+
+    public bool CustomModelIsFolder => true;
+
+    public string ImportCustomModel(string sourcePath)
+    {
+        // CTranslate2 shares Purfview's "_models" folder and faster-whisper folder layout.
+        return WhisperEnginePurfviewFasterWhisperXxl.ImportFasterWhisperFolderModel(sourcePath, GetAndCreateWhisperModelFolder(null));
+    }
+
     public async Task<string> GetHelpText()
     {
         var assetName = $"{StaticName.Replace(" ", string.Empty)}.txt";

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
@@ -126,6 +126,33 @@ public class WhisperEngineCpp : ISpeechToTextEngine
         return modelFileName;
     }
 
+    public bool SupportsCustomModels => true;
+
+    public bool CustomModelIsFolder => false;
+
+    public string ImportCustomModel(string sourcePath)
+    {
+        if (!File.Exists(sourcePath))
+        {
+            throw new FileNotFoundException("Model file not found.", sourcePath);
+        }
+
+        if (!sourcePath.EndsWith(".bin", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new Exception("A whisper.cpp model must be a ggml '.bin' file.");
+        }
+
+        if (new FileInfo(sourcePath).Length < 10_000_000)
+        {
+            throw new Exception("The model file is too small (must be at least 10 MB) - is it really a whisper.cpp model?");
+        }
+
+        var destination = Path.Combine(GetAndCreateWhisperModelFolder(null), Path.GetFileName(sourcePath));
+        File.Copy(sourcePath, destination, true);
+
+        return Path.GetFileNameWithoutExtension(destination);
+    }
+
     public async Task<string> GetHelpText()
     {
         var assetName = $"{StaticName.Replace(" ", string.Empty)}.txt";

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEnginePurfviewFasterWhisperXxl.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEnginePurfviewFasterWhisperXxl.cs
@@ -127,6 +127,67 @@ public class WhisperEnginePurfviewFasterWhisperXxl : ISpeechToTextEngine
         return modelName;
     }
 
+    public bool SupportsCustomModels => true;
+
+    public bool CustomModelIsFolder => true;
+
+    public string ImportCustomModel(string sourcePath)
+    {
+        return ImportFasterWhisperFolderModel(sourcePath, GetAndCreateWhisperModelFolder(null));
+    }
+
+    /// <summary>
+    /// Validates and copies a faster-whisper model folder (containing model.bin) into the
+    /// shared "_models" folder. The destination is normalized to "faster-whisper-&lt;name&gt;" so
+    /// both this engine and the CTranslate2 engine (which builds its --model path as
+    /// "_models/faster-whisper-&lt;name&gt;") resolve it. Returns the display name (without prefix).
+    /// </summary>
+    internal static string ImportFasterWhisperFolderModel(string sourceDir, string modelsFolder)
+    {
+        if (!Directory.Exists(sourceDir))
+        {
+            throw new DirectoryNotFoundException("Model folder not found: " + sourceDir);
+        }
+
+        var modelBin = Path.Combine(sourceDir, "model.bin");
+        if (!File.Exists(modelBin))
+        {
+            throw new Exception("A faster-whisper model folder must contain a 'model.bin' file.");
+        }
+
+        if (new FileInfo(modelBin).Length < 10_000_000)
+        {
+            throw new Exception("The 'model.bin' file is too small (must be at least 10 MB) - is it really a faster-whisper model?");
+        }
+
+        var sourceName = Path.GetFileName(sourceDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var baseName = sourceName;
+        if (baseName.StartsWith("faster-whisper-", StringComparison.OrdinalIgnoreCase))
+        {
+            baseName = baseName.Substring("faster-whisper-".Length);
+        }
+
+        var destFolder = Path.Combine(modelsFolder, "faster-whisper-" + baseName);
+        CopyDirectory(sourceDir, destFolder);
+
+        return baseName;
+    }
+
+    private static void CopyDirectory(string sourceDir, string destDir)
+    {
+        Directory.CreateDirectory(destDir);
+
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), true);
+        }
+
+        foreach (var subDir in Directory.GetDirectories(sourceDir))
+        {
+            CopyDirectory(subDir, Path.Combine(destDir, Path.GetFileName(subDir)));
+        }
+    }
+
     public override string ToString()
     {
         return Name;

--- a/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
@@ -18,6 +18,8 @@ public class LanguageAudioToText
     public string WhisperXxlSingleWords { get; set; }
     public string WhisperXxlHighlightWord { get; set; }
     public string SelectModel { get; set; }
+    public string AddCustomModelDotDotDot { get; set; }
+    public string CustomModelHelp { get; set; }
     public string ViewToolsLogFile { get; set; }
     public string ReDownloadX { get; set; }
     public string DownloadX { get; set; }
@@ -55,6 +57,8 @@ public class LanguageAudioToText
         WhisperXxlSingleWords = "Single words";
         WhisperXxlHighlightWord = "Highlight word";
         SelectModel = "Select model";
+        AddCustomModelDotDotDot = "Add custom model...";
+        CustomModelHelp = "You can use your own model: pick the model file (whisper.cpp ggml '.bin') or model folder (faster-whisper folder with a 'model.bin' inside). It is copied to the models folder and added to the list above.";
         ViewToolsLogFile = "View tools log file";
         ReDownloadX = "Re-download {0}";
         DownloadX = "Download {0}";


### PR DESCRIPTION
Addresses #11842 — "Add Whisper Models" / let users install their own models.

## Background
SE already auto-discovers custom/local models for some engines if you drop them in the right folder, but the feature is silent (no UI, no docs) — which is exactly why the reporter said "installing them in the Models directory does not help."

| Engine | Custom models | How |
|---|---|---|
| **whisper.cpp** | ✅ (existing) | `.bin` in `…/Cpp/Models/` |
| **Purfview XXL** | ✅ (existing) | folder w/ `model.bin` in `…/_models/` |
| **CTranslate2 (faster-whisper)** | ✅ (now verified) | shares Purfview's `_models` folder + model list |
| OpenAI / ConstMe / CrispASR | ❌ | hardcoded lists only |

## Changes
- **GUI:** an **"Add custom model…"** button in the model-download dialog plus a short help text, shown only for engines that support custom models. The button opens a file picker (whisper.cpp `.bin`) or folder picker (faster-whisper folder with `model.bin`), validates it (correct type + ≥10 MB), copies it into the engine's model folder, then refreshes the list and selects the new model.
- **CTranslate2 parity:** CTranslate2 builds its `--model` path as `_models/faster-whisper-<name>`, so the importer normalizes the destination folder name to `faster-whisper-<name>`. This makes a single imported faster-whisper model resolve under **both** Purfview XXL and CTranslate2.
- New `ISpeechToTextEngine` members `SupportsCustomModels` / `CustomModelIsFolder` / `ImportCustomModel(...)` (default no-op), implemented for the three Whisper engines.

## Notes
- No process `WorkingDirectory` or download logic changed.
- Validation mirrors the existing auto-discovery rules (`.bin`, `model.bin`, >10 MB).
- Build is green; tested on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)