### PR TITLE
Waveform: block overlap when drag-creating a new selection

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1056,6 +1056,40 @@ public class AudioVisualizer : Control
         if (_interactionMode == InteractionMode.New && newP != null && properties.IsLeftButtonPressed)
         {
             var seconds = RelativeXPositionToSeconds(point.X);
+
+            // Block overlap with neighbouring subtitles by default, like SE4 and the resize/move
+            // path: keep the dragged selection inside the empty gap around its anchor. Holding Shift
+            // or enabling "allow overlap" in settings bypasses the clamp.
+            if (!_isShiftDown && !Se.Settings.Waveform.AllowOverlap)
+            {
+                var lowerBound = 0.0;
+                var upperBound = double.MaxValue;
+                foreach (var p in _displayableParagraphs)
+                {
+                    if (p == newP)
+                    {
+                        continue;
+                    }
+
+                    var pEnd = p.EndTime.TotalSeconds;
+                    var pStart = p.StartTime.TotalSeconds;
+                    if (pEnd <= _newSelectionSeconds && pEnd + MinGapSeconds > lowerBound)
+                    {
+                        lowerBound = pEnd + MinGapSeconds;
+                    }
+
+                    if (pStart >= _newSelectionSeconds && pStart - MinGapSeconds < upperBound)
+                    {
+                        upperBound = pStart - MinGapSeconds;
+                    }
+                }
+
+                if (upperBound >= lowerBound)
+                {
+                    seconds = Math.Clamp(seconds, lowerBound, upperBound);
+                }
+            }
+
             if (seconds > _newSelectionSeconds)
             {
                 newP.StartTime = TimeSpan.FromSeconds(_newSelectionSeconds);


### PR DESCRIPTION
Part of #11602 (and an SE4-parity fix).

When dragging a new selection in the waveform (to insert a subtitle for that range), the drag extended freely into neighbouring subtitles. Resize/move already clamp against neighbours unless Shift is held or "allow overlap" is enabled, but the new-selection drag did not, so a new line could silently overlap, unlike SE4.

Clamp the dragged end to the empty gap around the selection's anchor (honouring the minimum gap); Shift or `Waveform.AllowOverlap` bypasses it. The rebindable "Insert new selection" shortcut already exists, so no shortcut change is needed.
