### PR TITLE
BinEdit: overhaul Tools menu UX — clear scope split, new commands, SE4 parity, and bug fixes

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -64,6 +64,7 @@ using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustBrightness;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustColor;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustDuration;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryApplyDurationLimits;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAppendSubtitle;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryResizeImages;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinarySettings;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.SetText;
@@ -305,6 +306,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<BinaryAdjustColorViewModel>();
         collection.AddTransient<BinaryAdjustDurationViewModel>();
         collection.AddTransient<BinaryApplyDurationLimitsViewModel>();
+        collection.AddTransient<BinaryAppendSubtitleViewModel>();
         collection.AddTransient<BinaryEditViewModel>();
         collection.AddTransient<BinaryOcrCharacterAddViewModel>();
         collection.AddTransient<BinaryOcrCharacterHistoryViewModel>();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
@@ -31,7 +31,7 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
         LoadSettings();
     }
 
-    public void Initialize(IList<BinarySubtitleItem> subtitles, IList<int> selectedIndices, Action refreshGrid)
+    public void Initialize(IList<BinarySubtitleItem> subtitles, IList<int> selectedIndices, Action refreshGrid, bool forceSelectedLines = false)
     {
         _subtitles = subtitles;
         _selectedIndices = selectedIndices;
@@ -41,6 +41,10 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
         if (!IsSelectionAvailable)
         {
             AdjustAll = true;
+        }
+        else if (forceSelectedLines)
+        {
+            AdjustSelectedLines = true;
         }
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesViewModel.cs
@@ -31,7 +31,7 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
         LoadSettings();
     }
 
-    public void Initialize(IList<BinarySubtitleItem> subtitles, IList<int> selectedIndices, Action refreshGrid, bool forceSelectedLines = false)
+    public void Initialize(IList<BinarySubtitleItem> subtitles, IList<int> selectedIndices, Action refreshGrid)
     {
         _subtitles = subtitles;
         _selectedIndices = selectedIndices;
@@ -41,10 +41,6 @@ public partial class BinaryAdjustAllTimesViewModel : ObservableObject
         if (!IsSelectionAvailable)
         {
             AdjustAll = true;
-        }
-        else if (forceSelectedLines)
-        {
-            AdjustSelectedLines = true;
         }
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationDisplay.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationDisplay.cs
@@ -10,7 +10,6 @@ public class BinaryAdjustDurationDisplay
     public bool IsPercentVisible { get; set; }
     public bool IsFixedVisible { get; set; }
     public bool IsRecalculateVisible { get; set; }
-    public bool IsEnabled { get; set; } = true;
 
     public BinaryAdjustDurationDisplay()
     {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationDisplay.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationDisplay.cs
@@ -10,7 +10,8 @@ public class BinaryAdjustDurationDisplay
     public bool IsPercentVisible { get; set; }
     public bool IsFixedVisible { get; set; }
     public bool IsRecalculateVisible { get; set; }
-    
+    public bool IsEnabled { get; set; } = true;
+
     public BinaryAdjustDurationDisplay()
     {
         Name = string.Empty;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
@@ -16,6 +16,7 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
 {
     [ObservableProperty] private ObservableCollection<BinaryAdjustDurationDisplay> _adjustTypes;
     [ObservableProperty] private BinaryAdjustDurationDisplay _selectedAdjustType;
+    [ObservableProperty] private bool _showRecalculateNote;
 
     [ObservableProperty] private double _adjustSeconds;
     [ObservableProperty] private int _adjustPercent;
@@ -32,6 +33,28 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
         _adjustTypes = new ObservableCollection<BinaryAdjustDurationDisplay>(BinaryAdjustDurationDisplay.ListAll());
         _selectedAdjustType = _adjustTypes[0];
         LoadSettings();
+    }
+
+    public void Initialize(IEnumerable<BinarySubtitleItem> itemsInScope)
+    {
+        var anyMissingText = itemsInScope.Any(s => string.IsNullOrWhiteSpace(s.Text));
+        if (!anyMissingText)
+        {
+            return;
+        }
+
+        var recalculate = AdjustTypes.FirstOrDefault(t => t.Type == BinaryAdjustDurationType.Recalculate);
+        if (recalculate != null)
+        {
+            AdjustTypes.Remove(recalculate);
+        }
+
+        if (SelectedAdjustType.Type == BinaryAdjustDurationType.Recalculate)
+        {
+            SelectedAdjustType = AdjustTypes[0];
+        }
+
+        ShowRecalculateNote = true;
     }
 
     public void AdjustDuration(List<BinarySubtitleItem> subtitles, List<int>? selectedIndices = null)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
@@ -16,7 +16,20 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
 {
     [ObservableProperty] private ObservableCollection<BinaryAdjustDurationDisplay> _adjustTypes;
     [ObservableProperty] private BinaryAdjustDurationDisplay _selectedAdjustType;
-    [ObservableProperty] private bool _showRecalculateNote;
+
+    private bool _recalculateUnavailable;
+
+    public bool IsRecalculateBlocked =>
+        _recalculateUnavailable && SelectedAdjustType?.Type == BinaryAdjustDurationType.Recalculate;
+
+    public bool ShowRecalculateControls =>
+        SelectedAdjustType?.Type == BinaryAdjustDurationType.Recalculate && !_recalculateUnavailable;
+
+    partial void OnSelectedAdjustTypeChanged(BinaryAdjustDurationDisplay value)
+    {
+        OnPropertyChanged(nameof(IsRecalculateBlocked));
+        OnPropertyChanged(nameof(ShowRecalculateControls));
+    }
 
     [ObservableProperty] private double _adjustSeconds;
     [ObservableProperty] private int _adjustPercent;
@@ -37,24 +50,12 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
 
     public void Initialize(IEnumerable<BinarySubtitleItem> itemsInScope)
     {
-        var anyMissingText = itemsInScope.Any(s => string.IsNullOrWhiteSpace(s.Text));
-        if (!anyMissingText)
+        _recalculateUnavailable = itemsInScope.Any(s => string.IsNullOrWhiteSpace(s.Text));
+        if (_recalculateUnavailable)
         {
-            return;
+            OnPropertyChanged(nameof(IsRecalculateBlocked));
+            OnPropertyChanged(nameof(ShowRecalculateControls));
         }
-
-        var recalculate = AdjustTypes.FirstOrDefault(t => t.Type == BinaryAdjustDurationType.Recalculate);
-        if (recalculate != null)
-        {
-            AdjustTypes.Remove(recalculate);
-        }
-
-        if (SelectedAdjustType.Type == BinaryAdjustDurationType.Recalculate)
-        {
-            SelectedAdjustType = AdjustTypes[0];
-        }
-
-        ShowRecalculateNote = true;
     }
 
     public void AdjustDuration(List<BinarySubtitleItem> subtitles, List<int>? selectedIndices = null)
@@ -215,6 +216,12 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
     [RelayCommand]
     private async Task Ok()
     {
+        if (IsRecalculateBlocked)
+        {
+            Window?.Close();
+            return;
+        }
+
         var msg = GetValidationError();
         if (!string.IsNullOrEmpty(msg))
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
@@ -25,10 +25,14 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
     public bool ShowRecalculateControls =>
         SelectedAdjustType?.Type == BinaryAdjustDurationType.Recalculate && !_recalculateUnavailable;
 
+    public bool ShowAdjustNote => !IsRecalculateBlocked;
+
     partial void OnSelectedAdjustTypeChanged(BinaryAdjustDurationDisplay value)
     {
         OnPropertyChanged(nameof(IsRecalculateBlocked));
         OnPropertyChanged(nameof(ShowRecalculateControls));
+        OnPropertyChanged(nameof(ShowAdjustNote));
+        OkCommand.NotifyCanExecuteChanged();
     }
 
     [ObservableProperty] private double _adjustSeconds;
@@ -55,6 +59,8 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
         {
             OnPropertyChanged(nameof(IsRecalculateBlocked));
             OnPropertyChanged(nameof(ShowRecalculateControls));
+            OnPropertyChanged(nameof(ShowAdjustNote));
+            OkCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -213,15 +219,11 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
         Se.SaveSettings();
     }
 
-    [RelayCommand]
+    private bool CanOk() => !IsRecalculateBlocked;
+
+    [RelayCommand(CanExecute = nameof(CanOk))]
     private async Task Ok()
     {
-        if (IsRecalculateBlocked)
-        {
-            Window?.Close();
-            return;
-        }
-
         var msg = GetValidationError();
         if (!string.IsNullOrEmpty(msg))
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
@@ -55,6 +55,7 @@ public class BinaryAdjustDurationWindow : Window
             Text = Se.Language.Tools.AdjustDurations.Note,
             Margin = new Thickness(10, 25, 10, 5),
         };
+        labelInfo.Bind(IsVisibleProperty, new Binding(nameof(vm.ShowAdjustNote)) { Source = vm });
 
         var labelRecalculateNote = new TextBlock
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
@@ -53,8 +53,20 @@ public class BinaryAdjustDurationWindow : Window
             VerticalAlignment = VerticalAlignment.Bottom,
             HorizontalAlignment = HorizontalAlignment.Left,
             Text = Se.Language.Tools.AdjustDurations.Note,
-            Margin = new Thickness(10, 25, 10, 15),
+            Margin = new Thickness(10, 25, 10, 5),
         };
+
+        var labelRecalculateNote = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Bottom,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Text = Se.Language.Tools.AdjustDurations.RecalculateRequiresOcrNote,
+            Margin = new Thickness(10, 0, 10, 15),
+            Foreground = Avalonia.Media.Brushes.OrangeRed,
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            MaxWidth = 380,
+        };
+        labelRecalculateNote.Bind(IsVisibleProperty, new Binding(nameof(vm.ShowRecalculateNote)) { Source = vm });
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
@@ -66,6 +78,7 @@ public class BinaryAdjustDurationWindow : Window
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
@@ -90,8 +103,9 @@ public class BinaryAdjustDurationWindow : Window
         grid.Add(panelRecalculate, 1, 0, 1, 2);
 
         grid.Add(labelInfo, 2, 0, 1, 2);
+        grid.Add(labelRecalculateNote, 3, 0, 1, 2);
 
-        grid.Add(panelButtons, 3, 0, 1, 2);
+        grid.Add(panelButtons, 4, 0, 1, 2);
 
         Content = grid;
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
@@ -66,7 +66,7 @@ public class BinaryAdjustDurationWindow : Window
             TextWrapping = Avalonia.Media.TextWrapping.Wrap,
             MaxWidth = 380,
         };
-        labelRecalculateNote.Bind(IsVisibleProperty, new Binding(nameof(vm.ShowRecalculateNote)) { Source = vm });
+        labelRecalculateNote.Bind(IsVisibleProperty, new Binding(nameof(vm.IsRecalculateBlocked)) { Source = vm });
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
@@ -321,12 +321,7 @@ public class BinaryAdjustDurationWindow : Window
         Grid.SetColumn(numericUpDownOptimal, 1);
         Grid.SetRow(numericUpDownOptimal, 1);
 
-        grid.Bind(Grid.IsVisibleProperty, new Binding
-        {
-            Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(BinaryAdjustDurationDisplay.IsRecalculateVisible)}",
-            Source = vm,
-            Mode = BindingMode.TwoWay,
-        });
+        grid.Bind(Grid.IsVisibleProperty, new Binding(nameof(vm.ShowRecalculateControls)) { Source = vm });
 
         return grid;
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAppendSubtitle/BinaryAppendSubtitleViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAppendSubtitle/BinaryAppendSubtitleViewModel.cs
@@ -1,0 +1,68 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAppendSubtitle;
+
+public partial class BinaryAppendSubtitleViewModel : ObservableObject
+{
+    [ObservableProperty] private bool _appendTimeCodes;
+    [ObservableProperty] private bool _keepTimeCodes;
+    [ObservableProperty] private TimeSpan _timeOffset;
+    [ObservableProperty] private bool _isTimeOffsetVisible;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public BinaryAppendSubtitleViewModel()
+    {
+    }
+
+    public void Initialize(TimeSpan suggestedOffset)
+    {
+        TimeOffset = suggestedOffset;
+
+        if (Se.Settings.Tools.BinEditAppendKeepTimeCodes)
+        {
+            KeepTimeCodes = true;
+        }
+        else
+        {
+            AppendTimeCodes = true;
+        }
+
+        IsTimeOffsetVisible = AppendTimeCodes;
+    }
+
+    partial void OnAppendTimeCodesChanged(bool value)
+    {
+        IsTimeOffsetVisible = value;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        Se.Settings.Tools.BinEditAppendKeepTimeCodes = KeepTimeCodes;
+        Se.SaveSettings();
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Cancel();
+        }
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAppendSubtitle/BinaryAppendSubtitleWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAppendSubtitle/BinaryAppendSubtitleWindow.cs
@@ -1,0 +1,69 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAppendSubtitle;
+
+public class BinaryAppendSubtitleWindow : Window
+{
+    public BinaryAppendSubtitleWindow(BinaryAppendSubtitleViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        vm.Window = this;
+        DataContext = vm;
+
+        var radioAppend = new RadioButton
+        {
+            Content = Se.Language.Tools.JoinSubtitles.AppendTimeCodes,
+            [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AppendTimeCodes)) { Mode = BindingMode.TwoWay },
+            Margin = new Thickness(0, 0, 0, 4),
+        };
+
+        var timeCodeUpDown = new TimeCodeUpDown
+        {
+            Margin = new Thickness(20, 0, 0, 8),
+            [!TimeCodeUpDown.ValueProperty] = new Binding(nameof(vm.TimeOffset)) { Mode = BindingMode.TwoWay },
+            [!IsVisibleProperty] = new Binding(nameof(vm.IsTimeOffsetVisible)),
+        };
+
+        var radioKeep = new RadioButton
+        {
+            Content = Se.Language.Tools.JoinSubtitles.KeepTimeCodes,
+            [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.KeepTimeCodes)) { Mode = BindingMode.TwoWay },
+        };
+
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = UiUtil.MakeWindowMargin(),
+            Children =
+            {
+                radioAppend,
+                timeCodeUpDown,
+                radioKeep,
+            },
+        };
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonBar = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var root = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Children = { panel, buttonBar },
+        };
+
+        Content = root;
+
+        Activated += delegate { buttonOk.Focus(); };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAppendSubtitle/BinaryAppendSubtitleWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAppendSubtitle/BinaryAppendSubtitleWindow.cs
@@ -21,7 +21,7 @@ public class BinaryAppendSubtitleWindow : Window
 
         var radioAppend = new RadioButton
         {
-            Content = Se.Language.Tools.JoinSubtitles.AppendTimeCodes,
+            Content = Se.Language.Tools.ImageBasedEdit.ShiftTimeCodes,
             [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.AppendTimeCodes)) { Mode = BindingMode.TwoWay },
             Margin = new Thickness(0, 0, 0, 4),
         };

