### PR TITLE
Spell check: recognize hyphenated names from the names list (#10126)

### DIFF
--- a/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
@@ -495,7 +495,32 @@ public class SpellCheckWordLists
         return _namesListUppercase.Contains(word) ||
                _namesListWithApostrophe.Contains(word) ||
                _nameList.IsInNamesMultiWordList(text, word) ||
-               _namesListUppercase.Contains(word);
+               IsPartOfKnownDashOrPeriodName(word, text);
+    }
+
+    /// <summary>
+    /// True when <paramref name="word"/> is a dash/period-delimited part of a known combined name or
+    /// word (e.g. "Soo" or "bin" of "Soo-bin") that actually appears in <paramref name="text"/>. The
+    /// spell-check tokenizer splits on '-' and '.', so without this a hyphenated name added to the
+    /// names list would be flagged part by part (#10126).
+    /// </summary>
+    private bool IsPartOfKnownDashOrPeriodName(string word, string text)
+    {
+        if (string.IsNullOrEmpty(word))
+        {
+            return false;
+        }
+
+        foreach (var combined in _wordsWithDashesOrPeriods)
+        {
+            var parts = combined.Split(PeriodAndDash, StringSplitOptions.RemoveEmptyEntries);
+            if (Array.IndexOf(parts, word) >= 0 && text.Contains(combined, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public bool HasUserWord(string word)

--- a/tests/UI/Features/SpellCheck/HyphenatedNameSpellCheckTests.cs
+++ b/tests/UI/Features/SpellCheck/HyphenatedNameSpellCheckTests.cs
@@ -1,0 +1,71 @@
+using Nikse.SubtitleEdit.Core.Interfaces;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.IO;
+
+namespace UITests.Features.SpellCheck;
+
+// #10126: a hyphenated name added to the names list (e.g. "Soo-bin") was flagged part by part,
+// because the tokenizer splits on '-'. HasNameExtended must recognize each part as a name when the
+// combined name is in the names list and present in the line.
+public class HyphenatedNameSpellCheckTests : IDisposable
+{
+    private const string LanguageName = "en_US";
+
+    private readonly string _originalDictionariesFolder;
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public HyphenatedNameSpellCheckTests()
+    {
+        _originalDictionariesFolder = Se.DictionariesFolder;
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeHyphenNameTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        Se.DictionariesFolder = _tempDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    [Fact]
+    public void HyphenatedNameInNamesList_RecognizesEachPart()
+    {
+        var wordLists = new SpellCheckWordLists(LanguageName, new AlwaysMissSpellChecker());
+        wordLists.AddName("Soo-bin");
+
+        const string line = "I met Soo-bin today.";
+        Assert.True(wordLists.HasNameExtended("Soo", line));
+        Assert.True(wordLists.HasNameExtended("bin", line));
+    }
+
+    [Fact]
+    public void DashNamePart_NotMatched_WhenCombinedNameAbsentFromLine()
+    {
+        var wordLists = new SpellCheckWordLists(LanguageName, new AlwaysMissSpellChecker());
+        wordLists.AddName("Soo-bin");
+
+        // "Soo" on its own (no "Soo-bin" in the line) must not be treated as a name.
+        Assert.False(wordLists.HasNameExtended("Soo", "I met Soo today."));
+    }
+
+    public void Dispose()
+    {
+        Se.DictionariesFolder = _originalDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private sealed class AlwaysMissSpellChecker : IDoSpell
+    {
+        public bool DoSpell(string word) => false;
+    }
+}


### PR DESCRIPTION
Fixes #10126.

### Problem
A name with a dash added to the names list (e.g. `Soo-bin`) is flagged part by part — the spell checker asks about `Soo` and `bin` separately. Cause:
- the tokenizer splits words on `-` / `.` (`SpellCheckWordLists.Split`),
- a dash-joined name has no space, so it's stored in the **single-word** names list, and
- the multi-word name check (`NameList.IsInNamesMultiWordList`) only matches **space**-separated parts.

(There was dead code — `ReplaceKnownWordsOrNamesWithBlanks` + `_wordsWithDashesOrPeriods` — that was meant to handle this, but it's never called in SE5.)

### Fix
Extend `HasNameExtended(word, text)` so a word is recognized as a name when it's a dash/period-delimited part of a known combined name/word (from the already-maintained `_wordsWithDashesOrPeriods`) **that actually appears in the line**.

- Covers names from the names file *and* runtime "Add to names" (`AddName` already records the combined word).
- Fixes both the interactive spell checker and the OCR fix engine — both classify via `IsName → HasNameExtended`.
- The combined name must be present in the line, so a bare part (`Soo` without `Soo-bin`) is still flagged — no false positives.

I chose this over reviving the dead `ReplaceKnownWordsOrNamesWithBlanks` text-preprocess path, which is heavier and riskier; `HasNameExtended` is already on the hot path and this is contained + unit-testable.

### Tests
`HyphenatedNameSpellCheckTests`: `Soo-bin` in the names list → both `Soo` and `bin` recognized; and a bare `Soo` (no `Soo-bin` in the line) is **not**. UI (481) + libuilogic (4) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)