### PR TITLE
Fix video playback speed reverting to 1.0x after Options/layout change

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -877,18 +877,45 @@ public partial class MainViewModel :
         Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
         RefreshSubtitlePreview();
 
-        if (savedAudioTrack != null && !string.IsNullOrEmpty(_videoFileName))
+        if (!string.IsNullOrEmpty(_videoFileName))
         {
             Dispatcher.UIThread.Post(async () =>
             {
                 var vp = GetVideoPlayerControl();
-                if (vp?.VideoPlayer is LibMpvDynamicPlayer mpv)
+                if (vp == null)
                 {
-                    await vp.WaitForPlayersReadyAsync();
+                    return;
+                }
+
+                await vp.WaitForPlayersReadyAsync();
+
+                // The rebuilt layout creates a fresh video player that starts at the default 1.0x, so
+                // re-apply the currently selected playback speed - otherwise it silently reverts to 1.0x
+                // after Options/layout changes even though the dropdown still shows the old value
+                // (discussion #11744).
+                ReapplyPlaybackSpeed();
+
+                if (savedAudioTrack != null && vp.VideoPlayer is LibMpvDynamicPlayer mpv)
+                {
                     mpv.SetAudioTrack(savedAudioTrack.Id);
                     var _ = Task.Run(LoadAudioTrackMenuItems);
                 }
             });
+        }
+    }
+
+    /// <summary>
+    /// Pushes the currently selected playback speed (<see cref="SelectedSpeed"/>, e.g. "2.0x") to the
+    /// video player. The speed is otherwise only sent to the player by the speed dropdown's
+    /// SelectionChanged event, so a recreated player (Options/layout rebuild) would stay at the default
+    /// 1.0x while the dropdown still shows the old value (discussion #11744).
+    /// </summary>
+    private void ReapplyPlaybackSpeed()
+    {
+        if (SelectedSpeed != null && SelectedSpeed.EndsWith("x", StringComparison.Ordinal) &&
+            double.TryParse(SelectedSpeed.Trim('x'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var speed))
+        {
+            GetVideoPlayerControl()?.SetSpeed(speed);
         }
     }
 


### PR DESCRIPTION
Reported in [discussion #11744](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17452234): set playback speed to 2.0x, open Options, change a setting, return — the video plays at 1.0x even though the speed dropdown still shows 2.0x. Re-selecting a speed restores it.

## Root cause
The speed is pushed to the player **only** by the speed dropdown's `SelectionChanged` handler (`InitWaveform.cs`). The `SelectedSpeed` VM property has no change handler that talks to the player, and there's no re-apply on reload. Changing a setting runs `ApplySettings()` → `SetLayout()` → `InitLayout.MakeLayout`, which **recreates the video player** (a fresh mpv/VLC instance at the default 1.0x). `SelectedSpeed` is unchanged, so the dropdown never re-fires `SelectionChanged`, so `SetSpeed(...)` is never re-issued — the new player stays at 1.0x while the dropdown still displays the old value. Picking a different speed then the original re-fires the event, which is the reported workaround.

## Fix
Re-apply the selected speed once the recreated player is ready, mirroring the existing audio-track restore in `SetLayout` (after `WaitForPlayersReadyAsync()`). New `ReapplyPlaybackSpeed()` helper parses `SelectedSpeed` (`"2.0x"` → `2.0`) and calls `SetSpeed`. This covers the reported Options case and ordinary layout changes (both go through `SetLayout`).

## Notes / scope
- Not covered here: the undocked-video-controls path (`VideoUndockControls`) and the fullscreen player, which also recreate the player. The default docked layout — the reported scenario — is fixed. Happy to extend to those if wanted.
- Build passes and the app launches cleanly; the actual playback-speed behavior is best confirmed on a machine with a video loaded (I can't exercise mpv/VLC playback headlessly here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)