### PR TITLE
Settings: add a text box for the grid single-line separator (#11961)

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -663,6 +663,8 @@ public class SettingsPage : UserControl
                 () => UiUtil.MakeComboBox(_vm.FontNames, _vm, nameof(_vm.SubtitleTextBoxAndGridFontName))),
             MakeNumericSetting(Se.Language.Options.Settings.SubtitleGridFontSize, nameof(_vm.SubtitleGridFontSize)),
             MakeCheckboxSetting(Se.Language.Options.Settings.SubtitleGridTextSingleLine, nameof(_vm.SubtitleGridTextSingleLine)),
+            new SettingsItem(Se.Language.Options.Settings.SubtitleGridTextSingleLineSeparator,
+                () => UiUtil.MakeTextBox(150, _vm, nameof(_vm.SubtitleGridTextSingleLineSeparator))),
             new SettingsItem(Se.Language.Options.Settings.SubtitleGridShowFormatting, () => UiUtil.MakeComboBox(_vm.SubtitleGridFormattings, _vm, nameof(_vm.SubtitleGridFormatting))),
             MakeCheckboxSetting(Se.Language.Options.Settings.SubtitleGridLiveSpellCheck, nameof(_vm.SubtitleGridLiveSpellCheck)),
             MakeNumericSetting(Se.Language.Options.Settings.TextBoxFontSize, nameof(_vm.TextBoxFontSize)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -291,6 +291,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private string _selectedFontName;
     [ObservableProperty] private double _subtitleGridFontSize;
     [ObservableProperty] private bool _subtitleGridTextSingleLine;
+    [ObservableProperty] private string _subtitleGridTextSingleLineSeparator = string.Empty;
     [ObservableProperty] private ObservableCollection<string> _subtitleGridFormattings;
     [ObservableProperty] private string _subtitleGridFormatting;
     [ObservableProperty] private string _subtitleTextBoxAndGridFontName;
@@ -739,6 +740,7 @@ public partial class SettingsViewModel : ObservableObject
         ShowPluginsMenu = appearance.ShowPluginsMenu;
         SubtitleGridFontSize = appearance.SubtitleGridFontSize;
         SubtitleGridTextSingleLine = appearance.SubtitleGridTextSingleLine;
+        SubtitleGridTextSingleLineSeparator = appearance.SubtitleGridTextSingleLineSeparator;
         SubtitleGridFormatting = MapGridFormattingToText(appearance.SubtitleGridFormattingType);
         SubtitleGridLiveSpellCheck = appearance.SubtitleGridLiveSpellCheck;
         SubtitleTextBoxAndGridFontName = appearance.SubtitleTextBoxAndGridFontName;
@@ -1428,6 +1430,7 @@ public partial class SettingsViewModel : ObservableObject
         appearance.ShowPluginsMenu = ShowPluginsMenu;
         appearance.SubtitleGridFontSize = SubtitleGridFontSize;
         appearance.SubtitleGridTextSingleLine = SubtitleGridTextSingleLine;
+        appearance.SubtitleGridTextSingleLineSeparator = SubtitleGridTextSingleLineSeparator;
         appearance.SubtitleGridFormattingType = MapGridFormattingToCode(SubtitleGridFormatting);
         appearance.SubtitleGridLiveSpellCheck = SubtitleGridLiveSpellCheck;
         appearance.SubtitleTextBoxAndGridFontName = string.IsNullOrEmpty(SubtitleTextBoxAndGridFontName) ? new Label().FontFamily.Name : SubtitleTextBoxAndGridFontName;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -74,6 +74,7 @@ public class LanguageSettings
     public string SubtitleTextBoxAndGridFontName { get; set; }
     public string SubtitleGridFontSize { get; set; }
     public string SubtitleGridTextSingleLine { get; set; }
+    public string SubtitleGridTextSingleLineSeparator { get; set; }
     public string SubtitleGridLiveSpellCheck { get; set; }
     public string SubtitleGridShowFormatting { get; set; }
     public string ShowUpDownStartTime { get; set; }
@@ -389,6 +390,7 @@ public class LanguageSettings
         SubtitleTextBoxAndGridFontName = "UI font in subtitle text box and grid";
         SubtitleGridFontSize = "Font size in subtitle grid";
         SubtitleGridTextSingleLine = "Show subtitle text as single line in grid";
+        SubtitleGridTextSingleLineSeparator = "Single line separator (e.g. <br />)";
         SubtitleGridLiveSpellCheck = "Live spell check in subtitle grid";
         SubtitleGridShowFormatting = "Show formatted (HTML/ASSA) text in subtitle grid";
         ShowUpDownStartTime = "Show up/down control for \"Show\"";


### PR DESCRIPTION
Fixes #11961.

The **"Show subtitle text as single line in grid"** appearance setting already used a configurable separator (`SeAppearance.SubtitleGridTextSingleLineSeparator`, default `" ⏎ "`) — consumed by the grid converters (`TextToSingleLineConverter`, syntax-highlight converter) — but there was **no UI to change it**, so users who want `<br />` (SE4-style) couldn't set it. ("Set up like SE4" already sets it to `<br />`, but otherwise it was stuck at the default.)

### Change
Adds a **separator text box** in the Settings page, right below the single-line checkbox, bound through `SettingsViewModel` (loaded from / saved to `SeAppearance.SubtitleGridTextSingleLineSeparator`). New language string `SubtitleGridTextSingleLineSeparator`.

Build green; full UI suite 480/481 — the one failure (`OpenAiSttServiceTests` SSE streaming) is a pre-existing flaky timing test that passes 31/31 in isolation, unrelated to this settings-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)