### PR TITLE
"Set up like SE4": show grid line breaks as "<br />" (#11286)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -71,6 +71,7 @@ v5.1.0-beta1 (26th June 2026)
 * seconv: bundle the Linux native libs (libSkiaSharp/libHarfBuzzSharp) so Fix common errors no longer crashes - thx Rouzax
 * seconv: expose the Fix-common-errors profile values (min gap, CPS, max lines, dialog/continuation style, ...) in --settings JSON - thx Rouzax
 * Add option to not auto-generate the waveform when opening a video (click the empty waveform to generate) - thx nugemon
+* "Set up like Subtitle Edit 4" now shows grid line breaks as "<br />" on a single row, like SE4 - thx bichitoxxx
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27
 * Update Russian translation - thx jekovcar

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -620,6 +620,12 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(WpmBackgroundBrush));
         OnPropertyChanged(nameof(GapBackgroundBrush));
         OnPropertyChanged(nameof(PixelWidth));
+
+        // The grid Text/OriginalText columns render through a converter that honors the
+        // "single line" + separator appearance settings, so re-notify them too; otherwise
+        // toggling single-line (or applying the SE4 look) wouldn't refresh the grid live.
+        OnPropertyChanged(nameof(Text));
+        OnPropertyChanged(nameof(OriginalText));
     }
 
     /// <summary>Updates all display properties from a fixed <see cref="Paragraph"/> in-place.</summary>

--- a/src/ui/Logic/Se4Setup/Se4SetupApplier.cs
+++ b/src/ui/Logic/Se4Setup/Se4SetupApplier.cs
@@ -142,6 +142,11 @@ public static class Se4SetupApplier
     {
         Se.Settings.Appearance.ToolbarShowEncoding = true;
         Se.Settings.Appearance.TextBoxShowButtonItalic = false;
+
+        // SE 4 showed each subtitle on a single grid row with line breaks rendered as
+        // "<br />" (Settings.General.ListViewLineSeparatorString default). Match that.
+        Se.Settings.Appearance.SubtitleGridTextSingleLine = true;
+        Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator = "<br />";
     }
 
     // The SE 4 waveform look, taken from the classic AudioVisualizer defaults


### PR DESCRIPTION
Toward #11286 — SE4 showed each subtitle on a single grid row with line breaks rendered as `<br />`. SE5 has the mechanism (`SubtitleGridTextSingleLine` + the hidden `SubtitleGridTextSingleLineSeparator`, default `" ⏎ "`), but the **"Set up like Subtitle Edit 4"** (Ctrl+4) action didn't configure it.

## Change
`Se4SetupApplier.ApplyToolbarAndEditBox()` now also sets:
```csharp
Se.Settings.Appearance.SubtitleGridTextSingleLine = true;
Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator = "<br />";
```
so applying the SE4 look reproduces SE4's single-row grid with `<br />` between lines (matching SE4's `Settings.General.ListViewLineSeparatorString` default, confirmed against `se4-legacy`).

## Note / design choice
The separator only renders in single-line grid mode, so I enabled `SubtitleGridTextSingleLine` too — otherwise the `<br />` wouldn't be visible and it wouldn't match SE4. If you'd rather Ctrl+4 only set the separator string and leave the single-line toggle to the user, say so and I'll drop that line.

This doesn't yet surface `SubtitleGridTextSingleLineSeparator` in the Settings UI (still JSON-only) — that's a separate follow-up if you want users to customize it outside the SE4 preset.

Builds clean (`dotnet build src/ui/UI.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)