### PR TITLE
seconv: run operations in arg order, repeating per occurrence (SE4 parity)

### DIFF
--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -8,6 +8,12 @@ namespace SeConv.Commands;
 
 internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
 {
+    /// <summary>
+    /// The original process arguments, captured in Program.Main before Spectre parsing.
+    /// Used to recover operation order/repetition, which the bound settings discard.
+    /// </summary>
+    public static string[] RawArgs { get; set; } = [];
+
     public sealed class Settings : CommandSettings
     {
         [CommandArgument(0, "<pattern>")]
@@ -358,24 +364,35 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
             }
 
-            // Build operations list
-            var operations = new List<string>();
-            if (settings.ApplyDurationLimits) operations.Add("ApplyDurationLimits");
-            if (settings.BalanceLines) operations.Add("BalanceLines");
-            if (settings.BeautifyTimeCodes) operations.Add("BeautifyTimeCodes");
-            if (settings.ConvertColorsToDialog) operations.Add("ConvertColorsToDialog");
-            if (fceRequested) operations.Add("FixCommonErrors");
-            if (settings.FixRtlViaUnicodeChars) operations.Add("FixRtlViaUnicodeChars");
-            if (settings.MergeSameTexts) operations.Add("MergeSameTexts");
-            if (settings.MergeSameTimeCodes) operations.Add("MergeSameTimeCodes");
-            if (settings.MergeShortLines) operations.Add("MergeShortLines");
-            if (settings.RedoCasing) operations.Add("RedoCasing");
-            if (settings.RemoveFormatting) operations.Add("RemoveFormatting");
-            if (settings.RemoveLineBreaks) operations.Add("RemoveLineBreaks");
-            if (settings.RemoveTextForHI) operations.Add("RemoveTextForHI");
-            if (settings.RemoveUnicodeControlChars) operations.Add("RemoveUnicodeControlChars");
-            if (settings.ReverseRtlStartEnd) operations.Add("ReverseRtlStartEnd");
-            if (settings.SplitLongLines) operations.Add("SplitLongLines");
+            // Build operations list. Operations run in the order the user typed them and
+            // repeat for each occurrence (SE4 parity) - e.g. "--fix-common-errors" twice
+            // runs two FCE passes. Spectre collapses repeated flags, so the order/count is
+            // recovered from the raw args. Fall back to a fixed order if raw args are missing.
+            List<string> operations;
+            if (RawArgs.Length > 0)
+            {
+                operations = OperationOrderParser.BuildOperations(RawArgs, fceRequested);
+            }
+            else
+            {
+                operations = new List<string>();
+                if (settings.ApplyDurationLimits) operations.Add("ApplyDurationLimits");
+                if (settings.BalanceLines) operations.Add("BalanceLines");
+                if (settings.BeautifyTimeCodes) operations.Add("BeautifyTimeCodes");
+                if (settings.ConvertColorsToDialog) operations.Add("ConvertColorsToDialog");
+                if (fceRequested) operations.Add("FixCommonErrors");
+                if (settings.FixRtlViaUnicodeChars) operations.Add("FixRtlViaUnicodeChars");
+                if (settings.MergeSameTexts) operations.Add("MergeSameTexts");
+                if (settings.MergeSameTimeCodes) operations.Add("MergeSameTimeCodes");
+                if (settings.MergeShortLines) operations.Add("MergeShortLines");
+                if (settings.RedoCasing) operations.Add("RedoCasing");
+                if (settings.RemoveFormatting) operations.Add("RemoveFormatting");
+                if (settings.RemoveLineBreaks) operations.Add("RemoveLineBreaks");
+                if (settings.RemoveTextForHI) operations.Add("RemoveTextForHI");
+                if (settings.RemoveUnicodeControlChars) operations.Add("RemoveUnicodeControlChars");
+                if (settings.ReverseRtlStartEnd) operations.Add("ReverseRtlStartEnd");
+                if (settings.SplitLongLines) operations.Add("SplitLongLines");
+            }
 
             // Validate --change-speed (must be > 0; 100 means no change)
             if (settings.ChangeSpeed.HasValue && settings.ChangeSpeed.Value <= 0)

--- a/src/seconv/Core/OperationOrderParser.cs
+++ b/src/seconv/Core/OperationOrderParser.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// Builds the ordered list of conversion operations from the raw command-line arguments,
+/// preserving both the order the user typed them in and any repetitions. This mirrors
+/// SE4's batch behaviour where, e.g., passing <c>--fix-common-errors</c> twice runs Fix
+/// Common Errors twice (a second pass can fix issues the first pass introduced).
+///
+/// Spectre.Console.Cli binds repeated boolean flags down to a single value and discards
+/// ordering, so the operation order/repetition has to be recovered from the raw args.
+/// </summary>
+internal static class OperationOrderParser
+{
+    // Canonical operation names (as understood by LibSEIntegration.ApplyOperations).
+    // The CLI exposes each as a lowercase-hyphenated flag plus a PascalCase alias; both
+    // normalize to the canonical name (lower-cased, dashes removed), so this list doubles
+    // as the alias table.
+    private static readonly string[] ToggleOperations =
+    {
+        "ApplyDurationLimits",
+        "BalanceLines",
+        "BeautifyTimeCodes",
+        "ConvertColorsToDialog",
+        "FixCommonErrors",
+        "FixRtlViaUnicodeChars",
+        "MergeSameTexts",
+        "MergeSameTimeCodes",
+        "MergeShortLines",
+        "RedoCasing",
+        "RemoveFormatting",
+        "RemoveLineBreaks",
+        "RemoveTextForHI",
+        "RemoveUnicodeControlChars",
+        "ReverseRtlStartEnd",
+        "SplitLongLines",
+    };
+
+    private static readonly Dictionary<string, string> ByNormalizedToken = BuildLookup();
+
+    private static Dictionary<string, string> BuildLookup()
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var op in ToggleOperations)
+        {
+            map[Normalize(op)] = op;
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Normalizes an arg/flag token to a comparable key: drops the leading <c>--</c> / <c>-</c> / <c>/</c>,
+    /// trims any <c>:value</c> or <c>=value</c> suffix, removes dashes, and lower-cases. So
+    /// <c>--fix-common-errors</c>, <c>--FixCommonErrors</c> and <c>/FixCommonErrors:x</c> all map to
+    /// <c>fixcommonerrors</c>.
+    /// </summary>
+    private static string Normalize(string token)
+    {
+        var t = token.TrimStart('/', '-');
+
+        var cut = t.IndexOfAny(new[] { ':', '=' });
+        if (cut >= 0)
+        {
+            t = t.Substring(0, cut);
+        }
+
+        return t.Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Returns the operations to apply, in the order they appear on the command line and
+    /// repeated as many times as they appear.
+    /// </summary>
+    /// <param name="rawArgs">The original process arguments.</param>
+    /// <param name="fceRequested">
+    /// True when Fix Common Errors was requested (a bare flag and/or <c>--fix-common-errors-rules</c>).
+    /// Guarantees at least one Fix Common Errors pass when only the rules option was supplied.
+    /// </param>
+    public static List<string> BuildOperations(IReadOnlyList<string> rawArgs, bool fceRequested)
+    {
+        var operations = new List<string>();
+        if (rawArgs == null)
+        {
+            return operations;
+        }
+
+        var sawBareFce = false;
+        int? rulesPosition = null;
+
+        foreach (var arg in rawArgs)
+        {
+            if (string.IsNullOrEmpty(arg) || (arg[0] != '-' && arg[0] != '/'))
+            {
+                continue; // positional (e.g. a file pattern) or a value, not a flag
+            }
+
+            var key = Normalize(arg);
+
+            // Fix Common Errors rules option configures the FCE pass(es) globally; it does
+            // not itself add a pass, but it does imply one when no bare flag is present.
+            if (key == "fixcommonerrorsrules")
+            {
+                rulesPosition ??= operations.Count;
+                continue;
+            }
+
+            if (ByNormalizedToken.TryGetValue(key, out var operation))
+            {
+                if (operation == "FixCommonErrors")
+                {
+                    sawBareFce = true;
+                }
+
+                operations.Add(operation);
+            }
+        }
+
+        // Back-compat: "--fix-common-errors-rules:..." on its own still runs one FCE pass.
+        if (fceRequested && !sawBareFce)
+        {
+            operations.Insert(rulesPosition ?? operations.Count, "FixCommonErrors");
+        }
+
+        return operations;
+    }
+}

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -70,6 +70,10 @@ internal class Program
             }
         }
 
