### PR TITLE
Main + binary edit menu: Alt/F10 toggle and Escape deactivation (Windows standard)

### DIFF
--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -42,6 +42,7 @@ public class MainView : ViewBase
             }
 
             _vm.Window.Closing += _vm.OnClosing;
+            _vm.Window.Deactivated += _vm.OnWindowDeactivated;
             _vm.Window.Loaded += (_, _) =>
             {
                 _vm.OnLoaded();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -292,6 +292,8 @@ public partial class MainViewModel :
     AudioVisualizerUndockedViewModel? _audioVisualizerUndockedViewModel;
     FindViewModel? _findViewModel;
     Control? _findPreviousFocus;
+    Control? _focusBeforeMainMenu;
+    bool _altMenuTogglePending;
     bool _findClosingProgrammatically;
     ReplaceViewModel? _replaceViewModel;
     Control? _replacePreviousFocus;
@@ -18381,6 +18383,57 @@ public partial class MainViewModel :
     }
 
     /// <summary>
+    /// Activates the main menu bar for keyboard navigation (Windows standard Alt/F10), remembering
+    /// the control that had focus so it can be restored on deactivation. Returns false on platforms
+    /// with a native menu (macOS), where the in-window <see cref="Menu"/> has no items (#11745).
+    /// </summary>
+    private bool ActivateMainMenu()
+    {
+        if (Menu == null || Menu.Items.Count == 0)
+        {
+            return false;
+        }
+
+        _focusBeforeMainMenu = Window?.FocusManager?.GetFocusedElement() as Control;
+        return TryFocusMainMenu();
+    }
+
+    /// <summary>
+    /// Closes any open drop-down and fully deactivates the main menu bar, restoring keyboard focus to
+    /// the control that was focused before activation (falling back to the subtitle grid). Mirrors the
+    /// Windows behavior where Alt/F10/Escape leave the menu and return to editing (#11745).
+    /// </summary>
+    private void DeactivateMainMenu()
+    {
+        Menu?.Close();
+        _altMenuTogglePending = false;
+
+        var restore = _focusBeforeMainMenu;
+        _focusBeforeMainMenu = null;
+
+        // Defer the focus change: closing the menu and moving focus from inside the key handler is
+        // racy, so let the current event finish first (same pattern as the find/replace focus restore).
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (restore is { IsEffectivelyVisible: true } && restore.Focus())
+            {
+                return;
+            }
+
+            SubtitleGrid?.Focus();
+        });
+    }
+
+    /// <summary>
+    /// A task switch (e.g. Alt+Tab) must not leave a pending bare-Alt menu toggle armed; otherwise the
+    /// next Alt release after returning to the window would spuriously activate the menu bar (#11745).
+    /// </summary>
+    internal void OnWindowDeactivated(object? sender, EventArgs e)
+    {
+        _altMenuTogglePending = false;
+    }
+
+    /// <summary>
     /// True when keyboard focus is on the main menu itself or one of its items (including items in
     /// an open drop-down, which live in a popup). Used to let the menu own arrow/Enter/Escape keys
     /// instead of the shortcut manager while it is being navigated (#11745).
@@ -18456,20 +18509,43 @@ public partial class MainViewModel :
                 return;
             }
 
-            // F10 moves keyboard focus into the main menu bar (standard Windows behavior), so the
-            // menu can be reached and read with a screen reader without a mouse (#11745).
-            if (k == Key.F10 && keyEventArgs.KeyModifiers == KeyModifiers.None && TryFocusMainMenu())
+            // F10 toggles main-menu activation (Windows standard): the first press moves keyboard focus
+            // into the menu bar, a second press deactivates it and restores the previous focus. This
+            // also lets the menu be reached and read with a screen reader without a mouse (#11745).
+            if (k == Key.F10 && keyEventArgs.KeyModifiers == KeyModifiers.None)
             {
-                keyEventArgs.Handled = true;
-                return;
+                if (IsMainMenuFocused())
+                {
+                    DeactivateMainMenu();
+                    keyEventArgs.Handled = true;
+                    return;
+                }
+
+                if (ActivateMainMenu())
+                {
+                    keyEventArgs.Handled = true;
+                    return;
+                }
             }
 
