### PR TITLE
Bump version to v5.1.0-beta1

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,7 +1,7 @@
 
 Subtitle Edit Changelog
 
-v5.1.0 (TBD)
+v5.1.0-beta1 (TBD)
 
 * Add auto-save of the open subtitle file (Options > General) - thx muaz978
 * Add remote/external llama.cpp server (URL) option to auto-translate - thx muaz978

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -15,7 +15,7 @@ namespace Nikse.SubtitleEdit.Logic.Config;
 
 public class Se
 {
-    public static string Version { get; set; } = "v5.0.0";
+    public static string Version { get; set; } = "v5.1.0-beta1";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Bumps the app version for the first 5.1.0 beta.

- `Se.Version`: `v5.0.0` → `v5.1.0-beta1`
- `change-log.txt` header: `v5.1.0 (TBD)` → `v5.1.0-beta1 (TBD)`

Builds clean (`dotnet build src/ui/UI.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)