### PR TITLE
Add "Favorite languages" setting (show favorites first in language combos)

### DIFF
--- a/src/libse/Common/LanguageFavorites.cs
+++ b/src/libse/Common/LanguageFavorites.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Shared "favorite languages" used to bubble the user's preferred languages to the top of
+    /// the various language combo boxes (auto-translate, speech-to-text, OCR, spell check, ...).
+    /// Favorites are stored as a ";"-separated list of two-letter ISO 639-1 codes in
+    /// <see cref="GeneralSettings.FavoriteLanguages"/>.
+    /// </summary>
+    public static class LanguageFavorites
+    {
+        /// <summary>
+        /// Parses a ";"-separated list of favorite language codes into normalized, distinct,
+        /// two-letter (lower-case) codes, preserving order.
+        /// </summary>
+        public static List<string> ParseCodes(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return new List<string>();
+            }
+
+            return raw.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(NormalizeTwoLetter)
+                .Where(s => s.Length > 0)
+                .Distinct()
+                .ToList();
+        }
+
+        /// <summary>
+        /// Returns the items ordered so favorite languages come first (in the user's favorite order),
+        /// while everything else keeps its original order. Matching is tolerant: two-letter, three-letter
+        /// and region-qualified codes (e.g. "pt-BR") all match on the base two-letter code.
+        /// </summary>
+        /// <param name="items">The items to order.</param>
+        /// <param name="codeSelector">Returns an item's language code (any ISO form).</param>
+        /// <param name="favoriteCodes">The favorite language codes, in priority order.</param>
+        /// <param name="pinTop">Optional predicate for items that must stay above the favorites
+        /// (e.g. an "Auto detect" entry). These keep their relative order at the very top.</param>
+        public static List<T> OrderWithFavoritesFirst<T>(
+            IEnumerable<T> items,
+            Func<T, string> codeSelector,
+            IList<string> favoriteCodes,
+            Func<T, bool> pinTop = null)
+        {
+            var list = items.ToList();
+            var favorites = (favoriteCodes ?? new List<string>())
+                .Select(NormalizeTwoLetter)
+                .Where(s => s.Length > 0)
+                .ToList();
+            if (favorites.Count == 0)
+            {
+                return list;
+            }
+
+            int Rank(T item)
+            {
+                if (pinTop != null && pinTop(item))
+                {
+                    return -1; // above the favorites block
+                }
+
+                var code = NormalizeTwoLetter(codeSelector(item));
+                if (code.Length == 0)
+                {
+                    return int.MaxValue;
+                }
+
+                var index = favorites.IndexOf(code);
+                return index >= 0 ? index : int.MaxValue;
+            }
+
+            // Stable ordering: sort by rank, preserving the original order within the same rank.
+            return list
+                .Select((item, originalIndex) => (item, originalIndex))
+                .OrderBy(x => Rank(x.item))
+                .ThenBy(x => x.originalIndex)
+                .Select(x => x.item)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Normalizes an ISO language code to a comparable lower-case two-letter code.
+        /// Handles two-letter ("en"), three-letter ("eng") and region-qualified ("pt-BR") forms.
+        /// Returns an empty string when the code cannot be mapped.
+        /// </summary>
+        public static string NormalizeTwoLetter(string code)
+        {
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                return string.Empty;
+            }
+
+            code = code.Trim().ToLowerInvariant();
+
+            // strip a region/script qualifier, e.g. "pt-br" or "zh_cn"
+            var separatorIndex = code.IndexOfAny(new[] { '-', '_' });
+            if (separatorIndex > 0)
+            {
+                code = code.Substring(0, separatorIndex);
+            }
+
+            if (code.Length == 2)
+            {
+                return code;
+            }
+
+            if (code.Length == 3)
+            {
+                var twoLetter = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(code);
+                return string.IsNullOrEmpty(twoLetter) ? code : twoLetter.ToLowerInvariant();
+            }
+
+            return code;
+        }
+    }
+}

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -74,6 +74,7 @@ using Nikse.SubtitleEdit.Features.Shared.FindText;
 using Nikse.SubtitleEdit.Features.Shared.GoToLineNumber;
 using Nikse.SubtitleEdit.Features.Shared.PickAlignment;
 using Nikse.SubtitleEdit.Features.Shared.PickFontName;
