### PR TITLE
Fix change speed and adjust-all-times dialog behavior

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7403,10 +7403,22 @@ public partial class MainViewModel :
             return;
         }
 
-        var result = await ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(vm => { vm.Initialize(Subtitles); });
+        var selectedIndices = SubtitleGrid.SelectedItems
+            .Cast<SubtitleLineViewModel>()
+            .Select(x => Subtitles.IndexOf(x))
+            .Where(i => i >= 0)
+            .OrderBy(i => i)
+            .ToList();
+
+        var result = await ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(vm => { vm.Initialize(Subtitles, selectedIndices); });
         if (result.OkPressed)
         {
-            ChangeSpeedViewModel.ChangeSpeed(Subtitles, result.SpeedPercent);
+            if (result.AdjustSelectedLinesAndForward && selectedIndices.Count > 0)
+                ChangeSpeedViewModel.ChangeSpeed(Subtitles.Skip(selectedIndices[0]), result.SpeedPercent);
+            else if (result.AdjustSelectedLines && selectedIndices.Count > 0)
+                ChangeSpeedViewModel.ChangeSpeed(selectedIndices.Select(i => Subtitles[i]), result.SpeedPercent);
+            else
+                ChangeSpeedViewModel.ChangeSpeed(Subtitles, result.SpeedPercent);
             _updateAudioVisualizer = true;
         }
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1473,29 +1473,51 @@ public partial class BinaryEditViewModel : ObservableObject
             }
         }
 
-        var result = await _windowService.ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(Window, vm => { vm.Initialize(selectedIndices.Count > 0); });
+        selectedIndices.Sort();
+
+        var selectedItems = selectedIndices.Count > 0
+            ? selectedIndices.Select(i => Subtitles[i]).ToList()
+            : null;
+
+        void RefreshGrid()
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (SubtitleGrid == null) return;
+                if (selectedItems != null)
+                {
+                    ApplyGridSelection(selectedItems);
+                }
+                else
+                {
+                    var idx = SubtitleGrid.SelectedIndex;
+                    SubtitleGrid.ItemsSource = null;
+                    SubtitleGrid.ItemsSource = Subtitles;
+                    SubtitleGrid.SelectedIndex = idx;
+                }
+            });
+        }
+
+        void ApplySpeed(double speed, bool all, bool selected, bool selectedAndForward)
+        {
+            var factor = 100.0 / speed;
+            if (selectedAndForward && selectedIndices.Count > 0)
+                ScaleBinarySubtitleTimes(Subtitles.Skip(selectedIndices[0]), factor);
+            else if (selected && selectedIndices.Count > 0)
+                ScaleBinarySubtitleTimes(selectedIndices.Select(i => Subtitles[i]), factor);
+            else
+                ScaleBinarySubtitleTimes(Subtitles, factor);
+            RefreshGrid();
+        }
+
+        var result = await _windowService.ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(Window, vm => { vm.Initialize(selectedIndices.Count > 0, ApplySpeed); });
 
         if (!result.OkPressed)
         {
             return;
         }
 
-        // result.SpeedPercent is percentage; factor is 100 / percent as used elsewhere
-        var factor = 100.0 / result.SpeedPercent;
-
-        if (result.AdjustSelectedLinesAndForward && selectedIndices.Count > 0)
-        {
-            var firstIndex = selectedIndices.Min();
-            ScaleBinarySubtitleTimes(Subtitles.Skip(firstIndex), factor);
-        }
-        else if (result.AdjustSelectedLines && selectedIndices.Count > 0)
-        {
-            ScaleBinarySubtitleTimes(selectedIndices.Select(i => Subtitles[i]), factor);
-        }
-        else
-        {
-            ScaleBinarySubtitleTimes(Subtitles, factor);
-        }
+        ApplySpeed(result.SpeedPercent, result.AdjustAll, result.AdjustSelectedLines, result.AdjustSelectedLinesAndForward);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1457,20 +1457,9 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(Window, vm => { });
-
-        if (!result.OkPressed)
+        var selectedIndices = new List<int>();
+        if (SubtitleGrid?.SelectedItems != null)
         {
-            return;
-        }
-
-        // result.SpeedPercent is percentage; factor is 100 / percent as used elsewhere
-        var factor = 100.0 / result.SpeedPercent;
-
-        var appliedToSelected = false;
-        if (SubtitleGrid?.SelectedItems != null && SubtitleGrid.SelectedItems.Count > 0)
-        {
-            var selectedIndices = new List<int>();
             foreach (var item in SubtitleGrid.SelectedItems)
             {
                 if (item is BinarySubtitleItem binaryItem)
@@ -1482,15 +1471,28 @@ public partial class BinaryEditViewModel : ObservableObject
                     }
                 }
             }
