### PR TITLE
Binary Edit - Adjust all times: live preview, layout polish, and bug fixes

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
@@ -24,7 +24,6 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
     private Action? _refreshGrid;
 
     public Window? Window { get; set; }
-    public bool OkPressed { get; private set; }
 
     public BinaryAdjustAllTimesViewModel()
     {
@@ -137,7 +136,6 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
     private void Ok()
     {
         SaveSettings();
-        OkPressed = true;
         Window?.Close();
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
@@ -15,6 +15,7 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
     [ObservableProperty] private bool _adjustAll;
     [ObservableProperty] private bool _adjustSelectedLines;
     [ObservableProperty] private bool _adjustSelectedLinesAndForward;
+    [ObservableProperty] private bool _isSelectionAvailable;
     [ObservableProperty] private string _totalAdjustmentInfo;
 
     private double _totalAdjustment;
@@ -26,6 +27,15 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
     {
         TotalAdjustmentInfo = string.Empty;
         LoadSettings();
+    }
+
+    public void Initialize(int selectedCount)
+    {
+        IsSelectionAvailable = selectedCount > 0;
+        if (!IsSelectionAvailable)
+        {
+            AdjustAll = true;
+        }
     }
 
     private void LoadSettings()
@@ -97,7 +107,6 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
 
         if (AdjustSelectedLinesAndForward && selectedIndices != null && selectedIndices.Count > 0)
         {
-            // Get the first selected index and all indices from there forward
             var firstIndex = selectedIndices[0];
             for (int i = firstIndex; i < subtitles.Count; i++)
             {
@@ -108,13 +117,17 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
         {
             indicesToProcess.AddRange(selectedIndices);
         }
-        else
+        else if (AdjustAll)
         {
-            // Adjust all
             for (int i = 0; i < subtitles.Count; i++)
             {
                 indicesToProcess.Add(i);
             }
+        }
+        else
+        {
+            // "Selected" mode active but no indices available — do nothing
+            return;
         }
 
         var adjustmentMs = _totalAdjustment * 1000.0;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
@@ -19,6 +19,9 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
     [ObservableProperty] private string _totalAdjustmentInfo;
 
     private double _totalAdjustment;
+    private IList<BinarySubtitleItem>? _subtitles;
+    private IList<int>? _selectedIndices;
+    private Action? _refreshGrid;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -29,9 +32,13 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
         LoadSettings();
     }
 
-    public void Initialize(int selectedCount)
+    public void Initialize(IList<BinarySubtitleItem> subtitles, IList<int> selectedIndices, Action refreshGrid)
     {
-        IsSelectionAvailable = selectedCount > 0;
+        _subtitles = subtitles;
+        _selectedIndices = selectedIndices;
+        _refreshGrid = refreshGrid;
+
+        IsSelectionAvailable = selectedIndices.Count > 0;
         if (!IsSelectionAvailable)
         {
             AdjustAll = true;
@@ -61,15 +68,58 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
         Se.Settings.Synchronization.AdjustAllTimes.IsSelectedLinesAndForwardSelected = AdjustSelectedLinesAndForward;
         Se.Settings.Synchronization.AdjustAllTimes.IsSelectedLinesSelected = AdjustSelectedLines;
         Se.Settings.Synchronization.AdjustAllTimes.IsAllSelected = AdjustAll;
-        
+
         Se.SaveSettings();
+    }
+
+    private void ApplyStep(double seconds)
+    {
+        if (_subtitles == null) return;
+
+        _totalAdjustment += seconds;
+        ShowTotalAdjustmentInfo();
+
+        var adjustmentMs = seconds * 1000.0;
+        var indicesToProcess = BuildIndicesToProcess();
+
+        foreach (var index in indicesToProcess)
+        {
+            if (index < 0 || index >= _subtitles.Count) continue;
+            var item = _subtitles[index];
+            var newStartTimeMs = item.StartTime.TotalMilliseconds + adjustmentMs;
+            if (newStartTimeMs < 0) newStartTimeMs = 0;
+            item.StartTime = TimeSpan.FromMilliseconds(newStartTimeMs);
+        }
+
+        _refreshGrid?.Invoke();
+    }
+
+    private IEnumerable<int> BuildIndicesToProcess()
+    {
+        if (_subtitles == null) yield break;
+
+        if (AdjustSelectedLinesAndForward && _selectedIndices != null && _selectedIndices.Count > 0)
+        {
+            var firstIndex = _selectedIndices[0];
+            for (var i = firstIndex; i < _subtitles.Count; i++)
+                yield return i;
+        }
+        else if (AdjustSelectedLines && _selectedIndices != null && _selectedIndices.Count > 0)
+        {
+            foreach (var i in _selectedIndices)
+                yield return i;
+        }
+        else if (AdjustAll)
+        {
+            for (var i = 0; i < _subtitles.Count; i++)
+                yield return i;
+        }
     }
 
     [RelayCommand]
     private void ShowEarlier()
     {
-        _totalAdjustment -= Adjustment.TotalSeconds;
-        ShowTotalAdjustmentInfo();
+        ApplyStep(-Adjustment.TotalSeconds);
     }
 
     private void ShowTotalAdjustmentInfo()
@@ -80,8 +130,7 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
     [RelayCommand]
     private void ShowLater()
     {
-        _totalAdjustment += Adjustment.TotalSeconds;
-        ShowTotalAdjustmentInfo();
+        ApplyStep(Adjustment.TotalSeconds);
     }
 
     [RelayCommand]
@@ -100,60 +149,4 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
             Window?.Close();
         }
     }
-
-    public void AdjustTimes(List<BinarySubtitleItem> subtitles, List<int>? selectedIndices = null)
-    {
-        var indicesToProcess = new List<int>();
-
-        if (AdjustSelectedLinesAndForward && selectedIndices != null && selectedIndices.Count > 0)
-        {
-            var firstIndex = selectedIndices[0];
-            for (int i = firstIndex; i < subtitles.Count; i++)
-            {
-                indicesToProcess.Add(i);
-            }
-        }
-        else if (AdjustSelectedLines && selectedIndices != null && selectedIndices.Count > 0)
-        {
-            indicesToProcess.AddRange(selectedIndices);
-        }
-        else if (AdjustAll)
-        {
-            for (int i = 0; i < subtitles.Count; i++)
-            {
-                indicesToProcess.Add(i);
-            }
-        }
-        else
-        {
-            // "Selected" mode active but no indices available — do nothing
-            return;
-        }
-
-        var adjustmentMs = _totalAdjustment * 1000.0;
-
-        foreach (var index in indicesToProcess)
-        {
-            if (index < 0 || index >= subtitles.Count)
-            {
-                continue;
-            }
-
-            var item = subtitles[index];
-            
-            // Adjust start time
-            var newStartTimeMs = item.StartTime.TotalMilliseconds + adjustmentMs;
-            if (newStartTimeMs < 0)
-            {
-                newStartTimeMs = 0;
-            }
-
-            item.StartTime = TimeSpan.FromMilliseconds(newStartTimeMs);            
-        }
-
-        // Reset total adjustment after applying
-        _totalAdjustment = 0;
-        TotalAdjustmentInfo = string.Empty;
-    }
 }
-

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesWindow.cs
@@ -19,12 +19,6 @@ public class BinaryAdjustAllTimesWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var label = new Label
-        {
-            Content = Se.Language.General.Adjustment,
-            Padding = new Thickness(0),
-        };
-
         var timeCodeUpDown = new TimeCodeUpDown
         {
             DataContext = vm,
@@ -94,7 +88,6 @@ public class BinaryAdjustAllTimesWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -107,12 +100,11 @@ public class BinaryAdjustAllTimesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(label, 0, 0);
-        grid.Add(timeCodeUpDown, 1, 0);
-        grid.Add(panelRadioButtons, 2, 0);
-        grid.Add(totalAdjustmentLabel, 3, 0);
-        grid.Add(panelShowButtons, 1, 1, 2, 1);
-        grid.Add(buttonOk, 3, 1);
+        grid.Add(timeCodeUpDown, 0, 0);
+        grid.Add(panelRadioButtons, 1, 0);
+        grid.Add(totalAdjustmentLabel, 2, 0);
+        grid.Add(panelShowButtons, 0, 1, 2, 1);
+        grid.Add(buttonOk, 2, 1);
 
         Content = grid;
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesWindow.cs
@@ -22,25 +22,17 @@ public class BinaryAdjustAllTimesWindow : Window
         var label = new Label
         {
             Content = Se.Language.General.Adjustment,
+            Padding = new Thickness(0),
         };
 
         var timeCodeUpDown = new TimeCodeUpDown
         {
             DataContext = vm,
+            Margin = new Thickness(0, 0, 0, 10),
             [!TimeCodeUpDown.ValueProperty] = new Binding(nameof(vm.Adjustment))
             {
                 Mode = BindingMode.TwoWay,
             }
-        };
-
-        var panelAdjustment = new StackPanel
-        {
-            Orientation = Orientation.Vertical,
-            Children =
-            {
-                label,
-                timeCodeUpDown,
-            },
         };
 
         var panelRadioButtons = new StackPanel
@@ -76,10 +68,11 @@ public class BinaryAdjustAllTimesWindow : Window
         };
 
         var buttonShowEarlier = UiUtil.MakeButton(Se.Language.Sync.ShowEarlier, vm.ShowEarlierCommand)
-            .WithLeftAlignment()
-            .WithMargin(0, 0, 0, 10);
+            .WithMinWidth(110);
+        buttonShowEarlier.Margin = new Thickness(0, 0, 0, 10);
+
         var buttonShowLater = UiUtil.MakeButton(Se.Language.Sync.ShowLater, vm.ShowLaterCommand)
-            .WithLeftAlignment();
+            .WithMinWidth(110);
 
         var panelShowButtons = new StackPanel
         {
@@ -101,6 +94,7 @@ public class BinaryAdjustAllTimesWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -113,11 +107,12 @@ public class BinaryAdjustAllTimesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(panelAdjustment, 0, 0);
-        grid.Add(panelRadioButtons, 1, 0);
-        grid.Add(totalAdjustmentLabel, 2, 0);
-        grid.Add(panelShowButtons, 0, 1, 2, 1);
-        grid.Add(buttonOk, 2, 1);
+        grid.Add(label, 0, 0);
+        grid.Add(timeCodeUpDown, 1, 0);
+        grid.Add(panelRadioButtons, 2, 0);
+        grid.Add(totalAdjustmentLabel, 3, 0);
+        grid.Add(panelShowButtons, 1, 1, 2, 1);
+        grid.Add(buttonOk, 3, 1);
 
         Content = grid;
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesWindow.cs
@@ -22,7 +22,6 @@ public class BinaryAdjustAllTimesWindow : Window
         var label = new Label
         {
             Content = Se.Language.General.Adjustment,
-            VerticalAlignment = VerticalAlignment.Center,
         };
 
         var timeCodeUpDown = new TimeCodeUpDown
@@ -36,28 +35,18 @@ public class BinaryAdjustAllTimesWindow : Window
 
         var panelAdjustment = new StackPanel
         {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Center,
+            Orientation = Orientation.Vertical,
             Children =
             {
                 label,
                 timeCodeUpDown,
-                UiUtil.MakeButton(Se.Language.Sync.ShowEarlier, vm.ShowEarlierCommand).WithMarginLeft(15),
-                UiUtil.MakeButton(Se.Language.Sync.ShowLater, vm.ShowLaterCommand),
             },
-        };
-
-        var totalAdjustmentLabel = new TextBlock
-        {
-            [!TextBlock.TextProperty] = new Binding(nameof(vm.TotalAdjustmentInfo)),
-            Margin = new Thickness(0, 10, 0, 0),
-            HorizontalAlignment = HorizontalAlignment.Center,
         };
 
         var panelRadioButtons = new StackPanel
         {
             Orientation = Orientation.Vertical,
-            Margin = new Thickness(50, 10, 0, 0),
+            Spacing = 0,
             Children =
             {
                 new RadioButton
@@ -68,19 +57,43 @@ public class BinaryAdjustAllTimesWindow : Window
                 new RadioButton
                 {
                     Content = Se.Language.Sync.AdjustSelectedLines,
-                    [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AdjustSelectedLines))
+                    [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AdjustSelectedLines)),
+                    [!RadioButton.IsEnabledProperty] = new Binding(nameof(vm.IsSelectionAvailable)),
                 },
                 new RadioButton
                 {
                     Content = Se.Language.Sync.AdjustSelectedLinesAndForward,
-                    [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AdjustSelectedLinesAndForward))
+                    [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AdjustSelectedLinesAndForward)),
+                    [!RadioButton.IsEnabledProperty] = new Binding(nameof(vm.IsSelectionAvailable)),
                 }
             },
         };
 
