### PR TITLE
Spell check: show a completion summary dialog (#12022)

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -480,6 +480,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<SortByViewModel>();
         collection.AddTransient<SourceViewViewModel>();
         collection.AddTransient<SpellCheckViewModel>();
+        collection.AddTransient<SpellCheckCompletedViewModel>();
         collection.AddTransient<SplitBreakLongLinesViewModel>();
         collection.AddTransient<SplitSubtitleViewModel>();
         collection.AddTransient<StatisticsViewModel>();

--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -32,7 +32,7 @@ public static class InitToolbar
 
     private static string _imagePath = string.Empty;
 
-    private static Grid CreateToolbar(MainViewModel vm)
+    private static void EnsureImagePath()
     {
         _imagePath = Path.Combine(Se.ThemesFolder, UiTheme.ThemeName);
         if (!Directory.Exists(_imagePath))
@@ -48,6 +48,11 @@ public static class InitToolbar
                 _imagePath = path;
             }
         }
+    }
+
+    private static Grid CreateToolbar(MainViewModel vm)
+    {
+        EnsureImagePath();
 
         var stackPanelLeft = new StackPanel
         {
@@ -528,8 +533,15 @@ public static class InitToolbar
         return grid;
     }
 
-    private static Image MakeImage(string image)
+    // Public so other windows (e.g. the spell-check completed dialog) can reuse the exact same
+    // themed/recolored toolbar icons. EnsureImagePath keeps it usable before the toolbar is built.
+    public static Image MakeImage(string image)
     {
+        if (string.IsNullOrEmpty(_imagePath))
+        {
+            EnsureImagePath();
+        }
+
         return new Image
         {
             Source = MakeOneColor(Path.Combine(_imagePath, image + ".png")),

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5722,17 +5722,23 @@ public partial class MainViewModel :
         // changes/skips, so the "X changed, Y skipped" result is never silently lost.
         if (result.OkPressed || result.TotalChangedWords > 0 || result.TotalSkippedWords > 0)
         {
-            var msg = string.Format(
-                Se.Language.Main.SpellCheckResult,
-                result.TotalChangedWords,
-                result.TotalSkippedWords);
-
-            await MessageBox.Show(
-                Window,
-                Se.Language.SpellCheck.SpellCheck,
-                msg,
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Information);
+            if (Se.Settings.SpellCheck.ShowCompletedMessage)
+            {
+                await ShowDialogAsync<SpellCheckCompletedWindow, SpellCheckCompletedViewModel>(
+                    vm => vm.Initialize(
+                        result.TotalChangedWords,
+                        result.TotalSkippedWords,
+                        result.TotalCorrectWords,
+                        result.TotalNames,
+                        result.TotalAddedWords));
+            }
+            else
+            {
+                // Dialog suppressed via "do not show again" - still surface the result in the status bar.
+                ShowStatus(Se.Language.SpellCheck.SpellCheckCompleted + " - " +
+                    string.Format(Se.Language.SpellCheck.ChangedWordsX, result.TotalChangedWords) + ", " +
+                    string.Format(Se.Language.SpellCheck.SkippedWordsX, result.TotalSkippedWords));
+            }
         }
     }
 

--- a/src/ui/Features/SpellCheck/ISpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/ISpellCheckManager.cs
@@ -11,6 +11,9 @@ public interface ISpellCheckManager : ISpellChecker
     List<SpellCheckResult> CheckSpelling(ObservableCollection<SubtitleLineViewModel> subtitles, SpellCheckResult? startFrom = null, int? stopBeforeLineIndex = null);
     int NoOfChangedWords { get; set; }
     int NoOfSkippedWords { get; set; }
+    int NoOfCorrectWords { get; set; }
+    int NoOfNames { get; set; }
+    int NoOfAddedWords { get; set; }
     void AddIgnoreWord(string word);
     void ChangeWord(string fromWord, string toWord, SpellCheckWord spellCheckWord, SubtitleLineViewModel p);
     void ChangeAllWord(string fromWord, string toWord, SpellCheckWord spellCheckWord, SubtitleLineViewModel p);

--- a/src/ui/Features/SpellCheck/SpellCheckCompletedViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckCompletedViewModel.cs
@@ -1,0 +1,69 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.SpellCheck;
+
+public partial class SpellCheckCompletedViewModel : ObservableObject
+{
+    [ObservableProperty] private string _changedWordsText;
+    [ObservableProperty] private string _skippedWordsText;
+    [ObservableProperty] private string _correctWordsText;
+    [ObservableProperty] private string _namesText;
+    [ObservableProperty] private string _addedWordsText;
+    [ObservableProperty] private bool _isCorrectWordsVisible;
+    [ObservableProperty] private bool _isNamesVisible;
+    [ObservableProperty] private bool _isAddedWordsVisible;
+    [ObservableProperty] private bool _doNotShowAgain;
+
+    public Window? Window { get; set; }
+
+    public SpellCheckCompletedViewModel()
+    {
+        _changedWordsText = string.Empty;
+        _skippedWordsText = string.Empty;
+        _correctWordsText = string.Empty;
+        _namesText = string.Empty;
+        _addedWordsText = string.Empty;
+    }
+
+    public void Initialize(int changedWords, int skippedWords, int correctWords, int names, int addedWords)
+    {
+        ChangedWordsText = string.Format(Se.Language.SpellCheck.ChangedWordsX, changedWords);
+        SkippedWordsText = string.Format(Se.Language.SpellCheck.SkippedWordsX, skippedWords);
+
+        // The optional rows only add value when non-zero, so keep the dialog tidy by hiding them at 0.
+        CorrectWordsText = string.Format(Se.Language.SpellCheck.CorrectWordsX, correctWords);
+        IsCorrectWordsVisible = correctWords > 0;
+
+        NamesText = string.Format(Se.Language.SpellCheck.NamesX, names);
+        IsNamesVisible = names > 0;
+
+        AddedWordsText = string.Format(Se.Language.SpellCheck.AddedToDictionaryX, addedWords);
+        IsAddedWordsVisible = addedWords > 0;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        if (DoNotShowAgain)
+        {
+            Se.Settings.SpellCheck.ShowCompletedMessage = false;
+            Se.SaveSettings();
+        }
+
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape || e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            Ok();
+        }
+    }
+}

--- a/src/ui/Features/SpellCheck/SpellCheckCompletedWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckCompletedWindow.cs
@@ -1,0 +1,164 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Main.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Optris.Icons.Avalonia;
+
+namespace Nikse.SubtitleEdit.Features.SpellCheck;
+
+public class SpellCheckCompletedWindow : Window
+{
+    public SpellCheckCompletedWindow(SpellCheckCompletedViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.SpellCheck.SpellCheck;
+        CanResize = false;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        vm.Window = this;
+        DataContext = vm;
+
+        var header = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                MakeHeaderIcon(36),
+                new TextBlock
+                {
+                    Text = Se.Language.SpellCheck.SpellCheckCompleted,
+                    FontSize = 17,
+                    FontWeight = FontWeight.SemiBold,
+                    VerticalAlignment = VerticalAlignment.Center,
+                },
+            },
+        };
+
+        var rows = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 9,
+            Children =
+            {
+                MakeCountRow(IconNames.Pencil, nameof(vm.ChangedWordsText), null),
+                MakeCountRow(IconNames.SkipNext, nameof(vm.SkippedWordsText), null),
+                MakeCountRow(IconNames.CheckBold, nameof(vm.CorrectWordsText), nameof(vm.IsCorrectWordsVisible)),
+                MakeCountRow(IconNames.Account, nameof(vm.NamesText), nameof(vm.IsNamesVisible)),
+                MakeCountRow(IconNames.Plus, nameof(vm.AddedWordsText), nameof(vm.IsAddedWordsVisible)),
+            },
+        };
+
+        // A subtle card around the counts so it reads as a grouped result rather than loose text.
+        var card = new Border
+        {
+            CornerRadius = new CornerRadius(8),
+            Background = new SolidColorBrush(Color.FromArgb(18, 128, 128, 128)),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(48, 128, 128, 128)),
+            BorderThickness = new Thickness(1),
+            Padding = new Thickness(16, 14, 24, 14),
+            Child = rows,
+        };
+
+        var checkBoxDoNotShowAgain = new CheckBox
+        {
+            Content = new TextBlock { Text = Se.Language.SpellCheck.DoNotShowThisAgain, FontSize = 13 },
+            Opacity = 0.8,
+            [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.DoNotShowAgain)) { Mode = BindingMode.TwoWay },
+        };
+
+        // Shrink the whole control (box + label) so it reads as a small, secondary option.
+        var checkBoxSmall = new LayoutTransformControl
+        {
+            LayoutTransform = new ScaleTransform(0.85, 0.85),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Child = checkBoxDoNotShowAgain,
+        };
+
+        var buttonDone = UiUtil.MakeButtonDone(vm.OkCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonDone);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+                new RowDefinition { Height = GridLength.Auto },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Star },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 14,
+            MinWidth = 320,
+        };
+
+        grid.Add(header, 0);
+        grid.Add(card, 1);
+        grid.Add(checkBoxSmall, 2);
+        grid.Add(buttonPanel, 3);
+
+        Content = grid;
+
+        Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    // Use the same SpellCheck icon as the main toolbar; fall back to a generic info icon if the
+    // themed image can't be loaded for any reason.
+    private static Control MakeHeaderIcon(double size)
+    {
+        try
+        {
+            var image = InitToolbar.MakeImage("SpellCheck");
+            image.Width = size;
+            image.Height = size;
+            image.VerticalAlignment = VerticalAlignment.Center;
+            return image;
+        }
+        catch
+        {
+            return MakeIcon(IconNames.Information, size, 1.0);
+        }
+    }
+
+    private static Control MakeIcon(string iconName, double size, double opacity)
+    {
+        var icon = new ContentControl
+        {
+            Width = size,
+            Height = size,
+            Opacity = opacity,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        Attached.SetIcon(icon, iconName);
+        return icon;
+    }
+
+    private static Control MakeCountRow(string iconName, string textPropertyPath, string? visiblePropertyPath)
+    {
+        var text = new TextBlock { VerticalAlignment = VerticalAlignment.Center, FontSize = 15 };
+        text.Bind(TextBlock.TextProperty, new Binding(textPropertyPath));
+
+        var row = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            Children = { MakeIcon(iconName, 20, 0.85), text },
+        };
+
+        if (visiblePropertyPath != null)
+        {
+            row.Bind(Visual.IsVisibleProperty, new Binding(visiblePropertyPath));
+        }
+
+        return row;
+    }
+}

