### PR TITLE
Save as: convert source-format native tags when changing format (#11954)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16422,6 +16422,20 @@ public partial class MainViewModel :
         _subtitle.FileName = saveAsResult.FileName;
         _converted = false;
         _lastOpenSaveFormat = saveAsResult.SubtitleFormat;
+
+        // When "Save as" targets a different format than the one currently loaded, convert the source
+        // format's native tags first - exactly like changing the format dropdown does. Without this,
+        // e.g. saving a WebVTT as SubRip kept the raw <c.color> class tags instead of <font color="...">
+        // (#11954). SaveSubtitle serializes from the grid, so push the converted text back into it.
+        var previousFormat = SelectedSubtitleFormat;
+        if (previousFormat != null && previousFormat.Name != saveAsResult.SubtitleFormat.Name)
+        {
+            _subtitle = GetUpdateSubtitle();
+            _subtitleOriginal = GetUpdateSubtitleOriginal();
+            previousFormat.RemoveNativeFormatting(_subtitle, saveAsResult.SubtitleFormat);
+            SetSubtitles(_subtitle, _subtitleOriginal);
+        }
+
         SetSubtitleFormat(saveAsResult.SubtitleFormat);
 
         // SetSubtitleFormat changes the format programmatically, which bypasses the format-change

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -141,4 +141,38 @@ public class WebVttTest
         Assert.Contains("<b>", converted7);
         Assert.Contains("#AB9216", converted7);
     }
+
+    // Covers the "Save as" conversion (#11954): saving a WebVTT to SubRip runs the source format's
+    // RemoveNativeFormatting, which must turn bare named color classes (no STYLE block) into
+    // <font color="..."> so players that don't understand <c.color> still show the color.
+    [Fact]
+    public void RemoveNativeFormatting_BareColorClass_ConvertsToFontColor()
+    {
+        var vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:04.000\r\n<c.magenta>Hello</c> world";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        Assert.Contains("<c.magenta>", subtitle.Paragraphs[0].Text);
+
+        new WebVTT().RemoveNativeFormatting(subtitle, new SubRip());
+        var converted = subtitle.Paragraphs[0].Text;
+
+        Assert.DoesNotContain("<c.", converted);
+        Assert.Contains("<font color=\"magenta\">", converted);
+        Assert.Contains("</font>", converted);
+        Assert.Contains("world", converted);
+    }
+
+    [Fact]
+    public void RemoveNativeFormatting_HexColorClass_ConvertsToFontColor()
+    {
+        var vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:04.000\r\n<c.color008000>Green</c>";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        new WebVTT().RemoveNativeFormatting(subtitle, new SubRip());
+        var converted = subtitle.Paragraphs[0].Text;
+
+        Assert.DoesNotContain("<c.", converted);
+        Assert.Contains("<font color=\"#008000\">", converted);
+        Assert.Contains("</font>", converted);
+    }
 }


### PR DESCRIPTION
Follow-up to #11954.

The format **dropdown** and **Batch Convert** already convert a source format's native tags when changing format (e.g. WebVTT `<c.color>` → `<font color="...">`). **"Save as"** to a different format did **not**: it calls `SetSubtitleFormat` programmatically, which by design bypasses the format-change handler that runs `RemoveNativeFormatting`. So saving a WebVTT as SubRip kept the raw `<c.magenta>` tags.

### Fix
In `SaveSubtitleAs`, when the chosen format differs from the currently-loaded one, run the **source** format's `RemoveNativeFormatting` before saving — and push the converted result back into the grid (since `SaveSubtitle` serializes from the grid, via `GetUpdateSubtitle`). This mirrors what the format dropdown does.

### Tests
Added libse tests for the WebVTT conversion that Save-as now triggers:
- bare named color class **without a STYLE block** (the issue's case): `<c.magenta>` → `<font color="magenta">`
- hex form: `<c.color008000>` → `<font color="#008000">`

libse (475) + UI (476) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)