### PR TITLE
Use editable model combobox in auto-translate window

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -82,6 +82,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private bool _modelIsVisible;
     [ObservableProperty] private bool _modelBrowseIsVisible;
     [ObservableProperty] private string _modelText;
+    [ObservableProperty] private ObservableCollection<string> _apiModels = new();
     [ObservableProperty] private bool _buttonModelIsVisible;
     [ObservableProperty] private bool _buttonDownloadIsVisible;
     [ObservableProperty] private ObservableCollection<SpeechToTextModelDisplay> _crispAsrModels = new();
@@ -108,7 +109,6 @@ public partial class AutoTranslateViewModel : ObservableObject
     private bool _translationInProgress = false;
     private bool _abort = false;
     private List<string> _apiUrls = new();
-    private List<string> _apiModels = new();
     private bool _onlyCurrentLine;
     private Subtitle _subtitle = new Subtitle();
     private int _translationProgressIndex;
@@ -1530,7 +1530,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         ApiSecretIsVisible = false;
 
         _apiUrls.Clear();
-        _apiModels.Clear();
+        ApiModels.Clear();
 
         var engineType = translator.GetType();
 
@@ -1661,7 +1661,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             });
 
             ModelIsVisible = true;
-            _apiModels = ChatGptTranslate.Models.ToList();
+            SetApiModels(ChatGptTranslate.Models);
 
             if (string.IsNullOrWhiteSpace(Configuration.Settings.Tools.ChatGptModel))
             {
@@ -1745,7 +1745,7 @@ public partial class AutoTranslateViewModel : ObservableObject
                 Se.Settings.AutoTranslate.OllamaUrl.TrimEnd('/'),
             });
 
-            _apiModels = Configuration.Settings.Tools.OllamaModels.Split(',').ToList();
+            SetApiModels(Configuration.Settings.Tools.OllamaModels.Split(','));
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
             ModelText = Se.Settings.AutoTranslate.OllamaModel;
@@ -1763,7 +1763,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.AnthropicApiKey;
             ApiKeyIsVisible = true;
 
-            _apiModels = AnthropicTranslate.Models.ToList();
+            SetApiModels(AnthropicTranslate.Models);
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
             ModelText = Configuration.Settings.Tools.AnthropicApiModel;
@@ -1787,7 +1787,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.PerplexityApiKey;
             ApiKeyIsVisible = true;
 
-            _apiModels = PerplexityTranslate.Models.ToList();
+            SetApiModels(PerplexityTranslate.Models);
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
             ModelText = Configuration.Settings.Tools.PerplexityModel;
@@ -1805,10 +1805,10 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.GroqApiKey;
             ApiKeyIsVisible = true;
 
-            _apiModels = GroqTranslate.Models.ToList();
+            SetApiModels(GroqTranslate.Models);
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
-            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.GroqModel) ? _apiModels[0] : Configuration.Settings.Tools.GroqModel;
+            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.GroqModel) ? ApiModels[0] : Configuration.Settings.Tools.GroqModel;
 
             return;
         }
@@ -1824,10 +1824,10 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.OpenRouterApiKey;
             ApiKeyIsVisible = true;
 
-            _apiModels = OpenRouterTranslate.Models.ToList();
+            SetApiModels(OpenRouterTranslate.Models);
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
-            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.OpenRouterModel) ? _apiModels[0] : Configuration.Settings.Tools.OpenRouterModel;
+            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.OpenRouterModel) ? ApiModels[0] : Configuration.Settings.Tools.OpenRouterModel;
 
             return;
         }
@@ -1837,10 +1837,10 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.GeminiProApiKey;
             ApiKeyIsVisible = true;
 
-            _apiModels = GeminiTranslate.Models.ToList();
+            SetApiModels(GeminiTranslate.Models);
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
-            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.GeminiModel) ? _apiModels[0] : Configuration.Settings.Tools.GeminiModel;
+            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.GeminiModel) ? ApiModels[0] : Configuration.Settings.Tools.GeminiModel;
 
             return;
         }
@@ -1855,10 +1855,10 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.NvidiaApiKey;
             ApiKeyIsVisible = true;
 
-            _apiModels = NvidiaTranslate.Models.ToList();
+            SetApiModels(NvidiaTranslate.Models);
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
-            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.NvidiaModel) ? _apiModels[0] : Configuration.Settings.Tools.NvidiaModel;
+            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.NvidiaModel) ? ApiModels[0] : Configuration.Settings.Tools.NvidiaModel;
 
             return;
         }
@@ -1873,10 +1873,10 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.AutoTranslateMistralApiKey;
             ApiKeyIsVisible = true;
 