-            // When the main menu has keyboard focus (opened via F10 or Alt), let it handle its own
-            // arrow/Enter/Escape navigation instead of consuming those keys as shortcuts. The window
-            // key handler tunnels (runs before the focused menu item), so without this the shortcut
-            // manager would eat Left/Right etc. and menu navigation would never work (#11745).
+            // Arm a "bare Alt" toggle so its release can activate/deactivate the menu bar (Windows
+            // standard). Any other key pressed while Alt is held (e.g. the access key in Alt+F) cancels
+            // it, so only Alt-alone toggles. The actual toggle happens on key-up (OnKeyUpHandler).
+            _altMenuTogglePending = k is Key.LeftAlt or Key.RightAlt;
+
+            // When the main menu has keyboard focus (opened via F10 or Alt), let it own its arrow/Enter
+            // navigation instead of consuming those keys as shortcuts. The window key handler tunnels
+            // (runs before the focused menu item), so without this the shortcut manager would eat
+            // Left/Right etc. Escape is handled here so that, once no drop-down is open, it fully
+            // deactivates the bar and restores focus instead of leaving it half-focused (#11745).
             if (IsMainMenuFocused())
             {
+                if (k == Key.Escape && !Menu.IsOpen)
+                {
+                    DeactivateMainMenu();
+                    keyEventArgs.Handled = true;
+                }
+
                 return;
             }
 
@@ -18653,6 +18729,23 @@ public partial class MainViewModel :
 
     public void OnKeyUpHandler(object? sender, KeyEventArgs e)
     {
+        // A bare Alt press+release toggles the main menu bar (Windows standard). _altMenuTogglePending
+        // is cleared if any other key was pressed while Alt was held, or on a window task switch, so
+        // this fires only for Alt-alone (#11745).
+        if (e.Key is Key.LeftAlt or Key.RightAlt && _altMenuTogglePending)
+        {
+            _altMenuTogglePending = false;
+            if (IsMainMenuFocused())
+            {
+                DeactivateMainMenu();
+                e.Handled = true;
+            }
+            else if (ActivateMainMenu())
+            {
+                e.Handled = true;
+            }
+        }
+
         if (_setEndAtKeyUpLine != null)
         {
             _setEndAtKeyUpLine = null;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -65,6 +65,8 @@ public partial class BinaryEditViewModel : ObservableObject
     public ObservableCollection<BinarySubtitleItem> Subtitles { get; set; }
 
     private ScrollViewer? _subtitleGridScrollViewer;
+    private Control? _focusBeforeMenu;
+    private bool _altMenuTogglePending;
 
     private readonly IFileHelper _fileHelper;
     private readonly IFolderHelper _folderHelper;
@@ -1926,20 +1928,43 @@ public partial class BinaryEditViewModel : ObservableObject
 
     public void OnKeyDown(KeyEventArgs e)
     {
-        // F10 moves keyboard focus into the menu bar (standard Windows behavior) so it can be
-        // reached and read without a mouse (#11745).
-        if (e.Key == Key.F10 && e.KeyModifiers == KeyModifiers.None && TryFocusMenu())
+        // F10 toggles menu-bar activation (Windows standard): the first press moves keyboard focus
+        // into the menu bar, a second press deactivates it and restores the previous focus, so it can
+        // be reached and read without a mouse (#11745).
+        if (e.Key == Key.F10 && e.KeyModifiers == KeyModifiers.None)
         {
-            e.Handled = true;
-            return;
+            if (IsMenuFocused())
+            {
+                DeactivateMenu();
+                e.Handled = true;
+                return;
+            }
+
+            if (ActivateMenu())
+            {
+                e.Handled = true;
+                return;
+            }
         }
+
+        // Arm a "bare Alt" toggle so its release can activate/deactivate the menu bar (Windows
+        // standard). Any other key while Alt is held (e.g. the access key in Alt+F) cancels it; the
+        // toggle itself happens on key-up (OnKeyUp).
+        _altMenuTogglePending = e.Key is Key.LeftAlt or Key.RightAlt;
 
         // While the menu has keyboard focus, let it own its own navigation keys. The window key
         // handler runs even on keys the menu already handled (handledEventsToo: true), so without
-        // this Escape would close the whole window instead of the menu, and arrow/Enter would be
-        // consumed as shortcuts, breaking menu navigation (#11745).
+        // this arrow/Enter would be consumed as shortcuts, breaking menu navigation. Escape is
+        // handled here so that, once no drop-down is open, it fully deactivates the bar and restores
+        // focus instead of leaving it half-focused (and without closing the whole window) (#11745).
         if (IsMenuFocused())
         {
+            if (e.Key == Key.Escape && Menu is { IsOpen: false })
+            {
+                DeactivateMenu();
+                e.Handled = true;
+            }
+
             return;
         }
 
@@ -1974,6 +1999,23 @@ public partial class BinaryEditViewModel : ObservableObject
 
     public void OnKeyUp(KeyEventArgs e)
     {
+        // A bare Alt press+release toggles the menu bar (Windows standard). _altMenuTogglePending is
+        // cleared if any other key was pressed while Alt was held, or on a window task switch, so this
+        // fires only for Alt-alone (#11745).
+        if (e.Key is Key.LeftAlt or Key.RightAlt && _altMenuTogglePending)
+        {
+            _altMenuTogglePending = false;
+            if (IsMenuFocused())
+            {
+                DeactivateMenu();
+                e.Handled = true;
+            }
+            else if (ActivateMenu())
+            {
+                e.Handled = true;
+            }
+        }
+
         _shortcutManager.OnKeyReleased(this, e);
     }
 
@@ -1990,6 +2032,57 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         return Menu.Items[0] is MenuItem firstItem && firstItem.Focus(NavigationMethod.Tab);
+    }
+
+    /// <summary>
+    /// Activates the menu bar for keyboard navigation (Windows standard Alt/F10), remembering the
+    /// control that had focus so it can be restored on deactivation. Returns false when the menu is
+    /// hidden (macOS uses the native menu) (#11745).
+    /// </summary>
+    private bool ActivateMenu()
+    {
+        if (Menu == null || !Menu.IsVisible || Menu.Items.Count == 0)
+        {
+            return false;
+        }
+
+        _focusBeforeMenu = Window?.FocusManager?.GetFocusedElement() as Control;
+        return TryFocusMenu();
+    }
+
+    /// <summary>
+    /// Closes any open drop-down and fully deactivates the menu bar, restoring keyboard focus to the
+    /// control that was focused before activation (falling back to the subtitle grid). Mirrors the
+    /// Windows behavior where Alt/F10/Escape leave the menu and return to editing (#11745).
+    /// </summary>
+    private void DeactivateMenu()
+    {
+        Menu?.Close();
+        _altMenuTogglePending = false;
+
+        var restore = _focusBeforeMenu;
+        _focusBeforeMenu = null;
+
+        // Defer the focus change: closing the menu and moving focus from inside the key handler is
+        // racy, so let the current event finish first.
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (restore is { IsEffectivelyVisible: true } && restore.Focus())
+            {
+                return;
+            }
+
+            SubtitleGrid?.Focus();
+        });
+    }
+
+    /// <summary>
+    /// A task switch (e.g. Alt+Tab) must not leave a pending bare-Alt menu toggle armed; otherwise the
+    /// next Alt release after returning to the window would spuriously activate the menu bar (#11745).
+    /// </summary>
+    internal void OnWindowDeactivated(object? sender, EventArgs e)
+    {
+        _altMenuTogglePending = false;
     }
 
     /// <summary>

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -136,6 +136,7 @@ public class BinaryEditWindow : Window
             vm.Loaded();
         };
         Closing += vm.OnClosing;
