### PR TITLE
Add ASSA storage style categories (#11921)

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -1,3 +1,4 @@
+using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
@@ -8,6 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -29,6 +31,8 @@ public partial class AssaStylesViewModel : ObservableObject
     [ObservableProperty] private StyleDisplay? _selectedFileStyle;
     [ObservableProperty] private ObservableCollection<StyleDisplay> _storageStyles;
     [ObservableProperty] private StyleDisplay? _selectedStorageStyle;
+    [ObservableProperty] private ObservableCollection<string> _storageCategories;
+    [ObservableProperty] private string _selectedStorageCategory;
     [ObservableProperty] private StyleDisplay? _currentStyle;
     [ObservableProperty] private ObservableCollection<string> _fonts;
     [ObservableProperty] private ObservableCollection<BorderStyleItem> _borderTypes;
@@ -44,12 +48,14 @@ public partial class AssaStylesViewModel : ObservableObject
     [ObservableProperty] private bool _isTakeUsagesFromVisible;
     [ObservableProperty] private bool _isSetStyleAsDefaultVisible;
     [ObservableProperty] private bool _isCopyToFileStylesVisible;
+    [ObservableProperty] private bool _isCategoryActionVisible;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
     public string Header { get; set; }
     public DataGrid FileStyleGrid { get; set; }
     public DataGrid StorageStyleGrid { get; set; }
+    public DataGridCollectionView StorageStylesView { get; }
     public Subtitle ResultSubtitle => _subtitle;
 
     private readonly IFileHelper _fileHelper;
@@ -58,6 +64,7 @@ public partial class AssaStylesViewModel : ObservableObject
     private Subtitle _subtitle;
     private string _subtitleFileName;
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private readonly List<string> _extraCategories = new();
 
     public AssaStylesViewModel(IFileHelper fileHelper, IWindowService windowService)
     {
@@ -67,6 +74,8 @@ public partial class AssaStylesViewModel : ObservableObject
         Title = string.Empty;
         FileStyles = new ObservableCollection<StyleDisplay>();
         StorageStyles = new ObservableCollection<StyleDisplay>();
+        StorageCategories = new ObservableCollection<string>();
+        SelectedStorageCategory = Se.Language.Assa.AllCategories;
         Fonts = new ObservableCollection<string>();
         BorderTypes = new ObservableCollection<BorderStyleItem>(BorderStyleItem.List());
         SelectedBorderType = BorderTypes[0];
@@ -79,6 +88,12 @@ public partial class AssaStylesViewModel : ObservableObject
         _subtitleFileName = string.Empty;
 
         LoadSettings();
+
+        StorageStylesView = new DataGridCollectionView(StorageStyles)
+        {
+            Filter = o => o is StyleDisplay s && IsStyleInSelectedCategory(s),
+        };
+        RebuildStorageCategories();
 
         _timerUpdatePreview = new System.Timers.Timer(500);
         _timerUpdatePreview.Elapsed += (s, e) =>
@@ -342,7 +357,7 @@ public partial class AssaStylesViewModel : ObservableObject
         {
             var style = item.ToSsaStyle();
             style.Name = MakeUniqueName(style.Name, StorageStyles);
-            StorageStyles.Add(new StyleDisplay(style));
+            StorageStyles.Add(new StyleDisplay(style) { Category = CategoryForNewStyle() });
         }
     }
 
@@ -408,6 +423,12 @@ public partial class AssaStylesViewModel : ObservableObject
             return;
         }
 
+        var category = CategoryForNewStyle();
+        foreach (var style in selectedStyles)
+        {
+            style.Category = category;
+        }
+
         StorageStyles.AddRange(selectedStyles);
 
         UpdateUsages();
@@ -430,7 +451,7 @@ public partial class AssaStylesViewModel : ObservableObject
         }
 
         var style = new SsaStyle { Name = name };
-        StorageStyles.Add(new StyleDisplay(style));
+        StorageStyles.Add(new StyleDisplay(style) { Category = CategoryForNewStyle() });
     }
 
     [RelayCommand]
@@ -528,7 +549,7 @@ public partial class AssaStylesViewModel : ObservableObject
 
             var style = selectedStyle.ToSsaStyle();
             style.Name = name;