--- a/src/ui/Features/Shared/BinaryEdit/BinaryApplyDurationLimits/BinaryApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryApplyDurationLimits/BinaryApplyDurationLimitsViewModel.cs
@@ -13,8 +13,6 @@ public partial class BinaryApplyDurationLimitsViewModel : ObservableObject
 {
     [ObservableProperty] private int _minimumDurationMs;
     [ObservableProperty] private int _maximumDurationMs;
-    [ObservableProperty] private bool _applyToAll;
-    [ObservableProperty] private bool _applyToSelectedLines;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -28,7 +26,6 @@ public partial class BinaryApplyDurationLimitsViewModel : ObservableObject
     {
         MinimumDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
         MaximumDurationMs = Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
-        ApplyToAll = true;
     }
 
     [RelayCommand]
@@ -62,7 +59,7 @@ public partial class BinaryApplyDurationLimitsViewModel : ObservableObject
     {
         var indicesToProcess = new List<int>();
 
-        if (ApplyToSelectedLines && selectedIndices != null && selectedIndices.Count > 0)
+        if (selectedIndices != null && selectedIndices.Count > 0)
         {
             indicesToProcess.AddRange(selectedIndices);
         }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryApplyDurationLimits/BinaryApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryApplyDurationLimits/BinaryApplyDurationLimitsWindow.cs
@@ -25,7 +25,6 @@ public class BinaryApplyDurationLimitsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -83,41 +82,11 @@ public class BinaryApplyDurationLimitsWindow : Window
         };
         grid.Add(maximumNumeric, 1, 1);
 
-        // Radio buttons panel
-        var radioPanel = new StackPanel
-        {
-            Orientation = Orientation.Vertical,
-            Spacing = 5,
-            Margin = new Thickness(0, 10, 0, 0),
-        };
-
-        var applyToAllRadio = new RadioButton
-        {
-            Content = "Apply to all", // TODO: Add Se.Language.General.ApplyToAll
-            [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.ApplyToAll))
-            {
-                Mode = BindingMode.TwoWay,
-            }
-        };
-        radioPanel.Children.Add(applyToAllRadio);
-
-        var applyToSelectedRadio = new RadioButton
-        {
-            Content = "Apply to selected lines", // TODO: Add Se.Language.General.ApplyToSelected
-            [!RadioButton.IsCheckedProperty] = new Binding(nameof(vm.ApplyToSelectedLines))
-            {
-                Mode = BindingMode.TwoWay,
-            }
-        };
-        radioPanel.Children.Add(applyToSelectedRadio);
-
-        grid.Add(radioPanel, 2, 0, 1, 2);
-
         // Button panel
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
-        grid.Add(buttonPanel, 3, 0, 1, 2);
+        grid.Add(buttonPanel, 2, 0, 1, 2);
 
         Content = grid;
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2162,6 +2162,18 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void SortByStartTime()
+    {
+        var sorted = Subtitles.OrderBy(s => s.StartTime).ToList();
+        Subtitles.Clear();
+        foreach (var item in sorted)
+        {
+            Subtitles.Add(item);
+        }
+        Renumber();
+    }
+
+    [RelayCommand]
     private async Task AppendSubtitle()
     {
         if (Window == null)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1073,7 +1073,18 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Get selected indices from the grid
+        result.ApplyLimits(Subtitles.ToList(), null);
+    }
+
+    [RelayCommand]
+    private async Task ApplyDurationLimitsSelectedLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Snapshot selection before dialog opens — focus shift can clear grid selection
         var selectedIndices = new List<int>();
         if (SubtitleGrid?.SelectedItems != null)
         {
@@ -1088,6 +1099,13 @@ public partial class BinaryEditViewModel : ObservableObject
                     }
                 }
             }
+        }
+
+        var result = await _windowService.ShowDialogAsync<BinaryApplyDurationLimitsWindow, BinaryApplyDurationLimitsViewModel>(Window, vm => { });
+
+        if (!result.OkPressed)
+        {
+            return;
         }
 
         result.ApplyLimits(Subtitles.ToList(), selectedIndices.Count > 0 ? selectedIndices : null);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1667,53 +1667,12 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task AdjustAllTimes()
-    {
-        if (Window == null)
-        {
-            return;
-        }
-
-        // Snapshot selection before the dialog opens so focus shift cannot clear it
-        var selectedIndices = new List<int>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    var index = Subtitles.IndexOf(binaryItem);
-                    if (index >= 0)
-                    {
-                        selectedIndices.Add(index);
-                    }
-                }
-            }
-        }
-
-        selectedIndices.Sort();
-
-        var selectedItems = selectedIndices.Count > 0
-            ? selectedIndices.Select(i => Subtitles[i]).ToList()
-            : null;
-
-        void RefreshGrid()
-        {
-            Dispatcher.UIThread.Post(() =>
-            {
-                if (SubtitleGrid == null || selectedItems == null) return;
-                SubtitleGrid.SelectedItems.Clear();
-                foreach (var item in selectedItems)
-                    SubtitleGrid.SelectedItems.Add(item);
-            });
-        }
-
-        await _windowService.ShowDialogAsync<BinaryAdjustAllTimesWindow, BinaryAdjustAllTimesViewModel>(
-            Window, vm => vm.Initialize(Subtitles, selectedIndices, RefreshGrid));
-    }
+    private async Task AdjustAllTimes() => await DoAdjustAllTimes();
 
     [RelayCommand]
-    private async Task AdjustAllTimesSelectedLines()
+    private async Task AdjustAllTimesSelectedLines() => await DoAdjustAllTimes(forceSelectedLines: true);
+
+    private async Task DoAdjustAllTimes(bool forceSelectedLines = false)
     {
         if (Window == null)
         {
@@ -1755,7 +1714,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         await _windowService.ShowDialogAsync<BinaryAdjustAllTimesWindow, BinaryAdjustAllTimesViewModel>(
-            Window, vm => vm.Initialize(Subtitles, selectedIndices, RefreshGrid, forceSelectedLines: true));
+            Window, vm => vm.Initialize(Subtitles, selectedIndices, RefreshGrid, forceSelectedLines));
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1118,29 +1118,40 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Get selected subtitles
+        var result = await _windowService.ShowDialogAsync<PickAlignment.PickAlignmentWindow, PickAlignment.PickAlignmentViewModel>(
+            Window, vm => vm.Initialize(null, Subtitles.Count));
+
+        if (!result.OkPressed || string.IsNullOrEmpty(result.Alignment))
+        {
+            return;
+        }
+
+        ApplyAlignmentToSubtitles(Subtitles.ToList(), result.Alignment);
+    }
+
+    [RelayCommand]
+    private async Task AlignmentSelectedLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
         var selectedItems = new List<BinarySubtitleItem>();
         if (SubtitleGrid?.SelectedItems != null)
         {
             foreach (var item in SubtitleGrid.SelectedItems)
             {
                 if (item is BinarySubtitleItem binaryItem)
-                {
                     selectedItems.Add(binaryItem);
-                }
             }
         }
 
-        // If no selection, nothing to do
         if (selectedItems.Count == 0)
         {
-            await MessageBox.Show(Window, Se.Language.General.Information,
-                "Please select one or more subtitles to adjust alignment.",
-                MessageBoxButtons.OK, MessageBoxIcon.Information);
             return;
         }
 
-        // Show alignment picker
         var result = await _windowService.ShowDialogAsync<PickAlignment.PickAlignmentWindow, PickAlignment.PickAlignmentViewModel>(
             Window, vm => vm.Initialize(null, selectedItems.Count));
 
@@ -1149,7 +1160,6 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Apply alignment to selected subtitles
         ApplyAlignmentToSubtitles(selectedItems, result.Alignment);
     }
 
@@ -1521,37 +1531,23 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void CenterHorizontally()
     {
-        // Get selected subtitles
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
+        foreach (var subtitle in Subtitles)
         {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    selectedItems.Add(binaryItem);
-                }
-            }
+            if (subtitle.Bitmap == null) continue;
+            subtitle.X = (subtitle.ScreenSize.Width - (int)subtitle.Bitmap.Size.Width) / 2;
         }
 
-        // If no selection, work on all subtitles
-        var itemsToResize = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+        UpdateOverlayPosition();
+    }
 
