### PR TITLE
Batch convert: honor selected custom format + image formats in the format picker

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1824,6 +1824,7 @@
     "filterLayersHideFromSubtitleGrid": "Hide from subtitle grid",
     "filterLayersHideFromVideoPreview": "Hide from video preview",
     "pickSubtitleFormat": "Choose subtitle format",
+    "pickSubtitleFormatImageBasedNoPreview": "Image-based subtitle format.\nBitmaps are generated during conversion - no text preview.",
     "pickLayerTitle": "Set layer",
     "recentColors": "Recent colors"
   },

--- a/src/ui/Features/Shared/PickSubtitleFormat/PickSubtitleFormatViewModel.cs
+++ b/src/ui/Features/Shared/PickSubtitleFormat/PickSubtitleFormatViewModel.cs
@@ -15,6 +15,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Shared.PickSubtitleFormat;
 
@@ -161,7 +162,7 @@ public partial class PickSubtitleFormatViewModel : ObservableObject
                 // placeholder for formats that have no text representation.
                 if (string.IsNullOrEmpty(extraPreview))
                 {
-                    ShowPlaceholderPreview("Image-based subtitle format.\nBitmaps are generated during conversion - no text preview.");
+                    ShowPlaceholderPreview(Se.Language.Tools.PickSubtitleFormatImageBasedNoPreview);
                 }
                 else
                 {

--- a/src/ui/Features/Shared/PickSubtitleFormat/PickSubtitleFormatViewModel.cs
+++ b/src/ui/Features/Shared/PickSubtitleFormat/PickSubtitleFormatViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Layout;
@@ -17,6 +18,12 @@ using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Shared.PickSubtitleFormat;
 
+/// <summary>
+/// A format offered by the picker that is not a real <see cref="SubtitleFormat"/> (e.g. batch-convert
+/// image outputs like Blu-ray sup). <paramref name="PreviewText"/> null means "no text preview".
+/// </summary>
+public sealed record PickSubtitleFormatExtraFormat(string Name, string? PreviewText);
+
 public partial class PickSubtitleFormatViewModel : ObservableObject
 {
     [ObservableProperty] private string _searchText;
@@ -31,6 +38,10 @@ public partial class PickSubtitleFormatViewModel : ObservableObject
     
     private readonly List<string> _allSubtitleFormatNames;
     private Subtitle _sampleSubtitle;
+
+    // Extra (non-SubtitleFormat) entries, e.g. batch-convert image/text outputs. Value is the preview
+    // text, or null for formats with no text preview (image-based).
+    private readonly Dictionary<string, string?> _extraFormatPreviews = new();
 
     public PickSubtitleFormatViewModel()
     {
@@ -49,9 +60,23 @@ public partial class PickSubtitleFormatViewModel : ObservableObject
         _sampleSubtitle.Paragraphs.Add(new Paragraph("This is a sample subtitle.", 3500, 6000));
     }
 
-    internal void Initialize(SubtitleFormat? subtitleFormat, Subtitle subtitle)
+    internal void Initialize(SubtitleFormat? subtitleFormat, Subtitle subtitle,
+        IReadOnlyList<PickSubtitleFormatExtraFormat>? extraFormats = null, string? selectedFormatName = null)
     {
-        SelectedSubtitleFormatName = subtitleFormat?.FriendlyName;
+        if (extraFormats != null)
+        {
+            foreach (var extra in extraFormats)
+            {
+                _extraFormatPreviews[extra.Name] = extra.PreviewText;
+                if (!_allSubtitleFormatNames.Contains(extra.Name))
+                {
+                    _allSubtitleFormatNames.Add(extra.Name);
+                    SubtitleFormatNames.Add(extra.Name);
+                }
+            }
+        }
+
+        SelectedSubtitleFormatName = selectedFormatName ?? subtitleFormat?.FriendlyName;
 
         if (subtitle.Paragraphs.Count > 1)
         {
@@ -128,39 +153,20 @@ public partial class PickSubtitleFormatViewModel : ObservableObject
             if (format != null)
             {
                 var text = format.ToText(_sampleSubtitle, "Sample");
-                PreviewText = text;
-                
-                // Limit preview to first 1000 characters for better display
-                if (text.Length > 1000)
+                ShowTextPreview(text, format);
+            }
+            else if (_extraFormatPreviews.TryGetValue(SelectedSubtitleFormatName, out var extraPreview))
+            {
+                // Batch-only format (e.g. image output): show its supplied preview text, or a
+                // placeholder for formats that have no text representation.
+                if (string.IsNullOrEmpty(extraPreview))
                 {
-                    text = text.Substring(0, 1000) + "\n\n... (truncated)";
-                    PreviewText = text;
+                    ShowPlaceholderPreview("Image-based subtitle format.\nBitmaps are generated during conversion - no text preview.");
                 }
-
-                // Create TextEditor with syntax highlighting
-                var textEditor = new TextEditor
+                else
                 {
-                    Text = text,
-                    IsReadOnly = true,
-                    ShowLineNumbers = true,
-                    WordWrap = false,
-                    VerticalAlignment = VerticalAlignment.Stretch,
-                    HorizontalAlignment = HorizontalAlignment.Stretch,
-                    FontFamily = new FontFamily("Courier New, Consolas, monospace"),
-                    FontSize = 12,
-                };
-
-                // Override the built-in link color with our softer pastel color
-                textEditor.TextArea.TextView.LinkTextForegroundBrush = UiUtil.MakeLinkForeground();
-
-                // Add syntax highlighting for subtitle source formats
-                var lineTransformer = GetLineTransformer(text, format);
-                if (lineTransformer != null)
-                {
-                    textEditor.TextArea.TextView.LineTransformers.Add(lineTransformer);
+                    ShowTextPreview(extraPreview, null);
                 }
-
-                PreviewContainer.Child = textEditor;
             }
             else
             {
@@ -179,6 +185,55 @@ public partial class PickSubtitleFormatViewModel : ObservableObject
             };
             PreviewContainer.Child = textBox;
         }
+    }
+
+    // Renders read-only source text (optionally syntax-highlighted for a known SubtitleFormat).
+    private void ShowTextPreview(string text, SubtitleFormat? format)
+    {
+        // Limit preview to first 1000 characters for better display
+        if (text.Length > 1000)
+        {
+            text = text.Substring(0, 1000) + "\n\n... (truncated)";
+        }
+
+        PreviewText = text;
+
+        var textEditor = new TextEditor
+        {
+            Text = text,
+            IsReadOnly = true,
+            ShowLineNumbers = true,
+            WordWrap = false,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            FontFamily = new FontFamily("Courier New, Consolas, monospace"),
+            FontSize = 12,
+        };
+
+        textEditor.TextArea.TextView.LinkTextForegroundBrush = UiUtil.MakeLinkForeground();
+
+        var lineTransformer = format != null ? GetLineTransformer(text, format) : null;
+        if (lineTransformer != null)
+        {
+            textEditor.TextArea.TextView.LineTransformers.Add(lineTransformer);
+        }
+
+        PreviewContainer.Child = textEditor;
+    }
+
+    // Shows an informational note for formats with no text preview (image-based outputs).
+    private void ShowPlaceholderPreview(string message)
+    {
+        PreviewText = message;
+        PreviewContainer.Child = new TextBlock
+        {
+            Text = message,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(10),
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Opacity = 0.7,
+        };
     }
 
     private static DocumentColorizingTransformer? GetLineTransformer(string text, SubtitleFormat subtitleFormat)

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1295,6 +1295,13 @@ public partial class BatchConvertViewModel : ObservableObject
 
             var result = await _windowService.ShowDialogAsync<ExportCustomTextFormatWindow, ExportCustomTextFormatViewModel>(Window,
                 vm => { vm.Initialize(subtitles, string.Empty, string.Empty, true); });
+
+            // Remember which custom format was chosen so batch convert uses it (not just the first one).
+            if (result.OkPressed && result.SelectedCustomFormat != null)
+            {
+                Se.Settings.Tools.BatchConvert.CustomTextFormatName = result.SelectedCustomFormat.Name;
+            }
+
             return;
         }
 
@@ -1425,19 +1432,63 @@ public partial class BatchConvertViewModel : ObservableObject
             return;
         }
 
