### PR TITLE
Add color adjustment for selected lines in image-based subtitle editor

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -61,6 +61,7 @@ using Nikse.SubtitleEdit.Features.Shared.AddToUserDictionary;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustAllTimes;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustAlpha;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustBrightness;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustColor;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustDuration;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryApplyDurationLimits;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryResizeImages;
@@ -298,6 +299,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<BinaryAdjustAllTimesViewModel>();
         collection.AddTransient<BinaryAdjustAlphaViewModel>();
         collection.AddTransient<BinaryAdjustBrightnessViewModel>();
+        collection.AddTransient<BinaryAdjustColorViewModel>();
         collection.AddTransient<BinaryAdjustDurationViewModel>();
         collection.AddTransient<BinaryApplyDurationLimitsViewModel>();
         collection.AddTransient<BinaryEditViewModel>();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
@@ -1,0 +1,154 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
+using Nikse.SubtitleEdit.Logic;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustColor;
+
+public partial class BinaryAdjustColorViewModel : ObservableObject
+{
+    [ObservableProperty] private Color _selectedColor;
+    [ObservableProperty] private IBrush _colorSwatchBrush;
+    [ObservableProperty] private Bitmap? _previewBitmap;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    private readonly IWindowService _windowService;
+    private List<BinarySubtitleItem> _subtitles = new();
+
+    public BinaryAdjustColorViewModel(IWindowService windowService)
+    {
+        _windowService = windowService;
+        _selectedColor = Color.FromRgb(255, 255, 0);
+        _colorSwatchBrush = new SolidColorBrush(_selectedColor);
+    }
+
+    public void Initialize(List<BinarySubtitleItem> subtitles)
+    {
+        _subtitles = subtitles;
+        UpdatePreview();
+    }
+
+    partial void OnSelectedColorChanged(Color value)
+    {
+        ColorSwatchBrush = new SolidColorBrush(value);
+        UpdatePreview();
+    }
+
+    [RelayCommand]
+    private async System.Threading.Tasks.Task ChooseColor()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<ColorPickerWindow, ColorPickerViewModel>(
+            Window, vm => vm.Initialize(SelectedColor));
+
+        if (result.OkPressed)
+        {
+            SelectedColor = result.SelectedColor;
+        }
+    }
+
+    private void UpdatePreview()
+    {
+        if (_subtitles.Count == 0 || _subtitles[0].Bitmap == null)
+        {
+            return;
+        }
+
+        using var originalBitmap = _subtitles[0].Bitmap!.ToSkBitmap();
+        var coloredBitmap = ColorBitmap(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
+        PreviewBitmap = coloredBitmap.ToAvaloniaBitmap();
+    }
+
+    public void ApplyAdjustments()
+    {
+        foreach (var subtitle in _subtitles)
+        {
+            if (subtitle.Bitmap == null)
+            {
+                continue;
+            }
+
+            using var originalBitmap = subtitle.Bitmap.ToSkBitmap();
+            var coloredBitmap = ColorBitmap(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
+            subtitle.Bitmap = coloredBitmap.ToAvaloniaBitmap();
+        }
+    }
+
+    private static SKBitmap ColorBitmap(SKBitmap originalBitmap, byte r, byte g, byte b)
+    {
+        var redPercent = r * 100.0 / 255;
+        var greenPercent = g * 100.0 / 255;
+        var bluePercent = b * 100.0 / 255;
+
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height);
+
+        unsafe
+        {
+            var srcPixels = originalBitmap.GetPixels();
+            var dstPixels = adjustedBitmap.GetPixels();
+
+            for (int i = 0; i < originalBitmap.Width * originalBitmap.Height; i++)
+            {
+                var pixel = ((uint*)srcPixels)[i];
+
+                var a = (byte)((pixel >> 24) & 0xFF);
+                var pr = (byte)((pixel >> 16) & 0xFF);
+                var pg = (byte)((pixel >> 8) & 0xFF);
+                var pb = (byte)(pixel & 0xFF);
+
+                int total = pr + pg + pb;
+                if (total > 100 && a > 0)
+                {
+                    pr = (byte)Math.Min(255, redPercent * total / 100);
+                    pg = (byte)Math.Min(255, greenPercent * total / 100);
+                    pb = (byte)Math.Min(255, bluePercent * total / 100);
+                }
+
+                ((uint*)dstPixels)[i] = (uint)((a << 24) | (pr << 16) | (pg << 8) | pb);
+            }
+        }
+
+        return adjustedBitmap;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        ApplyAdjustments();
+        OkPressed = true;
+        Window.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
@@ -23,12 +24,44 @@ public partial class BinaryAdjustColorViewModel : ObservableObject
 
     private readonly IWindowService _windowService;
     private List<BinarySubtitleItem> _subtitles = new();
+    private DispatcherTimer? _previewUpdateTimer;
+    private bool _isDirty;
 
     public BinaryAdjustColorViewModel(IWindowService windowService)
     {
         _windowService = windowService;
         _selectedColor = Color.FromRgb(255, 255, 0);
         _colorSwatchBrush = new SolidColorBrush(_selectedColor);
+        InitializeTimer();
+    }
+
+    private void InitializeTimer()
+    {
+        _previewUpdateTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(300)
+        };
+        _previewUpdateTimer.Tick += (_, _) =>
+        {
+            _previewUpdateTimer.Stop();
+            if (_isDirty)
+            {
+                _isDirty = false;
+                UpdatePreview();
+            }
+        };
+    }
+
+    private void SchedulePreviewUpdate()
+    {
+        if (_previewUpdateTimer == null)
+        {
+            return;
+        }
+
+        _isDirty = true;
+        _previewUpdateTimer.Stop();
+        _previewUpdateTimer.Start();
     }
 
     public void Initialize(List<BinarySubtitleItem> subtitles)
@@ -40,7 +73,7 @@ public partial class BinaryAdjustColorViewModel : ObservableObject
     partial void OnSelectedColorChanged(Color value)
     {
         ColorSwatchBrush = new SolidColorBrush(value);
-        UpdatePreview();
+        SchedulePreviewUpdate();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
@@ -93,7 +93,7 @@ public partial class BinaryAdjustColorViewModel : ObservableObject
         var greenPercent = g * 100.0 / 255;
         var bluePercent = b * 100.0 / 255;
 
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height);
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
 
         unsafe
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -30,7 +31,7 @@ public partial class BinaryAdjustColorViewModel : ObservableObject
     public BinaryAdjustColorViewModel(IWindowService windowService)
     {
         _windowService = windowService;
-        _selectedColor = Color.FromRgb(255, 255, 0);
+        _selectedColor = Se.Settings.Tools.LastColorPickerColor.FromHexToColor();
         _colorSwatchBrush = new SolidColorBrush(_selectedColor);
         InitializeTimer();
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorWindow.cs
@@ -1,0 +1,102 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustColor;
+
+public class BinaryAdjustColorWindow : Window
+{
+    public BinaryAdjustColorWindow(BinaryAdjustColorViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Tools.ImageBasedEdit.AdjustColor;
+        Width = 700;
+        Height = 400;
+        CanResize = true;
+        vm.Window = this;
+        DataContext = vm;
+
+        var mainGrid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Star),
+                new RowDefinition(GridLength.Auto),
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+
+        var contentGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(new GridLength(260)),
+                new ColumnDefinition(GridLength.Star),
+            },
+            ColumnSpacing = 10,
+        };
+
+        var leftPanel = MakeControlsPanel(vm);
+        contentGrid.Add(leftPanel, 0, 0);
+
+        var rightPanel = MakePreviewPanel(vm);
+        contentGrid.Add(rightPanel, 0, 1);
+
+        mainGrid.Add(contentGrid, 0, 0);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        mainGrid.Add(buttonPanel, 1, 0);
+
+        Content = mainGrid;
+
+        Activated += delegate { buttonOk.Focus(); };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    private static Button MakeControlsPanel(BinaryAdjustColorViewModel vm)
+    {
+        var swatchButton = new Button
+        {
+            Height = 60,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Stretch,
+            Padding = new Thickness(0),
+            Command = vm.ChooseColorCommand,
+            Content = new Border
+            {
+                CornerRadius = new CornerRadius(4),
+                [!Border.BackgroundProperty] = new Binding(nameof(vm.ColorSwatchBrush)),
+            },
+        };
+        return swatchButton;
+    }
+
+    private static Border MakePreviewPanel(BinaryAdjustColorViewModel vm)
+    {
+        var scrollViewer = new ScrollViewer
+        {
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+        };
+
+        var image = new Image
+        {
+            Stretch = Stretch.None,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Image.SourceProperty] = new Binding(nameof(vm.PreviewBitmap)),
+        };
+
+        scrollViewer.Content = image;
+
+        return UiUtil.MakeBorderForControl(scrollViewer);
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1292,6 +1292,55 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task AdjustColor()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var selectedItems = new List<BinarySubtitleItem>();
+        if (SubtitleGrid?.SelectedItems != null)
+        {
+            foreach (var item in SubtitleGrid.SelectedItems)
+            {
+                if (item is BinarySubtitleItem binaryItem)
+                {
+                    selectedItems.Add(binaryItem);
+                }
+            }
+        }
+
+        var itemsToAdjust = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+
+        if (itemsToAdjust.Count == 0)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Information,
+                "No subtitles to adjust.",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<BinaryAdjustColor.BinaryAdjustColorWindow, BinaryAdjustColor.BinaryAdjustColorViewModel>(
+            Window, vm => vm.Initialize(itemsToAdjust));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        if (SubtitleGrid != null)
+        {
+            var currentIndex = SubtitleGrid.SelectedIndex;
+            SubtitleGrid.ItemsSource = null;
+            SubtitleGrid.ItemsSource = Subtitles;
+            SubtitleGrid.SelectedIndex = currentIndex;
+        }
+
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
     private void CenterHorizontally()
     {
         // Get selected subtitles

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -259,6 +259,11 @@ public class BinaryEditWindow : Window
                 },
                 new MenuItem
                 {
+                    Header = Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot,
+                    Command = vm.AdjustColorCommand,
+                },
+                new MenuItem
+                {
                     Header =  Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
                     Command = vm.CenterHorizontallyCommand,
                 },

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -39,6 +39,7 @@ public static class InitNativeMacMenuBinaryEdit
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot, vm.ResizeImagesCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot, vm.AdjustBrightnessCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot, vm.AdjustAlphaCommand);
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot, vm.AdjustColorCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CenterHorizontally, vm.CenterHorizontallyCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
         root.Items.Add(new NativeMenuItem(Clean(l.ToolsSelectedLines)) { Menu = toolsMenu });