-        if (itemsToResize.Count == 0)
+    [RelayCommand]
+    private void CenterHorizontallySelectedLines()
+    {
+        if (SubtitleGrid?.SelectedItems == null) return;
+        foreach (var item in SubtitleGrid.SelectedItems)
         {
-            return;
-        }
-
-        foreach (var subtitle in itemsToResize)
-        {
-            if (subtitle.Bitmap == null)
-            {
-                continue;
-            }
-
-            var screenWidth = subtitle.ScreenSize.Width;
-            var imageWidth = (int)subtitle.Bitmap.Size.Width;
-            subtitle.X = (screenWidth - imageWidth) / 2;
+            if (item is BinarySubtitleItem subtitle && subtitle.Bitmap != null)
+                subtitle.X = (subtitle.ScreenSize.Width - (int)subtitle.Bitmap.Size.Width) / 2;
         }
 
         UpdateOverlayPosition();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -51,7 +51,6 @@ public partial class BinaryEditViewModel : ObservableObject
     [ObservableProperty] private bool _isInsertBeforeVisible;
     [ObservableProperty] private bool _isInsertAfterVisible;
     [ObservableProperty] private bool _isToggleForcedVisible;
-    [ObservableProperty] private bool _isInsertSubtitleVisible;
 
     public IOcrSubtitle? OcrSubtitle { get; set; }
 
@@ -2026,10 +2025,9 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task InsertSubtitle()
+    private async Task AppendSubtitle()
     {
-        var selectedItem = SelectedSubtitle;
-        if (Window == null || selectedItem == null)
+        if (Window == null)
         {
             return;
         }
@@ -2054,9 +2052,14 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var oldLastTime = selectedItem.EndTime.TotalMilliseconds;
-        var newFirstTime = ocrItems.First().StartTime.TotalMilliseconds;
-        var timeOffset = oldLastTime - newFirstTime + 1000;
+        double timeOffset = 0;
+        if (Subtitles.Count > 0)
+        {
+            var lastItem = Subtitles[^1];
+            var newFirstTime = ocrItems.First().StartTime.TotalMilliseconds;
+            timeOffset = lastItem.EndTime.TotalMilliseconds - newFirstTime + 1000;
+        }
+
         foreach (var ocrItem in ocrItems)
         {
             var newItem = new BinarySubtitleItem(ocrItem, -1);
@@ -2505,7 +2508,6 @@ public partial class BinaryEditViewModel : ObservableObject
         IsToggleForcedVisible = selectedCount > 0;
         IsInsertAfterVisible = selectedCount == 1;
         IsInsertBeforeVisible = selectedCount == 1;
-        IsInsertSubtitleVisible = selectedCount == 1 && selectedIndex == Subtitles.Count - 1;
     }
 
     internal void OnDataGridDoubleTapped(TappedEventArgs e)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1638,6 +1638,8 @@ public partial class BinaryEditViewModel : ObservableObject
                 vm.Initialize(Subtitles, selectedIndices, RefreshGrid);
                 if (forceSelectedLines)
                 {
+                    vm.AdjustAll = false;
+                    vm.AdjustSelectedLinesAndForward = false;
                     vm.AdjustSelectedLines = true;
                 }
             });

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1047,9 +1047,12 @@ public partial class BinaryEditViewModel : ObservableObject
             }
         }
 
-        var itemsInScope = selectedIndices.Count > 0
-            ? selectedIndices.Select(i => Subtitles[i])
-            : Subtitles.AsEnumerable();
+        if (selectedIndices.Count == 0)
+        {
+            return;
+        }
+
+        var itemsInScope = selectedIndices.Select(i => Subtitles[i]);
 
         var result = await _windowService.ShowDialogAsync<BinaryAdjustDuration.BinaryAdjustDurationWindow, BinaryAdjustDuration.BinaryAdjustDurationViewModel>(Window, vm => vm.Initialize(itemsInScope));
 
@@ -1058,7 +1061,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        result.AdjustDuration(Subtitles.ToList(), selectedIndices.Count > 0 ? selectedIndices : null);
+        result.AdjustDuration(Subtitles.ToList(), selectedIndices);
     }
 
     [RelayCommand]
@@ -1104,6 +1107,11 @@ public partial class BinaryEditViewModel : ObservableObject
             }
         }
 
+        if (selectedIndices.Count == 0)
+        {
+            return;
+        }
+
         var result = await _windowService.ShowDialogAsync<BinaryApplyDurationLimitsWindow, BinaryApplyDurationLimitsViewModel>(Window, vm => { });
 
         if (!result.OkPressed)
@@ -1111,7 +1119,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        result.ApplyLimits(Subtitles.ToList(), selectedIndices.Count > 0 ? selectedIndices : null);
+        result.ApplyLimits(Subtitles.ToList(), selectedIndices);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1560,20 +1560,21 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void TopAlign()
     {
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                    selectedItems.Add(binaryItem);
-            }
-        }
-
-        var itemsToAlign = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
         var marginTop = Se.Settings.Tools.BinEditTopMargin;
-        foreach (var subtitle in itemsToAlign)
+        foreach (var subtitle in Subtitles)
             subtitle.Y = marginTop;
+
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
+    private void TopAlignSelectedLines()
+    {
+        var marginTop = Se.Settings.Tools.BinEditTopMargin;
+        if (SubtitleGrid?.SelectedItems == null) return;
+        foreach (var item in SubtitleGrid.SelectedItems)
+            if (item is BinarySubtitleItem subtitle)
+                subtitle.Y = marginTop;
 
         UpdateOverlayPosition();
     }
@@ -1581,23 +1582,25 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void BottomAlign()
     {
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
+        var marginBottom = Se.Settings.Tools.BinEditBottomMargin;
+        foreach (var subtitle in Subtitles)
         {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                    selectedItems.Add(binaryItem);
-            }
+            if (subtitle.Bitmap == null) continue;
+            subtitle.Y = subtitle.ScreenSize.Height - (int)subtitle.Bitmap.Size.Height - marginBottom;
         }
 
-        var itemsToAlign = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
+    private void BottomAlignSelectedLines()
+    {
         var marginBottom = Se.Settings.Tools.BinEditBottomMargin;
-        foreach (var subtitle in itemsToAlign)
+        if (SubtitleGrid?.SelectedItems == null) return;
+        foreach (var item in SubtitleGrid.SelectedItems)
         {
-            if (subtitle.Bitmap == null)
-                continue;
-            subtitle.Y = subtitle.ScreenSize.Height - (int)subtitle.Bitmap.Size.Height - marginBottom;
+            if (item is BinarySubtitleItem subtitle && subtitle.Bitmap != null)
+                subtitle.Y = subtitle.ScreenSize.Height - (int)subtitle.Bitmap.Size.Height - marginBottom;
         }
 
         UpdateOverlayPosition();
@@ -1606,34 +1609,12 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void Crop()
     {
-        // Get selected subtitles
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
+        var itemsToCrop = Subtitles.ToList();
+        if (itemsToCrop.Count == 0) return;
+
+        foreach (var subtitle in itemsToCrop)
         {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    selectedItems.Add(binaryItem);
-                }
-            }
-        }
-
-        // If no selection, work on all subtitles
-        var itemsToResize = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
-
-        if (itemsToResize.Count == 0)
-        {
-            return;
-        }
-
-        foreach (var subtitle in itemsToResize)
-        {
-            if (subtitle.Bitmap == null)
-            {
-                continue;
-            }
-
+            if (subtitle.Bitmap == null) continue;
             using var skBitmap = subtitle.Bitmap.ToSkBitmap();
             using var cropped = skBitmap.CropTransparentColors(out var offsetX, out var offsetY);
             var old = subtitle.Bitmap;
@@ -1651,6 +1632,36 @@ public partial class BinaryEditViewModel : ObservableObject
             SubtitleGrid.SelectedIndex = currentIndex;
         }
 
+        UpdateOverlayPosition();
+        RefreshStatusText();
+    }
+
+    [RelayCommand]
+    private void CropSelectedLines()
+    {
+        var selectedItems = new List<BinarySubtitleItem>();
+        if (SubtitleGrid?.SelectedItems != null)
+        {
+            foreach (var item in SubtitleGrid.SelectedItems)
+                if (item is BinarySubtitleItem binaryItem)
+                    selectedItems.Add(binaryItem);
+        }
+
+        if (selectedItems.Count == 0) return;
+
+        foreach (var subtitle in selectedItems)
+        {
+            if (subtitle.Bitmap == null) continue;
+            using var skBitmap = subtitle.Bitmap.ToSkBitmap();
+            using var cropped = skBitmap.CropTransparentColors(out var offsetX, out var offsetY);
+            var old = subtitle.Bitmap;
+            subtitle.Bitmap = cropped.ToAvaloniaBitmap();
+            old?.Dispose();
+            subtitle.X += offsetX;
+            subtitle.Y += offsetY;
+        }
+
+        ApplyGridSelection(selectedItems);
         UpdateOverlayPosition();
         RefreshStatusText();
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1012,7 +1012,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryAdjustDuration.BinaryAdjustDurationWindow, BinaryAdjustDuration.BinaryAdjustDurationViewModel>(Window, vm => { });
+        var result = await _windowService.ShowDialogAsync<BinaryAdjustDuration.BinaryAdjustDurationWindow, BinaryAdjustDuration.BinaryAdjustDurationViewModel>(Window, vm => vm.Initialize(Subtitles));
 
         if (!result.OkPressed)
         {
@@ -1047,7 +1047,11 @@ public partial class BinaryEditViewModel : ObservableObject
             }
         }
 
