### PR TITLE
Keep ASSA "Set style" menu in header order, not alphabetical (#11921)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18294,8 +18294,8 @@ public partial class MainViewModel :
 
                 MenuItemStyles.Items.Clear();
                 var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(_subtitle.Header);
-                var stylesToAdd = styles.Select(p => p.Name).Where(p => !string.IsNullOrEmpty(p)).DistinctBy(p => p)
-                    .OrderBy(p => p);
+                // Keep styles in the order they are defined in the header (user-defined order), do not sort alphabetically (#11921)
+                var stylesToAdd = styles.Select(p => p.Name).Where(p => !string.IsNullOrEmpty(p)).DistinctBy(p => p);
                 foreach (var style in stylesToAdd)
                 {
                     MenuItemStyles.Items.Add(new MenuItem


### PR DESCRIPTION
Part of #11921.

The right-click subtitle grid **Set style** submenu listed ASSA/SSA style names sorted alphabetically (`.OrderBy(p => p)`), which discarded the user-defined order from the style header. As reported in #11921: *"when applying styles, the list automatically sorts itself alphabetically; it doesn't maintain the order I set."*

This lists the styles in the order they appear in the ASSA header (the user-defined order) instead.

The other part of #11921 — restoring SE4's **style categories** — is a larger feature and will follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)