+        var currentRealFormat = SubtitleFormat.AllSubtitleFormats.FirstOrDefault(p => p.Name == SelectedTargetFormat);
+        var extraFormats = BuildExtraFormatPickerEntries();
+
         var viewModel = await _windowService.ShowDialogAsync<PickSubtitleFormatWindow, PickSubtitleFormatViewModel>(Window, vm =>
         {
-            vm.Initialize(SubtitleFormat.AllSubtitleFormats.FirstOrDefault(p => p.Name == SelectedTargetFormat) ?? new SubRip(), new Subtitle());
+            vm.Initialize(currentRealFormat ?? new SubRip(), new Subtitle(), extraFormats,
+                currentRealFormat == null ? SelectedTargetFormat : null);
         });
 
         if (viewModel.OkPressed)
         {
-            var selectedFormat = viewModel.GetSelectedFormat();
-            if (selectedFormat != null && selectedFormat.Name != SelectedTargetFormat)
+            // Real formats round-trip through GetSelectedFormat().Name; the batch-only ones are only
+            // identified by their (display) name.
+            var selectedName = viewModel.GetSelectedFormat()?.Name ?? viewModel.SelectedSubtitleFormatName;
+            if (!string.IsNullOrEmpty(selectedName) && selectedName != SelectedTargetFormat)
             {
-                SelectedTargetFormat = selectedFormat.Name;
+                SelectedTargetFormat = selectedName;
             }
         }
