### PR TITLE
Add two more custom video move forward/back jumps (custom 3 & 4)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11402,6 +11402,10 @@ public partial class MainViewModel :
             (nameof(VideoMoveCustom1ForwardCommand),VideoMoveCustom1ForwardCommand),
             (nameof(VideoMoveCustom2BackCommand),   VideoMoveCustom2BackCommand),
             (nameof(VideoMoveCustom2ForwardCommand),VideoMoveCustom2ForwardCommand),
+            (nameof(VideoMoveCustom3BackCommand),   VideoMoveCustom3BackCommand),
+            (nameof(VideoMoveCustom3ForwardCommand),VideoMoveCustom3ForwardCommand),
+            (nameof(VideoMoveCustom4BackCommand),   VideoMoveCustom4BackCommand),
+            (nameof(VideoMoveCustom4ForwardCommand),VideoMoveCustom4ForwardCommand),
             (nameof(PlayCommand),                   PlayCommand),
             (nameof(PauseCommand),                  PauseCommand),
             (nameof(TogglePlayPauseCommand),        TogglePlayPauseCommand),
@@ -13090,6 +13094,30 @@ public partial class MainViewModel :
     private void VideoMoveCustom2Forward()
     {
         MoveVideoPositionMs(Se.Settings.Video.MoveVideoPositionCustom2Forward);
+    }
+
+    [RelayCommand]
+    private void VideoMoveCustom3Back()
+    {
+        MoveVideoPositionMs(-Se.Settings.Video.MoveVideoPositionCustom3Back);
+    }
+
+    [RelayCommand]
+    private void VideoMoveCustom3Forward()
+    {
+        MoveVideoPositionMs(Se.Settings.Video.MoveVideoPositionCustom3Forward);
+    }
+
+    [RelayCommand]
+    private void VideoMoveCustom4Back()
+    {
+        MoveVideoPositionMs(-Se.Settings.Video.MoveVideoPositionCustom4Back);
+    }
+
+    [RelayCommand]
+    private void VideoMoveCustom4Forward()
+    {
+        MoveVideoPositionMs(Se.Settings.Video.MoveVideoPositionCustom4Forward);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -215,6 +215,10 @@ public partial class ShortcutsViewModel : ObservableObject
         _configurableCommands.Add(vm.VideoMoveCustom1ForwardCommand);
         _configurableCommands.Add(vm.VideoMoveCustom2BackCommand);
         _configurableCommands.Add(vm.VideoMoveCustom2ForwardCommand);
+        _configurableCommands.Add(vm.VideoMoveCustom3BackCommand);
+        _configurableCommands.Add(vm.VideoMoveCustom3ForwardCommand);
+        _configurableCommands.Add(vm.VideoMoveCustom4BackCommand);
+        _configurableCommands.Add(vm.VideoMoveCustom4ForwardCommand);
         _configurableCommands.Add(vm.SetActor1Command);
         _configurableCommands.Add(vm.SetActor2Command);
         _configurableCommands.Add(vm.SetActor3Command);
@@ -770,6 +774,74 @@ public partial class ShortcutsViewModel : ObservableObject
                 if (flatNodeForward != null)
                 {
                     flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom2ForwardX, Se.Settings.Video.MoveVideoPositionCustom2Forward);
+                }
+            }
+        }
+        else if (node.ShortCut.Action == MainViewModel.VideoMoveCustom3BackCommand)
+        {
+            var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
+            {
+                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom3Back);
+            });
+            if (result.OkPressed)
+            {
+                Se.Settings.Video.MoveVideoPositionCustom3Back = result.Milliseconds;
+
+                var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom3BackCommand);
+                if (flatNodeBack != null)
+                {
+                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom3BackX, Se.Settings.Video.MoveVideoPositionCustom3Back);
+                }
+            }
+        }
+        else if (node.ShortCut.Action == MainViewModel.VideoMoveCustom3ForwardCommand)
+        {
+            var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
+            {
+                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom3Forward);
+            });
+            if (result.OkPressed)
+            {
+                Se.Settings.Video.MoveVideoPositionCustom3Forward = result.Milliseconds;
+
+                var flatNodeForward = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom3ForwardCommand);
+                if (flatNodeForward != null)
+                {
+                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom3ForwardX, Se.Settings.Video.MoveVideoPositionCustom3Forward);
+                }
+            }
+        }
+        else if (node.ShortCut.Action == MainViewModel.VideoMoveCustom4BackCommand)
+        {
+            var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
+            {
+                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom4Back);
+            });
+            if (result.OkPressed)
+            {
+                Se.Settings.Video.MoveVideoPositionCustom4Back = result.Milliseconds;
+
+                var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom4BackCommand);
+                if (flatNodeBack != null)
+                {
+                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom4BackX, Se.Settings.Video.MoveVideoPositionCustom4Back);
+                }
+            }
+        }
+        else if (node.ShortCut.Action == MainViewModel.VideoMoveCustom4ForwardCommand)
+        {
+            var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
+            {
+                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom4Forward);
+            });
+            if (result.OkPressed)
+            {
+                Se.Settings.Video.MoveVideoPositionCustom4Forward = result.Milliseconds;
+
+                var flatNodeForward = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom4ForwardCommand);
+                if (flatNodeForward != null)
+                {
+                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom4ForwardX, Se.Settings.Video.MoveVideoPositionCustom4Forward);
                 }
             }
         }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -432,6 +432,30 @@ public partial class BinaryEditViewModel : ObservableObject
         MoveVideoPositionMs(Se.Settings.Video.MoveVideoPositionCustom2Forward);
     }
 