+using Nikse.SubtitleEdit.Features.Shared.PickLanguage;
 using Nikse.SubtitleEdit.Features.Shared.PickLayer;
 using Nikse.SubtitleEdit.Features.Shared.PickLayerFilter;
 using Nikse.SubtitleEdit.Features.Shared.PickMatroskaTrack;
@@ -431,6 +432,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<PickMp4TrackViewModel>();
         collection.AddTransient<PickOllamaModelViewModel>();
         collection.AddTransient<PickRuleProfileViewModel>();
+        collection.AddTransient<PickLanguageViewModel>();
         collection.AddTransient<PickSpellCheckDictionaryViewModel>();
         collection.AddTransient<PickSubtitleFormatViewModel>();
         collection.AddTransient<PickTsTrackViewModel>();

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -358,7 +358,7 @@ public partial class OcrViewModel : ObservableObject
             Name = GetDictionaryNameNone(),
             DictionaryFileName = string.Empty,
         });
-        Dictionaries.AddRange(spellCheckLanguages);
+        Dictionaries.AddRange(LanguageFavoritesHelper.Order(spellCheckLanguages, d => SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(d)));
         if (Dictionaries.Count > 0)
         {
             if (!string.IsNullOrEmpty(Se.Settings.Ocr.LastLanguageDictionaryFile))

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -9,6 +9,7 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared.PickLanguage;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Optris.Icons.Avalonia;
@@ -344,6 +345,7 @@ public class SettingsPage : UserControl
             }),
 
             new SettingsItem(Se.Language.Options.Settings.FavoriteSubtitleFormats, () => MakeFavoritesGrid(_vm)),
+            new SettingsItem(Se.Language.Options.Settings.FavoriteLanguages, () => MakeLanguageFavoritesGrid(_vm)),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.Options.Settings.SyntaxColoring,
@@ -810,6 +812,54 @@ public class SettingsPage : UserControl
         var buttonRemove = UiUtil.MakeButton(Se.Language.General.Remove, vm.RemoveFavoriteSubtitleFormatCommand).WithMinWidth(100);
         var buttonMoveUp = UiUtil.MakeButton(Se.Language.General.MoveUp, vm.MoveUpFavoriteSubtitleFormatCommand).WithMinWidth(100);
         var buttonMoveDown = UiUtil.MakeButton(Se.Language.General.MoveDown, vm.MoveDownFavoriteSubtitleFormatCommand).WithMinWidth(100);
+
+        var buttonStack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 5,
+            Margin = new Thickness(5, 0, 0, 0),
+            Children = { buttonAdd, buttonRemove, buttonMoveUp, buttonMoveDown }
+        };
+
+        grid.Add(UiUtil.MakeBorderForControlNoPadding(listBox), 0, 0);
+        grid.Add(buttonStack, 0, 1);
+
+        return grid;
+    }
+
+    private Grid MakeLanguageFavoritesGrid(SettingsViewModel vm)
+    {
+        // Grid with list of favorite languages, with buttons to add/remove/move-up/move-down
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = new Thickness(0, 5, 0, 0),
+        };
+
+        var listBox = new ListBox
+        {
+            DataContext = vm,
+            Height = 250,
+            Width = 250,
+            [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(vm.FavoriteLanguages)),
+            [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(vm.SelectedFavoriteLanguage)) { Mode = BindingMode.TwoWay },
+            ItemTemplate = new FuncDataTemplate<PickLanguageDisplay>((l, _) =>
+                new TextBlock { Text = l?.ToString() }, true)
+        };
+
+        var buttonAdd = UiUtil.MakeButton(Se.Language.General.Add, vm.AddFavoriteLanguageCommand).WithMinWidth(100);
+        var buttonRemove = UiUtil.MakeButton(Se.Language.General.Remove, vm.RemoveFavoriteLanguageCommand).WithMinWidth(100);
+        var buttonMoveUp = UiUtil.MakeButton(Se.Language.General.MoveUp, vm.MoveUpFavoriteLanguageCommand).WithMinWidth(100);
+        var buttonMoveDown = UiUtil.MakeButton(Se.Language.General.MoveDown, vm.MoveDownFavoriteLanguageCommand).WithMinWidth(100);
 
         var buttonStack = new StackPanel
         {

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -20,6 +20,7 @@ using Nikse.SubtitleEdit.Features.Tools.BeautifyTimeCodes.Profile;
 using Nikse.SubtitleEdit.Features.Options.Settings.WaveformThemes;
 using Nikse.SubtitleEdit.Features.Options.Settings.WaveformToolbarItems;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Shared.PickLanguage;
 using Nikse.SubtitleEdit.Features.Shared.PickSubtitleFormat;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Features.Video.BurnIn;
@@ -121,6 +122,9 @@ public partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty] private ObservableCollection<string> _favoriteSubtitleFormats;
     [ObservableProperty] private string? _selectedFavoriteSubtitleFormat;
