### PR TITLE
Fix Change Speed: double-apply (Apply+OK) and 0% crash

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7455,15 +7455,11 @@ public partial class MainViewModel :
             .OrderBy(i => i)
             .ToList();
 
+        // The dialog applies the change itself (idempotently, from a snapshot taken when it
+        // opened), so we must not re-apply here - doing so compounded the factor (Apply + OK).
         var result = await ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(vm => { vm.Initialize(Subtitles, selectedIndices); });
         if (result.OkPressed)
         {
-            if (result.AdjustSelectedLinesAndForward && selectedIndices.Count > 0)
-                ChangeSpeedViewModel.ChangeSpeed(Subtitles.Skip(selectedIndices[0]), result.SpeedPercent);
-            else if (result.AdjustSelectedLines && selectedIndices.Count > 0)
-                ChangeSpeedViewModel.ChangeSpeed(selectedIndices.Select(i => Subtitles[i]), result.SpeedPercent);
-            else
-                ChangeSpeedViewModel.ChangeSpeed(Subtitles, result.SpeedPercent);
             _updateAudioVisualizer = true;
         }
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1597,26 +1597,46 @@ public partial class BinaryEditViewModel : ObservableObject
             });
         }
 
+        // Snapshot the original times so Apply/Change recompute from them (idempotent) instead
+        // of compounding the factor when both Apply and Change (OK) are used.
+        var originalTimes = Subtitles.ToDictionary(
+            s => s,
+            s => (s.StartTime.TotalMilliseconds, s.EndTime.TotalMilliseconds));
+
+        void ApplyScaled(IEnumerable<BinarySubtitleItem> items, double factor)
+        {
+            foreach (var s in items)
+            {
+                if (!originalTimes.TryGetValue(s, out var o))
+                {
+                    continue;
+                }
+
+                s.StartTime = TimeSpan.FromMilliseconds(o.Item1 * factor);
+                s.EndTime = TimeSpan.FromMilliseconds(o.Item2 * factor);
+            }
+        }
+
         void ApplySpeed(double speed, bool all, bool selected, bool selectedAndForward)
         {
+            if (speed <= 0)
+            {
+                return;
+            }
+
             var factor = 100.0 / speed;
             if (selectedAndForward && selectedIndices.Count > 0)
-                ScaleBinarySubtitleTimes(Subtitles.Skip(selectedIndices[0]), factor);
+                ApplyScaled(Subtitles.Skip(selectedIndices[0]), factor);
             else if (selected && selectedIndices.Count > 0)
-                ScaleBinarySubtitleTimes(selectedIndices.Select(i => Subtitles[i]), factor);
+                ApplyScaled(selectedIndices.Select(i => Subtitles[i]), factor);
             else
-                ScaleBinarySubtitleTimes(Subtitles, factor);
+                ApplyScaled(Subtitles, factor);
             RefreshGrid();
         }
 
-        var result = await _windowService.ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(Window, vm => { vm.Initialize(selectedIndices.Count > 0, ApplySpeed); });
-
-        if (!result.OkPressed)
-        {
-            return;
-        }
-
-        ApplySpeed(result.SpeedPercent, result.AdjustAll, result.AdjustSelectedLines, result.AdjustSelectedLinesAndForward);
+        // The dialog applies via this callback (on both Apply and Change/OK), so there is
+        // nothing to re-apply here - re-applying compounded the factor.
+        await _windowService.ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(Window, vm => { vm.Initialize(selectedIndices.Count > 0, ApplySpeed); });
     }
 
     [RelayCommand]

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -23,6 +23,11 @@ public partial class ChangeSpeedViewModel : ObservableObject
     private IList<int>? _selectedIndices;
     private Action<double, bool, bool, bool>? _binaryApplyCallback;
 
