### PR TITLE
Fix multi-character custom tags in Remove text for hearing impaired (#11850)

### DIFF
--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -1517,7 +1517,10 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     break;
                 }
 
-                text = text.Remove(start, end - start + 1);
+                // 'end' is the start index of endTag; remove through the whole end tag, not
+                // just its first character, so multi-character custom tags (e.g. "<<"/">>",
+                // "<i>"/"</i>") are fully stripped instead of leaving the trailing characters.
+                text = text.Remove(start, end - start + endTag.Length);
                 if (start > 3 && text.Length - start > 1 &&
                     text[start] == ':' && text[start - 1] == ' ' && ".?!".Contains(text[start - 2]))
                 {

--- a/tests/libse/Forms/RemoveTextForHITest.cs
+++ b/tests/libse/Forms/RemoveTextForHITest.cs
@@ -1,0 +1,116 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms;
+
+namespace LibSETests.Forms;
+
+public class RemoveTextForHITest
+{
+    private static RemoveTextForHI MakeRemover(string customStart = "", string customEnd = "")
+    {
+        var settings = new RemoveTextForHISettings(new Subtitle())
+        {
+            OnlyIfInSeparateLine = false,
+            RemoveTextBetweenSquares = false,
+            RemoveTextBetweenBrackets = false,
+            RemoveTextBetweenParentheses = false,
+            RemoveTextBetweenQuestionMarks = false,
+            RemoveTextBetweenCustomTags = false,
+            RemoveInterjections = false,
+            RemoveIfAllUppercase = false,
+            RemoveTextBeforeColon = false,
+            RemoveWhereContains = false,
+            RemoveIfOnlyMusicSymbols = false,
+            CustomStart = customStart,
+            CustomEnd = customEnd,
+        };
+
+        return new RemoveTextForHI(settings);
+    }
+
+    // --- Custom tags: the bug from issue #11850 ---
+
+    [Fact]
+    public void Custom_SingleChar_RemovesBetween()
+    {
+        var remover = MakeRemover("(", ")");
+        remover.Settings.RemoveTextBetweenCustomTags = true;
+
+        Assert.Equal("Hello", remover.RemoveHearImpairedTags("(noise) Hello"));
+    }
+
+    [Fact]
+    public void Custom_MultiChar_RemovesWholeEndTag()
+    {
+        // Before the fix only the first char of the end tag (">") was removed,
+        // leaving "> Hello".
+        var remover = MakeRemover("<<", ">>");
+        remover.Settings.RemoveTextBetweenCustomTags = true;
+
+        Assert.Equal("Hello", remover.RemoveHearImpairedTags("<<noise>> Hello"));
+    }
+
+    [Fact]
+    public void Custom_MultiChar_HtmlLikeTags()
+    {
+        var remover = MakeRemover("<i>", "</i>");
+        remover.Settings.RemoveTextBetweenCustomTags = true;
+
+        Assert.Equal("Hello", remover.RemoveHearImpairedTags("<i>noise</i> Hello"));
+    }
+
+    [Fact]
+    public void Custom_MultiChar_InMiddle()
+    {
+        var remover = MakeRemover("[[", "]]");
+        remover.Settings.RemoveTextBetweenCustomTags = true;
+
+        Assert.Equal("Hello there", remover.RemoveHearImpairedTags("Hello [[noise]] there"));
+    }
+
+    // --- Predefined tags: regression guards (must keep working after the fix) ---
+
+    [Fact]
+    public void Squares_RemovesBetween()
+    {
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBetweenSquares = true;
+
+        Assert.Equal("Hello", remover.RemoveHearImpairedTags("[noise] Hello"));
+    }
+
+    [Fact]
+    public void Squares_WithColon_RemovesNameAndColon()
+    {
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBetweenSquares = true;
+
+        Assert.Equal("Hello", remover.RemoveHearImpairedTags("[MAN]: Hello"));
+    }
+
+    [Fact]
+    public void Parentheses_RemovesBetween()
+    {
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBetweenParentheses = true;
+
+        Assert.Equal("Bye", remover.RemoveHearImpairedTags("(SIGH) Bye"));
+    }
+
+    [Fact]
+    public void Parentheses_WithColon_RemovesNameAndColon()
+    {
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBetweenParentheses = true;
+
+        Assert.Equal("Hello", remover.RemoveHearImpairedTags("(MAN): Hello"));
+    }
+
+    [Fact]
+    public void CurlyBrackets_RemovesBetween()
+    {
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBetweenBrackets = true;
+
+        Assert.Equal("Hello", remover.RemoveHearImpairedTags("{noise} Hello"));
+    }
+}


### PR DESCRIPTION
Fixes #11850

## Problem
The "Remove text between" custom start/end fields accept multiple characters, but only the **first character of the end tag** was actually used during processing — silently. Multi-character end tags left their trailing characters behind.

## Root cause
`RemoveTextForHI.RemoveTextBetweenTags` (`src/libse/Forms/RemoveTextForHI.cs`):

```csharp
var end = text.IndexOf(endTag, start + startTag.Length, StringComparison.Ordinal); // start index of endTag
...
text = text.Remove(start, end - start + 1);   // removes through only the FIRST char of endTag
```

`end` is the **start index** of the end tag, so `+ 1` only consumes its first character.
- Single-char end tags (`)`, `]`): `+1 == endTag.Length` → correct.
- Multi-char tags (`>>`, `</i>`): the extra characters remain.

Example — start `<<`, end `>>`, text `"<<noise>> Hello"` → removed `"<<noise>"` → left **`"> Hello"`**, which the reporter saw as "only the first character is used."

## Fix
```csharp
text = text.Remove(start, end - start + endTag.Length);
```

Single-character tags are unaffected (length 1). The predefined bracket/paren/colon paths share this method and still produce identical output (verified by tests).

## Tests
New `tests/libse/Forms/RemoveTextForHITest.cs`:
- Custom single-char `( )`, multi-char `<< >>`, HTML-like `<i> </i>`, and mid-line `[[ ]]`
- Regression guards for predefined squares, curly brackets, parentheses, and the `:`-suffixed name variants (`[MAN]:`, `(MAN):`)

All 9 new tests pass; full libse suite green (463 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)