### PR TITLE
Fix 24 fps read as 23.976 (and 30 as 29.97) (#11847)

### DIFF
--- a/src/ui/Logic/Media/FfmpegMediainfo2.cs
+++ b/src/ui/Logic/Media/FfmpegMediainfo2.cs
@@ -175,9 +175,10 @@ public class FfmpegMediaInfo2
     }
 
     /// <summary>
-    /// Rounded to nearest known frame rate if close.
+    /// Snaps a reported frame rate to the closest known frame rate when it is very close,
+    /// e.g. ffmpeg's two-decimal "23.98"/"29.97" become the canonical 23.976/29.97.
     /// </summary>
-    private static decimal NormalizeFrameRate(double frameRate)
+    internal static decimal NormalizeFrameRate(double frameRate)
     {
         // Common video frame rates (including NTSC variants)
         double[] knownRates =
@@ -185,18 +186,28 @@ public class FfmpegMediaInfo2
             23.976, 24.0, 25.0, 29.97, 30.0, 48.0, 50.0, 59.94, 60.0, 120.0
         };
 
-        for (double tolerance = 0.05; tolerance < 2; tolerance += 0.5)
+        // Pick the CLOSEST known rate rather than the first one within a tolerance window.
+        // 24.0 is only 0.024 from 23.976 (and 30.0 only 0.03 from 29.97), so the old
+        // order-dependent "first within 0.05" check wrongly collapsed 24 -> 23.976 and
+        // 30 -> 29.97 (issue #11847).
+        var closest = knownRates[0];
+        var smallestDiff = double.MaxValue;
+        foreach (var known in knownRates)
         {
-            foreach (var known in knownRates)
+            var diff = Math.Abs(frameRate - known);
+            if (diff < smallestDiff)
             {
-                if (Math.Abs(frameRate - known) < tolerance)
-                {
-                    return (decimal)known;
-                }
+                smallestDiff = diff;
+                closest = known;
             }
         }
 
-        // Not close to any known frame rate, return as-is
+        // Only snap when genuinely close to a known rate; otherwise keep the exact value.
+        if (smallestDiff < 0.06)
+        {
+            return (decimal)closest;
+        }
+
         return (decimal)frameRate;
     }
 

--- a/tests/UI/Logic/FfmpegFrameRateTests.cs
+++ b/tests/UI/Logic/FfmpegFrameRateTests.cs
@@ -1,0 +1,41 @@
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic;
+
+public class FfmpegFrameRateTests
+{
+    // Exact known rates must stay exactly themselves (issue #11847: 24 -> 23.976, 30 -> 29.97).
+    [Theory]
+    [InlineData(24.0, 24.0)]
+    [InlineData(30.0, 30.0)]
+    [InlineData(25.0, 25.0)]
+    [InlineData(50.0, 50.0)]
+    [InlineData(60.0, 60.0)]
+    [InlineData(48.0, 48.0)]
+    [InlineData(120.0, 120.0)]
+    public void NormalizeFrameRate_KeepsExactIntegerRates(double input, double expected)
+    {
+        Assert.Equal((decimal)expected, FfmpegMediaInfo2.NormalizeFrameRate(input));
+    }
+
+    // ffmpeg prints NTSC rates with two decimals; snap those to the canonical values.
+    [Theory]
+    [InlineData(23.98, 23.976)]
+    [InlineData(23.976, 23.976)]
+    [InlineData(29.97, 29.97)]
+    [InlineData(59.94, 59.94)]
+    public void NormalizeFrameRate_SnapsNtscRatesToCanonical(double input, double expected)
+    {
+        Assert.Equal((decimal)expected, FfmpegMediaInfo2.NormalizeFrameRate(input));
+    }
+
+    // Values not close to any known rate are returned unchanged (no over-aggressive snapping).
+    [Theory]
+    [InlineData(26.0)]
+    [InlineData(15.0)]
+    [InlineData(100.0)]
+    public void NormalizeFrameRate_KeepsUnknownRates(double input)
+    {
+        Assert.Equal((decimal)input, FfmpegMediaInfo2.NormalizeFrameRate(input));
+    }
+}


### PR DESCRIPTION
Fixes #11847

## Problem
A 24.000 fps video was read as **23.976**, and a 30.000 fps video as **29.97**. Manually changing the SRT frame rate only helped until the file was reopened, and SE could show **two different** frame rates for the same file.

## Root cause
`FfmpegMediaInfo2.NormalizeFrameRate` matched the **first** known rate within an expanding tolerance window (starting at `0.05`), iterating the array in order:

```csharp
double[] knownRates = { 23.976, 24.0, 25.0, 29.97, 30.0, ... };
for (double tolerance = 0.05; tolerance < 2; tolerance += 0.5)
    foreach (var known in knownRates)
        if (Math.Abs(frameRate - known) < tolerance) return (decimal)known;
```

`23.976` precedes `24.0`, and `|24.0 − 23.976| = 0.024 < 0.05`, so a real 24.0 snapped to 23.976 before 24.0 was ever tested. Same for `30.0 → 29.97` (`0.03 < 0.05`).

The "two different rates" symptom: `MediaInfoViewViewModel` shows the normalized `FramesRate` (→ 29.97/23.976) while `MainViewModel` uses `FramesRateNonNormalized` (→ raw 30/24). The `NonNormalized` field was a workaround for this very bug.

## Fix
Pick the **closest** known rate instead of the first within tolerance, and only snap when within `0.06`:
- Exact integer rates stay exact (24, 25, 30, 50, 60, …).
- ffmpeg's two-decimal NTSC values still snap to canonical (`23.98 → 23.976`, `29.97 → 29.97`, `59.94 → 59.94`).
- Genuinely unknown rates are returned unchanged (no over-aggressive snapping; the old loop could snap e.g. 26 → 25).

This also resolves the reopen-revert and the two-different-rates display, since `FramesRate` now equals `FramesRateNonNormalized` for these common rates.

## Verified against the reporter's sample
`file_example_AVI_1920_2_3MG.avi` is actually **30 fps** (AVI header `dwRate/dwScale = 30/1`; ffmpeg `r_frame_rate=30/1`, 901 frames / 30.03 s). Before the fix SE normalized it to 29.97; after the fix it stays 30.

## Tests
New `tests/UI/Logic/FfmpegFrameRateTests.cs` — exact rates, NTSC snapping, and unknown-rate pass-through (14 cases, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)