-        var result = await _windowService.ShowDialogAsync<BinaryAdjustDuration.BinaryAdjustDurationWindow, BinaryAdjustDuration.BinaryAdjustDurationViewModel>(Window, vm => { });
+        var itemsInScope = selectedIndices.Count > 0
+            ? selectedIndices.Select(i => Subtitles[i])
+            : Subtitles.AsEnumerable();
+
+        var result = await _windowService.ShowDialogAsync<BinaryAdjustDuration.BinaryAdjustDurationWindow, BinaryAdjustDuration.BinaryAdjustDurationViewModel>(Window, vm => vm.Initialize(itemsInScope));
 
         if (!result.OkPressed)
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1443,6 +1443,52 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void TopAlign()
+    {
+        var selectedItems = new List<BinarySubtitleItem>();
+        if (SubtitleGrid?.SelectedItems != null)
+        {
+            foreach (var item in SubtitleGrid.SelectedItems)
+            {
+                if (item is BinarySubtitleItem binaryItem)
+                    selectedItems.Add(binaryItem);
+            }
+        }
+
+        var itemsToAlign = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+        var marginTop = Se.Settings.Tools.BinEditTopMargin;
+        foreach (var subtitle in itemsToAlign)
+            subtitle.Y = marginTop;
+
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
+    private void BottomAlign()
+    {
+        var selectedItems = new List<BinarySubtitleItem>();
+        if (SubtitleGrid?.SelectedItems != null)
+        {
+            foreach (var item in SubtitleGrid.SelectedItems)
+            {
+                if (item is BinarySubtitleItem binaryItem)
+                    selectedItems.Add(binaryItem);
+            }
+        }
+
+        var itemsToAlign = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+        var marginBottom = Se.Settings.Tools.BinEditBottomMargin;
+        foreach (var subtitle in itemsToAlign)
+        {
+            if (subtitle.Bitmap == null)
+                continue;
+            subtitle.Y = subtitle.ScreenSize.Height - (int)subtitle.Bitmap.Size.Height - marginBottom;
+        }
+
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
     private void Crop()
     {
         // Get selected subtitles

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2169,18 +2169,6 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var suggestedOffset = Subtitles.Count > 0
-            ? Subtitles[^1].EndTime + TimeSpan.FromMilliseconds(1000)
-            : TimeSpan.Zero;
-
-        var settings = await _windowService.ShowDialogAsync<BinaryAppendSubtitle.BinaryAppendSubtitleWindow, BinaryAppendSubtitle.BinaryAppendSubtitleViewModel>(
-            Window, vm => vm.Initialize(suggestedOffset));
-
-        if (!settings.OkPressed)
-        {
-            return;
-        }
-
         var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.General.OpenSubtitleFileTitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.xml;*.mkv;*.mks", Se.Language.General.AllFiles, "*.*");
         if (string.IsNullOrEmpty(fileName))
         {
@@ -2198,6 +2186,18 @@ public partial class BinaryEditViewModel : ObservableObject
         if (ocrItems.Count == 0)
         {
             await MessageBox.Show(Window, Se.Language.General.Error, "No subtitles found in the file.", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        var suggestedOffset = Subtitles.Count > 0
+            ? Subtitles[^1].EndTime + TimeSpan.FromMilliseconds(1000)
+            : TimeSpan.Zero;
+
+        var settings = await _windowService.ShowDialogAsync<BinaryAppendSubtitle.BinaryAppendSubtitleWindow, BinaryAppendSubtitle.BinaryAppendSubtitleViewModel>(
+            Window, vm => vm.Initialize(suggestedOffset));
+
+        if (!settings.OkPressed)
+        {
             return;
         }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1392,19 +1392,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    selectedItems.Add(binaryItem);
-                }
-            }
-        }
-
-        var itemsToAdjust = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+        var itemsToAdjust = Subtitles.ToList();
 
         if (itemsToAdjust.Count == 0)
         {
@@ -1424,17 +1412,50 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (SubtitleGrid != null)
         {
-            if (selectedItems.Count > 0)
-                ApplyGridSelection(selectedItems);
-            else
+            var currentIndex = SubtitleGrid.SelectedIndex;
+            SubtitleGrid.ItemsSource = null;
+            SubtitleGrid.ItemsSource = Subtitles;
+            SubtitleGrid.SelectedIndex = currentIndex;
+        }
+
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
+    private async Task AdjustColorSelectedLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Snapshot selection before dialog opens — focus shift can clear grid selection
+        var selectedItems = new List<BinarySubtitleItem>();
+        if (SubtitleGrid?.SelectedItems != null)
+        {
+            foreach (var item in SubtitleGrid.SelectedItems)
             {
-                var currentIndex = SubtitleGrid.SelectedIndex;
-                SubtitleGrid.ItemsSource = null;
-                SubtitleGrid.ItemsSource = Subtitles;
-                SubtitleGrid.SelectedIndex = currentIndex;
+                if (item is BinarySubtitleItem binaryItem)
+                {
+                    selectedItems.Add(binaryItem);
+                }
             }
         }
 
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        using var result = await _windowService.ShowDialogAsync<BinaryAdjustColor.BinaryAdjustColorWindow, BinaryAdjustColor.BinaryAdjustColorViewModel>(
+            Window, vm => vm.Initialize(selectedItems));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        ApplyGridSelection(selectedItems);
         UpdateOverlayPosition();
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2561,7 +2561,6 @@ public partial class BinaryEditViewModel : ObservableObject
     internal void OnContextMenuOpening()
     {
         var selectedCount = SubtitleGrid?.SelectedItems?.Count ?? 0;
-        var selectedIndex = SubtitleGrid?.SelectedIndex ?? -1;
         HasSelection = selectedCount > 0;
         IsToggleForcedVisible = selectedCount > 0;
         IsInsertAfterVisible = selectedCount == 1;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1020,7 +1020,18 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Get selected indices from the grid
+        result.AdjustDuration(Subtitles.ToList(), null);
+    }
+
+    [RelayCommand]
+    private async Task AdjustDurationsSelectedLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Snapshot selection before dialog opens — focus shift can clear grid selection
         var selectedIndices = new List<int>();
         if (SubtitleGrid?.SelectedItems != null)
         {
@@ -1035,6 +1046,13 @@ public partial class BinaryEditViewModel : ObservableObject
                     }
                 }
             }
+        }
+
+        var result = await _windowService.ShowDialogAsync<BinaryAdjustDuration.BinaryAdjustDurationWindow, BinaryAdjustDuration.BinaryAdjustDurationViewModel>(Window, vm => { });
+
+        if (!result.OkPressed)
+        {
+            return;
         }
 
         result.AdjustDuration(Subtitles.ToList(), selectedIndices.Count > 0 ? selectedIndices : null);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1596,7 +1596,15 @@ public partial class BinaryEditViewModel : ObservableObject
     private async Task AdjustAllTimes() => await DoAdjustAllTimes();
 
     [RelayCommand]
-    private async Task AdjustAllTimesSelectedLines() => await DoAdjustAllTimes(forceSelectedLines: true);
+    private async Task AdjustAllTimesSelectedLines()
+    {
+        if (SubtitleGrid?.SelectedItems?.Count == 0)
+        {
+            return;
+        }
+
+        await DoAdjustAllTimes(forceSelectedLines: true);
+    }
 
     private async Task DoAdjustAllTimes(bool forceSelectedLines = false)
     {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2140,6 +2140,8 @@ public partial class BinaryEditViewModel : ObservableObject
     {
         var selectedItem = SelectedSubtitle;
         var sorted = Subtitles.OrderBy(s => s.StartTime).ToList();
+        foreach (var item in sorted)
+            item.PropertyChanged -= OnSubtitleItemPropertyChanged;
         Subtitles.Clear();
         foreach (var item in sorted)
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1714,7 +1714,14 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         await _windowService.ShowDialogAsync<BinaryAdjustAllTimesWindow, BinaryAdjustAllTimesViewModel>(
-            Window, vm => vm.Initialize(Subtitles, selectedIndices, RefreshGrid, forceSelectedLines));
+            Window, vm =>
+            {
+                vm.Initialize(Subtitles, selectedIndices, RefreshGrid);
+                if (forceSelectedLines)
+                {
+                    vm.AdjustSelectedLines = true;
+                }
+            });
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2082,6 +2082,18 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
+        var suggestedOffset = Subtitles.Count > 0
+            ? Subtitles[^1].EndTime
+            : TimeSpan.Zero;
+
+        var settings = await _windowService.ShowDialogAsync<BinaryAppendSubtitle.BinaryAppendSubtitleWindow, BinaryAppendSubtitle.BinaryAppendSubtitleViewModel>(
+            Window, vm => vm.Initialize(suggestedOffset));
+
+        if (!settings.OkPressed)
+        {
+            return;
+        }
+
         var imageSubtitle = await LoadImageSubtitle(fileName);
         if (imageSubtitle == null)
         {
@@ -2093,18 +2105,6 @@ public partial class BinaryEditViewModel : ObservableObject
         if (ocrItems.Count == 0)
         {
             await MessageBox.Show(Window, Se.Language.General.Error, "No subtitles found in the file.", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            return;
-        }
-
-        var suggestedOffset = Subtitles.Count > 0
-            ? Subtitles[^1].EndTime
-            : TimeSpan.Zero;
-
-        var settings = await _windowService.ShowDialogAsync<BinaryAppendSubtitle.BinaryAppendSubtitleWindow, BinaryAppendSubtitle.BinaryAppendSubtitleViewModel>(
-            Window, vm => vm.Initialize(suggestedOffset));
-
-        if (!settings.OkPressed)
-        {
             return;
         }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -47,7 +47,7 @@ public partial class BinaryEditViewModel : ObservableObject
     [ObservableProperty] private string _statusText;
     [ObservableProperty] private string _currentPosition;
     [ObservableProperty] private string _currentSize;
-    [ObservableProperty] private bool _isDeleteVisible;
+    [ObservableProperty] private bool _hasSelection;
     [ObservableProperty] private bool _isInsertBeforeVisible;
     [ObservableProperty] private bool _isInsertAfterVisible;
     [ObservableProperty] private bool _isToggleForcedVisible;
@@ -2674,7 +2674,7 @@ public partial class BinaryEditViewModel : ObservableObject
     {
         var selectedCount = SubtitleGrid?.SelectedItems?.Count ?? 0;
         var selectedIndex = SubtitleGrid?.SelectedIndex ?? -1;
-        IsDeleteVisible = selectedCount > 0;
+        HasSelection = selectedCount > 0;
         IsToggleForcedVisible = selectedCount > 0;
         IsInsertAfterVisible = selectedCount == 1;
         IsInsertBeforeVisible = selectedCount == 1;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2164,6 +2164,7 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void SortByStartTime()
     {
+        var selectedItem = SelectedSubtitle;
         var sorted = Subtitles.OrderBy(s => s.StartTime).ToList();
         Subtitles.Clear();
         foreach (var item in sorted)
@@ -2171,6 +2172,17 @@ public partial class BinaryEditViewModel : ObservableObject
             Subtitles.Add(item);
         }
         Renumber();
+        if (SubtitleGrid != null)
+        {
+            var newIndex = selectedItem != null ? Subtitles.IndexOf(selectedItem) : -1;
+            SubtitleGrid.ItemsSource = null;
+            SubtitleGrid.ItemsSource = Subtitles;
+            if (newIndex >= 0)
+            {
+                SubtitleGrid.SelectedIndex = newIndex;
+            }
+        }
+        RefreshStatusText();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2187,7 +2187,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         var suggestedOffset = Subtitles.Count > 0
-            ? Subtitles[^1].EndTime + TimeSpan.FromMilliseconds(1000)
+            ? Subtitles[^1].EndTime
             : TimeSpan.Zero;
 
         var settings = await _windowService.ShowDialogAsync<BinaryAppendSubtitle.BinaryAppendSubtitleWindow, BinaryAppendSubtitle.BinaryAppendSubtitleViewModel>(

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2177,10 +2177,7 @@ public partial class BinaryEditViewModel : ObservableObject
             var newIndex = selectedItem != null ? Subtitles.IndexOf(selectedItem) : -1;
             SubtitleGrid.ItemsSource = null;
             SubtitleGrid.ItemsSource = Subtitles;
-            if (newIndex >= 0)
-            {
-                SubtitleGrid.SelectedIndex = newIndex;
-            }
+            SelectAndScrollToRow(newIndex);
         }
         RefreshStatusText();
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2032,6 +2032,18 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
+        var suggestedOffset = Subtitles.Count > 0
+            ? Subtitles[^1].EndTime + TimeSpan.FromMilliseconds(1000)
+            : TimeSpan.Zero;
+
+        var settings = await _windowService.ShowDialogAsync<BinaryAppendSubtitle.BinaryAppendSubtitleWindow, BinaryAppendSubtitle.BinaryAppendSubtitleViewModel>(
+            Window, vm => vm.Initialize(suggestedOffset));
+
+        if (!settings.OkPressed)
+        {
+            return;
+        }
+
         var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.General.OpenSubtitleFileTitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.xml;*.mkv;*.mks", Se.Language.General.AllFiles, "*.*");
         if (string.IsNullOrEmpty(fileName))
         {
@@ -2052,19 +2064,19 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        double timeOffset = 0;
-        if (Subtitles.Count > 0)
-        {
-            var lastItem = Subtitles[^1];
-            var newFirstTime = ocrItems.First().StartTime.TotalMilliseconds;
-            timeOffset = lastItem.EndTime.TotalMilliseconds - newFirstTime + 1000;
-        }
-
         foreach (var ocrItem in ocrItems)
         {
             var newItem = new BinarySubtitleItem(ocrItem, -1);
-            newItem.StartTime = TimeSpan.FromMilliseconds(ocrItem.StartTime.TotalMilliseconds + timeOffset);
-            newItem.EndTime = TimeSpan.FromMilliseconds(ocrItem.EndTime.TotalMilliseconds + timeOffset);
+            if (settings.AppendTimeCodes)
+            {
+                newItem.StartTime = ocrItem.StartTime + settings.TimeOffset;
+                newItem.EndTime = ocrItem.EndTime + settings.TimeOffset;
+            }
+            else
+            {
+                newItem.StartTime = ocrItem.StartTime;
+                newItem.EndTime = ocrItem.EndTime;
+            }
             Subtitles.Add(newItem);
         }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1226,21 +1226,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Get selected subtitles
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    selectedItems.Add(binaryItem);
-                }
-            }
-        }
-
-        // If no selection, work on all subtitles
-        var itemsToResize = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+        var itemsToResize = Subtitles.ToList();
 
         if (itemsToResize.Count == 0)
         {
@@ -1258,7 +1244,6 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Refresh grid to show updated bitmaps
         if (SubtitleGrid != null)
         {
             var currentIndex = SubtitleGrid.SelectedIndex;
@@ -1271,14 +1256,14 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task AdjustBrightness()
+    private async Task ResizeImagesSelectedLines()
     {
         if (Window == null)
         {
             return;
         }
 
-        // Get selected subtitles
+        // Snapshot selection before dialog opens — focus shift can clear grid selection
         var selectedItems = new List<BinarySubtitleItem>();
         if (SubtitleGrid?.SelectedItems != null)
         {
@@ -1291,8 +1276,32 @@ public partial class BinaryEditViewModel : ObservableObject
             }
         }
 
-        // If no selection, work on all subtitles
-        var itemsToAdjust = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        using var result = await _windowService.ShowDialogAsync<BinaryResizeImages.BinaryResizeImagesWindow, BinaryResizeImages.BinaryResizeImagesViewModel>(
+            Window, vm => vm.Initialize(selectedItems));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        ApplyGridSelection(selectedItems);
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
+    private async Task AdjustBrightness()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var itemsToAdjust = Subtitles.ToList();
 
         if (itemsToAdjust.Count == 0)
         {
@@ -1310,32 +1319,26 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Refresh grid to show updated bitmaps
         if (SubtitleGrid != null)
         {
-            if (selectedItems.Count > 0)
-                ApplyGridSelection(selectedItems);
-            else
-            {
-                var currentIndex = SubtitleGrid.SelectedIndex;
-                SubtitleGrid.ItemsSource = null;
-                SubtitleGrid.ItemsSource = Subtitles;
-                SubtitleGrid.SelectedIndex = currentIndex;
-            }
+            var currentIndex = SubtitleGrid.SelectedIndex;
+            SubtitleGrid.ItemsSource = null;
+            SubtitleGrid.ItemsSource = Subtitles;
+            SubtitleGrid.SelectedIndex = currentIndex;
         }
 
         UpdateOverlayPosition();
     }
 
     [RelayCommand]
-    private async Task AdjustAlpha()
+    private async Task AdjustBrightnessSelectedLines()
     {
         if (Window == null)
         {
             return;
         }
 
-        // Get selected subtitles
+        // Snapshot selection before dialog opens — focus shift can clear grid selection
         var selectedItems = new List<BinarySubtitleItem>();
         if (SubtitleGrid?.SelectedItems != null)
         {
@@ -1348,8 +1351,32 @@ public partial class BinaryEditViewModel : ObservableObject
             }
         }
 
-        // If no selection, work on all subtitles
-        var itemsToAdjust = selectedItems.Count > 0 ? selectedItems : Subtitles.ToList();
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        using var result = await _windowService.ShowDialogAsync<BinaryAdjustBrightness.BinaryAdjustBrightnessWindow, BinaryAdjustBrightness.BinaryAdjustBrightnessViewModel>(
+            Window, vm => vm.Initialize(selectedItems));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        ApplyGridSelection(selectedItems);
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
+    private async Task AdjustAlpha()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var itemsToAdjust = Subtitles.ToList();
 
         if (itemsToAdjust.Count == 0)
         {
@@ -1367,20 +1394,52 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Refresh grid to show updated bitmaps
         if (SubtitleGrid != null)
         {
-            if (selectedItems.Count > 0)
-                ApplyGridSelection(selectedItems);
-            else
+            var currentIndex = SubtitleGrid.SelectedIndex;
+            SubtitleGrid.ItemsSource = null;
+            SubtitleGrid.ItemsSource = Subtitles;
+            SubtitleGrid.SelectedIndex = currentIndex;
+        }
+
+        UpdateOverlayPosition();
+    }
+
+    [RelayCommand]
+    private async Task AdjustAlphaSelectedLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Snapshot selection before dialog opens — focus shift can clear grid selection
+        var selectedItems = new List<BinarySubtitleItem>();
+        if (SubtitleGrid?.SelectedItems != null)
+        {
+            foreach (var item in SubtitleGrid.SelectedItems)
             {
-                var currentIndex = SubtitleGrid.SelectedIndex;
-                SubtitleGrid.ItemsSource = null;
-                SubtitleGrid.ItemsSource = Subtitles;
-                SubtitleGrid.SelectedIndex = currentIndex;
+                if (item is BinarySubtitleItem binaryItem)
+                {
+                    selectedItems.Add(binaryItem);
+                }
             }
         }
 
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        using var result = await _windowService.ShowDialogAsync<BinaryAdjustAlpha.BinaryAdjustAlphaWindow, BinaryAdjustAlpha.BinaryAdjustAlphaViewModel>(
+            Window, vm => vm.Initialize(selectedItems));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        ApplyGridSelection(selectedItems);
         UpdateOverlayPosition();
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1713,6 +1713,52 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task AdjustAllTimesSelectedLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Snapshot selection before the dialog opens so focus shift cannot clear it
+        var selectedIndices = new List<int>();
+        if (SubtitleGrid?.SelectedItems != null)
+        {
+            foreach (var item in SubtitleGrid.SelectedItems)
+            {
+                if (item is BinarySubtitleItem binaryItem)
+                {
+                    var index = Subtitles.IndexOf(binaryItem);
+                    if (index >= 0)
+                    {
+                        selectedIndices.Add(index);
+                    }
+                }
+            }
+        }
+
+        selectedIndices.Sort();
+
+        var selectedItems = selectedIndices.Count > 0
+            ? selectedIndices.Select(i => Subtitles[i]).ToList()
+            : null;
+
+        void RefreshGrid()
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (SubtitleGrid == null || selectedItems == null) return;
+                SubtitleGrid.SelectedItems.Clear();
+                foreach (var item in selectedItems)
+                    SubtitleGrid.SelectedItems.Add(item);
+            });
+        }
+
+        await _windowService.ShowDialogAsync<BinaryAdjustAllTimesWindow, BinaryAdjustAllTimesViewModel>(
+            Window, vm => vm.Initialize(Subtitles, selectedIndices, RefreshGrid, forceSelectedLines: true));
+    }
+
+    [RelayCommand]
     private async Task ChangeFrameRate()
     {
         if (Window == null)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2188,6 +2188,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
+        var firstAppendedIndex = Subtitles.Count;
         foreach (var ocrItem in ocrItems)
         {
             var newItem = new BinarySubtitleItem(ocrItem, -1);
@@ -2205,6 +2206,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         Renumber();
+        SelectAndScrollToRow(firstAppendedIndex);
         RefreshStatusText();
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1030,22 +1030,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Snapshot selection before dialog opens — focus shift can clear grid selection
-        var selectedIndices = new List<int>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    var index = Subtitles.IndexOf(binaryItem);
-                    if (index >= 0)
-                    {
-                        selectedIndices.Add(index);
-                    }
-                }
-            }
-        }
+        var selectedIndices = GetSelectedIndices();
 
         if (selectedIndices.Count == 0)
         {
@@ -1090,22 +1075,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Snapshot selection before dialog opens — focus shift can clear grid selection
-        var selectedIndices = new List<int>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    var index = Subtitles.IndexOf(binaryItem);
-                    if (index >= 0)
-                    {
-                        selectedIndices.Add(index);
-                    }
-                }
-            }
-        }
+        var selectedIndices = GetSelectedIndices();
 
         if (selectedIndices.Count == 0)
         {
@@ -1149,15 +1119,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                    selectedItems.Add(binaryItem);
-            }
-        }
+        var selectedItems = GetSelectedItems();
 
         if (selectedItems.Count == 0)
         {
@@ -1285,18 +1247,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Snapshot selection before dialog opens — focus shift can clear grid selection
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    selectedItems.Add(binaryItem);
-                }
-            }
-        }
+        var selectedItems = GetSelectedItems();
 
         if (selectedItems.Count == 0)
         {
@@ -1360,18 +1311,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Snapshot selection before dialog opens — focus shift can clear grid selection
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    selectedItems.Add(binaryItem);
-                }
-            }
-        }
+        var selectedItems = GetSelectedItems();
 
         if (selectedItems.Count == 0)
         {
@@ -1435,18 +1375,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Snapshot selection before dialog opens — focus shift can clear grid selection
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    selectedItems.Add(binaryItem);
-                }
-            }
-        }
+        var selectedItems = GetSelectedItems();
 
         if (selectedItems.Count == 0)
         {
@@ -1510,18 +1439,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Snapshot selection before dialog opens — focus shift can clear grid selection
-        var selectedItems = new List<BinarySubtitleItem>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    selectedItems.Add(binaryItem);
-                }
-            }
-        }
+        var selectedItems = GetSelectedItems();
 
         if (selectedItems.Count == 0)
         {
@@ -1687,22 +1605,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        // Snapshot selection before the dialog opens so focus shift cannot clear it
-        var selectedIndices = new List<int>();
-        if (SubtitleGrid?.SelectedItems != null)
-        {
-            foreach (var item in SubtitleGrid.SelectedItems)
-            {
-                if (item is BinarySubtitleItem binaryItem)
-                {
-                    var index = Subtitles.IndexOf(binaryItem);
-                    if (index >= 0)
-                    {
-                        selectedIndices.Add(index);
-                    }
-                }
-            }
-        }
+        var selectedIndices = GetSelectedIndices();
 
         selectedIndices.Sort();
 
@@ -1978,7 +1881,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var selectedItems = SubtitleGrid.SelectedItems.Cast<BinarySubtitleItem>().ToList();
+        var selectedItems = GetSelectedItems();
         foreach (var item in selectedItems)
         {
             item.IsForced = !item.IsForced;
@@ -1996,6 +1899,13 @@ public partial class BinaryEditViewModel : ObservableObject
     {
         ApplyGridSelection(Subtitles.Where(s => !s.IsForced).ToList(), preserveScroll: true);
     }
+
+    // Captured before any await so focus shift cannot clear the grid selection.
+    private List<BinarySubtitleItem> GetSelectedItems() =>
+        SubtitleGrid?.SelectedItems?.Cast<BinarySubtitleItem>().ToList() ?? [];
+
+    private List<int> GetSelectedIndices() =>
+        GetSelectedItems().Select(item => Subtitles.IndexOf(item)).Where(i => i >= 0).ToList();
 
     // Adding many rows to a realized DataGrid's SelectedItems is O(n) visual work per
     // row, so selecting all forced/non-forced lines on a large file hangs (#11529).

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -533,6 +533,8 @@ public class BinaryEditWindow : Window
         flyout.Items.Add(menuItemCropSelectedLines);
         menuItemCropSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
+        flyout.Items.Add(new Separator());
+
         var menuItemAdjustBrightnessSelectedLines = new MenuItem
         {
             Header = Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot,

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -500,6 +500,19 @@ public class BinaryEditWindow : Window
         };
         flyout.Items.Add(menuItemSelectNonForcedLines);
 
+        var separatorDurations = new Separator() { DataContext = vm };
+        flyout.Items.Add(separatorDurations);
+        separatorDurations.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemAdjustDurations = new MenuItem
+        {
+            Header = Se.Language.Main.Menu.AdjustDurations,
+            DataContext = vm,
+            Command = vm.AdjustDurationsSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemAdjustDurations);
+        menuItemAdjustDurations.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
         var separatorInsertSubtitle = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorInsertSubtitle);
         separatorInsertSubtitle.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertSubtitleVisible)));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -238,6 +238,16 @@ public class BinaryEditWindow : Window
                     Header = Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
                     Command = vm.CenterHorizontallyCommand,
                 },
