### PR TITLE
Add 'auto-generate waveform' option with click-to-generate (#11542)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -69,6 +69,7 @@ v5.1.0-beta1 (26th June 2026)
 * seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax
 * seconv: bundle the Linux native libs (libSkiaSharp/libHarfBuzzSharp) so Fix common errors no longer crashes - thx Rouzax
 * seconv: expose the Fix-common-errors profile values (min gap, CPS, max lines, dialog/continuation style, ...) in --settings JSON - thx Rouzax
+* Add option to not auto-generate the waveform when opening a video (click the empty waveform to generate) - thx nugemon
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27
 * Update Russian translation - thx jekovcar

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -407,6 +407,17 @@ public class AudioVisualizer : Control
     public event ParagraphNullableEventHandler? OnPrimaryDoubleClicked;
     public event PositionEventHandler? OnSetStartAndOffsetTheRest;
 
+    /// <summary>Raised when the user clicks the empty waveform to generate it on demand
+    /// (shown only when auto-generate is off and there are no cached peaks).</summary>
+    public event EventHandler? OnGenerateWaveformRequested;
+
+    /// <summary>When true and there are no <see cref="WavePeaks"/>, a "click to generate"
+    /// hint is drawn and a click raises <see cref="OnGenerateWaveformRequested"/>.</summary>
+    public bool ShowClickToGenerateHint { get; set; }
+
+    /// <summary>Localized hint text drawn over the empty waveform (see <see cref="ShowClickToGenerateHint"/>).</summary>
+    public string ClickToGenerateText { get; set; } = string.Empty;
+
     public AudioVisualizer()
     {
         AllSelectedParagraphs = new List<SubtitleLineViewModel>();
@@ -859,6 +870,15 @@ public class AudioVisualizer : Control
         e.Handled = true;
         var point = e.GetPosition(this);
         _startPointerPosition = point;
+
+        // No waveform yet and auto-generate is off: a click generates it on demand.
+        if (WavePeaks == null && ShowClickToGenerateHint &&
+            e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            OnGenerateWaveformRequested?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
         if (IsReadOnly)
         {
             InvalidateVisual();
@@ -1657,6 +1677,18 @@ public class AudioVisualizer : Control
             DrawShotChanges(context, ref renderCtx);
             DrawCurrentVideoPosition(context, ref renderCtx);
             DrawNewParagraph(context, ref renderCtx);
+
+            if (WavePeaks == null && ShowClickToGenerateHint && !string.IsNullOrEmpty(ClickToGenerateText))
+            {
+                var hint = new FormattedText(
+                    ClickToGenerateText,
+                    CultureInfo.CurrentCulture,
+                    FlowDirection.LeftToRight,
+                    Typeface.Default,
+                    14,
+                    Brushes.Gainsboro);
+                context.DrawText(hint, new Point((width - hint.Width) / 2, (height - hint.Height) / 2));
+            }
 
             if (IsFocused)
             {

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -108,6 +108,7 @@ public class InitWaveform
             vm.AudioVisualizer.PointerReleased += vm.ControlMacPointerReleased;
             vm.AudioVisualizer.OnSelectRequested += vm.AudioVisualizerSelectRequested;
             vm.AudioVisualizer.OnSetStartAndOffsetTheRest += vm.AudioVisualizerSetStartAndOffsetTheRest;
+            vm.AudioVisualizer.OnGenerateWaveformRequested += vm.AudioVisualizerOnGenerateWaveformRequested;
 
             // Create a Flyout for the DataGrid
             var flyout = new MenuFlyout();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16806,28 +16806,17 @@ public partial class MainViewModel :
         var spectrogramFileName = WavePeakGenerator2.SpectrogramDrawer.GetSpectrogramFileName(videoFileName, trackNumber);
         var needToGenerate = !File.Exists(peakWaveFileName) || (Se.Settings.Waveform.GenerateSpectrogram && !File.Exists(spectrogramFileName));
 
-        // Hidden setting: when WaveformAutoGenerate is off, never kick off ffmpeg extraction on
-        // video open. Cached peaks still load via the branch below, so existing waveforms keep
-        // showing; the user generates new ones on demand.
+        if (AudioVisualizer != null)
+        {
+            AudioVisualizer.ClickToGenerateText = Se.Language.Main.ClickToGenerateWaveform;
+        }
+
+        // When WaveformAutoGenerate is off, never kick off ffmpeg extraction on video open.
+        // Cached peaks still load via the branch below, so existing waveforms keep showing;
+        // the user generates new ones on demand by clicking the empty waveform.
         if (needToGenerate && Se.Settings.Waveform.WaveformAutoGenerate)
         {
-            if (FfmpegHelper.IsFfmpegInstalled())
-            {
-                lock (_waveformsBeingGeneratedLock)
-                {
-                    if (!_waveformsBeingGenerated.Add(peakWaveFileName))
-                    {
-                        return; // already generating for this peak-wave file
-                    }
-                }
-
-                var tempWaveFileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.wav");
-                var process = WaveFileExtractor.GetCommandLineProcess(videoFileName, trackNumber, tempWaveFileName,
-                    Configuration.Settings.General.VlcWaveTranscodeSettings, out _);
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                Task.Run(async () => { await ExtractWaveformAndSpectrogramAndShotChanges(process, tempWaveFileName, peakWaveFileName, spectrogramFileName, videoFileName); });
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            }
+            StartWaveformExtraction(videoFileName, trackNumber, peakWaveFileName, spectrogramFileName);
         }
         else if (File.Exists(peakWaveFileName))
         {
@@ -16838,6 +16827,7 @@ public partial class MainViewModel :
                 Dispatcher.UIThread.Post(() =>
                 {
                     AudioVisualizer.WavePeaks = wavePeaks;
+                    AudioVisualizer.ShowClickToGenerateHint = false;
 
                     if (IsSmpteTimingEnabled)
                     {
@@ -16869,6 +16859,60 @@ public partial class MainViewModel :
                 });
             }
         }
+        else if (AudioVisualizer != null)
+        {
+            // No cached waveform and auto-generate is off: show the click-to-generate hint.
+            Dispatcher.UIThread.Post(() =>
+            {
+                AudioVisualizer.ShowClickToGenerateHint = true;
+                AudioVisualizer.InvalidateVisual();
+            });
+        }
+    }
+
+    // Kicks off ffmpeg waveform/spectrogram extraction (no-op if ffmpeg is missing or a
+    // generation for this peak file is already running). Shared by the auto-on-open path
+    // and the on-demand "click the empty waveform" path.
+    private void StartWaveformExtraction(string videoFileName, int trackNumber, string peakWaveFileName, string spectrogramFileName)
+    {
+        if (!FfmpegHelper.IsFfmpegInstalled())
+        {
+            return;
+        }
+
+        lock (_waveformsBeingGeneratedLock)
+        {
+            if (!_waveformsBeingGenerated.Add(peakWaveFileName))
+            {
+                return; // already generating for this peak-wave file
+            }
+        }
+
+        if (AudioVisualizer != null)
+        {
+            AudioVisualizer.ShowClickToGenerateHint = false;
+        }
+
+        var tempWaveFileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.wav");
+        var process = WaveFileExtractor.GetCommandLineProcess(videoFileName, trackNumber, tempWaveFileName,
+            Configuration.Settings.General.VlcWaveTranscodeSettings, out _);
+#pragma warning disable CS4014 // fire-and-forget; extraction posts results back to the UI thread
+        Task.Run(async () => { await ExtractWaveformAndSpectrogramAndShotChanges(process, tempWaveFileName, peakWaveFileName, spectrogramFileName, videoFileName); });
+#pragma warning restore CS4014
+    }
+
+    // Handler for clicking the empty waveform when auto-generate is off.
+    internal void AudioVisualizerOnGenerateWaveformRequested(object? sender, EventArgs e)
+    {
+        if (string.IsNullOrEmpty(_videoFileName))
+        {
+            return;
+        }
+
+        var trackNumber = _audioTrack?.FfIndex ?? -1;
+        var peakWaveFileName = WavePeakGenerator2.GetPeakWaveFileName(_videoFileName, trackNumber);
+        var spectrogramFileName = WavePeakGenerator2.SpectrogramDrawer.GetSpectrogramFileName(_videoFileName, trackNumber);
+        StartWaveformExtraction(_videoFileName, trackNumber, peakWaveFileName, spectrogramFileName);
     }
 
     private void GetMediaInformation(string videoFileName)

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -453,6 +453,7 @@ public class SettingsPage : UserControl
         [
             new SettingsItem(Se.Language.Options.Settings.WaveformDrawStyle,
                 () => UiUtil.MakeComboBox(_vm.WaveformDrawStyles, _vm, nameof(_vm.SelectedWaveformDrawStyle))),
+            MakeCheckboxSetting(Se.Language.Options.Settings.WaveformAutoGenerate, nameof(_vm.WaveformAutoGenerate)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformGenerateSpectrogram, nameof(_vm.WaveformGenerateSpectrogram)),
             new SettingsItem(Se.Language.Options.Settings.WaveformSpectrogramMode,
                 () => UiUtil.MakeComboBox(_vm.WaveformSpectrogramStyles, _vm, nameof(_vm.SelectedWaveformSpectrogramStyle))),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -227,6 +227,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private string _selectedWaveformDrawStyle;
 
     [ObservableProperty] private bool _waveformGenerateSpectrogram;
+    [ObservableProperty] private bool _waveformAutoGenerate;
     [ObservableProperty] private ObservableCollection<string> _waveformSpectrogramStyles;
     [ObservableProperty] private string _selectedWaveformSpectrogramStyle;
 
@@ -788,6 +789,7 @@ public partial class SettingsViewModel : ObservableObject
         }
 
         WaveformGenerateSpectrogram = Se.Settings.Waveform.GenerateSpectrogram;
+        WaveformAutoGenerate = Se.Settings.Waveform.WaveformAutoGenerate;
         if (Se.Settings.Waveform.SpectrogramStyle == SeSpectrogramStyle.Classic.ToString())
         {
             SelectedWaveformSpectrogramStyle = WaveformSpectrogramStyles[0];
@@ -1472,6 +1474,7 @@ public partial class SettingsViewModel : ObservableObject
         }
 
         Se.Settings.Waveform.GenerateSpectrogram = WaveformGenerateSpectrogram;
+        Se.Settings.Waveform.WaveformAutoGenerate = WaveformAutoGenerate;
         if (SelectedWaveformSpectrogramStyle == Se.Language.Waveform.SpectrogramClassic)
         {
             Se.Settings.Waveform.SpectrogramStyle = SeSpectrogramStyle.Classic.ToString();

--- a/src/ui/Logic/Config/Language/Main/LanguageMain.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMain.cs
@@ -43,6 +43,7 @@ public class LanguageMain
     public string LineXTextChangedFromYToZ { get; set; }
     public string LineXTimingChanged { get; set; }
     public string LoadingWaveInfoFromCache { get; set; }
+    public string ClickToGenerateWaveform { get; set; }
     public string NoTextInClipboard { get; set; }
     public string NumberOfLinesEvenlyDistributedX { get; set; }
     public string OneLineCopiedFromOriginal { get; set; }
@@ -159,6 +160,7 @@ public class LanguageMain
         LineXTextChangedFromYToZ = "Line {0}: Text changed from \"{1}\" to \"{2}\"";
         LineXTimingChanged = "Line {0}: Timing changed";
         LoadingWaveInfoFromCache = "Loading wave info from cache...";
+        ClickToGenerateWaveform = "Click to generate waveform";
         NoTextInClipboard = "No text in clipboard";
         NumberOfLinesEvenlyDistributedX = "Evenly distributed {0} lines";
         OneLineCopiedFromOriginal = "One line copied from original subtitle";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -243,6 +243,7 @@ public class LanguageSettings
     public string WaveFormsAndSpectrogramFoldersContainsX { get; set; }
     public string DeleteWaveformAndSpectrogramFoldersQuestion { get; set; }
     public string WaveformGenerateSpectrogram { get; set; }
+    public string WaveformAutoGenerate { get; set; }
     public string WaveformSpectrogramMode { get; set; }
     public string WaveformCenterOnSingleClick { get; set; }
     public string WaveformSingleClickSelectsSubtitle { get; set; }
@@ -557,6 +558,7 @@ public class LanguageSettings
         WaveFormsAndSpectrogramFoldersContainsX = "\"Waveforms\" and \"spectrogram\" folders contains {0}";
         DeleteWaveformAndSpectrogramFoldersQuestion = "Delete \"Waveforms\" and \"Spectrogram\" files?";
         WaveformGenerateSpectrogram = "Generate spectrogram";
+        WaveformAutoGenerate = "Auto-generate waveform when opening a video";
         WaveformSpectrogramMode = "Spectrogram mode";
         WaveformCenterOnSingleClick = "Center on single click";
         WaveformSingleClickSelectsSubtitle = "Select subtitle on single click";


### PR DESCRIPTION
Implements #11542 — an option to not auto-generate the waveform (SE4 behaviour).

## What
- New **Settings → Waveform/spectrogram** checkbox: **"Auto-generate waveform when opening a video"** (default **on** → unchanged behaviour). It surfaces the existing `WaveformAutoGenerate` setting, which the load path already honored.
- When **off**, opening a video no longer kicks off ffmpeg extraction. Cached peaks still load as before.
- **Click-to-generate** (answers the design question): when there's no waveform and auto-generate is off, the empty waveform shows a **"Click to generate waveform"** hint and a left-click generates it on demand — so "off" isn't a dead end. This matches SE4's click-the-empty-waveform behaviour (no modal prompt).

## How
- `AudioVisualizer`: added `ShowClickToGenerateHint` + `ClickToGenerateText` + `OnGenerateWaveformRequested`. The hint is drawn in `Render` and the click handled in `OnPointerPressed` **only when `WavePeaks == null`** (never touches the normal hot path).
- `MainViewModel`: extracted the ffmpeg extraction into a shared `StartWaveformExtraction(...)` used by both the auto-on-open path and the new on-demand handler; sets the hint when a video is open with no cached peaks and auto-generate is off; clears it once peaks load.
- New language strings: `WaveformAutoGenerate`, `ClickToGenerateWaveform`.

## Verify
Builds clean; app launches cleanly with the changes. Manual UX check (recommended): Settings → uncheck the option → open a video → empty waveform shows the hint → click → waveform generates. (ffmpeg-missing case is a no-op, same as the auto path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)