### PR TITLE
Add editable whitelist for "Remove if all uppercase" (#11563)

### DIFF
--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -1550,6 +1550,19 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 return text;
             }
 
+            var whitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (Settings.UppercaseWhitelist != null)
+            {
+                foreach (var w in Settings.UppercaseWhitelist)
+                {
+                    var trimmedWord = w.Trim();
+                    if (trimmedWord.Length > 0)
+                    {
+                        whitelist.Add(trimmedWord);
+                    }
+                }
+            }
+
             var sb = new StringBuilder();
             char[] endTrimChars = { '.', '!', '?', ':' };
             char[] trimChars = { ' ', '-', '—' };
@@ -1559,7 +1572,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 if (lineNoHtml == lineNoHtml.ToUpperInvariant() && lineNoHtml != lineNoHtml.ToLowerInvariant())
                 {
                     var temp = lineNoHtml.TrimEnd(endTrimChars).Trim().Trim(trimChars);
-                    if (temp.Length == 1 || temp == "YES" || temp == "NO" || temp == "WHY" || temp == "HI" || temp == "OK")
+                    // Single-letter lines (e.g. "I") are always kept; otherwise keep only the
+                    // user-configurable whitelist words / acronyms (OK, TV, WWE, ...) - issue #11563.
+                    if (temp.Length == 1 || whitelist.Contains(temp))
                     {
                         sb.AppendLine(line);
                     }

--- a/src/libse/Forms/RemoveTextForHISettings.cs
+++ b/src/libse/Forms/RemoveTextForHISettings.cs
@@ -9,6 +9,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
     {
         public bool OnlyIfInSeparateLine { get; set; }
         public bool RemoveIfAllUppercase { get; set; }
+        public List<string> UppercaseWhitelist { get; set; }
         public bool RemoveTextBeforeColon { get; set; }
         public bool RemoveTextBeforeColonOnlyUppercase { get; set; }
         public bool ColonSeparateLine { get; set; }
@@ -30,6 +31,11 @@ namespace Nikse.SubtitleEdit.Core.Forms
         {
             OnlyIfInSeparateLine = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBetweenOnlySeparateLines;
             RemoveIfAllUppercase = Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfAllUppercase;
+            UppercaseWhitelist = new List<string>();
+            foreach (var item in (Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfAllUppercaseWhitelist ?? string.Empty).Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                UppercaseWhitelist.Add(item.Trim());
+            }
             RemoveTextBeforeColon = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBeforeColon;
             RemoveTextBeforeColonOnlyUppercase = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBeforeColonOnlyIfUppercase;
             ColonSeparateLine = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBeforeColonOnlyOnSeparateLine;

--- a/src/libse/Settings/RemoveTextForHearingImpairedSettings.cs
+++ b/src/libse/Settings/RemoveTextForHearingImpairedSettings.cs
@@ -20,6 +20,13 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string RemoveIfContainsText { get; set; }
         public bool RemoveIfOnlyMusicSymbols { get; set; }
 
+        /// <summary>
+        /// Comma-separated all-uppercase words that should NOT be removed by "Remove if all uppercase"
+        /// (e.g. acronyms and short interjections like OK, TV, WWE). Single-letter lines (e.g. "I") are
+        /// always kept regardless of this list.
+        /// </summary>
+        public string RemoveIfAllUppercaseWhitelist { get; set; }
+
         public RemoveTextForHearingImpairedSettings()
         {
             RemoveTextBetweenBrackets = true;
@@ -33,6 +40,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             RemoveTextBeforeColonOnlyIfUppercase = true;
             RemoveIfContainsText = "¶";
             RemoveIfOnlyMusicSymbols = true;
+            RemoveIfAllUppercaseWhitelist = "YES, NO, WHY, HI, OK, TV, OK.";
         }
     }
 }

--- a/src/libse/Settings/RemoveTextForHearingImpairedSettings.cs
+++ b/src/libse/Settings/RemoveTextForHearingImpairedSettings.cs
@@ -40,7 +40,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             RemoveTextBeforeColonOnlyIfUppercase = true;
             RemoveIfContainsText = "¶";
             RemoveIfOnlyMusicSymbols = true;
-            RemoveIfAllUppercaseWhitelist = "YES, NO, WHY, HI, OK, TV, OK.";
+            RemoveIfAllUppercaseWhitelist = "YES, NO, WHY, HI, OK, TV";
         }
     }
 }

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -56,6 +56,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [ObservableProperty] private bool _isRemoveTextBeforeColonUppercaseOn;
     [ObservableProperty] private bool _isRemoveTextBeforeColonSeparateLineOn;
     [ObservableProperty] private bool _isRemoveTextUppercaseLineOn;
