### PR TITLE
Binary edit: dispose SKBitmaps in export paths (native memory leak)

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -933,7 +933,10 @@ public partial class BinaryEditViewModel : ObservableObject
         exportHandler.WriteHeader(fileOrFolderName, imageParameter);
         for (var i = 0; i < Subtitles.Count; i++)
         {
-            imageParameter.Bitmap = Subtitles[i].Bitmap!.ToSkBitmap();
+            // ToSkBitmap allocates a new SKBitmap each call; dispose it per iteration so the
+            // export of a large file doesn't accumulate one undisposed native bitmap per line.
+            using var skBitmap = Subtitles[i].Bitmap!.ToSkBitmap();
+            imageParameter.Bitmap = skBitmap;
             imageParameter.Text = Subtitles[i].Text;
             imageParameter.StartTime = Subtitles[i].StartTime;
             imageParameter.EndTime = Subtitles[i].EndTime;
@@ -1704,7 +1707,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var skBitmap = selectedItem.Bitmap.ToSkBitmap();
+        using var skBitmap = selectedItem.Bitmap.ToSkBitmap();
         var pngBytes = skBitmap.ToPngArray();
         System.IO.File.WriteAllBytes(fileName, pngBytes);
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinarySubtitleItem.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinarySubtitleItem.cs
@@ -81,7 +81,10 @@ public partial class BinarySubtitleItem : ObservableObject
         _duration = item.Duration;
         _screenWidth = item.ScreenWidth;
         _screenHeight = item.ScreenHeight;
-        _bitmap = new SKBitmap(1, 1, true).ToAvaloniaBitmap();
+        using (var placeholder = new SKBitmap(1, 1, true))
+        {
+            _bitmap = placeholder.ToAvaloniaBitmap();
+        }
         Number = item.Number;
         IsForced = false;
         Text = string.Empty;


### PR DESCRIPTION
From the bug hunt. `ToSkBitmap()` / `new SKBitmap(...)` allocate native bitmaps; `ToAvaloniaBitmap()` and `ToPngArray()` only **read** them (they copy, they don't take ownership), so the source must be disposed by the caller. Three spots didn't:

- **`DoExport()`** — created one `SKBitmap` per subtitle line in the export loop and never disposed it, so exporting a large file leaked one native bitmap per line. Now disposed per iteration via `using`.
- **`ExportImage()`** — the single `SKBitmap` used for PNG export was not disposed.
- **`BinarySubtitleItem`** placeholder constructor — the 1×1 `SKBitmap` used to seed the Avalonia placeholder bitmap was not disposed.

No behavior change; binary-edit tests (9) and full UI suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)