### PR TITLE
Fix bare Alt not activating the main menu bar (Windows)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18628,7 +18628,14 @@ public partial class MainViewModel :
         }
 
         _focusBeforeMainMenu = Window?.FocusManager?.GetFocusedElement() as Control;
-        return TryFocusMainMenu();
+
+        // Defer focusing the menu bar: when this runs from a key handler (bare Alt key-up, F10),
+        // Avalonia's own access-key handler also processes the same key and resets focus afterwards,
+        // which undid a synchronous focus here - so bare Alt showed the access-key underlines but
+        // never actually activated the bar. Let the current key event finish first, mirroring the
+        // deferred focus restore in DeactivateMainMenu (#11745).
+        Dispatcher.UIThread.Post(() => TryFocusMainMenu());
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem
Bare **Alt** (press + release with no other key) is supposed to activate the menu bar for keyboard navigation (Windows standard, added in #11745), but in RC3 it doesn't:
- Press/hold Alt → access-key underlines appear; **release** → underlines vanish, **menu bar not activated**.
- Quick Alt → underlines flash, then nothing.
- After opening a menu with Alt+letter, a subsequent bare Alt **does** toggle it closed correctly.

## Cause
`ActivateMainMenu` focused the first menu item **synchronously inside the Alt key-up handler** (`TryFocusMainMenu` → `firstItem.Focus()`). Avalonia's own access-key handler processes the **same Alt key-up afterwards** — it hides the underlines and resets the access-key session, which **undoes** the focus we just set, so activation never sticks.

This is why *closing* works but *opening* doesn't: `DeactivateMainMenu` already **defers** its focus change (`Dispatcher.UIThread.Post`) with the comment *"moving focus from inside the key handler is racy"* — `ActivateMainMenu` was the one place that didn't.

## Fix
Defer the activation focus the same way, so the key event (and Avalonia's access-key handling) finishes before we focus the menu bar. No-op on macOS (native menu — `ActivateMainMenu` returns early).

## ⚠️ Verification
This path is Windows/Linux only (inert on macOS, where I'm developing), so I couldn't reproduce it locally. Builds clean and the change is low-risk (mirrors the existing `DeactivateMainMenu` pattern), but it should be **confirmed on Windows**: bare Alt should now activate the menu bar on release, and Alt again / Escape should deactivate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)