+    }
+
+    // The batch-only output formats (image-based + plain/custom text) are not real SubtitleFormats, so
+    // they must be added to the format picker explicitly. Text formats get a real preview; image-based
+    // ones pass null (the picker shows a "no text preview" placeholder).
+    private static IReadOnlyList<PickSubtitleFormatExtraFormat> BuildExtraFormatPickerEntries()
+    {
+        var sample = new List<Paragraph>
+        {
+            new("Hello, World!", 1000, 3000),
+            new("This is a sample subtitle.", 3500, 6000),
+        };
+
+        var plainTextPreview = string.Join(Environment.NewLine + Environment.NewLine, sample.Select(p => p.Text));
+
+        string? customTextPreview = null;
+        var customFormats = Se.Settings.File.ExportCustomFormats.Select(c => new CustomFormatItem(c)).ToList();
+        var selectedCustom = customFormats.FirstOrDefault(c => c.Name == Se.Settings.Tools.BatchConvert.CustomTextFormatName)
+                             ?? customFormats.FirstOrDefault();
+        if (selectedCustom != null)
+        {
+            customTextPreview = Nikse.SubtitleEdit.UiLogic.Export.CustomTextFormatter.GenerateCustomText(
+                selectedCustom.ToTemplate(), sample, "Sample", string.Empty);
+        }
+
+        return new List<PickSubtitleFormatExtraFormat>
+        {
+            new(BatchConverter.FormatBluRaySup, null),
+            new(BatchConverter.FormatVobSub, null),
+            new(BatchConverter.FormatBdnXml, null),
+            new(BatchConverter.FormatDostImage, null),
+            new(BatchConverter.FormatFcpImage, null),
+            new(BatchConverter.FormatDCinemaInterop, null),
+            new(BatchConverter.FormatDCinemaSmpte2014, null),
+            new(BatchConverter.FormatImagesWithTimeCodesInFileName, null),
+            new(BatchConverter.FormatPlainText, plainTextPreview),
+            new(BatchConverter.FormatCustomTextFormat, customTextPreview),
+        };
     }
 
     // Parses a file and appends the resulting item(s) to _allBatchItems only (no UI-bound
@@ -2398,9 +2449,18 @@ public partial class BatchConvertViewModel : ObservableObject
 
     internal void ComboBoxSubtitleFormatPointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        Dispatcher.UIThread.Post(async () =>
+        // Open the format picker on right-click (or Mac Ctrl+left-click), like the main window's
+        // format combo; a plain left-click still opens the normal dropdown.
+        var props = e.GetCurrentPoint(null).Properties;
+        var isMacCtrlLeftClick = OperatingSystem.IsMacOS()
+                                 && props.IsLeftButtonPressed
+                                 && e.KeyModifiers.HasFlag(KeyModifiers.Control)
+                                 && !e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+        if (props.IsRightButtonPressed || isMacCtrlLeftClick)
         {
-            await ShowSubtitleFormatPicker();
-        });
+            Dispatcher.UIThread.Post(async () => { await ShowSubtitleFormatPicker(); });
+            e.Handled = true;
+        }
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -193,7 +193,12 @@ public class BatchConvertWindow : Window
 
         var comboBoxSubtitleFormat = UiUtil.MakeComboBox(vm.TargetFormats, vm, nameof(vm.SelectedTargetFormat));
         comboBoxSubtitleFormat.SelectionChanged += (_, _) => vm.ComboBoxSubtitleFormatChanged();
