### PR TITLE
Spell check: show source image (Blu-ray sup) for current line (#11719)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -14,6 +14,7 @@ v5.1.0-beta2 (TBD)
 * Fix "Change speed" radio buttons disabled/not respected in the main window
 * Binary edit: wire up "Change speed", respect the selected-lines radio, and always apply "Change frame rate" to all lines
 * Binary edit: keep the grid scroll position after "Adjust all times" and "Change speed"
+* Spell check: show the source image (Blu-ray sup) for the current line, loadable via right-click (SE4 parity) - thx fraternl
 
 -----------------------------------------------------------------------------------------------------
 

--- a/change-log.txt
+++ b/change-log.txt
@@ -14,7 +14,7 @@ v5.1.0-beta2 (TBD)
 * Fix "Change speed" radio buttons disabled/not respected in the main window
 * Binary edit: wire up "Change speed", respect the selected-lines radio, and always apply "Change frame rate" to all lines
 * Binary edit: keep the grid scroll position after "Adjust all times" and "Change speed"
-* Spell check: show the source image (Blu-ray sup) for the current line, loadable via right-click (SE4 parity) - thx fraternl
+* Spell check: show the source image (Blu-ray sup / VobSub) for the current line (image button left of Done) - thx fraternl
 
 -----------------------------------------------------------------------------------------------------
 

--- a/change-log.txt
+++ b/change-log.txt
@@ -14,7 +14,7 @@ v5.1.0-beta2 (TBD)
 * Fix "Change speed" radio buttons disabled/not respected in the main window
 * Binary edit: wire up "Change speed", respect the selected-lines radio, and always apply "Change frame rate" to all lines
 * Binary edit: keep the grid scroll position after "Adjust all times" and "Change speed"
-* Spell check: show the source image (Blu-ray sup / VobSub) for the current line (image button left of Done) - thx fraternl
+* Spell check: show the source image (Blu-ray sup, VobSub, BDN XML) for the current line (image button left of Done) - thx fraternl
 
 -----------------------------------------------------------------------------------------------------
 

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -165,6 +165,7 @@ using Nikse.SubtitleEdit.Logic.Initializers;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Plugins;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
+using Nikse.SubtitleEdit.Logic.Ocr;
 using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
 using Nikse.SubtitleEdit.Logic.UndoRedo;
 using AssaApplyCustomOverrideTagsViewModel = Nikse.SubtitleEdit.Features.Assa.AssaApplyCustomOverrideTags.AssaApplyCustomOverrideTagsViewModel;
@@ -197,6 +198,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<IBinaryOcrMatcher, BinaryOcrMatcher>();
         collection.AddSingleton<IFileHelper, FileHelper>();
         collection.AddSingleton<IFolderHelper, FolderHelper>();
+        collection.AddSingleton<IOcrImageSourceHolder, OcrImageSourceHolder>();
         collection.AddTransient<IAutoBackupService, AutoBackupService>();
         collection.AddTransient<IBatchConverter, BatchConverter>();
         collection.AddTransient<IBatchConvertItemSplitter, BatchConvertTransportStreamSplitter>();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -152,6 +152,7 @@ using Nikse.SubtitleEdit.Logic.Config.Language;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Initializers;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.Ocr;
 using Nikse.SubtitleEdit.Logic.Platform.Windows;
 using Nikse.SubtitleEdit.Logic.Plugins;
 using Nikse.SubtitleEdit.Logic.UndoRedo;
@@ -373,6 +374,7 @@ public partial class MainViewModel :
     private readonly IAutoBackupService _autoBackupService;
     private readonly IUndoRedoManager _undoRedoManager;
     private readonly IBluRayHelper _bluRayHelper;
+    private readonly IOcrImageSourceHolder _ocrImageSourceHolder;
     private readonly IMpvReloader _mpvReloader;
     private readonly IVlcReloader _vlcReloader;
     private readonly IFindService _findService;
@@ -439,6 +441,7 @@ public partial class MainViewModel :
         IAutoBackupService autoBackupService,
         IUndoRedoManager undoRedoManager,
         IBluRayHelper bluRayHelper,
+        IOcrImageSourceHolder ocrImageSourceHolder,
         IMpvReloader mpvReloader,
         IVlcReloader vlcReloader,
         IFindService findService,
@@ -465,6 +468,7 @@ public partial class MainViewModel :
         _autoBackupService = autoBackupService;
         _undoRedoManager = undoRedoManager;
         _bluRayHelper = bluRayHelper;
+        _ocrImageSourceHolder = ocrImageSourceHolder;
         _mpvReloader = mpvReloader;
         _vlcReloader = vlcReloader;
         _findService = findService;
@@ -14240,6 +14244,12 @@ public partial class MainViewModel :
         {
             return;
         }
+
+        // Drop any image source kept from a previous OCR session; the image-import branches
+        // below re-populate it via the OCR window, while plain text subtitles leave it cleared
+        // so spell check does not show unrelated images (#11719).
+        _ocrImageSourceHolder.Source = null;
+        _ocrImageSourceHolder.FileName = null;
 
         var ext = Path.GetExtension(fileName);
         var fileSize = (long)0;

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -40,6 +40,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Dictionaries;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.Ocr;
 using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
 using SkiaSharp;
@@ -159,6 +160,7 @@ public partial class OcrViewModel : ObservableObject
     private readonly ISpellCheckManager _spellCheckManager;
     private readonly IOcrFixEngine _ocrFixEngine;
     private readonly IBinaryOcrMatcher _binaryOcrMatcher;
+    private readonly IOcrImageSourceHolder _ocrImageSourceHolder;
     private PreProcessingSettings? _preProcessingSettings;
     private bool _isCtrlDown;
     private bool _textBoxFontIsCustom;
@@ -184,7 +186,8 @@ public partial class OcrViewModel : ObservableObject
         IFileHelper fileHelper,
         ISpellCheckManager spellCheckManager,
         IOcrFixEngine ocrFixEngine,
-        IBinaryOcrMatcher binaryOcrMatcher)
+        IBinaryOcrMatcher binaryOcrMatcher,
+        IOcrImageSourceHolder ocrImageSourceHolder)
     {
         _nOcrCaseFixer = nOcrCaseFixer;
         _windowService = windowService;
@@ -192,6 +195,7 @@ public partial class OcrViewModel : ObservableObject
         _spellCheckManager = spellCheckManager;
         _ocrFixEngine = ocrFixEngine;
         _binaryOcrMatcher = binaryOcrMatcher;
+        _ocrImageSourceHolder = ocrImageSourceHolder;
 
         Title = Se.Language.Ocr.Ocr;
         OcrEngines = new ObservableCollection<OcrEngineItem>(OcrEngineItem.GetOcrEngines());
@@ -1769,6 +1773,10 @@ public partial class OcrViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
+
+        // Remember the image source so spell check can show the original images (#11719)
+        _ocrImageSourceHolder.Source = _ocrSubtitle;
+        _ocrImageSourceHolder.FileName = _sourceFileName;
 
         OcredSubtitle.Clear();
         var number = 1;

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -2,7 +2,10 @@ using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
@@ -12,6 +15,7 @@ using Nikse.SubtitleEdit.Features.SpellCheck.EditWholeText;
 using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -45,6 +49,8 @@ public partial class SpellCheckViewModel : ObservableObject
     [ObservableProperty] private bool _isPrompting;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _paragraphs;
     [ObservableProperty] private SubtitleLineViewModel? _selectedParagraph;
+    [ObservableProperty] private Bitmap? _sourceImage;
+    [ObservableProperty] private bool _hasSourceImage;
     [ObservableProperty] private bool _isUndoVisible;
     [ObservableProperty] private string _undoText;
 
@@ -58,7 +64,12 @@ public partial class SpellCheckViewModel : ObservableObject
 
     private readonly ISpellCheckManager _spellCheckManager;
     private readonly IWindowService _windowService;
+    private readonly IFileHelper _fileHelper;
     private IFocusSubtitleLine? _focusSubtitleLine;
+
+    // Optional source image (Blu-ray .sup) loaded via the context menu so the original
+    // bitmap of the current line can be compared while spell-checking OCR results (#11719).
+    private IOcrSubtitle? _ocrSourceImages;
 
     private SpellCheckWord _currentSpellCheckWord;
     private SpellCheckResult? _lastSpellCheckResult;
@@ -73,9 +84,10 @@ public partial class SpellCheckViewModel : ObservableObject
     private int? _stopBeforeLineIndex;
     private bool _hasWrapped;
 
-    public SpellCheckViewModel(ISpellCheckManager spellCheckManager, IWindowService windowService)
+    public SpellCheckViewModel(ISpellCheckManager spellCheckManager, IWindowService windowService, IFileHelper fileHelper)
     {
         _spellCheckManager = spellCheckManager;
+        _fileHelper = fileHelper;
         if (Se.Settings.SpellCheck.SpellCheckProvider == SeSpellCheck.SpellCheckMsWord && WordSpellCheck.IsWordInstalled())
         {
             _spellCheckManager.WordSpellChecker = new WordSpellCheck();
@@ -232,6 +244,80 @@ public partial class SpellCheckViewModel : ObservableObject
             }
 
             _spellCheckManager.Initialize(SelectedDictionary.DictionaryFileName, SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(SelectedDictionary));
+        }
+    }
+
+    // Lets the user attach the original Blu-ray .sup so the source image of the current
+    // line is shown while spell-checking OCR'd text (SE4 parity, #11719).
+    [RelayCommand]
+    private async Task LoadSourceImage()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenFile(
+            Window, Se.Language.SpellCheck.LoadSourceImage, "Blu-ray sup", ".sup");
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        try
+        {
+            var log = new System.Text.StringBuilder();
+            var pcsList = BluRaySupParser.ParseBluRaySup(fileName, log);
+            if (pcsList.Count == 0)
+            {
+                return;
+            }
+
+            _ocrSourceImages = new OcrSubtitleBluRay(pcsList);
+            HasSourceImage = true;
+            UpdateSourceImage();
+        }
+        catch
+        {
+            // Bad/unsupported file: leave the panel as-is.
+        }
+    }
+
+    partial void OnSelectedParagraphChanged(SubtitleLineViewModel? value)
+    {
+        UpdateSourceImage();
+    }
+
+    // Shows the source bitmap whose start time is closest to the current line (SE4 matched
+    // by timecode, which survives merges/deletes better than a plain index).
+    private void UpdateSourceImage()
+    {
+        if (_ocrSourceImages == null || SelectedParagraph == null || _ocrSourceImages.Count == 0)
+        {
+            SourceImage = null;
+            return;
+        }
+
+        var targetMs = SelectedParagraph.StartTime.TotalMilliseconds;
+        var bestIndex = 0;
+        var bestDistance = double.MaxValue;
+        for (var i = 0; i < _ocrSourceImages.Count; i++)
+        {
+            var distance = Math.Abs(_ocrSourceImages.GetStartTime(i).TotalMilliseconds - targetMs);
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                bestIndex = i;
+            }
+        }
+
+        try
+        {
+            SourceImage = _ocrSourceImages.GetBitmap(bestIndex).ToAvaloniaBitmap();
+        }
+        catch
+        {
+            SourceImage = null;
         }
     }
 

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Core.VobSub;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -258,7 +259,7 @@ public partial class SpellCheckViewModel : ObservableObject
         }
 
         var fileName = await _fileHelper.PickOpenFile(
-            Window, Se.Language.SpellCheck.LoadSourceImage, "Blu-ray sup", ".sup");
+            Window, Se.Language.SpellCheck.LoadSourceImage, "Blu-ray sup", ".sup", "VobSub", ".sub");
         if (string.IsNullOrEmpty(fileName))
         {
             return;
@@ -266,20 +267,43 @@ public partial class SpellCheckViewModel : ObservableObject
 
         try
         {
-            var log = new System.Text.StringBuilder();
-            var pcsList = BluRaySupParser.ParseBluRaySup(fileName, log);
-            if (pcsList.Count == 0)
+            var source = LoadImageSource(fileName);
+            if (source == null || source.Count == 0)
             {
                 return;
             }
 
-            _ocrSourceImages = new OcrSubtitleBluRay(pcsList);
+            _ocrSourceImages = source;
             HasSourceImage = true;
             UpdateSourceImage();
         }
         catch
         {
             // Bad/unsupported file: leave the panel as-is.
+        }
+    }
+
+    // Loads an image-based subtitle file into an IOcrSubtitle for the source-image preview.
+    private static IOcrSubtitle? LoadImageSource(string fileName)
+    {
+        var ext = System.IO.Path.GetExtension(fileName).ToLowerInvariant();
+        switch (ext)
+        {
+            case ".sup":
+                var pcsList = BluRaySupParser.ParseBluRaySup(fileName, new System.Text.StringBuilder());
+                return pcsList.Count > 0 ? new OcrSubtitleBluRay(pcsList) : null;
+
+            case ".sub":
+            case ".idx":
+                var vobSubParser = new VobSubParser(true);
+                var subFileName = System.IO.Path.ChangeExtension(fileName, ".sub");
+                var idxFileName = System.IO.Path.ChangeExtension(fileName, ".idx");
+                vobSubParser.OpenSubIdx(subFileName, idxFileName);
+                var packs = vobSubParser.MergeVobSubPacks();
+                return packs.Count > 0 ? new OcrSubtitleVobSub(packs, vobSubParser.IdxPalette) : null;
+
+            default:
+                return null;
         }
     }
 

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -5,6 +5,8 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
+using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.VobSub;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
@@ -18,6 +20,7 @@ using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.Ocr;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -67,6 +70,8 @@ public partial class SpellCheckViewModel : ObservableObject
     private readonly ISpellCheckManager _spellCheckManager;
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
+    private readonly IBluRayHelper _bluRayHelper;
+    private readonly IOcrImageSourceHolder _ocrImageSourceHolder;
     private IFocusSubtitleLine? _focusSubtitleLine;
 
     // Optional source image (Blu-ray .sup) loaded via the context menu so the original