-            _apiModels = MistralTranslate.Models.ToList();
+            SetApiModels(MistralTranslate.Models);
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
-            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.AutoTranslateMistralModel) ? _apiModels[0] : Configuration.Settings.Tools.AutoTranslateMistralModel;
+            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.AutoTranslateMistralModel) ? ApiModels[0] : Configuration.Settings.Tools.AutoTranslateMistralModel;
 
             return;
         }
@@ -1891,10 +1891,10 @@ public partial class AutoTranslateViewModel : ObservableObject
             ApiKeyText = Configuration.Settings.Tools.DeepSeekApiKey;
             ApiKeyIsVisible = true;
 
-            _apiModels = DeepSeekTranslate.Models.ToList();
+            SetApiModels(DeepSeekTranslate.Models);
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
-            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.DeepSeekModel) ? _apiModels[0] : Configuration.Settings.Tools.DeepSeekModel;
+            ModelText = string.IsNullOrEmpty(Configuration.Settings.Tools.DeepSeekModel) ? ApiModels[0] : Configuration.Settings.Tools.DeepSeekModel;
 
             return;
         }
@@ -1933,6 +1933,17 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (SelectedAutoTranslator is LlamaCppTranslate)
         {
             SetAutoTranslatorEngine(SelectedAutoTranslator);
+        }
+    }
+
+    // Repopulates the model dropdown in place (keeping the same ObservableCollection instance the
+    // editable model combo is bound to) with the known models for the selected engine.
+    private void SetApiModels(IEnumerable<string> models)
+    {
+        ApiModels.Clear();
+        foreach (var model in models)
+        {
+            ApiModels.Add(model);
         }
     }
 

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -315,7 +315,7 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(UiUtil.MakeTextBox(200, vm, nameof(vm.ApiUrlText), nameof(vm.ApiUrlIsVisible)).WithMarginRight(15));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.ModelIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ModelText), nameof(vm.ModelIsVisible)));
+        settingsPanel.Children.Add(UiUtil.MakeComboBoxEditable(double.NaN, vm.ApiModels, vm, nameof(vm.ModelText), nameof(vm.ModelIsVisible)));
         settingsPanel.Children.Add(UiUtil.MakeButtonBrowse(vm.BrowseModelCommand, nameof(vm.ModelBrowseIsVisible)).WithMarginLeft(5));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.CrispAsrModelComboIsVisible)).WithMarginRight(5));

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -315,7 +315,7 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(UiUtil.MakeTextBox(200, vm, nameof(vm.ApiUrlText), nameof(vm.ApiUrlIsVisible)).WithMarginRight(15));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.ModelIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeComboBoxEditable(double.NaN, vm.ApiModels, vm, nameof(vm.ModelText), nameof(vm.ModelIsVisible)));
+        settingsPanel.Children.Add(UiUtil.MakeComboBoxEditable(150, vm.ApiModels, vm, nameof(vm.ModelText), nameof(vm.ModelIsVisible)));
         settingsPanel.Children.Add(UiUtil.MakeButtonBrowse(vm.BrowseModelCommand, nameof(vm.ModelBrowseIsVisible)).WithMarginLeft(5));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.CrispAsrModelComboIsVisible)).WithMarginRight(5));

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -565,6 +565,50 @@ public static class UiUtil
         return MakeComboBox(sourceItems, viewModal, propertySelectedPath, null);
     }
 