-        comboBoxSubtitleFormat.PointerPressed += vm.ComboBoxSubtitleFormatPointerPressed;
+        // Tunnel phase so right-click / Mac Ctrl+click opens the format picker before the ComboBox
+        // consumes the click to open its dropdown (matches the main window's format combo).
+        comboBoxSubtitleFormat.AddHandler(InputElement.PointerPressedEvent,
+            vm.ComboBoxSubtitleFormatPointerPressed,
+            RoutingStrategies.Tunnel,
+            handledEventsToo: true);
         comboBoxSubtitleFormat.Width = 240;
 
         var buttonTargetFormatSettings = UiUtil.MakeButton(vm.ShowTargetFormatSettingsCommand, IconNames.Settings)

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -651,7 +651,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             subtitles.Add(sv);
         }
 
-        var selectedCustomFormat = customFormats.FirstOrDefault();
+        var customFormatName = Se.Settings.Tools.BatchConvert.CustomTextFormatName;
+        var selectedCustomFormat =
+            customFormats.FirstOrDefault(f => f.Name == customFormatName)
+            ?? customFormats.FirstOrDefault();
         if (selectedCustomFormat == null)
         {
             item.Status = string.Format(Se.Language.General.ErrorX, Se.Language.General.Error);

--- a/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
@@ -34,6 +34,7 @@ public class LanguageTools
     public string FilterLayersHideFromSubtitleGrid { get; set; }
     public string FilterLayersHideFromVideoPreview { get; set; }
     public string PickSubtitleFormat { get; set; }
+    public string PickSubtitleFormatImageBasedNoPreview { get; set; }
     public string PickLayerTitle { get; set; }
     public string RecentColors { get; set; }
 
@@ -47,6 +48,7 @@ public class LanguageTools
         FilterLayersHideFromSubtitleGrid = "Hide from subtitle grid";
         FilterLayersHideFromVideoPreview = "Hide from video preview";
         PickSubtitleFormat = "Choose subtitle format";
+        PickSubtitleFormatImageBasedNoPreview = "Image-based subtitle format.\nBitmaps are generated during conversion - no text preview.";
         PickLayerTitle = "Set layer";
         RecentColors = "Recent colors";
     }

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -8,6 +8,7 @@ public class SeBatchConvert
     public string OutputFolder { get; set; }
     public bool Overwrite { get; set; }
     public string TargetFormat { get; set; }
+    public string CustomTextFormatName { get; set; } = string.Empty;
     public string TargetEncoding { get; set; }
     public string OcrEngine { get; set; }
     public string TesseractLanguage { get; set; }


### PR DESCRIPTION
From discussion #11925. Batch convert already has "Custom text format" and image output formats in its **dropdown**, but two gaps remained:

### 1. Custom text format selection was ignored
`SaveCustomSubtitleFormat` always used `customFormats.FirstOrDefault()`. Now the batch "Custom text format" **Settings** dialog persists the chosen format (`SeBatchConvert.CustomTextFormatName`) and the converter uses it (falling back to the first).

### 2. Image/text batch formats were missing from the format **picker** dialog
The picker (`PickSubtitleFormatWindow`, opened from the format combo) listed only real `SubtitleFormat`s, so the batch-only outputs (Blu-ray sup, VobSub, BDN-XML, DOST/image, FCP/image, D-Cinema interop & SMPTE 2014, Images-with-timecodes, Plain text, Custom text format) couldn't be picked there — only via the dropdown. They're now included.
- **Preview:** text formats (Plain text, Custom text format) get a real preview; image-based formats show a *"Image-based subtitle format — bitmaps are generated during conversion (no text preview)"* placeholder.
- Picker now keys off the selected **name** so batch-only formats round-trip.

### 3. Picker activation matches the main window
Right-click (or Mac Ctrl+click) on the format combo opens the picker via a Tunnel handler; a normal left-click opens the dropdown — same UX as the main window's format combo.

Full solution builds with 0 warnings; all tests pass (1117). App launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)