+    [RelayCommand]
+    private void VideoMoveCustom3Back()
+    {
+        MoveVideoPositionMs(-Se.Settings.Video.MoveVideoPositionCustom3Back);
+    }
+
+    [RelayCommand]
+    private void VideoMoveCustom3Forward()
+    {
+        MoveVideoPositionMs(Se.Settings.Video.MoveVideoPositionCustom3Forward);
+    }
+
+    [RelayCommand]
+    private void VideoMoveCustom4Back()
+    {
+        MoveVideoPositionMs(-Se.Settings.Video.MoveVideoPositionCustom4Back);
+    }
+
+    [RelayCommand]
+    private void VideoMoveCustom4Forward()
+    {
+        MoveVideoPositionMs(Se.Settings.Video.MoveVideoPositionCustom4Forward);
+    }
+
 
     private void MoveVideoPositionMs(int ms)
     {

--- a/src/ui/Logic/BinaryEditShortcuts.cs
+++ b/src/ui/Logic/BinaryEditShortcuts.cs
@@ -42,6 +42,14 @@ public static class BinaryEditShortcuts
             string.Format(Se.Language.General.VideoCustom2BackX, Se.Settings.Video.MoveVideoPositionCustom2Back));
         AddShortcutIfExists(shortcuts, keys, nameof(vm.VideoMoveCustom2ForwardCommand), vm.VideoMoveCustom2ForwardCommand,
             string.Format(Se.Language.General.VideoCustom2ForwardX, Se.Settings.Video.MoveVideoPositionCustom2Forward));
+        AddShortcutIfExists(shortcuts, keys, nameof(vm.VideoMoveCustom3BackCommand), vm.VideoMoveCustom3BackCommand,
+            string.Format(Se.Language.General.VideoCustom3BackX, Se.Settings.Video.MoveVideoPositionCustom3Back));
+        AddShortcutIfExists(shortcuts, keys, nameof(vm.VideoMoveCustom3ForwardCommand), vm.VideoMoveCustom3ForwardCommand,
+            string.Format(Se.Language.General.VideoCustom3ForwardX, Se.Settings.Video.MoveVideoPositionCustom3Forward));
+        AddShortcutIfExists(shortcuts, keys, nameof(vm.VideoMoveCustom4BackCommand), vm.VideoMoveCustom4BackCommand,
+            string.Format(Se.Language.General.VideoCustom4BackX, Se.Settings.Video.MoveVideoPositionCustom4Back));
+        AddShortcutIfExists(shortcuts, keys, nameof(vm.VideoMoveCustom4ForwardCommand), vm.VideoMoveCustom4ForwardCommand,
+            string.Format(Se.Language.General.VideoCustom4ForwardX, Se.Settings.Video.MoveVideoPositionCustom4Forward));
 
         return shortcuts;
     }

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -656,6 +656,10 @@ public class LanguageGeneral
     public string VideoCustom1ForwardX { get; set; }
     public string VideoCustom2BackX { get; set; }
     public string VideoCustom2ForwardX { get; set; }
+    public string VideoCustom3BackX { get; set; }
+    public string VideoCustom3ForwardX { get; set; }
+    public string VideoCustom4BackX { get; set; }
+    public string VideoCustom4ForwardX { get; set; }
     public string VideoEncodingX { get; set; }
     public string VideoExtension { get; set; }
     public string VideoFile { get; set; }
@@ -1397,6 +1401,10 @@ public class LanguageGeneral
         VideoCustom1ForwardX = "Video, custom milliseconds ({0:#,###,##0}) forward, 1";
         VideoCustom2BackX = "Video, custom milliseconds ({0:#,###,##0}) back, 2";
         VideoCustom2ForwardX = "Video, custom milliseconds ({0:#,###,##0}) forward, 2";
+        VideoCustom3BackX = "Video, custom milliseconds ({0:#,###,##0}) back, 3";
+        VideoCustom3ForwardX = "Video, custom milliseconds ({0:#,###,##0}) forward, 3";
+        VideoCustom4BackX = "Video, custom milliseconds ({0:#,###,##0}) back, 4";
+        VideoCustom4ForwardX = "Video, custom milliseconds ({0:#,###,##0}) forward, 4";
         VideoEncodingX = "Video encoding: {0}";
         VideoExtension = "Video file extension";
         VideoFile = "Video file";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -24,6 +24,10 @@ public class SeVideo
     public int MoveVideoPositionCustom1Forward { get; set; }
     public int MoveVideoPositionCustom2Back { get; set; }
     public int MoveVideoPositionCustom2Forward { get; set; }
