### PR TITLE
Fix OCR window not opening (NRE) - regression breaking .sup/VobSub open

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -394,7 +394,10 @@ public partial class OcrViewModel : ObservableObject
 
     private void AutoSelectDictionaryForOcrLanguage(string? languageCode)
     {
-        if (string.IsNullOrEmpty(languageCode) || Dictionaries.Count == 0)
+        // Dictionaries is null while the constructor is still running (the language combo boxes are
+        // populated before it is created), and the OCR-language setters fire this via OnChanged - so
+        // guard against null or it NREs in the ctor and the OCR window fails to open (#11907 follow-up).
+        if (string.IsNullOrEmpty(languageCode) || Dictionaries is null || Dictionaries.Count == 0)
         {
             return;
         }


### PR DESCRIPTION
**Regression fix** — opening a `.sup` (and any OCR source: VobSub, etc.) silently did nothing.

## Cause
Introduced by the OCR-language → dictionary auto-select (#11907). In the `OcrViewModel` constructor, `SelectedGoogleLensLanguage` is set **before** `Dictionaries` is initialized. The generated `[ObservableProperty]` setter fires `OnSelectedGoogleLensLanguageChanged` → `AutoSelectDictionaryForOcrLanguage("en")`, which dereferenced the still-`null` `Dictionaries` (`Dictionaries.Count`) → **NullReferenceException in the constructor**. So `ShowDialogAsync<OcrWindow, OcrViewModel>` threw and the OCR window never opened (the exception was swallowed by the async dispatch, so nothing appeared and nothing was logged to the SE error log).

## Fix
One-line null guard in `AutoSelectDictionaryForOcrLanguage` (`Dictionaries is null` → return early). The language setters can fire during construction before the collection exists.

## Verified
Build clean; reporter confirmed opening `.sup` works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)