--- a/src/ui/Features/SpellCheck/SpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckManager.cs
@@ -17,6 +17,9 @@ public class SpellCheckManager : SpellChecker, ISpellCheckManager
     public delegate void SpellCheckWordChangedHandler(object sender, SpellCheckWordChangedEvent e);
     public event SpellCheckWordChangedHandler? OnWordChanged;
     public int NoOfChangedWords { get; set; }
+    public int NoOfCorrectWords { get; set; }
+    public int NoOfNames { get; set; }
+    public int NoOfAddedWords { get; set; }
 
     private SpellCheckResult? _currentResult;
 
@@ -135,6 +138,7 @@ public class SpellCheckManager : SpellChecker, ISpellCheckManager
 
         if (IsName(word, text))
         {
+            NoOfNames++;
             return true;
         }
 
@@ -180,6 +184,11 @@ public class SpellCheckManager : SpellChecker, ISpellCheckManager
         {
             ChangeWord(word, ChangeAllDictionary[word] + word.Remove(0, word.TrimEnd('\'').Length), words[wordIndex], p);
             return true;
+        }
+
+        if (isCorrect)
+        {
+            NoOfCorrectWords++;
         }
 
         return isCorrect;

--- a/src/ui/Features/SpellCheck/SpellCheckUndoItem.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckUndoItem.cs
@@ -27,6 +27,9 @@ public class SpellCheckUndoItem
     public string ActionWord { get; set; } = string.Empty;
     public int NoOfChangedWords { get; set; }
     public int NoOfSkippedWords { get; set; }
