### PR TITLE
BinaryEdit window: correctness, resource safety, and selection fixes

### DIFF
--- a/src/ui/Features/Assa/AssaImageColorPicker/AssaImageColorPickerViewModel.cs
+++ b/src/ui/Features/Assa/AssaImageColorPicker/AssaImageColorPickerViewModel.cs
@@ -117,7 +117,7 @@ public partial class AssaImageColorPickerViewModel : ObservableObject
 
         if (string.IsNullOrEmpty(videoFileName))
         {
-            Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetHeight, TargetHeight);
+            Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetWidth, TargetHeight);
             return;
         }
 
@@ -130,12 +130,12 @@ public partial class AssaImageColorPickerViewModel : ObservableObject
             }
             catch
             {
-                Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetHeight, TargetHeight);
+                Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetWidth, TargetHeight);
             }
         }
         else
         {
-            Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetHeight, TargetHeight);
+            Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetWidth, TargetHeight);
         }
 
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
@@ -48,7 +48,7 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject, IDisposable
         };
         _previewUpdateTimer.Tick += (_, _) =>
         {
-            _previewUpdateTimer.Stop();
+            _previewUpdateTimer?.Stop();
             if (_isDirty)
             {
                 _isDirty = false;
@@ -240,7 +240,9 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
+        _isDirty = false;
         _previewUpdateTimer?.Stop();
+        _previewUpdateTimer = null;
         var oldPreview = PreviewBitmap;
         PreviewBitmap = null;
         oldPreview?.Dispose();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustAlpha;
 
-public partial class BinaryAdjustAlphaViewModel : ObservableObject
+public partial class BinaryAdjustAlphaViewModel : ObservableObject, IDisposable
 {
     [ObservableProperty] private double _alphaAdjustment;
     [ObservableProperty] private double _transparencyThreshold;
@@ -105,13 +105,15 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject
 
         var firstSubtitle = _subtitles[0];
         using var originalBitmap = firstSubtitle.Bitmap!.ToSkBitmap();
-        
-        // Create checkered background
+
+        var oldBg = CheckeredBackgroundBitmap;
         CheckeredBackgroundBitmap = CreateCheckeredBackground(originalBitmap.Width, originalBitmap.Height);
-        
-        // Apply alpha adjustments
-        var adjustedBitmap = AdjustAlpha(originalBitmap, (float)AlphaAdjustment, (byte)TransparencyThreshold);
+        oldBg?.Dispose();
+
+        using var adjustedBitmap = AdjustAlpha(originalBitmap, (float)AlphaAdjustment, (byte)TransparencyThreshold);
+        var old = PreviewBitmap;
         PreviewBitmap = adjustedBitmap.ToAvaloniaBitmap();
+        old?.Dispose();
     }
 
     public void ApplyAdjustments()
@@ -124,8 +126,10 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject
             }
 
             using var originalBitmap = subtitle.Bitmap.ToSkBitmap();
-            var adjustedBitmap = AdjustAlpha(originalBitmap, (float)AlphaAdjustment, (byte)TransparencyThreshold);
+            using var adjustedBitmap = AdjustAlpha(originalBitmap, (float)AlphaAdjustment, (byte)TransparencyThreshold);
+            var old = subtitle.Bitmap;
             subtitle.Bitmap = adjustedBitmap.ToAvaloniaBitmap();
+            old?.Dispose();
         }
     }
 
