### PR TITLE
Add 'New' button to the Fix common errors rule profiles window (#12013)

### DIFF
--- a/src/ui/Features/Options/Settings/ProfilesViewModel.cs
+++ b/src/ui/Features/Options/Settings/ProfilesViewModel.cs
@@ -178,6 +178,36 @@ public partial class ProfilesViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void New()
+    {
+        // Start from the built-in "Default" profile (or any existing one) so the new profile has
+        // sensible rule values to tweak; fall back to a blank profile if the list is empty.
+        var template = Profiles.FirstOrDefault(p => p.Name == "Default") ?? Profiles.FirstOrDefault();
+        var newProfile = template != null ? new ProfileDisplay(template) : new ProfileDisplay();
+        newProfile.Name = GetUniqueProfileName(Se.Language.General.NewProfile);
+        Profiles.Add(newProfile);
+        SelectedProfile = newProfile;
+    }
+
+    private string GetUniqueProfileName(string baseName)
+    {
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            baseName = "New profile";
+        }
+
+        var name = baseName;
+        var i = 1;
+        while (Profiles.Any(p => p.Name == name))
+        {
+            i++;
+            name = $"{baseName} {i}";
+        }
+
+        return name;
+    }
+
+    [RelayCommand]
     private void Copy()
     {
         if (SelectedProfile == null)

--- a/src/ui/Features/Options/Settings/ProfilesWindow.cs
+++ b/src/ui/Features/Options/Settings/ProfilesWindow.cs
@@ -121,12 +121,14 @@ public class ProfilesWindow : Window
         dataGrid.Bind(DataGrid.ItemsSourceProperty, new Binding(nameof(vm.Profiles)) { Source = vm });
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedProfile)) { Source = vm });
 
+        var buttonNew = UiUtil.MakeButton(vm.NewCommand, IconNames.New, Se.Language.General.NewProfile);
         var buttonExport = UiUtil.MakeButton(vm.ExportCommand, IconNames.Export, Se.Language.General.ExportDotDotDot);
         var buttonImport = UiUtil.MakeButton(vm.ImportCommand, IconNames.Import, Se.Language.General.ImportDotDotDot);
         var buttonCopy = UiUtil.MakeButton(vm.CopyCommand, IconNames.Copy, Se.Language.General.Copy);
         var buttonDelete = UiUtil.MakeButton(vm.DeleteCommand, IconNames.Trash, Se.Language.General.Delete);
         var buttonClear = UiUtil.MakeButton(vm.ClearCommand, IconNames.Close, Se.Language.General.Clear);
         var panelButtons = UiUtil.MakeButtonBar(
+            buttonNew,
             buttonExport,
             buttonImport,
             buttonCopy,


### PR DESCRIPTION
## What
Adds the missing **New** button to the rule profiles window (Settings → Fix common errors profiles). SE4 had it; SE5 only offered Export/Import/Copy/Delete/Clear, so there was no way to create a profile from scratch.

## Details
- New `NewCommand` in `ProfilesViewModel`: creates a profile pre-filled from the built-in **Default** profile's values (falls back to a blank profile if the list is empty), with a unique name ("New profile", "New profile 2", …), and selects it for editing.
- Added the `New` icon button (`IconNames.New`) as the first button in the bar, using the hinted `MakeButton(command, icon, hint)` overload — so it shows a "New profile" tooltip when *Show hints* is enabled, consistent with the other buttons.

The other icon buttons already had hints via the same overload; nothing missing there.

Fixes #12013

🤖 Generated with [Claude Code](https://claude.com/claude-code)