+    public int NoOfCorrectWords { get; set; }
+    public int NoOfNames { get; set; }
+    public int NoOfAddedWords { get; set; }
     public List<(SubtitleLineViewModel Paragraph, string Text)> ParagraphTexts { get; set; } = new();
     public SpellCheckResult? ResumeFrom { get; set; }
 }

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -62,6 +62,9 @@ public partial class SpellCheckViewModel : ObservableObject
     public Window? Window { get; set; }
     public int TotalChangedWords { get; set; }
     public int TotalSkippedWords { get; set; }
+    public int TotalCorrectWords { get; set; }
+    public int TotalNames { get; set; }
+    public int TotalAddedWords { get; set; }
 
     public bool OkPressed { get; private set; }
     public StackPanel PanelWholeText { get; internal set; }
@@ -485,6 +488,9 @@ public partial class SpellCheckViewModel : ObservableObject
     {
         TotalChangedWords = _spellCheckManager.NoOfChangedWords;
         TotalSkippedWords = _spellCheckManager.NoOfSkippedWords;
+        TotalCorrectWords = _spellCheckManager.NoOfCorrectWords;
+        TotalNames = _spellCheckManager.NoOfNames;
+        TotalAddedWords = _spellCheckManager.NoOfAddedWords;
     }
 
     private void SetLanguage(string? dictionaryFileName)
