### PR TITLE
Fix umlaut diacritics clipped in OCR window on macOS (#11997)

### DIFF
--- a/src/ui/Features/Ocr/OcrSubtitleItem.cs
+++ b/src/ui/Features/Ocr/OcrSubtitleItem.cs
@@ -117,7 +117,9 @@ public partial class OcrSubtitleItem : ObservableObject
     {
         if (FixResult != null)
         {
-            return FixResult.GetFormattedText();
+            var formatted = FixResult.GetFormattedText();
+            UiUtil.FixMacDiacriticClipping(formatted);
+            return formatted;
         }
 
         var tb = new TextBlock { Text = Text };
@@ -125,6 +127,8 @@ public partial class OcrSubtitleItem : ObservableObject
         {
             tb.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         }
+
+        UiUtil.FixMacDiacriticClipping(tb);
         return tb;
     }
 

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -643,6 +643,7 @@ public class OcrWindow : Window
         textBoxText.Bind(FontFamilyProperty, new Binding(nameof(vm.TextBoxFontFamily)) { Mode = BindingMode.TwoWay });
         textBoxText.Bind(FontSizeProperty, new Binding(nameof(vm.TextBoxFontSize)) { Mode = BindingMode.TwoWay });
         textBoxText.Bind(TextBox.FontWeightProperty, new Binding(nameof(vm.TextBoxFontWeight)) { Mode = BindingMode.TwoWay });
+        UiUtil.FixMacDiacriticClipping(textBoxText);
 
         // Create a Flyout for the TextBox
         var flyout = new MenuFlyout();

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -90,6 +90,31 @@ public static class UiUtil
         };
     }
 
+    // On macOS the default UI font's ascent sits right at the cap height, so Avalonia's line box
+    // clips the dots on tall diacritics (Ä/Ö/Ü) at the top - in text boxes and grid cells alike
+    // (issue #11997). Giving the line a bit of extra leading (LineHeight) lifts the line box so the
+    // diacritics fit; padding does not help a TextBox, but LineHeight fixes both TextBox and TextBlock.
+    // Bound to the live FontSize (rather than a fixed value) so it scales with the chosen font size,
+    // and applied only on macOS so Windows/Linux line spacing is unchanged.
+    private static readonly IValueConverter DiacriticLineHeightConverter =
+        new FuncValueConverter<double, double>(fontSize =>
+            double.IsNaN(fontSize) || fontSize <= 0 ? double.NaN : fontSize * 1.4);
+
+    public static void FixMacDiacriticClipping(Control? control)
+    {
+        if (control == null || !OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        control.Bind(TextBlock.LineHeightProperty, new Binding
+        {
+            Source = control,
+            Path = nameof(TextBlock.FontSize),
+            Converter = DiacriticLineHeightConverter,
+        });
+    }
+
     public static Button MakeButton(string text)
     {
         return MakeButton(text, null);


### PR DESCRIPTION
## Problem
On macOS the dots of tall diacritics (Ä/Ö/Ü) are clipped at the *top* in the OCR window — both the subtitle list (grid) and the "Text" edit box. The text data is fine (copy works); it's a pure render clip.

## Root cause
The macOS default UI font (San Francisco) has an ascent metric that sits right at the cap height, so Avalonia's line box clips the diacritic dots. (A font like Arial doesn't clip — so it's partly font-metric driven, but the robust fix is font-independent.)

Verified by rendering real CoreText to a bitmap on macOS:
- `TextBlock` default / `new FontFamily("Default")` → **clipped**
- `TextBox` default → **clipped**; **padding does NOT fix a TextBox** (only a TextBlock)
- **`LineHeight` (extra leading) fixes both** `TextBox` and `TextBlock`

## Fix
New `UiUtil.FixMacDiacriticClipping(control)` — **macOS-only**; binds `LineHeight = FontSize × 1.4` to the live font size (so it scales with the chosen subtitle font, and leaves Windows/Linux line spacing untouched). Applied to:
- the OCR grid's text `TextBlock` (incl. the OCR-fixed-line path), and
- the OCR "Text" edit box.

Confirmed visually fixed on macOS with the reporter's German subtitle.

## Follow-up
The reporter sees this app-wide; the same helper can be applied to the main grid + edit box in a follow-up.

Fixes #11997 (OCR window; main window to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)