### PR TITLE
Add grid click action "Go to subtitle and play and focus text box" (#11602)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20802,6 +20802,15 @@ public partial class MainViewModel :
                 return;
             }
 
+            if (Se.Settings.General.SubtitleDoubleClickAction == SubtitleDoubleClickActionType.GoToSubtitleAndPlayAndFocusTextBox.ToString())
+            {
+                vp.Position = seconds;
+                vp.VideoPlayer.Play();
+                AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
+                FocusEditTextBox();
+                return;
+            }
+
             // SubtitleDoubleClickActionType.GoToSubtitleAndPause
             vp.VideoPlayer.Pause();
             vp.Position = seconds;
@@ -20927,6 +20936,15 @@ public partial class MainViewModel :
             {
                 vp.VideoPlayer.Pause();
                 vp.Position = seconds;
+                AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
+                FocusEditTextBox();
+                return;
+            }
+
+            if (Se.Settings.General.SubtitleSingleClickAction == SubtitleSingleClickActionType.GoToSubtitleAndPlayAndFocusTextBox.ToString())
+            {
+                vp.Position = seconds;
+                vp.VideoPlayer.Play();
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 FocusEditTextBox();
             }

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -492,7 +492,8 @@ public partial class SettingsViewModel : ObservableObject
             Se.Language.Options.Settings.GridGoToSubtitleAndPause,
             Se.Language.Options.Settings.GridGoToSubtitleAndPlay,
             Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition,
-            Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox
+            Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox,
+            Se.Language.Options.Settings.GridGoToSubtitleAndPlayAndFocusTextBox
         ];
         SelectedSubtitleSingleClickActionType = SubtitleSingleClickActionTypes[0];
 
@@ -502,7 +503,8 @@ public partial class SettingsViewModel : ObservableObject
             Se.Language.Options.Settings.GridGoToSubtitleAndPause,
             Se.Language.Options.Settings.GridGoToSubtitleAndPlay,
             Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition,
-            Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox
+            Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox,
+            Se.Language.Options.Settings.GridGoToSubtitleAndPlayAndFocusTextBox
         ];
         SelectedSubtitleDoubleClickActionType = SubtitleDoubleClickActionTypes[0];
 
@@ -1248,6 +1250,7 @@ public partial class SettingsViewModel : ObservableObject
         { SubtitleSingleClickActionType.GoToSubtitleAndPlay.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPlay },
         { SubtitleSingleClickActionType.GoToSubtitleAndSetVideoPosition.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition },
         { SubtitleSingleClickActionType.GoToSubtitleAndPauseAndFocusTextBox.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox },
+        { SubtitleSingleClickActionType.GoToSubtitleAndPlayAndFocusTextBox.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPlayAndFocusTextBox },
     };
 
     private static Dictionary<string, string> SingleClickTextToActionMap => _singleClickActionToTextMap.ToDictionary(x => x.Value, x => x.Key);
@@ -1285,6 +1288,7 @@ public partial class SettingsViewModel : ObservableObject
         { SubtitleDoubleClickActionType.GoToSubtitleAndPlay.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPlay },
         { SubtitleDoubleClickActionType.GoToSubtitleOnly.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition },
         { SubtitleDoubleClickActionType.GoToSubtitleAndPauseAndFocusTextBox.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox },
+        { SubtitleDoubleClickActionType.GoToSubtitleAndPlayAndFocusTextBox.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPlayAndFocusTextBox },
     };
 
     // Rebuilds the static language-dependent maps in place so callers keep their reference.

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -268,6 +268,7 @@ public class LanguageSettings
     public string GridGoToSubtitleAndPause { get; set; }
     public string GridGoToSubtitleAndPlay { get; set; }
     public string GridGoToSubtitleAndPauseAndFocusTextBox { get; set; }
+    public string GridGoToSubtitleAndPlayAndFocusTextBox { get; set; }
     public string SubtitleGridFormattingNone { get; set; }
     public string SubtitleGridFormattingShowFormatting { get; set; }
     public string SubtitleGridFormattingShowTags { get; set; }
@@ -583,6 +584,7 @@ public class LanguageSettings
         GridGoToSubtitleAndPause = "Go to subtitle and pause";
         GridGoToSubtitleAndPlay = "Go to subtitle and play";
         GridGoToSubtitleAndPauseAndFocusTextBox = "Go to subtitle and pause and focus text box";
+        GridGoToSubtitleAndPlayAndFocusTextBox = "Go to subtitle and play and focus text box";
         SubtitleGridFormattingNone = "No formatting";
         SubtitleGridFormattingShowFormatting = "Show formatting";
         SubtitleGridFormattingShowTags = "Show tags";

--- a/src/ui/Logic/Config/SubtitleDoubleClickActionType.cs
+++ b/src/ui/Logic/Config/SubtitleDoubleClickActionType.cs
@@ -7,4 +7,5 @@ public enum SubtitleDoubleClickActionType
     GoToSubtitleAndPlay,
     GoToSubtitleOnly,
     GoToSubtitleAndPauseAndFocusTextBox,
+    GoToSubtitleAndPlayAndFocusTextBox,
 }

--- a/src/ui/Logic/Config/SubtitleSingleClickActionType.cs
+++ b/src/ui/Logic/Config/SubtitleSingleClickActionType.cs
@@ -8,4 +8,5 @@ public enum SubtitleSingleClickActionType
     GoToSubtitleAndPlay,
     GoToSubtitleAndSetVideoPosition,
     GoToSubtitleAndPauseAndFocusTextBox,
+    GoToSubtitleAndPlayAndFocusTextBox,
 }


### PR DESCRIPTION
Part of #11602 (suggestion 2).

The single-click and double-click grid action lists offered a pause-and-focus variant but not a play-and-focus one. This adds **Go to subtitle and play and focus text box** to both, so the video keeps playing while the caret moves into the edit box (edit text without stopping playback).

Wires the new value through both click-action enums, both handlers, the settings combo boxes, the action/label maps, and the language string.