+    // Snapshot of the subtitle times when the dialog opened. Both "Apply" and "Change" (OK)
+    // recompute from this snapshot (original x factor), so applying repeatedly - e.g. Apply
+    // then Change - is idempotent and never compounds the factor.
+    private List<(double Start, double End)>? _originalTimes;
+
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
@@ -49,23 +54,55 @@ public partial class ChangeSpeedViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
+        Apply(); // apply once; idempotent (recomputed from the original snapshot)
         Window?.Close();
     }
 
     [RelayCommand]
     private void Apply()
     {
-        if (_subtitles != null)
+        if (SpeedPercent <= 0)
         {
-            if (AdjustSelectedLinesAndForward && _selectedIndices?.Count > 0)
-                ChangeSpeed(_subtitles.Skip(_selectedIndices[0]), SpeedPercent);
-            else if (AdjustSelectedLines && _selectedIndices?.Count > 0)
-                ChangeSpeed(_selectedIndices.Select(i => _subtitles[i]), SpeedPercent);
-            else
-                ChangeSpeed(_subtitles, SpeedPercent);
             return;
         }
+
+        if (_subtitles != null)
+        {
+            ApplyToSubtitles();
+            return;
+        }
+
         _binaryApplyCallback?.Invoke(SpeedPercent, AdjustAll, AdjustSelectedLines, AdjustSelectedLinesAndForward);
+    }
+
+    private void ApplyToSubtitles()
+    {
+        if (_subtitles == null || _originalTimes == null)
+        {
+            return;
+        }
+
+        var factor = 100.0 / SpeedPercent;
+
+        IEnumerable<int> indices;
+        if (AdjustSelectedLinesAndForward && _selectedIndices?.Count > 0)
+            indices = Enumerable.Range(_selectedIndices[0], _subtitles.Count - _selectedIndices[0]);
+        else if (AdjustSelectedLines && _selectedIndices?.Count > 0)
+            indices = _selectedIndices;
+        else
+            indices = Enumerable.Range(0, _subtitles.Count);
+
+        foreach (var i in indices)
+        {
+            if (i < 0 || i >= _subtitles.Count || i >= _originalTimes.Count)
+            {
+                continue;
+            }
+
+            _subtitles[i].SetTimes(
+                TimeSpan.FromMilliseconds(_originalTimes[i].Start * factor),
+                TimeSpan.FromMilliseconds(_originalTimes[i].End * factor));
+        }
     }
 
     [RelayCommand]
@@ -78,19 +115,36 @@ public partial class ChangeSpeedViewModel : ObservableObject
     {
         _subtitles = subtitles;
         _selectedIndices = selectedIndices;
+        _originalTimes = subtitles
+            .Select(s => (s.StartTime.TotalMilliseconds, s.EndTime.TotalMilliseconds))
+            .ToList();
         IsSelectionAvailable = selectedIndices.Count > 0;
-        if (!IsSelectionAvailable)
-            AdjustAll = true;
+        SetDefaultScope(IsSelectionAvailable);
     }
 
     internal void Initialize(bool isSelectionAvailable, Action<double, bool, bool, bool> binaryApplyCallback)
     {
         IsSelectionAvailable = isSelectionAvailable;
-        if (!isSelectionAvailable)
+        SetDefaultScope(isSelectionAvailable);
+        _binaryApplyCallback = binaryApplyCallback;
+    }
+
+    // Default to "selected lines" when a selection is available (mirrors the Adjust all times
+    // dialog), otherwise "all lines".
+    private void SetDefaultScope(bool isSelectionAvailable)
+    {
+        if (isSelectionAvailable)
+        {
+            AdjustSelectedLines = true;
+            AdjustAll = false;
+            AdjustSelectedLinesAndForward = false;
+        }
+        else
         {
             AdjustAll = true;
+            AdjustSelectedLines = false;
+            AdjustSelectedLinesAndForward = false;
         }
-        _binaryApplyCallback = binaryApplyCallback;
     }
 
     internal void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