+        var totalAdjustmentLabel = new TextBlock
+        {
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.TotalAdjustmentInfo)),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        var buttonShowEarlier = UiUtil.MakeButton(Se.Language.Sync.ShowEarlier, vm.ShowEarlierCommand)
+            .WithLeftAlignment()
+            .WithMargin(0, 0, 0, 10);
+        var buttonShowLater = UiUtil.MakeButton(Se.Language.Sync.ShowLater, vm.ShowLaterCommand)
+            .WithLeftAlignment();
+
+        var panelShowButtons = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            VerticalAlignment = VerticalAlignment.Top,
+            Children =
+            {
+                buttonShowEarlier,
+                buttonShowLater,
+            },
+        };
+
         var buttonOk = UiUtil.MakeButtonDone(vm.OkCommand);
-        var buttonPanel = UiUtil.MakeButtonBar(buttonOk);
-        
+
         var grid = new Grid
         {
             RowDefinitions =
@@ -88,23 +101,23 @@ public class BinaryAdjustAllTimesWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
             },
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
             },
             Margin = UiUtil.MakeWindowMargin(),
             ColumnSpacing = 10,
-            RowSpacing = 10,
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(panelAdjustment, 0);
-        grid.Add(totalAdjustmentLabel, 1);
-        grid.Add(panelRadioButtons, 2);
-        grid.Add(buttonPanel, 3);
+        grid.Add(panelAdjustment, 0, 0);
+        grid.Add(panelRadioButtons, 1, 0);
+        grid.Add(totalAdjustmentLabel, 2, 0);
+        grid.Add(panelShowButtons, 0, 1, 2, 1);
+        grid.Add(buttonOk, 2, 1);
 
         Content = grid;
 