-
-            if (selectedIndices.Count > 0)
-            {
-                ScaleBinarySubtitleTimes(selectedIndices.Select(i => Subtitles[i]), factor);
-                appliedToSelected = true;
-            }
         }
 
-        if (!appliedToSelected)
+        var result = await _windowService.ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(Window, vm => { vm.Initialize(selectedIndices.Count > 0); });
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        // result.SpeedPercent is percentage; factor is 100 / percent as used elsewhere
+        var factor = 100.0 / result.SpeedPercent;
+
+        if (result.AdjustSelectedLinesAndForward && selectedIndices.Count > 0)
+        {
+            var firstIndex = selectedIndices.Min();
+            ScaleBinarySubtitleTimes(Subtitles.Skip(firstIndex), factor);
+        }
+        else if (result.AdjustSelectedLines && selectedIndices.Count > 0)
+        {
+            ScaleBinarySubtitleTimes(selectedIndices.Select(i => Subtitles[i]), factor);
+        }
+        else
         {
             ScaleBinarySubtitleTimes(Subtitles, factor);
         }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1415,12 +1415,10 @@ public partial class BinaryEditViewModel : ObservableObject
         {
             Dispatcher.UIThread.Post(() =>
             {
-                if (SubtitleGrid == null) return;
-                if (selectedItems != null)
-                {
-                    ApplyGridSelection(selectedItems, preserveScroll: true);
-                }
-                // else: PropertyChanged handles display update; no refresh needed
+                if (SubtitleGrid == null || selectedItems == null) return;
+                SubtitleGrid.SelectedItems.Clear();
+                foreach (var item in selectedItems)
+                    SubtitleGrid.SelectedItems.Add(item);
             });
         }
 
@@ -1481,12 +1479,10 @@ public partial class BinaryEditViewModel : ObservableObject
         {
             Dispatcher.UIThread.Post(() =>
             {
-                if (SubtitleGrid == null) return;
-                if (selectedItems != null)
-                {
-                    ApplyGridSelection(selectedItems, preserveScroll: true);
-                }
-                // else: PropertyChanged handles display update; no refresh needed
+                if (SubtitleGrid == null || selectedItems == null) return;
+                SubtitleGrid.SelectedItems.Clear();
+                foreach (var item in selectedItems)
+                    SubtitleGrid.SelectedItems.Add(item);
             });
         }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1,6 +1,8 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
@@ -61,6 +63,8 @@ public partial class BinaryEditViewModel : ObservableObject
     public Border? VideoContentBorder { get; set; }
     public bool OkPressed { get; private set; }
     public ObservableCollection<BinarySubtitleItem> Subtitles { get; set; }
+
+    private ScrollViewer? _subtitleGridScrollViewer;
 
     private readonly IFileHelper _fileHelper;
     private readonly IFolderHelper _folderHelper;
@@ -1414,15 +1418,9 @@ public partial class BinaryEditViewModel : ObservableObject
                 if (SubtitleGrid == null) return;
                 if (selectedItems != null)
                 {
-                    ApplyGridSelection(selectedItems);
+                    ApplyGridSelection(selectedItems, preserveScroll: true);
                 }
-                else
-                {
-                    var idx = SubtitleGrid.SelectedIndex;
-                    SubtitleGrid.ItemsSource = null;
-                    SubtitleGrid.ItemsSource = Subtitles;
-                    SubtitleGrid.SelectedIndex = idx;
-                }
+                // else: PropertyChanged handles display update; no refresh needed
             });
         }
 
@@ -1486,15 +1484,9 @@ public partial class BinaryEditViewModel : ObservableObject
                 if (SubtitleGrid == null) return;
                 if (selectedItems != null)
                 {
-                    ApplyGridSelection(selectedItems);
+                    ApplyGridSelection(selectedItems, preserveScroll: true);
                 }
-                else
-                {
-                    var idx = SubtitleGrid.SelectedIndex;
-                    SubtitleGrid.ItemsSource = null;
-                    SubtitleGrid.ItemsSource = Subtitles;
-                    SubtitleGrid.SelectedIndex = idx;
-                }
+                // else: PropertyChanged handles display update; no refresh needed
             });
         }
 
