### PR TITLE
Fix icon-button hints not showing in dialogs on macOS

### DIFF
--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -404,14 +404,51 @@ public static class UiUtil
             Command = command,
         };
 
-        if (Se.Settings.Appearance.ShowHints)
-        {
-            ToolTip.SetTip(button, hint);
-        }
-
         Attached.SetIcon(button, iconName);
 
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            AttachHoverTooltip(button, hint);
+        }
+
         return button;
+    }
+
+    // On macOS, Avalonia's built-in ToolTip hover service does not open on hover inside modal
+    // dialogs - the popup itself works (a forced ToolTip.IsOpen renders it, and the pointer-over
+    // state is detected), but the hover trigger never fires, so icon-button hints were invisible in
+    // every dialog. Windows/Linux work fine and keep the native behaviour; on macOS we drive the
+    // tooltip ourselves: open it after a short hover and close it when the pointer leaves. (#12013)
+    public static void AttachHoverTooltip(Control control, string hint)
+    {
+        ToolTip.SetTip(control, hint);
+
+        if (!OperatingSystem.IsMacOS())
+        {
+            return; // native ToolTip hover service works on Windows/Linux
+        }
+
+        System.Threading.CancellationTokenSource? hoverCts = null;
+
+        control.PointerEntered += (_, _) =>
+        {
+            hoverCts?.Cancel();
+            hoverCts = new System.Threading.CancellationTokenSource();
+            var token = hoverCts.Token;
+            DispatcherTimer.RunOnce(() =>
+            {
+                if (!token.IsCancellationRequested && control.IsPointerOver)
+                {
+                    ToolTip.SetIsOpen(control, true);
+                }
+            }, TimeSpan.FromMilliseconds(400));
+        };
+
+        control.PointerExited += (_, _) =>
+        {
+            hoverCts?.Cancel();
+            ToolTip.SetIsOpen(control, false);
+        };
     }
 
 


### PR DESCRIPTION
## Problem
On **macOS**, hovering the icon buttons in dialog windows (e.g. the Fix-common-errors **rule profiles** window — Export/Import/Copy/Delete/Clear) showed **no hint**, even though "Show hints" is on. The same buttons work on **Windows**.

## Root cause (diagnosed by instrumenting the real window)
Avalonia's built-in **ToolTip hover service does not fire inside modal dialogs on macOS**:
- The tooltip popup itself works — a forced `ToolTip.IsOpen = true` renders the hint correctly.
- Pointer-over is detected — `PointerEntered`/`PointerMoved` fire and the button's hover visual state changes.
- The config is normal — `ServiceEnabled=True`, `ShowDelay=400`, button enabled & hit-testable, window active.
- Yet on a valid 2-second hover, `ToolTip.IsOpen` never flips to true — and a brand-new plain test button in the same window behaves identically, so it's **window-wide**, not button-specific.

It's macOS + modal-dialog specific (Windows/Linux are fine).

## Fix
In the hinted `MakeButton(command, icon, hint)` overload, on **macOS only**, drive the tooltip manually: open it after a short hover (`PointerEntered` + 400 ms) and close it on `PointerExited`. Windows/Linux keep the native service unchanged.

Verified working on macOS; no behaviour change on Windows/Linux.

(Surfaced while adding the rule-profiles "New" button, #12013.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)