@@ -112,4 +125,3 @@ public class BinaryAdjustAllTimesWindow : Window
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }
-

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1384,14 +1384,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryAdjustAllTimesWindow, BinaryAdjustAllTimesViewModel>(Window, vm => { });
-
-        if (!result.OkPressed)
-        {
-            return;
-        }
-
-        // Get selected indices from the grid
+        // Snapshot selection before the dialog opens so focus shift cannot clear it
         var selectedIndices = new List<int>();
         if (SubtitleGrid?.SelectedItems != null)
         {
@@ -1406,6 +1399,14 @@ public partial class BinaryEditViewModel : ObservableObject
                     }
                 }
             }
+        }
+
+        var result = await _windowService.ShowDialogAsync<BinaryAdjustAllTimesWindow, BinaryAdjustAllTimesViewModel>(
+            Window, vm => vm.Initialize(selectedIndices.Count));
+
+        if (!result.OkPressed)
+        {
+            return;
         }
 
         result.AdjustTimes(Subtitles.ToList(), selectedIndices.Count > 0 ? selectedIndices : null);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1401,23 +1401,20 @@ public partial class BinaryEditViewModel : ObservableObject
             }
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryAdjustAllTimesWindow, BinaryAdjustAllTimesViewModel>(
-            Window, vm => vm.Initialize(selectedIndices.Count));
-
-        if (!result.OkPressed)
+        var capturedIndex = SubtitleGrid?.SelectedIndex ?? -1;
+        void RefreshGrid()
         {
-            return;
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (SubtitleGrid == null) return;
+                SubtitleGrid.ItemsSource = null;
+                SubtitleGrid.ItemsSource = Subtitles;
+                SubtitleGrid.SelectedIndex = capturedIndex;
+            });
         }
 
