### PR TITLE
Fix Blu-ray sup export crash on Linux (HarfBuzz symbol clash) (#11864)

### DIFF
--- a/src/libuilogic/HarfBuzzNativeFix.cs
+++ b/src/libuilogic/HarfBuzzNativeFix.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.UiLogic;
+
+/// <summary>
+/// Works around a native HarfBuzz symbol clash on Linux (issue #11864).
+///
+/// The app ships its own <c>libHarfBuzzSharp.so</c> (used by SkiaSharp.HarfBuzz / SKShaper for
+/// text shaping in the image-based subtitle export). On a real Linux desktop the GL / font stack
+/// also pulls in the system <c>libharfbuzz.so.0</c>, and both export the global <c>hb_*</c> symbols.
+/// ELF symbol interposition can then route libHarfBuzzSharp's internal <c>hb_face_destroy</c> call
+/// to the mismatched system copy, crashing the shaper on teardown (SIGSEGV in <c>hb_face_destroy</c>).
+///
+/// Loading libHarfBuzzSharp with <c>RTLD_DEEPBIND</c> makes it resolve its own <c>hb_*</c> symbols
+/// first, so create and destroy always use the same HarfBuzz. Call <see cref="Apply"/> once, as early
+/// as possible at startup, before any SkiaSharp.HarfBuzz use.
+/// </summary>
+public static class HarfBuzzNativeFix
+{
+    private const int RtldNow = 2;
+    private const int RtldDeepBind = 8;
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern IntPtr dlopen(string fileName, int flags);
+
+    private static bool _applied;
+    private static IntPtr _handle;
+
+    public static void Apply()
+    {
+        if (_applied || !OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        // Escape hatch in case deep-binding ever misbehaves on an exotic distro.
+        if (Environment.GetEnvironmentVariable("SE_DISABLE_HARFBUZZ_FIX") == "1")
+        {
+            return;
+        }
+
+        _applied = true;
+
+        NativeLibrary.SetDllImportResolver(typeof(HarfBuzzSharp.Blob).Assembly, (name, _, _) =>
+        {
+            if (name != "libHarfBuzzSharp")
+            {
+                return IntPtr.Zero;
+            }
+
+            if (_handle != IntPtr.Zero)
+            {
+                return _handle;
+            }
+
+            foreach (var path in CandidatePaths())
+            {
+                if (!File.Exists(path))
+                {
+                    continue;
+                }
+
+                var handle = dlopen(path, RtldNow | RtldDeepBind);
+                if (handle != IntPtr.Zero)
+                {
+                    _handle = handle;
+                    return handle;
+                }
+            }
+
+            // Could not deep-bind; fall back to the default resolution so behaviour is unchanged.
+            return IntPtr.Zero;
+        });
+    }
+
+    private static string[] CandidatePaths()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        return
+        [
+            Path.Combine(baseDir, "libHarfBuzzSharp.so"),
+            Path.Combine(baseDir, "runtimes", "linux-x64", "native", "libHarfBuzzSharp.so"),
+        ];
+    }
+}

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -10,6 +10,10 @@ internal class Program
 {
     static int Main(string[] args)
     {
+        // Must run before any SkiaSharp.HarfBuzz use (image-based export) so the bundled
+        // libHarfBuzzSharp deep-binds its own hb_* symbols and doesn't crash on Linux (#11864).
+        Nikse.SubtitleEdit.UiLogic.HarfBuzzNativeFix.Apply();
+
         // Encoding code pages and the headless EBU UI helper are wired by the
         // module initializer in SeConv.Core.Bootstrap.
 

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -32,6 +32,10 @@ namespace Nikse.SubtitleEdit
         [STAThread]
         public static void Main(string[] args)
         {
+            // Must run before any SkiaSharp.HarfBuzz use so the bundled libHarfBuzzSharp
+            // deep-binds its own hb_* symbols and doesn't crash the export shaper on Linux (#11864).
+            Nikse.SubtitleEdit.UiLogic.HarfBuzzNativeFix.Apply();
+
             try
             {
                 // Global exception handling


### PR DESCRIPTION
## Problem
Exporting Blu-ray (sup) crashes with `Segmentation fault` on real Linux desktops (#11864). The reporter's gdb backtrace is the key:

```
#0  hb_face_destroy ()  from /lib/x86_64-linux-gnu/libharfbuzz.so.0           ← SYSTEM HarfBuzz
#1  hb_font_destroy ()  from .../runtimes/linux-x64/native/libHarfBuzzSharp.so ← BUNDLED HarfBuzz
```

## Root cause
Two HarfBuzz copies live in the process: the bundled `libHarfBuzzSharp.so` (used by `SkiaSharp.HarfBuzz` / `SKShaper` to shape the export text) and the system `libharfbuzz.so.0` that the desktop GL/font stack pulls in. Both export the global `hb_*` symbols, so ELF interposition routes libHarfBuzzSharp's internal `hb_face_destroy` to the mismatched system copy → SIGSEGV on teardown.

This is **not** GPU- or version-mismatch related (the packages are aligned). It only manifests when a system libharfbuzz is present, which is why it never reproduced in headless/CI.

## Fix
Load `libHarfBuzzSharp` with `RTLD_DEEPBIND` at startup (via a `DllImportResolver`) so it resolves its own `hb_*` symbols first — create and destroy then use the same HarfBuzz. Applied from both the UI and `seconv` entry points (both shape via `SKShaper`). A `SE_DISABLE_HARFBUZZ_FIX=1` env escape hatch is included.

Linux-only; no-op on Windows/macOS.

## Verification (Docker, linux-x64, system libharfbuzz `LD_PRELOAD`ed to force the clash)
Real `seconv` converting SRT → Blu-ray sup:
- Fix **disabled** (`SE_DISABLE_HARFBUZZ_FIX=1`): **SIGSEGV (139)** — reproduces the reporter's crash.
- Fix **active**: valid `.sup`, exit 0.

An isolated `SKShaper` shape/dispose harness shows the same: crashes under preload, survives with the deep-bind resolver.

⚠️ Best confirmed by the reporter on real NVIDIA/Ubuntu hardware.

Fixes #11864

🤖 Generated with [Claude Code](https://claude.com/claude-code)