+        // Capture the raw args so the convert command can recover operation order/repetition
+        // (Spectre collapses repeated flags and discards ordering).
+        ConvertCommand.RawArgs = args;
+
         // Set up Spectre.Console CLI with default command
         var app = new CommandApp<ConvertCommand>();
         app.Configure(config =>

--- a/tests/seconv/Core/OperationOrderParserTest.cs
+++ b/tests/seconv/Core/OperationOrderParserTest.cs
@@ -1,0 +1,78 @@
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+public class OperationOrderParserTest
+{
+    [Fact]
+    public void RepeatedFixCommonErrors_RunsOncePerOccurrence()
+    {
+        // Regression for discussion #11744: repeated --fix-common-errors must run multiple passes.
+        var args = new[] { "in.srt", "subrip", "--overwrite", "--fix-common-errors", "--fix-common-errors" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: true);
+
+        Assert.Equal(new[] { "FixCommonErrors", "FixCommonErrors" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void PreservesCommandLineOrder()
+    {
+        var args = new[] { "in.srt", "subrip", "--remove-text-for-hi", "--fix-common-errors", "--balance-lines" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: true);
+
+        Assert.Equal(new[] { "RemoveTextForHI", "FixCommonErrors", "BalanceLines" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void InterleavedRepeats_KeepOrderAndCount()
+    {
+        var args = new[] { "--fix-common-errors", "--balance-lines", "--fix-common-errors" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: true);
+
+        Assert.Equal(new[] { "FixCommonErrors", "BalanceLines", "FixCommonErrors" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void PascalCaseAndHyphenAliasesBothMatch()
+    {
+        var args = new[] { "--FixCommonErrors", "--remove-formatting" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: true);
+
+        Assert.Equal(new[] { "FixCommonErrors", "RemoveFormatting" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void RulesOptionAloneImpliesOneFcePass()
+    {
+        var args = new[] { "in.srt", "subrip", "--fix-common-errors-rules:FixCommas" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: true);
+
+        Assert.Equal(new[] { "FixCommonErrors" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void RulesOptionDoesNotAddExtraPassWhenBareFlagPresent()
+    {
+        var args = new[] { "--fix-common-errors", "--fix-common-errors-rules:FixCommas" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: true);
+
+        Assert.Equal(new[] { "FixCommonErrors" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void NonOperationFlagsAndPositionalsAreIgnored()
+    {
+        var args = new[] { "my-balance-lines-file.srt", "subrip", "--encoding", "utf-8", "--overwrite" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: false);
+
+        Assert.Empty(ops);
+    }
+}


### PR DESCRIPTION
Addresses the seconv discussion [#11744 (comment 17442878)](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17442878): you couldn't run **multiple Fix Common Errors passes** in one invocation, because repeated `--fix-common-errors` flags were collapsed to one.

## What changed
Conversion operations now run **in the order typed** and **repeat once per occurrence** — matching SE4's batch behaviour:
- `seconv in.srt subrip --overwrite --fix-common-errors --fix-common-errors` → **two** FCE passes (a second pass fixes issues the first introduces).
- `--remove-text-for-hi --fix-common-errors --balance-lines` runs in exactly that order.

## How
`Spectre.Console.Cli` binds repeated `bool` flags down to a single value and discards ordering, so the operation order/count is recovered from the **raw process args** (captured in `Program.Main` → `ConvertCommand.RawArgs`) via a new `OperationOrderParser`:
- Recognises all 16 toggle operations by both their hyphen and PascalCase aliases (normalised: strip leading `-`/`/`, drop `:value`, remove dashes, lower-case).
- Ignores positionals/values (only tokens starting with `-`/`/` are considered).
- `--fix-common-errors-rules:…` configures the FCE pass(es) globally and still implies one pass when no bare flag is present (no double-count when both are given).
- The previous fixed-order, de-duplicated bool block is kept as a **fallback** when raw args are unavailable.

The pipeline already executed the operations list in order (`LibSEIntegration.ApplyOperations`), so no downstream change was needed — only how the list is built.

## Behaviour note
Operations previously ran in a curated fixed order regardless of how they were typed; they now follow command-line order. This is the SE4 behaviour the discussion asks for, but it's a (documentable) change for existing scripts.

## Tests
`OperationOrderParserTest` (7 cases): repetition, order, interleaving, alias forms, rules-implies-one-pass, rules-with-bare-flag no double count, positional/value ignored. Full seconv suite: **171 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)