### PR TITLE
Subtitle grid: triple-click a row to focus the text box without seeking (#11602)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -19169,6 +19169,13 @@ public partial class MainViewModel :
     public void SubtitleGrid_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         StopSubtitleGridDragSelectAutoScroll();
+        if (e.ClickCount <= 1)
+        {
+            // Fresh click sequence: clear any triple-click marker that a previous
+            // sequence may have left set (self-heals if the third Tapped was missed).
+            _pendingTripleClickFocus = false;
+        }
+
         _subtitleGridIsControlPressed = false;
         _subtitleGridIsLeftClick = false;
         _subtitleGridIsRightClick = false;
@@ -19211,6 +19218,18 @@ public partial class MainViewModel :
 
             var isShiftPressed = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
             var rowIndex = GetDataGridRowIndexFromPoint(e.GetPosition(SubtitleGrid));
+
+            // Triple-click a row: focus the edit text box without moving the video
+            // position (#11602). The third click would otherwise re-fire the
+            // single-click action as a plain Tapped, so cancel the pending
+            // single-click and mark the upcoming third Tapped as focus-only.
+            if (e.ClickCount >= 3 && _subtitleGridIsLeftClick && rowIndex >= 0 && rowIndex < Subtitles.Count)
+            {
+                _singleTapCancellationTokenSource?.Cancel();
+                _pendingTripleClickFocus = true;
+                SubtitleGrid.SelectedItem = Subtitles[rowIndex];
+                return;
+            }
 
             if (_subtitleGridIsLeftClick && isShiftPressed && rowIndex >= 0)
             {
@@ -20754,6 +20773,16 @@ public partial class MainViewModel :
     internal void OnSubtitleGridDoubleTapped(object? sender, TappedEventArgs e)
     {
         _singleTapCancellationTokenSource?.Cancel();
+
+        // Should the third click of a triple-click arrive as a DoubleTapped rather
+        // than a Tapped, honour the focus-only marker instead of seeking (#11602).
+        if (_pendingTripleClickFocus)
+        {
+            _pendingTripleClickFocus = false;
+            FocusEditTextBox();
+            return;
+        }
+
         OnSubtitleGridDoubleTapped(sender);
     }
 
@@ -20854,9 +20883,21 @@ public partial class MainViewModel :
     }
 
     private CancellationTokenSource? _singleTapCancellationTokenSource;
+    private bool _pendingTripleClickFocus;
 
     internal async void OnSubtitleGridSingleTapped(object? sender, TappedEventArgs e)
     {
+        // A triple-click marks this tap (the third) for "focus text box only" and
+        // must not run the configured single-click action (which would seek). See
+        // SubtitleGrid_PointerPressed (#11602).
+        if (_pendingTripleClickFocus)
+        {
+            _pendingTripleClickFocus = false;
+            _singleTapCancellationTokenSource?.Cancel();
+            FocusEditTextBox();
+            return;
+        }
+
         _singleTapCancellationTokenSource?.Cancel();
         var cts = _singleTapCancellationTokenSource = new CancellationTokenSource();
 


### PR DESCRIPTION
## Subtitle grid: triple-click to focus the text box without seeking

Implements suggestion #3 from #11602.

### Problem
There was no quick way to jump from a grid row straight into editing its text without also moving the video position. Double-click runs the configured action (which seeks), and a third click just re-fired the single-click action.

### Change
A triple-click on a grid row now moves keyboard focus to the edit text box and leaves the video position untouched.

### Implementation notes
- The third click is detected in `SubtitleGrid_PointerPressed` via `PointerPressedEventArgs.ClickCount`. When count reaches 3 on a valid row with the left button, it cancels the pending single-click timer and marks the upcoming tap as focus-only, then selects the row.
- Both the single-tap and double-tap handlers honour that marker (the third click can surface as either depending on the platform's gesture counting), focusing the edit text box instead of running the seek action.
- The marker is cleared at the start of every fresh click sequence (click count 1), so a missed third tap cannot leave it stuck.
- No seeking, no playback change, and the existing single/double-click actions are unchanged.

### Files
- `src/ui/Features/Main/MainViewModel.cs`
