### PR TITLE
Remove text for HI: show count of lines found (#11966)

### DIFF
--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -69,6 +69,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [ObservableProperty] private string _fixText;
     [ObservableProperty] private bool _fixTextEnabled;
     [ObservableProperty] private bool _isApplyVisible;
+    [ObservableProperty] private string _linesFoundText;
 
     public Window? Window { get; set; }
 
@@ -91,6 +92,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
         Languages = new ObservableCollection<LanguageItem>(LanguageItem.GetAll());
         Fixes = new ObservableCollection<RemoveItem>();
         FixText = string.Empty;
+        LinesFoundText = string.Format(Se.Language.Tools.RemoveTextForHearingImpaired.LinesFoundX, 0);
         _timer = new Timer(500);
         _timer.Elapsed += TimerElapsed;
         FixedSubtitle = new Subtitle();
@@ -283,6 +285,8 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
             }
         }
 
+        LinesFoundText = string.Format(Se.Language.Tools.RemoveTextForHearingImpaired.LinesFoundX, newFixes.Count);
+
         if (newFixes.Count == Fixes.Count)
         {
             var same = true;
@@ -305,8 +309,6 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
 
         Fixes.Clear();
         Fixes.AddRange(newFixes);
-
-        //groupBoxLinesFound.Text = string.Format(_language.LinesFoundX, count);
     }
 
     public RemoveTextForHISettings GetSettings(Subtitle subtitle)

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -270,7 +270,7 @@ public class RemoveTextForHearingImpairedWindow : Window
         return UiUtil.MakeBorderForControl(grid);
     }
 
-    private Border MakeFixesView(RemoveTextForHearingImpairedViewModel vm)
+    private Grid MakeFixesView(RemoveTextForHearingImpairedViewModel vm)
     {
         var dataGrid = new DataGrid
         {
@@ -332,7 +332,29 @@ public class RemoveTextForHearingImpairedWindow : Window
         new DataGridCheckboxMultiSelect<RemoveItem>(dataGrid,
             item => item.Apply, (item, v) => item.Apply = v);
 
-        return UiUtil.MakeBorderForControl(dataGrid);
+        var labelLinesFound = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.LinesFoundText));
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowSpacing = 5,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+
+        grid.Add(UiUtil.MakeBorderForControl(dataGrid), 0, 0);
+        grid.Add(labelLinesFound, 1, 0);
+
+        return grid;
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Logic/Config/Language/Tools/LanguageRemoveTextForHearingImpaired.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageRemoveTextForHearingImpaired.cs
@@ -18,6 +18,7 @@ public class LanguageRemoveTextForHearingImpaired
     public string IfLineContains { get; set; }
     public string IfLineOnlyContainsMusicSymbols { get; set; }
     public string RemoveInterjections { get; set; }
+    public string LinesFoundX { get; set; }
 
     public LanguageRemoveTextForHearingImpaired()
     {
@@ -37,5 +38,6 @@ public class LanguageRemoveTextForHearingImpaired
         IfLineContains = "If line contains";
         IfLineOnlyContainsMusicSymbols = "If line only contains music symbols";
         RemoveInterjections = "Remove interjections";
+        LinesFoundX = "Lines found: {0}";
     }
 }


### PR DESCRIPTION
Fixes #11966

In SE5's *Remove text for hearing impaired* window the count of affected lines (shown in SE4 as "Lines found: X") was missing. This restores it as a label below the preview grid, updating live as options change.

## Changes
- **`LanguageRemoveTextForHearingImpaired.cs`** — add `LinesFoundX` string (`"Lines found: {0}"`).
- **`RemoveTextForHearingImpairedViewModel.cs`** — add observable `LinesFoundText`, set it from the number of fixes in `GeneratePreview` (replacing the leftover commented-out line).
- **`RemoveTextForHearingImpairedWindow.cs`** — add a label bound to `LinesFoundText` below the preview DataGrid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)