### PR TITLE
seconv: escape paths/messages in console output (fix #11862)

### DIFF
--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -326,7 +326,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (Exception ex)
                 {
-                    AnsiConsole.MarkupLine($"[red]Error loading --settings file: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[red]Error loading --settings file: {ex.Message}[/]");
                     return 1;
                 }
             }
@@ -353,7 +353,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (ArgumentException ex)
                 {
-                    AnsiConsole.MarkupLine($"[red]Error: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
                     return 1;
                 }
             }
@@ -394,7 +394,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (FormatException ex)
                 {
-                    AnsiConsole.MarkupLine($"[red]Error: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
                     return 1;
                 }
             }
@@ -409,7 +409,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (FormatException ex)
                 {
-                    AnsiConsole.MarkupLine($"[red]Error: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
                     return 1;
                 }
             }
@@ -424,7 +424,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (FormatException ex)
                 {
-                    AnsiConsole.MarkupLine($"[red]Error: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
                     return 1;
                 }
             }
@@ -565,7 +565,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                     AnsiConsole.MarkupLine("[red]Errors:[/]");
                     foreach (var error in result.Errors)
                     {
-                        AnsiConsole.MarkupLine($"  [red]•[/] {error.EscapeMarkup()}");
+                        AnsiConsole.MarkupLineInterpolated($"  [red]•[/] {error}");
                     }
                 }
 
@@ -582,10 +582,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             }
             else
             {
-                AnsiConsole.MarkupLine($"[red]Error: {ex.Message}[/]");
+                AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
                 if (ex.InnerException != null)
                 {
-                    AnsiConsole.MarkupLine($"[dim]{ex.InnerException.Message}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[dim]{ex.InnerException.Message}[/]");
                 }
             }
             return 1;

--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -241,7 +241,7 @@ internal static class ContainerSubtitleLoader
                 }
                 catch (Exception ex)
                 {
-                    AnsiConsole.MarkupLine($"[yellow]Warning: PGS OCR failed on MKV track #{track.TrackNumber}: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[yellow]Warning: PGS OCR failed on MKV track #{track.TrackNumber}: {ex.Message}[/]");
                 }
                 continue;
             }
@@ -258,7 +258,7 @@ internal static class ContainerSubtitleLoader
                 }
                 catch (Exception ex)
                 {
-                    AnsiConsole.MarkupLine($"[yellow]Warning: VobSub OCR failed on MKV track #{track.TrackNumber}: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[yellow]Warning: VobSub OCR failed on MKV track #{track.TrackNumber}: {ex.Message}[/]");
                 }
                 continue;
             }
@@ -269,7 +269,7 @@ internal static class ContainerSubtitleLoader
             var format = Utilities.LoadMatroskaTextSubtitle(track, matroska, matroskaSubtitle, subtitle);
             if (subtitle.Paragraphs.Count == 0 || format == null)
             {
-                AnsiConsole.MarkupLine($"[yellow]Warning: track #{track.TrackNumber} produced no subtitles ({track.CodecId.EscapeMarkup()}).[/]");
+                AnsiConsole.MarkupLineInterpolated($"[yellow]Warning: track #{track.TrackNumber} produced no subtitles ({track.CodecId}).[/]");
                 continue;
             }
             subtitle.Renumber();
@@ -316,7 +316,7 @@ internal static class ContainerSubtitleLoader
                 }
                 catch (Exception ex)
                 {
-                    AnsiConsole.MarkupLine($"[yellow]Warning: VobSub OCR failed on MP4 track #{trackId}: {ex.Message.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($"[yellow]Warning: VobSub OCR failed on MP4 track #{trackId}: {ex.Message}[/]");
                 }
                 continue;
             }
