### PR TITLE
Use async JSON serialization in PluginRunner

### DIFF
--- a/src/ui/Logic/Plugins/PluginRunner.cs
+++ b/src/ui/Logic/Plugins/PluginRunner.cs
@@ -31,7 +31,7 @@ public class PluginRunner : IPluginRunner
 
             await using (var requestStream = File.Create(requestPath))
             {
-                JsonSerializer.Serialize(requestStream, request, PluginJsonContext.Default.PluginRequest);
+                await JsonSerializer.SerializeAsync(requestStream, request, PluginJsonContext.Default.PluginRequest, cancellationToken);
             }
 
             var startInfo = new ProcessStartInfo


### PR DESCRIPTION
Serialize the plugin request with `JsonSerializer.SerializeAsync` and pass the cancellation token, so the write to the request stream does not block and honors cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)