### PR TITLE
Fix invalid JSON in AI translate request bodies (#11965)

### DIFF
--- a/src/libse/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libse/AutoTranslate/ChatGptTranslate.cs
@@ -102,7 +102,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 Configuration.Settings.Tools.ChatGptPrompt = new ToolsSettings().ChatGptPrompt;
             }
             var prompt = string.Format(Configuration.Settings.Tools.ChatGptPrompt, sourceLanguageCode, targetLanguageCode);
-            var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+            var input = "{\"model\": \"" + Json.EncodeJsonText(model) + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);

--- a/src/libse/SubtitleFormats/Json.cs
+++ b/src/libse/SubtitleFormats/Json.cs
@@ -13,6 +13,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public static string EncodeJsonText(string text, string newLineCharacter = "<br />")
         {
+            // Normalize every line-break variant up front so a stray \n or \r (e.g. from a
+            // non-platform line ending) becomes the placeholder instead of being emitted as a
+            // raw control character, which would otherwise make the JSON body invalid.
+            text = text.Replace("\r\n", "\n").Replace('\r', '\n');
+
             var sb = new StringBuilder(text.Length);
             foreach (var c in text)
             {
@@ -24,12 +29,34 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     case '"':
                         sb.Append("\\\"");
                         break;
+                    case '\n':
+                        sb.Append(newLineCharacter);
+                        break;
+                    case '\t':
+                        sb.Append("\\t");
+                        break;
+                    case '\b':
+                        sb.Append("\\b");
+                        break;
+                    case '\f':
+                        sb.Append("\\f");
+                        break;
                     default:
-                        sb.Append(c);
+                        if (c < ' ')
+                        {
+                            // Any other control character (U+0000–U+001F) must be \u-escaped to be valid JSON.
+                            sb.Append("\\u");
+                            sb.Append(((int)c).ToString("x4"));
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
                         break;
                 }
             }
-            return sb.ToString().Replace(Environment.NewLine, newLineCharacter);
+
+            return sb.ToString();
         }
 
         public static string DecodeJsonText(string text)
@@ -77,6 +104,25 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         sb.Append(unescaped);
                         i += 5;
                         keepNext = false;
+                    }
+                    else if (i + 1 < text.Length)
+                    {
+                        var handled = true;
+                        switch (text[i + 1])
+                        {
+                            case 't': sb.Append('\t'); break;
+                            case 'b': sb.Append('\b'); break;
+                            case 'f': sb.Append('\f'); break;
+                            case 'n': sb.Append('\n'); break;
+                            case 'r': sb.Append('\r'); break;
+                            default: handled = false; break;
+                        }
+
+                        if (handled)
+                        {
+                            i++; // also consume the escaped letter
+                            keepNext = false;
+                        }
                     }
                 }
                 else

--- a/tests/libse/Core/JsonTest.cs
+++ b/tests/libse/Core/JsonTest.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
 namespace LibSETests.Core;
 
@@ -7,14 +7,14 @@ public class JsonTest
     [Fact]
     public void TestUnicodeFirst()
     {
-        var result = Json.DecodeJsonText("\u05d1 ");
+        var result = Json.DecodeJsonText("ב ");
         Assert.Equal("ב ", result);
     }
 
     [Fact]
     public void TestUnicodeLast()
     {
-        var result = Json.DecodeJsonText(" \u05d1");
+        var result = Json.DecodeJsonText(" ב");
         Assert.Equal(" ב", result);
     }
 
@@ -22,18 +22,51 @@ public class JsonTest
     public void TestConsecutiveUnicodeEscapes()
     {
         // Raw JSON unicode escapes (as they appear in API responses like Baidu)
-        // \u5bf9 = 对, \u4e0d = 不, \u8d77 = 起 → "对不起" (I'm sorry in Chinese)
+        // 对 = 对, 不 = 不, 起 = 起 → "对不起" (I'm sorry in Chinese)
         var input = "\\u5bf9\\u4e0d\\u8d77";
         var result = Json.DecodeJsonText(input);
-        Assert.Equal("\u5bf9\u4e0d\u8d77", result);
+        Assert.Equal("对不起", result);
     }
 
     [Fact]
     public void TestMixedUnicodeAndLiteralChars()
     {
         // Mixed: literal 对, escaped 不, literal 起 (as Baidu API may return)
-        var input = "\u5bf9\\u4e0d\u8d77";
+        var input = "对\\u4e0d起";
         var result = Json.DecodeJsonText(input);
-        Assert.Equal("\u5bf9\u4e0d\u8d77", result);
+        Assert.Equal("对不起", result);
+    }
+
+    [Fact]
+    public void TestEncodeTabIsEscaped()
+    {
+        // A literal tab is a JSON control character and must be escaped, otherwise the
+        // request body is invalid JSON (see issue #11965).
+        var result = Json.EncodeJsonText("a\tb");
+        Assert.Equal("a\\tb", result);
+    }
+
+    [Fact]
+    public void TestEncodeStrayNewLineIsNotRawControlChar()
+    {
+        // A bare \n (non-platform line ending) must become the placeholder, not a raw
+        // control character that breaks the JSON body.
+        var result = Json.EncodeJsonText("a\nb");
+        Assert.Equal("a<br />b", result);
+        Assert.DoesNotContain('\n', result);
+    }
+
+    [Fact]
+    public void TestEncodeOtherControlCharIsUnicodeEscaped()
+    {
+        var result = Json.EncodeJsonText("ab");
+        Assert.Equal("a\\u0001b", result);
+    }
+
+    [Fact]
+    public void TestEncodeDecodeTabRoundTrip()
+    {
+        var result = Json.DecodeJsonText(Json.EncodeJsonText("a\tb"));
+        Assert.Equal("a\tb", result);
     }
 }


### PR DESCRIPTION
Fixes #11965

## Problem
A user hit a `400 Bad Request` from the OpenAI API when translating:

> "We could not parse the JSON body of your request… what was sent was not valid JSON"

This is **SE5** (stack trace shows `Features.Translate.AutoTranslateViewModel` / `MergeAndSplitHelper`). The reported model `gpt-4o-mini` is a red herring — a bad model returns `model_not_found`, not a JSON-parse error.

## Root cause
The AI translators build their request bodies by hand via `Json.EncodeJsonText`, which only escaped `\` and `"` and replaced `Environment.NewLine`. JSON forbids literal control characters (U+0000–U+001F) inside strings, but tabs and stray `\n`/`\r` (e.g. a non-platform line ending) passed through raw — producing an invalid JSON payload that OpenAI rejects. Because every AI translator (ChatGPT, Anthropic, Gemini, Groq, Mistral, DeepSeek, …) funnels through this one helper, they were all affected.

## Fix
- `Json.EncodeJsonText`: normalize all line-break variants up front, and escape `\t`, `\b`, `\f` and `\u00XX` for remaining control chars so the output is always valid JSON. Normal text (platform newlines, no control chars) encodes identically to before.
- `Json.DecodeJsonText`: handle `\t \b \f \n \r` so the SE JSON subtitle format still round-trips.
- `ChatGptTranslate`: also encode the model name (defense in depth).
- Added unit tests for tab/stray-newline/control-char encoding and round-trip.

All 485 libse tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)