### PR TITLE
seconv: bundle Linux native libs (SkiaSharp/HarfBuzz) (#11872)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -66,6 +66,7 @@ v5.1.0-beta1 (26th June 2026)
 * Add Traditional Chinese (zh-Hant) translation - thx love80312
 * Add Hebrew and Swedish whisper.cpp models for download - thx darnn
 * seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax
+* seconv: bundle the Linux native libs (libSkiaSharp/libHarfBuzzSharp) so Fix common errors no longer crashes - thx Rouzax
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27
 * Update Russian translation - thx jekovcar

--- a/src/seconv/SeConv.csproj
+++ b/src/seconv/SeConv.csproj
@@ -17,6 +17,18 @@
   <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.57.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
+
+    <!--
+      seconv uses SkiaSharp (FixCommonErrors pixel-width measurement, image output) and
+      SkiaSharp.HarfBuzz (image text shaping) via libse / libuilogic. The base SkiaSharp /
+      HarfBuzzSharp packages bundle the macOS/Windows natives but NOT Linux, so the Linux
+      publish shipped without libSkiaSharp.so / libHarfBuzzSharp.so and crashed with
+      DllNotFoundException (issue #11872). Reference the Linux native assets explicitly
+      (only deployed for the linux RID). HarfBuzz native is pinned to the managed wrapper
+      version 14.2.0 to avoid an ABI mismatch (cf. issue #11864).
+    -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.148.0" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #11872 — `SeConv-Linux-x64.tar.gz` shipped without the SkiaSharp native libs, so the default `--fix-common-errors` (the `FixShortLinesPixelWidth` rule measures text via SkiaSharp) crashed with `DllNotFoundException: Unable to load shared library 'libSkiaSharp'` (surfacing from a GC finalizer → nondeterministic `Aborted (core dumped)`).

## Root cause
seconv uses SkiaSharp via `libse`/`libuilogic`, but the base `SkiaSharp` / `HarfBuzzSharp` packages bundle the **macOS/Windows** natives only — **Linux requires the explicit `*.NativeAssets.Linux` packages** (the desktop UI references the Skia one for exactly this reason). seconv didn't, so the Linux publish contained just `./seconv` + `./LICENSE`.

## Fix
Add to `SeConv.csproj`:
```xml
<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.148.0" />
<PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.0" />
```
HarfBuzz native pinned to the managed wrapper version (14.2.0) to avoid the ABI mismatch from #11864. (seconv has no Avalonia, so no 8.3.1.3 conflict here.)

## Verified
Cross-published `-r linux-x64 --self-contained -p:PublishSingleFile=true` on macOS — the output now contains:
```
libHarfBuzzSharp.so
libSkiaSharp.so
seconv
```
(Before: only `seconv`.)

## Note on libonigwrap
The report also listed `libonigwrap.so`, but that comes from `AvaloniaEdit.TextMate` (UI-only); seconv has no reference to it, so it's intentionally not added. Copying it as a workaround was harmless but unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)