### PR TITLE
Update change-log (beta3) and correct stale HarfBuzz comment

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -23,9 +23,13 @@ v5.1.0-beta3 (TBD)
 * Fix Visual sync not honoring the selected audio track - thx zoltan-antal
 * Fix menu: Escape needing a 3rd press and stale menu state after Alt+Tab - thx kylesskim-sys
 * Fix CrispASR Parakeet ignoring the selected language - thx sergechaly
+* Fix Qwen3 ASR (CPP) failing with "'0x0D' is invalid within a JSON string" - thx ProFire
+* Fix unsaved-changes prompt treating a dismissed dialog (close/Escape) as a choice - thx pdjdev
 * Use nameof for rule IDs in FixCommonErrorsRunner - thx ivandrofly
 * Update Turkish translation - thx bilimiyorum
 * Update Japanese translation - thx hisui3393
+* Update Italian translation - thx bovirus
+* Update Korean translation - thx 12si27
 
 -----------------------------------------------------------------------------------------------------
 
@@ -47,7 +51,6 @@ v5.1.0-beta2 (28th of June 2026)
 * Update Portuguese (Brazil) translation - thx igorruckert
 * Update Turkish translation - thx bilimiyorum
 * Update Korean translation - thx 12si27
-* Fix crash exporting Blu-ray sup on Linux (HarfBuzz native/managed version mismatch) - thx CannaraX
 * Fix "Join subtitles" by time codes not sorting the joined lines by time - thx han8mr8
 * seconv: run operations in the given order, repeating each occurrence (e.g. "--fix-common-errors" twice runs two passes) - thx Rouzax
 * seconv: bundle the Linux native libs (libSkiaSharp/libHarfBuzzSharp) so Fix common errors no longer crashes - thx Rouzax

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -45,12 +45,12 @@
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
 		<PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.4" />
 		<!--
-		  Pin the Linux native HarfBuzz to match the managed HarfBuzzSharp (14.2.0) that
-		  SkiaSharp.HarfBuzz pulls in. Avalonia references HarfBuzzSharp.NativeAssets.Linux
-		  8.3.1.3, and without this NuGet leaves the Linux native at 8.3.1.3 while unifying
-		  the managed wrapper up to 14.2.0 - an ABI mismatch that crashes the BluRay (sup)
-		  text shaper with "double free or corruption" on Linux (issue #11864). macOS/Windows
-		  already get the matching 14.2.0 native.
+		  Pin the Linux native HarfBuzz to match the managed HarfBuzzSharp (8.3.1.5) that
+		  SkiaSharp.HarfBuzz 3.119.4 resolves to. Avalonia references HarfBuzzSharp.NativeAssets.Linux
+		  8.3.1.3, and without this NuGet leaves the Linux native behind while unifying the
+		  managed wrapper up - an ABI mismatch that crashes the BluRay (sup) text shaper with
+		  "double free or corruption" on Linux (issue #11864). macOS/Windows already get the
+		  matching native.
 		-->
 		<PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.5" />
 		<PackageReference Include="TagLibSharp" Version="2.3.0" />


### PR DESCRIPTION
## Changes

**change-log.txt**
- Add missing beta3 entries: Qwen3 ASR `0x0D` JSON fix (thx ProFire), save-changes dialog dismissal (thx pdjdev), Italian (thx bovirus) and Korean (thx 12si27) translations.
- Remove the beta2 line `Fix crash exporting Blu-ray sup on Linux (HarfBuzz native/managed version mismatch)` — the crash is **not** actually fixed; it persists on real Linux desktops (see #11864).

**src/ui/UI.csproj**
- The Linux `HarfBuzzSharp.NativeAssets.Linux` pin comment still referenced the old `14.2.0` / SkiaSharp `4.148.0` numbers. Correct it to the shipped `8.3.1.5` / `3.119.4` (the package versions were realigned to Avalonia's in 40b73e464).

🤖 Generated with [Claude Code](https://claude.com/claude-code)