-        result.AdjustTimes(Subtitles.ToList(), selectedIndices.Count > 0 ? selectedIndices : null);
-
-        if (SubtitleGrid != null)
-        {
-            var currentIndex = SubtitleGrid.SelectedIndex;
-            SubtitleGrid.ItemsSource = null;
-            SubtitleGrid.ItemsSource = Subtitles;
-            SubtitleGrid.SelectedIndex = currentIndex;
-        }
+        await _windowService.ShowDialogAsync<BinaryAdjustAllTimesWindow, BinaryAdjustAllTimesViewModel>(
+            Window, vm => vm.Initialize(Subtitles, selectedIndices, RefreshGrid));
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1401,15 +1401,28 @@ public partial class BinaryEditViewModel : ObservableObject
             }
         }
 
-        var capturedIndex = SubtitleGrid?.SelectedIndex ?? -1;
+        selectedIndices.Sort();
+
+        var selectedItems = selectedIndices.Count > 0
+            ? selectedIndices.Select(i => Subtitles[i]).ToList()
+            : null;
+
         void RefreshGrid()
         {
             Dispatcher.UIThread.Post(() =>
             {
                 if (SubtitleGrid == null) return;
-                SubtitleGrid.ItemsSource = null;
-                SubtitleGrid.ItemsSource = Subtitles;
-                SubtitleGrid.SelectedIndex = capturedIndex;
+                if (selectedItems != null)
+                {
+                    ApplyGridSelection(selectedItems);
+                }
+                else
+                {
+                    var idx = SubtitleGrid.SelectedIndex;
+                    SubtitleGrid.ItemsSource = null;
+                    SubtitleGrid.ItemsSource = Subtitles;
+                    SubtitleGrid.SelectedIndex = idx;
+                }
             });
         }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1409,6 +1409,14 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         result.AdjustTimes(Subtitles.ToList(), selectedIndices.Count > 0 ? selectedIndices : null);
