### PR TITLE
Add "Auto detect" language for standard Whisper engines (#11848)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -343,8 +343,6 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     // The mainstream Whisper engines that can auto-detect the spoken language
     // (useful for files with mixed languages). See issue #11848.
-    // CTranslate2 is intentionally excluded: auto-detect does not work reliably
-    // through SE's CTranslate2 pipeline (--model_directory rewrite + detection output).
     private static bool EngineSupportsAutoLanguageDetection(ISpeechToTextEngine engine)
     {
         return engine.Choice is WhisperChoice.Cpp
@@ -353,6 +351,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             or WhisperChoice.CppCuBlasLib
             or WhisperChoice.ConstMe
             or WhisperChoice.PurfviewFasterWhisperXxl
+            or WhisperChoice.CTranslate2
             or WhisperChoice.OpenAi;
     }
 
@@ -3492,10 +3491,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         var m = engine.GetModelForCmdLine(model);
 
         // Automatic language detection (#11848). whisper.cpp/Const-me accept the literal
-        // "auto" (their default is "en", so the flag is required). Purfview Faster-Whisper
-        // and OpenAI reject "auto" but auto-detect when no --language is given, so the flag
-        // is omitted there. (CTranslate2 is not offered an auto option - see
-        // EngineSupportsAutoLanguageDetection.)
+        // "auto" (their default is "en", so the flag is required). The faster-whisper based
+        // engines (Purfview, CTranslate2) and OpenAI reject "auto" but auto-detect when no
+        // --language is given, so the flag is omitted there.
         var languageArg = $"--language {language} ";
         if (language.Equals("auto", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -343,6 +343,8 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     // The mainstream Whisper engines that can auto-detect the spoken language
     // (useful for files with mixed languages). See issue #11848.
+    // CTranslate2 is intentionally excluded: auto-detect does not work reliably
+    // through SE's CTranslate2 pipeline (--model_directory rewrite + detection output).
     private static bool EngineSupportsAutoLanguageDetection(ISpeechToTextEngine engine)
     {
         return engine.Choice is WhisperChoice.Cpp
@@ -351,7 +353,6 @@ public partial class SpeechToTextViewModel : ObservableObject
             or WhisperChoice.CppCuBlasLib
             or WhisperChoice.ConstMe
             or WhisperChoice.PurfviewFasterWhisperXxl
-            or WhisperChoice.CTranslate2
             or WhisperChoice.OpenAi;
     }
 
@@ -3491,9 +3492,10 @@ public partial class SpeechToTextViewModel : ObservableObject
         var m = engine.GetModelForCmdLine(model);
 
         // Automatic language detection (#11848). whisper.cpp/Const-me accept the literal
-        // "auto" (their default is "en", so the flag is required). The faster-whisper based
-        // engines (Purfview, CTranslate2) and OpenAI reject "auto" but auto-detect when no
-        // --language is given, so the flag is omitted there.
+        // "auto" (their default is "en", so the flag is required). Purfview Faster-Whisper
+        // and OpenAI reject "auto" but auto-detect when no --language is given, so the flag
+        // is omitted there. (CTranslate2 is not offered an auto option - see
+        // EngineSupportsAutoLanguageDetection.)
         var languageArg = $"--language {language} ";
         if (language.Equals("auto", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -222,7 +222,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         SelectedEngine = Engines[0];
 
-        Languages = new ObservableCollection<WhisperLanguage>(SelectedEngine.Languages);
+        Languages = new ObservableCollection<WhisperLanguage>(GetEngineLanguages(GetEffectiveSelectedEngine()));
         SelectedLanguage = PickDefaultLanguage(Languages);
 
         Models = new ObservableCollection<SpeechToTextModelDisplay>();
@@ -339,6 +339,35 @@ public partial class SpeechToTextViewModel : ObservableObject
             CrispAsrEngine crispAsrEngine => crispAsrEngine.SelectedBackend,
             _ => SelectedEngine,
         };
+    }
+
+    // The mainstream Whisper engines that can auto-detect the spoken language
+    // (useful for files with mixed languages). See issue #11848.
+    private static bool EngineSupportsAutoLanguageDetection(ISpeechToTextEngine engine)
+    {
+        return engine.Choice is WhisperChoice.Cpp
+            or WhisperChoice.CppCuBlas
+            or WhisperChoice.CppVulkan
+            or WhisperChoice.CppCuBlasLib
+            or WhisperChoice.ConstMe
+            or WhisperChoice.PurfviewFasterWhisperXxl
+            or WhisperChoice.CTranslate2
+            or WhisperChoice.OpenAi;
+    }
+
+    // Builds the language dropdown for an engine, prepending an "Auto detect" entry
+    // (code "auto") for engines that support automatic language detection.
+    private static IEnumerable<WhisperLanguage> GetEngineLanguages(ISpeechToTextEngine engine)
+    {
+        if (EngineSupportsAutoLanguageDetection(engine))
+        {
+            yield return new WhisperLanguage("auto", "Auto detect");
+        }
+
+        foreach (var language in engine.Languages)
+        {
+            yield return language;
+        }
     }
 
     private static bool IsTranslateAvailable(ISpeechToTextEngine engine)
@@ -3460,8 +3489,22 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         var w = engine.GetExecutable();
         var m = engine.GetModelForCmdLine(model);
+
+        // Automatic language detection (#11848). whisper.cpp/Const-me accept the literal
+        // "auto" (their default is "en", so the flag is required). The faster-whisper based
+        // engines (Purfview, CTranslate2) and OpenAI reject "auto" but auto-detect when no
+        // --language is given, so the flag is omitted there.
+        var languageArg = $"--language {language} ";
+        if (language.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            languageArg = settings.WhisperChoice is WhisperChoice.Cpp or WhisperChoice.CppCuBlas
+                or WhisperChoice.CppVulkan or WhisperChoice.CppCuBlasLib or WhisperChoice.ConstMe
+                ? "--language auto "
+                : string.Empty;
+        }
+
         var parameters =
-            $"--language {language} --model \"{m}\" {outputSrt}{translateToEnglish}{args} \"{waveFileName}\"{postParams}";
+            $"{languageArg}--model \"{m}\" {outputSrt}{translateToEnglish}{args} \"{waveFileName}\"{postParams}";
 
         if (engine is WhisperEngineCTranslate2)
         {
@@ -3908,7 +3951,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         UpdateBackendSelectionUi();
 
         Languages.Clear();
-        foreach (var l in engine.Languages)
+        foreach (var l in GetEngineLanguages(engine))
         {
             Languages.Add(l);
         }


### PR DESCRIPTION
Fixes #11848

## Problem
The standard Whisper engines always sent `--language <code>` based on the dropdown, so there was **no way to use automatic language detection** — needed for files with mixed languages. For the faster-whisper based engines, forcing a language alongside multilingual-detection settings also produces a "settings conflict" abort, exactly as the reporter described.

## Change
Add an **"Auto detect"** entry (code `auto`) to the language dropdown for the five standard engines: whisper.cpp (+ cuBLAS / Vulkan / cuBLAS-lib), Const-me, Purfview Faster-Whisper-XXL, CTranslate2, and OpenAI. (CrispASR/WhisperX engines keep their own lists and are unaffected.)

When "Auto detect" is selected, the command line is built per engine family:
- **whisper.cpp / Const-me** → `--language auto` (whisper.cpp's default is `en`, and it accepts the literal `auto`).
- **Purfview / CTranslate2 / OpenAI** → `--language` is **omitted** (faster-whisper and openai-whisper reject the literal `auto` but auto-detect when no language is given; default `None`).

## Verified locally (macOS)
- `whisper-cli --language auto --model tiny.en --output-srt sample.wav` → transcribes fine, no conflict.
- `whisper-ctranslate2 --language auto …` → `error: invalid choice: 'auto'`; but SE's actual form `whisper-ctranslate2 --model_directory <dir> --output_format srt sample.wav` (no `--language`) auto-detects and writes a valid SRT.

Build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)