### PR TITLE
Spell check: don't flag words wrapped in single quotes (#11975)

### DIFF
--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -303,6 +303,22 @@ public class SpellChecker : ISpellChecker, IDoSpell
         }
 
         var isCorrect = IsWordCorrect(word);
+
+        // A word wrapped in single quotes used as quotation marks (e.g. 'Een ridder ...') keeps the
+        // leading/trailing apostrophe attached during splitting, so retry without them. The apostrophe
+        // is not a split char because it is part of contractions like 'n / don't. (#11975)
+        if (!isCorrect)
+        {
+            var trimmed = word.Trim('\'');
+            if (trimmed.Length > 0 && trimmed != word &&
+                (IsWordCorrect(trimmed) ||
+                 IsName(trimmed, text) ||
+                 (WordLists != null && WordLists.HasUserWord(trimmed))))
+            {
+                isCorrect = true;
+            }
+        }
+
         return isCorrect;
     }
 

--- a/src/ui/Features/SpellCheck/SpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckManager.cs
@@ -155,6 +155,21 @@ public class SpellCheckManager : SpellChecker, ISpellCheckManager
 
         var isCorrect = DoSpell(word) || IsEnglishInApostropheActuallyIng(word);
 
+        // A word wrapped in single quotes used as quotation marks (e.g. 'Een ridder ...') keeps the
+        // leading/trailing apostrophe attached during splitting, so retry without them. The apostrophe
+        // is not a split char because it is part of contractions like 'n / don't. (#11975)
+        if (!isCorrect)
+        {
+            var trimmed = word.Trim('\'');
+            if (trimmed.Length > 0 && trimmed != word &&
+                (DoSpell(trimmed) ||
+                 IsName(trimmed, text) ||
+                 (WordLists != null && WordLists.HasUserWord(trimmed))))
+            {
+                isCorrect = true;
+            }
+        }
+
         if (ChangeAllDictionary.ContainsKey(word) && NotSameSpecialEnding(words[wordIndex], ChangeAllDictionary[word], text))
         {
             ChangeWord(word, ChangeAllDictionary[word], words[wordIndex], p);


### PR DESCRIPTION
Fixes #11975

## Problem

A subtitle line wrapped in single quotes used as quotation marks, e.g. `'Een ridder heeft moed gezworen.'`, was flagged by the spell checker on the first word. The issue reporter saw the common word `een` flagged.

The leading `'` (which the reporter calls an "accent") stays attached to the first word during word splitting, producing `'Een`. The apostrophe is **intentionally not** a split character because it's part of contractions like `'n` and `don't`, so `'Een` fails the dictionary lookup and gets flagged.

![screenshot](https://github.com/user-attachments/assets/7a8033a4-0cf4-4b98-b021-d06039ac6294)

## Fix

When a word isn't found, retry the lookup with the surrounding apostrophes trimmed — only accepting it when the trimmed form is a real dictionary word, name, or user word (so genuine typos like `'Eenn'` are still flagged). This mirrors the existing behavior in `OcrFixEngine`, which already trims `' " -` and re-checks.

Applied in two places that lacked it:
- `SpellCheckManager` — the interactive spell-check window (shown in the screenshot).
- `SpellChecker` base `IsWordCorrect` — used by the editor's red-underline highlighting, so quoted words aren't underlined either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)