### PR TITLE
Add "Go to next/previous time code" video shortcuts (#11867)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11094,6 +11094,71 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void VideoGoToNextTimeCode()
+    {
+        GoToNearestTimeCode(forward: true);
+    }
+
+    [RelayCommand]
+    private void VideoGoToPreviousTimeCode()
+    {
+        GoToNearestTimeCode(forward: false);
+    }
+
+    // Moves the video playhead to the nearest subtitle cue boundary (any start or end
+    // time) before/after the current position, stepping through both starts and ends.
+    // Ports SE4's GoToNearestTimeCode. A 1 ms dead-zone keeps repeated presses advancing.
+    private void GoToNearestTimeCode(bool forward)
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp == null)
+        {
+            return;
+        }
+
+        var positionMs = vp.Position * 1000.0;
+
+        SubtitleLineViewModel? found = null;
+        var foundSeconds = 0.0;
+        var bestDistance = double.MaxValue;
+
+        foreach (var s in Subtitles)
+        {
+            foreach (var timeMs in new[] { s.StartTime.TotalMilliseconds, s.EndTime.TotalMilliseconds })
+            {
+                if (timeMs >= TimeCode.MaxTimeTotalMilliseconds - 0.01)
+                {
+                    continue;
+                }
+
+                var onRequestedSide = forward ? timeMs > positionMs + 1 : timeMs < positionMs - 1;
+                if (!onRequestedSide)
+                {
+                    continue;
+                }
+
+                var distance = Math.Abs(timeMs - positionMs);
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    found = s;
+                    foundSeconds = timeMs / 1000.0;
+                }
+            }
+        }
+
+        if (found == null)
+        {
+            return;
+        }
+
+        vp.Position = foundSeconds;
+        SelectAndScrollToRow(Subtitles.IndexOf(found));
+        AudioVisualizerCenterOnPositionIfNeeded(found, foundSeconds);
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
     private void FocusSelectedLine()
     {
         var idx = SelectedSubtitleIndex ?? -1;

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -127,6 +127,8 @@ public static class Se4ShortcutsImporter
         ["MainVideoGoToStartCurrent"] = nameof(MainViewModel.VideoSetPositionCurrentSubtitleStartCommand),
         ["MainVideoGoToPrevSubtitle"] = nameof(MainViewModel.GoToPreviousLineAndSetVideoPositionCommand),
         ["MainVideoGoToNextSubtitle"] = nameof(MainViewModel.GoToNextLineAndSetVideoPositionCommand),
+        ["MainVideoGoToPrevTimeCode"] = nameof(MainViewModel.VideoGoToPreviousTimeCodeCommand),
+        ["MainVideoGoToNextTimeCode"] = nameof(MainViewModel.VideoGoToNextTimeCodeCommand),
         ["MainVideoStop"] = nameof(MainViewModel.PauseCommand),
         ["MainVideoSelectNextSubtitle"] = nameof(MainViewModel.GoToNextLineCommand),
 

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -148,6 +148,8 @@ public class LanguageSettingsShortcuts
     public string GoToPreviousLineAndSetVideoPosition { get; set; }
     public string GoToPreviousLineFromVideoPosition { get; set; }
     public string GoToNextLineFromVideoPosition { get; set; }
+    public string VideoGoToPreviousTimeCode { get; set; }
+    public string VideoGoToNextTimeCode { get; set; }
     public string GoToNextLineAndSetVideoPosition { get; set; }
     public string TextBoxDeleteSelectionNoClipboard { get; set; }
     public string TextBoxCut { get; set; }
@@ -451,6 +453,8 @@ public class LanguageSettingsShortcuts
         GoToNextLineAndSetVideoPosition = "Go to next subtitle and set video position";
         GoToPreviousLineFromVideoPosition = "Go to previous subtitle (from current video position)";
         GoToNextLineFromVideoPosition = "Go to next subtitle (from current video position)";
+        VideoGoToPreviousTimeCode = "Go to previous time code";
+        VideoGoToNextTimeCode = "Go to next time code";
         TextBoxDeleteSelectionNoClipboard = "Text box: Delete selection (no clipboard)";
         TextBoxCut = "Text box: Cut";
         TextBoxCut2 = "Text box: Cut (alternative)";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -218,6 +218,8 @@ public static class ShortcutsMain
         { nameof(MainViewModel.GoToPreviousLineAndSetVideoPositionCommand), Se.Language.Options.Shortcuts.GoToPreviousLineAndSetVideoPosition },
         { nameof(MainViewModel.GoToPreviousLineFromVideoPositionCommand), Se.Language.Options.Shortcuts.GoToPreviousLineFromVideoPosition },
         { nameof(MainViewModel.GoToNextLineFromVideoPositionCommand), Se.Language.Options.Shortcuts.GoToNextLineFromVideoPosition },
+        { nameof(MainViewModel.VideoGoToPreviousTimeCodeCommand), Se.Language.Options.Shortcuts.VideoGoToPreviousTimeCode },
+        { nameof(MainViewModel.VideoGoToNextTimeCodeCommand), Se.Language.Options.Shortcuts.VideoGoToNextTimeCode },
 
         { nameof(MainViewModel.SaveLanguageFileCommand), Se.Language.Main.SaveLanguageFile },
 
@@ -525,6 +527,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.GoToNextLineAndSetVideoPositionCommand, nameof(vm.GoToNextLineAndSetVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousLineFromVideoPositionCommand, nameof(vm.GoToPreviousLineFromVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineFromVideoPositionCommand, nameof(vm.GoToNextLineFromVideoPositionCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoGoToPreviousTimeCodeCommand, nameof(vm.VideoGoToPreviousTimeCodeCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoGoToNextTimeCodeCommand, nameof(vm.VideoGoToNextTimeCodeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SaveLanguageFileCommand, nameof(vm.SaveLanguageFileCommand), ShortcutCategory.General);
 
         AddShortcut(shortcuts, vm.UnbreakCommand, nameof(vm.UnbreakCommand), ShortcutCategory.General);


### PR DESCRIPTION
Adds two of the three SE4 shortcuts requested in #11867 (the third — "Move text after cursor position to next subtitle and go to next" — already landed in #11855 / v5.1.0-beta1).

## What
- **Go to next time code** / **Go to previous time code** — move the video playhead to the nearest subtitle **cue boundary** (any start *or* end time), stepping through both. Distinct from the existing `Go to next/previous subtitle (from video position)`, which selects a grid line rather than stepping the playhead across in/out points.

## Behavior (ported from SE4 `Forms/Main.cs` `GoToNearestTimeCode`)
- Considers every paragraph start and end time; picks the closest one on the requested side.
- 1 ms dead-zone so repeated presses keep advancing.
- Skips max-time (`99:59:59,999`) boundaries.
- Moves `vp.Position`, selects/scrolls the owning row, recenters the waveform.

## Wiring
- `VideoGoToNextTimeCode` / `VideoGoToPreviousTimeCode` `[RelayCommand]`s in `MainViewModel`.
- Registered in `ShortcutsMain` (General category, **no default key** — SE4 shipped these unbound too).
- Language strings `VideoGoToNextTimeCode` / `VideoGoToPreviousTimeCode`.
- SE4 importer maps `MainVideoGoToPrevTimeCode` / `MainVideoGoToNextTimeCode` so existing SE4 keybindings carry over.

Builds clean (`dotnet build src/ui/UI.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)