@@ -86,10 +91,12 @@ public partial class SpellCheckViewModel : ObservableObject
     private int? _stopBeforeLineIndex;
     private bool _hasWrapped;
 
-    public SpellCheckViewModel(ISpellCheckManager spellCheckManager, IWindowService windowService, IFileHelper fileHelper)
+    public SpellCheckViewModel(ISpellCheckManager spellCheckManager, IWindowService windowService, IFileHelper fileHelper, IBluRayHelper bluRayHelper, IOcrImageSourceHolder ocrImageSourceHolder)
     {
         _spellCheckManager = spellCheckManager;
         _fileHelper = fileHelper;
+        _bluRayHelper = bluRayHelper;
+        _ocrImageSourceHolder = ocrImageSourceHolder;
         if (Se.Settings.SpellCheck.SpellCheckProvider == SeSpellCheck.SpellCheckMsWord && WordSpellCheck.IsWordInstalled())
         {
             _spellCheckManager.WordSpellChecker = new WordSpellCheck();
@@ -261,7 +268,7 @@ public partial class SpellCheckViewModel : ObservableObject
 
         var fileNames = await _fileHelper.PickOpenFiles(
             Window, Se.Language.SpellCheck.LoadSourceImage,
-            "Image based subtitles", new List<string> { "*.sup", "*.sub", "*.idx", "*.xml" },
+            "Image based subtitles", new List<string> { "*.sup", "*.sub", "*.idx", "*.xml", "*.ts", "*.m2ts", "*.mts", "*.mkv", "*.mks" },
             string.Empty, new List<string>());
         var fileName = fileNames.FirstOrDefault();
         if (string.IsNullOrEmpty(fileName))
@@ -288,7 +295,7 @@ public partial class SpellCheckViewModel : ObservableObject
     }
 
     // Loads an image-based subtitle file into an IOcrSubtitle for the source-image preview.
-    private static IOcrSubtitle? LoadImageSource(string fileName)
+    private IOcrSubtitle? LoadImageSource(string fileName)
     {
         var ext = System.IO.Path.GetExtension(fileName).ToLowerInvariant();
         switch (ext)
@@ -319,6 +326,42 @@ public partial class SpellCheckViewModel : ObservableObject
                 return bdnSubtitle.Paragraphs.Count > 0
                     ? new OcrSubtitleBdn(bdnSubtitle, fileName, isSon: false)
                     : null;
+
+            case ".ts":
+            case ".m2ts":
+            case ".mts":
+                var tsParser = new TransportStreamParser();
+                tsParser.Parse(fileName, (_, _) => { });
+                if (tsParser.SubtitlePacketIds.Count == 0)
+                {
+                    return null;
+                }
+
+                var subtitles = tsParser.GetDvbSubtitles(tsParser.SubtitlePacketIds[0]);
+                return subtitles.Count > 0 ? new OcrSubtitleTransportStream(tsParser, subtitles, fileName) : null;
+
+            case ".mkv":
+            case ".mks":
+                using (var matroska = new MatroskaFile(fileName))
+                {
+                    if (!matroska.IsValid)
+                    {
+                        return null;
+                    }
+
+                    // Only Blu-ray (PGS) tracks are handled for manual load here; VobSub/DVB
+                    // tracks need the async Matroska extraction in the OCR window, and those
+                    // are covered automatically via the auto-attach path after OCR (#11719).
+                    var track = matroska.GetTracks(true)
+                        .FirstOrDefault(t => t.CodecId.Equals("S_HDMV/PGS", StringComparison.OrdinalIgnoreCase));
+                    if (track == null)
+                    {
+                        return null;
+                    }
+
+                    var pcsData = _bluRayHelper.LoadBluRaySubFromMatroska(track, matroska, out _);
+                    return pcsData.Count > 0 ? new OcrSubtitleMkvBluRay(track, pcsData) : null;
+                }
 
             default:
                 return null;
@@ -369,6 +412,15 @@ public partial class SpellCheckViewModel : ObservableObject
         Paragraphs.Clear();
         Paragraphs.AddRange(paragraphs);
         SetLanguage(dictionaryFileName);
+
+        // Auto-attach the image source from the most recent OCR session so the original
+        // bitmaps show up automatically when spell-checking OCR'd text - no manual load
+        // needed. Works for every format OCR can read (sup, VobSub, BDN, TS, MKV, ...) (#11719).
+        if (_ocrImageSourceHolder.Source is { Count: > 0 } ocrSource)
+        {
+            _ocrSourceImages = ocrSource;
+            HasSourceImage = true;
+        }
 
         // Posted to run after the window exists (Window is assigned in the window ctor),
         // so the "continue from current line?" prompt and the close hook have an owner.

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.VobSub;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -258,8 +259,11 @@ public partial class SpellCheckViewModel : ObservableObject
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenFile(
-            Window, Se.Language.SpellCheck.LoadSourceImage, "Blu-ray sup", ".sup", "VobSub", ".sub");
+        var fileNames = await _fileHelper.PickOpenFiles(
+            Window, Se.Language.SpellCheck.LoadSourceImage,
+            "Image based subtitles", new List<string> { "*.sup", "*.sub", "*.idx", "*.xml" },
+            string.Empty, new List<string>());
+        var fileName = fileNames.FirstOrDefault();
         if (string.IsNullOrEmpty(fileName))
         {
             return;
@@ -301,6 +305,20 @@ public partial class SpellCheckViewModel : ObservableObject
                 vobSubParser.OpenSubIdx(subFileName, idxFileName);
                 var packs = vobSubParser.MergeVobSubPacks();
                 return packs.Count > 0 ? new OcrSubtitleVobSub(packs, vobSubParser.IdxPalette) : null;
+
+            case ".xml":
+                var bdnLines = System.IO.File.ReadAllLines(fileName).ToList();
+                var bdn = new BdnXml();
+                if (!bdn.IsMine(bdnLines, fileName))
+                {
+                    return null;
+                }
+
+                var bdnSubtitle = new Subtitle();
+                bdn.LoadSubtitle(bdnSubtitle, bdnLines, fileName);
+                return bdnSubtitle.Paragraphs.Count > 0
+                    ? new OcrSubtitleBdn(bdnSubtitle, fileName, isSon: false)
+                    : null;
 
             default:
                 return null;

--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -61,7 +61,11 @@ public class SpellCheckWindow : Window
         var panelSuggestions = MakeSuggestions(vm);
 
         var buttonDone = UiUtil.MakeButtonDone(vm.OkCommand).WithLeftAlignment();
-        var panelButtonsOk = UiUtil.MakeButtonBar(buttonDone);
+        // Icon button left of "Done" to attach/show the source image(s) — a context menu
+        // alone isn't reliable on macOS (panels without a background aren't hit-tested).
+        var buttonLoadSourceImage = UiUtil.MakeButton(vm.LoadSourceImageCommand, IconNames.Image);
+        ToolTip.SetTip(buttonLoadSourceImage, Se.Language.SpellCheck.LoadSourceImage);
+        var panelButtonsOk = UiUtil.MakeButtonBar(buttonLoadSourceImage, buttonDone);
 
         var grid = new Grid
         {
@@ -96,9 +100,17 @@ public class SpellCheckWindow : Window
         grid.Add(panelSuggestions, 1, 1, 2);
 
         // Source image (e.g. Blu-ray .sup) of the current line, shown when the user has
-        // attached it via the context menu (#11719). Right-clicking anywhere offers "Load
-        // source image..." (SE4 parity).
-        var loadSourceImageMenu = new ContextMenu
+        // attached it (#11719) via the image button (left of Done) or by right-clicking the image.
+        var sourceImage = new Image
+        {
+            Stretch = Stretch.Uniform,
+            MaxHeight = 140,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Margin = new Thickness(0, 8, 0, 0),
+            [!Image.SourceProperty] = new Binding(nameof(SpellCheckViewModel.SourceImage)),
+        };
+        var sourceImageBorder = UiUtil.MakeBorderForControl(sourceImage);
+        sourceImageBorder.ContextMenu = new ContextMenu
         {
             ItemsSource = new[]
             {
@@ -109,18 +121,6 @@ public class SpellCheckWindow : Window
                 },
             },
         };
-        borderWholeText.ContextMenu = loadSourceImageMenu;
-
-        var sourceImage = new Image
-        {
-            Stretch = Stretch.Uniform,
-            MaxHeight = 140,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            Margin = new Thickness(0, 8, 0, 0),
-            [!Image.SourceProperty] = new Binding(nameof(SpellCheckViewModel.SourceImage)),
-        };
-        var sourceImageBorder = UiUtil.MakeBorderForControl(sourceImage);
-        sourceImageBorder.ContextMenu = loadSourceImageMenu;
         sourceImageBorder.Bind(Visual.IsVisibleProperty, new Binding(nameof(SpellCheckViewModel.HasSourceImage)));
         grid.Add(sourceImageBorder, 4, 0, 2);
 

--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -71,6 +71,7 @@ public class SpellCheckWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },  // source image (#11719)
             },
             ColumnDefinitions =
             {
@@ -93,6 +94,35 @@ public class SpellCheckWindow : Window
 
         grid.Add(labelDictionary, 0, 1);
         grid.Add(panelSuggestions, 1, 1, 2);
+
+        // Source image (e.g. Blu-ray .sup) of the current line, shown when the user has
+        // attached it via the context menu (#11719). Right-clicking anywhere offers "Load
+        // source image..." (SE4 parity).
+        var loadSourceImageMenu = new ContextMenu
+        {
+            ItemsSource = new[]
+            {
+                new MenuItem
+                {
+                    Header = Se.Language.SpellCheck.LoadSourceImage,
+                    Command = vm.LoadSourceImageCommand,
+                },
+            },
+        };
+        borderWholeText.ContextMenu = loadSourceImageMenu;
+
+        var sourceImage = new Image
+        {
+            Stretch = Stretch.Uniform,
+            MaxHeight = 140,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Margin = new Thickness(0, 8, 0, 0),
+            [!Image.SourceProperty] = new Binding(nameof(SpellCheckViewModel.SourceImage)),
+        };
+        var sourceImageBorder = UiUtil.MakeBorderForControl(sourceImage);
+        sourceImageBorder.ContextMenu = loadSourceImageMenu;
+        sourceImageBorder.Bind(Visual.IsVisibleProperty, new Binding(nameof(SpellCheckViewModel.HasSourceImage)));
+        grid.Add(sourceImageBorder, 4, 0, 2);
 
         Content = grid;
 

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -52,7 +52,7 @@ public class LanguageSpellCheck
         XOfYNamesImported = "{0} of {1} names imported (the rest may already exist).";
         NoDictionariesFound = "No dictionaries found";
         WordNotFound = "Word not found";
-        LoadSourceImage = "Load source image (Blu-ray sup)...";
+        LoadSourceImage = "Show source images too...";
         LineXofY = "Spell checker - line {0} of {1}";
         ChangeWordFromXToY = "Change word from '{0}' to '{1}'";
         ChangeAllWordsFromXToY = "Change all words from '{0}' to '{1}'";

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -17,6 +17,7 @@ public class LanguageSpellCheck
     public string XOfYNamesImported { get; set; }
     public string NoDictionariesFound { get; set; }
     public string WordNotFound { get; set; }
+    public string LoadSourceImage { get; set; }
     public string LineXofY { get; set; }
     public string ChangeWordFromXToY { get; set; }
     public string ChangeAllWordsFromXToY { get; set; }
@@ -51,6 +52,7 @@ public class LanguageSpellCheck
         XOfYNamesImported = "{0} of {1} names imported (the rest may already exist).";
         NoDictionariesFound = "No dictionaries found";
         WordNotFound = "Word not found";
+        LoadSourceImage = "Load source image (Blu-ray sup)...";
         LineXofY = "Spell checker - line {0} of {1}";
         ChangeWordFromXToY = "Change word from '{0}' to '{1}'";
         ChangeAllWordsFromXToY = "Change all words from '{0}' to '{1}'";

--- a/src/ui/Logic/Ocr/IOcrImageSourceHolder.cs
+++ b/src/ui/Logic/Ocr/IOcrImageSourceHolder.cs
@@ -1,0 +1,20 @@
+using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+
+namespace Nikse.SubtitleEdit.Logic.Ocr;
+
+/// <summary>
+/// Holds the image source (Blu-ray sup, VobSub, BDN, transport stream, Matroska, ...)
+/// from the most recent OCR session so other features (e.g. spell check) can show the
+/// original images for the OCR'd lines without re-parsing the source file. (#11719)
+/// </summary>
+public interface IOcrImageSourceHolder
+{
+    IOcrSubtitle? Source { get; set; }
+    string? FileName { get; set; }
+}
+
+public class OcrImageSourceHolder : IOcrImageSourceHolder
+{
+    public IOcrSubtitle? Source { get; set; }
+    public string? FileName { get; set; }
+}


### PR DESCRIPTION
Addresses #11719 — in SE4 the spell-check dialog showed the original bitmap of the current line (for OCR'd sup/vob subtitles) so you could compare against the image; SE5 had nothing.

## What
- An **image panel** in the spell-check window showing the current line's source bitmap (hidden until a source is loaded).
- A **right-click → "Load source image (Blu-ray sup)…"** context menu (SE4 parity) on the text/image area: pick a `.sup`, it's parsed and the matching image is shown.
- The shown image follows the spell-check as it moves between lines, matched by **closest start time** (SE4-style — survives merges/deletes better than a raw index).

## How
- Reuses the existing OCR image stack: `BluRaySupParser.ParseBluRaySup` → `OcrSubtitleBluRay` (`IOcrSubtitle`) → `GetBitmap(index)` → `ToAvaloniaBitmap`.
- `SpellCheckViewModel`: `LoadSourceImageCommand`, `SourceImage`/`HasSourceImage`, and `OnSelectedParagraphChanged` refreshes the image.
- New language string `LoadSourceImage`.

## Scope / follow-ups
SE5 doesn't currently **retain the OCR image source** on the document, so this ships the **manual load** path (which the issue + SE4 both have). Two natural follow-ups:
- Auto-attach the source when a subtitle was just OCR'd (no manual load needed).
- **VobSub (.sub/.idx)** support — only `.sup` is wired here; the vobsub path needs idx+palette parsing.

Builds clean. ⚠️ Worth a quick manual check (open Spell check on an OCR'd subtitle → right-click → Load source image → navigate words and confirm the image tracks the line), since the panel/flyout can only be exercised by opening the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)