### PR TITLE
Add "Play from just before text" video shortcut (#11517)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11121,6 +11121,28 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void VideoPlayFromJustBeforeText()
+    {
+        var s = SelectedSubtitle;
+        var vp = GetVideoPlayerControl();
+        if (s == null || vp == null)
+        {
+            return;
+        }
+
+        // Start playback a little before the subtitle's start so the lead-in is
+        // visible; clamp to the start when it is right at the beginning.
+        var startSeconds = s.StartTime.TotalSeconds;
+        var position = startSeconds > 1 ? startSeconds - 0.5 : startSeconds;
+
+        vp.VideoPlayer.Pause();
+        vp.Position = position;
+        PinPlayheadTo(position);
+        vp.VideoPlayer.Play();
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
     private void RemoveBlankLines()
     {
         var blankLines = Subtitles.Where(s => string.IsNullOrWhiteSpace(s.Text)).ToList();

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -120,6 +120,7 @@ public static class Se4ShortcutsImporter
         ["MainVideoToggleBrightness"] = nameof(MainViewModel.VideoToggleBrightnessCommand),
         ["MainVideoToggleVideoControls"] = nameof(MainViewModel.VideoUndockControlsCommand),
         ["MainVideoPlayFromBeginning"] = nameof(MainViewModel.PlayFromStartOfVideoCommand),
+        ["MainVideoPlayFromJustBefore"] = nameof(MainViewModel.VideoPlayFromJustBeforeTextCommand),
         ["MainVideoPlaySelectedLines"] = nameof(MainViewModel.PlaySelectedLinesWithoutLoopCommand),
         ["MainVideoLoopSelectedLines"] = nameof(MainViewModel.PlaySelectedLinesWithLoopCommand),
         ["MainVideoReset"] = nameof(MainViewModel.ResetWaveformZoomAndSpeedCommand),

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -403,6 +403,7 @@ public class LanguageGeneral
     public string PickVideoPosition { get; set; }
     public string Play { get; set; }
     public string PlayFromStartOfVideo { get; set; }
+    public string PlayFromJustBeforeText { get; set; }
     public string PlayNext { get; set; }
     public string PlayNextAndStop { get; set; }
     public string PlayNextAndLoop { get; set; }
@@ -1143,6 +1144,7 @@ public class LanguageGeneral
         PickVideoPosition = "Pick video position";
         Play = "Play";
         PlayFromStartOfVideo = "Play from start of video";
+        PlayFromJustBeforeText = "Play from just before text";
         PlayNext = "Play next";
         PlayNextAndStop = "Play next (and stop)";
         PlayNextAndLoop = "Play next (and loop)";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -377,6 +377,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.WaveformPasteFromClipboardCommand), Se.Language.General.WaveformPasteFromClipboard },
         { nameof(MainViewModel.FocusSelectedLineCommand), Se.Language.General.FocusSelectedLine },
         { nameof(MainViewModel.PlayFromStartOfVideoCommand), Se.Language.General.PlayFromStartOfVideo },
+        { nameof(MainViewModel.VideoPlayFromJustBeforeTextCommand), Se.Language.General.PlayFromJustBeforeText },
         { nameof(MainViewModel.RemoveBlankLinesCommand), Se.Language.General.RemoveBlankLines },
         { nameof(MainViewModel.InsertSubtitleAtVideoPositionSetEndAtKeyUpCommand), Se.Language.General.NewSubtitleStartKeyDownSetEndKeyUp },
         { nameof(MainViewModel.SetSubtitleStartAtVideoPositionSetEndAtKeyUpAndGoToNextCommand), Se.Language.General.SetSubtitleStartAtVideoPositionSetEndAtKeyUpAndGoToNext },
@@ -727,6 +728,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.WaveformPasteFromClipboardCommand, nameof(vm.WaveformPasteFromClipboardCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.FocusSelectedLineCommand, nameof(vm.FocusSelectedLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.PlayFromStartOfVideoCommand, nameof(vm.PlayFromStartOfVideoCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoPlayFromJustBeforeTextCommand, nameof(vm.VideoPlayFromJustBeforeTextCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.RemoveBlankLinesCommand, nameof(vm.RemoveBlankLinesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.InsertSubtitleAtVideoPositionSetEndAtKeyUpCommand, nameof(vm.InsertSubtitleAtVideoPositionSetEndAtKeyUpCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SetSubtitleStartAtVideoPositionSetEndAtKeyUpAndGoToNextCommand, nameof(vm.SetSubtitleStartAtVideoPositionSetEndAtKeyUpAndGoToNextCommand), ShortcutCategory.General);


### PR DESCRIPTION
## Restore "Video Play from just before text"

[#11517](https://github.com/SubtitleEdit/subtitleedit/issues/11517) reports this SE4 shortcut as **disappeared** in the rewrite. This adds it back.

`VideoPlayFromJustBeforeText` seeks to **0.5s before** the selected subtitle's start (or to the start itself when it's within the first second), pauses, then plays — mirroring the legacy `ButtonBeforeTextClick` behavior from SE4's `Main.cs`.

## Wiring

- Command in `MainViewModel`, registered in `ShortcutsMain` (General category, **no default key** — users assign their own).
- Language string `PlayFromJustBeforeText` (= "Play from just before text", legacy wording reused).
- SE4 import mapping added: `MainVideoPlayFromJustBefore` → `VideoPlayFromJustBeforeTextCommand`, so existing SE4 keybindings (default `Shift+F10`) import automatically.

## Note on the rest of #11517

The other items in that issue (Video 500ms/1s/custom back & forward) already exist and are mapped in the rewrite (`Video500MsBackCommand`, `VideoOneSecondBackCommand`, `VideoMoveCustom1/2*`, etc.), so this PR scopes to the one genuinely missing command. The "not functioning" reports for those are a separate matter and not addressed here.

Builds clean (`dotnet build src/ui/UI.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)