### PR TITLE
Add "Apply" button to Remove text for hearing impaired (#11948)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5498,14 +5498,19 @@ public partial class MainViewModel :
             return;
         }
 
+        void ApplyToGrid(Subtitle applied)
+        {
+            ReplaceSubtitles(applied.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
+            SelectAndScrollToRow(0);
+            _updateAudioVisualizer = true;
+        }
+
         var result = await ShowDialogAsync<RemoveTextForHearingImpairedWindow, RemoveTextForHearingImpairedViewModel>(
-            vm => { vm.Initialize(GetUpdateSubtitle()); });
+            vm => { vm.Initialize(GetUpdateSubtitle(), ApplyToGrid); });
 
         if (result.OkPressed)
         {
-            ReplaceSubtitles(
-                result.FixedSubtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
-            SelectAndScrollToRow(0);
+            ApplyToGrid(result.FixedSubtitle);
         }
     }
 

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -68,6 +68,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [ObservableProperty] private RemoveItem? _selectedFix;
     [ObservableProperty] private string _fixText;
     [ObservableProperty] private bool _fixTextEnabled;
+    [ObservableProperty] private bool _isApplyVisible;
 
     public Window? Window { get; set; }
 
@@ -78,6 +79,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     private RemoveTextForHI? _removeTextForHiLib;
     private readonly Timer _timer;
     private readonly IWindowService _windowService;
+    private Action<Subtitle>? _applyCallback;
 
     public RemoveTextForHearingImpairedViewModel(IWindowService windowService)
     {
@@ -97,7 +99,18 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
 
     public void Initialize(Subtitle subtitle)
     {
+        Initialize(subtitle, null);
+    }
+
+    /// <param name="applyCallback">
+    /// When set, an "Apply" button is shown that pushes the current fixes to the caller without
+    /// closing the window, so the user can run a pass, adjust options, and continue (SE4 parity, #11948).
+    /// </param>
+    public void Initialize(Subtitle subtitle, Action<Subtitle>? applyCallback)
+    {
         _subtitle = subtitle;
+        _applyCallback = applyCallback;
+        IsApplyVisible = applyCallback != null;
         LoadSettings();
         _removeTextForHiLib = new RemoveTextForHI(GetSettings(_subtitle));
     }
@@ -159,13 +172,11 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
         Se.SaveSettings();
     }
 
-    [RelayCommand]
-    private void Ok()
+    // Builds a subtitle with the currently-ticked fixes applied (empty results removed).
+    private Subtitle BuildFixedSubtitle()
     {
-        SaveSettings();
-        OkPressed = true;
-        FixedSubtitle = new Subtitle(_subtitle, false);
-        FixedSubtitle.Paragraphs.Clear();
+        var result = new Subtitle(_subtitle, false);
+        result.Paragraphs.Clear();
         for (var index = 0; index < _subtitle.Paragraphs.Count; index++)
         {
             var p = _subtitle.Paragraphs[index];
@@ -175,12 +186,35 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
                 p.Text = fixedParagraph.After;
             }
 
-            FixedSubtitle.Paragraphs.Add(p);
+            result.Paragraphs.Add(p);
         }
 
-        FixedSubtitle.RemoveEmptyLines();
+        result.RemoveEmptyLines();
+        return result;
+    }
 
+    [RelayCommand]
+    private void Ok()
+    {
+        SaveSettings();
+        OkPressed = true;
+        FixedSubtitle = BuildFixedSubtitle();
         Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Apply()
+    {
+        SaveSettings();
+
+        var applied = BuildFixedSubtitle();
+        _applyCallback?.Invoke(applied);
+
+        // Keep iterating against the applied result: re-base the working subtitle and refresh the
+        // preview so already-removed text isn't offered again (#11948).
+        _subtitle = new Subtitle(applied);
+        _removeTextForHiLib = new RemoveTextForHI(GetSettings(_subtitle));
+        GeneratePreview();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -35,8 +35,11 @@ public class RemoveTextForHearingImpairedWindow : Window
         var fixesView = MakeFixesView(vm);
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonApply = UiUtil.MakeButton(Se.Language.General.Apply, vm.ApplyCommand)
+            .WithBindIsVisible(nameof(vm.IsApplyVisible));
         var panelButtons = UiUtil.MakeButtonBar(
             buttonOk,
+            buttonApply,
             UiUtil.MakeButtonCancel(vm.CancelCommand)
         );
 

--- a/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
+++ b/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
@@ -1,0 +1,49 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
+
+namespace UITests.Features.Tools.RemoveTextForHearingImpaired;
+
+public class RemoveTextForHearingImpairedViewModelTests
+{
+    private static RemoveTextForHearingImpairedViewModel Resolve()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        return services.BuildServiceProvider().GetRequiredService<RemoveTextForHearingImpairedViewModel>();
+    }
+
+    [AvaloniaFact]
+    public void Apply_IsHidden_WhenNoCallbackProvided()
+    {
+        var vm = Resolve();
+        vm.Initialize(new Subtitle());
+        Assert.False(vm.IsApplyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Apply_PushesTickedFixesToCallback_WithoutNeedingOk()
+    {
+        var vm = Resolve();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("[door slams]", 0, 1000));
+        sub.Paragraphs.Add(new Paragraph("Hello there", 1000, 2000));
+
+        Subtitle? applied = null;
+        vm.Initialize(sub, s => applied = s);
+
+        Assert.True(vm.IsApplyVisible);
+
+        // Simulate the preview: line 0 becomes empty (removed), line 1 unchanged.
+        vm.Fixes.Add(new RemoveItem(true, 0, "[door slams]", string.Empty, sub.Paragraphs[0]));
+
+        vm.ApplyCommand.Execute(null);
+
+        Assert.NotNull(applied);
+        Assert.False(vm.OkPressed); // Apply must not close / set OkPressed
+        Assert.Single(applied!.Paragraphs); // the emptied line was dropped
+        Assert.Equal("Hello there", applied.Paragraphs[0].Text);
+    }
+}


### PR DESCRIPTION
Fixes #11948 (SE4 parity).

SE4's **Remove text for hearing impaired** window had an **Apply** button: run a pass against the subtitle, then adjust the options (e.g. untick *only if UPPERCASE*) and continue. SE5 only had OK/Cancel.

### What this adds
An **Apply** button that:
- commits the currently-ticked fixes to the main subtitle **via a callback (without closing)**,
- re-bases the window's working subtitle to the applied result and refreshes the live preview, so already-removed text isn't offered again,
- leaves **OK/Cancel unchanged** (OK still applies + closes; idempotent after Apply since the preview is regenerated).

### Scope
The Apply button is shown only when an apply callback is wired — i.e. the **full-subtitle** tool (Tools → Remove text for hearing impaired), which is the workflow in the issue. The **selected-lines** invocation keeps OK/Cancel only, because its block write-back (insert fixed lines where the selection started, dropping empties) isn't safe to repeat while the window stays open.

### Tests
`RemoveTextForHearingImpairedViewModelTests`: Apply pushes ticked fixes to the callback without setting OkPressed, drops emptied lines, and the button is hidden when no callback is provided. Build + full UI suite (476) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)