### PR TITLE
Fix single line separator not showing in main grid when set to markup

### DIFF
--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -294,19 +294,6 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             return new InlineCollection();
         }
 
-        if (Se.Settings.Appearance.SubtitleGridTextSingleLine)
-        {
-            var separator = Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator;
-            if (string.IsNullOrEmpty(separator))
-            {
-                separator = " ";
-            }
-
-            str = str
-                .Replace("\r\n", separator)
-                .Replace("\n", separator);
-        }
-
         // Truncate long strings for performance
         if (str.Length > 200)
         {
@@ -332,7 +319,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         {
             if (!firstLine)
             {
-                inlines.Add(new LineBreak());
+                AppendLineSeparator(inlines);
             }
 
             if (line.Length > 0)
@@ -1381,9 +1368,28 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             return false;
         }
 
-        inlines.Add(new LineBreak());
+        AppendLineSeparator(inlines);
         i += c == '\r' && c2 == '\n' ? 2 : 1;
         return true;
+    }
+
+    private static void AppendLineSeparator(InlineCollection inlines)
+    {
+        if (Se.Settings.Appearance.SubtitleGridTextSingleLine)
+        {
+            var separator = Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator;
+            if (string.IsNullOrEmpty(separator))
+            {
+                separator = " ";
+            }
+
+            // Add the separator as literal text so markup-like separators (e.g. "<br />")
+            // are shown verbatim instead of being parsed away by the formatter.
+            inlines.Add(new Run(separator));
+            return;
+        }
+
+        inlines.Add(new LineBreak());
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)


### PR DESCRIPTION
## Summary
- When **Settings → single line separator** is set to a markup value such as `<br />`, the separator did not appear between collapsed lines in the main subtitle grid.
- Cause: the grid converter (`TextWithSubtitleSyntaxHighlightingConverter`) replaced newlines with the separator string *before* running the syntax formatter. In the default `ShowFormatting` mode, `<br />` was then parsed as an HTML tag and silently dropped.
- Fix: emit the separator as a literal `Run` at the line-break boundary (`AppendLineSeparator`), so it renders verbatim in all formatting modes (ShowFormatting / ShowTags / none). As a side benefit, the separator no longer inherits surrounding italic/bold/color formatting.

## Test plan
- [x] Open Settings and set the single line separator to `<br />`, enable single-line grid display.
- [x] Load a subtitle with multi-line text and confirm `<br />` now shows between lines in the main grid.
- [x] Verify the default separator ` ⏎ ` still displays correctly.
- [x] Confirm separators display in all three grid formatting modes (Show formatting, Show tags, None).

## Image

<img width="731" height="462" alt="image" src="https://github.com/user-attachments/assets/cb52570a-684e-4f9b-bd4a-7ff42afead7e" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)