### PR TITLE
Clear stuck shortcut keys when the main window loses focus (#11548)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18655,6 +18655,13 @@ public partial class MainViewModel :
     {
         _altMenuTogglePending = false;
 
+        // Drop any held-key state when focus leaves the window. A modal dialog (e.g. the
+        // "Save changes?" prompt that Ctrl+O raises on a changed file) steals focus, so the KeyUp
+        // for the held keys never reaches the main window and they stay "stuck down". That left
+        // every shortcut afterwards (Ctrl+I, Find, Replace, ...) unable to match until the set was
+        // cleared by some other action (issue #11548).
+        _shortcutManager.ClearKeys();
+
         // A task switch (Alt+Tab) must also drop any active menu-bar state. Otherwise Avalonia leaves
         // the access-key underlines / selection armed and they reappear when the window is re-activated,
         // leaving the bar in a half-active "limbo" state (#11745 beta-2 feedback).


### PR DESCRIPTION
Fixes #11548.

**Problem:** a modal dialog steals focus, so the KeyUp for keys held when it opened never reaches the main window and they stay 'down' in the shortcut manager. Most visibly: Ctrl+O on a changed file raises the 'Save changes?' prompt; after dismissing it, Ctrl+I (toggle italic), Find, Replace and every other shortcut stop matching (active set is still {Ctrl, O, …}). Reproduced on Linux per the issue.

**Fix:** clear the held-key state in `OnWindowDeactivated`, which already runs whenever the window loses focus (modal dialogs, Alt+Tab), so the set is empty again next time the window is active. One-line, cross-platform.

Developed on macOS; verified compiling via CI.