--- a/src/ui/Features/Shared/ColorPicker/ColorPickerViewModel.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorPickerViewModel.cs
@@ -128,6 +128,17 @@ public partial class ColorPickerViewModel : ObservableObject
         }
     }
 
+    public void SelectRecentColor(Color color)
+    {
+        if (!_isUpdating)
+        {
+            _isUpdating = true;
+            SelectedColor = color;
+            UpdateFromColor(color);
+            _isUpdating = false;
+        }
+    }
+
     private void UpdateColorFromRgb()
     {
         _isUpdating = true;

--- a/src/ui/Features/Shared/ColorPicker/ColorPickerViewModel.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorPickerViewModel.cs
@@ -284,8 +284,10 @@ public partial class ColorPickerViewModel : ObservableObject
                     try
                     {
                         var color = clipboardText.FromHexToColor();
+                        _isUpdating = true;
                         SelectedColor = color;
                         UpdateFromColor(color);
+                        _isUpdating = false;
                     }
                     catch
                     {

--- a/src/ui/Features/Shared/ColorPicker/ColorPickerWindow.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorPickerWindow.cs
@@ -339,7 +339,7 @@ public class ColorPickerWindow : Window
                     nameof(vm.LastColorPickerColor7) => vm.LastColorPickerColor7,
                     _ => Colors.White
                 };
-                vm.SelectedColor = color;
+                vm.SelectRecentColor(color);
             }
         };
 

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -25,6 +25,8 @@ public class LanguageImageBasedEdit
     public string ResizeImages { get; set; }
     public string Percentage { get; set; }
     public string ResizeImagesInfo { get; set; }
