### PR TITLE
Add regression test: OcrViewModel constructs from DI without throwing

### DIFF
--- a/tests/UI/Features/Ocr/OcrViewModelConstructionTests.cs
+++ b/tests/UI/Features/Ocr/OcrViewModelConstructionTests.cs
@@ -1,0 +1,28 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Ocr;
+
+namespace UITests.Features.Ocr;
+
+public class OcrViewModelConstructionTests
+{
+    /// <summary>
+    /// Regression guard (#11907 follow-up / "cannot open .sup"): the OcrViewModel constructor sets a
+    /// language property whose [ObservableProperty] OnChanged auto-selects a spell-check dictionary;
+    /// that ran before Dictionaries was initialized and threw a NullReferenceException, so the OCR
+    /// window failed to construct and opening .sup / VobSub / any OCR source silently did nothing.
+    /// Resolving it from the real DI container must not throw.
+    /// </summary>
+    [AvaloniaFact]
+    public void OcrViewModel_ResolvesFromDiContainer_WithoutThrowing()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+
+        var viewModel = provider.GetRequiredService<OcrViewModel>();
+
+        Assert.NotNull(viewModel);
+    }
+}


### PR DESCRIPTION
Follow-up to #11923 (the "cannot open .sup" NRE). Adds a headless test that builds the real DI container (`AddSubtitleEditServices`) and resolves `OcrViewModel`, asserting the constructor doesn't throw.

This catches the exact class of bug that broke OCR opening: a constructor that NREs because an `[ObservableProperty]` OnChanged ran before its backing collection was initialized.

Verified effective: with #11923's null guard reverted, the test fails with `System.NullReferenceException`; with the guard in place it passes. Full UI suite: 467 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)