### PR TITLE
change-log.txt: credit contributors for beta2 work

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -14,11 +14,16 @@ v5.1.0-beta2 (TBD)
 * Fix "Change speed" radio buttons disabled/not respected in the main window - thx mjuhasz
 * Binary edit: wire up "Change speed", respect the selected-lines radio, and always apply "Change frame rate" to all lines - thx mjuhasz
 * Binary edit: keep the grid scroll position after "Adjust all times" and "Change speed" - thx mjuhasz
+* Binary edit: add "Adjust color" for selected lines in the image-based subtitle editor (Tools > Selected lines) - thx mjuhasz
 * Spell check: show the source image for the current line - auto-attached after OCR, or loaded via the image button left of Done (Blu-ray sup, VobSub, BDN XML, transport stream, Matroska) - thx fraternl
 * Add two more configurable "move video position custom" forward/back jumps (custom 3 and 4)
 * Main and binary-edit menu: Alt/F10 toggle menu activation and Escape deactivates it (Windows standard) - thx GrampaWildWilly
 * Update Polish translation - thx Adam Malich
 * Update Japanese translation - thx hisui3393
+* Update Italian translation - thx bovirus
+* Update Bulgarian translation - thx jekovcar
+* Update Russian translation - thx jekovcar
+* Use asynchronous JSON serialization in the plugin runner - thx ivandrofly
 * Fix video playback speed reverting to 1.0x after changing settings or layout - thx Hakunamatata67
 
 -----------------------------------------------------------------------------------------------------

--- a/change-log.txt
+++ b/change-log.txt
@@ -10,10 +10,10 @@ v5.1.0-beta2 (TBD)
 * seconv: expose the Fix-common-errors profile values (min gap, CPS, max lines, dialog/continuation style, ...) in --settings JSON - thx Rouzax
 * Add option to not auto-generate the waveform when opening a video (click the empty waveform to generate) - thx nugemon
 * "Set up like Subtitle Edit 4" now shows grid line breaks as "<br />" on a single row, like SE4 - thx bichitoxxx
-* Redesign the "Change speed" dialog to match the "Adjust all times" dialog
-* Fix "Change speed" radio buttons disabled/not respected in the main window
-* Binary edit: wire up "Change speed", respect the selected-lines radio, and always apply "Change frame rate" to all lines
-* Binary edit: keep the grid scroll position after "Adjust all times" and "Change speed"
+* Redesign the "Change speed" dialog to match the "Adjust all times" dialog - thx mjuhasz
+* Fix "Change speed" radio buttons disabled/not respected in the main window - thx mjuhasz
+* Binary edit: wire up "Change speed", respect the selected-lines radio, and always apply "Change frame rate" to all lines - thx mjuhasz
+* Binary edit: keep the grid scroll position after "Adjust all times" and "Change speed" - thx mjuhasz
 * Spell check: show the source image for the current line - auto-attached after OCR, or loaded via the image button left of Done (Blu-ray sup, VobSub, BDN XML, transport stream, Matroska) - thx fraternl
 * Add two more configurable "move video position custom" forward/back jumps (custom 3 and 4)
 * Main and binary-edit menu: Alt/F10 toggle menu activation and Escape deactivates it (Windows standard) - thx GrampaWildWilly


### PR DESCRIPTION
Adds credits / entries for v5.1.0-beta2 contributions from external contributors.

**Credited existing entries** (from #11887 and #11880):
- Redesign "Change speed" dialog; fix radio buttons; binary edit change-speed wiring; keep grid scroll position — thx mjuhasz

**New entries added (with credits):**
- Binary edit "Adjust color" for selected lines (#11894) — thx mjuhasz
- Update Italian translation (#11891) — thx bovirus
- Update Bulgarian translation (#11886) — thx jekovcar
- Update Russian translation (#11885) — thx jekovcar
- Async JSON serialization in the plugin runner (#11879) — thx ivandrofly

🤖 Generated with [Claude Code](https://claude.com/claude-code)