-            StorageStyles.Add(new StyleDisplay(style));
+            StorageStyles.Add(new StyleDisplay(style) { Category = CategoryForNewStyle() });
         }
     }
 
@@ -592,6 +613,195 @@ public partial class AssaStylesViewModel : ObservableObject
         }
 
         selectedStyle.IsDefault = true;
+    }
+
+    private string DefaultCategoryLabel => Se.Language.Assa.DefaultCategory;
+    private string AllCategoriesLabel => Se.Language.Assa.AllCategories;
+
+    private string CategoryLabelToStored(string label)
+        => label == DefaultCategoryLabel || label == AllCategoriesLabel ? string.Empty : label;
+
+    private string StoredToCategoryLabel(string stored)
+        => string.IsNullOrEmpty(stored) ? DefaultCategoryLabel : stored;
+
+    private bool IsStyleInSelectedCategory(StyleDisplay style)
+        => SelectedStorageCategory == AllCategoriesLabel ||
+           StoredToCategoryLabel(style.Category) == SelectedStorageCategory;
+
+    private string CategoryForNewStyle()
+        => SelectedStorageCategory == AllCategoriesLabel ? string.Empty : CategoryLabelToStored(SelectedStorageCategory);
+
+    private void RebuildStorageCategories()
+    {
+        var previous = SelectedStorageCategory;
+
+        var labels = StorageStyles
+            .Select(s => StoredToCategoryLabel(s.Category))
+            .Concat(_extraCategories)
+            .Where(l => l != DefaultCategoryLabel && l != AllCategoriesLabel)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(l => l, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        StorageCategories.Clear();
+        StorageCategories.Add(AllCategoriesLabel);
+        StorageCategories.Add(DefaultCategoryLabel);
+        foreach (var label in labels)
+        {
+            StorageCategories.Add(label);
+        }
+
+        SelectedStorageCategory = StorageCategories.Contains(previous) ? previous : AllCategoriesLabel;
+    }
+
+    partial void OnSelectedStorageCategoryChanged(string value)
+    {
+        StorageStylesView?.Refresh();
+        IsCategoryActionVisible = value != AllCategoriesLabel && value != DefaultCategoryLabel;
+    }
+
+    [RelayCommand]
+    private async Task NewCategory()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window, vm =>
+        {
+            vm.Initialize(Se.Language.Assa.NewCategory, string.Empty, 250, 20, true);
+        });
+
+        if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text))
+        {
+            return;
+        }
+
+        var name = result.Text.Trim();
+        if (name == AllCategoriesLabel || name == DefaultCategoryLabel)
+        {
+            return;
+        }
+
+        if (!_extraCategories.Contains(name, StringComparer.OrdinalIgnoreCase))
+        {
+            _extraCategories.Add(name);
+        }
+
+        RebuildStorageCategories();
+        SelectedStorageCategory = StorageCategories.FirstOrDefault(c => c.Equals(name, StringComparison.OrdinalIgnoreCase)) ?? SelectedStorageCategory;
+    }
+
+    [RelayCommand]
+    private async Task RenameCategory()
+    {
+        if (Window == null || SelectedStorageCategory == AllCategoriesLabel || SelectedStorageCategory == DefaultCategoryLabel)
+        {
+            return;
+        }
+
+        var oldName = SelectedStorageCategory;
+        var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window, vm =>
+        {
+            vm.Initialize(Se.Language.Assa.RenameCategory, oldName, 250, 20, true);
+        });
+
+        if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text))
+        {
+            return;
+        }
+
+        var newName = result.Text.Trim();
+        if (newName == oldName || newName == AllCategoriesLabel || newName == DefaultCategoryLabel)
+        {
+            return;
+        }
+
+        var newStored = CategoryLabelToStored(newName);
+        foreach (var style in StorageStyles.Where(s => StoredToCategoryLabel(s.Category) == oldName))
+        {
+            style.Category = newStored;
+        }
+
+        _extraCategories.RemoveAll(c => c.Equals(oldName, StringComparison.OrdinalIgnoreCase));
+        if (!_extraCategories.Contains(newName, StringComparer.OrdinalIgnoreCase))
+        {
+            _extraCategories.Add(newName);
+        }
+
+        RebuildStorageCategories();
+        SelectedStorageCategory = StorageCategories.FirstOrDefault(c => c.Equals(newName, StringComparison.OrdinalIgnoreCase)) ?? AllCategoriesLabel;
+    }
+
+    [RelayCommand]
+    private void DeleteCategory()
+    {
+        if (Window == null || SelectedStorageCategory == AllCategoriesLabel || SelectedStorageCategory == DefaultCategoryLabel)
+        {
+            return;
+        }
+
+        var name = SelectedStorageCategory;
+        Dispatcher.UIThread.Post(async void () =>
+        {
+            var answer = await MessageBox.Show(
+                Window!,
+                Se.Language.Assa.DeleteCategory,
+                string.Format(Se.Language.Assa.DeleteCategoryQuestion, name),
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            foreach (var style in StorageStyles.Where(s => StoredToCategoryLabel(s.Category) == name))
+            {
+                style.Category = string.Empty;
+            }
+
+            _extraCategories.RemoveAll(c => c.Equals(name, StringComparison.OrdinalIgnoreCase));
+            RebuildStorageCategories();
+            SelectedStorageCategory = AllCategoriesLabel;
+        });
+    }
+
+    [RelayCommand]
+    private async Task MoveToCategory()
+    {
+        var selectedItems = StorageStyleGrid.SelectedItems.Cast<StyleDisplay>().ToList();
+        if (Window == null || selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window, vm =>
+        {
+            vm.Initialize(Se.Language.Assa.MoveToCategoryDotDotDot, DefaultCategoryLabel, 250, 20, true);
+        });
+
+        if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text))
+        {
+            return;
+        }
+
+        var label = result.Text.Trim();
+        var stored = CategoryLabelToStored(label);
+        if (!string.IsNullOrEmpty(stored) && !_extraCategories.Contains(label, StringComparer.OrdinalIgnoreCase))
+        {
+            _extraCategories.Add(label);
+        }
+
+        foreach (var style in selectedItems)
+        {
+            style.Category = stored;
+        }
+
+        RebuildStorageCategories();
+        SelectedStorageCategory = StorageCategories.Contains(label) ? label : SelectedStorageCategory;
+        StorageStylesView.Refresh();
     }
 
     private void Close()

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -240,6 +240,7 @@ public class AssaStylesWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(2, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(2, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(2, GridUnitType.Star) },
                 new RowDefinition { Height = new GridLength(2, GridUnitType.Auto) },
             },
