### PR TITLE
Update change-log.txt (beta2): recent work + translations

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,21 @@ Subtitle Edit Changelog
 
 v5.1.0-beta2 (TBD)
 
+* Add ASSA style categories - group storage styles (e.g. per project) in the Styles window - thx bichitoxxx
+* ASSA styles: keep the "Set style" menu in style order instead of sorting alphabetically - thx bichitoxxx
+* Batch convert: honor the selected custom text format and add the image-based formats in the format picker
+* Add "Remove text for hearing impaired" and "Save as..." to the grid "Selected lines" menu
+* OCR: auto-select the spell-check dictionary from the OCR language (SE4 parity) - thx fraternl
+* OCR: use user OCR-fix replace lists (e.g. xxx_OCRFixReplaceList_User.xml) - thx fraternl
+* seconv: support "Fix common OCR errors" with bundled English dictionaries
+* Binary edit: correctness, resource-safety and selection fixes
+* Make icon-button tooltips honor the "Show hints" appearance setting
+* Fix text box selection shortcuts (e.g. "Selection to lowercase") being inactive and hidden - thx abc16361
+* Fix EBU STL Save/Save As writing an invalid 14-byte file - thx jancisefcik
+* Fix seconv failing to start due to a SkiaSharp native/managed version mismatch - thx pcspeak
+* Update Portuguese (Brazil) translation - thx igorruckert
+* Update Turkish translation - thx bilimiyorum
+* Update Korean translation - thx 12si27
 * Fix crash exporting Blu-ray sup on Linux (HarfBuzz native/managed version mismatch) - thx CannaraX
 * Fix "Join subtitles" by time codes not sorting the joined lines by time - thx han8mr8
 * seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax


### PR DESCRIPTION
Adds v5.1.0-beta2 change-log entries for user-facing changes merged since the last update (#11901), with `- thx <name>` credits for issue reporters and translators:

- ASSA style categories (#11933) + Set-style menu order (#11932) — thx bichitoxxx
- Batch convert custom/image format picker (#11930)
- Grid "Selected lines": Remove text for HI + Save as… (#11918)
- OCR dictionary auto-select & user OCR-fix lists (#11909/#11905) — thx fraternl
- seconv Fix-common-OCR-errors (#11908)
- Binary edit fixes (#11920)
- Tooltips honor "Show hints" (#11934)
- Text-box selection shortcuts (#11915) — thx abc16361
- EBU STL 14-byte file fix (#11916) — thx jancisefcik
- seconv SkiaSharp mismatch (#11931) — thx pcspeak
- Translations: Portuguese (Brazil) — thx igorruckert; Turkish — thx bilimiyorum; Korean — thx 12si27

In-beta regressions (e.g. the .sup-open NRE) and internal-only changes (tests, build) are intentionally not listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)