### PR TITLE
Qwen3 ASR: bump bundled engine to v0.1.4 (ggml 0.15.3)

### DIFF
--- a/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
@@ -18,9 +18,9 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
 
     // Built by https://github.com/niksedk/qwen3-asr.cpp (.github/workflows/release.yml) — these
     // are the binaries with the JSON word-truncation fix (issue #11717) plus the valid-JSON fix
-    // for non-finite/oversized timestamps (issue #11375). CPU for every platform, plus Vulkan
-    // (GPU) for win64 and linux-x64.
-    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.3/";
+    // for non-finite/oversized timestamps (issue #11375), on the ggml 0.15.3 backend. CPU for
+    // every platform, plus Vulkan (GPU) for win64 and linux-x64.
+    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.4/";
     private const string WindowsUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64.zip";
     private const string WindowsVulkanUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64-vulkan.zip";
     private const string MacArmUrl = ReleaseUrlBase + "qwen3-asr-cpp-mac.zip";


### PR DESCRIPTION
Follow-up to #11990. Bumps the bundled Qwen3 ASR CPP engine download from v0.1.3 to **v0.1.4**.

v0.1.4 contains the same JSON fixes as v0.1.3 (word-truncation #11717, non-finite/oversized timestamps #11375) **plus** an updated **ggml 0.15.3** backend. All platform binaries — including the win64 / linux-x64 Vulkan (GPU) builds — are published on the [niksedk/qwen3-asr.cpp v0.1.4 release](https://github.com/niksedk/qwen3-asr.cpp/releases/tag/v0.1.4).

No hash-manager update needed (the qwen3-asr-cpp downloads are not hash-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)