+    [ObservableProperty] private string _uppercaseWhitelist = string.Empty;
     [ObservableProperty] private bool _isRemoveTextContainsOn;
     [ObservableProperty] private string _textContains;
     [ObservableProperty] private bool _isRemoveOnlyMusicSymbolsOn;
@@ -132,6 +133,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
         IsRemoveTextBeforeColonSeparateLineOn = settings.IsRemoveTextBeforeColonSeparateLineOn;
 
         IsRemoveTextUppercaseLineOn = settings.IsRemoveTextUppercaseLineOn;
+        UppercaseWhitelist = settings.UppercaseWhitelist;
 
         IsRemoveTextContainsOn = settings.IsRemoveTextContainsOn;
         TextContains = settings.TextContains;
@@ -160,6 +162,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
         settings.IsRemoveTextBeforeColonSeparateLineOn = IsRemoveTextBeforeColonSeparateLineOn;
 
         settings.IsRemoveTextUppercaseLineOn = IsRemoveTextUppercaseLineOn;
+        settings.UppercaseWhitelist = UppercaseWhitelist;
 
         settings.IsRemoveTextContainsOn = IsRemoveTextContainsOn;
         settings.TextContains = TextContains;
@@ -314,10 +317,14 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
         var textContainsList = TextContains.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries)
             .Select(p => p.Trim()).ToList();
 