@@ -1674,24 +1666,33 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void SelectForcedLines()
     {
-        ApplyGridSelection(Subtitles.Where(s => s.IsForced).ToList());
+        ApplyGridSelection(Subtitles.Where(s => s.IsForced).ToList(), preserveScroll: true);
     }
 
     [RelayCommand]
     private void SelectNonForcedLines()
     {
-        ApplyGridSelection(Subtitles.Where(s => !s.IsForced).ToList());
+        ApplyGridSelection(Subtitles.Where(s => !s.IsForced).ToList(), preserveScroll: true);
     }
 
     // Adding many rows to a realized DataGrid's SelectedItems is O(n) visual work per
     // row, so selecting all forced/non-forced lines on a large file hangs (#11529).
     // Detaching ItemsSource de-realizes the rows so the adds only touch the grid's
     // internal selection table; a single layout pass repaints after we reattach.
-    private void ApplyGridSelection(IReadOnlyList<BinarySubtitleItem> items)
+    private void ApplyGridSelection(IReadOnlyList<BinarySubtitleItem> items, bool preserveScroll = false)
     {
         if (SubtitleGrid == null)
         {
             return;
+        }
+
+        ScrollViewer? scrollViewer = null;
+        Vector savedOffset = default;
+        if (preserveScroll)
+        {
+            _subtitleGridScrollViewer ??= SubtitleGrid.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+            scrollViewer = _subtitleGridScrollViewer;
+            savedOffset = scrollViewer?.Offset ?? default;
         }
 
         var itemsSource = SubtitleGrid.ItemsSource;
@@ -1702,6 +1703,13 @@ public partial class BinaryEditViewModel : ObservableObject
         foreach (var item in items)
         {
             SubtitleGrid.SelectedItems.Add(item);
+        }
+
+        if (preserveScroll && scrollViewer != null)
+        {
+            var offset = savedOffset;
+            var sv = scrollViewer;
+            Dispatcher.UIThread.Post(() => sv.Offset = offset, DispatcherPriority.Background);
         }
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1446,35 +1446,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         var ratio = ChangeFrameRateViewModel.GetFrameRateRatio(result.SelectedFromFrameRate, result.SelectedToFrameRate);
-
-        // If there are selected items in the grid, apply only to them
-        var appliedToSelected = false;
-        if (SubtitleGrid?.SelectedItems != null && SubtitleGrid.SelectedItems.Count > 0)
-        {
-            var selectedIndices = new List<int>();
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    var index = Subtitles.IndexOf(binaryItem);
-                    if (index >= 0)
-                    {
-                        selectedIndices.Add(index);
-                    }
-                }
-            }
-
-            if (selectedIndices.Count > 0)
-            {
-                ScaleBinarySubtitleTimes(selectedIndices.Select(i => Subtitles[i]), ratio);
-                appliedToSelected = true;
-            }
-        }
-
-        if (!appliedToSelected)
-        {
-            ScaleBinarySubtitleTimes(Subtitles, ratio);
-        }
+        ScaleBinarySubtitleTimes(Subtitles, ratio);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
@@ -28,31 +28,28 @@ public class AdjustAllTimesWindow : Window
             }
         };
 
-        var gridAdjustment = new Grid
-        {
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
-            },
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-            },
-            ColumnSpacing = 5,
-            RowSpacing = 5,
-        };
+        var buttonShowEarlier = UiUtil.MakeButton(Se.Language.Sync.ShowEarlier, vm.ShowEarlierCommand)
+            .WithMinWidth(110);
+        buttonShowEarlier.Margin = new Thickness(0, 0, 0, 10);
 