@@ -253,6 +254,16 @@ public class AssaStylesWindow : Window
 
         var label = UiUtil.MakeLabel(Se.Language.Assa.StylesSaved).WithBold();
 
+        var labelCategory = UiUtil.MakeLabel(Se.Language.Assa.Category);
+        var comboBoxCategory = UiUtil.MakeComboBox(vm.StorageCategories, vm, nameof(vm.SelectedStorageCategory)).WithMinWidth(160);
+        var buttonNewCategory = UiUtil.MakeButton(vm.NewCategoryCommand, IconNames.Plus, Se.Language.Assa.NewCategory);
+        var buttonRenameCategory = UiUtil.MakeButton(vm.RenameCategoryCommand, IconNames.Pencil, Se.Language.Assa.RenameCategory)
+            .WithBindIsVisible(nameof(vm.IsCategoryActionVisible));
+        var buttonDeleteCategory = UiUtil.MakeButton(vm.DeleteCategoryCommand, IconNames.Trash, Se.Language.Assa.DeleteCategory)
+            .WithBindIsVisible(nameof(vm.IsCategoryActionVisible));
+        var panelCategory = UiUtil.MakeHorizontalPanel(labelCategory, comboBoxCategory, buttonNewCategory, buttonRenameCategory, buttonDeleteCategory)
+            .WithAlignmentLeft();
+
         var dataGrid = new DataGrid
         {
             AutoGenerateColumns = false,
@@ -264,7 +275,7 @@ public class AssaStylesWindow : Window
             Width = double.NaN,
             Height = double.NaN,
             DataContext = vm,
-            ItemsSource = vm.StorageStyles,
+            ItemsSource = vm.StorageStylesView,
             Columns =
             {
                 new DataGridTextColumn
@@ -272,6 +283,13 @@ public class AssaStylesWindow : Window
                     Header = Se.Language.General.Name,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     Binding = new Binding(nameof(StyleDisplay.Name)),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.Assa.Category,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(StyleDisplay.Category)),
                     IsReadOnly = true,
                 },
                 new DataGridTextColumn