@@ -669,6 +675,7 @@ public partial class SpellCheckViewModel : ObservableObject
         var status = string.Format(Se.Language.SpellCheck.WordXAddedToNamesList, CurrentWord);
         PushUndo(status, SpellCheckUndoAction.AddToNames, CurrentWord);
         _spellCheckManager.AddToNames(CurrentWord);
+        _spellCheckManager.NoOfNames++;
         ShowStatus(status);
         DoSpellCheck();
     }
@@ -685,6 +692,7 @@ public partial class SpellCheckViewModel : ObservableObject
         var status = string.Format(Se.Language.SpellCheck.WordXAddedToUserDictionary, CurrentWord);
         PushUndo(status, SpellCheckUndoAction.AddToDictionary, CurrentWord);
         _spellCheckManager.AdToUserDictionary(CurrentWord);
+        _spellCheckManager.NoOfAddedWords++;
         ShowStatus(status);
         DoSpellCheck();
     }
@@ -746,6 +754,9 @@ public partial class SpellCheckViewModel : ObservableObject
     {
         TotalChangedWords = _spellCheckManager.NoOfChangedWords;
         TotalSkippedWords = _spellCheckManager.NoOfSkippedWords;
+        TotalCorrectWords = _spellCheckManager.NoOfCorrectWords;
+        TotalNames = _spellCheckManager.NoOfNames;
+        TotalAddedWords = _spellCheckManager.NoOfAddedWords;
         OkPressed = true;
         Se.Settings.SpellCheck.LastLanguageDictionaryName = SelectedDictionary?.Name;
         Se.Settings.SpellCheck.LastLanguageDictionaryFile = SelectedDictionary?.DictionaryFileName;
@@ -777,6 +788,9 @@ public partial class SpellCheckViewModel : ObservableObject
             ActionWord = actionWord,
             NoOfChangedWords = _spellCheckManager.NoOfChangedWords,
             NoOfSkippedWords = _spellCheckManager.NoOfSkippedWords,
+            NoOfCorrectWords = _spellCheckManager.NoOfCorrectWords,
+            NoOfNames = _spellCheckManager.NoOfNames,
+            NoOfAddedWords = _spellCheckManager.NoOfAddedWords,
             ParagraphTexts = Paragraphs.Select(p => (p, p.Text)).ToList(),
 
             // Re-scan from just before the acted-on word so it is shown again after undo.
@@ -832,6 +846,9 @@ public partial class SpellCheckViewModel : ObservableObject
         // Restore counters and the scan position, then re-check so the word reappears.
         _spellCheckManager.NoOfChangedWords = item.NoOfChangedWords;
         _spellCheckManager.NoOfSkippedWords = item.NoOfSkippedWords;
+        _spellCheckManager.NoOfCorrectWords = item.NoOfCorrectWords;
+        _spellCheckManager.NoOfNames = item.NoOfNames;
+        _spellCheckManager.NoOfAddedWords = item.NoOfAddedWords;
         _lastSpellCheckResult = item.ResumeFrom;
 
         if (_undoList.Count > 0)

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -36,6 +36,13 @@ public class LanguageSpellCheck
     public string EditWholeText { get; set; }
     public string ContinueFromCurrentLine { get; set; }
     public string ContinueFromTop { get; set; }
+    public string SpellCheckCompleted { get; set; }
+    public string ChangedWordsX { get; set; }
+    public string SkippedWordsX { get; set; }
+    public string CorrectWordsX { get; set; }
+    public string NamesX { get; set; }
+    public string AddedToDictionaryX { get; set; }
+    public string DoNotShowThisAgain { get; set; }
 
     public LanguageSpellCheck()
     {
@@ -71,5 +78,12 @@ public class LanguageSpellCheck
         EditWholeText = "Edit whole text";
         ContinueFromCurrentLine = "Continue spell check from the current line?\n\nYes = continue from the current line\nNo = start from the beginning";
         ContinueFromTop = "Spell check reached the end of the subtitle.\n\nContinue from the top?";
+        SpellCheckCompleted = "Spell check completed";
+        ChangedWordsX = "Changed words: {0}";
+        SkippedWordsX = "Skipped words: {0}";
+        CorrectWordsX = "Correct words: {0}";
+        NamesX = "Names: {0}";
+        AddedToDictionaryX = "Added to dictionary: {0}";
+        DoNotShowThisAgain = "Do not show this message again";
     }
 }