-        gridAdjustment.Add(timeCodeUpDown, 0, 1);
-        gridAdjustment.Add(UiUtil.MakeButton(Se.Language.Sync.ShowEarlier, vm.ShowEarlierCommand), 0, 2);
-        gridAdjustment.Add(UiUtil.MakeButton(Se.Language.Sync.ShowLater, vm.ShowLaterCommand), 0, 3);
+        var buttonShowLater = UiUtil.MakeButton(Se.Language.Sync.ShowLater, vm.ShowLaterCommand)
+            .WithMinWidth(110);
+
+        var panelShowButtons = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            VerticalAlignment = VerticalAlignment.Top,
+            Children =
+            {
+                buttonShowEarlier,
+                buttonShowLater,
+            },
+        };
 
         var panelRadioButtons = new StackPanel
         {
             Orientation = Orientation.Vertical,
-            Margin = new Thickness(10, 10, 0, 0),
+            Spacing = 0,
             Children =
             {
                 new RadioButton
@@ -76,20 +73,21 @@ public class AdjustAllTimesWindow : Window
         var buttonHelp = UiUtil.MakeButton(vm.ShowHelpCommand, IconNames.Help, Se.Language.Sync.AdjustAllShortcuts);
         var buttonOk = UiUtil.MakeButtonDone(vm.OkCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonHelp, buttonOk);
-        
+
         var labelStatus = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.StatusText));
-        
+
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
             },
             Margin = UiUtil.MakeWindowMargin(),
             ColumnSpacing = 10,
@@ -98,11 +96,11 @@ public class AdjustAllTimesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(gridAdjustment, 0);
-        grid.Add(panelRadioButtons, 1);
-        grid.Add(labelStatus, 2);
-        grid.Add(panelButtons, 2);
-
+        grid.Add(timeCodeUpDown,    0, 0);
+        grid.Add(panelShowButtons,  0, 1, 2, 1);
+        grid.Add(panelRadioButtons, 1, 0);
+        grid.Add(labelStatus,       2, 0);
+        grid.Add(panelButtons,      2, 1);
 
         Content = grid;
 

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -5,7 +5,9 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Sync.ChangeSpeed;
 
@@ -18,10 +20,11 @@ public partial class ChangeSpeedViewModel : ObservableObject
     [ObservableProperty] private bool _isSelectionAvailable;
 
     private ObservableCollection<SubtitleLineViewModel>? _subtitles;
+    private IList<int>? _selectedIndices;
     private Action<double, bool, bool, bool>? _binaryApplyCallback;
 
     public Window? Window { get; set; }
-    
+
     public bool OkPressed { get; private set; }
 
     public ChangeSpeedViewModel()
@@ -33,7 +36,7 @@ public partial class ChangeSpeedViewModel : ObservableObject
     [RelayCommand]
     private void SetFromDropFrameValue()
     {
-        SpeedPercent = 100.1001; 
+        SpeedPercent = 100.1001;
     }
 
     [RelayCommand]
@@ -54,22 +57,30 @@ public partial class ChangeSpeedViewModel : ObservableObject
     {
         if (_subtitles != null)
         {
-            ChangeSpeed(_subtitles, SpeedPercent);
+            if (AdjustSelectedLinesAndForward && _selectedIndices?.Count > 0)
+                ChangeSpeed(_subtitles.Skip(_selectedIndices[0]), SpeedPercent);
+            else if (AdjustSelectedLines && _selectedIndices?.Count > 0)
+                ChangeSpeed(_selectedIndices.Select(i => _subtitles[i]), SpeedPercent);
+            else
+                ChangeSpeed(_subtitles, SpeedPercent);
             return;
         }
         _binaryApplyCallback?.Invoke(SpeedPercent, AdjustAll, AdjustSelectedLines, AdjustSelectedLinesAndForward);
     }
 
-    [RelayCommand]                   
-    private void Cancel() 
+    [RelayCommand]
+    private void Cancel()
     {
         Window?.Close();
     }
 
-    internal void Initialize(ObservableCollection<SubtitleLineViewModel> subtitles)
+    internal void Initialize(ObservableCollection<SubtitleLineViewModel> subtitles, IList<int> selectedIndices)
     {
         _subtitles = subtitles;
-        IsSelectionAvailable = true;
+        _selectedIndices = selectedIndices;
+        IsSelectionAvailable = selectedIndices.Count > 0;
+        if (!IsSelectionAvailable)
+            AdjustAll = true;
     }
 
     internal void Initialize(bool isSelectionAvailable, Action<double, bool, bool, bool> binaryApplyCallback)
@@ -96,11 +107,11 @@ public partial class ChangeSpeedViewModel : ObservableObject
         }
     }
 
