### PR TITLE
Show the grid single-line separator in a distinct color

### DIFF
--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -1384,8 +1384,10 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             // Add the separator as literal text so markup-like separators (e.g. "<br />")
-            // are shown verbatim instead of being parsed away by the formatter.
-            inlines.Add(new Run(separator));
+            // are shown verbatim instead of being parsed away by the formatter. Render it in the
+            // soft blue accent (AttributeBrush) - a mid-tone that reads on both light and dark
+            // themes - so the separator stands out clearly from the actual subtitle text.
+            inlines.Add(new Run(separator) { Foreground = AttributeBrush });
             return;
         }
 


### PR DESCRIPTION
## What
Follow-up to #11999. In single-line grid display the collapsed-line separator (e.g. ` ⏎ ` or `<br />`) rendered in the normal text color, blending in with the subtitle text.

## Change
Render the separator `Run` in the converter's existing soft-blue accent (`AttributeBrush`, `86,156,214`) — a mid-tone that's legible on **both** light and dark themes — so it reads clearly as a delimiter, distinct from the actual text.

One line in `AppendLineSeparator`:
```csharp
inlines.Add(new Run(separator) { Foreground = AttributeBrush });
```

(Reused an existing theme-neutral palette color rather than a `DynamicResource` theme brush, which wouldn't resolve reliably on a code-built inline `Run`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)