### PR TITLE
seconv: expose FixCommonErrors profile values in --settings (#11874)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -66,6 +66,7 @@ v5.1.0-beta1 (26th June 2026)
 * Add Traditional Chinese (zh-Hant) translation - thx love80312
 * Add Hebrew and Swedish whisper.cpp models for download - thx darnn
 * seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax
+* seconv: expose the Fix-common-errors profile values (min gap, CPS, max lines, dialog/continuation style, ...) in --settings JSON - thx Rouzax
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27
 * Update Russian translation - thx jekovcar

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -265,7 +265,18 @@ Available template tokens: `{title}`, `{number}`, `{start}`, `{end}`, `{duration
 {
   "general": {
     "subtitleLineMaximumLength": 43,
-    "subtitleMaximumDisplayMilliseconds": 8000
+    "subtitleMinimumDisplayMilliseconds": 1000,
+    "subtitleMaximumDisplayMilliseconds": 8000,
+    "currentFrameRate": 23.976,
+    "defaultFrameRate": 23.976,
+    "minimumMillisecondsBetweenLines": 24,
+    "maxNumberOfLines": 2,
+    "mergeLinesShorterThan": 33,
+    "subtitleMaximumCharactersPerSeconds": 25.0,
+    "subtitleOptimalCharactersPerSeconds": 15.0,
+    "subtitleMaximumWordsPerMinute": 400.0,
+    "dialogStyle": "DashBothLinesWithSpace",
+    "continuationStyle": "None"
   },
   "removeTextForHearingImpaired": {
     "removeTextBeforeColon": true,
@@ -279,6 +290,8 @@ Available template tokens: `{title}`, `{number}`, `{start}`, `{end}`, `{duration
   }
 }
 ```
+
+The `general` section mirrors `Configuration.Settings.General`; any key left out keeps the libse default. The profile-shaping values (`minimumMillisecondsBetweenLines`, `maxNumberOfLines`, `mergeLinesShorterThan`, `subtitleMaximumCharactersPerSeconds`, `subtitleOptimalCharactersPerSeconds`, `subtitleMaximumWordsPerMinute`, `dialogStyle`, `continuationStyle`) feed Fix common errors and the split/merge operations, so set them to reproduce an SE4 profile. `dialogStyle` and `continuationStyle` take the enum names (case-insensitive): `dialogStyle` ∈ `DashBothLinesWithSpace`, `DashBothLinesWithoutSpace`, `DashSecondLineWithSpace`, `DashSecondLineWithoutSpace`; `continuationStyle` ∈ `None`, `NoneTrailingDots`, `NoneTrailingEllipsis`, `OnlyTrailingDots`, `LeadingTrailingDots`, `LeadingTrailingEllipsis`, `LeadingTrailingDash`, … (see the Fix common errors continuation styles).
 
 ```bash
 seconv *.srt subrip --settings:my.json --profile:broadcast --remove-text-for-hi

--- a/src/seconv/Core/SeConvSettings.cs
+++ b/src/seconv/Core/SeConvSettings.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 
 namespace SeConv.Core;
 
@@ -79,6 +80,28 @@ internal sealed class SeConvSettings
                 s.General.CurrentFrameRate = g.CurrentFrameRate.Value;
             if (g.DefaultFrameRate.HasValue)
                 s.General.DefaultFrameRate = g.DefaultFrameRate.Value;
