### PR TITLE
Auto-translate (llama.cpp): add Qwen 3.5 and Aya Expanse models

### DIFF
--- a/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
@@ -79,6 +79,16 @@ public static class LlamaCppServerManager
         new LlamaCppModel("Qwen 3.5 9B (Q4_K_M)", "Qwen_Qwen3.5-9B-Q4_K_M.gguf", "5.7 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q4_K_M.gguf",
             ChatTemplate: "chatml", NoJinja: true),
+
+        // Aya Expanse 8B (Cohere) - a dedicated multilingual model (23 languages), a good translation
+        // alternative to the Gemma/Qwen families. Uses its own embedded (Cohere) chat template, so we
+        // leave ChatTemplate/NoJinja at their defaults instead of forcing gemma/chatml. Kept to <= 8 GB.
+        new LlamaCppModel("Aya Expanse 8B (Q4_K_M)", "aya-expanse-8b-Q4_K_M.gguf", "4.7 GB",
+            "https://huggingface.co/bartowski/aya-expanse-8b-GGUF/resolve/main/aya-expanse-8b-Q4_K_M.gguf"),
+        new LlamaCppModel("Aya Expanse 8B (Q5_K_M)", "aya-expanse-8b-Q5_K_M.gguf", "5.4 GB",
+            "https://huggingface.co/bartowski/aya-expanse-8b-GGUF/resolve/main/aya-expanse-8b-Q5_K_M.gguf"),
+        new LlamaCppModel("Aya Expanse 8B (Q8_0)", "aya-expanse-8b-Q8_0.gguf", "7.9 GB",
+            "https://huggingface.co/bartowski/aya-expanse-8b-GGUF/resolve/main/aya-expanse-8b-Q8_0.gguf"),
     };
 
     public static readonly IReadOnlyList<LlamaCppModel> OcrModels = new[]

--- a/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppServerManager.cs
@@ -67,6 +67,18 @@ public static class LlamaCppServerManager
         new LlamaCppModel("Qwen 3 8B (Q4_K_M)", "Qwen_Qwen3-8B-Q4_K_M.gguf", "4.7 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3-8B-GGUF/resolve/main/Qwen_Qwen3-8B-Q4_K_M.gguf",
             ChatTemplate: "chatml", NoJinja: true),
+
+        // Qwen 3.5 - newer Qwen generation. Same chatml + --no-jinja handling as Qwen 3 (bypasses the
+        // embedded thinking template so the output is clean translation). Kept to <= 8 GB.
+        new LlamaCppModel("Qwen 3.5 4B (Q4_K_M)", "Qwen_Qwen3.5-4B-Q4_K_M.gguf", "2.8 GB",
+            "https://huggingface.co/bartowski/Qwen_Qwen3.5-4B-GGUF/resolve/main/Qwen_Qwen3.5-4B-Q4_K_M.gguf",
+            ChatTemplate: "chatml", NoJinja: true),
+        new LlamaCppModel("Qwen 3.5 4B (Q8_0)", "Qwen_Qwen3.5-4B-Q8_0.gguf", "4.3 GB",
+            "https://huggingface.co/bartowski/Qwen_Qwen3.5-4B-GGUF/resolve/main/Qwen_Qwen3.5-4B-Q8_0.gguf",
+            ChatTemplate: "chatml", NoJinja: true),
+        new LlamaCppModel("Qwen 3.5 9B (Q4_K_M)", "Qwen_Qwen3.5-9B-Q4_K_M.gguf", "5.7 GB",
+            "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q4_K_M.gguf",
+            ChatTemplate: "chatml", NoJinja: true),
     };
 
     public static readonly IReadOnlyList<LlamaCppModel> OcrModels = new[]


### PR DESCRIPTION
Adds newer/alternative models to the curated llama.cpp auto-translate list (we currently ship TranslateGemma + Qwen 3). All URLs **verified to resolve (HTTP 200)**, all **≤ 8 GB**, no hash-table changes needed (translate model downloads aren't hash-verified).

### Qwen 3.5 (newer Qwen generation)
| Model | Quant | Size |
|---|---|---|
| Qwen 3.5 4B | Q4_K_M | 2.8 GB |
| Qwen 3.5 4B | Q8_0 | 4.3 GB |
| Qwen 3.5 9B | Q4_K_M | 5.7 GB |

Same `chatml` + `--no-jinja` handling as the existing Qwen 3 entries (suppresses `<think>` blocks → clean translation).

### Aya Expanse 8B (Cohere) — dedicated multilingual (23 languages)
| Model | Quant | Size |
|---|---|---|
| Aya Expanse 8B | Q4_K_M | 4.7 GB |
| Aya Expanse 8B | Q5_K_M | 5.4 GB |
| Aya Expanse 8B | Q8_0 | 7.9 GB |

Aya uses its **own embedded (Cohere) chat template**, so `ChatTemplate`/`NoJinja` are left at defaults (no `--chat-template`/`--no-jinja`) → llama-server uses the model's bundled template. (Aya Expanse 32B is 18 GB → excluded by the 8 GB rule.)

### Not added
- **Llama 4 Scout** — 109B MoE, ~60 GB at Q4; far over 8 GB and not consumer-runnable.
- **GLM-4.6 / 4.7 / 5** — hundreds of GB; GLM-5.2 doesn't exist.
- **Gemma 3 12B-it** — redundant with the existing TranslateGemma 12B.

> Existing Gemma/Qwen 3 entries are kept. I matched/templated each family as above but couldn't run inference here — a quick manual translate sanity-check of one Qwen 3.5 and one Aya model before release is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)