+    /// <summary>
+    /// An editable ComboBox: the dropdown offers <paramref name="sourceItems"/> as suggestions while
+    /// the typed/selected value is bound (two-way) to <paramref name="propertyTextPath"/>. Used where a
+    /// free-text field should also present a list of known values (e.g. translator model names).
+    /// </summary>
+    public static ComboBox MakeComboBoxEditable(
+        double width,
+        ObservableCollection<string> sourceItems,
+        object viewModal,
+        string propertyTextPath,
+        string? propertyIsVisiblePath)
+    {
+        var comboBox = new ComboBox
+        {
+            // double.NaN lets the box auto-size to its content (the selected model name).
+            Width = width,
+            MinWidth = 150,
+            IsEditable = true,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
+        comboBox.ItemsSource = sourceItems;
+        comboBox.DataContext = viewModal;
+
+        comboBox.Bind(ComboBox.TextProperty, new Binding
+        {
+            Path = propertyTextPath,
+            Mode = BindingMode.TwoWay,
+        });
+
+        if (propertyIsVisiblePath != null)
+        {
+            comboBox.Bind(ComboBox.IsVisibleProperty, new Binding
+            {
+                Path = propertyIsVisiblePath,
+                Mode = BindingMode.TwoWay,
+            });
+        }
+
+        return comboBox;
+    }
+
     public static TextBox MakeTextBox(double width, object viewModel, string propertyTextPath)
     {
         return MakeTextBox(width, viewModel, propertyTextPath, null);

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -570,8 +570,9 @@ public static class UiUtil
     /// the typed/selected value is bound (two-way) to <paramref name="propertyTextPath"/>. Used where a
     /// free-text field should also present a list of known values (e.g. translator model names).
     /// </summary>
+    /// <param name="minWidth">Lower bound on the auto-sized width so short values don't collapse.</param>
     public static ComboBox MakeComboBoxEditable(
-        double width,
+        double minWidth,
         ObservableCollection<string> sourceItems,
         object viewModal,
         string propertyTextPath,
@@ -579,9 +580,7 @@ public static class UiUtil
     {
         var comboBox = new ComboBox
         {
-            // double.NaN lets the box auto-size to its content (the selected model name).
-            Width = width,
-            MinWidth = 150,
+            MinWidth = minWidth,
             IsEditable = true,
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Center,
@@ -606,7 +605,56 @@ public static class UiUtil
             });
         }
 
+        AutoSizeEditableComboBoxWidth(comboBox, sourceItems);
         return comboBox;
+    }
+
+    // The Fluent ComboBox template hosts its text in a star-sized grid column, so inside a finite-width
+    // parent (e.g. a WrapPanel) a Width="Auto" box stretches to fill the row instead of fitting its text.
+    // To get a true fit-to-content box we measure the items and the current value ourselves and pin the
+    // width, re-measuring whenever the value, the item list, or the resolved font changes.
+    private static void AutoSizeEditableComboBoxWidth(ComboBox comboBox, ObservableCollection<string> sourceItems)
+    {
+        // Glyph column (32) + the editable text box paddings/caret; keeps the value from being clipped.
+        const double chromeWidth = 56;
+        var measurer = new TextBlock();
+
+        void UpdateWidth()
+        {
+            measurer.FontFamily = comboBox.FontFamily;
+            measurer.FontSize = comboBox.FontSize;
+            measurer.FontStyle = comboBox.FontStyle;
+            measurer.FontWeight = comboBox.FontWeight;
+
+            var widest = 0.0;
+            foreach (var item in sourceItems)
+            {
+                widest = Math.Max(widest, MeasureTextWidth(measurer, item));
+            }
+
+            widest = Math.Max(widest, MeasureTextWidth(measurer, comboBox.Text));
+            comboBox.Width = widest + chromeWidth;
+        }
+
+        sourceItems.CollectionChanged += (_, _) => UpdateWidth();
+        comboBox.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == ComboBox.TextProperty)
+            {
+                UpdateWidth();
+            }
+        };
+
+        // Font values are only resolved once the box is in the visual tree; measure then for accuracy.
+        comboBox.AttachedToVisualTree += (_, _) => UpdateWidth();
+        UpdateWidth();
+    }
+
+    private static double MeasureTextWidth(TextBlock measurer, string? text)
+    {
+        measurer.Text = text ?? string.Empty;
+        measurer.Measure(Size.Infinity);
+        return measurer.DesiredSize.Width;
     }
 
     public static TextBox MakeTextBox(double width, object viewModel, string propertyTextPath)


### PR DESCRIPTION
## Summary
- Replace the plain model text box in the auto-translate window with an **editable combobox** that lists the selected translator's known models.
- The box stays editable, so a custom model name can still be typed (and the Ollama/Anthropic browse button keeps working).
- Added `UiUtil.MakeComboBoxEditable(...)` helper (editable `ComboBox` binding its `Text` two-way and offering items as suggestions).
- Converted the view model's `_apiModels` list into an observable `ApiModels` collection, repopulated in place per engine via a new `SetApiModels(...)` helper.
- The combobox auto-sizes to fit the selected model (`Width = Auto`, `MinWidth = 150`).

## Test plan
- [ ] Open Auto-translate.
- [ ] Select an engine with a model list (ChatGPT, Anthropic, Gemini, Groq, OpenRouter, Nvidia, Mistral, DeepSeek, Perplexity, Ollama).
- [ ] Confirm the Model field is now a dropdown listing that engine's models, with the saved/default model selected.
- [ ] Type a custom model name and confirm it is accepted and persisted.
- [ ] Switch engines and confirm the dropdown repopulates with the new engine's models.
- [ ] Confirm the box widens/narrows to fit the selected model name.

## Image

<img width="1264" height="780" alt="image" src="https://github.com/user-attachments/assets/6a784c81-a0ab-4bc0-9d82-aea3e417290b" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