+    public int MoveVideoPositionCustom3Back { get; set; }
+    public int MoveVideoPositionCustom3Forward { get; set; }
+    public int MoveVideoPositionCustom4Back { get; set; }
+    public int MoveVideoPositionCustom4Forward { get; set; }
 
     public string MpvPreviewFontName { get; set; }
     public int MpvPreviewFontSize { get; set; }
@@ -55,6 +59,10 @@ public class SeVideo
         MoveVideoPositionCustom1Forward = 2000; // 2 seconds
         MoveVideoPositionCustom2Back = 5000; // 5 seconds
         MoveVideoPositionCustom2Forward = 5000; // 5 seconds
+        MoveVideoPositionCustom3Back = 10000; // 10 seconds
+        MoveVideoPositionCustom3Forward = 10000; // 10 seconds
+        MoveVideoPositionCustom4Back = 30000; // 30 seconds
+        MoveVideoPositionCustom4Forward = 30000; // 30 seconds
 
         MpvPreviewFontName = "Arial";
         MpvPreviewFontSize = 20;

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -250,6 +250,10 @@ public static class ShortcutsMain
         { nameof(MainViewModel.VideoMoveCustom1ForwardCommand),  string.Format(Se.Language.General.VideoCustom1ForwardX, Se.Settings.Video.MoveVideoPositionCustom1Forward) },
         { nameof(MainViewModel.VideoMoveCustom2BackCommand),  string.Format(Se.Language.General.VideoCustom2BackX, Se.Settings.Video.MoveVideoPositionCustom2Back) },
         { nameof(MainViewModel.VideoMoveCustom2ForwardCommand),  string.Format(Se.Language.General.VideoCustom2ForwardX, Se.Settings.Video.MoveVideoPositionCustom2Forward) },
+        { nameof(MainViewModel.VideoMoveCustom3BackCommand),  string.Format(Se.Language.General.VideoCustom3BackX, Se.Settings.Video.MoveVideoPositionCustom3Back) },
+        { nameof(MainViewModel.VideoMoveCustom3ForwardCommand),  string.Format(Se.Language.General.VideoCustom3ForwardX, Se.Settings.Video.MoveVideoPositionCustom3Forward) },
+        { nameof(MainViewModel.VideoMoveCustom4BackCommand),  string.Format(Se.Language.General.VideoCustom4BackX, Se.Settings.Video.MoveVideoPositionCustom4Back) },
+        { nameof(MainViewModel.VideoMoveCustom4ForwardCommand),  string.Format(Se.Language.General.VideoCustom4ForwardX, Se.Settings.Video.MoveVideoPositionCustom4Forward) },
 
         { nameof(MainViewModel.WaveformSetStartAndOffsetTheRestCommand),  Se.Language.General.SetStartAndOffsetTheRest },
         { nameof(MainViewModel.WaveformSetEndAndOffsetTheRestCommand),  Se.Language.General.SetEndAndOffsetTheRest },
@@ -609,6 +613,10 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.VideoMoveCustom1ForwardCommand, nameof(vm.VideoMoveCustom1ForwardCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.VideoMoveCustom2BackCommand, nameof(vm.VideoMoveCustom2BackCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.VideoMoveCustom2ForwardCommand, nameof(vm.VideoMoveCustom2ForwardCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoMoveCustom3BackCommand, nameof(vm.VideoMoveCustom3BackCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoMoveCustom3ForwardCommand, nameof(vm.VideoMoveCustom3ForwardCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoMoveCustom4BackCommand, nameof(vm.VideoMoveCustom4BackCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoMoveCustom4ForwardCommand, nameof(vm.VideoMoveCustom4ForwardCommand), ShortcutCategory.General);
 
         AddShortcut(shortcuts, vm.WaveformSetStartAndOffsetTheRestCommand, nameof(vm.WaveformSetStartAndOffsetTheRestCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformSetEndAndOffsetTheRestCommand, nameof(vm.WaveformSetEndAndOffsetTheRestCommand), ShortcutCategory.Waveform);


### PR DESCRIPTION
## What

Extends the user-configurable **"move video position custom"** jumps from **2** to **4** forward and **4** back.

SE5 already supports moving the video forward/back by a selectable number of milliseconds (Options → Shortcuts → "Video, custom milliseconds … back/forward"), but only offered two slots. This adds custom **3** and **4** so users can map several different jump sizes (e.g. ±250 ms, ±2 s, ±10 s, ±30 s) to different shortcut keys.

- New settings `MoveVideoPositionCustom3/4 Back/Forward` (defaults: custom 3 = 10 s, custom 4 = 30 s).
- New commands `VideoMoveCustom3/4 Back/Forward` in the main view and the binary-edit window.
- Wired through shortcut registration, labels, the `PickMillisecondsWindow` picker in Options → Shortcuts, and `BinaryEditShortcuts`.

Mirrors the existing custom 1/2 pattern exactly; no default keys assigned (user-configurable like the originals).

## Test
- Build is clean.
- Options → Shortcuts now lists custom 1–4 back/forward; clicking each opens the ms picker and persists the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)