@@ -343,6 +361,15 @@ public class AssaStylesWindow : Window
         menuItemClearSetAsDefault.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsSetStyleAsDefaultVisible)) { Source = vm });
         flyout.Items.Add(menuItemClearSetAsDefault);
 
+        var menuItemMoveToCategory = new MenuItem
+        {
+            Header = Se.Language.Assa.MoveToCategoryDotDotDot,
+            DataContext = vm,
+            Command = vm.MoveToCategoryCommand,
+        };
+        menuItemMoveToCategory.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsStorageStyleSelected)) { Source = vm });
+        flyout.Items.Add(menuItemMoveToCategory);
+
         var buttonNew = UiUtil.MakeButton(vm.StorageNewCommand, IconNames.Plus, Se.Language.General.New);
         var buttonDuplicate = UiUtil.MakeButton(vm.StorageDuplicateCommand, IconNames.Duplicate, Se.Language.General.Duplicate);
         var buttonRemove = UiUtil.MakeButton(vm.StorageRemoveCommand, IconNames.Trash, Se.Language.General.Delete);
@@ -361,8 +388,9 @@ public class AssaStylesWindow : Window
         ).WithAlignmentLeft();
 
         grid.Add(label, 0, 0);
-        grid.Add(dataGrid, 1, 0);
-        grid.Add(panelButtons, 2, 0);
+        grid.Add(panelCategory, 1, 0);
+        grid.Add(dataGrid, 2, 0);
+        grid.Add(panelButtons, 3, 0);
 
         return UiUtil.MakeBorderForControl(grid);
     }

--- a/src/ui/Features/Assa/StyleDisplay.cs
+++ b/src/ui/Features/Assa/StyleDisplay.cs
@@ -44,6 +44,7 @@ public partial class StyleDisplay : ObservableObject
     [ObservableProperty] private BorderStyleItem _borderStyle;
     [ObservableProperty] private bool _isSelected;
     [ObservableProperty] private bool _isDefault;
+    [ObservableProperty] private string _category = string.Empty;
 
     public string OriginalName { get; set; } = string.Empty;
 
@@ -198,6 +199,7 @@ public partial class StyleDisplay : ObservableObject
         MarginRight = style.MarginRight;
         MarginVertical = style.MarginVertical;
         IsDefault = style.IsDefault;
+        Category = style.Category;
 
         if (style.UseOpaqueBox)
         {

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -78,6 +78,14 @@ public class LanguageAssa
     public string StylesTitle { get; set; }
     public string StylesInFile { get; set; }
     public string StylesSaved { get; set; }
+    public string Category { get; set; }
+    public string AllCategories { get; set; }
+    public string DefaultCategory { get; set; }
+    public string NewCategory { get; set; }
+    public string RenameCategory { get; set; }
+    public string DeleteCategory { get; set; }
+    public string MoveToCategoryDotDotDot { get; set; }
+    public string DeleteCategoryQuestion { get; set; }
     public string StylesTitleX { get; set; }
     public string PropertiesTitleX { get; set; }
     public string AttachmentsTitleX { get; set; }
@@ -282,6 +290,14 @@ public class LanguageAssa
         StylesTitle = "Advanced Sub Station Alpha styles";
         StylesInFile = "Styles in file";
         StylesSaved = "Styles saved";
+        Category = "Category";
+        AllCategories = "[All]";
+        DefaultCategory = "Default";
+        NewCategory = "New category...";
+        RenameCategory = "Rename category...";
+        DeleteCategory = "Delete category";
+        MoveToCategoryDotDotDot = "Move to category...";
+        DeleteCategoryQuestion = "Delete category \"{0}\"? Styles in it will be moved to the default category.";
         StylesTitleX = "Styles - {0}";
         PropertiesTitleX = "Properties - {0}";
         AttachmentsTitleX = "Attachments - {0}";

--- a/src/ui/Logic/Config/SeAssaStyle.cs
+++ b/src/ui/Logic/Config/SeAssaStyle.cs
@@ -29,6 +29,7 @@ public class SeAssaStyle
         UseOpaqueBox = style.BorderStyle.Style == BorderStyleType.OneBox;
         UseOpaqueBoxPerLine = style.BorderStyle.Style == BorderStyleType.BoxPerLine;
         IsDefault = style.IsDefault;
+        Category = style.Category;
     }
 
     public string Name { get; set; } = string.Empty;
