### PR TITLE
Pass selected language to CrispASR Parakeet backend

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -14,7 +14,7 @@ public class CrispAsrParakeet : CrispAsrEngineBase
     public override string Url => "https://github.com/CrispStrobe/CrispASR";
     public override string BackendName => "parakeet";
     public override string DefaultLanguage => "en";
-    public override bool IncludeLanguage => false;
+    public override bool IncludeLanguage => true;
     public override bool HasNativeTimestamps => true;
 
     public override List<WhisperLanguage> Languages =>


### PR DESCRIPTION
## Problem

Issue #11988: the Crisp ASR module ignores language settings — selecting Russian for Parakeet transcribes as English.

## Cause

`CrispAsrParakeet` declared `IncludeLanguage => false`, a leftover from when Parakeet was an English-only model. In `SpeechToTextViewModel`, the `-l <lang>` argument is only appended when `IncludeLanguage` is true (or language is "auto"), so the user's language choice was dropped and the `parakeet` backend fell back to its built-in English default.

Parakeet now ships multilingual `tdt-0.6b-v3` models and the engine lists 14 languages, and the binary accepts `-l LANG` for parakeet.

## Fix

Set `IncludeLanguage => true` so the selected language is forwarded (matching Kyutai/Cohere/Canary). "Auto detect" still passes `-l auto`.

Fixes #11988

🤖 Generated with [Claude Code](https://claude.com/claude-code)