### PR TITLE
Add CrispASR ARK-ASR speech-to-text backend

### DIFF
--- a/src/libse/AudioToText/WhisperChoice.cs
+++ b/src/libse/AudioToText/WhisperChoice.cs
@@ -30,6 +30,7 @@
         public const string CrispAsrMadlad = "Crisp ASR MADLAD";
         public const string CrispAsrMega = "Crisp ASR Mega";
         public const string CrispAsrSenseVoice = "Crisp ASR SenseVoice";
+        public const string CrispAsrArk = "Crisp ASR ARK";
         public const string OpenAiCompatible = "OpenAI Compatible";
     }
 }

--- a/src/ui/Assets/SpeechToText/CrispASRARK.txt
+++ b/src/ui/Assets/SpeechToText/CrispASRARK.txt
@@ -1,0 +1,7 @@
+
+🏹 ARK-ASR-3B  (⚠️ experimental / work-in-progress)
+
+Type: Whisper-large-v3 encoder (partial RoPE) + Qwen2.5-3B LM decoder
+Focus: 🌍 Multilingual transcription (19 languages)
+Note: large model (3.5 - 7.5 GB); word timestamps via a forced aligner (-am)
+

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrArk.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrArk.cs
@@ -1,0 +1,166 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+public class CrispAsrArk : CrispAsrEngineBase
+{
+    public static string StaticName => "Crisp ASR ARK";
+    public override string Name => StaticName;
+    public override string Choice => WhisperChoice.CrispAsrArk;
+    public override string Url => "https://github.com/CrispStrobe/CrispASR";
+    public override string BackendName => "ark-asr";
+    public override string DefaultLanguage => "en";
+    public override bool IncludeLanguage => true;
+
+    // ARK-ASR-3B = Whisper-large-v3 encoder (partial RoPE) + Qwen2.5-3B LM decoder.
+    // 19 languages per the CrispASR model card.
+    public override List<WhisperLanguage> Languages =>
+        new()
+        {
+            new WhisperLanguage("zh", "chinese"),
+            new WhisperLanguage("en", "english"),
+            new WhisperLanguage("de", "german"),
+            new WhisperLanguage("ja", "japanese"),
+            new WhisperLanguage("fr", "french"),
+            new WhisperLanguage("ko", "korean"),
+            new WhisperLanguage("es", "spanish"),
+            new WhisperLanguage("pl", "polish"),
+            new WhisperLanguage("it", "italian"),
+            new WhisperLanguage("ro", "romanian"),
+            new WhisperLanguage("hu", "hungarian"),
+            new WhisperLanguage("cs", "czech"),
+            new WhisperLanguage("nl", "dutch"),
+            new WhisperLanguage("fi", "finnish"),
+            new WhisperLanguage("hr", "croatian"),
+            new WhisperLanguage("sk", "slovak"),
+            new WhisperLanguage("sl", "slovenian"),
+            new WhisperLanguage("et", "estonian"),
+            new WhisperLanguage("lt", "lithuanian"),
+        };
+
+    public override List<WhisperModel> Models =>
+       new()
+       {
+            new WhisperModel
+            {
+                Name = "ark-asr-3b-q4_k.gguf",
+                Size = "3.52 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/ark-asr-3b-GGUF/resolve/main/ark-asr-3b-q4_k.gguf"
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "ark-asr-3b-q8_0.gguf",
+                Size = "4.29 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/ark-asr-3b-GGUF/resolve/main/ark-asr-3b-q8_0.gguf"
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "ark-asr-3b-f16.gguf",
+                Size = "7.51 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/ark-asr-3b-GGUF/resolve/main/ark-asr-3b-f16.gguf"
+                ],
+            },
+       };
+
+    public override string Extension => string.Empty;
+    public override string UnpackSkipFolder => string.Empty;
+
+    public override bool IsEngineInstalled()
+    {
+        var executableFile = GetExecutable();
+        return File.Exists(executableFile);
+    }
+
+    public override string ToString()
+    {
+        return CrispAsrEngine.GetBackendDisplayName(this);
+    }
+
+    public override string GetAndCreateWhisperFolder()
+    {
+        var folder = Se.CrispAsrFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = GetAndCreateWhisperFolder();
+        var modelsFolder = Path.Combine(folder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public override string GetExecutable()
+    {
+        string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+        return fullPath;
+    }
+
+    public override bool IsModelInstalled(WhisperModel model)
+    {
+        var modelFile = GetModelForCmdLine(model.Name);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string GetModelForCmdLine(string modelName)
+    {
+        var modelFileName = Path.Combine(GetAndCreateWhisperModelFolder(null), modelName);
+        return modelFileName;
+    }
+
+
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        var folder = GetAndCreateWhisperModelFolder(whisperModel);
+        var fileNameOnly = Path.GetFileName(url);
+        var fileName = Path.Combine(folder, fileNameOnly);
+        return fileName;
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "crispasr.exe";
+        }
+
+        return "crispasr";
+    }
+
+    public override bool CanBeDownloaded()
+    {
+        return true;
+    }
+
+    public override string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrArk;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrArk = value;
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -33,6 +33,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
             new CrispAsrOmni(),
             new CrispAsrKyutai(),
             new CrispAsrSenseVoice(),
+            new CrispAsrArk(),
         };
 
         SelectedBackend = _backends[0];

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -59,6 +59,7 @@ public class SeAudioToText
     public string CommandLineParameterCrispAsrKyutai { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrMega { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrSenseVoice { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrArk { get; set; } = "--max-len 50 --split-on-punct";
     public string CrispAsrForcedAligner { get; set; } = "built-in";
 
     public string WhisperExtraSettingsHistory { get; set; } = string.Empty;


### PR DESCRIPTION
## What
Adds **ARK-ASR** as a new CrispASR speech-to-text backend (Video → Audio to text → Crisp ASR).

ARK-ASR-3B = Whisper-large-v3 encoder (partial RoPE) + Qwen2.5-3B LM decoder — a new backend in CrispASR v0.8.6.

## Details (parallel to the existing Crisp ASR backends, e.g. Granite)
- New `CrispAsrArk` backend: `--backend ark-asr`, 19 languages (zh, en, de, ja, fr, ko, es, pl, it, ro, hu, cs, nl, fi, hr, sk, sl, et, lt), three GGUF models from [`cstr/ark-asr-3b-GGUF`](https://huggingface.co/cstr/ark-asr-3b-GGUF) (q4_k 3.52 GB / q8_0 4.29 GB / f16 7.51 GB).
- Registered in `CrispAsrEngine` backend list; `WhisperChoice.CrispAsrArk` + `CommandLineParameterCrispAsrArk` setting; `CrispASRARK.txt` help asset.

## Notes
- Requires the **CrispASR v0.8.6** engine binary (the backend doesn't exist in older builds; an older binary errors with `unknown backend 'ark-asr'`). The download URL is already on v0.8.6 (#12003) for fresh installs.
- CrispStrobe marks ARK-ASR **⚠️ experimental/WIP**; noted in the help text. Word timestamps come via a forced aligner (the UI aligner picker), as with the other LLM-decoder backends.

Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)