### PR TITLE
Don't include Google Lens retry status in OCR text (#12016)

### DIFF
--- a/src/ui/Features/Ocr/Engines/GoogleLensOcr.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleLensOcr.cs
@@ -248,6 +248,14 @@ public class GoogleLensOcr
             return;
         }
 
+        // The chrome-lens tool prints transient status lines to stdout while retrying a failed
+        // request (e.g. "Server error 502: Retrying 1/3..."). These are diagnostics, not OCR text,
+        // so keep them out of the subtitle. (#12016)
+        if (Regex.IsMatch(line, @"Retrying \d+\s*/\s*\d+", RegexOptions.IgnoreCase))
+        {
+            return;
+        }
+
         results[fileName] += line + Environment.NewLine;
     }
 


### PR DESCRIPTION
## Problem
With the **Google Lens** OCR engine, when the server transiently fails, status lines like `Server error 502: Retrying 1/3...` end up **inside the OCR'd subtitle text** (see #12016).

## Cause
The Google Lens engine runs the external **chrome-lens** tool (timminator/Chrome-Lens-OCR) and collects its stdout lines into the result after the `OCR Results:` marker (`GoogleLensOcr.AddLineToResult`). It already filters a couple of status lines (`No OCR text found.`, `Request error (possibly proxy-related)`), but **not** the retry status the tool prints while re-attempting a failed request — so those lines were appended to the subtitle.

## Fix
Skip lines matching the tool's retry status (`Retrying <n>/<m>`, e.g. `Server error 502: Retrying 1/3...`) in `AddLineToResult`, so transient diagnostics don't become subtitle text. If the retry ultimately fails, that line just produces empty text for the frame instead of garbage.

The matched pattern (`Retrying \d+/\d+`) is distinctive enough that it won't hit real subtitle text. (This engine is the source of the reported message; the other OCR engines surface failures as exceptions rather than stdout text.)

Fixes #12016

🤖 Generated with [Claude Code](https://claude.com/claude-code)