### PR TITLE
Add Hebrew and Swedish whisper.cpp models to the download list

### DIFF
--- a/src/libse/AudioToText/WhisperCppModel.cs
+++ b/src/libse/AudioToText/WhisperCppModel.cs
@@ -267,6 +267,27 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                 Size = "3.1 GB Norwegian",
                 Urls = new []{ "https://huggingface.co/NbAiLab/nb-whisper-large/resolve/main/ggml-model.bin" },
             },
+            new WhisperModel
+            {
+                Name = "large-v3-turbo.he",
+                Rename = true,
+                Size = "1.62 GB Hebrew",
+                Urls = new []{ "https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin" },
+            },
+            new WhisperModel
+            {
+                Name = "medium.sv",
+                Rename = true,
+                Size = "1.53 GB Swedish",
+                Urls = new []{ "https://huggingface.co/KBLab/kb-whisper-medium/resolve/main/ggml-model.bin" },
+            },
+            new WhisperModel
+            {
+                Name = "large.sv",
+                Rename = true,
+                Size = "3.1 GB Swedish",
+                Urls = new []{ "https://huggingface.co/KBLab/kb-whisper-large/resolve/main/ggml-model.bin" },
+            },
         };
     }
 }


### PR DESCRIPTION
Adds the ggml whisper.cpp models linked from [#11842](https://github.com/SubtitleEdit/subtitleedit/issues/11842) (darnn's comment) to `WhisperCppModel`, so they appear in the model download list:

| Model name | Language | Size | Source |
|---|---|---|---|
| `large-v3-turbo.he` | Hebrew | 1.62 GB | `ivrit-ai/whisper-large-v3-turbo-ggml` |
| `medium.sv` | Swedish | 1.53 GB | `KBLab/kb-whisper-medium` |
| `large.sv` | Swedish | 3.1 GB | `KBLab/kb-whisper-large` |

The Norwegian medium/large from that comment are **already** in the list (`medium.nb`, `large.nb` from NbAiLab), so they're not duplicated.

Each repo hosts the model as `ggml-model.bin`; the existing download path saves it under the model's own name (`<Name>.bin`), so the shared source filename doesn't collide — same pattern as the existing `*.nb` entries (`Rename = true`).

Builds clean (`dotnet build src/libse/libse.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)