--- a/src/ui/Logic/Config/SeSpellCheck.cs
+++ b/src/ui/Logic/Config/SeSpellCheck.cs
@@ -11,6 +11,7 @@ public class SeSpellCheck
     public string? LastLanguageDictionaryName { get; set; }
     public bool PromptForUnknownOneLetterWords { get; set; } = false;
     public bool TreatInQuoteASIng { get; set; } = true;
+    public bool ShowCompletedMessage { get; set; } = true;
 
     public SeSpellCheck()
     {

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -2,6 +2,7 @@
 
 internal class IconNames
 {
+    public const string Account = "mdi-account";
     public const string AlignHorizontalCenter = "mdi-align-horizontal-center";
     public const string AlignHorizontalDistribute = "mdi-align-horizontal-distribute";
     public const string AnimationPlay = "mdi-animation-play";


### PR DESCRIPTION
## Problem
A user reported (#12022) that spell check no longer says how many words were replaced — the previous version showed a summary, the rewrite only had a basic message box.

## What this does
Adds a proper **spell-check completion dialog** and restores the full set of summary counters from SE4.

### Dialog
- New `SpellCheckCompletedWindow` / `SpellCheckCompletedViewModel`: a small **card-style** summary with the **SpellCheck toolbar icon** in the header and a per-row icon for each count.
- **"Do not show this message again"** checkbox → persists `Se.Settings.SpellCheck.ShowCompletedMessage`. When suppressed, the result is shown in the **status bar** instead, so it's never silently lost (same fallback SE4 used).

### Counters (all five SE4 items)
Tracks **Changed**, **Skipped**, **Correct words**, **Names**, and **Added to dictionary**. Changed/Skipped always show; the other three are hidden when zero to keep it tidy. The three new counters are wired through the manager, the `ISpellCheckManager` interface, and the **undo snapshot** so undo rewinds them too.

### Supporting change
- `InitToolbar.MakeImage` is now public (path resolution extracted to `EnsureImagePath`) so the dialog reuses the exact themed/recolored toolbar **SpellCheck** icon.
- Added `IconNames.Account` (`mdi-account`) for the Names row.

New language strings added to `LanguageSpellCheck`. Builds clean; verified by running spell check (change / add-name / add-to-dictionary) and confirming each row + the persisted checkbox.

Fixes #12022

🤖 Generated with [Claude Code](https://claude.com/claude-code)

