### PR TITLE
Add DeepL formality picker (SE4 parity, #11707)

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -91,6 +91,10 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels = new();
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
     [ObservableProperty] private bool _llamaCppModelComboIsVisible;
+
+    [ObservableProperty] private ObservableCollection<DeepLFormalityItem> _formalities = new();
+    [ObservableProperty] private DeepLFormalityItem? _selectedFormality;
+    [ObservableProperty] private bool _formalityIsVisible;
     [ObservableProperty] private bool _llamaCppButtonsAreVisible;
     [ObservableProperty] private bool _llamaCppRemoteToggleIsVisible;
     [ObservableProperty] private bool _llamaCppUseRemoteServer;
@@ -160,6 +164,15 @@ public partial class AutoTranslateViewModel : ObservableObject
         };
         SelectedAutoTranslator = AutoTranslators[0];
         AutoTranslatorLinkText = SelectedAutoTranslator.Name;
+
+        Formalities = new ObservableCollection<DeepLFormalityItem>
+        {
+            new("default", "Default"),
+            new("more", "More formal"),
+            new("less", "Less formal"),
+            new("prefer_more", "More formal (fall back to default)"),
+            new("prefer_less", "Less formal (fall back to default)"),
+        };
 
         Rows = new ObservableCollection<TranslateRow>();
         IsTranslateEnabled = true;
@@ -1455,6 +1468,37 @@ public partial class AutoTranslateViewModel : ObservableObject
         UpdateTargetLanguages(translator);
     }
 
+    partial void OnSelectedTargetLanguageChanged(TranslationPair? value)
+    {
+        UpdateFormalityVisibility();
+    }
+
+    partial void OnSelectedFormalityChanged(DeepLFormalityItem? value)
+    {
+        var code = value?.Code ?? "default";
+        Configuration.Settings.Tools.AutoTranslateDeepLFormality = code;
+        Se.Settings.AutoTranslate.DeepLFormality = code;
+    }
+
+    // Formality only applies to DeepL, and only for target languages that support it
+    // (HasFormality - e.g. German/French/Spanish/Japanese..., but not English).
+    private void UpdateFormalityVisibility()
+    {
+        FormalityIsVisible = SelectedAutoTranslator is DeepLTranslate && SelectedTargetLanguage?.HasFormality == true;
+    }
+
+    private void LoadSelectedFormality()
+    {
+        var code = Configuration.Settings.Tools.AutoTranslateDeepLFormality;
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            code = "default";
+        }
+
+        SelectedFormality = Formalities.FirstOrDefault(f => f.Code.Equals(code, StringComparison.OrdinalIgnoreCase))
+                            ?? Formalities.FirstOrDefault();
+    }
+
     private void SetAutoTranslatorEngine(IAutoTranslator translator)
     {
         SelectedAutoTranslator = translator;
@@ -1465,8 +1509,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         ApiUrlIsVisible = false;
         ApiUrlText = string.Empty;
         ButtonApiUrlIsVisible = false;
-        //LabelFormality.IsVisible = false;
-        //PickerFormality.IsVisible = false;
+        FormalityIsVisible = false;
         ModelIsVisible = false;
         ModelBrowseIsVisible = false;
         ButtonModelIsVisible = false;
@@ -1512,9 +1555,6 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         if (engineType == typeof(DeepLTranslate))
         {
-            //LabelFormality.IsVisible = true;
-            //PickerFormality.IsVisible = true;
-
             FillUrls(new List<string>
             {
                 Configuration.Settings.Tools.AutoTranslateDeepLUrl,
@@ -1524,7 +1564,8 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.AutoTranslateDeepLApiKey;
             ApiKeyIsVisible = true;
 
-            //SelectFormality();
+            LoadSelectedFormality();
+            UpdateFormalityVisibility();
 
             return;
         }

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -304,6 +304,9 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.ApiKey, vm, null, nameof(vm.ApiKeyIsVisible)).WithMarginRight(5));
         settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiKeyText), nameof(vm.ApiKeyIsVisible)).WithMarginRight(15));
 
