### PR TITLE
Fix recent issue reports: waveform More tooltip, edit-box focus, OCR user partial-words

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -657,6 +657,7 @@ public class InitWaveform
         var buttonMore = new NonSpaceButton
         {
             Margin = new Thickness(settingMore.LeftMargin, 0, settingMore.RightMargin, 0),
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(Se.Language.General.More, shortcuts),
         };
         Attached.SetIcon(buttonMore, "fa-ellipsis-v");
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12054,7 +12054,7 @@ public partial class MainViewModel :
 
     private void FocusEditTextBox()
     {
-        Dispatcher.UIThread.Post(() =>
+        Dispatcher.UIThread.Post(async () =>
         {
             if (AudioVisualizer != null && AudioVisualizer.IsFocused)
             {
@@ -12063,7 +12063,7 @@ public partial class MainViewModel :
 
             ActivateWindow(Window);
             EditTextBox.Focus();
-            Task.Delay(10);
+            await Task.Delay(10);
             EditTextBox.Focus();
         });
     }

--- a/src/ui/Features/Ocr/FixEngine/OcrFixReplaceList2.cs
+++ b/src/ui/Features/Ocr/FixEngine/OcrFixReplaceList2.cs
@@ -95,6 +95,51 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 }
             }
 
+            foreach (var kp in LoadReplaceList(userDoc, "RemovedPartialWords"))
+            {
+                if (_partialWordReplaceList.ContainsKey(kp.Key))
+                {
+                    _partialWordReplaceList.Remove(kp.Key);
+                }
+            }
+            foreach (var kp in LoadReplaceList(userDoc, "PartialWords"))
+            {
+                if (!_partialWordReplaceList.ContainsKey(kp.Key))
+                {
+                    _partialWordReplaceList.Add(kp.Key, kp.Value);
+                }
+            }
+
+            foreach (var kp in LoadReplaceList(userDoc, "RemovedPartialWordsAlways"))
+            {
+                if (_partialWordAlwaysReplaceList.ContainsKey(kp.Key))
+                {
+                    _partialWordAlwaysReplaceList.Remove(kp.Key);
+                }
+            }
+            foreach (var kp in LoadReplaceList(userDoc, "PartialWordsAlways"))
+            {
+                if (!_partialWordAlwaysReplaceList.ContainsKey(kp.Key))
+                {
+                    _partialWordAlwaysReplaceList.Add(kp.Key, kp.Value);
+                }
+            }
+
+            foreach (var kp in LoadReplaceList(userDoc, "RemovedPartialLinesAlways"))
+            {
+                if (_partialLineAlwaysReplaceList.ContainsKey(kp.Key))
+                {
+                    _partialLineAlwaysReplaceList.Remove(kp.Key);
+                }
+            }
+            foreach (var kp in LoadReplaceList(userDoc, "PartialLinesAlways"))
+            {
+                if (!_partialLineAlwaysReplaceList.ContainsKey(kp.Key))
+                {
+                    _partialLineAlwaysReplaceList.Add(kp.Key, kp.Value);
+                }
+            }
+
             foreach (var kp in LoadReplaceList(userDoc, "RemovedBeginLines"))
             {
                 if (_beginLineReplaceList.ContainsKey(kp.Key))


### PR DESCRIPTION
Three fixes found while triaging recent open issues during the bug hunt.

- **#11895** — the waveform **"More" (…)** toolbar button had no tooltip, unlike its neighbours (Center, Auto-select). Added `ToolTip.Tip`. (Note: the Center toggle next to it already has its tip set in code; if it still doesn't show, that's a separate runtime/ToggleButton matter needing a Windows repro.)
- **#11700** — `FocusEditTextBox` had `Task.Delay(10);` **not awaited** (fire-and-forget), so the intended "focus, wait, focus again" retry collapsed into two back-to-back `Focus()` calls. Now `await`ed (lambda made async). Plausibly the rc-4 edit-box focus complaint.
- **#11722** — the per-language `*_User.xml` OCR-fix list was loaded, but the user-file merge only covered WholeWords / PartialLines / Begin/End/WholeLines / RegularExpressions. **PartialWords, PartialWordsAlways and PartialLinesAlways** (and their `Removed*` counterparts) were skipped, so a Dutch user's partial-word entries in `nld_OCRFixReplaceList_User.xml` were silently ignored. Now merged like the others.

Build passes; app launches cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)