+
+    [ObservableProperty] private ObservableCollection<PickLanguageDisplay> _favoriteLanguages;
+    [ObservableProperty] private PickLanguageDisplay? _selectedFavoriteLanguage;
 
     [ObservableProperty] private ObservableCollection<TextEncoding> _encodings;
     [ObservableProperty] private TextEncoding _defaultEncoding;
@@ -466,6 +470,7 @@ public partial class SettingsViewModel : ObservableObject
         DefaultSubtitleFormats = new ObservableCollection<string>(defaultSubtitleFormats);
         SaveSubtitleFormats = new ObservableCollection<string>(saveSubtitleFormats);
         FavoriteSubtitleFormats = new ObservableCollection<string>();
+        FavoriteLanguages = new ObservableCollection<PickLanguageDisplay>();
         SelectedDefaultSubtitleFormat = DefaultSubtitleFormats.First();
         SelectedSaveSubtitleFormat = SaveSubtitleFormats.First();
         Encodings = new ObservableCollection<TextEncoding>(EncodingHelper.GetEncodings());
@@ -666,6 +671,18 @@ public partial class SettingsViewModel : ObservableObject
                     FavoriteSubtitleFormats.Add(format);
                 }
             }
+        }
+
+        FavoriteLanguages.Clear();
+        foreach (var code in LanguageFavorites.ParseCodes(general.FavoriteLanguages))
+        {
+            var iso = Iso639Dash2LanguageCode.List.FirstOrDefault(l =>
+                string.Equals(l.TwoLetterCode, code, StringComparison.OrdinalIgnoreCase));
+            FavoriteLanguages.Add(new PickLanguageDisplay
+            {
+                Code = code,
+                Name = iso?.EnglishName ?? code,
+            });
         }
 
         AllowSingleLetterShortcutsInTextbox = Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox;
@@ -1352,6 +1369,8 @@ public partial class SettingsViewModel : ObservableObject
         }
         general.FavoriteSubtitleFormats = sbFavorites.ToString().TrimEnd(';');
 
+        general.FavoriteLanguages = string.Join(";", FavoriteLanguages.Select(l => l.Code));
+
         Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox = AllowSingleLetterShortcutsInTextbox;
         Se.Settings.Tools.SpellCheckEnglishTreatInApostropheAsIng = SpellCheckEnglishTreatInApostropheAsIng;
         Se.Settings.Tools.GoToLineNumberAlsoSetVideoPosition = GoToLineNumberAlsoSetVideoPosition;
@@ -1961,6 +1980,82 @@ public partial class SettingsViewModel : ObservableObject
                 var selectedItem = SelectedFavoriteSubtitleFormat;
                 FavoriteSubtitleFormats.Move(index, index + 1);
                 SelectedFavoriteSubtitleFormat = selectedItem;
