### PR TITLE
Qwen3 ASR: use v0.1.3 engine, always log unparseable JSON (#11375)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngine.cs
@@ -15,7 +15,7 @@ public class Qwen3AsrCppEngine : ISpeechToTextEngine
     public static string StaticName => "Qwen3 ASR CPP";
     public string Name => StaticName;
     public string Choice => WhisperChoice.Qwen3AsrCpp;
-    public string Url => "https://github.com/woct0rdho/qwen3-asr.cpp";
+    public string Url => "https://github.com/niksedk/qwen3-asr.cpp";
 
     public List<WhisperLanguage> Languages
     {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -932,8 +932,13 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             Se.LogError(ex, $"Failed to read Qwen3 ASR CPP output JSON '{jsonPath}'");
             // Persist the offending output so the failure is diagnosable — the temp .json is
-            // deleted below, so logging its raw content here is the only record (issue #11717).
-            Se.WriteToolsLog($"Qwen3 ASR CPP output JSON failed to parse ({ex.Message}):{Environment.NewLine}{rawJson}");
+            // deleted below, so logging its raw content here is the only record (issue #11717,
+            // #11375). Force the write: the "write tools log" setting is off by default, so without
+            // this the JSON that caused the parse error never reaches the user's bug report.
+            var loggedJson = string.IsNullOrEmpty(rawJson)
+                ? "<output JSON could not be read>"
+                : rawJson;
+            Se.WriteToolsLog($"Qwen3 ASR CPP output JSON failed to parse ({ex.Message}):{Environment.NewLine}{loggedJson}", true);
             Dispatcher.UIThread.Invoke<Task>(async () =>
             {
                 LogToConsole($"Speech to text ({settings.WhisperChoice}) failed: {ex.Message}{Environment.NewLine}");

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -597,7 +597,17 @@ public class Se
 
     public static void WriteToolsLog(string log)
     {
-        if (!Settings.Tools.WriteToolsLog)
+        WriteToolsLog(log, false);
+    }
+
+    /// <summary>
+    /// Writes an entry to the tools log. When <paramref name="force"/> is true the entry is written
+    /// even if the "write tools log" setting is off — use this for hard-failure diagnostics (e.g. an
+    /// engine produced output that could not be parsed) that must be available for a bug report.
+    /// </summary>
+    public static void WriteToolsLog(string log, bool force)
+    {
+        if (!force && !Settings.Tools.WriteToolsLog)
         {
             return;
         }

--- a/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
@@ -17,9 +17,10 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
     private readonly HttpClient _httpClient;
 
     // Built by https://github.com/niksedk/qwen3-asr.cpp (.github/workflows/release.yml) — these
-    // are the binaries with the JSON word-truncation fix (issue #11717). CPU for every platform,
-    // plus Vulkan (GPU) for win64 and linux-x64.
-    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.2/";
+    // are the binaries with the JSON word-truncation fix (issue #11717) plus the valid-JSON fix
+    // for non-finite/oversized timestamps (issue #11375). CPU for every platform, plus Vulkan
+    // (GPU) for win64 and linux-x64.
+    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.3/";
     private const string WindowsUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64.zip";
     private const string WindowsVulkanUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64-vulkan.zip";
     private const string MacArmUrl = ReleaseUrlBase + "qwen3-asr-cpp-mac.zip";


### PR DESCRIPTION
Fixes #11375.

## Problem
The Qwen3 ASR CPP engine could fail *after* a seemingly successful transcription with a JSON parse error:
- RC2: `'0x0D' is invalid within a JSON string`
- 5.1.0 beta1: `'w' is invalid after a value. Expected either ',', '}', or ']'.`

The forced-aligner output JSON *was* logged via `Se.WriteToolsLog` on failure, but that call is gated behind the **default-off** `WriteToolsLog` setting, so the JSON that caused the failure never made it into a bug report — leaving the failure undiagnosable.

## Root cause
The engine could emit invalid JSON for some inputs (e.g. non-Latin scripts), where a failed forced alignment leaves a word's `start`/`end` as `NaN`/`Inf` and `"%.3f"` renders `nan`/`-nan(ind)`/`inf` — not valid JSON. Fixed engine-side in [niksedk/qwen3-asr.cpp v0.1.3](https://github.com/niksedk/qwen3-asr.cpp/releases/tag/v0.1.3) (coerce non-finite timestamps to 0.0; build JSON fields with `std::string` so a large value can never truncate the line).

## Changes (SE side)
- **Always log the offending JSON.** New `Se.WriteToolsLog(log, force)` overload; the Qwen3 parse-failure path force-writes the raw output JSON so it is available for diagnosis even with the tools log disabled (falls back to a marker if the file could not be read).
- **Bump the engine download to v0.1.3** (`Qwen3AsrCppDownloadService`), which emits valid JSON for non-finite/oversized timestamps.
- **Fix the report link.** `Qwen3AsrCppEngine.Url` now points at the `niksedk` fork SE actually ships/builds from, so the "report it at ..." message routes reports to the correct repo.

## Notes
- The `qwen3-asr-cpp` downloads are not hash-verified (no `DownloadHashManager` entry), so the version bump needs no hash update.
- Builds clean (`dotnet build src/ui/UI.csproj`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)