-    internal static void ChangeSpeed(ObservableCollection<SubtitleLineViewModel> subtitles, double speedPercent)
+    internal static void ChangeSpeed(IEnumerable<SubtitleLineViewModel> subtitles, double speedPercent)
     {
+        var factor = 100.0 / speedPercent;
         foreach (var subtitle in subtitles)
         {
-            var factor = 100.0 / speedPercent;
             subtitle.SetTimes(
                 TimeSpan.FromMilliseconds(subtitle.StartTime.TotalMilliseconds * factor),
                 TimeSpan.FromMilliseconds(subtitle.EndTime.TotalMilliseconds * factor));

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -15,6 +15,7 @@ public partial class ChangeSpeedViewModel : ObservableObject
     [ObservableProperty] private bool _adjustAll;
     [ObservableProperty] private bool _adjustSelectedLines;
     [ObservableProperty] private bool _adjustSelectedLinesAndForward;
+    [ObservableProperty] private bool _isSelectionAvailable;
 
     private ObservableCollection<SubtitleLineViewModel>? _subtitles;
 
@@ -64,8 +65,17 @@ public partial class ChangeSpeedViewModel : ObservableObject
     }
 
     internal void Initialize(ObservableCollection<SubtitleLineViewModel> subtitles)
-    { 
+    {
         _subtitles = subtitles;
+    }
+
+    internal void Initialize(bool isSelectionAvailable)
+    {
+        IsSelectionAvailable = isSelectionAvailable;
+        if (!isSelectionAvailable)
+        {
+            AdjustAll = true;
+        }
     }
 
     internal void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -69,6 +69,7 @@ public partial class ChangeSpeedViewModel : ObservableObject
     internal void Initialize(ObservableCollection<SubtitleLineViewModel> subtitles)
     {
         _subtitles = subtitles;
+        IsSelectionAvailable = true;
     }
 
     internal void Initialize(bool isSelectionAvailable, Action<double, bool, bool, bool> binaryApplyCallback)

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -18,6 +18,7 @@ public partial class ChangeSpeedViewModel : ObservableObject
     [ObservableProperty] private bool _isSelectionAvailable;
 
     private ObservableCollection<SubtitleLineViewModel>? _subtitles;
+    private Action<double, bool, bool, bool>? _binaryApplyCallback;
 
     public Window? Window { get; set; }
     
@@ -50,12 +51,12 @@ public partial class ChangeSpeedViewModel : ObservableObject
     [RelayCommand]
     private void Apply()
     {
-        if (_subtitles == null)
+        if (_subtitles != null)
         {
+            ChangeSpeed(_subtitles, SpeedPercent);
             return;
         }
-
-        ChangeSpeed(_subtitles, SpeedPercent);
+        _binaryApplyCallback?.Invoke(SpeedPercent, AdjustAll, AdjustSelectedLines, AdjustSelectedLinesAndForward);
     }
 
     [RelayCommand]                   
@@ -69,13 +70,14 @@ public partial class ChangeSpeedViewModel : ObservableObject
         _subtitles = subtitles;
     }
 
-    internal void Initialize(bool isSelectionAvailable)
+    internal void Initialize(bool isSelectionAvailable, Action<double, bool, bool, bool> binaryApplyCallback)
     {
         IsSelectionAvailable = isSelectionAvailable;
         if (!isSelectionAvailable)
         {
             AdjustAll = true;
         }
+        _binaryApplyCallback = binaryApplyCallback;
     }
 
     internal void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -26,6 +26,7 @@ public partial class ChangeSpeedViewModel : ObservableObject
 
     public ChangeSpeedViewModel()
     {
+        SpeedPercent = 100.0;
         AdjustAll = true;
     }
 

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
@@ -20,16 +20,14 @@ public class ChangeSpeedWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var label = new Label
+        var labelSpeed = new Label
         {
             Content = Se.Language.Sync.SpeedInPercentage,
-            VerticalAlignment = VerticalAlignment.Center,
         };
 
         var numericUpDownSpeed = new NumericUpDown
         {
             Width = 150,
-            Margin = new Thickness(0, 0, 10, 0),
             Minimum = 0,
             Maximum = 1000,
             Increment = 0.1m,
@@ -44,25 +42,22 @@ public class ChangeSpeedWindow : Window
         var buttonFromDropFrame = UiUtil.MakeButton(Se.Language.Sync.FromDropFrameValue, vm.SetFromDropFrameValueCommand);
         var buttonToDropFrame = UiUtil.MakeButton(Se.Language.Sync.ToDropFrameValue, vm.SetToDropFrameValueCommand);
 
-        var panelSpeed = new StackPanel
+        var panelFromToButtons = new StackPanel
         {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Left,
-            Margin = new Thickness(0, 0, 10, 0),
+            Orientation = Orientation.Vertical,
+            VerticalAlignment = VerticalAlignment.Top,
+            Spacing = 10,
             Children =
             {
-                label,
-                numericUpDownSpeed,
                 buttonFromDropFrame,
-                buttonToDropFrame
-            }
+                buttonToDropFrame,
+            },
         };
 
         var panelRadioButtons = new StackPanel
         {
             Orientation = Orientation.Vertical,
-            Margin = new Thickness(50, 10, 0, 0),
+            Spacing = 0,
             Children =
             {
                 new RadioButton
@@ -96,10 +91,12 @@ public class ChangeSpeedWindow : Window
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
             },
             ColumnDefinitions =
             {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
             },
             Margin = UiUtil.MakeWindowMargin(),
@@ -109,9 +106,11 @@ public class ChangeSpeedWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(panelSpeed, 0);
-        grid.Add(panelRadioButtons, 1);
-        grid.Add(buttonPanel, 2);
+        grid.Add(labelSpeed,         0, 0);
+        grid.Add(numericUpDownSpeed, 1, 0);
+        grid.Add(panelFromToButtons, 1, 1, 2, 1);
+        grid.Add(panelRadioButtons,  2, 0);
+        grid.Add(buttonPanel,        3, 0, 1, 2);
 
         Content = grid;
 

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
@@ -73,12 +73,14 @@ public class ChangeSpeedWindow : Window
                 new RadioButton
                 {
                     Content = Se.Language.Sync.AdjustSelectedLines,
-                    [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AdjustSelectedLines))
+                    [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AdjustSelectedLines)),
+                    [!RadioButton.IsEnabledProperty] = new Binding(nameof(vm.IsSelectionAvailable)),
                 },
                 new RadioButton
                 {
                     Content = Se.Language.Sync.AdjustSelectedLinesAndForward,
-                    [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AdjustSelectedLinesAndForward))
+                    [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AdjustSelectedLinesAndForward)),
+                    [!RadioButton.IsEnabledProperty] = new Binding(nameof(vm.IsSelectionAvailable)),
                 }
             },
         };

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
@@ -28,6 +28,7 @@ public class ChangeSpeedWindow : Window
         var numericUpDownSpeed = new NumericUpDown
         {
             Width = 150,
+            HorizontalAlignment = HorizontalAlignment.Left,
             Minimum = 0,
             Maximum = 1000,
             Increment = 0.1m,
@@ -40,7 +41,9 @@ public class ChangeSpeedWindow : Window
         };
 
         var buttonFromDropFrame = UiUtil.MakeButton(Se.Language.Sync.FromDropFrameValue, vm.SetFromDropFrameValueCommand);