+        var uppercaseWhitelist = (UppercaseWhitelist ?? string.Empty).Split([',', ';'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(p => p.Trim()).Where(p => p.Length > 0).ToList();
+
         var settings = new RemoveTextForHISettings(subtitle)
         {
             OnlyIfInSeparateLine = IsOnlySeparateLine,
             RemoveIfAllUppercase = IsRemoveTextUppercaseLineOn,
+            UppercaseWhitelist = uppercaseWhitelist,
             RemoveTextBeforeColon = IsRemoveTextBeforeColonOn,
             RemoveTextBeforeColonOnlyUppercase = IsRemoveTextBeforeColonUppercaseOn,
             ColonSeparateLine = IsRemoveTextBeforeColonSeparateLineOn,

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -190,7 +190,10 @@ public class RemoveTextForHearingImpairedWindow : Window
     {
         var comboBoxLineUppercase = UiUtil.MakeCheckBox(Se.Language.Tools.RemoveTextForHearingImpaired.IfLineIsUppercase, vm, nameof(vm.IsRemoveTextUppercaseLineOn));
         var textBoxWhitelist = UiUtil.MakeTextBox(160, vm, nameof(vm.UppercaseWhitelist)).WithMarginLeft(5);
-        ToolTip.SetTip(textBoxWhitelist, Se.Language.Tools.RemoveTextForHearingImpaired.KeepUppercaseWords);
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(textBoxWhitelist, Se.Language.Tools.RemoveTextForHearingImpaired.KeepUppercaseWords);
+        }
         var panel = new StackPanel
         {
             Orientation = Orientation.Horizontal,

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -189,7 +189,19 @@ public class RemoveTextForHearingImpairedWindow : Window
     private static Border MakeUppercaseLineView(RemoveTextForHearingImpairedViewModel vm)
     {
         var comboBoxLineUppercase = UiUtil.MakeCheckBox(Se.Language.Tools.RemoveTextForHearingImpaired.IfLineIsUppercase, vm, nameof(vm.IsRemoveTextUppercaseLineOn));
-        return UiUtil.MakeBorderForControl(comboBoxLineUppercase).WithMarginBottom(5);
+        var textBoxWhitelist = UiUtil.MakeTextBox(160, vm, nameof(vm.UppercaseWhitelist)).WithMarginLeft(5);
+        ToolTip.SetTip(textBoxWhitelist, Se.Language.Tools.RemoveTextForHearingImpaired.KeepUppercaseWords);
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children =
+            {
+                comboBoxLineUppercase,
+                textBoxWhitelist,
+            }
+        };
+
+        return UiUtil.MakeBorderForControl(panel).WithMarginBottom(5);
     }
 
     private static Border MakeLineContainsView(RemoveTextForHearingImpairedViewModel vm)

--- a/src/ui/Logic/Config/Language/Tools/LanguageRemoveTextForHearingImpaired.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageRemoveTextForHearingImpaired.cs
@@ -15,6 +15,7 @@ public class LanguageRemoveTextForHearingImpaired
     public string OnlyIfTextIsUppercase { get; set; }
     public string OnlyOnSeparateLine { get; set; }
     public string IfLineIsUppercase { get; set; }
+    public string KeepUppercaseWords { get; set; }
     public string IfLineContains { get; set; }
     public string IfLineOnlyContainsMusicSymbols { get; set; }
     public string RemoveInterjections { get; set; }
@@ -34,6 +35,7 @@ public class LanguageRemoveTextForHearingImpaired
         OnlyIfTextIsUppercase = "Only if text is uppercase";
         OnlyOnSeparateLine = "Only on separate line";
         IfLineIsUppercase = "If line is uppercase";
+        KeepUppercaseWords = "Keep these words (comma separated)";
         IfLineContains = "If line contains";
         IfLineOnlyContainsMusicSymbols = "If line only contains music symbols";
         RemoveInterjections = "Remove interjections";

--- a/src/ui/Logic/Config/SeRemoveTextForHi.cs
+++ b/src/ui/Logic/Config/SeRemoveTextForHi.cs
@@ -49,7 +49,7 @@ public class SeRemoveTextForHi
         CustomStart = "?";
         CustomEnd = "?";
         TextContains = string.Empty;
-        UppercaseWhitelist = "YES, NO, WHY, HI, OK, TV, OK.";
+        UppercaseWhitelist = "YES, NO, WHY, HI, OK, TV";
 
         Interjections =
         [

--- a/src/ui/Logic/Config/SeRemoveTextForHi.cs
+++ b/src/ui/Logic/Config/SeRemoveTextForHi.cs
@@ -26,6 +26,9 @@ public class SeRemoveTextForHi
 
     public bool IsRemoveTextUppercaseLineOn { get; set; }
 
+    // Comma-separated all-uppercase words kept by "remove if all uppercase" (issue #11563).
+    public string UppercaseWhitelist { get; set; }
+
     public bool IsRemoveTextContainsOn { get; set; }
     public string TextContains { get; set; }
 
@@ -46,6 +49,7 @@ public class SeRemoveTextForHi
         CustomStart = "?";
         CustomEnd = "?";
         TextContains = string.Empty;
+        UppercaseWhitelist = "YES, NO, WHY, HI, OK, TV, OK.";
 
         Interjections =
         [


### PR DESCRIPTION
Fixes #11563.

**Problem:** 'Remove text for hearing impaired' → 'Remove if all uppercase' deleted short all-caps lines like `OK`, `WWE` and other acronyms, because the keep-list was hardcoded (`YES/NO/WHY/HI/OK` + single char) and not user-editable.

**Fix:** replace the hardcoded list with a configurable, comma-separated **whitelist** (default `YES, NO, WHY, HI, OK, TV, OK.`) shown as a text box next to the 'If line is uppercase' checkbox. All-uppercase lines matching the whitelist (case-insensitive) are kept; single-letter lines like `I` are always kept.

Wired through libse (`RemoveTextForHISettings` / `RemoveTextForHI` + the persisted default) and the SE5 settings/view-model/window, so it benefits both the dialog and batch convert.