@@ -416,7 +416,7 @@ internal static class ContainerSubtitleLoader
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[yellow]Warning: DVB-sub OCR failed: {ex.Message.EscapeMarkup()}[/]");
+                AnsiConsole.MarkupLineInterpolated($"[yellow]Warning: DVB-sub OCR failed: {ex.Message}[/]");
             }
         }
 

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -69,7 +69,7 @@ internal class SubtitleConverter
                         var outputFile = ResolveOutputFileName(inputFile, options);
                         if (!options.Quiet)
                         {
-                            AnsiConsole.Markup($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [dim]->[/] [green]{outputFile}[/]...");
+                            AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [dim]->[/] [green]{outputFile}[/]...");
                         }
                         await ConvertFileAsync(inputFile, outputFile, options);
                         result.SuccessfulFiles++;
@@ -92,10 +92,10 @@ internal class SubtitleConverter
                         {
                             var outputFile = ResolveOutputFileName(inputFile, options, track.LanguageCode, track.TrackNumber);
                             var trackLabel = track.TrackNumber.HasValue ? $"#{track.TrackNumber.Value} " : string.Empty;
-                            var langLabel = string.IsNullOrEmpty(track.LanguageCode) ? string.Empty : $"[[{track.LanguageCode.EscapeMarkup()}]] ";
+                            var langLabel = string.IsNullOrEmpty(track.LanguageCode) ? string.Empty : $"[{track.LanguageCode}] ";
                             if (!options.Quiet)
                             {
-                                AnsiConsole.Markup($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [yellow]{trackLabel.EscapeMarkup()}[/][blue]{langLabel}[/][dim]->[/] [green]{outputFile}[/]...");
+                                AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [yellow]{trackLabel}[/][blue]{langLabel}[/][dim]->[/] [green]{outputFile}[/]...");
                             }
                             await ConvertTrackAsync(track, outputFile, options);
                             result.SuccessfulFiles++;
@@ -116,7 +116,7 @@ internal class SubtitleConverter
 
                     if (!options.Quiet)
                     {
-                        AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
+                        AnsiConsole.MarkupLineInterpolated($" [red]error: {msg}[/]");
                     }
                 }
 
@@ -202,7 +202,7 @@ internal class SubtitleConverter
             var label = vobFiles.Count == 1
                 ? Path.GetFileName(vobFiles[0])
                 : $"{vobFiles.Count} VOB files";
-            AnsiConsole.Markup($"[dim]vob:[/] [cyan]{label.EscapeMarkup()}[/] [dim]->[/] [green]{outputBase.EscapeMarkup()}[/]...");
+            AnsiConsole.MarkupInterpolated($"[dim]vob:[/] [cyan]{label}[/] [dim]->[/] [green]{outputBase}[/]...");
         }
 
         try
@@ -232,7 +232,7 @@ internal class SubtitleConverter
                     AnsiConsole.MarkupLine($" [green]done ({totalWritten} subtitle(s) across {outputs.Count} streams).[/]");
                     foreach (var o in outputs)
                     {
-                        AnsiConsole.MarkupLine($"  [dim]stream 0x{o.StreamId:X2}:[/] [green]{o.Path.EscapeMarkup()}[/] ({o.Written})");
+                        AnsiConsole.MarkupLineInterpolated($"  [dim]stream 0x{o.StreamId:X2}:[/] [green]{o.Path}[/] ({o.Written})");
                     }
                 }
             }
@@ -248,7 +248,7 @@ internal class SubtitleConverter
             }
             if (!options.Quiet)
             {
-                AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
+                AnsiConsole.MarkupLineInterpolated($" [red]error: {msg}[/]");
             }
         }
 
@@ -322,7 +322,7 @@ internal class SubtitleConverter
         var outputFile = ResolveOutputFileName(inputFile, options);
         if (!options.Quiet)
         {
-            AnsiConsole.Markup($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile).EscapeMarkup()}[/] [dim](img→img)→[/] [green]{outputFile.EscapeMarkup()}[/]...");
+            AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [dim](img→img)→[/] [green]{outputFile}[/]...");
         }
 
         IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem>? items = null;
