### PR TITLE
Fix text-box shortcuts (Selection to lowercase, etc.) being dead and hidden

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2519,6 +2519,7 @@
       "categorySubtitleGridAndTextBox": "Subtitle list view & text box",
       "categorySubtitleGrid": "Subtitle list view",
       "categoryWaveform": "Waveform",
+      "categoryTextBox": "Text box",
       "generalSetupLikeSe4": "Set up like Subtitle Edit 4 (theme, shortcuts, replace rules)",
       "generalMergeSelectedLines": "Merge selected lines",
       "generalMergeWithPrevious": "Merge with previous",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18747,6 +18747,18 @@ public partial class MainViewModel :
             // "Toggle dialog dashes" works in whichever text box has focus, like SE 4).
             if (EditTextBox.IsFocused || EditTextBoxOriginal.IsFocused)
             {
+                // TextBox-category shortcuts (e.g. "Selection to lowercase" Ctrl+U, SE4 parity) are
+                // dispatched here - they were previously registered but never run (#11906). The native
+                // clipboard commands (Cut/Copy/Paste/Select all) are skipped so Avalonia's built-in
+                // handling keeps working on whichever text box is focused.
+                var textBoxCommand = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.TextBox.ToString());
+                if (textBoxCommand != null && !IsNativeTextBoxClipboardCommand(textBoxCommand))
+                {
+                    keyEventArgs.Handled = true;
+                    textBoxCommand.Execute(null);
+                    return;
+                }
+
                 var relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.SubtitleGridAndTextBox.ToString());
                 if (relayCommand != null)
                 {
@@ -18767,6 +18779,17 @@ public partial class MainViewModel :
             }
         }
     }
+
+    // These TextBox-category commands duplicate Avalonia's built-in TextBox key handling and are
+    // hardcoded to the primary EditTextBox, so we let the focused control handle them natively
+    // instead of routing them through the shortcut manager (they remain for the right-click menu).
+    private bool IsNativeTextBoxClipboardCommand(IRelayCommand command) =>
+        ReferenceEquals(command, TextBoxCutCommand) ||
+        ReferenceEquals(command, TextBoxCut2Command) ||
+        ReferenceEquals(command, TextBoxCopyCommand) ||
+        ReferenceEquals(command, TextBoxPasteCommand) ||
+        ReferenceEquals(command, TextBoxSelectAllCommand) ||
+        ReferenceEquals(command, TextBoxDeleteSelectionCommand);
 
     public void OnKeyUpHandler(object? sender, KeyEventArgs e)
     {

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -239,6 +239,7 @@ public partial class ShortcutsViewModel : ObservableObject
             Se.Language.Options.Shortcuts.CategorySubtitleGridAndTextBox, searchText);
         AddShortcuts(ShortcutCategory.SubtitleGrid, Se.Language.Options.Shortcuts.CategorySubtitleGrid, searchText);
         AddShortcuts(ShortcutCategory.Waveform, Se.Language.Options.Shortcuts.CategoryWaveform, searchText);
+        AddShortcuts(ShortcutCategory.TextBox, Se.Language.Options.Shortcuts.CategoryTextBox, searchText);
     }
 
     private void AddShortcuts(ShortcutCategory category, string categoryName, string searchText)

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -13,6 +13,7 @@ public class LanguageSettingsShortcuts
     public string CategorySubtitleGridAndTextBox { get; set; }
     public string CategorySubtitleGrid { get; set; }
     public string CategoryWaveform { get; set; }
+    public string CategoryTextBox { get; set; }
 
     public string GeneralSetupLikeSe4 { get; set; }
 
@@ -314,6 +315,7 @@ public class LanguageSettingsShortcuts
         CategorySubtitleGridAndTextBox = "Subtitle list view & text box";
         CategorySubtitleGrid = "Subtitle list view";
         CategoryWaveform = "Waveform";
+        CategoryTextBox = "Text box";
 
         GeneralSetupLikeSe4 = "Set up like Subtitle Edit 4 (theme, shortcuts, replace rules)";
         GeneralMergeSelectedLines = "Merge selected lines";


### PR DESCRIPTION
Fixes #11906 — Ctrl+U "Text box: Selection to lowercase" did nothing, wasn't in Options → Shortcuts, yet still showed up as a conflict when assigning Ctrl+U elsewhere.

## Root cause
The whole `ShortcutCategory.TextBox` was half-wired: its commands (`SelectionToLower`/`Upper`, `GoogleIt`, `SplitAtTextBoxCursorPosition`, `TextBoxItalic`, …) were registered with default keys (so conflict detection saw them), but:
- **Never dispatched** — `OnKeyDownHandler` only checks `SubtitleGridAndTextBox` when a text box is focused; `TextBox` was checked nowhere. So Ctrl+U etc. never fired.
- **Never shown** — the Shortcuts settings tree was built from only General / SubtitleGridAndTextBox / SubtitleGrid / Waveform.

## Fix
- Dispatch the `TextBox` category when an edit box is focused, so the SE4 feature works again. The native clipboard commands (`Cut/Copy/Paste/Select all`, hardcoded to the primary box and handled natively by Avalonia) are explicitly skipped, so clipboard keys keep working correctly on whichever text box has focus — no double-handling/regression.
- Add the **"Text box"** category to Options → Shortcuts (`CategoryTextBox` string + English.json), so these shortcuts are visible and rebindable. The reporter can now use Ctrl+U for lowercase *or* rebind it for "Toggle focus".

## Test
Build clean; app launches; UI + tests unaffected. Behavior: with text selected in the edit box, Ctrl+U lowercases / Ctrl+Shift+U uppercases; the "Text box" group now appears in Options → Shortcuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)