### PR TITLE
Add ASSA "Replace style with..." (SE4 parity)

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -396,6 +396,72 @@ public partial class AssaStylesViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task FileReplaceWith()
+    {
+        var selectedItems = FileStyleGrid.SelectedItems.Cast<StyleDisplay>().ToList();
+        if (Window == null || selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var oldNames = selectedItems.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Candidate targets: the other file styles, plus storage styles not already in the file.
+        var candidates = FileStyles.Where(p => !oldNames.Contains(p.Name)).ToList();
+        candidates.AddRange(StorageStyles.Where(s => FileStyles.All(f => !f.Name.Equals(s.Name, StringComparison.OrdinalIgnoreCase))));
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
+        {
+            var styles = candidates.Select(p => new StyleDisplay(p.ToSsaStyle())).ToList();
+            vm.Initialize(Se.Language.Assa.ReplaceStyleWithDotDotDot, styles, Se.Language.General.Ok, false);
+        });
+
+        var target = result.Styles.FirstOrDefault(p => p.IsSelected) ?? result.SelectedStyle;
+        if (!result.OkPressed || target == null)
+        {
+            return;
+        }
+
+        // If the target came from storage and isn't in the file yet, add it.
+        var targetInFile = FileStyles.FirstOrDefault(f => f.Name.Equals(target.Name, StringComparison.OrdinalIgnoreCase));
+        if (targetInFile == null)
+        {
+            targetInFile = new StyleDisplay(target.ToSsaStyle());
+            FileStyles.Add(targetInFile);
+        }
+
+        // Re-point every line that used one of the replaced styles to the target.
+        RepointParagraphsToStyle(_subtitle, oldNames, targetInFile.Name);
+
+        // Remove the replaced styles (but never the target itself).
+        foreach (var old in selectedItems.Where(s => !s.Name.Equals(targetInFile.Name, StringComparison.OrdinalIgnoreCase)))
+        {
+            FileStyles.Remove(old);
+        }
+
+        SelectedFileStyle = targetInFile;
+        CurrentStyle = targetInFile;
+        UpdateUsages();
+    }
+
+    // Re-points every paragraph that uses one of <paramref name="oldNames"/> (its style, via Extra,
+    // optionally prefixed with '*') to <paramref name="targetName"/>. Used by "Replace style with...".
+    internal static void RepointParagraphsToStyle(Subtitle subtitle, ISet<string> oldNames, string targetName)
+    {
+        foreach (var paragraph in subtitle.Paragraphs)
+        {
+            if (paragraph.Extra != null && oldNames.Contains(paragraph.Extra.TrimStart('*')))
+            {
+                paragraph.Extra = targetName;
+            }
+        }
+    }
+
+    [RelayCommand]
     private async Task StorageImport()
     {
         if (Window == null)

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -211,6 +211,15 @@ public class AssaStylesWindow : Window
         menuItemTakeUsagesFrom.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsTakeUsagesFromVisible)) { Source = vm });
         flyout.Items.Add(menuItemTakeUsagesFrom);
 
+        var menuItemReplaceWith = new MenuItem
+        {
+            Header = Se.Language.Assa.ReplaceStyleWithDotDotDot,
+            DataContext = vm,
+            Command = vm.FileReplaceWithCommand,
+        };
+        menuItemReplaceWith.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsFileStyleSelected)) { Source = vm });
+        flyout.Items.Add(menuItemReplaceWith);
+
         var buttonNew = UiUtil.MakeButton(vm.FileNewCommand, IconNames.Plus, Se.Language.General.New);
         var buttonRemove = UiUtil.MakeButton(vm.FileRemoveCommand, IconNames.Trash, Se.Language.General.Delete);
         var buttonDuplicate = UiUtil.MakeButton(vm.FilesDuplicateCommand, IconNames.Duplicate, Se.Language.General.Duplicate);

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -105,6 +105,7 @@ public class LanguageAssa
     public string CopyToFileStyles { get; set; }
     public string SetStyleAsDefault { get; set; }
     public string TakeUsagesFromDotDotDot { get; set; }
+    public string ReplaceStyleWithDotDotDot { get; set; }
     public string NoAttachmentsFound { get; set; }
     public string DeleteStyleQuestion { get; set; }
     public string DeleteStylesQuestion { get; set; }
@@ -317,6 +318,7 @@ public class LanguageAssa
         CopyToFileStyles = "Copy to file styles";
         SetStyleAsDefault = "Set style as default";
         TakeUsagesFromDotDotDot = "Take usages from...";
+        ReplaceStyleWithDotDotDot = "Replace style with...";
         NoAttachmentsFound = "No attachments found in selected ASSA file.";
         DeleteStyleQuestion = "Delete style?";
         DeleteStylesQuestion = "Delete styles?";

--- a/tests/UI/Features/Assa/AssaStylesViewModelTests.cs
+++ b/tests/UI/Features/Assa/AssaStylesViewModelTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Headless.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Assa;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -9,6 +11,22 @@ namespace UITests.Features.Assa;
 
 public class AssaStylesViewModelTests
 {
+    [Fact]
+    public void RepointParagraphsToStyle_ReassignsOnlyMatchingStyles()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("a", 0, 1000) { Extra = "Old1" });
+        subtitle.Paragraphs.Add(new Paragraph("b", 1000, 2000) { Extra = "*Old2" }); // '*' prefix
+        subtitle.Paragraphs.Add(new Paragraph("c", 2000, 3000) { Extra = "Keep" });
+
+        var oldNames = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase) { "Old1", "Old2" };
+        AssaStylesViewModel.RepointParagraphsToStyle(subtitle, oldNames, "Target");
+
+        Assert.Equal("Target", subtitle.Paragraphs[0].Extra);
+        Assert.Equal("Target", subtitle.Paragraphs[1].Extra);
+        Assert.Equal("Keep", subtitle.Paragraphs[2].Extra);
+    }
+
     /// <summary>
     /// The AssaStylesViewModel constructor builds the storage-style category list and a filtered
     /// DataGridCollectionView over the stored styles (#11921). Resolving it from the real DI


### PR DESCRIPTION
Restores a missing SE4 feature (gap #2 from the parity hunt). SE4's styles window had **"Replace style with…"** (`src/ui/Forms/Assa/ReplaceStyleWith.cs`); SE5 had no equivalent.

### What it does
Adds a **"Replace style with…"** item to the **file-styles** context menu in the ASSA styles window. With one or more file styles selected:
1. Opens the style picker to choose a **target** — another file style, or a **storage** style not already in the file.
2. Re-points every line that used a replaced style (`Extra`, incl. the `*` prefix) to the target.
3. If the target came from storage, adds it to the file styles.
4. Removes the replaced style(s) (never the target).

### Notes
- Reuses the existing `AssaStylePicker` for target selection (no new dialog).
- Core re-pointing logic extracted to `AssaStylesViewModel.RepointParagraphsToStyle(...)` with a unit test (matching styles reassigned, `*`-prefixed handled, others untouched).
- Scoped to the **ASSA** styles window (where this matters most). The SSA styles window has a separate VM; happy to mirror it in a follow-up.

Build + full UI suite (474) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)