### PR TITLE
Fix UITests build: expose libuilogic internals

### DIFF
--- a/src/libuilogic/Properties/AssemblyInfo.cs
+++ b/src/libuilogic/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UITests")]

--- a/tests/UI/Features/SpellCheck/UserDictionaryNormalizationTests.cs
+++ b/tests/UI/Features/SpellCheck/UserDictionaryNormalizationTests.cs
@@ -17,6 +17,7 @@ public class UserDictionaryNormalizationTests : IDisposable
     private readonly string _nfdWord = HangulWord.Normalize(NormalizationForm.FormD);
 
     private readonly string _originalDictionariesFolder;
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
     private readonly string _tempDictionariesFolder;
 
     public UserDictionaryNormalizationTests()
@@ -24,11 +25,15 @@ public class UserDictionaryNormalizationTests : IDisposable
         // Redirect the dictionaries folder to an isolated temp dir so the real
         // user dictionary is not touched and pre-existing words don't leak in.
         _originalDictionariesFolder = Se.DictionariesFolder;
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
         _tempDictionariesFolder = Path.Combine(
             Path.GetTempPath(),
             "SeUserDictTest_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempDictionariesFolder);
         Se.DictionariesFolder = _tempDictionariesFolder;
+        // SpellCheckWordLists reads its folder from SpellCheckConfig (wired to Se in Program.cs at
+        // startup, which the tests don't run); point it at the same temp dir.
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
     }
 
     [Fact]
@@ -51,6 +56,7 @@ public class UserDictionaryNormalizationTests : IDisposable
     public void Dispose()
     {
         Se.DictionariesFolder = _originalDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
         try
         {
             Directory.Delete(_tempDictionariesFolder, recursive: true);


### PR DESCRIPTION
## Summary
- `OcrFixEngine.SplitLine` (an `internal` member) was moved from the `ui` project into the new `libuilogic` project, but `InternalsVisibleTo("UITests")` existed only in `UI.csproj`. This broke the `UITests` build with `CS0117: 'OcrFixEngine' does not contain a definition for 'SplitLine'`.
- Added `src/libuilogic/Properties/AssemblyInfo.cs` with `[assembly: InternalsVisibleTo("UITests")]`. A code file is used rather than the MSBuild `<AssemblyAttribute>` item because `LibUiLogic.csproj` sets `GenerateAssemblyInfo=false`, which would skip a generated attribute.

## Test plan
- [x] `dotnet build tests/UI/UITests.csproj` succeeds (previously failed with CS0117).
- [x] `dotnet test tests/UI/UITests.csproj --filter "ClassName~OcrFixEngineSplitLineTests"` runs the `SplitLine` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)