### PR TITLE
Make icon-button hint overload respect "Show hints" setting

### DIFF
--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -377,8 +377,12 @@ public static class UiUtil
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center,
             Command = command,
-            [ToolTip.TipProperty] = hint,
         };
+
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(button, hint);
+        }
 
         Attached.SetIcon(button, iconName);
 


### PR DESCRIPTION
`UiUtil.MakeButton(command, iconName, hint)` set the button tooltip **unconditionally**, so windows that use this overload (e.g. the ASSA styles window) showed icon-button hints even when the user had turned off **Options → Appearance → Show hints**.

Every other place in the app builds the icon button and then guards the tooltip with `if (Se.Settings.Appearance.ShowHints) ToolTip.SetTip(...)` (e.g. `MultipleReplaceWindow`). This makes the overload follow the same rule, so the setting is honored consistently.

```csharp
if (Se.Settings.Appearance.ShowHints)
{
    ToolTip.SetTip(button, hint);
}
```

No behavior change when hints are enabled (the default); when disabled, buttons created via this overload no longer show tooltips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)