### PR TITLE
Fix EBU STL Save/Save As writing an invalid 14-byte file

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15992,6 +15992,14 @@ public partial class MainViewModel :
             AutoTrimWhiteSpaces();
         }
 
+        // Binary formats (EBU STL, PAC, Cavena, ...) can't be written as text: their ToText() returns
+        // a stub (EBU's is literally "Not supported!", the 14-byte file in #11910). Persist them via
+        // their binary writer instead of WriteAllText.
+        if (SelectedSubtitleFormat is IBinaryPersistableSubtitle binaryFormat)
+        {
+            return await SaveBinarySubtitle(binaryFormat, isAutoSave);
+        }
+
         var text = GetUpdateSubtitle(true).ToText(SelectedSubtitleFormat);
 
         if (Se.Settings.General.ForceCrLfOnSave)
@@ -16033,6 +16041,53 @@ public partial class MainViewModel :
 
             await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK,
                 MessageBoxIcon.Error);
+            return false;
+        }
+
+        _changeSubtitleHash = GetFastHash();
+        _lastOpenSaveFormat = SelectedSubtitleFormat;
+
+        new BookmarkPersistence(GetUpdateSubtitle(), _subtitleFileName).Save();
+
+        return true;
+    }
+
+    // Writes a binary subtitle format (e.g. EBU STL) via its IBinaryPersistableSubtitle writer,
+    // in batch mode so it re-uses the existing/auto-detected header without a dialog. Fixes the
+    // 14-byte invalid file produced when these formats went through the text save path (#11910).
+    private async Task<bool> SaveBinarySubtitle(IBinaryPersistableSubtitle binaryFormat, bool isAutoSave)
+    {
+        try
+        {
+            // EBU STL needs a UI helper to resolve its header; reuse the same one as File > Export.
+            if (binaryFormat is Ebu)
+            {
+                Ebu.EbuUiHelper ??= new UiEbuSaveHelper();
+            }
+
+            using var ms = new MemoryStream();
+            if (!binaryFormat.Save(_subtitleFileName, ms, GetUpdateSubtitle(true), batchMode: true))
+            {
+                if (!isAutoSave)
+                {
+                    ShowStatus(string.Format(Se.Language.General.CouldNotSaveFileXErrorY, _subtitleFileName, string.Empty));
+                }
+
+                return false;
+            }
+
+            await File.WriteAllBytesAsync(_subtitleFileName, ms.ToArray());
+        }
+        catch (Exception ex)
+        {
+            var message = string.Format(Se.Language.General.CouldNotSaveFileXErrorY, _subtitleFileName, ex.Message);
+            if (isAutoSave)
+            {
+                ShowStatus(message);
+                return false;
+            }
+
+            await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return false;
         }
 

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -1,0 +1,68 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Interfaces;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.IO;
+
+namespace LibSETests.SubtitleFormats;
+
+public class EbuTest
+{
+    // Minimal headless stand-in for the UI's EBU save helper so the binary writer can run in a test.
+    private sealed class TestEbuUiHelper : Ebu.IEbuUiHelper
+    {
+        public byte JustificationCode { get; set; }
+        public void Initialize(Ebu.EbuGeneralSubtitleInformation header, byte justificationCode, string fileName, Subtitle subtitle) { }
+        public bool ShowDialogOk() => true;
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("Second line", 4000, 6000));
+        return subtitle;
+    }
+
+    // Regression for #11910: EBU STL Save produced a 14-byte invalid file ("Not supported!")
+    // because the binary format went through the text save path. The binary writer must emit a real
+    // EBU file (1024-byte GSI header + TTI blocks) that reads back.
+    [Fact]
+    public void EbuStl_BinarySave_ProducesValidFileNotFourteenByteStub()
+    {
+        Ebu.EbuUiHelper = new TestEbuUiHelper();
+        var subtitle = MakeSubtitle();
+
+        using var ms = new MemoryStream();
+        var ok = ((IBinaryPersistableSubtitle)new Ebu()).Save("test.stl", ms, subtitle, batchMode: true);
+        var bytes = ms.ToArray();
+
+        Assert.True(ok);
+        Assert.True(bytes.Length >= 1024, $"EBU file is only {bytes.Length} bytes (regression #11910)");
+    }
+
+    [Fact]
+    public void EbuStl_BinarySave_RoundTripsParagraphs()
+    {
+        Ebu.EbuUiHelper = new TestEbuUiHelper();
+        var subtitle = MakeSubtitle();
+
+        using var ms = new MemoryStream();
+        ((IBinaryPersistableSubtitle)new Ebu()).Save("test.stl", ms, subtitle, batchMode: true);
+
+        var loaded = new Subtitle();
+        new Ebu().LoadSubtitle(loaded, ms.ToArray());
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Contains("Hello world", loaded.Paragraphs[0].Text);
+        Assert.Contains("Second line", loaded.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void EbuStl_ToText_IsNotUsableForSaving()
+    {
+        // Guards the root cause: ToText is a stub for this binary format, so the save path must use
+        // the IBinaryPersistableSubtitle writer instead (#11910).
+        Assert.IsAssignableFrom<IBinaryPersistableSubtitle>(new Ebu());
+        Assert.True(new Ebu().ToText(MakeSubtitle(), string.Empty).Length < 20);
+    }
+}


### PR DESCRIPTION
Fixes #11910 — editing an EBU STL file and using **Save**/**Save As** produced a 14-byte invalid file (only File → Export worked).

## Root cause
`SaveSubtitle` (the path both Save and Save As use) always does `SelectedSubtitleFormat.ToText()` + `WriteAllText`. EBU STL is a **binary** format whose `ToText()` returns the stub `"Not supported!"` — exactly 14 bytes. Binary formats only had a working writer via the dedicated File → Export commands.

## Fix
In `SaveSubtitle`, route `IBinaryPersistableSubtitle` formats (EBU STL, PAC, Cavena, CapMaker, …) through their binary writer (`Save(... Stream ...)` + `WriteAllBytes`) instead of the text path. New `SaveBinarySubtitle` helper:
- Wires EBU's UI save helper (same one File → Export uses).
- Saves in **batch mode** so it reuses the existing/auto-detected GSI header without popping a dialog on every Ctrl+S.

## Tests
Added `tests/libse/SubtitleFormats/EbuTest.cs`:
- binary save produces a valid file (≥ 1024-byte GSI header, not the 14-byte stub),
- paragraphs round-trip through Save → Load,
- guard that `Ebu` is `IBinaryPersistableSubtitle` and its `ToText` is a stub (documents why the binary path is required).

Full solution builds with 0 warnings; all tests pass (libse 473, incl. 3 new). App launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)