### PR TITLE
Fix "Join subtitles" by time codes not sorting by time (#11881)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -64,6 +64,7 @@ v5.1.0-beta1 (26th June 2026)
 * Fix Ollama OCR runaway repetition / hang
 * Fix ASSA "Set position" frame grab and rotation, and the blank preview - thx bichitoxxx
 * Fix crash exporting Blu-ray sup on Linux (HarfBuzz native/managed version mismatch) - thx CannaraX
+* Fix "Join subtitles" by time codes not sorting the joined lines by time - thx han8mr8
 * Add Traditional Chinese (zh-Hant) translation - thx love80312
 * Add Hebrew and Swedish whisper.cpp models for download - thx darnn
 * seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax

--- a/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesViewModel.cs
+++ b/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -378,6 +379,14 @@ public partial class JoinSubtitlesViewModel : ObservableObject
                 p.EndTime.TotalMilliseconds += addMs;
                 JoinedSubtitle.Paragraphs.Add(p);
             }
+        }
+
+        // "Keep time codes" (join by time) must interleave paragraphs from all files in
+        // time order; otherwise files whose time codes overlap come out concatenated in
+        // file order, not sorted (issue #11881). Mirrors SE4's JoinSubtitles.
+        if (KeepTimeCodes)
+        {
+            JoinedSubtitle.Sort(SubtitleSortCriteria.StartTime);
         }
 
         JoinedSubtitle.Renumber();


### PR DESCRIPTION
Fixes #11881 — "Join subtitles" by time codes works in SE4 but not SE5.

## Cause (diffed against `se4-legacy`)
The "keep time codes / already correct time codes" mode is meant to **interleave** all paragraphs from all files in time order. SE4 sorts the joined result (`Forms/JoinSubtitles.cs`):
```csharp
if (radioButtonJoinPlain.Checked)
    JoinedSubtitle.Sort(SubtitleSortCriteria.StartTime);
JoinedSubtitle.Renumber();
```
SE5's `JoinSubtitlesViewModel.SortAndLoad` **never sorts** — it only bubble-sorts the *files* by their first start time, then concatenates. So files whose time codes overlap (e.g. A `[10s…50s]`, B `[20s…30s]`) come out `10, 50, 20, 30` instead of `10, 20, 30, 50`.

## Fix
Mirror SE4: sort the joined subtitle by start time when `KeepTimeCodes`.
```csharp
if (KeepTimeCodes)
    JoinedSubtitle.Sort(SubtitleSortCriteria.StartTime);
JoinedSubtitle.Renumber();
```
("Append time codes" mode is unaffected — it shifts each file after the previous, already in order.)

Builds clean (`dotnet build src/ui/UI.csproj`).

## Not addressed here
The issue also asks for a "save original subtitle" button (SE4 parity) — that's a separate feature, out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)