+            }
+        }
+
+        await Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private async Task AddFavoriteLanguage()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var existingCodes = FavoriteLanguages.Select(l => l.Code).ToList();
+        var viewModel = await _windowService.ShowDialogAsync<PickLanguageWindow, PickLanguageViewModel>(
+            Window, vm => vm.Initialize(existingCodes));
+
+        if (viewModel.OkPressed && viewModel.SelectedLanguage != null)
+        {
+            var selected = viewModel.SelectedLanguage;
+            if (FavoriteLanguages.All(l => !string.Equals(l.Code, selected.Code, StringComparison.OrdinalIgnoreCase)))
+            {
+                FavoriteLanguages.Add(selected);
+                SelectedFavoriteLanguage = selected;
+            }
+        }
+    }
+
+    [RelayCommand]
+    private async Task RemoveFavoriteLanguage()
+    {
+        if (SelectedFavoriteLanguage != null && FavoriteLanguages.Contains(SelectedFavoriteLanguage))
+        {
+            var index = FavoriteLanguages.IndexOf(SelectedFavoriteLanguage);
+            FavoriteLanguages.Remove(SelectedFavoriteLanguage);
+
+            if (FavoriteLanguages.Count > 0)
+            {
+                SelectedFavoriteLanguage = index < FavoriteLanguages.Count
+                    ? FavoriteLanguages[index]
+                    : FavoriteLanguages[FavoriteLanguages.Count - 1];
+            }
+        }
+
+        await Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private async Task MoveUpFavoriteLanguage()
+    {
+        if (SelectedFavoriteLanguage != null && FavoriteLanguages.Contains(SelectedFavoriteLanguage))
+        {
+            var index = FavoriteLanguages.IndexOf(SelectedFavoriteLanguage);
+            if (index > 0)
+            {
+                var selectedItem = SelectedFavoriteLanguage;
+                FavoriteLanguages.Move(index, index - 1);
+                SelectedFavoriteLanguage = selectedItem;
+            }
+        }
+
+        await Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private async Task MoveDownFavoriteLanguage()
+    {
+        if (SelectedFavoriteLanguage != null && FavoriteLanguages.Contains(SelectedFavoriteLanguage))
+        {
+            var index = FavoriteLanguages.IndexOf(SelectedFavoriteLanguage);
+            if (index < FavoriteLanguages.Count - 1)
+            {
+                var selectedItem = SelectedFavoriteLanguage;
+                FavoriteLanguages.Move(index, index + 1);
+                SelectedFavoriteLanguage = selectedItem;
             }
         }
 

--- a/src/ui/Features/Options/WordLists/WordListsViewModel.cs
+++ b/src/ui/Features/Options/WordLists/WordListsViewModel.cs
@@ -109,11 +109,17 @@ public partial class WordListsViewModel : ObservableObject
             // English is the default selected language
             Languages.Clear();
             Se.Settings.Options.LastLanguage = Se.Settings.Options.LastLanguage ?? "en_US";
+            var languageItems = new List<LanguageItem>();
             for (var index = 0; index < cultures.Count; index++)
             {
                 var ci = cultures[index];
                 var cultureCode = ci.Name.Replace('-', '_');
-                Languages.Add(new LanguageItem(ci.EnglishName, ci.TwoLetterISOLanguageName, cultureCode));
+                languageItems.Add(new LanguageItem(ci.EnglishName, ci.TwoLetterISOLanguageName, cultureCode));
+            }
+
+            foreach (var item in LanguageFavoritesHelper.Order(languageItems, l => l.TwoLetterISOLanguageName))
+            {
+                Languages.Add(item);
             }
         }
     }

--- a/src/ui/Features/Shared/PickLanguage/PickLanguageDisplay.cs
+++ b/src/ui/Features/Shared/PickLanguage/PickLanguageDisplay.cs
@@ -1,0 +1,9 @@
+namespace Nikse.SubtitleEdit.Features.Shared.PickLanguage;
+
+public class PickLanguageDisplay
+{
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+
+    public override string ToString() => $"{Name} ({Code})";
+}

--- a/src/ui/Features/Shared/PickLanguage/PickLanguageViewModel.cs
+++ b/src/ui/Features/Shared/PickLanguage/PickLanguageViewModel.cs
@@ -1,0 +1,110 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Shared.PickLanguage;
+
+public partial class PickLanguageViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<PickLanguageDisplay> _languages;
+    [ObservableProperty] private PickLanguageDisplay? _selectedLanguage;
+    [ObservableProperty] private string _searchText;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    private readonly List<PickLanguageDisplay> _all;
+
+    public PickLanguageViewModel()
+    {
+        _searchText = string.Empty;
+        _all = Iso639Dash2LanguageCode.List
+            .Where(l => !string.IsNullOrEmpty(l.TwoLetterCode))
+            .GroupBy(l => l.TwoLetterCode.ToLowerInvariant())
+            .Select(g => g.First())
+            .Select(l => new PickLanguageDisplay { Code = l.TwoLetterCode.ToLowerInvariant(), Name = l.EnglishName })
+            .OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        _languages = new ObservableCollection<PickLanguageDisplay>(_all);
+    }
+
+    /// <summary>
+    /// Hide languages that are already in the favorites list.
+    /// </summary>
+    public void Initialize(IEnumerable<string> excludeCodes)
+    {
+        var exclude = new HashSet<string>(
+            (excludeCodes ?? Enumerable.Empty<string>()).Select(LanguageFavorites.NormalizeTwoLetter),
+            StringComparer.OrdinalIgnoreCase);
+
+        _all.RemoveAll(l => exclude.Contains(l.Code));
+        SearchTextChanged();
+    }
+
+    public void SearchTextChanged()
+    {
+        var filter = SearchText?.Trim() ?? string.Empty;
+        var items = string.IsNullOrEmpty(filter)
+            ? _all
+            : _all.Where(l =>
+                l.Name.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                l.Code.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        Languages.Clear();
+        foreach (var item in items)
+        {
+            Languages.Add(item);
+        }
+
+        if (SelectedLanguage == null && Languages.Count > 0)
+        {
+            SelectedLanguage = Languages[0];
+        }
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() => { Window?.Close(); });
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        if (SelectedLanguage == null)
+        {
+            return;
+        }
+
+        OkPressed = true;
+        Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        OkPressed = false;
+        Close();
+    }
+
+    public void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            CancelCommand.Execute(null);
+        }
+        else if (e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            OkCommand.Execute(null);
+        }
+    }
+}