+                new MenuItem
+                {
+                    Header = Se.Language.Tools.ImageBasedEdit.TopAlignLines,
+                    Command = vm.TopAlignCommand,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.Tools.ImageBasedEdit.BottomAlignLines,
+                    Command = vm.BottomAlignCommand,
+                },
                 new Separator(),
                 new MenuItem
                 {
@@ -409,19 +419,6 @@ public class BinaryEditWindow : Window
         UiUtil.AttachMacContextFlyoutHandler(dataGrid);
         flyout.Opening += (_, _) => vm.OnContextMenuOpening();
 
-        var menuItemDelete = new MenuItem
-        {
-            Header = Se.Language.General.Delete,
-            DataContext = vm,
-            Command = vm.DeleteSectedLinesCommand,
-        };
-        flyout.Items.Add(menuItemDelete);
-        menuItemDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
-
-        var separatorInsert = new Separator() { DataContext = vm };
-        flyout.Items.Add(separatorInsert);
-        separatorInsert.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertBeforeVisible)));
-
         var menuItemInsertBefore = new MenuItem
         {
             Header = Se.Language.General.InsertBefore,
@@ -466,7 +463,7 @@ public class BinaryEditWindow : Window
         {
             Header = Se.Language.Tools.ImageBasedEdit.TopAlignLines,
             DataContext = vm,
-            Command = vm.TopAlignCommand,
+            Command = vm.TopAlignSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemTopAlign);
         menuItemTopAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
@@ -475,7 +472,7 @@ public class BinaryEditWindow : Window
         {
             Header = Se.Language.Tools.ImageBasedEdit.BottomAlignLines,
             DataContext = vm,
-            Command = vm.BottomAlignCommand,
+            Command = vm.BottomAlignSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemBottomAlign);
         menuItemBottomAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
@@ -521,6 +518,15 @@ public class BinaryEditWindow : Window
         };
         flyout.Items.Add(menuItemResizeImagesSelectedLines);
         menuItemResizeImagesSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemCropSelectedLines = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.CropImages,
