### PR TITLE
Adjust all times: add independent extend start/end option (#11602)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21002,6 +21002,53 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
+    public void ExtendStartEndTimes(TimeSpan extendStartEarlier, TimeSpan extendEndLater, bool adjustAll,
+        bool adjustSelectedLines, bool adjustSelectedLinesAndForward)
+    {
+        if (extendStartEarlier <= TimeSpan.Zero && extendEndLater <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        List<SubtitleLineViewModel> targets;
+        if (adjustSelectedLines)
+        {
+            targets = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        }
+        else if (adjustSelectedLinesAndForward)
+        {
+            var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+            if (selectedItems.Count == 0)
+            {
+                return;
+            }
+
+            var firstSelectedIndex = selectedItems.Min(p => Subtitles.IndexOf(p));
+            targets = Subtitles.Skip(firstSelectedIndex).ToList();
+        }
+        else
+        {
+            targets = Subtitles.ToList();
+        }
+
+        foreach (var p in targets)
+        {
+            // Extend start earlier keeps the end fixed; extend end later keeps the
+            // start fixed. Both grow the line's duration. SetTimes applies both ends
+            // atomically and recomputes duration.
+            var newStart = extendStartEarlier > TimeSpan.Zero ? p.StartTime - extendStartEarlier : p.StartTime;
+            var newEnd = extendEndLater > TimeSpan.Zero ? p.EndTime + extendEndLater : p.EndTime;
+            if (newStart < TimeSpan.Zero)
+            {
+                newStart = TimeSpan.Zero;
+            }
+
+            p.SetTimes(newStart, newEnd);
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
 
     internal void DurationChanged()
     {

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
@@ -14,6 +14,8 @@ namespace Nikse.SubtitleEdit.Features.Sync.AdjustAllTimes;
 public partial class AdjustAllTimesViewModel : ObservableObject
 {
     [ObservableProperty] private TimeSpan _adjustment;
+    [ObservableProperty] private TimeSpan _extendStartEarlier;
+    [ObservableProperty] private TimeSpan _extendEndLater;
     [ObservableProperty] private bool _adjustAll;
     [ObservableProperty] private bool _adjustSelectedLines;
     [ObservableProperty] private bool _adjustSelectedLinesAndForward;
@@ -58,6 +60,8 @@ public partial class AdjustAllTimesViewModel : ObservableObject
     private void LoadSettings()
     {
         Adjustment = TimeSpan.FromSeconds(Se.Settings.Synchronization.AdjustAllTimes.Seconds);
+        ExtendStartEarlier = TimeSpan.FromSeconds(Se.Settings.Synchronization.AdjustAllTimes.ExtendStartSeconds);
+        ExtendEndLater = TimeSpan.FromSeconds(Se.Settings.Synchronization.AdjustAllTimes.ExtendEndSeconds);
         if (Se.Settings.Synchronization.AdjustAllTimes.IsSelectedLinesAndForwardSelected)
         {
             AdjustSelectedLinesAndForward = true;
@@ -75,6 +79,8 @@ public partial class AdjustAllTimesViewModel : ObservableObject
     private void SaveSettings()
     {
         Se.Settings.Synchronization.AdjustAllTimes.Seconds = Adjustment.TotalSeconds;
+        Se.Settings.Synchronization.AdjustAllTimes.ExtendStartSeconds = ExtendStartEarlier.TotalSeconds;
+        Se.Settings.Synchronization.AdjustAllTimes.ExtendEndSeconds = ExtendEndLater.TotalSeconds;
         Se.Settings.Synchronization.AdjustAllTimes.IsSelectedLinesAndForwardSelected = AdjustSelectedLinesAndForward;
         Se.Settings.Synchronization.AdjustAllTimes.IsSelectedLinesSelected = AdjustSelectedLines;
         Se.Settings.Synchronization.AdjustAllTimes.IsAllSelected = AdjustAll;
@@ -118,6 +124,28 @@ public partial class AdjustAllTimesViewModel : ObservableObject
         ShowStatus(string.Format(Se.Language.Sync.TotalAdjustmentX, new TimeCode(_totalAdjustment).ToShortDisplayString()));
         _isNegativeAdjustment = false;
         Apply();
+    }
+
+    [RelayCommand]
+    private void Extend()
+    {
+        if (ExtendStartEarlier <= TimeSpan.Zero && ExtendEndLater <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        SaveSettings();
+        _adjustCallback?.ExtendStartEndTimes(
+            ExtendStartEarlier,
+            ExtendEndLater,
+            AdjustAll,
+            AdjustSelectedLines,
+            AdjustSelectedLinesAndForward);
+
+        ShowStatus(string.Format(
+            Se.Language.Sync.ExtendedStartEndX,
+            new TimeCode(ExtendStartEarlier).ToShortDisplayString(),
+            new TimeCode(ExtendEndLater).ToShortDisplayString()));
     }
 
     [RelayCommand]

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
@@ -70,6 +70,69 @@ public class AdjustAllTimesWindow : Window
             },
         };
 
+        // Independent extend: grow each line's duration by moving the start earlier
+        // and/or the end later, leaving the opposite edge fixed. Uses the same All /
+        // Selected / Selected-and-forward scope as the show earlier/later buttons above.
+        var timeCodeExtendStart = new TimeCodeUpDown
+        {
+            DataContext = vm,
+            [!TimeCodeUpDown.ValueProperty] = new Binding(nameof(vm.ExtendStartEarlier))
+            {
+                Mode = BindingMode.TwoWay,
+            }
+        };
+
+        var timeCodeExtendEnd = new TimeCodeUpDown
+        {
+            DataContext = vm,
+            [!TimeCodeUpDown.ValueProperty] = new Binding(nameof(vm.ExtendEndLater))
+            {
+                Mode = BindingMode.TwoWay,
+            }
+        };
+
+        var rowExtendStart = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                new Label { Content = Se.Language.Sync.ExtendStartEarlier, Width = 120 },
+                timeCodeExtendStart,
+            },
+        };
+
+        var rowExtendEnd = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                new Label { Content = Se.Language.Sync.ExtendEndLater, Width = 120 },
+                timeCodeExtendEnd,
+            },
+        };
+
+        var buttonExtend = UiUtil.MakeButton(Se.Language.Sync.Extend, vm.ExtendCommand)
+            .WithMinWidth(110);
+
+        var panelExtend = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 10,
+            Children =
+            {
+                new Label { Content = Se.Language.Sync.ExtendDuration },
+                rowExtendStart,
+                rowExtendEnd,
+                buttonExtend,
+            },
+        };
+
+        var borderExtend = UiUtil.MakeBorderForControl(panelExtend);
+
         var buttonHelp = UiUtil.MakeButton(vm.ShowHelpCommand, IconNames.Help, Se.Language.Sync.AdjustAllShortcuts);
         var buttonOk = UiUtil.MakeButtonDone(vm.OkCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonHelp, buttonOk);
@@ -80,6 +143,7 @@ public class AdjustAllTimesWindow : Window
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -99,8 +163,9 @@ public class AdjustAllTimesWindow : Window
         grid.Add(timeCodeUpDown,    0, 0);
         grid.Add(panelShowButtons,  0, 1, 2, 1);
         grid.Add(panelRadioButtons, 1, 0);
-        grid.Add(labelStatus,       2, 0);
-        grid.Add(panelButtons,      2, 1);
+        grid.Add(borderExtend,      2, 0, 1, 2);
+        grid.Add(labelStatus,       3, 0);
+        grid.Add(panelButtons,      3, 1);
 
         Content = grid;
 

--- a/src/ui/Features/Sync/AdjustAllTimes/IAdjustCallback.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/IAdjustCallback.cs
@@ -5,4 +5,6 @@ namespace Nikse.SubtitleEdit.Features.Sync.AdjustAllTimes;
 public interface IAdjustCallback
 {
     void Adjust(TimeSpan adjustment, bool adjustAll, bool adjustSelectedLines, bool adjustSelectedLinesAndForward);
+
+    void ExtendStartEndTimes(TimeSpan extendStartEarlier, TimeSpan extendEndLater, bool adjustAll, bool adjustSelectedLines, bool adjustSelectedLinesAndForward);
 }

--- a/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
+++ b/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
@@ -24,6 +24,11 @@ public class LanguageSync
     public string AdjustAllTimes { get; set; }
     public string ShowEarlier { get; set; }
     public string ShowLater { get; set; }
+    public string ExtendDuration { get; set; }
+    public string ExtendStartEarlier { get; set; }
+    public string ExtendEndLater { get; set; }
+    public string Extend { get; set; }
+    public string ExtendedStartEndX { get; set; }
     public string ChangeFrameRate { get; set; }
     public string SetSyncPoint { get; set; }
     public string SyncPoints { get; set; }
@@ -58,6 +63,11 @@ public class LanguageSync
         AdjustAllTimes = "Adjust all times (show earlier/later)";
         ShowEarlier = "Show earlier";
         ShowLater = "Show later";
+        ExtendDuration = "Extend duration (independent start/end)";
+        ExtendStartEarlier = "Start earlier by";
+        ExtendEndLater = "End later by";
+        Extend = "Extend";
+        ExtendedStartEndX = "Extended start by {0}, end by {1}";
         ChangeFrameRate = "Change frame rate";
         SetSyncPoint = "Set sync point";
         SyncPoints = "Sync points";

--- a/src/ui/Logic/Config/SeAdjustAllTimes.cs
+++ b/src/ui/Logic/Config/SeAdjustAllTimes.cs
@@ -3,6 +3,8 @@
 public class SeAdjustAllTimes
 {
     public double Seconds { get; set; }
+    public double ExtendStartSeconds { get; set; }
+    public double ExtendEndSeconds { get; set; }
     public bool IsAllSelected { get; set; }
     public bool IsSelectedLinesSelected { get; set; }
     public bool IsSelectedLinesAndForwardSelected { get; set; }
@@ -10,6 +12,8 @@ public class SeAdjustAllTimes
     public SeAdjustAllTimes()
     {
         Seconds = 0.1d;
+        ExtendStartSeconds = 0.5d;
+        ExtendEndSeconds = 0.5d;
         IsAllSelected = true;
     }
 }


### PR DESCRIPTION
## Adjust all times: independent extend start/end

Implements suggestion #1 from #11602.

### Problem
The Adjust all times dialog only offers "Show earlier" / "Show later", which shift the whole line (start and end move together by the same amount). There was no way to grow a line's duration by pulling only its start earlier or pushing only its end later.

### Change
Adds an "Extend duration (independent start/end)" section to the dialog:

- "Start earlier by" moves each line's start time earlier while keeping its end fixed.
- "End later by" moves each line's end time later while keeping its start fixed.
- The two amounts are independent; you can set either, both, or leave one at zero.
- The Extend action respects the same All / Selected lines / Selected lines and forward scope as the existing buttons.
- Both amounts persist across sessions (new ExtendStartSeconds / ExtendEndSeconds settings, default 0.5s).

The existing "Show earlier" / "Show later" behaviour is unchanged.

### Implementation notes
- New `IAdjustCallback.ExtendStartEndTimes(...)` implemented in `MainViewModel`, applying the edit atomically via `SubtitleLineViewModel.SetTimes` (recomputes duration, never exposes start greater than end). A start that would go negative is clamped to zero.
- View model adds `ExtendStartEarlier` / `ExtendEndLater` observable properties, an `Extend` command, and load/save of the two new settings.
- Window adds the section UI (two TimeCodeUpDown editors plus an Extend button) below the existing controls.

### Files
- `src/ui/Logic/Config/SeAdjustAllTimes.cs`
- `src/ui/Features/Sync/AdjustAllTimes/IAdjustCallback.cs`
- `src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs`
- `src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs`
- `src/ui/Features/Main/MainViewModel.cs`
- `src/ui/Logic/Config/Language/Sync/LanguageSync.cs`