--- a/src/ui/Features/Shared/PickLanguage/PickLanguageWindow.cs
+++ b/src/ui/Features/Shared/PickLanguage/PickLanguageWindow.cs
@@ -1,0 +1,98 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Styling;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Shared.PickLanguage;
+
+public class PickLanguageWindow : Window
+{
+    public PickLanguageWindow(PickLanguageViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Options.Settings.FavoriteLanguages;
+        CanResize = true;
+        Width = 500;
+        Height = 600;
+        MinWidth = 350;
+        MinHeight = 400;
+        vm.Window = this;
+        DataContext = vm;
+
+        var labelSearch = UiUtil.MakeLabel(Se.Language.General.Search);
+        var textBoxSearch = new TextBox
+        {
+            Margin = new Thickness(5, 0, 0, 0),
+            Width = 250,
+        };
+        textBoxSearch.Bind(TextBox.TextProperty, new Binding(nameof(vm.SearchText)) { Source = vm });
+        textBoxSearch.TextChanged += (_, _) => vm.SearchTextChanged();
+
+        var panelSearch = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Margin = new Thickness(0, 0, 0, 10),
+            Children =
+            {
+                labelSearch,
+                textBoxSearch,
+            }
+        };
+
+        var listBoxLanguages = new ListBox
+        {
+            Height = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+        listBoxLanguages.Styles.Add(new Style(x => x.OfType<ListBoxItem>())
+        {
+            Setters =
+            {
+                new Setter(ListBoxItem.PaddingProperty, new Thickness(4, 2)),
+                new Setter(ListBoxItem.MarginProperty, new Thickness(0)),
+            }
+        });
+        listBoxLanguages.Bind(ItemsControl.ItemsSourceProperty, new Binding(nameof(vm.Languages)));
+        listBoxLanguages.Bind(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty, new Binding(nameof(vm.SelectedLanguage)) { Mode = BindingMode.TwoWay });
+        listBoxLanguages.DoubleTapped += (_, _) => vm.OkCommand.Execute(null);
+
+        var listBoxBorder = UiUtil.MakeBorderForControl(listBoxLanguages);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },  // Search
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },  // ListBox
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },  // Buttons
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 0,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(panelSearch, 0);
+        grid.Add(listBoxBorder, 1);
+        grid.Add(buttonPanel, 2);
+
+        Content = grid;
+
+        Activated += delegate { textBoxSearch.Focus(); };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -213,7 +213,7 @@ public partial class SpellCheckViewModel : ObservableObject
 
         var spellCheckLanguages = _spellCheckManager.GetDictionaryLanguages(Se.DictionariesFolder);
         Dictionaries.Clear();