+            DataContext = vm,
+            Command = vm.CropSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemCropSelectedLines);
+        menuItemCropSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
 
         var menuItemAdjustBrightnessSelectedLines = new MenuItem
         {
@@ -570,6 +576,19 @@ public class BinaryEditWindow : Window
         };
         flyout.Items.Add(menuItemApplyDurationLimits);
         menuItemApplyDurationLimits.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var separatorDelete = new Separator() { DataContext = vm };
+        flyout.Items.Add(separatorDelete);
+        separatorDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemDelete = new MenuItem
+        {
+            Header = Se.Language.General.Delete,
+            DataContext = vm,
+            Command = vm.DeleteSectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemDelete);
+        menuItemDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
 
         vm.SubtitleGrid = dataGrid;
         dataGrid.SelectionChanged += vm.SubtitleGridSelectionChanged;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -289,6 +289,11 @@ public class BinaryEditWindow : Window
                 new Separator(),
                 new MenuItem
                 {
+                    Header = Se.Language.Tools.ImageBasedEdit.SortByStartTime,
+                    Command = vm.SortByStartTimeCommand,
+                },
+                new MenuItem
+                {
                     Header = Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot,
                     Command = vm.AppendSubtitleCommand,
                 },

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -453,7 +453,7 @@ public class BinaryEditWindow : Window
             Command = vm.AlignmentSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemAlign);
-        menuItemAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemCenterH = new MenuItem
         {
@@ -462,7 +462,7 @@ public class BinaryEditWindow : Window
             Command = vm.CenterHorizontallySelectedLinesCommand,
         };
         flyout.Items.Add(menuItemCenterH);
-        menuItemCenterH.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemCenterH.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemTopAlign = new MenuItem
         {
@@ -471,7 +471,7 @@ public class BinaryEditWindow : Window
             Command = vm.TopAlignSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemTopAlign);
-        menuItemTopAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemTopAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemBottomAlign = new MenuItem
         {
@@ -480,11 +480,11 @@ public class BinaryEditWindow : Window
             Command = vm.BottomAlignSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemBottomAlign);
-        menuItemBottomAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemBottomAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var separatorForced = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorForced);
-        separatorForced.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        separatorForced.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemToggleForced = new MenuItem
         {
@@ -513,7 +513,7 @@ public class BinaryEditWindow : Window
 
         var separatorVisualOps = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorVisualOps);
-        separatorVisualOps.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        separatorVisualOps.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemResizeImagesSelectedLines = new MenuItem
         {
@@ -522,7 +522,7 @@ public class BinaryEditWindow : Window
             Command = vm.ResizeImagesSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemResizeImagesSelectedLines);
-        menuItemResizeImagesSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemResizeImagesSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemCropSelectedLines = new MenuItem
         {
@@ -531,7 +531,7 @@ public class BinaryEditWindow : Window
             Command = vm.CropSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemCropSelectedLines);
-        menuItemCropSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemCropSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemAdjustBrightnessSelectedLines = new MenuItem
         {
@@ -540,7 +540,7 @@ public class BinaryEditWindow : Window
             Command = vm.AdjustBrightnessSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemAdjustBrightnessSelectedLines);
-        menuItemAdjustBrightnessSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemAdjustBrightnessSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemAdjustAlphaSelectedLines = new MenuItem
         {
@@ -549,7 +549,7 @@ public class BinaryEditWindow : Window
             Command = vm.AdjustAlphaSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemAdjustAlphaSelectedLines);
-        menuItemAdjustAlphaSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemAdjustAlphaSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemAdjustColorSelectedLines = new MenuItem
         {
@@ -558,11 +558,11 @@ public class BinaryEditWindow : Window
             Command = vm.AdjustColorSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemAdjustColorSelectedLines);
-        menuItemAdjustColorSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemAdjustColorSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var separatorDurations = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorDurations);
-        separatorDurations.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        separatorDurations.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemAdjustDurations = new MenuItem
         {
@@ -571,7 +571,7 @@ public class BinaryEditWindow : Window
             Command = vm.AdjustDurationsSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemAdjustDurations);
-        menuItemAdjustDurations.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemAdjustDurations.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemApplyDurationLimits = new MenuItem
         {
@@ -580,7 +580,7 @@ public class BinaryEditWindow : Window
             Command = vm.ApplyDurationLimitsSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemApplyDurationLimits);
-        menuItemApplyDurationLimits.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemApplyDurationLimits.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemAdjustAllTimesSelectedLines = new MenuItem
         {
@@ -589,11 +589,11 @@ public class BinaryEditWindow : Window
             Command = vm.AdjustAllTimesSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemAdjustAllTimesSelectedLines);
-        menuItemAdjustAllTimesSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemAdjustAllTimesSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var separatorDelete = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorDelete);
-        separatorDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        separatorDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemDelete = new MenuItem
         {
@@ -602,7 +602,7 @@ public class BinaryEditWindow : Window
             Command = vm.DeleteSectedLinesCommand,
         };
         flyout.Items.Add(menuItemDelete);
-        menuItemDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        menuItemDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         vm.SubtitleGrid = dataGrid;
         dataGrid.SelectionChanged += vm.SubtitleGridSelectionChanged;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -243,6 +243,11 @@ public class BinaryEditWindow : Window
                     Header = Se.Language.General.AlignmentDotDotDot,
                     Command = vm.AlignmentCommand,
                 },
+                new MenuItem
+                {
+                    Header =  Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
+                    Command = vm.CenterHorizontallyCommand,
+                },
                 new Separator(),
                 new MenuItem
                 {
@@ -263,12 +268,6 @@ public class BinaryEditWindow : Window
                 {
                     Header = Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot,
                     Command = vm.AdjustColorCommand,
-                },
-                new Separator(),
-                new MenuItem
-                {
-                    Header =  Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
-                    Command = vm.CenterHorizontallyCommand,
                 },
                 new MenuItem
                 {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -444,7 +444,7 @@ public class BinaryEditWindow : Window
 
         var separatorAlignment = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorAlignment);
-        separatorAlignment.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertBeforeVisible)));
+        separatorAlignment.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         var menuItemAlign = new MenuItem
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -431,6 +431,50 @@ public class BinaryEditWindow : Window
         flyout.Items.Add(menuItemInsertAfter);
         menuItemInsertAfter.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertAfterVisible)));
 
+        var separatorAlignment = new Separator() { DataContext = vm };
+        flyout.Items.Add(separatorAlignment);
+        separatorAlignment.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemAlign = new MenuItem
+        {
+            Header = Se.Language.General.AlignmentDotDotDot,
+            DataContext = vm,
+            Command = vm.AlignmentCommand,
+        };
+        flyout.Items.Add(menuItemAlign);
+        menuItemAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemCenterH = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
+            DataContext = vm,
+            Command = vm.CenterHorizontallyCommand,
+        };
+        flyout.Items.Add(menuItemCenterH);
+        menuItemCenterH.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemTopAlign = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.TopAlignLines,
+            DataContext = vm,
+            Command = vm.TopAlignCommand,
+        };
+        flyout.Items.Add(menuItemTopAlign);
+        menuItemTopAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemBottomAlign = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.BottomAlignLines,
+            DataContext = vm,
+            Command = vm.BottomAlignCommand,
+        };
+        flyout.Items.Add(menuItemBottomAlign);
+        menuItemBottomAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var separatorForced = new Separator() { DataContext = vm };
+        flyout.Items.Add(separatorForced);
+        separatorForced.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
         var menuItemToggleForced = new MenuItem
         {
             Header = Se.Language.General.ToggleForced,

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -445,7 +445,7 @@ public class BinaryEditWindow : Window
         {
             Header = Se.Language.General.AlignmentDotDotDot,
             DataContext = vm,
-            Command = vm.AlignmentCommand,
+            Command = vm.AlignmentSelectedLinesCommand,
         };
         flyout.Items.Add(menuItemAlign);
         menuItemAlign.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
@@ -454,7 +454,7 @@ public class BinaryEditWindow : Window
         {
             Header = Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
             DataContext = vm,
-            Command = vm.CenterHorizontallyCommand,
+            Command = vm.CenterHorizontallySelectedLinesCommand,
         };
         flyout.Items.Add(menuItemCenterH);
         menuItemCenterH.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -577,6 +577,15 @@ public class BinaryEditWindow : Window
         flyout.Items.Add(menuItemApplyDurationLimits);
         menuItemApplyDurationLimits.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
 
+        var menuItemAdjustAllTimesSelectedLines = new MenuItem
+        {
+            Header = Se.Language.Sync.ShowEarlierLaterDotDotDot,
+            DataContext = vm,
+            Command = vm.AdjustAllTimesSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemAdjustAllTimesSelectedLines);
+        menuItemAdjustAllTimesSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
         var separatorDelete = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorDelete);
         separatorDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -230,22 +230,12 @@ public class BinaryEditWindow : Window
             {
                 new MenuItem
                 {
-                    Header = l.AdjustDurations,
-                    Command = vm.AdjustDurationsCommand,
-                },
-                new MenuItem
-                {
-                    Header = l.ApplyDurationLimits,
-                    Command = vm.ApplyDurationLimitsCommand,
-                },
-                new MenuItem
-                {
                     Header = Se.Language.General.AlignmentDotDotDot,
                     Command = vm.AlignmentCommand,
                 },
                 new MenuItem
                 {
-                    Header =  Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
+                    Header = Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
                     Command = vm.CenterHorizontallyCommand,
                 },
                 new Separator(),
@@ -256,12 +246,18 @@ public class BinaryEditWindow : Window
                 },
                 new MenuItem
                 {
+                    Header = Se.Language.Tools.ImageBasedEdit.CropImages,
+                    Command = vm.CropCommand,
+                },
+                new Separator(),
+                new MenuItem
+                {
                     Header = Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot,
                     Command = vm.AdjustBrightnessCommand,
                 },
                 new MenuItem
                 {
-                    Header =  Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot,
+                    Header = Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot,
                     Command = vm.AdjustAlphaCommand,
                 },
                 new MenuItem