+        buttonFromDropFrame.HorizontalAlignment = HorizontalAlignment.Stretch;
         var buttonToDropFrame = UiUtil.MakeButton(Se.Language.Sync.ToDropFrameValue, vm.SetToDropFrameValueCommand);
+        buttonToDropFrame.HorizontalAlignment = HorizontalAlignment.Stretch;
 
         var panelFromToButtons = new StackPanel
         {


### PR DESCRIPTION
  Fixes several bugs in the Change Speed and Adjust All Times dialogs across the main window and binary edit view, and brings the layouts of these dialogs into visual consistency with each other.

  ## Changes

  **Bug fixes**
  - Main window change speed now respects the selected radio button (apply to all vs. selected) when executing
  - Binary edit change speed now respects the dialog's radio button selection instead of always applying to all
  - Binary edit change frame rate now always applies to all subtitles (radio button was misleadingly present)
  - Binary edit Apply button for change speed was not wired up; now connected
  - Adjust timings and change speed in the binary edit window now preserve the grid scroll position instead of jumping to the top.

  **Defaults**
  - Change speed dialog now initializes the speed field to 100% instead of empty

  **Layout / visual consistency**
  - Change speed dialog layout redesigned to match the Adjust All Times (also Find/Replace) dialog style
  - Change speed dialog: left-aligned controls, equalized From/To button widths
  - Adjust All Times dialog layout updated to match the binary edit version

<img width="520" height="387" alt="adjust all times" src="https://github.com/user-attachments/assets/fc0f4c9e-aa42-4f84-9b57-976dd8ae5b10" />

<img width="548" height="418" alt="change speed" src="https://github.com/user-attachments/assets/2b94ad85-ce23-461c-8b90-a3b8918ddc88" />