+
+        if (SubtitleGrid != null)
+        {
+            var currentIndex = SubtitleGrid.SelectedIndex;
+            SubtitleGrid.ItemsSource = null;
+            SubtitleGrid.ItemsSource = Subtitles;
+            SubtitleGrid.SelectedIndex = currentIndex;
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -497,7 +497,7 @@ public class BinaryEditWindow : Window
         dataGrid.Columns.Add(new DataGridTextColumn
         {
             Header = Se.Language.General.NumberSymbol,
-            Width = new DataGridLength(50),
+            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
             MinWidth = 40,
             IsReadOnly = true,
             Binding = new Binding(nameof(BinarySubtitleItem.Number)),
@@ -507,8 +507,8 @@ public class BinaryEditWindow : Window
         dataGrid.Columns.Add(new DataGridTextColumn
         {
             Header = Se.Language.General.Show,
-            Width = new DataGridLength(105),
-            MinWidth = 90,
+            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            MinWidth = 100,
             IsReadOnly = true,
             Binding = new Binding(nameof(BinarySubtitleItem.StartTime)) { Converter = new TimeSpanToDisplayFullConverter() },
             CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
@@ -517,8 +517,8 @@ public class BinaryEditWindow : Window
         dataGrid.Columns.Add(new DataGridTextColumn
         {
             Header = Se.Language.General.Duration,
-            Width = new DataGridLength(90),
-            MinWidth = 70,
+            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            MinWidth = 60,
             IsReadOnly = true,
             Binding = new Binding(nameof(BinarySubtitleItem.Duration)) { Converter = new TimeSpanToDisplayShortConverter() },
             CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -28,8 +28,8 @@ public class LanguageImageBasedEdit
 
     public LanguageImageBasedEdit()
     {
-        EditImagedBaseSubtitle = "Edit imaged-based subtitle";
-        EditImagedBaseSubtitleX = "Edit imaged-based subtitle: {0}";
+        EditImagedBaseSubtitle = "Edit image-based subtitle";
+        EditImagedBaseSubtitleX = "Edit image-based subtitle: {0}";
         ResizeImagesDotDotDot = "Resize images...";
         AdjustBrightnessDotDotDot = "Adjust brightness...";
         AdjustAlphaDotDotDot = "Adjust alpha...";


### PR DESCRIPTION
This branch reworks the **"Adjust All Times" dialog** for **binary (image-based) subtitles**.

The core behavioral change is **live adjustments**: ShowEarlier/ShowLater now modify subtitle data immediately on each click, rather than accumulating a value and applying only on Done.


https://github.com/user-attachments/assets/3e28a1a8-571a-4421-9e02-ea72f5f1b90f


Secondary changes include
* a UI layout rework,
* disabling selection-based radio buttons when no rows are selected,
* fixing a selection-snapshot race condition, and
* switching binary edit grid columns to auto-width.
* "Edit image-based subtitle" window title typo
* make sure the for non-continuous selections and "Adjust selected lines and forward" timing is applied from the first selected subtitle onwards 

The Done button merely closes the dialog so could be dropped (similar to the Find/Replace dialogs) but for the sake of consistency with other similar dialogs I kept it.

<img width="498" height="347" alt="dialog" src="https://github.com/user-attachments/assets/8507a8b9-ee6d-42b6-a4fe-310e8dde191d" />


<img width="719" height="465" alt="main grid" src="https://github.com/user-attachments/assets/fb1150bb-92e1-4032-a1cd-6c11358de226" />
