### PR TITLE
Update change-log.txt (beta2)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -14,7 +14,12 @@ v5.1.0-beta2 (TBD)
 * Fix "Change speed" radio buttons disabled/not respected in the main window
 * Binary edit: wire up "Change speed", respect the selected-lines radio, and always apply "Change frame rate" to all lines
 * Binary edit: keep the grid scroll position after "Adjust all times" and "Change speed"
-* Spell check: show the source image (Blu-ray sup, VobSub, BDN XML) for the current line (image button left of Done) - thx fraternl
+* Spell check: show the source image for the current line - auto-attached after OCR, or loaded via the image button left of Done (Blu-ray sup, VobSub, BDN XML, transport stream, Matroska) - thx fraternl
+* Add two more configurable "move video position custom" forward/back jumps (custom 3 and 4)
+* Main and binary-edit menu: Alt/F10 toggle menu activation and Escape deactivates it (Windows standard) - thx GrampaWildWilly
+* Update Polish translation - thx Adam Malich
+* Update Japanese translation - thx hisui3393
+* Fix video playback speed reverting to 1.0x after changing settings or layout - thx Hakunamatata67
 
 -----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds beta2 change-log entries for this session's merged work:

- Spell-check source image — reworded to cover auto-attach after OCR plus the manual loader's added formats (transport stream, Matroska) (#11892)
- Two more configurable "move video position custom" forward/back jumps (#11893)
- Main + binary-edit menu Alt/F10 toggle and Escape deactivation (#11900)
- Polish (#11898) and Japanese (#11899) translation updates
- Fix playback speed reverting to 1.0x after settings/layout change (#11901)

🤖 Generated with [Claude Code](https://claude.com/claude-code)