### PR TITLE
Update change-log for seconv operation order/repetition

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -65,6 +65,7 @@ v5.1.0-beta1 (26th June 2026)
 * Fix ASSA "Set position" frame grab and rotation, and the blank preview - thx bichitoxxx
 * Add Traditional Chinese (zh-Hant) translation - thx love80312
 * Add Hebrew and Swedish whisper.cpp models for download - thx darnn
+* seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27
 * Update Russian translation - thx jekovcar


### PR DESCRIPTION
Adds the changelog entry for #11870 (seconv runs operations in the given order, repeating each occurrence). The feature merged before the changelog line landed, so this adds it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)