+    public string AdjustColorDotDotDot { get; set; }
+    public string AdjustColor { get; set; }
 
     public LanguageImageBasedEdit()
     {
@@ -51,5 +53,7 @@ public class LanguageImageBasedEdit
         ResizeImages = "Resize images";
         Percentage = "Percentage";
         ResizeImagesInfo = "Enter the percentage to resize images.\nPreview updates automatically.";
+        AdjustColorDotDotDot = "Adjust color...";
+        AdjustColor = "Adjust color";
     }
 }

--- a/src/ui/Logic/SkBitmapExtensions.cs
+++ b/src/ui/Logic/SkBitmapExtensions.cs
@@ -186,6 +186,8 @@ internal static class SkBitmapExtensions
             int srcStride = skBitmap.RowBytes;
             int dstStride = lockedBitmap.RowBytes;
 
+            bool sourceIsPremul = skBitmap.AlphaType == SKAlphaType.Premul;
+
             unsafe
             {
                 byte* srcBase = (byte*)skBitmap.GetPixels();
@@ -209,6 +211,10 @@ internal static class SkBitmapExtensions
                         else if (a == 0)
                         {
                             dstRow[x] = 0; // Fully transparent
+                        }
+                        else if (sourceIsPremul)
+                        {
+                            dstRow[x] = pixel; // Already premultiplied, copy as-is
                         }
                         else
                         {


### PR DESCRIPTION
  ## Summary

  Ports SE4's "Change color for selected lines" feature to the SE5 image-based subtitle editor (PGS/SUP/VobSub). Applies a brightness-preserving hue shift to the pixel data of selected subtitle bitmaps, accessible via **Tools → Selected Lines → Adjust color...**.

  - Clicking a color swatch opens the existing `ColorPickerWindow` (color wheel, RGBA sliders, hex input, recent colors — persisted across sessions)
  - Bright pixels (R+G+B > 100) shift toward the chosen hue while luminosity is preserved; dark pixels (outlines/shadows) are left unchanged
  - Also fixes a pre-existing bug where clicking a recent color in `ColorPickerWindow` did not update the RGBA sliders or hex field

  ## Changes

  - New `BinaryAdjustColor/` feature with `BinaryAdjustColorViewModel` and `BinaryAdjustColorWindow`
  - `BinaryEditViewModel`: new `AdjustColorCommand` wired to the Tools menu and macOS native menu
  - `ColorPickerViewModel`: new `SelectRecentColor()` method so recent color clicks update all controls
  - Language strings: `AdjustColorDotDotDot`, `AdjustColor`


  ## Design note

  I also considered the flow we have in the main subtitle window where we right click -> select Color and then the color picker pops up. Now we have an intermediate window that shows the swatch and the preview. I consider the preview useful for binary subtitle image adjustments (surprising things can happen, vs. setting a color for a text subtitle which is straightforward). We already have the preview for Adjust brightness so I re-used the same concept. Unlike the Adjust brightness window though, I re-used the Color picker instead of sliders because we already have a color picker, its recent colors are persisted, and it's the common way to pick and preview colors.

The video below also shows the bug I fixed: click on a recent color and sliders/wheel/hex field all update immediately.

https://github.com/user-attachments/assets/fa5db619-278c-4c84-a624-7c59334d0435

