### PR TITLE
OCR: dispose fresh SKBitmaps from GetSkBitmapClean (native leak)

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -2427,7 +2427,7 @@ public partial class OcrViewModel : ObservableObject
                 var lines = p.Text.Trim().SplitToLines();
                 if (lines.Count > 1 && p.Text.Length < 40)
                 {
-                    var bmp = item.GetSkBitmapClean();
+                    using var bmp = item.GetSkBitmapClean(); // fresh bitmap each call; dispose to avoid a native leak
                     var nbmp = new NikseBitmap2(bmp);
                     nbmp.MakeOneColor(SKColors.White);
                     var lineImages = NikseBitmapImageSplitter2.SplitToLinesTransparentOrBlack(nbmp);
@@ -2509,7 +2509,7 @@ public partial class OcrViewModel : ObservableObject
                 var lines = p.Text.Trim().SplitToLines();
                 if (lines.Count > 1 && p.Text.Length < 40)
                 {
-                    var bmp = item.GetSkBitmapClean();
+                    using var bmp = item.GetSkBitmapClean(); // fresh bitmap each call; dispose to avoid a native leak
                     var nbmp = new NikseBitmap2(bmp);
                     nbmp.MakeOneColor(SKColors.White);
                     var lineImages = NikseBitmapImageSplitter2.SplitToLinesTransparentOrBlack(nbmp);
@@ -4635,7 +4635,7 @@ public partial class OcrViewModel : ObservableObject
             // Get image position and screen dimensions
             var position = item.GetPosition();
             var screenSize = item.GetScreenSize();
-            var bitmap = item.GetSkBitmapClean();
+            using var bitmap = item.GetSkBitmapClean(); // fresh bitmap each call; dispose to avoid a native leak
 
             if (bitmap == null || screenSize.Width == 0 || screenSize.Height == 0)
             {
@@ -4753,14 +4753,16 @@ public partial class OcrViewModel : ObservableObject
 
     private List<OcrSubtitleItem> SplitImageToLines(OcrSubtitleItem item)
     {
-        if (!HasCaptureAlignment || item.GetSkBitmapClean() == null)
+        // (GetSkBitmapClean never returns null - it substitutes a 1x1 - so the old "== null"
+        //  check only allocated and leaked a native bitmap.)
+        if (!HasCaptureAlignment)
         {
             return new List<OcrSubtitleItem> { item };
         }
 
         try
         {
-            var bitmap = item.GetSkBitmapClean();
+            using var bitmap = item.GetSkBitmapClean(); // fresh bitmap each call; dispose to avoid a native leak
             var lines = new List<OcrSubtitleItem>();
 
             // Simple line detection: split image horizontally based on text regions


### PR DESCRIPTION
From the bug hunt. While verifying the reported "OCR bitmap leaks", most were **false positives**: `GetSkBitmap()` caches and owns the bitmap on the `OcrSubtitleItem`, so disposing those would be a use-after-dispose. They're left untouched.

The real leaks are around **`GetSkBitmapClean()`**, which allocates a *fresh* `SKBitmap` every call. Several callers used and dropped the result without disposing:

- `RunGoogleLensOcr` line-split paths (×2) and the capture-alignment split path — now `using`.
- `SplitImageToLines()` called `GetSkBitmapClean()` purely for a `== null` check and discarded the bitmap. Since `GetSkBitmapClean` never returns null (it substitutes a 1×1), that check only ever leaked — removed.

`NikseBitmap2` copies the source pixels, so disposing the source after constructing it is safe. Build + full UI suite (469) green.

### Not included (deliberately)
The "`async void` swallows exceptions" idea is defensive only (no confirmed bug) and risky to retrofit across this large, regression-prone file, so I left it out rather than churn it blindly. Worth a focused follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)