-        Dictionaries.AddRange(spellCheckLanguages);
+        Dictionaries.AddRange(LanguageFavoritesHelper.Order(spellCheckLanguages, d => SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(d)));
         if (Dictionaries.Count > 0)
         {
             if (!string.IsNullOrEmpty(Se.Settings.SpellCheck.LastLanguageDictionaryFile))

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -97,7 +97,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             languages.Add(new LanguageDisplayItem(ci, ci.EnglishName));
         }
 
-        Languages = new ObservableCollection<LanguageDisplayItem>(languages.OrderBy(p => p.ToString()));
+        Languages = new ObservableCollection<LanguageDisplayItem>(
+            LanguageFavoritesHelper.Order(languages.OrderBy(p => p.ToString()), p => p.Code.TwoLetterISOLanguageName));
 
         var languageCode = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle); // Guess language based on subtitle contents
         Language = languageCode;

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -528,7 +528,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             return;
         }
 
-        foreach (var language in autoTranslator.GetSupportedSourceLanguages())
+        foreach (var language in LanguageFavoritesHelper.Order(autoTranslator.GetSupportedSourceLanguages(), p => p.Code))
         {
             SourceLanguages.Add(language);
         }
@@ -577,7 +577,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             return;
         }
 
-        foreach (var language in autoTranslator.GetSupportedTargetLanguages())
+        foreach (var language in LanguageFavoritesHelper.Order(autoTranslator.GetSupportedTargetLanguages(), p => p.Code))
         {
             TargetLanguages.Add(language);
         }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -359,15 +359,15 @@ public partial class SpeechToTextViewModel : ObservableObject
     // (code "auto") for engines that support automatic language detection.
     private static IEnumerable<WhisperLanguage> GetEngineLanguages(ISpeechToTextEngine engine)
     {
+        var result = new List<WhisperLanguage>();
         if (EngineSupportsAutoLanguageDetection(engine))
         {
-            yield return new WhisperLanguage("auto", "Auto detect");
+            result.Add(new WhisperLanguage("auto", "Auto detect"));
         }
 
-        foreach (var language in engine.Languages)
-        {
-            yield return language;
-        }
+        // Bubble the user's favorite languages to the top (the "Auto detect" entry stays first).
+        result.AddRange(LanguageFavoritesHelper.Order(engine.Languages, l => l.Code));
+        return result;
     }
 
     private static bool IsTranslateAvailable(ISpeechToTextEngine engine)

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -186,6 +186,7 @@ public class LanguageSettings
     public string DefaultFormat { get; set; }
     public string DefaultSaveAsFormat { get; set; }
     public string FavoriteSubtitleFormats { get; set; }
+    public string FavoriteLanguages { get; set; }
 
     public string ShowStopButton { get; set; }
     public string ShowFullscreenButton { get; set; }