@@ -29,7 +29,7 @@ public class ChangeSpeedWindow : Window
         {
             Width = 150,
             HorizontalAlignment = HorizontalAlignment.Left,
-            Minimum = 0,
+            Minimum = 1, // a speed of 0% means a 100/0 factor (divide by zero / infinite times)
             Maximum = 1000,
             Increment = 0.1m,
             DataContext = vm,

--- a/tests/UI/Features/Sync/ChangeSpeed/ChangeSpeedViewModelTests.cs
+++ b/tests/UI/Features/Sync/ChangeSpeed/ChangeSpeedViewModelTests.cs
@@ -1,11 +1,86 @@
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Sync.ChangeSpeed;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace UITests.Features.Sync.ChangeSpeed;
 
 public class ChangeSpeedViewModelTests
 {
+    private static ObservableCollection<SubtitleLineViewModel> OneLine()
+        => new()
+        {
+            new()
+            {
+                StartTime = TimeSpan.FromMilliseconds(1000),
+                EndTime = TimeSpan.FromMilliseconds(3000),
+            },
+        };
+
+    [Fact]
+    public void ApplyThenOk_DoesNotCompoundTheFactor()
+    {
+        // Regression (#bug-hunt): "Apply" then "Change"(OK) used to apply the factor twice
+        // (125% -> x0.8 -> x0.8 = x0.64). The dialog now recomputes from the original snapshot,
+        // so the result is the same as applying once.
+        var subtitles = OneLine();
+        var vm = new ChangeSpeedViewModel();
+        vm.Initialize(subtitles, new List<int>());
+        vm.SpeedPercent = 125.0;
+
+        vm.ApplyCommand.Execute(null);
+        vm.OkCommand.Execute(null);
+
+        Assert.Equal(800, subtitles[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(2400, subtitles[0].EndTime.TotalMilliseconds, 3);
+        Assert.True(vm.OkPressed);
+    }
+
+    [Fact]
+    public void ApplyRepeatedly_IsIdempotent()
+    {
+        var subtitles = OneLine();
+        var vm = new ChangeSpeedViewModel();
+        vm.Initialize(subtitles, new List<int>());
+        vm.SpeedPercent = 125.0;
+
+        vm.ApplyCommand.Execute(null);
+        vm.ApplyCommand.Execute(null);
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Equal(800, subtitles[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(2400, subtitles[0].EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void Ok_WithoutApply_AppliesOnce()
+    {
+        var subtitles = OneLine();
+        var vm = new ChangeSpeedViewModel();
+        vm.Initialize(subtitles, new List<int>());
+        vm.SpeedPercent = 125.0;
+
+        vm.OkCommand.Execute(null);
+
+        Assert.Equal(800, subtitles[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(2400, subtitles[0].EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void ZeroSpeed_IsIgnored_NoDivideByZero()
+    {
+        var subtitles = OneLine();
+        var vm = new ChangeSpeedViewModel();
+        vm.Initialize(subtitles, new List<int>());
+        vm.SpeedPercent = 0.0;
+
+        vm.OkCommand.Execute(null);
+
+        // Times unchanged (no Infinity/overflow).
+        Assert.Equal(1000, subtitles[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(3000, subtitles[0].EndTime.TotalMilliseconds, 3);
+    }
+
     [Fact]
     public void ChangeSpeed_125Percent_ScalesAllLines()
     {


### PR DESCRIPTION
From the bug hunt over recent commits. The Change Speed redesign introduced a data-corruption bug.

### Double-apply (data corruption)
The dialog has both an **Apply** and a **Change**(OK) button:
- `ChangeSpeedViewModel.Apply()` mutated the times **in place**, and
- the host re-applied the same factor on OK (`MainViewModel.cs:7466`, `BinaryEditViewModel.cs:1619`).

So **Apply → Change** applied the factor twice — 125% became ×0.8 then ×0.8 = **×0.64**. Affected both the main window and binary edit.

**Fix:** make application idempotent. The dialog snapshots the original times when it opens; both Apply and Change recompute from that snapshot (`original × factor`). The hosts no longer re-apply on OK. Apply-then-OK, or Apply clicked repeatedly, now yields the same result as applying once.

### 0% crash
`Minimum = 0` allowed a speed of 0 → `100/0` → `TimeSpan.FromMilliseconds(Infinity)` (overflow/crash). Minimum is now `1`, and Apply ignores non-positive speeds.

### Minor
Default the scope radio to **selected lines** when lines are selected (matches the Adjust all times dialog).

### Tests
Added regression tests: idempotent Apply+OK, repeated Apply, OK-without-Apply, zero-speed no-op. Full UI suite green (473).

🤖 Generated with [Claude Code](https://claude.com/claude-code)