### PR TITLE
Enable Qwen3 ASR CPP on macOS

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -212,7 +212,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         // Add OpenAI Compatible STT engine (available on all platforms)
         Engines.Add(new OpenAiCompatibleSttEngine());
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             //Engines.Add(new ChatLlmCppEngine());
             Engines.Add(new Qwen3AsrCppEngine());

--- a/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
@@ -18,9 +18,10 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
 
     // Built by https://github.com/niksedk/qwen3-asr.cpp (.github/workflows/release.yml) — these
     // are the binaries with the JSON word-truncation fix (issue #11717) plus the valid-JSON fix
-    // for non-finite/oversized timestamps (issue #11375), on the ggml 0.15.3 backend. CPU for
-    // every platform, plus Vulkan (GPU) for win64 and linux-x64.
-    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.4/";
+    // for non-finite/oversized timestamps (issue #11375), on the ggml 0.15.3 backend. v0.1.5 adds
+    // the macOS/Linux dylib-loading fix (relative rpath + SONAME libs) so the engine runs off the
+    // build machine. CPU for every platform, plus Vulkan (GPU) for win64 and linux-x64.
+    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.5/";
     private const string WindowsUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64.zip";
     private const string WindowsVulkanUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64-vulkan.zip";
     private const string MacArmUrl = ReleaseUrlBase + "qwen3-asr-cpp-mac.zip";


### PR DESCRIPTION
## What
Enables the **Qwen3 ASR CPP** speech-to-text engine on macOS (it was Windows/Linux only).

## Details
- `SpeechToTextViewModel`: add `OSPlatform.OSX` to the engine-list gate. The download service already ships macOS arm64 (`qwen3-asr-cpp-mac.zip`) and x64 (`qwen3-asr-cpp-mac-x64.zip`) binaries, and there's no other Mac-specific gate, so this is all that was needed. (Vulkan/GPU builds aren't offered on Mac; it uses the CPU build.)
- `Qwen3AsrCppDownloadService`: bump `ReleaseUrlBase` `v0.1.4` → **`v0.1.5`**.

## Why v0.1.5
The v0.1.4 macOS binary fails to launch off the build machine:
```
dyld: Library not loaded: @rpath/libqwen3-asr.dylib
  tried: '/Users/runner/work/qwen3-asr.cpp/.../build/libqwen3-asr.dylib' (no such file)
```
Two packaging bugs (rpath baked to the CI build dir; missing SONAME dylibs) — fixed in niksedk/qwen3-asr.cpp#6 and released as v0.1.5. Verified locally that with the fix the engine runs with no `DYLD_*` override.

## ⚠️ Merge ordering
Depends on the **v0.1.5 release** of qwen3-asr.cpp being published (build in progress). Don't merge until those assets are live, or Mac downloads will 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)