### PR TITLE
Fix flaky OpenAiSttService SSE test (deterministic progress)

### DIFF
--- a/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
@@ -216,8 +216,12 @@ public class OpenAiSttServiceTests
 
         var deltas = new List<string>();
         var reportedSegments = new List<OpenAiCompatibleSegment>();
-        var deltaProgress = new Progress<string>(d => deltas.Add(d));
-        var segmentProgress = new Progress<OpenAiCompatibleSegment>(s => reportedSegments.Add(s));
+        // Use a synchronous IProgress so callbacks run inline on the parse thread (the service reports
+        // synchronously while reading the stream). The BCL Progress<T> instead posts callbacks to a
+        // SynchronizationContext / the thread pool, which under full-suite parallelism either arrived
+        // late or raced on the (non-thread-safe) lists - making this test flaky.
+        var deltaProgress = new SyncProgress<string>(d => deltas.Add(d));
+        var segmentProgress = new SyncProgress<OpenAiCompatibleSegment>(s => reportedSegments.Add(s));
 
         var ct = TestContext.Current.CancellationToken;
         var wav = MakeTinyWav();
@@ -228,9 +232,7 @@ public class OpenAiSttServiceTests
             // Both deltas should be appended in order.
             Assert.Equal("Hello there", response.Text);
 
-            // Progress<T> marshals to a SynchronizationContext; in xunit the
-            // continuation is queued, so allow it to drain.
-            await WaitForAsync(() => deltas.Count >= 2 && reportedSegments.Count >= 1);
+            // Reported synchronously during TranscribeAsync, so the lists are complete on return.
             Assert.Equal(new[] { "Hello", " there" }, deltas);
 
             Assert.NotNull(response.Segments);
@@ -615,18 +617,15 @@ public class OpenAiSttServiceTests
         return resp;
     }
 
-    private static async Task WaitForAsync(Func<bool> predicate, int timeoutMs = 2000)
+    // Runs IProgress callbacks inline (no SynchronizationContext / thread-pool marshaling), so progress
+    // reported synchronously by the service is observed deterministically and without a data race.
+    private sealed class SyncProgress<T> : IProgress<T>
     {
-        var deadline = Environment.TickCount + timeoutMs;
-        while (Environment.TickCount < deadline)
-        {
-            if (predicate())
-            {
-                return;
-            }
+        private readonly Action<T> _onReport;
 
-            await Task.Delay(10);
-        }
+        public SyncProgress(Action<T> onReport) => _onReport = onReport;
+
+        public void Report(T value) => _onReport(value);
     }
 
     private sealed class StubHandler : HttpMessageHandler


### PR DESCRIPTION
`TranscribeAsync_SseStream_AccumulatesDeltasAndReportsDoneSegments` intermittently failed in the full (parallel) test run while always passing in isolation.

### Root cause (test-only)
The service reports deltas/segments **synchronously** via `IProgress<T>.Report` while parsing the SSE stream (before `TranscribeAsync` returns). The test used the BCL **`Progress<T>`**, which doesn't run callbacks inline — it posts them to the captured `SynchronizationContext`, or to the **thread pool** if none. The test then polled `WaitForAsync(..., 2000ms)` and asserted on plain `List<>`s. Under full-suite xUnit parallelism this flaked two ways:
- posted callbacks delayed past the 2 s deadline → incomplete list → ordered-equality assert fails;
- with no sync context, callbacks ran on thread-pool threads, racing on the non-thread-safe `List<>`.

Production `Progress<T>` (marshaling to the UI thread) is correct — this was purely a test artifact, and only this one test used the pattern.

### Fix
Use a tiny synchronous `IProgress<T>` stub so callbacks run inline on the parse thread; the lists are complete and ordered when `TranscribeAsync` returns, so assertions run directly and the polling `WaitForAsync` helper is removed.

### Verification
Ran the full UI suite **3×: 481/481** each time (previously intermittently 480/481), and the class 5× in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)