@@ -184,7 +188,7 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject
     public static Bitmap CreateCheckeredBackground(int width, int height)
     {
         const int checkSize = 10;
-        var bitmap = new SKBitmap(width, height);
+        using var bitmap = new SKBitmap(width, height);
         
         using (var canvas = new SKCanvas(bitmap))
         {
@@ -232,5 +236,16 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+    }
+
+    public void Dispose()
+    {
+        _previewUpdateTimer?.Stop();
+        var oldPreview = PreviewBitmap;
+        PreviewBitmap = null;
+        oldPreview?.Dispose();
+        var oldBg = CheckeredBackgroundBitmap;
+        CheckeredBackgroundBitmap = null;
+        oldBg?.Dispose();
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
@@ -131,20 +131,20 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject
 
     private static SKBitmap AdjustAlpha(SKBitmap originalBitmap, float alphaAdjustment, byte transparencyThreshold)
     {
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height);
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
 
         unsafe
         {
             var originalPixels = originalBitmap.GetPixels();
             var adjustedPixels = adjustedBitmap.GetPixels();
-            
+
             for (int y = 0; y < originalBitmap.Height; y++)
             {
                 for (int x = 0; x < originalBitmap.Width; x++)
                 {
                     var index = y * originalBitmap.Width + x;
                     var pixel = ((uint*)originalPixels)[index];
-                    
+
                     var a = (byte)((pixel >> 24) & 0xFF);
                     var r = (byte)((pixel >> 16) & 0xFF);
                     var g = (byte)((pixel >> 8) & 0xFF);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaWindow.cs
@@ -173,12 +173,7 @@ public class BinaryAdjustAlphaWindow : Window
             VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
         };
 
-        // Canvas with checkered background and image overlay
-        var canvas = new Canvas
-        {
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
+        var grid = new Grid();
 
         var backgroundImage = new Image
         {
@@ -187,7 +182,7 @@ public class BinaryAdjustAlphaWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             [!Image.SourceProperty] = new Binding(nameof(vm.CheckeredBackgroundBitmap)),
         };
-        canvas.Children.Add(backgroundImage);
+        grid.Children.Add(backgroundImage);
 
         var previewImage = new Image
         {
@@ -196,9 +191,9 @@ public class BinaryAdjustAlphaWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             [!Image.SourceProperty] = new Binding(nameof(vm.PreviewBitmap)),
         };
-        canvas.Children.Add(previewImage);
+        grid.Children.Add(previewImage);
 
-        scrollViewer.Content = canvas;
+        scrollViewer.Content = grid;
 
         vm.PreviewImage = previewImage;
         vm.BackgroundImage = backgroundImage;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
@@ -49,7 +49,7 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject, IDispos
         };
         _previewUpdateTimer.Tick += (_, _) =>
         {
-            _previewUpdateTimer.Stop();
+            _previewUpdateTimer?.Stop();
             if (_isDirty)
             {
                 _isDirty = false;
@@ -230,7 +230,9 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject, IDispos
 
     public void Dispose()
     {
+        _isDirty = false;
         _previewUpdateTimer?.Stop();
+        _previewUpdateTimer = null;
         var old = PreviewBitmap;
         PreviewBitmap = null;
         old?.Dispose();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustBrightness;
 
-public partial class BinaryAdjustBrightnessViewModel : ObservableObject
+public partial class BinaryAdjustBrightnessViewModel : ObservableObject, IDisposable
 {
     [ObservableProperty] private double _brightness;
     [ObservableProperty] private double _contrast;
@@ -113,9 +113,10 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject
 
         var firstSubtitle = _subtitles[0];
         using var originalBitmap = firstSubtitle.Bitmap!.ToSkBitmap();
-        
-        var adjustedBitmap = AdjustBrightness(originalBitmap, (float)Brightness, (float)Contrast, (float)(Gamma / 100.0));
+        using var adjustedBitmap = AdjustBrightness(originalBitmap, (float)Brightness, (float)Contrast, (float)(Gamma / 100.0));
+        var old = PreviewBitmap;
         PreviewBitmap = adjustedBitmap.ToAvaloniaBitmap();
+        old?.Dispose();
     }
 
     public void ApplyAdjustments()
@@ -128,8 +129,10 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject
             }
 
             using var originalBitmap = subtitle.Bitmap.ToSkBitmap();
-            var adjustedBitmap = AdjustBrightness(originalBitmap, (float)Brightness, (float)Contrast, (float)(Gamma / 100.0));
+            using var adjustedBitmap = AdjustBrightness(originalBitmap, (float)Brightness, (float)Contrast, (float)(Gamma / 100.0));
+            var old = subtitle.Bitmap;
             subtitle.Bitmap = adjustedBitmap.ToAvaloniaBitmap();
+            old?.Dispose();
         }
     }
 
@@ -223,5 +226,13 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+    }
+
+    public void Dispose()
+    {
+        _previewUpdateTimer?.Stop();
+        var old = PreviewBitmap;
+        PreviewBitmap = null;
+        old?.Dispose();
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
@@ -135,8 +135,8 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject
 
     private static SKBitmap AdjustBrightness(SKBitmap originalBitmap, float brightness, float contrast, float gamma)
     {
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height);
-        
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+
         // Normalize values for calculations
         var brightnessAdjust = brightness; // -100 to 100
         var contrastAdjust = (contrast + 100) / 100.0f; // Convert -100 to 100 range to 0 to 2 multiplier

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustColor;
 
-public partial class BinaryAdjustColorViewModel : ObservableObject
+public partial class BinaryAdjustColorViewModel : ObservableObject, IDisposable
 {
     [ObservableProperty] private Color _selectedColor;
     [ObservableProperty] private IBrush _colorSwatchBrush;
@@ -102,8 +102,10 @@ public partial class BinaryAdjustColorViewModel : ObservableObject
         }
 
         using var originalBitmap = _subtitles[0].Bitmap!.ToSkBitmap();
-        var coloredBitmap = ColorBitmap(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
+        using var coloredBitmap = ColorBitmap(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
+        var old = PreviewBitmap;
         PreviewBitmap = coloredBitmap.ToAvaloniaBitmap();
+        old?.Dispose();
     }
 
     public void ApplyAdjustments()
@@ -116,8 +118,10 @@ public partial class BinaryAdjustColorViewModel : ObservableObject
             }
 
             using var originalBitmap = subtitle.Bitmap.ToSkBitmap();
-            var coloredBitmap = ColorBitmap(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
+            using var coloredBitmap = ColorBitmap(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
+            var old = subtitle.Bitmap;
             subtitle.Bitmap = coloredBitmap.ToAvaloniaBitmap();
+            old?.Dispose();
         }
     }
 
@@ -184,5 +188,13 @@ public partial class BinaryAdjustColorViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+    }
+
+    public void Dispose()
+    {
+        _previewUpdateTimer?.Stop();
+        var old = PreviewBitmap;
+        PreviewBitmap = null;
+        old?.Dispose();
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
@@ -44,7 +44,7 @@ public partial class BinaryAdjustColorViewModel : ObservableObject, IDisposable
         };
         _previewUpdateTimer.Tick += (_, _) =>
         {
-            _previewUpdateTimer.Stop();
+            _previewUpdateTimer?.Stop();
             if (_isDirty)
             {
                 _isDirty = false;
@@ -192,7 +192,9 @@ public partial class BinaryAdjustColorViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
+        _isDirty = false;
         _previewUpdateTimer?.Stop();
+        _previewUpdateTimer = null;
         var old = PreviewBitmap;
         PreviewBitmap = null;
         old?.Dispose();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorWindow.cs
@@ -60,8 +60,14 @@ public class BinaryAdjustColorWindow : Window
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 
-    private static Button MakeControlsPanel(BinaryAdjustColorViewModel vm)
+    private static StackPanel MakeControlsPanel(BinaryAdjustColorViewModel vm)
     {
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 10,
+        };
+
         var swatchButton = new Button
         {
             Height = 60,
@@ -76,7 +82,19 @@ public class BinaryAdjustColorWindow : Window
                 [!Border.BackgroundProperty] = new Binding(nameof(vm.ColorSwatchBrush)),
             },
         };
-        return swatchButton;
+        panel.Children.Add(swatchButton);
+
+        var infoText = new TextBlock
+        {
+            Text = Se.Language.Tools.ImageBasedEdit.ColorAdjustmentInfo,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 4, 0, 0),
+            FontSize = 11,
+            Foreground = Brushes.Gray,
+        };
+        panel.Children.Add(infoText);
+
+        return panel;
     }
 
     private static Border MakePreviewPanel(BinaryAdjustColorViewModel vm)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -152,12 +152,23 @@ public partial class BinaryEditViewModel : ObservableObject
 
     partial void OnSelectedSubtitleChanged(BinarySubtitleItem? value)
     {
-        if (VideoPlayerControl?.IsPlaying != true)
+        if (!IsVideoPlaying())
         {
             DisplayedSubtitle = value;
         }
 
         UpdateOverlayPosition();
+    }
+
+    private bool IsVideoPlaying()
+    {
+        var vp = VideoPlayerControl;
+        if (vp == null || string.IsNullOrEmpty(vp.VideoPlayer.FileName))
+        {
+            return false;
+        }
+
+        return vp.IsPlaying;
     }
 
     partial void OnDisplayedSubtitleChanged(BinarySubtitleItem? value)
@@ -173,6 +184,9 @@ public partial class BinaryEditViewModel : ObservableObject
     internal void SubtitleGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         RefreshStatusText();
+        SelectedSubtitle = e.AddedItems?.Count > 0
+            ? e.AddedItems[0] as BinarySubtitleItem
+            : SubtitleGrid?.SelectedItem as BinarySubtitleItem;
     }
 
     private void RefreshStatusText()
@@ -284,6 +298,10 @@ public partial class BinaryEditViewModel : ObservableObject
         // Update subtitle overlay
         if (SubtitleOverlayImage == null || DisplayedSubtitle == null || DisplayedSubtitle.Bitmap == null)
         {
+            if (SubtitleOverlayImage != null)
+            {
+                SubtitleOverlayImage.IsVisible = false;
+            }
             return;
         }
 
@@ -292,8 +310,12 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (subtitleScreenWidth <= 0 || subtitleScreenHeight <= 0)
         {
+            SubtitleOverlayImage.IsVisible = false;
             return;
         }
+
+        SubtitleOverlayImage.IsVisible = true;
+        SubtitleOverlayImage.Source = DisplayedSubtitle.Bitmap;
 
         // Calculate scale based on rectangle
         var scaleX = rectWidth / subtitleScreenWidth;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1275,10 +1275,15 @@ public partial class BinaryEditViewModel : ObservableObject
         // Refresh grid to show updated bitmaps
         if (SubtitleGrid != null)
         {
-            var currentIndex = SubtitleGrid.SelectedIndex;
-            SubtitleGrid.ItemsSource = null;
-            SubtitleGrid.ItemsSource = Subtitles;
-            SubtitleGrid.SelectedIndex = currentIndex;
+            if (selectedItems.Count > 0)
+                ApplyGridSelection(selectedItems);
+            else
+            {
+                var currentIndex = SubtitleGrid.SelectedIndex;
+                SubtitleGrid.ItemsSource = null;
+                SubtitleGrid.ItemsSource = Subtitles;
+                SubtitleGrid.SelectedIndex = currentIndex;
+            }
         }
 
         UpdateOverlayPosition();
@@ -1327,10 +1332,15 @@ public partial class BinaryEditViewModel : ObservableObject
         // Refresh grid to show updated bitmaps
         if (SubtitleGrid != null)
         {
-            var currentIndex = SubtitleGrid.SelectedIndex;
-            SubtitleGrid.ItemsSource = null;
-            SubtitleGrid.ItemsSource = Subtitles;
-            SubtitleGrid.SelectedIndex = currentIndex;
+            if (selectedItems.Count > 0)
+                ApplyGridSelection(selectedItems);
+            else
+            {
+                var currentIndex = SubtitleGrid.SelectedIndex;
+                SubtitleGrid.ItemsSource = null;
+                SubtitleGrid.ItemsSource = Subtitles;
+                SubtitleGrid.SelectedIndex = currentIndex;
+            }
         }
 
         UpdateOverlayPosition();
@@ -1376,10 +1386,15 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (SubtitleGrid != null)
         {
-            var currentIndex = SubtitleGrid.SelectedIndex;
-            SubtitleGrid.ItemsSource = null;
-            SubtitleGrid.ItemsSource = Subtitles;
-            SubtitleGrid.SelectedIndex = currentIndex;
+            if (selectedItems.Count > 0)
+                ApplyGridSelection(selectedItems);
+            else
+            {
+                var currentIndex = SubtitleGrid.SelectedIndex;
+                SubtitleGrid.ItemsSource = null;
+                SubtitleGrid.ItemsSource = Subtitles;
+                SubtitleGrid.SelectedIndex = currentIndex;
+            }
         }
 
         UpdateOverlayPosition();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1839,7 +1839,7 @@ public partial class BinaryEditViewModel : ObservableObject
         try
         {
             using var stream = File.OpenRead(fileName);
-            var skBitmap = SkiaSharp.SKBitmap.Decode(stream);
+            using var skBitmap = SkiaSharp.SKBitmap.Decode(stream);
             if (skBitmap == null)
             {
                 await MessageBox.Show(Window, Se.Language.General.Error, "Unable to load image file.",

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1215,7 +1215,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryResizeImages.BinaryResizeImagesWindow, BinaryResizeImages.BinaryResizeImagesViewModel>(
+        using var result = await _windowService.ShowDialogAsync<BinaryResizeImages.BinaryResizeImagesWindow, BinaryResizeImages.BinaryResizeImagesViewModel>(
             Window, vm => vm.Initialize(itemsToResize));
 
         if (!result.OkPressed)
@@ -1267,7 +1267,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryAdjustBrightness.BinaryAdjustBrightnessWindow, BinaryAdjustBrightness.BinaryAdjustBrightnessViewModel>(
+        using var result = await _windowService.ShowDialogAsync<BinaryAdjustBrightness.BinaryAdjustBrightnessWindow, BinaryAdjustBrightness.BinaryAdjustBrightnessViewModel>(
             Window, vm => vm.Initialize(itemsToAdjust));
 
         if (!result.OkPressed)
@@ -1319,7 +1319,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryAdjustAlpha.BinaryAdjustAlphaWindow, BinaryAdjustAlpha.BinaryAdjustAlphaViewModel>(
+        using var result = await _windowService.ShowDialogAsync<BinaryAdjustAlpha.BinaryAdjustAlphaWindow, BinaryAdjustAlpha.BinaryAdjustAlphaViewModel>(
             Window, vm => vm.Initialize(itemsToAdjust));
 
         if (!result.OkPressed)
@@ -1369,7 +1369,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryAdjustColor.BinaryAdjustColorWindow, BinaryAdjustColor.BinaryAdjustColorViewModel>(
+        using var result = await _windowService.ShowDialogAsync<BinaryAdjustColor.BinaryAdjustColorWindow, BinaryAdjustColor.BinaryAdjustColorViewModel>(
             Window, vm => vm.Initialize(itemsToAdjust));
 
         if (!result.OkPressed)
@@ -1460,7 +1460,9 @@ public partial class BinaryEditViewModel : ObservableObject
 
             using var skBitmap = subtitle.Bitmap.ToSkBitmap();
             using var cropped = skBitmap.CropTransparentColors(out var offsetX, out var offsetY);
+            var old = subtitle.Bitmap;
             subtitle.Bitmap = cropped.ToAvaloniaBitmap();
+            old?.Dispose();
             subtitle.X += offsetX;
             subtitle.Y += offsetY;
         }
@@ -1845,7 +1847,9 @@ public partial class BinaryEditViewModel : ObservableObject
                 return;
             }
 
+            var old = selectedItem.Bitmap;
             selectedItem.Bitmap = skBitmap.ToAvaloniaBitmap();
+            old?.Dispose();
 
             UpdateOverlayPosition();
             RefreshStatusText();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -184,9 +184,6 @@ public partial class BinaryEditViewModel : ObservableObject
     internal void SubtitleGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         RefreshStatusText();
-        SelectedSubtitle = e.AddedItems?.Count > 0
-            ? e.AddedItems[0] as BinarySubtitleItem
-            : SubtitleGrid?.SelectedItem as BinarySubtitleItem;
     }
 
     private void RefreshStatusText()

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -725,12 +725,8 @@ public class BinaryEditWindow : Window
             Stretch = Stretch.Fill,
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Top,
+            IsVisible = false,
             Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.Hand),
-            [!Visual.IsVisibleProperty] = new Binding($"{nameof(vm.DisplayedSubtitle)}.{nameof(BinarySubtitleItem.Bitmap)}")
-            {
-                Converter = new NotNullConverter()
-            },
-            [!Image.SourceProperty] = new Binding($"{nameof(vm.DisplayedSubtitle)}.{nameof(BinarySubtitleItem.Bitmap)}"),
         };
 
         videoGrid.Children.Add(overlayImage);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
@@ -45,7 +45,7 @@ public partial class BinaryResizeImagesViewModel : ObservableObject, IDisposable
         };
         _previewUpdateTimer.Tick += (_, _) =>
         {
-            _previewUpdateTimer.Stop();
+            _previewUpdateTimer?.Stop();
             if (_isDirty)
             {
                 _isDirty = false;
@@ -194,7 +194,9 @@ public partial class BinaryResizeImagesViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
+        _isDirty = false;
         _previewUpdateTimer?.Stop();
+        _previewUpdateTimer = null;
         var old = PreviewBitmap;
         PreviewBitmap = null;
         old?.Dispose();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryResizeImages;
 
-public partial class BinaryResizeImagesViewModel : ObservableObject
+public partial class BinaryResizeImagesViewModel : ObservableObject, IDisposable
 {
     [ObservableProperty] private int _percentage;
     [ObservableProperty] private Bitmap? _previewBitmap;
@@ -97,8 +97,10 @@ public partial class BinaryResizeImagesViewModel : ObservableObject
         var newWidth = (int)(originalBitmap.Width * Percentage / 100.0);
         var newHeight = (int)(originalBitmap.Height * Percentage / 100.0);
 
-        var resizedBitmap = ResizeBitmap(originalBitmap, newWidth, newHeight);
+        using var resizedBitmap = ResizeBitmap(originalBitmap, newWidth, newHeight);
+        var old = PreviewBitmap;
         PreviewBitmap = resizedBitmap.ToAvaloniaBitmap();
+        old?.Dispose();
         
         ImageSizeText = $"Original: {_originalWidth} × {_originalHeight} px\nNew: {newWidth} × {newHeight} px";
     }
@@ -117,8 +119,10 @@ public partial class BinaryResizeImagesViewModel : ObservableObject
             var newWidth = (int)(originalBitmap.Width * Percentage / 100.0);
             var newHeight = (int)(originalBitmap.Height * Percentage / 100.0);
 
-            var resizedBitmap = ResizeBitmap(originalBitmap, newWidth, newHeight);
+            using var resizedBitmap = ResizeBitmap(originalBitmap, newWidth, newHeight);
+            var old = subtitle.Bitmap;
             subtitle.Bitmap = resizedBitmap.ToAvaloniaBitmap();
+            old?.Dispose();
         }
     }
 
@@ -186,5 +190,13 @@ public partial class BinaryResizeImagesViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+    }
+
+    public void Dispose()
+    {
+        _previewUpdateTimer?.Stop();
+        var old = PreviewBitmap;
+        PreviewBitmap = null;
+        old?.Dispose();
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -27,6 +27,7 @@ public class LanguageImageBasedEdit
     public string ResizeImagesInfo { get; set; }
     public string AdjustColorDotDotDot { get; set; }
     public string AdjustColor { get; set; }
+    public string ColorAdjustmentInfo { get; set; }
 
     public LanguageImageBasedEdit()
     {
@@ -55,5 +56,6 @@ public class LanguageImageBasedEdit
         ResizeImagesInfo = "Enter the percentage to resize images.\nPreview updates automatically.";
         AdjustColorDotDotDot = "Adjust color...";
         AdjustColor = "Adjust color";
+        ColorAdjustmentInfo = "Click the color swatch to pick a color. Bright subtitle pixels shift toward the chosen hue; dark outlines and shadows are preserved.\nPreview shows the first selected subtitle.";
     }
 }


### PR DESCRIPTION
  A collection of fixes and small improvements to the binary subtitle edit window and its sub-dialogs (Adjust Alpha, Adjust Brightness, Adjust Color, Resize Images). They touch the same area so I'm submitting them in a single PR, otherwise I'd have to stack them.

  ### Resource safety

  - **Fix SKBitmap and Avalonia Bitmap disposal leaks** in all four sub-dialog ViewModels — preview and background bitmaps are now properly disposed before being replaced on each update.
  - **Dispose decoded SKBitmap in `ImportImage`** after pixel data is copied into the Avalonia bitmap.
  - **Guard sub-dialog VMs against post-Dispose timer ticks** — timer callbacks now check `_disposed` before acting, preventing use-after-dispose on fast dialog close.

  ### Rendering correctness

  - **Fix double premultiplication** in Adjust Alpha and Adjust Brightness — output bitmaps are now created with `SKAlphaType.Premul` so pixel values are not multiplied a second time when composited.
  - **Fix `CreateCheckeredBackground` swapped width/height args** — `TargetHeight` was passed for both dimensions, producing a square background on non-square images.

  ### Layout and UX

  - **Fix Adjust Alpha preview layout** — replaced `Canvas` with `Grid` so the preview image centers correctly instead of anchoring to the top-left.
  - **Add info label to Adjust Color dialog** — explains that clicking the swatch selects a hue, bright pixels shift toward it, and dark outlines/shadows are preserved.
  - **Show PGS subtitle image in the binary edit window without video** — the overlay image is now displayed from the loaded subtitle bitmap when no video is open.

  ### Grid selection

  - **Restore full multi-selection after sub-dialog operations** (Adjust Alpha/Brightness/Color) — after refreshing the grid, the original selected item set is reapplied via `ApplyGridSelection` so multi-select is not collapsed to a single row.