@@ -269,10 +265,16 @@ public class BinaryEditWindow : Window
                     Header = Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot,
                     Command = vm.AdjustColorCommand,
                 },
+                new Separator(),
                 new MenuItem
                 {
-                    Header =  Se.Language.Tools.ImageBasedEdit.CropImages,
-                    Command = vm.CropCommand,
+                    Header = l.AdjustDurations,
+                    Command = vm.AdjustDurationsCommand,
+                },
+                new MenuItem
+                {
+                    Header = l.ApplyDurationLimits,
+                    Command = vm.ApplyDurationLimitsCommand,
                 },
                 new Separator(),
                 new MenuItem

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -506,6 +506,19 @@ public class BinaryEditWindow : Window
         };
         flyout.Items.Add(menuItemSelectNonForcedLines);
 
+        var separatorAdjustColor = new Separator() { DataContext = vm };
+        flyout.Items.Add(separatorAdjustColor);
+        separatorAdjustColor.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemAdjustColorSelectedLines = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot,
+            DataContext = vm,
+            Command = vm.AdjustColorSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemAdjustColorSelectedLines);
+        menuItemAdjustColorSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
         var separatorDurations = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorDurations);
         separatorDurations.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -273,6 +273,12 @@ public class BinaryEditWindow : Window
                     Header =  Se.Language.Tools.ImageBasedEdit.CropImages,
                     Command = vm.CropCommand,
                 },
+                new Separator(),
+                new MenuItem
+                {
+                    Header = Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot,
+                    Command = vm.AppendSubtitleCommand,
+                },
             },
         });
 
@@ -521,19 +527,6 @@ public class BinaryEditWindow : Window
         };
         flyout.Items.Add(menuItemApplyDurationLimits);
         menuItemApplyDurationLimits.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
-
-        var separatorInsertSubtitle = new Separator() { DataContext = vm };
-        flyout.Items.Add(separatorInsertSubtitle);
-        separatorInsertSubtitle.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertSubtitleVisible)));
-
-        var menuItemInsertSubtitle = new MenuItem
-        {
-            Header = Se.Language.General.InsertSubtitleAfterCurrentLine,
-            DataContext = vm,
-            Command = vm.InsertSubtitleCommand,
-        };
-        flyout.Items.Add(menuItemInsertSubtitle);
-        menuItemInsertSubtitle.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertSubtitleVisible)));
 
         vm.SubtitleGrid = dataGrid;
         dataGrid.SelectionChanged += vm.SubtitleGridSelectionChanged;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -225,7 +225,7 @@ public class BinaryEditWindow : Window
         // Tools menu
         menu.Items.Add(new MenuItem
         {
-            Header = l.ToolsSelectedLines,
+            Header = l.Tools,
             Items =
             {
                 new MenuItem

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -243,6 +243,7 @@ public class BinaryEditWindow : Window
                     Header = Se.Language.General.AlignmentDotDotDot,
                     Command = vm.AlignmentCommand,
                 },
+                new Separator(),
                 new MenuItem
                 {
                     Header = Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot,
@@ -263,6 +264,7 @@ public class BinaryEditWindow : Window
                     Header = Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot,
                     Command = vm.AdjustColorCommand,
                 },
+                new Separator(),
                 new MenuItem
                 {
                     Header =  Se.Language.Tools.ImageBasedEdit.CenterHorizontally,
@@ -506,9 +508,36 @@ public class BinaryEditWindow : Window
         };
         flyout.Items.Add(menuItemSelectNonForcedLines);
 
-        var separatorAdjustColor = new Separator() { DataContext = vm };
-        flyout.Items.Add(separatorAdjustColor);
-        separatorAdjustColor.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        var separatorVisualOps = new Separator() { DataContext = vm };
+        flyout.Items.Add(separatorVisualOps);
+        separatorVisualOps.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemResizeImagesSelectedLines = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot,
+            DataContext = vm,
+            Command = vm.ResizeImagesSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemResizeImagesSelectedLines);
+        menuItemResizeImagesSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemAdjustBrightnessSelectedLines = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot,
+            DataContext = vm,
+            Command = vm.AdjustBrightnessSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemAdjustBrightnessSelectedLines);
+        menuItemAdjustBrightnessSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
+        var menuItemAdjustAlphaSelectedLines = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot,
+            DataContext = vm,
+            Command = vm.AdjustAlphaSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemAdjustAlphaSelectedLines);
+        menuItemAdjustAlphaSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
 
         var menuItemAdjustColorSelectedLines = new MenuItem
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -439,7 +439,7 @@ public class BinaryEditWindow : Window
 
         var separatorAlignment = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorAlignment);
-        separatorAlignment.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+        separatorAlignment.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertBeforeVisible)));
 
         var menuItemAlign = new MenuItem
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -513,6 +513,15 @@ public class BinaryEditWindow : Window
         flyout.Items.Add(menuItemAdjustDurations);
         menuItemAdjustDurations.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
 
+        var menuItemApplyDurationLimits = new MenuItem
+        {
+            Header = Se.Language.Main.Menu.ApplyDurationLimits,
+            DataContext = vm,
+            Command = vm.ApplyDurationLimitsSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemApplyDurationLimits);
+        menuItemApplyDurationLimits.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)));
+
         var separatorInsertSubtitle = new Separator() { DataContext = vm };
         flyout.Items.Add(separatorInsertSubtitle);
         separatorInsertSubtitle.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsInsertSubtitleVisible)));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
@@ -126,24 +126,13 @@ public partial class BinaryResizeImagesViewModel : ObservableObject, IDisposable
         }
     }
 
-    private SKBitmap ResizeBitmap(SKBitmap originalBitmap, int width, int height)
+    private static SKBitmap ResizeBitmap(SKBitmap originalBitmap, int width, int height)
     {
-        var resizedBitmap = new SKBitmap(width, height);
-        using (var canvas = new SKCanvas(resizedBitmap))
-        {
-            canvas.Clear(SKColors.Transparent);
-
-            var scale = SKMatrix.CreateScale((float)width / originalBitmap.Width,
-                                             (float)height / originalBitmap.Height);
-
-            using (var shader = SKShader.CreateBitmap(originalBitmap, SKShaderTileMode.Clamp, SKShaderTileMode.Clamp, scale))
-            using (var paint = new SKPaint())
-            {
-                paint.Shader = shader;
-                paint.IsAntialias = true;
-                canvas.DrawRect(new SKRect(0, 0, width, height), paint);
-            }
-        }
+        var resizedBitmap = new SKBitmap(width, height, originalBitmap.ColorType, originalBitmap.AlphaType);
+        using var canvas = new SKCanvas(resizedBitmap);
+        canvas.Clear(SKColors.Transparent);
+        using var paint = new SKPaint { FilterQuality = SKFilterQuality.High, IsAntialias = true };
+        canvas.DrawBitmap(originalBitmap, new SKRect(0, 0, width, height), paint);
         return resizedBitmap;
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesViewModel.cs
@@ -131,8 +131,8 @@ public partial class BinaryResizeImagesViewModel : ObservableObject, IDisposable
         var resizedBitmap = new SKBitmap(width, height, originalBitmap.ColorType, originalBitmap.AlphaType);
         using var canvas = new SKCanvas(resizedBitmap);
         canvas.Clear(SKColors.Transparent);
-        using var paint = new SKPaint { FilterQuality = SKFilterQuality.High, IsAntialias = true };
-        canvas.DrawBitmap(originalBitmap, new SKRect(0, 0, width, height), paint);
+        using var image = SKImage.FromBitmap(originalBitmap);
+        canvas.DrawImage(image, new SKRect(0, 0, width, height), new SKSamplingOptions(SKCubicResampler.Mitchell));
         return resizedBitmap;
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -36,10 +36,12 @@ public static class InitNativeMacMenuBinaryEdit
         Add(toolsMenu, l.AdjustDurations, vm.AdjustDurationsCommand);
         Add(toolsMenu, l.ApplyDurationLimits, vm.ApplyDurationLimitsCommand);
         Add(toolsMenu, Se.Language.General.AlignmentDotDotDot, vm.AlignmentCommand);
+        toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot, vm.ResizeImagesCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot, vm.AdjustBrightnessCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot, vm.AdjustAlphaCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot, vm.AdjustColorCommand);
+        toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CenterHorizontally, vm.CenterHorizontallyCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -33,16 +33,18 @@ public static class InitNativeMacMenuBinaryEdit
 
         // Tools menu
         var toolsMenu = new NativeMenu();
-        Add(toolsMenu, l.AdjustDurations, vm.AdjustDurationsCommand);
-        Add(toolsMenu, l.ApplyDurationLimits, vm.ApplyDurationLimitsCommand);
         Add(toolsMenu, Se.Language.General.AlignmentDotDotDot, vm.AlignmentCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CenterHorizontally, vm.CenterHorizontallyCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot, vm.ResizeImagesCommand);
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
+        toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot, vm.AdjustBrightnessCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot, vm.AdjustAlphaCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot, vm.AdjustColorCommand);
-        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
+        toolsMenu.Items.Add(new NativeMenuItemSeparator());
+        Add(toolsMenu, l.AdjustDurations, vm.AdjustDurationsCommand);
+        Add(toolsMenu, l.ApplyDurationLimits, vm.ApplyDurationLimitsCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot, vm.AppendSubtitleCommand);
         root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolsMenu });

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -36,13 +36,12 @@ public static class InitNativeMacMenuBinaryEdit
         Add(toolsMenu, l.AdjustDurations, vm.AdjustDurationsCommand);
         Add(toolsMenu, l.ApplyDurationLimits, vm.ApplyDurationLimitsCommand);
         Add(toolsMenu, Se.Language.General.AlignmentDotDotDot, vm.AlignmentCommand);
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CenterHorizontally, vm.CenterHorizontallyCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot, vm.ResizeImagesCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot, vm.AdjustBrightnessCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot, vm.AdjustAlphaCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot, vm.AdjustColorCommand);
-        toolsMenu.Items.Add(new NativeMenuItemSeparator());
-        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CenterHorizontally, vm.CenterHorizontallyCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot, vm.AppendSubtitleCommand);

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -42,7 +42,7 @@ public static class InitNativeMacMenuBinaryEdit
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot, vm.AdjustColorCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CenterHorizontally, vm.CenterHorizontallyCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
-        root.Items.Add(new NativeMenuItem(Clean(l.ToolsSelectedLines)) { Menu = toolsMenu });
+        root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolsMenu });
 
         // Synchronization menu
         var syncMenu = new NativeMenu();

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -48,6 +48,7 @@ public static class InitNativeMacMenuBinaryEdit
         Add(toolsMenu, l.AdjustDurations, vm.AdjustDurationsCommand);
         Add(toolsMenu, l.ApplyDurationLimits, vm.ApplyDurationLimitsCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.SortByStartTime, vm.SortByStartTimeCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot, vm.AppendSubtitleCommand);
         root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolsMenu });
 

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -35,6 +35,8 @@ public static class InitNativeMacMenuBinaryEdit
         var toolsMenu = new NativeMenu();
         Add(toolsMenu, Se.Language.General.AlignmentDotDotDot, vm.AlignmentCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CenterHorizontally, vm.CenterHorizontallyCommand);
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.TopAlignLines, vm.TopAlignCommand);
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.BottomAlignLines, vm.BottomAlignCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot, vm.ResizeImagesCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -42,6 +42,8 @@ public static class InitNativeMacMenuBinaryEdit
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustColorDotDotDot, vm.AdjustColorCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CenterHorizontally, vm.CenterHorizontallyCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
+        toolsMenu.Items.Add(new NativeMenuItemSeparator());
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot, vm.AppendSubtitleCommand);
         root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolsMenu });
 
         // Synchronization menu

