### PR TITLE
Add label to waveform "Edit toolbar..." settings row

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -457,7 +457,7 @@ public class SettingsPage : UserControl
             MakeNumericSettingInt(Se.Language.Options.Settings.WaveformSpectrogramCombinedWaveformHeight, nameof(_vm.WaveformSpectrogramCombinedWaveformHeight), 10, 90),
 
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformShowToolbar, nameof(_vm.WaveformShowToolbar)),
-            new SettingsItem(string.Empty,
+            new SettingsItem(Se.Language.Options.Settings.WaveformShowToolbarEditLabel,
                 () => UiUtil.MakeButton(Se.Language.Options.Settings.WaveformShowToolbarEdit, _vm.EditWaveformToolbarPropertiesCommand)),
 
             new SettingsItem(Se.Language.Options.Settings.WaveformSingleClickAction, () => new ComboBox

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -130,6 +130,7 @@ public class LanguageSettings
     public string WaveformCenterVideoPosition { get; set; }
     public string WaveformShowToolbar { get; set; }
     public string WaveformShowToolbarEdit { get; set; }
+    public string WaveformShowToolbarEditLabel { get; set; }
     public string WaveformSpectrogramCombinedWaveformHeight { get; set; }
     public string ShowWaveformToolbarPlay { get; set; }
     public string ShowWaveformToolbarRepeat { get; set; }
@@ -443,6 +444,7 @@ public class LanguageSettings
         WaveformCenterVideoPosition = "Center video position";
         WaveformShowToolbar = "Show toolbar";
         WaveformShowToolbarEdit = "Edit toolbar...";
+        WaveformShowToolbarEditLabel = "Toolbar items";
         WaveformSpectrogramCombinedWaveformHeight = "Waveform/spectrogram combined, waveform height %";
         ShowWaveformToolbarPlay = "Toolbar: show play button";
         ShowWaveformToolbarRepeat = "Toolbar: show repeat button";


### PR DESCRIPTION
## Make the waveform toolbar settings row searchable

In **Settings > Waveform/spectrogram**, the "Edit toolbar..." button sat on a row with an empty label. The settings search filter matches the typed query against each row's label (`SettingsItem.Filter`), so this row could never be found via search.

This adds the label **"Toolbar items"** to the row, so it:
- shows up when searching settings (e.g. "toolbar"), and
- reads clearly next to the button.

The button itself keeps its "Edit toolbar..." text.

New language string `WaveformShowToolbarEditLabel`.

Builds clean (`dotnet build src/ui/UI.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)