### PR TITLE
Fix spell check window: Undo/Google it overlap; put Undo at the bottom

### DIFF
--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -248,7 +248,7 @@ public class SpellCheckWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // "Google it" row - without it the new Undo button (row 6) and Google it (row 7) overlap
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // extra row for the Undo button so "Google it" (row 6) and Undo (row 7) don't overlap
             },
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Top,
@@ -265,8 +265,8 @@ public class SpellCheckWindow : Window
         grid.Add(buttonSkipAll, 3, 1);
         grid.Add(buttonAddToNames, 4, 0, 1, 2);
         grid.Add(buttonAddToDictionary, 5, 0, 1, 2);
-        grid.Add(buttonUndo, 6, 0, 1, 2);
-        grid.Add(buttonGoogleSearch, 7, 0, 1, 2);
+        grid.Add(buttonGoogleSearch, 6, 0, 1, 2);
+        grid.Add(buttonUndo, 7, 0, 1, 2);
 
         return grid;
     }

--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -248,6 +248,7 @@ public class SpellCheckWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // "Google it" row - without it the new Undo button (row 6) and Google it (row 7) overlap
             },
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Top,


### PR DESCRIPTION
The spell check window's word-fix grid had **7 row definitions (0-6)** but the (newer) **Undo** button and **Google it** needed rows 6 and 7 — with no row 7 definition, Avalonia collapsed the eighth button onto row 6, so they overlapped.

Fix:
- Add the missing 8th `RowDefinition`.
- Order the buttons so **"Google it" is row 6 and "Undo" is the last row (7)** — Undo at the bottom, as requested.

Resulting order: Change / Change all · Skip once / Skip all · Add to names · Add to dictionary · Google it · Undo.

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)