@@ -345,7 +345,7 @@ internal class SubtitleConverter
             result.Files.Add(new FileConversionResult(inputFile, null, false, msg));
             if (!options.Quiet)
             {
-                AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
+                AnsiConsole.MarkupLineInterpolated($" [red]error: {msg}[/]");
             }
         }
         finally
@@ -399,7 +399,7 @@ internal class SubtitleConverter
             if (!options.Quiet)
             {
                 var trackLabel = $"#{track.TrackNumber} ";
-                AnsiConsole.Markup($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile).EscapeMarkup()}[/] [yellow]{trackLabel}[/][dim](PGS img→img)→[/] [green]{outputFile.EscapeMarkup()}[/]...");
+                AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [yellow]{trackLabel}[/][dim](PGS img→img)→[/] [green]{outputFile}[/]...");
             }
 
             IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem>? items = null;
@@ -422,7 +422,7 @@ internal class SubtitleConverter
                 result.Files.Add(new FileConversionResult(inputFile, null, false, msg));
                 if (!options.Quiet)
                 {
-                    AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($" [red]error: {msg}[/]");
                 }
             }
             finally
@@ -478,7 +478,7 @@ internal class SubtitleConverter
 
             if (!options.Quiet)
             {
-                AnsiConsole.Markup($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile).EscapeMarkup()}[/] [yellow]PID {pid} [/][dim](DVB img→img)→[/] [green]{outputFile.EscapeMarkup()}[/]...");
+                AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [yellow]PID {pid} [/][dim](DVB img→img)→[/] [green]{outputFile}[/]...");
             }
 
             try
@@ -499,7 +499,7 @@ internal class SubtitleConverter
                 result.Files.Add(new FileConversionResult(inputFile, null, false, msg));
                 if (!options.Quiet)
                 {
-                    AnsiConsole.MarkupLine($" [red]error: {msg.EscapeMarkup()}[/]");
+                    AnsiConsole.MarkupLineInterpolated($" [red]error: {msg}[/]");
                 }
             }
             finally

--- a/src/seconv/Helpers/InfoLintReporter.cs
+++ b/src/seconv/Helpers/InfoLintReporter.cs
@@ -29,7 +29,7 @@ internal static class InfoLintReporter
             return;
         }
 
-        AnsiConsole.MarkupLine($"[bold cyan]{info.Path.EscapeMarkup()}[/]");
+        AnsiConsole.MarkupLineInterpolated($"[bold cyan]{info.Path}[/]");
         var table = new Table().Border(TableBorder.Rounded);
         table.AddColumn("[yellow]Field[/]");
         table.AddColumn("[green]Value[/]");
@@ -73,11 +73,11 @@ internal static class InfoLintReporter
         {
             if (report.IsClean)
             {
-                AnsiConsole.MarkupLine($"[green]✓[/] {report.Path.EscapeMarkup()} [dim](clean)[/]");
+                AnsiConsole.MarkupLineInterpolated($"[green]✓[/] {report.Path} [dim](clean)[/]");
                 continue;
             }
 
-            AnsiConsole.MarkupLine($"[yellow]⚠[/] {report.Path.EscapeMarkup()} [dim]({report.Issues.Count} issues)[/]");
+            AnsiConsole.MarkupLineInterpolated($"[yellow]⚠[/] {report.Path} [dim]({report.Issues.Count} issues)[/]");
             var table = new Table().Border(TableBorder.Minimal);
             table.AddColumn("[yellow]#[/]");
             table.AddColumn("[cyan]Type[/]");

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -86,10 +86,10 @@ internal class Program
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[red]Fatal error: {ex.Message}[/]");
+            AnsiConsole.MarkupLineInterpolated($"[red]Fatal error: {ex.Message}[/]");
             if (ex.InnerException != null)
             {
-                AnsiConsole.MarkupLine($"[red]  {ex.InnerException.Message}[/]");
+                AnsiConsole.MarkupLineInterpolated($"[red]  {ex.InnerException.Message}[/]");
             }
             return 1;
         }
