### PR TITLE
Visual sync: honor the selected audio track (#11952)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7406,7 +7406,7 @@ public partial class MainViewModel :
         var result = await ShowDialogAsync<VisualSyncWindow, VisualSyncViewModel>(vm =>
         {
             var paragraphs = Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList();
-            vm.Initialize(paragraphs, _videoFileName, _subtitleFileName, AudioVisualizer);
+            vm.Initialize(paragraphs, _videoFileName, _subtitleFileName, AudioVisualizer, _audioTrack?.Id ?? -1);
         });
 
         if (result.OkPressed)

--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -83,7 +84,8 @@ public partial class VisualSyncViewModel : ObservableObject
         List<SubtitleLineViewModel> paragraphs,
         string? videoFileName,
         string? subtitleFileName,
-        AudioVisualizer? audioVisualizer)
+        AudioVisualizer? audioVisualizer,
+        int audioTrackId = -1)
     {
         SetVideoInFo(videoFileName);
         Paragraphs = new ObservableCollection<SubtitleDisplayItem>(paragraphs.Select(p => new SubtitleDisplayItem(p)));
@@ -94,8 +96,7 @@ public partial class VisualSyncViewModel : ObservableObject
         {
             if (!string.IsNullOrEmpty(videoFileName))
             {
-                _ = VideoPlayerControlLeft.Open(videoFileName);
-                _ = VideoPlayerControlRight.Open(videoFileName);
+                _ = OpenPlayersAsync(videoFileName, audioTrackId);
             }
 
             if (audioVisualizer != null)
@@ -107,6 +108,30 @@ public partial class VisualSyncViewModel : ObservableObject
             StartTitleTimer();
             _updateAudioVisualizer = true;
         });
+    }
+
+    // Opens both preview players and, once each video is loaded, applies the audio track the user
+    // selected in the main window. Without this Visual Sync always played the default track (#11952).
+    private async Task OpenPlayersAsync(string videoFileName, int audioTrackId)
+    {
+        await Task.WhenAll(
+            VideoPlayerControlLeft.Open(videoFileName),
+            VideoPlayerControlRight.Open(videoFileName));
+
+        if (audioTrackId <= 0)
+        {
+            return;
+        }
+
+        if (VideoPlayerControlLeft.VideoPlayer is LibMpvDynamicPlayer mpvLeft)
+        {
+            mpvLeft.SetAudioTrack(audioTrackId);
+        }
+
+        if (VideoPlayerControlRight.VideoPlayer is LibMpvDynamicPlayer mpvRight)
+        {
+            mpvRight.SetAudioTrack(audioTrackId);
+        }
     }
 
     private void SetVideoInFo(string? videoFileName)


### PR DESCRIPTION
Fixes #11952.

### Root cause
Visual sync always played the video's **default** audio track. `ShowVisualSync` passed only the file name, and `VisualSyncViewModel` opened both preview players with no audio-track argument, so mpv fell back to its default — and there's no track picker in the dialog. As the reporter noted, every other audio consumer already honors the selection: speech-to-text and get-audio-clips pass `_audioTrack?.FfIndex`, and the main player applies `mpv.SetAudioTrack(_audioTrack.Id)` after load. Visual sync was the only one dropping it.

### Fix
- `ShowVisualSync` now passes `_audioTrack?.Id` into `VisualSyncViewModel.Initialize`.
- After both preview players finish loading the video, the VM applies the track via `LibMpvDynamicPlayer.SetAudioTrack(...)` — mirroring the main window.

Notes:
- Uses the mpv track **`Id`** (what `SetAudioTrack` takes), not the ffmpeg `FfIndex` used by the shell-out features.
- No-op when no specific track is selected (`<= 0`) or for non-mpv players (VLC), matching existing behavior.
- The Manual-sync variant has no video player, so it's unaffected.

⚠️ **Needs manual verification** with a multi-audio-track video — mpv audio-track switching can't be exercised in the headless test suite. Build + full UI suite (476) green.

Scope: this honors the already-selected track (the report). An in-dialog audio-track dropdown ("no way to change it" from within Visual sync) would be a separate, larger enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)