### PR TITLE
seconv: run FixCommonErrors to convergence (#11873)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -66,6 +66,7 @@ v5.1.0-beta1 (26th June 2026)
 * Add Traditional Chinese (zh-Hant) translation - thx love80312
 * Add Hebrew and Swedish whisper.cpp models for download - thx darnn
 * seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax
+* seconv: run Fix common errors to convergence (matching SE4), so a single pass no longer under-converges - thx Rouzax
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27
 * Update Russian translation - thx jekovcar

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -18,6 +18,10 @@ namespace SeConv.Core;
 /// </summary>
 internal static class FixCommonErrorsRunner
 {
+    // Upper bound on convergence passes (SE4 used a fixed 3); we loop until stable but
+    // never beyond this, to guard against a rule pair that oscillates forever.
+    private const int MaxPasses = 10;
+
     private static readonly IReadOnlyList<(string Id, Func<IFixCommonError> Factory)> Rules = BuildRules();
 
     public static IReadOnlyList<string> AvailableRuleIds { get; } =
@@ -89,6 +93,32 @@ internal static class FixCommonErrorsRunner
             Language = language,
         };
 
+        // Fix Common Errors is not idempotent in a single pass: one rule can create a
+        // condition another rule fixes on the next pass. SE4's batch converter ran the
+        // whole suite three times per /FixCommonErrors (issue #11873). Run to convergence
+        // here - repeat until a pass changes nothing, capped to avoid pathological loops.
+        var previousSnapshot = Snapshot(subtitle);
+        for (var pass = 0; pass < MaxPasses; pass++)
+        {
+            RunSinglePass(subtitle, wanted, explicitlyNamed, language, callbacks);
+
+            var snapshot = Snapshot(subtitle);
+            if (snapshot == previousSnapshot)
+            {
+                break;
+            }
+
+            previousSnapshot = snapshot;
+        }
+    }
+
+    private static void RunSinglePass(
+        Subtitle subtitle,
+        HashSet<string>? wanted,
+        HashSet<string>? explicitlyNamed,
+        string language,
+        EmptyFixCallback callbacks)
+    {
         foreach (var (id, factory) in Rules)
         {
             if (wanted != null && !wanted.Contains(id))
@@ -116,6 +146,21 @@ internal static class FixCommonErrorsRunner
                 // A rogue rule shouldn't kill the conversion. Skip and continue.
             }
         }
+    }
+
+    // A signature of the subtitle's timing + text, used to detect when a Fix Common
+    // Errors pass has stopped changing anything (convergence).
+    private static string Snapshot(Subtitle subtitle)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var p in subtitle.Paragraphs)
+        {
+            sb.Append(p.StartTime.TotalMilliseconds).Append('|')
+              .Append(p.EndTime.TotalMilliseconds).Append('|')
+              .Append(p.Text).Append('\n');
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -264,4 +264,38 @@ public class FixCommonErrorsRunnerTest
             new[] { "FixSpanishInvertedQuestionAndExclamationMarks", "FixCommas" },
             named);
     }
+
+    [Fact]
+    public void RunAll_RunsToConvergence_SecondRunMakesNoChange()
+    {
+        // Regression for #11873: FixCommonErrors must converge within a single call
+        // (SE4 ran the suite 3x). After one RunAll the result must be a fixed point, so
+        // a second RunAll changes nothing.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("hello ,world  .", 0, 2000));
+        sub.Paragraphs.Add(new Paragraph(string.Empty, 2100, 2200));
+        sub.Paragraphs.Add(new Paragraph("this  is   a    test...", 3000, 6000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.RunAll(sub);
+        var afterFirst = Snapshot(sub);
+
+        FixCommonErrorsRunner.RunAll(sub);
+        var afterSecond = Snapshot(sub);
+
+        Assert.Equal(afterFirst, afterSecond);
+    }
+
+    private static string Snapshot(Subtitle subtitle)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var p in subtitle.Paragraphs)
+        {
+            sb.Append(p.StartTime.TotalMilliseconds).Append('|')
+              .Append(p.EndTime.TotalMilliseconds).Append('|')
+              .Append(p.Text).Append('\n');
+        }
+
+        return sb.ToString();
+    }
 }


### PR DESCRIPTION
Fixes #11873 — seconv ran each FixCommonErrors rule exactly once, so its output under-converged versus SE4 (whose batch converter ran the whole suite **3×** per `/FixCommonErrors`). FixCommonErrors isn't idempotent in a single pass: one rule can create a condition another rule fixes on the next pass.

## Fix
`FixCommonErrorsRunner.Run` now loops the rule suite **until a pass changes nothing** (timing + text snapshot comparison), capped at 10 passes to guard against an oscillating rule pair. This converges like SE4 while being robust to edge cases (SE4's fixed 3 could under-converge; loop-until-stable can't).

The single-pass logic is factored into `RunSinglePass`; the public `Run`/`RunAll` API is unchanged, so all callers (CLI + tests) get convergence for free.

## Relationship to #11870
#11870 made repeated `--fix-common-errors` flags run multiple passes (arg-order model). This change makes a **single** `--fix-common-errors` already converge, matching SE4's default. They compose cleanly (a repeated flag just runs convergence again — a no-op the second time).

## Test
`RunAll_RunsToConvergence_SecondRunMakesNoChange` asserts the result is a fixed point (a second `RunAll` changes nothing). Full FCE runner suite: 21 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)