### PR TITLE
Fix bug-hunt findings in recent menu and spell-check work

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1669,6 +1669,7 @@ public partial class MainViewModel :
 
         AddToRecentFiles(true);
         ResetSubtitle();
+        ClearOcrImageSource();
         VideoCloseFile();
         AddToRecentFiles(false);
     }
@@ -1684,7 +1685,18 @@ public partial class MainViewModel :
 
         AddToRecentFiles(true);
         ResetSubtitle();
+        ClearOcrImageSource();
         AddToRecentFiles(false);
+    }
+
+    // Drop any image source kept from a previous OCR session when starting a fresh subtitle, so spell
+    // check does not show unrelated images. This is intentionally NOT in ResetSubtitle(), which the OCR
+    // import flows call right before ReplaceSubtitles - clearing there would wipe the just-OCR'd source
+    // and break the spell-check auto-attach for image-based formats (#11719).
+    private void ClearOcrImageSource()
+    {
+        _ocrImageSourceHolder.Source = null;
+        _ocrImageSourceHolder.FileName = null;
     }
 
     private void ResetSubtitle(SubtitleFormat? format = null)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18519,6 +18519,13 @@ public partial class MainViewModel :
 
             _lastKeyPressedMs = ms;
 
+            // Arm a "bare Alt" toggle so its release can activate/deactivate the menu bar (Windows
+            // standard). This must run before the early-returns below so that any other key in an Alt
+            // chord (e.g. Space in Alt+Space, which opens the window system menu and returns early)
+            // clears it; the modifier check rejects AltGr (Ctrl+Alt) on international keyboards. The
+            // toggle itself happens on key-up (OnKeyUpHandler) (#11745).
+            _altMenuTogglePending = (k is Key.LeftAlt or Key.RightAlt) && keyEventArgs.KeyModifiers == KeyModifiers.Alt;
+
             if (UiUtil.TryHandleWindowSystemMenu(keyEventArgs, Window))
             {
                 return;
@@ -18554,11 +18561,6 @@ public partial class MainViewModel :
                     return;
                 }
             }
-
-            // Arm a "bare Alt" toggle so its release can activate/deactivate the menu bar (Windows
-            // standard). Any other key pressed while Alt is held (e.g. the access key in Alt+F) cancels
-            // it, so only Alt-alone toggles. The actual toggle happens on key-up (OnKeyUpHandler).
-            _altMenuTogglePending = k is Key.LeftAlt or Key.RightAlt;
 
             // When the main menu has keyboard focus (opened via F10 or Alt), let it own its arrow/Enter
             // navigation instead of consuming those keys as shortcuts. The window key handler tunnels

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1949,8 +1949,8 @@ public partial class BinaryEditViewModel : ObservableObject
 
         // Arm a "bare Alt" toggle so its release can activate/deactivate the menu bar (Windows
         // standard). Any other key while Alt is held (e.g. the access key in Alt+F) cancels it; the
-        // toggle itself happens on key-up (OnKeyUp).
-        _altMenuTogglePending = e.Key is Key.LeftAlt or Key.RightAlt;
+        // modifier check rejects AltGr (Ctrl+Alt). The toggle itself happens on key-up (OnKeyUp).
+        _altMenuTogglePending = (e.Key is Key.LeftAlt or Key.RightAlt) && e.KeyModifiers == KeyModifiers.Alt;
 
         // While the menu has keyboard focus, let it own its own navigation keys. The window key
         // handler runs even on keys the menu already handled (handledEventsToo: true), so without
@@ -1959,7 +1959,11 @@ public partial class BinaryEditViewModel : ObservableObject
         // focus instead of leaving it half-focused (and without closing the whole window) (#11745).
         if (IsMenuFocused())
         {
-            if (e.Key == Key.Escape && Menu is { IsOpen: false })
+            // Only deactivate when this Escape did not just close an open drop-down. The handler runs
+            // (handledEventsToo) after the focused MenuItem, which marks the event handled when it
+            // closes a submenu - so !e.Handled distinguishes "leave the bar" from "close the submenu",
+            // giving the two-stage Escape behavior instead of collapsing both in one press (#11745).
+            if (e.Key == Key.Escape && !e.Handled && Menu is { IsOpen: false })
             {
                 DeactivateMenu();
                 e.Handled = true;

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -377,9 +377,14 @@ public partial class SpellCheckViewModel : ObservableObject
     // by timecode, which survives merges/deletes better than a plain index).
     private void UpdateSourceImage()
     {
+        // Dispose the previously shown bitmap before replacing it; UpdateSourceImage runs on every
+        // line change during a spell-check pass, and both the Avalonia Bitmap and the SKBitmap hold
+        // unmanaged memory, so without this a long pass leaks one bitmap per line (#11719).
         if (_ocrSourceImages == null || SelectedParagraph == null || _ocrSourceImages.Count == 0)
         {
+            var previousEmpty = SourceImage;
             SourceImage = null;
+            previousEmpty?.Dispose();
             return;
         }
 
@@ -396,14 +401,18 @@ public partial class SpellCheckViewModel : ObservableObject
             }
         }
 
+        var previous = SourceImage;
         try
         {
-            SourceImage = _ocrSourceImages.GetBitmap(bestIndex).ToAvaloniaBitmap();
+            using var sourceBitmap = _ocrSourceImages.GetBitmap(bestIndex);
+            SourceImage = sourceBitmap.ToAvaloniaBitmap();
         }
         catch
         {
             SourceImage = null;
         }
+
+        previous?.Dispose();
     }
 
     public void Initialize(ObservableCollection<SubtitleLineViewModel> paragraphs, int? selectedSubtitleIndex, IFocusSubtitleLine focusSubtitleLine, string? dictionaryFileName)


### PR DESCRIPTION
Fixes found during a bug hunt over the recent beta2 commits. All confirmed by reading the code.

### Menu keyboard handling (follow-up to #11900)
- **Alt+Space spuriously opened the menu (Windows).** The bare-Alt toggle was armed on Alt-down but `TryHandleWindowSystemMenu` returned before the arming/clearing line, so the Space in Alt+Space never cleared it and releasing Alt opened the menu bar. The arming now runs *before* the early returns and only arms for Alt with no other modifier.
- **AltGr tap toggled the menu (international keyboards).** AltGr = Ctrl+RightAlt; a bare AltGr tap ended with the toggle armed. Arming now requires `KeyModifiers == Alt` (main + binary edit), rejecting AltGr.
- **Binary edit: single Escape over-collapsed the menu.** Because that window's key handler runs after the focused MenuItem, one Escape both closed the drop-down and deactivated the bar. Now guarded with `!e.Handled` so the first Escape only closes the drop-down (two-stage, matching the main window).

### Spell-check source image (follow-up to #11892)
- **Bitmap leak per line.** `UpdateSourceImage` runs on every line change during a spell-check pass and replaced `SourceImage` without disposing the old Avalonia `Bitmap` (or the intermediate `SKBitmap`) — leaking one of each per line. Now disposes the previous bitmap and `using`s the SKBitmap.

Build passes; app launches cleanly. The menu behaviors are Windows/Linux-only (no-op on macOS native menu) and are best confirmed on a Windows/Linux box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)