@@ -56,6 +57,11 @@ public class SeAssaStyle
     public bool UseOpaqueBox { get; set; }
     public bool UseOpaqueBoxPerLine { get; set; }
     public bool IsDefault { get; set; }
+
+    /// <summary>
+    /// Optional category for grouping storage styles (e.g. per project). Empty = the default category.
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
 
     public SeAssaStyle()
     {

--- a/tests/UI/Features/Assa/AssaStylesViewModelTests.cs
+++ b/tests/UI/Features/Assa/AssaStylesViewModelTests.cs
@@ -1,0 +1,68 @@
+using System.Linq;
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Assa;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Assa;
+
+public class AssaStylesViewModelTests
+{
+    /// <summary>
+    /// The AssaStylesViewModel constructor builds the storage-style category list and a filtered
+    /// DataGridCollectionView over the stored styles (#11921). Resolving it from the real DI
+    /// container must not throw, and the category list must always offer "All" + "Default".
+    /// </summary>
+    [AvaloniaFact]
+    public void AssaStylesViewModel_ResolvesFromDiContainer_WithCategories()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+
+        var viewModel = provider.GetRequiredService<AssaStylesViewModel>();
+
+        Assert.NotNull(viewModel);
+        Assert.NotNull(viewModel.StorageStylesView);
+        Assert.Contains(Se.Language.Assa.AllCategories, viewModel.StorageCategories);
+        Assert.Contains(Se.Language.Assa.DefaultCategory, viewModel.StorageCategories);
+    }
+
+    /// <summary>
+    /// A stored style with a category must surface that category in the combo list and the style
+    /// must be filtered into its category when selected.
+    /// </summary>
+    [AvaloniaFact]
+    public void AssaStylesViewModel_SurfacesStoredCategories()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+
+        Se.Settings.Assa.StoredStyles.Add(new SeAssaStyle
+        {
+            Name = "ProjectA-Title",
+            Category = "Project A",
+            ColorPrimary = "#FFFFFFFF",
+            ColorSecondary = "#FFFFFFFF",
+            ColorOutline = "#FF000000",
+            ColorShadow = "#FF000000",
+        });
+
+        try
+        {
+            var viewModel = provider.GetRequiredService<AssaStylesViewModel>();
+
+            Assert.Contains("Project A", viewModel.StorageCategories);
+
+            viewModel.SelectedStorageCategory = "Project A";
+            var visible = viewModel.StorageStylesView.Cast<StyleDisplay>().ToList();
+            Assert.Contains(visible, s => s.Name == "ProjectA-Title");
+        }
+        finally
+        {
+            Se.Settings.Assa.StoredStyles.RemoveAll(s => s.Name == "ProjectA-Title");
+        }
+    }
+}


### PR DESCRIPTION
Part of #11921 (the main request).

SE4 let you group reusable **storage** styles into named categories — e.g. a separate set per project — instead of one excessively long list. SE5 only had a flat storage list. This restores categories in the ASSA styles window.

### What's added
- `SeAssaStyle` / `StyleDisplay` carry an optional **`Category`** (empty = the default category).
- The *Styles saved* (storage) panel gets a **category combo** — `[All]` / `Default` / your own categories — that filters the grid via a `DataGridCollectionView`. A new **Category** column shows each style's group (handy in the `[All]` view).
- **New** / **Rename** / **Delete** category buttons, plus a **"Move to category…"** context-menu item on the selected storage styles.
  - Deleting a category moves its styles back to the default category (nothing is deleted).
- New / duplicated / copied / imported storage styles inherit the **currently selected category**.

### Migration
Existing flat storage styles have an empty category, so they load into **Default** — nothing is lost on upgrade.

### Notes
- The companion sort fix (the *"applies alphabetically"* part of #11921) is in #11932.
- Scope is ASSA storage styles, matching the issue. SSA styles are unchanged.

### Tests
- New `AssaStylesViewModelTests` (DI construction + category surfacing/filtering).
- Full UI suite green (469 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)