### PR TITLE
Menu: fix Escape needing a 3rd press + stale menu state after Alt+Tab (#11745)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18635,6 +18635,14 @@ public partial class MainViewModel :
     internal void OnWindowDeactivated(object? sender, EventArgs e)
     {
         _altMenuTogglePending = false;
+
+        // A task switch (Alt+Tab) must also drop any active menu-bar state. Otherwise Avalonia leaves
+        // the access-key underlines / selection armed and they reappear when the window is re-activated,
+        // leaving the bar in a half-active "limbo" state (#11745 beta-2 feedback).
+        if (Menu is { IsOpen: true } || IsMainMenuFocused())
+        {
+            DeactivateMainMenu();
+        }
     }
 
     /// <summary>
@@ -18744,14 +18752,31 @@ public partial class MainViewModel :
             // (runs before the focused menu item), so without this the shortcut manager would eat
             // Left/Right etc. Escape is handled here so that, once no drop-down is open, it fully
             // deactivates the bar and restores focus instead of leaving it half-focused (#11745).
-            if (IsMainMenuFocused())
+            // Escape leaves the menu bar in two deterministic steps (Windows standard): if a drop-down
+            // is open, the first Escape closes it but keeps the bar active; the next Escape (nothing
+            // open) fully deactivates and restores focus. We also gate on Menu.IsOpen, because focus can
+            // briefly leave the menu right after a drop-down closes - relying on focus alone previously
+            // needed a third Escape to leave the bar (#11745 beta-2 feedback).
+            if (k == Key.Escape && keyEventArgs.KeyModifiers == KeyModifiers.None && (IsMainMenuFocused() || Menu.IsOpen))
             {
-                if (k == Key.Escape && !Menu.IsOpen)
+                if (Menu.IsOpen)
+                {
+                    Menu.Close();
+                    TryFocusMainMenu(); // keep the bar focused so the next Escape deactivates it
+                }
+                else
                 {
                     DeactivateMainMenu();
-                    keyEventArgs.Handled = true;
                 }
 
+                keyEventArgs.Handled = true;
+                return;
+            }
+
+            // While the menu bar owns keyboard focus, let it handle its own arrow/Enter navigation
+            // instead of consuming those keys as shortcuts.
+            if (IsMainMenuFocused())
+            {
                 return;
             }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2148,6 +2148,14 @@ public partial class BinaryEditViewModel : ObservableObject
     internal void OnWindowDeactivated(object? sender, EventArgs e)
     {
         _altMenuTogglePending = false;
+
+        // A task switch (Alt+Tab) must also drop any active menu-bar state, otherwise Avalonia leaves
+        // the access-key underlines / selection armed and they reappear when the window is re-activated
+        // (#11745 beta-2 feedback).
+        if (Menu is { IsOpen: true } || IsMenuFocused())
+        {
+            DeactivateMenu();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Addresses two items from GrampaWildWilly's beta-2 feedback on the keyboard menu-bar work (#11745, PR #11822 / #11900).

### 1. Escape needed three presses to leave the menu bar (main window)
The main window's key handler tunnels (runs *before* the focused menu item), so it could only infer "a drop-down just closed" from `Menu.IsOpen` — fragile once focus briefly leaves the menu after a drop-down closes, which required a third Escape.

Now Escape is handled in two deterministic steps, gated on `IsMainMenuFocused() || Menu.IsOpen`:
- **First Escape** (a drop-down is open) → closes it and keeps the bar focused.
- **Next Escape** (nothing open) → fully deactivates and restores focus.

### 2. Alt+Tab away/back left the bar in a half-active "limbo" state (both windows)
`OnWindowDeactivated` only cleared the pending bare-Alt toggle, so Avalonia's access-key underlines/selection stayed armed and reappeared on return. It now deactivates the menu (close + restore focus) when it was active — applied to **both** the main window and the **binary-edit** window.

### Scope note on binary edit
The binary-edit key handler runs with `handledEventsToo` (after the menu), so its Escape two-stage (via `!e.Handled`) is **not** subject to item #1 — only the Alt+Tab cleanup (#2) is mirrored there.

### Not included
- "Alt should be a clean activate/deactivate toggle with persistent underlines" and "F10 focus box": these are tangled with Avalonia's `AccessKeyHandler` / focus adorner (and the box aids the accessibility this work is for). Left for a separate design discussion.

⚠️ **Needs Windows verification** — this menu-bar code is Windows-only (the in-window `Menu` is empty on macOS), so it can't be runtime-tested on the dev machine. Build + full UI suite (474) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)