+
+            if (g.MinimumMillisecondsBetweenLines.HasValue)
+                s.General.MinimumMillisecondsBetweenLines = g.MinimumMillisecondsBetweenLines.Value;
+            if (g.MaxNumberOfLines.HasValue)
+                s.General.MaxNumberOfLines = g.MaxNumberOfLines.Value;
+            if (g.MergeLinesShorterThan.HasValue)
+                s.General.MergeLinesShorterThan = g.MergeLinesShorterThan.Value;
+            if (g.SubtitleMaximumCharactersPerSeconds.HasValue)
+                s.General.SubtitleMaximumCharactersPerSeconds = g.SubtitleMaximumCharactersPerSeconds.Value;
+            if (g.SubtitleOptimalCharactersPerSeconds.HasValue)
+                s.General.SubtitleOptimalCharactersPerSeconds = g.SubtitleOptimalCharactersPerSeconds.Value;
+            if (g.SubtitleMaximumWordsPerMinute.HasValue)
+                s.General.SubtitleMaximumWordsPerMinute = g.SubtitleMaximumWordsPerMinute.Value;
+
+            // Enums are carried as strings; parse case-insensitively and ignore bad values
+            // so a typo doesn't abort the whole settings load.
+            if (!string.IsNullOrWhiteSpace(g.DialogStyle)
+                && Enum.TryParse<DialogType>(g.DialogStyle, ignoreCase: true, out var dialogStyle))
+                s.General.DialogStyle = dialogStyle;
+            if (!string.IsNullOrWhiteSpace(g.ContinuationStyle)
+                && Enum.TryParse<ContinuationStyle>(g.ContinuationStyle, ignoreCase: true, out var continuationStyle))
+                s.General.ContinuationStyle = continuationStyle;
         }
 
         if (Tools is { } t)
@@ -119,6 +142,21 @@ internal sealed class SeConvSettings
         public int? SubtitleMaximumDisplayMilliseconds { get; set; }
         public double? CurrentFrameRate { get; set; }
         public double? DefaultFrameRate { get; set; }
