### PR TITLE
Add CSV import/export to Multiple replace (#12015)

### DIFF
--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -84,8 +84,8 @@ Right-click a category node to open its context menu:
 - **New rule** — add a rule to this category
 - **Move up / Move down** — reorder categories
 - **Delete** — remove the category and all its rules
-- **Import** — load rules from a `.template` file (JSON or legacy SE4 XML)
-- **Export** — save selected categories to a `.template` file
+- **Import** — load rules from a `.template` file (JSON or legacy SE4 XML) or a `.csv` file
+- **Export** — save selected categories to a `.template` (JSON) or `.csv` file
 
 ### Managing rules
 
@@ -118,6 +118,33 @@ The expand/collapse buttons (`+` / `−`) above the tree expand or collapse all 
 ### Import / Export
 
 Rule sets are stored as JSON `.template` files and can be shared across installations. The export dialog lets you choose which categories to include. SE4-format XML files can also be imported.
+
+Rules can also be exported to and imported from **CSV** (choose the `.csv` type in the export/import dialog), which is convenient for editing rules in a spreadsheet or sharing them as a simple table.
+
+The CSV has one row per rule with this header:
+
+```csv
+Category,Find,ReplaceWith,Description,Active,Type
+```
+
+| Column | Description |
+|---|---|
+| `Category` | Category the rule belongs to (rules with the same name are grouped; empty becomes `Default`) |
+| `Find` | Text or pattern to search for |
+| `ReplaceWith` | Replacement text (may be empty) |
+| `Description` | Optional note |
+| `Active` | `true` or `false` — whether the rule is enabled |
+| `Type` | `CaseInsensitive`, `CaseSensitive`, or `RegularExpression` |
+
+Values are quoted per RFC 4180, so `Find`/`ReplaceWith` may contain commas, double quotes (written as `""`) and line breaks. The header row is optional on import; unknown `Type` values fall back to `CaseInsensitive`. Files are written as UTF-8 (with BOM) so non-ASCII rules open correctly in spreadsheet apps.
+
+Example:
+
+```csv
+Category,Find,ReplaceWith,Description,Active,Type
+General,"hello, world","say ""hi""",greeting,true,CaseInsensitive
+Regex,\d+,#,strip numbers,true,RegularExpression
+```
 
 ## Modify Selection
 

--- a/src/ui/Features/Edit/MultipleReplace/CsvExporter.cs
+++ b/src/ui/Features/Edit/MultipleReplace/CsvExporter.cs
@@ -1,11 +1,54 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using Nikse.SubtitleEdit.Features.Options.Settings;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 
-public static  class CsvExporter
+/// <summary>
+/// Exports multiple-replace rules to a portable CSV file.
+/// Columns: Category,Find,ReplaceWith,Description,Active,Type
+/// Values are RFC 4180 quoted so patterns containing commas, quotes or newlines round-trip.
+/// </summary>
+public static class CsvExporter
 {
+    public const string Header = "Category,Find,ReplaceWith,Description,Active,Type";
+
+    public static string Export(CategoryImportExportItem item)
+    {
+        var sb = new StringBuilder();
+        sb.Append(Header).Append("\r\n");
+
+        if (item.Categories != null)
+        {
+            foreach (var category in item.Categories)
+            {
+                if (category.Rules == null)
+                {
+                    continue;
+                }
+
+                foreach (var rule in category.Rules)
+                {
+                    sb.Append(Escape(category.Name)).Append(',');
+                    sb.Append(Escape(rule.Find)).Append(',');
+                    sb.Append(Escape(rule.ReplaceWith)).Append(',');
+                    sb.Append(Escape(rule.Description)).Append(',');
+                    sb.Append(rule.IsActive ? "true" : "false").Append(',');
+                    sb.Append(Escape(rule.Type)).Append("\r\n");
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string Escape(string? value)
+    {
+        value ??= string.Empty;
+        if (value.IndexOfAny(['"', ',', '\n', '\r']) >= 0)
+        {
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
+        }
+
+        return value;
+    }
 }

--- a/src/ui/Features/Edit/MultipleReplace/CsvImporter.cs
+++ b/src/ui/Features/Edit/MultipleReplace/CsvImporter.cs
@@ -1,11 +1,196 @@
-﻿using System;
+using Nikse.SubtitleEdit.Features.Options.Settings;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 
-public static  class CsvImporter
+/// <summary>
+/// Imports multiple-replace rules from a CSV file written by <see cref="CsvExporter"/>.
+/// Expects the columns Category,Find,ReplaceWith,Description,Active,Type (a header row is
+/// optional - columns are matched by name when present, otherwise by position). RFC 4180 quoting
+/// is honored so patterns with commas, quotes or newlines round-trip.
+/// </summary>
+public static class CsvImporter
 {
+    public static CategoryImportExportItem Import(string csv)
+    {
+        var result = new CategoryImportExportItem
+        {
+            Categories = new List<CategoryImportExportItem.RuleImportExportCategory>(),
+        };
+
+        var rows = ParseCsv(csv);
+        if (rows.Count == 0)
+        {
+            return result;
+        }
+
+        var header = rows[0];
+        var hasHeader = header.Any(h => string.Equals(h.Trim(), "Find", StringComparison.OrdinalIgnoreCase));
+
+        int Col(string name, int fallback)
+        {
+            for (var i = 0; i < header.Count; i++)
+            {
+                if (string.Equals(header[i].Trim(), name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return i;
+                }
+            }
+
+            return fallback;
+        }
+
+        var catIdx = hasHeader ? Col("Category", 0) : 0;
+        var findIdx = hasHeader ? Col("Find", 1) : 1;
+        var replaceIdx = hasHeader ? Col("ReplaceWith", 2) : 2;
+        var descIdx = hasHeader ? Col("Description", 3) : 3;
+        var activeIdx = hasHeader ? Col("Active", 4) : 4;
+        var typeIdx = hasHeader ? Col("Type", 5) : 5;
+
+        var byCategory = new Dictionary<string, CategoryImportExportItem.RuleImportExportCategory>(StringComparer.Ordinal);
+        var order = new List<string>();
+
+        for (var r = hasHeader ? 1 : 0; r < rows.Count; r++)
+        {
+            var row = rows[r];
+            if (row.Count == 0 || row.All(string.IsNullOrEmpty))
+            {
+                continue;
+            }
+
+            string Get(int i) => i >= 0 && i < row.Count ? row[i] : string.Empty;
+
+            var find = Get(findIdx);
+            if (string.IsNullOrEmpty(find))
+            {
+                continue; // a rule must have something to find
+            }
+
+            var categoryName = Get(catIdx).Trim();
+            if (string.IsNullOrEmpty(categoryName))
+            {
+                categoryName = "Default";
+            }
+
+            if (!byCategory.TryGetValue(categoryName, out var category))
+            {
+                category = new CategoryImportExportItem.RuleImportExportCategory
+                {
+                    Name = categoryName,
+                    Rules = new List<CategoryImportExportItem.RuleImportExportItem>(),
+                };
+                byCategory[categoryName] = category;
+                order.Add(categoryName);
+            }
+
+            category.Rules!.Add(new CategoryImportExportItem.RuleImportExportItem
+            {
+                Find = find,
+                ReplaceWith = Get(replaceIdx),
+                Description = Get(descIdx),
+                IsActive = ParseBool(Get(activeIdx)),
+                Type = ParseType(Get(typeIdx)),
+            });
+        }
+
+        result.Categories = order.Select(n => byCategory[n]).ToList();
+        return result;
+    }
+
+    private static bool ParseBool(string value)
+    {
+        value = value.Trim();
+        return value.Equals("true", StringComparison.OrdinalIgnoreCase)
+               || value.Equals("1", StringComparison.Ordinal)
+               || value.Equals("yes", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ParseType(string value)
+    {
+        return Enum.TryParse<MultipleReplaceType>(value.Trim(), true, out var type)
+            ? type.ToString()
+            : MultipleReplaceType.CaseInsensitive.ToString();
+    }
+
+    // RFC 4180 CSV parser: handles quoted fields with embedded commas, doubled quotes ("") and newlines.
+    private static List<List<string>> ParseCsv(string text)
+    {
+        // Strip a leading UTF-8 BOM if present (Excel writes one).
+        if (text.Length > 0 && text[0] == '﻿')
+        {
+            text = text.Substring(1);
+        }
+
+        var rows = new List<List<string>>();
+        var row = new List<string>();
+        var field = new StringBuilder();
+        var inQuotes = false;
+
+        void EndField() => row.Add(field.ToString());
+        void EndRow()
+        {
+            EndField();
+            rows.Add(row);
+            row = new List<string>();
+        }
+
+        var i = 0;
+        while (i < text.Length)
+        {
+            var c = text[i];
+
+            if (inQuotes)
+            {
+                if (c == '"')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '"')
+                    {
+                        field.Append('"');
+                        i += 2;
+                        continue;
+                    }
+
+                    inQuotes = false;
+                    i++;
+                    continue;
+                }
+
+                field.Append(c);
+                i++;
+                continue;
+            }
+
+            switch (c)
+            {
+                case '"':
+                    inQuotes = true;
+                    break;
+                case ',':
+                    EndField();
+                    field.Clear();
+                    break;
+                case '\r':
+                    break;
+                case '\n':
+                    EndRow();
+                    field.Clear();
+                    break;
+                default:
+                    field.Append(c);
+                    break;
+            }
+
+            i++;
+        }
+
+        if (field.Length > 0 || row.Count > 0)
+        {
+            EndRow();
+        }
+
+        return rows;
+    }
 }

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -499,27 +499,31 @@ public partial class MultipleReplaceViewModel : ObservableObject
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.Options.Settings.OpenRuleFile, "Replace rules", ".template");
+        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.Options.Settings.OpenRuleFile, "Replace rules", ".template", "CSV (comma separated)", ".csv");
         if (string.IsNullOrEmpty(fileName))
         {
             return;
         }
 
-        // import from json
+        // import from json, SE4 xml or csv
         List<RuleTreeNode>? imported = null;
         try
         {
-            var jsonOrXml = System.IO.File.ReadAllText(fileName);
+            var content = System.IO.File.ReadAllText(fileName);
 
-            CategoryImportExportItem? temp = null;
+            CategoryImportExportItem? temp;
 
-            if (jsonOrXml.Contains("<MultipleSearchAndReplaceList>"))
+            if (fileName.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
             {
-                temp = Se4XmlImporter.ImportFromXml(jsonOrXml);
+                temp = CsvImporter.Import(content);
+            }
+            else if (content.Contains("<MultipleSearchAndReplaceList>"))
+            {
+                temp = Se4XmlImporter.ImportFromXml(content);
             }
             else
             {
-                temp = JsonSerializer.Deserialize<CategoryImportExportItem>(jsonOrXml, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                temp = JsonSerializer.Deserialize<CategoryImportExportItem>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             }
 
             if (temp == null)
@@ -587,7 +591,11 @@ public partial class MultipleReplaceViewModel : ObservableObject
             return;
         }
 
-        var fileName = await _fileHelper.PickSaveFile(Window, ".template", "SE_Replace_Rules", Se.Language.Options.Settings.SaveRuleProfilesFile);
+        var fileName = await _fileHelper.PickSaveFile(
+            Window,
+            new[] { ("Replace rules", ".template"), ("CSV (comma separated)", ".csv") },
+            "SE_Replace_Rules",
+            Se.Language.Options.Settings.SaveRuleProfilesFile);
         if (string.IsNullOrEmpty(fileName))
         {
             return;
@@ -600,8 +608,16 @@ public partial class MultipleReplaceViewModel : ObservableObject
         }
 
         var export = new CategoryImportExportItem(toExport);
-        var json = JsonSerializer.Serialize(export, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-        System.IO.File.WriteAllText(fileName, json);
+        if (fileName.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
+        {
+            // UTF-8 with BOM so Excel opens non-ASCII rules correctly.
+            System.IO.File.WriteAllText(fileName, CsvExporter.Export(export), new System.Text.UTF8Encoding(true));
+        }
+        else
+        {
+            var json = JsonSerializer.Serialize(export, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            System.IO.File.WriteAllText(fileName, json);
+        }
 
         _ = await _windowService.ShowDialogAsync<PromptFileSavedWindow, PromptFileSavedViewModel>(Window,
             vm =>


### PR DESCRIPTION
## What
Adds **CSV** as an import/export format for Multiple replace rules, for portability (editing rules in a spreadsheet, sharing as a simple table). Requested in #12015.

Multiple replace already imported/exported rule categories as JSON `.template` files; this adds `.csv` alongside it.

## Details
- Implemented the (previously empty stub) **`CsvExporter`** and **`CsvImporter`** with **RFC 4180** quoting and a compliant parser, so `Find`/`ReplaceWith` values containing commas, double quotes (`""`) and line breaks round-trip correctly.
- Columns: `Category,Find,ReplaceWith,Description,Active,Type`. Header row is optional on import (columns matched by name, else by position); empty `Category` → `Default`; unknown `Type` → `CaseInsensitive`. Export writes UTF-8 with BOM so non-ASCII rules open correctly in Excel.
- Wired `.csv` into the existing import/export file pickers, routing by extension (`.csv` → CSV, `.template` → JSON / SE4 XML).
- Documented the format in `docs/features/edit.md`.

## Verification
Round-trip tested against the built assembly with tricky values (commas, embedded quotes, embedded newlines, regex `\d+,\s`, empty fields, multiple categories) — export → import reproduces every rule exactly.

```csv
Category,Find,ReplaceWith,Description,Active,Type
"Cat, A","hello, world","say ""hi""","line1
line2",true,RegularExpression
Default,foo,bar,simple,true,CaseInsensitive
```

Fixes #12015

🤖 Generated with [Claude Code](https://claude.com/claude-code)