@@ -510,6 +511,7 @@ public class LanguageSettings
         DefaultFormat = "Default format";
         DefaultSaveAsFormat = "Default \"Save as\" format";
         FavoriteSubtitleFormats = "Favorite subtitle formats";
+        FavoriteLanguages = "Favorite languages";
         FilesAndLogs = "Files and logs";
         ShowErrorLogFile = "Show error log file";
         ShowToolsLogFile = "Show tools log file";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -42,6 +42,7 @@ public class SeGeneral
     public string DefaultSubtitleFormat { get; set; }
     public string DefaultSaveAsFormat { get; set; }
     public string FavoriteSubtitleFormats { get; set; }
+    public string FavoriteLanguages { get; set; }
     public string DefaultEncoding { get; set; }
     public string SubtitleEnterKeyAction { get; set; }
     public string SubtitleSingleClickAction { get; set; }
@@ -177,6 +178,7 @@ public class SeGeneral
         AutoBackupDeleteAfterDays = 90;
         DefaultSaveAsFormat = new SubRip().FriendlyName;
         FavoriteSubtitleFormats = new SubRip().FriendlyName + ";" + new AdvancedSubStationAlpha().FriendlyName;
+        FavoriteLanguages = string.Empty;
         CpsLineLengthStrategy = nameof(CalcAll);
         RememberPositionAndSize = true;
 

--- a/src/ui/Logic/LanguageFavoritesHelper.cs
+++ b/src/ui/Logic/LanguageFavoritesHelper.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// UI-side accessor for the user's favorite languages (stored in <see cref="SeGeneral.FavoriteLanguages"/>).
+/// Bubbles favorite languages to the top of the various language combo boxes.
+/// </summary>
+public static class LanguageFavoritesHelper
+{
+    /// <summary>
+    /// The favorite language codes (normalized two-letter) in the user's chosen order.
+    /// </summary>
+    public static List<string> GetCodes()
+    {
+        return LanguageFavorites.ParseCodes(Se.Settings.General.FavoriteLanguages);
+    }
+
+    /// <summary>
+    /// Orders the items so favorite languages come first (in the user's order), the rest unchanged.
+    /// </summary>
+    /// <param name="items">Items to order.</param>
+    /// <param name="codeSelector">Returns an item's language code (any ISO form).</param>
+    /// <param name="pinTop">Optional predicate for items that stay above the favorites (e.g. "Auto detect").</param>
+    public static List<T> Order<T>(IEnumerable<T> items, Func<T, string> codeSelector, Func<T, bool>? pinTop = null)
+    {
+        return LanguageFavorites.OrderWithFavoritesFirst(items, codeSelector, GetCodes(), pinTop);
+    }
+}

