### PR TITLE
Treat save-changes dialog dismissal as Cancel instead of No

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1952,7 +1952,7 @@ public partial class MainViewModel :
             var promptText = string.Format(Se.Language.General.SaveChangesToX, name);
             var dr = await MessageBox.Show(Window!, Se.Language.General.SaveChangesTitle, promptText,
                 MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
-            if (dr == MessageBoxResult.Cancel || dr == MessageBoxResult.None)
+            if (dr != MessageBoxResult.Yes && dr != MessageBoxResult.No)
             {
                 return;
             }
@@ -16027,7 +16027,7 @@ public partial class MainViewModel :
 
             var dr = await MessageBox.Show(Window!, Se.Language.General.SaveChangesTitle, promptText,
                 MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
-            if (dr == MessageBoxResult.Cancel || dr == MessageBoxResult.None)
+            if (dr != MessageBoxResult.Yes && dr != MessageBoxResult.No)
             {
                 return false;
             }
@@ -16072,7 +16072,7 @@ public partial class MainViewModel :
 
             var dr = await MessageBox.Show(Window!, Se.Language.General.SaveChangesTitle, promptText,
                 MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
-            if (dr == MessageBoxResult.Cancel || dr == MessageBoxResult.None)
+            if (dr != MessageBoxResult.Yes && dr != MessageBoxResult.No)
             {
                 return false;
             }
@@ -16703,7 +16703,7 @@ public partial class MainViewModel :
                     MessageBoxButtons.YesNoCancel,
                     MessageBoxIcon.Question);
 
-                if (result == MessageBoxResult.Cancel || result == MessageBoxResult.None)
+                if (result != MessageBoxResult.Yes && result != MessageBoxResult.No)
                 {
                     // Stay cancelled - window won't close
                     return;
@@ -21092,7 +21092,7 @@ public partial class MainViewModel :
             MessageBoxButtons.YesNoCancel,
             MessageBoxIcon.Question);
 
-        if (result == MessageBoxResult.Cancel || result == MessageBoxResult.None)
+        if (result != MessageBoxResult.Yes && result != MessageBoxResult.No)
         {
             return;
         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1952,7 +1952,7 @@ public partial class MainViewModel :
             var promptText = string.Format(Se.Language.General.SaveChangesToX, name);
             var dr = await MessageBox.Show(Window!, Se.Language.General.SaveChangesTitle, promptText,
                 MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
-            if (dr == MessageBoxResult.Cancel)
+            if (dr == MessageBoxResult.Cancel || dr == MessageBoxResult.None)
             {
                 return;
             }
@@ -16027,7 +16027,7 @@ public partial class MainViewModel :
 
             var dr = await MessageBox.Show(Window!, Se.Language.General.SaveChangesTitle, promptText,
                 MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
-            if (dr == MessageBoxResult.Cancel)
+            if (dr == MessageBoxResult.Cancel || dr == MessageBoxResult.None)
             {
                 return false;
             }
@@ -16072,7 +16072,7 @@ public partial class MainViewModel :
 
             var dr = await MessageBox.Show(Window!, Se.Language.General.SaveChangesTitle, promptText,
                 MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
-            if (dr == MessageBoxResult.Cancel)
+            if (dr == MessageBoxResult.Cancel || dr == MessageBoxResult.None)
             {
                 return false;
             }
@@ -16703,7 +16703,7 @@ public partial class MainViewModel :
                     MessageBoxButtons.YesNoCancel,
                     MessageBoxIcon.Question);
 
-                if (result == MessageBoxResult.Cancel)
+                if (result == MessageBoxResult.Cancel || result == MessageBoxResult.None)
                 {
                     // Stay cancelled - window won't close
                     return;
@@ -21092,7 +21092,7 @@ public partial class MainViewModel :
             MessageBoxButtons.YesNoCancel,
             MessageBoxIcon.Question);
 
-        if (result == MessageBoxResult.Cancel)
+        if (result == MessageBoxResult.Cancel || result == MessageBoxResult.None)
         {
             return;
         }


### PR DESCRIPTION
## Problem

When a "Save changes?" dialog is closed without clicking any button, the result was incorrectly treated as `No`, causing unsaved changes to be silently discarded. SE4 handled this correctly by treating it as a cancellation.

## Cause & Fix

`MessageBox.Show` returns `MessageBoxResult.None` when no button is clicked. The affected code paths only checked for `MessageBoxResult.Cancel`, so `None` fell through to the "No" branch.

The fix adds `|| dr == MessageBoxResult.None` to all five save-changes guard conditions in `MainViewModel.cs`:

- `FileCloseTranslation`
- `HasChangesContinue`
- `ContinueNewOrExitOriginal`
- `OnClosing`
- `OnWindowClosing`

## Testing

Tested on Windows 11 x64 (local build).