### PR TITLE
Fix VLC not loading from a non-ASCII (e.g. Chinese) path on Windows (#12001)

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/NativeMethods.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/NativeMethods.cs
@@ -115,7 +115,9 @@ internal static class NativeMethods
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     internal static extern IntPtr LoadLibraryW(string dllToLoad);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
+    // Unicode (LoadLibraryExW) so paths with non-ASCII characters (e.g. Chinese user/install
+    // folders) are passed through correctly - the ANSI variant mangles them and the load fails (#12001).
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     internal static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, uint dwFlags);
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Ansi)]
@@ -125,7 +127,9 @@ internal static class NativeMethods
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool FreeLibrary(IntPtr hModule);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
+    // Unicode (SetDllDirectoryW) so a non-ASCII dependency directory (e.g. a Chinese path) is set
+    // correctly; the ANSI variant mangles it so libvlccore.dll / plugins are not found (#12001).
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool SetDllDirectory(string lpPathName);
 
@@ -217,8 +221,9 @@ internal static class NativeMethods
 
                 if (handle == IntPtr.Zero)
                 {
-                    // Fall back to regular LoadLibrary
-                    handle = LoadLibrary(fileName);
+                    // Fall back to a plain load - use the Unicode variant so non-ASCII paths
+                    // (e.g. Chinese folders) are not mangled by ANSI marshalling (#12001).
+                    handle = LoadLibraryW(fileName);
                 }
 
                 if (handle == IntPtr.Zero)


### PR DESCRIPTION
## Problem
After downloading VLC, the files are present in the VLC folder but SE doesn't recognize them and keeps prompting to download (#12001). Reported on a Windows path that contains **Chinese characters**.

## Root cause
SE finds `libvlc.dll` with `File.Exists` (managed → Unicode-safe), but the actual native load in `CrossLoadLibrary` used **ANSI-marshalled** Win32 APIs:
- `LoadLibraryEx` — no `CharSet` → defaults to `CharSet.Ansi`
- `LoadLibrary` (fallback) — `CharSet.Ansi`
- `SetDllDirectory` — `CharSet.Ansi`

With non-ASCII characters in the path, the ANSI marshaller mangles it, so the load (and the dependency-directory hint for `libvlccore.dll`/plugins) fails → SE concludes VLC isn't installed → re-prompts. (`File.Exists` succeeding while the load fails is exactly the "files exist but not recognized" symptom.)

`CrossLoadLibrary` already set the working directory + `SetDllDirectory` + `LOAD_WITH_ALTERED_SEARCH_PATH`, but still handed the full non-ASCII path to the ANSI `LoadLibraryEx`.

## Fix
Use the Unicode (W) variants for the path APIs:
- `LoadLibraryEx` → `CharSet.Unicode`
- `SetDllDirectory` → `CharSet.Unicode`
- fallback `LoadLibrary` → `LoadLibraryW`

`libvlc_new` only receives the ASCII arg `--no-sub-autodetect-file`, and VLC 3.x resolves its own plugin directory via wide APIs, so once libvlc loads from the Unicode path, plugins resolve too.

## Verification
⚠️ Windows-only with a non-ASCII path — couldn't reproduce on macOS. Compiles clean; the change is strictly more correct (ANSI→Unicode for path APIs). Best confirmed on Windows with a Chinese folder path.

Fixes #12001

🤖 Generated with [Claude Code](https://claude.com/claude-code)