--- a/tests/libse/Common/LanguageFavoritesTest.cs
+++ b/tests/libse/Common/LanguageFavoritesTest.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common;
+
+public class LanguageFavoritesTest
+{
+    private class Lang
+    {
+        public string Code { get; init; } = string.Empty;
+        public override string ToString() => Code;
+    }
+
+    private static List<Lang> Make(params string[] codes) => codes.Select(c => new Lang { Code = c }).ToList();
+
+    [Fact]
+    public void ParseCodes_NormalizesAndDedupes()
+    {
+        var codes = LanguageFavorites.ParseCodes("en; eng ;pt-BR;EN");
+        Assert.Equal(new[] { "en", "pt" }, codes.ToArray());
+    }
+
+    [Fact]
+    public void ParseCodes_EmptyReturnsEmpty()
+    {
+        Assert.Empty(LanguageFavorites.ParseCodes(null));
+        Assert.Empty(LanguageFavorites.ParseCodes(" "));
+    }
+
+    [Fact]
+    public void NormalizeTwoLetter_HandlesForms()
+    {
+        Assert.Equal("en", LanguageFavorites.NormalizeTwoLetter("EN"));
+        Assert.Equal("pt", LanguageFavorites.NormalizeTwoLetter("pt-BR"));
+        Assert.Equal("zh", LanguageFavorites.NormalizeTwoLetter("zh_CN"));
+        Assert.Equal("en", LanguageFavorites.NormalizeTwoLetter("eng"));
+        Assert.Equal(string.Empty, LanguageFavorites.NormalizeTwoLetter(""));
+    }
+
+    [Fact]
+    public void OrderWithFavoritesFirst_PutsFavoritesFirstInUserOrder()
+    {
+        var items = Make("de", "en", "fr", "es");
+        var ordered = LanguageFavorites.OrderWithFavoritesFirst(items, x => x.Code, new[] { "es", "en" });
+        Assert.Equal(new[] { "es", "en", "de", "fr" }, ordered.Select(x => x.Code).ToArray());
+    }
+
+    [Fact]
+    public void OrderWithFavoritesFirst_NoFavoritesKeepsOrder()
+    {
+        var items = Make("de", "en", "fr");
+        var ordered = LanguageFavorites.OrderWithFavoritesFirst(items, x => x.Code, new List<string>());
+        Assert.Equal(new[] { "de", "en", "fr" }, ordered.Select(x => x.Code).ToArray());
+    }
+
+    [Fact]
+    public void OrderWithFavoritesFirst_TolerantCodeMatching()
+    {
+        // item codes are region-qualified / three-letter; favorites are two-letter
+        var items = Make("pt-BR", "deu", "en-US");
+        var ordered = LanguageFavorites.OrderWithFavoritesFirst(items, x => x.Code, new[] { "de", "pt" });
+        Assert.Equal(new[] { "deu", "pt-BR", "en-US" }, ordered.Select(x => x.Code).ToArray());
+    }
+
+    [Fact]
+    public void OrderWithFavoritesFirst_PinTopStaysAboveFavorites()
+    {
+        var items = Make("auto", "de", "en");
+        var ordered = LanguageFavorites.OrderWithFavoritesFirst(
+            items, x => x.Code, new[] { "en" }, x => x.Code == "auto");
+        Assert.Equal(new[] { "auto", "en", "de" }, ordered.Select(x => x.Code).ToArray());
+    }
+}


### PR DESCRIPTION
Adds a **Favorite languages** setting, mirroring the existing *Favorite subtitle formats*. Pick your preferred languages once in Settings, and every language combo box lists them first.

## Settings
- New **"Favorite languages"** row with **Add / Remove / Move up / Move down**.
- **Add** opens a new searchable `PickLanguage` dialog (full ISO 639 list, already-added languages filtered out).
- Stored in `SeGeneral.FavoriteLanguages` (`;`-separated two-letter ISO codes).

## Combos that now show favorites first
- Auto-translate **source + target**
- **Speech-to-text** (Whisper/Crisp) — the **"Auto detect"** entry stays pinned above favorites
- **Spell-check** dictionaries and **OCR** dictionaries
- **Word lists** language, **Fix common errors** language

## Core
- `LanguageFavorites` (libse) — a pure ordering helper. Favorites come first in the user's chosen order; everything else keeps its order. Tolerant matching: two-letter (`en`), three-letter (`eng`) and region-qualified (`pt-BR`) codes all match on the base two-letter code. Optional `pinTop` predicate keeps entries like "Auto detect" above the favorites block.
- `LanguageFavoritesHelper` (UI) reads the live settings store and calls the helper.
- Unit tests: `LanguageFavoritesTest` (7 cases) — all passing.

## Notes / scope
- **EBU STL** language combo intentionally skipped: it uses EBU-specific codes (not ISO), so favorites can't match meaningfully.
- **Visual separator** between the favorites block and the rest was deferred — inserting a non-selectable divider into each heterogeneous combo (TranslationPair / WhisperLanguage / …) risks selection bugs; ordering-only is the safe first version. Easy follow-up.
- Default selection logic in each combo is unchanged (selection is by code, independent of order).

Builds clean (`dotnet build src/ui/UI.csproj`); launched and exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)