### PR TITLE
Fix Blu-ray sup export crash on Linux (HarfBuzz version mismatch) (#11864)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -63,6 +63,7 @@ v5.1.0-beta1 (26th June 2026)
 * Fix Tesseract OCR blanking colored (non-white) text, and surface OCR errors instead of blank lines
 * Fix Ollama OCR runaway repetition / hang
 * Fix ASSA "Set position" frame grab and rotation, and the blank preview - thx bichitoxxx
+* Fix crash exporting Blu-ray sup on Linux (HarfBuzz native/managed version mismatch) - thx CannaraX
 * Add Traditional Chinese (zh-Hant) translation - thx love80312
 * Add Hebrew and Swedish whisper.cpp models for download - thx darnn
 * seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -75,11 +75,13 @@ public static class ImageRenderer
 
         var segments = ParseTextWithStyling(text, fontColor);
 
-        // Create fonts
-        using var regularTypeface = SKTypeface.FromFamilyName(fontName, SKFontStyle.Normal);
-        using var boldTypeface = SKTypeface.FromFamilyName(fontName, SKFontStyle.Bold);
-        using var italicTypeface = SKTypeface.FromFamilyName(fontName, SKFontStyle.Italic);
-        using var boldItalicTypeface = SKTypeface.FromFamilyName(fontName, SKFontStyle.BoldItalic);
+        // Create fonts. SKTypeface.FromFamilyName can return null when the family is not
+        // found (and on some platforms when no default is available); fall back to the
+        // default typeface so we never hand a null typeface to SKFont / SKShaper.
+        using var regularTypeface = ResolveTypeface(fontName, SKFontStyle.Normal);
+        using var boldTypeface = ResolveTypeface(fontName, SKFontStyle.Bold);
+        using var italicTypeface = ResolveTypeface(fontName, SKFontStyle.Italic);
+        using var boldItalicTypeface = ResolveTypeface(fontName, SKFontStyle.BoldItalic);
 
         using var regularFont = new SKFont(ip.IsBold ? boldTypeface : regularTypeface, fontSize);
         using var boldFont = new SKFont(boldTypeface, fontSize);
@@ -130,6 +132,16 @@ public static class ImageRenderer
         //System.IO.File.WriteAllBytes(@"C:\temp\debug_with_margins.png", bitmapWithMargins.ToPngArray());
 
         return bitmapWithMargins;
+    }
+
+    // SKTypeface.FromFamilyName may return null when the requested family is missing.
+    // Passing a null typeface into SKFont / SKShaper risks a native crash, so fall back
+    // to the default typeface.
+    private static SKTypeface ResolveTypeface(string fontName, SKFontStyle style)
+    {
+        return SKTypeface.FromFamilyName(fontName, style)
+            ?? SKTypeface.FromFamilyName(null, style)
+            ?? SKTypeface.Default;
     }
 
     private static SKBitmap DrawBoxBehindText(

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -44,6 +44,15 @@
 		<PackageReference Include="SharpCompress" Version="0.49.1" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.148.0" />
 		<PackageReference Include="SkiaSharp.HarfBuzz" Version="4.148.0" />
+		<!--
+		  Pin the Linux native HarfBuzz to match the managed HarfBuzzSharp (14.2.0) that
+		  SkiaSharp.HarfBuzz pulls in. Avalonia references HarfBuzzSharp.NativeAssets.Linux
+		  8.3.1.3, and without this NuGet leaves the Linux native at 8.3.1.3 while unifying
+		  the managed wrapper up to 14.2.0 - an ABI mismatch that crashes the BluRay (sup)
+		  text shaper with "double free or corruption" on Linux (issue #11864). macOS/Windows
+		  already get the matching 14.2.0 native.
+		-->
+		<PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.0" />
 		<PackageReference Include="TagLibSharp" Version="2.3.0" />
 		<PackageReference Include="WeCantSpell.Hunspell" Version="7.0.1" />
 	</ItemGroup>

--- a/src/ui/packages.lock.json
+++ b/src/ui/packages.lock.json
@@ -110,6 +110,12 @@
           "Google.LongRunning": "[3.5.0, 4.0.0)"
         }
       },
+      "HarfBuzzSharp.NativeAssets.Linux": {
+        "type": "Direct",
+        "requested": "[14.2.0, )",
+        "resolved": "14.2.0",
+        "contentHash": "KgdkGoqCoRPAdekskR9asBbY5tzfqRcYQ0/+hz8rvPMAmbQqX1g57xr6rbGUyIVY5j5ioExZWUZ10QocUVpgwQ=="
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
         "requested": "[11.0.0-preview.2.26159.112, )",
@@ -394,11 +400,6 @@
           "HarfBuzzSharp.NativeAssets.Win32": "14.2.0",
           "HarfBuzzSharp.NativeAssets.macOS": "14.2.0"
         }
-      },
-      "HarfBuzzSharp.NativeAssets.Linux": {
-        "type": "Transitive",
-        "resolved": "8.3.1.3",
-        "contentHash": "RI6A1LgmooU30+4QIyFt5rmBCzP0VzTR+587IJSGvYIsHHWlahFufihYxtraLfsIhW7I8dn6+xX+DZGygOPKWQ=="
       },
       "HarfBuzzSharp.NativeAssets.macOS": {
         "type": "Transitive",


### PR DESCRIPTION
Fixes #11864 — exporting Blu-ray (sup) crashes on Linux right after the export window opens, with `double free or corruption (out)` / `Aborted (core dumped)`.

## Root cause (Linux-only)
The `.sup` export rasterizes text via `SkiaSharp.HarfBuzz` `SKShaper` (`libuilogic/Export/ImageRenderer.cs`). The dependency graph has a HarfBuzz **managed/native version mismatch on Linux**:

| | managed `HarfBuzzSharp` | native `HarfBuzzSharp.NativeAssets.Linux` |
|---|---|---|
| Avalonia.Skia / Avalonia.HarfBuzz 12.0.5 | 8.3.1.3 | **8.3.1.3** |
| SkiaSharp.HarfBuzz 4.148.0 | **14.2.0** | — |
| resolved | **14.2.0** (unified up) | **8.3.1.3** (nothing pulled 14.x) |

So the managed wrapper (14.2.0) P/Invoked a mismatched native `libHarfBuzzSharp.so` (8.3.1.3) → heap corruption when the shaper runs. macOS/Windows already resolve the matching 14.2.0 native, which is why it's Linux-only.

## Fix
- Pin `HarfBuzzSharp.NativeAssets.Linux` to **14.2.0** in `UI.csproj` (mirrors the existing explicit `SkiaSharp.NativeAssets.Linux` reference; native-asset packages aren't transitive).
- Harden `ImageRenderer`: `SKTypeface.FromFamilyName` can return null — fall back to the default typeface instead of passing null to `SKFont`/`SKShaper`.

## Verification
Builds clean on macOS (`dotnet build src/ui/UI.csproj`). ⚠️ **Needs a Linux smoke-test** of the Blu-ray sup export to confirm the abort is gone — I can't reproduce the Linux native path from macOS. A `gdb` backtrace from the reporter would also confirm `libHarfBuzzSharp` frames pre-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)