@@ -293,7 +293,7 @@ internal class Program
             }
             else
             {
-                AnsiConsole.MarkupLine($"[red]Error: {ex.Message.EscapeMarkup()}[/]");
+                AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
             }
             return 1;
         }

--- a/tests/seconv/Core/SubtitleConverterTest.cs
+++ b/tests/seconv/Core/SubtitleConverterTest.cs
@@ -98,4 +98,34 @@ public class SubtitleConverterTest : IDisposable
         var outputFiles = Directory.GetFiles(outputFolder, "*.ass");
         Assert.Equal(2, outputFiles.Length);
     }
+
+    [Fact]
+    public async Task ConvertAsync_PathWithSquareBrackets_DoesNotCrashOnMarkup()
+    {
+        // Regression for #11862: a path containing '[' or ']' (e.g. a release-group
+        // folder like "Title [1080p Bluray]") must not be parsed as Spectre.Console
+        // markup. Before the fix this threw "Could not find color or style '1080p'".
+        var bracketFolder = Path.Combine(_tempRoot, "Title [1080p Bluray]");
+        Directory.CreateDirectory(bracketFolder);
+        var inputFile = Path.Combine(bracketFolder, "input [v2].srt");
+        await File.WriteAllTextAsync(inputFile, SrtContent, TestContext.Current.CancellationToken);
+
+        var outputFolder = Path.Combine(bracketFolder, "out [done]");
+        Directory.CreateDirectory(outputFolder);
+
+        var options = new ConversionOptions
+        {
+            Patterns = [inputFile],
+            Format = "Advanced Sub Station Alpha",
+            OutputFolder = outputFolder,
+            Overwrite = true,
+        };
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(options);
+
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+        Assert.Equal(1, result.SuccessfulFiles);
+        Assert.Single(Directory.GetFiles(outputFolder, "*.ass"));
+    }
 }


### PR DESCRIPTION
Fixes #11862 — seconv crashed on any input whose path contained `[` or `]` (folder **or** file name), because paths/filenames/exception messages were interpolated into Spectre.Console markup without escaping. Spectre parsed e.g. `Title [1080p Bluray]` as a style tag → `Could not find color or style '1080p'` / `malformed markup tag`.

## Fix
Switched the affected calls from `AnsiConsole.Markup(Line)($"…")` to **`AnsiConsole.Markup(Line)Interpolated($"…")`**, which auto-escapes the interpolation holes while keeping the literal `[red]…[/]` style tags — and removed the now-redundant `.EscapeMarkup()` (which would otherwise double-escape). Files: `Program.cs`, `Core/SubtitleConverter.cs`, `Core/ContainerSubtitleLoader.cs`, `Commands/ConvertCommand.cs`, `Helpers/InfoLintReporter.cs`.

### Confirmed root-cause sites
- `SubtitleConverter.cs:72` / `:98` — the conversion progress line printed `Path.GetFileName(inputFile)` and `outputFile` unescaped (the main path; covers brackets in folder **and** file name).

### Related bugs fixed (the "also check for related bugs" pass)
- `Program.cs` fatal handler and `ConvertCommand.cs` error handler interpolated `ex.Message` / `InnerException.Message` **unescaped**. These are **not gated by `--quiet`/`--json`**, so they reproduced in those modes too — and the error printer crashing *masked the real error* (the reporter's "malformed markup tag at position 135").
- Container/track OCR warnings and the VobSub/PGS/DVB image-conversion lines had the same latent issue.

### Scoped out (low risk, noted)
- `InfoLintReporter` info-table metadata rows (`Format`/`Encoding`/`Language`) go through `Table.AddRow(string)`, which also parses markup, but those values aren't user paths. `HelpDisplay` already pre-escapes its dynamic values. `ImageOcrLoader`'s `{what}` is built from counts/track numbers only.

## Test
Added `ConvertAsync_PathWithSquareBrackets_DoesNotCrashOnMarkup` — converts a file with `[`/`]` in **both** the folder name (`Title [1080p Bluray]`) and the file name (`input [v2].srt`) and asserts success. Full seconv suite: **164 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)