--- a/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
+++ b/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
@@ -34,6 +34,7 @@ public class LanguageSync
     public string AdjustAllShortcuts { get; set; }
     public string OffsetInSeconds { get; set; }
     public string SpeedFactor { get; set; }
+    public string ShowEarlierLaterDotDotDot { get; set; }
 
     public LanguageSync()
     {
@@ -67,5 +68,6 @@ public class LanguageSync
         AdjustAllShortcuts = "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 10 ms\r\n• Ctrl + Left/Right: Move 100 ms\r\n• Alt + Left/Right: Move 500 ms";
         OffsetInSeconds = "Offset in seconds";
         SpeedFactor = "Speed factor";
+        ShowEarlierLaterDotDotDot = "Show earlier/later...";
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageAdjustDisplayDurations.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageAdjustDisplayDurations.cs
@@ -16,6 +16,7 @@ public class LanguageAdjustDisplayDurations
     public string EnforceDurationLimits { get; set; }
     public string CheckShotChanges { get; set; }
     public string BatchCheckShotChanges { get; set; }
+    public string RecalculateRequiresOcrNote { get; set; }
 
     public LanguageAdjustDisplayDurations()
     {
@@ -33,5 +34,6 @@ public class LanguageAdjustDisplayDurations
         EnforceDurationLimits = "Enforce minimum and maximum duration";
         CheckShotChanges = "Don't extend past shot changes";
         BatchCheckShotChanges = "Respect shot changes (if available)";
+        RecalculateRequiresOcrNote = "Recalculate is unavailable — one or more subtitles have no OCR text. Run OCR first.";
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -31,6 +31,7 @@ public class LanguageImageBasedEdit
     public string TopAlignLines { get; set; }
     public string BottomAlignLines { get; set; }
     public string AppendSubtitleDotDotDot { get; set; }
+    public string SortByStartTime { get; set; }
 
     public LanguageImageBasedEdit()
     {
@@ -63,5 +64,6 @@ public class LanguageImageBasedEdit
         TopAlignLines = "Top align";
         BottomAlignLines = "Bottom align";
         AppendSubtitleDotDotDot = "Append subtitle...";
+        SortByStartTime = "Sort by start time";
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -30,6 +30,7 @@ public class LanguageImageBasedEdit
     public string ColorAdjustmentInfo { get; set; }
     public string TopAlignLines { get; set; }
     public string BottomAlignLines { get; set; }
+    public string AppendSubtitleDotDotDot { get; set; }
 
     public LanguageImageBasedEdit()
     {
@@ -61,5 +62,6 @@ public class LanguageImageBasedEdit
         ColorAdjustmentInfo = "Click the color swatch to pick a color. Bright subtitle pixels shift toward the chosen hue; dark outlines and shadows are preserved.\nPreview shows the first selected subtitle.";
         TopAlignLines = "Top align";
         BottomAlignLines = "Bottom align";
+        AppendSubtitleDotDotDot = "Append subtitle...";
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -31,6 +31,7 @@ public class LanguageImageBasedEdit
     public string TopAlignLines { get; set; }
     public string BottomAlignLines { get; set; }
     public string AppendSubtitleDotDotDot { get; set; }
+    public string ShiftTimeCodes { get; set; }
     public string SortByStartTime { get; set; }
 
     public LanguageImageBasedEdit()
@@ -64,6 +65,7 @@ public class LanguageImageBasedEdit
         TopAlignLines = "Top align";
         BottomAlignLines = "Bottom align";
         AppendSubtitleDotDotDot = "Append subtitle...";
+        ShiftTimeCodes = "Shift time codes by";
         SortByStartTime = "Sort by start time";
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -28,6 +28,8 @@ public class LanguageImageBasedEdit
     public string AdjustColorDotDotDot { get; set; }
     public string AdjustColor { get; set; }
     public string ColorAdjustmentInfo { get; set; }
+    public string TopAlignLines { get; set; }
+    public string BottomAlignLines { get; set; }
 
     public LanguageImageBasedEdit()
     {
@@ -57,5 +59,7 @@ public class LanguageImageBasedEdit
         AdjustColorDotDotDot = "Adjust color...";
         AdjustColor = "Adjust color";
         ColorAdjustmentInfo = "Click the color swatch to pick a color. Bright subtitle pixels shift toward the chosen hue; dark outlines and shadows are preserved.\nPreview shows the first selected subtitle.";
+        TopAlignLines = "Top align";
+        BottomAlignLines = "Bottom align";
     }
 }

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -30,6 +30,7 @@ public class SeTools
     public string NvidiaPrompt { get; set; }
     public bool JoinKeepTimeCodes { get; set; }
     public int JoinAppendMilliseconds { get; set; }
+    public bool BinEditAppendKeepTimeCodes { get; set; }
 
     public string MergeTwoSubtitlesOutputFormat { get; set; }
     public string MergeTwoSubtitlesFontName1 { get; set; }


### PR DESCRIPTION
 ## Summary

  This PR reworks the Binary Edit (BinEdit) Tools menu UX around a single clear principle: **Tools menu = always all subtitles; context menu = always selected lines**. Along the way it adds several missing commands, fixes several bugs, and eliminates duplicated code.

The "selection or all" fallback is an antipattern because the user has no way to know which branch fired — the menu looks identical either way. Separating scope by surface (menu bar vs. context menu) is the standard convention and the one SE4 used.

Menu bar - Tools menu:
<img width="532" height="406" alt="Tools menu" src="https://github.com/user-attachments/assets/774d51ec-5c84-4d06-8957-80421e78d4ba" />

Context menu:
<img width="137" height="406" alt="Context menu" src="https://github.com/user-attachments/assets/b6dbe675-8632-47f8-9d40-a21f07f22530" />

  ---

  ## The problem with "Tools (selected lines)"

  The original menu header "Tools (selected lines)" was misleading and internally inconsistent. In practice, the commands used an "if selection else all" fallback: if you had a selection they'd act on it, otherwise they'd silently act on everything. This created two problems:

  1. **The menu lied.** The label promised "selected lines" but the actual scope depended on runtime state. A user who opened the menu without selecting anything would get a whole-file operation without any indication that the scope had changed.
  2. **The context menu was redundant for the wrong reason.** The context menu duplicated the same commands, but with no clear reason why — since the Tools menu already fell back to all lines, the scope difference between the two wasn't communicated anywhere.

  The standard UX pattern for this situation (used by virtually every subtitle editor, including SE4 and NLE apps) is:
  - **Menu bar** → operates on everything, always
  - **Right-click / context menu** → operates on the current selection, always shown only when a selection exists

  ---

  ## What changed

  ### Menu rename and Tools menu scope fix

  The menu header is renamed from "Tools (selected lines)" to "Tools" to accurately reflect that it now always acts on all subtitles — the ambiguous selection-fallback is gone. Every command in the Tools menu operates on `Subtitles` (the full list), not on `SelectedItems`.

  ### Context menu: selection-scoped commands

  All visual and timing operations are now also available in the right-click context menu, appearing only when `HasSelection` is true. This replaces the old ad-hoc `IsDeleteVisible` / `IsInsertSubtitleVisible` booleans with a single `HasSelection` property that drives the entire selection-dependent section.

  The context menu now has a structured layout when lines are selected:

  | Group | Items |
  |-------|-------|
  | Alignment | Alignment…, Center horizontally, Top align, Bottom align |
  | Visual ops | Resize images…, Crop images, Adjust brightness…, Adjust alpha…, Adjust color… |
  | Timing | Adjust durations…, Apply duration limits…, Show earlier/later… |
  | Destructive | Delete |

  The Insert before / Insert after items (single-selection only) retain their position above the selection-dependent block.

  ### New commands

  - **Top Align** and **Bottom Align** — were entirely absent from the UI; now in the Tools menu (all) and context menu (selected)
  - **Sort by start time** — added to Tools menu; scrolls the previously-selected item into view and refreshes status text after sorting
  - **Append Subtitle…** — moved from context menu to the Tools menu (it's a file-level operation, not a selection operation); now opens a proper dialog to choose between shifting time codes by a calculated offset vs. keeping original time codes; file picker is shown before the offset dialog so canceling the file picker doesn't needlessly open a second dialog; scrolls to the first appended item after import

  ### Tools menu grouping

  Commands are reorganised into logical groups separated by dividers:

  1. **Position** — Alignment…, Center horizontally, Top align, Bottom align
  2. **Visual** — Resize images…, Crop images
  3. **Color** — Adjust brightness…, Adjust alpha…, Adjust color…
  4. **Timing** — Adjust durations…, Apply duration limits…
  5. **File** — Sort by start time, Append subtitle…

  ---

  ## Bug fixes (notable mentions )

  - **Resize Images incorrect scale** — the resize factor was computed incorrectly in the original implementation, producing wrong output image dimensions; fixed.
  - **Recalculate unavailable when OCR text is missing** — if any subtitle in scope has no OCR text, Recalculate would silently produce wrong durations. The OK button is now disabled and an explanatory warning is shown instead.
  - **ApplyDurationLimits in-dialog scope selector** — the dialog contained unfinished "Apply to all / Apply to selected lines" radio buttons (left as TODO comments) that didn't wire up to language strings and duplicated scope logic that belongs at the call site. Removed; scope is now controlled by which entry point is used (Tools menu vs. context menu), consistent with every other command.
  - **Append Subtitle offset** — the original implementation shifted all incoming time codes by `lastSubtitle.EndTime + 1 000 ms`, hard-coded. If the appended file had its own internal offsets this produced overlaps or large gaps. The new dialog lets the user explicitly choose a shift offset (pre-filled from the last subtitle's end time) or keep the original time codes unchanged.

  ---

  ## Code quality (notable mentions)

  - Extracted `GetSelectedItems()` and `GetSelectedIndices()` helpers to replace eight near-identical `foreach (var item in SubtitleGrid.SelectedItems)` blocks scattered across the view model. Selection
  is captured before any `await` so focus shifts during async dialogs cannot clear it.
  - Replaced deprecated `SKFilterQuality` with `SKSamplingOptions` in `ResizeBitmap`.
  - Removed dead `selectedIndex` variable in `OnContextMenuOpening`.
  - Removed dead `IsEnabled` property from `BinaryAdjustDurationDisplay`.