+        settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Formality, vm, null, nameof(vm.FormalityIsVisible)).WithMarginRight(5));
+        settingsPanel.Children.Add(UiUtil.MakeComboBox(vm.Formalities, vm, nameof(vm.SelectedFormality), nameof(vm.FormalityIsVisible)).WithWidth(220).WithMarginRight(15));
+
         var checkBoxLlamaCppRemote = UiUtil.MakeCheckBox(Se.Language.General.LlamaCppUseRemoteServer, vm, nameof(vm.LlamaCppUseRemoteServer)).WithMarginRight(15);
         checkBoxLlamaCppRemote.Bind(CheckBox.IsVisibleProperty, new Binding(nameof(vm.LlamaCppRemoteToggleIsVisible)));
         settingsPanel.Children.Add(checkBoxLlamaCppRemote);

--- a/src/ui/Features/Translate/DeepLFormalityItem.cs
+++ b/src/ui/Features/Translate/DeepLFormalityItem.cs
@@ -1,0 +1,19 @@
+namespace Nikse.SubtitleEdit.Features.Translate;
+
+/// <summary>
+/// A DeepL "formality" option (e.g. default / more formal / less formal). The <see cref="Code"/>
+/// is the value sent to the DeepL API; <see cref="Name"/> is shown in the picker.
+/// </summary>
+public class DeepLFormalityItem
+{
+    public string Code { get; }
+    public string Name { get; }
+
+    public DeepLFormalityItem(string code, string name)
+    {
+        Code = code;
+        Name = name;
+    }
+
+    public override string ToString() => Name;
+}

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -26,6 +26,7 @@ public class LanguageGeneral
     public string AlphaAdjustment { get; set; }
     public string AlphaThreshold { get; set; }
     public string ApiKey { get; set; }
+    public string Formality { get; set; }
     public string ApiSecret { get; set; }
     public string Appearance { get; set; }
     public string Append { get; set; }
@@ -771,6 +772,7 @@ public class LanguageGeneral
         AlphaAdjustment = "Alpha adjustment";
         AlphaThreshold = "Alpha threshold";
         ApiKey = "API key";
+        Formality = "Formality";
         ApiSecret = "Secret";
         Appearance = "Appearance";
         Append = "Append";


### PR DESCRIPTION
Fixes #11707.

SE4 lets you pick DeepL **formality**; in SE5 the setting and backend were already wired (`SeAutoTranslate.DeepLFormality`, `Configuration…AutoTranslateDeepLFormality`, `DeepLTranslate._formality`) but the **UI picker had been commented out**, so it was unreachable.

### What this adds
- A **Formality** combo in the auto-translate window: *Default / More formal / Less formal / More formal (fall back to default) / Less formal (fall back to default)* — DeepL's documented `formality` values.
- Shown **only for DeepL** and **only when the target language supports formality** (`TranslationPair.HasFormality`: German, French, Italian, Spanish (+es-419), Dutch, Polish, Portuguese (pt-PT/pt-BR), Russian, Japanese — **not** English, etc.). Visibility refreshes when you change engine or target language.
- The choice is written to both the live libse config and SE settings, so it applies to the current run and persists.

### DeepL online cross-check (per your request)
- **Formality flags are already current** — DeepL's documented formality-supported set (`DE, FR, IT, ES, ES-419, NL, PL, PT-BR, PT-PT, JA, RU`) matches SE5's `HasFormality` flags exactly. No flag changes needed.
- **Missing target variants:** DeepL now also lists `fr-CA` (Canadian French) and `de-CH` (Swiss German), which SE5 doesn't have. Neither supports formality. I left these out of this PR because I couldn't confirm SE5's classic DeepL endpoint accepts those `target_lang` codes without a 400 — happy to add them in a follow-up if you confirm.
- DeepL also exposes a large **"next-gen" beta** language set (80+ codes); out of scope here.

Build + full UI suite (469) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)