+
+        // FixCommonErrors / split / merge profile values (issue #11874). These let a
+        // --settings JSON reproduce an SE4 profile so batch output matches.
+        public int? MinimumMillisecondsBetweenLines { get; set; }
+        public int? MaxNumberOfLines { get; set; }
+        public int? MergeLinesShorterThan { get; set; }
+        public double? SubtitleMaximumCharactersPerSeconds { get; set; }
+        public double? SubtitleOptimalCharactersPerSeconds { get; set; }
+        public double? SubtitleMaximumWordsPerMinute { get; set; }
+
+        // Enum-valued; carried as strings and parsed case-insensitively (see ApplyBaseSections).
+        // DialogStyle: DialogType, e.g. "DashBothLinesWithSpace".
+        // ContinuationStyle: ContinuationStyle, e.g. "NoneTrailingDots".
+        public string? DialogStyle { get; set; }
+        public string? ContinuationStyle { get; set; }
     }
 
     internal sealed class ToolsSection

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -220,6 +220,25 @@ seconv movie.ts fcpimage                                       # DVB-sub → FCP
 > seconv movie.srt subrip --settings:./hi.json --remove-text-for-hi
 > ```
 >
+> The `general` section can carry the Fix-common-errors / split / merge profile
+> values so batch output matches an SE4 profile: `minimumMillisecondsBetweenLines`,
+> `maxNumberOfLines`, `mergeLinesShorterThan`, `subtitleMaximumCharactersPerSeconds`,
+> `subtitleOptimalCharactersPerSeconds`, `subtitleMaximumWordsPerMinute`,
+> `dialogStyle`, `continuationStyle` (the last two take enum names, case-insensitive),
+> alongside `subtitleLineMaximumLength`, `subtitleMinimumDisplayMilliseconds`,
+> `subtitleMaximumDisplayMilliseconds`, `currentFrameRate`, `defaultFrameRate`.
+>
+> ```json
+> {
+>   "general": {
+>     "minimumMillisecondsBetweenLines": 24,
+>     "maxNumberOfLines": 2,
+>     "subtitleMaximumCharactersPerSeconds": 25.0,
+>     "dialogStyle": "DashBothLinesWithSpace"
+>   }
+> }
+> ```
+>
 > The full list of supported keys lives in `src/seconv/Core/SeConvSettings.cs`.
 
 ### Plain text output (`--format plaintext`)

--- a/tests/seconv/Core/SeConvSettingsTest.cs
+++ b/tests/seconv/Core/SeConvSettingsTest.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using SeConv.Core;
 using Xunit;
 
@@ -101,6 +102,50 @@ public class SeConvSettingsTest : IDisposable
         {
             Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = savedMin;
             Configuration.Settings.RemoveTextForHearingImpaired.RemoveInterjections = savedInterj;
+        }
+    }
+
+    [Fact]
+    public void ApplyToLibSe_AppliesProfileGeneralValues()
+    {
+        // Regression for #11874: the FixCommonErrors profile values must be mappable.
+        var g = Configuration.Settings.General;
+        var saved = (g.MinimumMillisecondsBetweenLines, g.MaxNumberOfLines, g.MergeLinesShorterThan,
+            g.SubtitleMaximumCharactersPerSeconds, g.SubtitleOptimalCharactersPerSeconds,
+            g.SubtitleMaximumWordsPerMinute, g.DialogStyle, g.ContinuationStyle);
+        try
+        {
+            var path = WriteSettings("""
+                {
+                  "general": {
+                    "minimumMillisecondsBetweenLines": 24,
+                    "maxNumberOfLines": 3,
+                    "mergeLinesShorterThan": 40,
+                    "subtitleMaximumCharactersPerSeconds": 20.5,
+                    "subtitleOptimalCharactersPerSeconds": 15.0,
+                    "subtitleMaximumWordsPerMinute": 240.0,
+                    "dialogStyle": "DashSecondLineWithSpace",
+                    "continuationStyle": "nonetrailingdots"
+                  }
+                }
+                """);
+
+            SeConvSettings.Load(path).ApplyToLibSe();
+
+            Assert.Equal(24, g.MinimumMillisecondsBetweenLines);
+            Assert.Equal(3, g.MaxNumberOfLines);
+            Assert.Equal(40, g.MergeLinesShorterThan);
+            Assert.Equal(20.5, g.SubtitleMaximumCharactersPerSeconds);
+            Assert.Equal(15.0, g.SubtitleOptimalCharactersPerSeconds);
+            Assert.Equal(240.0, g.SubtitleMaximumWordsPerMinute);
+            Assert.Equal(DialogType.DashSecondLineWithSpace, g.DialogStyle);
+            Assert.Equal(ContinuationStyle.NoneTrailingDots, g.ContinuationStyle); // case-insensitive parse
+        }
+        finally
+        {
+            (g.MinimumMillisecondsBetweenLines, g.MaxNumberOfLines, g.MergeLinesShorterThan,
+                g.SubtitleMaximumCharactersPerSeconds, g.SubtitleOptimalCharactersPerSeconds,
+                g.SubtitleMaximumWordsPerMinute, g.DialogStyle, g.ContinuationStyle) = saved;
         }
     }
 


### PR DESCRIPTION
Fixes #11874 — `--settings` JSON mapped only 5 of libse's `General` values, so an SE4 FixCommonErrors profile couldn't be reproduced. The reporter measured ~1366/2834 lines differing vs SE4 (≈24 ms end-time drift from the unset `MinimumMillisecondsBetweenLines`, plus break-position differences from CPS / max-lines / merge-shorter-than defaults).

## Fix
Added eight nullable fields to `SeConvSettings.GeneralSection` and copied them onto `Configuration.Settings.General` in `ApplyBaseSections()` (mirrors the existing pattern):

- `minimumMillisecondsBetweenLines`, `maxNumberOfLines`, `mergeLinesShorterThan` (int)
- `subtitleMaximumCharactersPerSeconds`, `subtitleOptimalCharactersPerSeconds`, `subtitleMaximumWordsPerMinute` (double)
- `dialogStyle` → `DialogType`, `continuationStyle` → `ContinuationStyle` (**enums**, carried as strings and parsed case-insensitively; unparseable values are ignored so a typo doesn't abort the whole settings load)

`profiles` reuses `GeneralSection`, so named profiles get these values too.

## Tests
`ApplyToLibSe_AppliesProfileGeneralValues` — round-trips all eight (incl. an enum name and a lower-cased enum to prove case-insensitive parsing) and asserts they land on `Configuration.Settings.General`. Full seconv suite: **172 passing**.

## Docs
Updated `docs/reference/command-line.md` (expanded the Settings JSON example + a note on the profile-shaping keys and enum names) and `src/seconv/README.md`.

## Scope note
The reporter's stretch ask — load a full SE profile for 1:1 parity — is a much larger feature (SE4's `Settings.xml` has many more fields, and parity also depends on rule set/order). This PR closes the **measured** gap; full-profile import can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)