### PR TITLE
Fix dialogs opening behind undocked video/audio windows (#11971)

### DIFF
--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -158,6 +158,11 @@ namespace Nikse.SubtitleEdit.Logic
             ApplyRightToLeftSettings(window);
             UiTheme.ApplyScaleToWindow(window);
 
+            // Keep the dialog above undocked tool windows (audio visualizer / video player), which
+            // float on top of the main window via the same helper. Without this the dialog opens
+            // behind them in undocked mode. (#11971)
+            KeepTopmostWhileOwnerActive(window, owner);
+
             await window.ShowDialog(owner);
 
             return window;
@@ -187,8 +192,13 @@ namespace Nikse.SubtitleEdit.Logic
             ApplyRightToLeftSettings(window);
             UiTheme.ApplyScaleToWindow(window);
 
+            // Keep the dialog above undocked tool windows (audio visualizer / video player), which
+            // float on top of the main window via the same helper. Without this the dialog opens
+            // behind them in undocked mode. (#11971)
+            KeepTopmostWhileOwnerActive(window, owner);
+
             await window.ShowDialog(owner);
-            
+
             return viewModel;
         }
 


### PR DESCRIPTION
Fixes #11971

## Problem

With the video controls / audio visualizer **undocked**, opening Settings (also Shortcuts, Word lists, Speech to Text) makes the dialog appear *behind* the undocked Audio visualizer window. The Find dialog is unaffected. Clicking **Apply** in Settings sends it behind again.

## Root cause

Undocked windows float above the main window via `WindowService.KeepTopmostWhileOwnerActive(window, Window!)`, which sets `Topmost = owner.IsActive || child.IsActive`. So while the main window is active, they have `Topmost = true`.

- **Find** (works): shown via `ShowWindow` **plus** `KeepTopmostWhileOwnerActive`, so it joins the same "topmost-while-active" tier and, activated last, sits on top.
- **Settings / Shortcuts / Word lists / Speech to Text** (broken): shown via `ShowDialogAsync` → plain `window.ShowDialog(owner)` with no topmost handling, so they are normal (non-topmost) windows and render beneath the `Topmost=true` undocked window.

The deferred topmost-recompute doesn't rescue it: a modal dialog is an *owned child* of the main window, so the main window never fires `Deactivated`, the undocked window's `Topmost` is never lowered, and the dialog stays hidden. "Apply" re-activates the main window and re-asserts the same state.

## Fix

Apply `KeepTopmostWhileOwnerActive(window, owner)` to dialogs in both `ShowDialogAsync` overloads (`WindowsService.cs`). The dialog joins the topmost tier — activated last, it sits above the undocked windows — and, unlike a blanket `Topmost = true`, it still drops below other applications when SE loses focus (the macOS `NSWindowLevel.Floating` caveat the helper was written for). One central change fixes Settings, Shortcuts, Word lists, Speech to Text, and any future `ShowDialogAsync` dialog.

This also keeps the undocked windows linked/floating with the main app — dialogs now float *above* them rather than dropping the linkage.

## Testing

- Builds clean (`UI.csproj`).
- Manual verification of undocked-mode z-order on Windows recommended before release (I can't drive the GUI here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)