+        Deactivated += vm.OnWindowDeactivated;
     }
 
     private static Menu MakeTopMenu(BinaryEditViewModel vm)


### PR DESCRIPTION
Follow-up to #11822 for #11745, addressing the keyboard-menu feedback in [PR #11822](https://github.com/SubtitleEdit/subtitleedit/pull/11822#issuecomment-4813859033).

PR #11822 made arrow keys reach the focused menu (Left/Right between top menus, open/collapse submenus). This adds the activation/deactivation half of the Windows menu keyboard interface, to **both windows that have an in-window menu bar — the main window and the binary edit window** (both previously had the same minimal F10-focus code):

- **F10 toggles** the menu bar — first press activates (focus moves in), second press deactivates and restores the previously focused control.
- **Bare Alt** press+release toggles it the same way. The toggle is armed on Alt-down and cancelled if any other key is pressed while Alt is held (so `Alt+F` etc. still works as an access key); the toggle fires on Alt-up.
- **Escape**, once no drop-down is open, fully deactivates the bar and restores focus to the editing control instead of leaving it half-focused with the access-key cues still showing (the "pathological Esc" the reporter described). In the binary edit window this no longer closes the whole window when Esc is used to leave the menu.
- A window **task switch (Alt+Tab)** clears the pending Alt toggle (`Window.Deactivated`) so returning to the window doesn't spuriously open the menu.

### Scope / platforms
- Windows (and the in-window Linux menu). **No effect on macOS**, which uses the native menu bar — the in-window `Menu` has no items / is hidden there, so activation is a no-op and the Option key is left untouched.
- Still **not** covered here (separate framework-level items from the same comment): right-arrow from a deep submenu wrapping to the next top menu (Avalonia `Menu` navigation), and the mnemonic-underline "limbo" after Esc→Alt+Tab→back (Avalonia `AccessKeyHandler` state). The `Window.Deactivated` hook added here is a step toward the latter.

Build passes; app launches cleanly. (Menu-toggle behavior itself is only observable on Windows/Linux.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)