### PR TITLE
[macOS] Fix Option+Arrow word navigation in AvaloniaEdit editors (color tags, source view)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18834,6 +18834,7 @@ public partial class MainViewModel :
                             && (keyEventArgs.KeyModifiers == KeyModifiers.Alt
                                 || keyEventArgs.KeyModifiers == (KeyModifiers.Shift | KeyModifiers.Alt)))))
                 {
+                    _shortcutManager.ClearKeys();
                     return;
                 }
 

--- a/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
@@ -1,11 +1,15 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 using AvaloniaEdit;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Editing;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 
@@ -17,6 +21,7 @@ public class TextEditorWrapper : ITextBoxWrapper
     private readonly SubtitleTextAlignmentTransformer _alignmentTransformer;
     private EventHandler? _alignmentUpdateHandler;
     private TextAlignment _currentAlignment = TextAlignment.Left;
+    private int? _wordNavAnchor;
 
     public bool HasFocus { get; set; }
 
@@ -40,6 +45,111 @@ public class TextEditorWrapper : ITextBoxWrapper
                 UpdateAlignmentTransform();
             }
         };
+
+        // Fix Option+Right/Left (Alt on macOS) word navigation to match standard TextBox behavior:
+        // AvaloniaEdit moves to start of next word; macOS convention is end of current word.
+        _textEditor.TextArea.AddHandler(
+            InputElement.KeyDownEvent,
+            OnTextAreaKeyDown,
+            RoutingStrategies.Tunnel);
+    }
+
+    private void OnTextAreaKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (sender is not TextArea textArea)
+            return;
+
+        var isAlt = (e.KeyModifiers & KeyModifiers.Alt) != 0;
+        var isCtrl = (e.KeyModifiers & KeyModifiers.Control) != 0;
+        var isShift = (e.KeyModifiers & KeyModifiers.Shift) != 0;
+
+        // Only apply on macOS: Option+Arrow is the word navigation key there.
+        // On Windows/Linux, Ctrl+Arrow is used and AvaloniaEdit's default behavior
+        // already matches the platform convention.
+        if (!isAlt || isCtrl || (e.Key != Key.Right && e.Key != Key.Left) || !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return;
+
+        var document = textArea.Document;
+        var caretOffset = textArea.Caret.Offset;
+
+        var newOffset = e.Key == Key.Right
+            ? GetWordRightOffset(document, caretOffset)
+            : GetWordLeftOffset(document, caretOffset);
+
+        if (isShift)
+        {
+            // Initialise or reset the anchor: on first Shift+Option press, or whenever
+            // the selection was cleared externally (click, non-Shift move) since last time.
+            if (_wordNavAnchor == null || textArea.Selection.IsEmpty)
+                _wordNavAnchor = caretOffset;
+
+            textArea.Caret.Offset = newOffset;
+            textArea.Selection = Selection.Create(textArea, _wordNavAnchor.Value, newOffset);
+        }
+        else
+        {
+            _wordNavAnchor = null;
+            textArea.Caret.Offset = newOffset;
+            textArea.Selection = Selection.Create(textArea, newOffset, newOffset);
+        }
+
+        e.Handled = true;
+    }
+
+    private static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+    private static bool IsNonNewlineWhiteSpace(char c) => c != '\n' && char.IsWhiteSpace(c);
+
+    private static int GetWordRightOffset(TextDocument document, int offset)
+    {
+        var length = document.TextLength;
+        if (offset >= length)
+            return length;
+
+        // Skip non-newline whitespace (spaces, tabs)
+        while (offset < length && IsNonNewlineWhiteSpace(document.GetCharAt(offset)))
+            offset++;
+
+        if (offset >= length)
+            return length;
+
+        // A newline is its own stop — consume it and land at start of next line
+        if (document.GetCharAt(offset) == '\n')
+            return offset + 1;
+
+        // Skip a contiguous run of the same character category (alphanumeric vs punctuation)
+        var wordChar = IsWordChar(document.GetCharAt(offset));
+        while (offset < length
+               && !char.IsWhiteSpace(document.GetCharAt(offset))
+               && IsWordChar(document.GetCharAt(offset)) == wordChar)
+            offset++;
+
+        return offset;
+    }
+
+    private static int GetWordLeftOffset(TextDocument document, int offset)
+    {
+        if (offset <= 0)
+            return 0;
+
+        // Skip non-newline whitespace backward
+        while (offset > 0 && IsNonNewlineWhiteSpace(document.GetCharAt(offset - 1)))
+            offset--;
+
+        if (offset == 0)
+            return 0;
+
+        // A newline is its own stop — consume it and land at end of previous line
+        if (document.GetCharAt(offset - 1) == '\n')
+            return offset - 1;
+
+        // Skip a contiguous run of the same character category backward
+        var wordChar = IsWordChar(document.GetCharAt(offset - 1));
+        while (offset > 0
+               && !char.IsWhiteSpace(document.GetCharAt(offset - 1))
+               && IsWordChar(document.GetCharAt(offset - 1)) == wordChar)
+            offset--;
+
+        return offset;
     }
 
     public string Text


### PR DESCRIPTION
  ## Problem
  
  When color tags are enabled or the source view (F2) is open, the edit box uses AvaloniaEdit's `TextEditor` instead of the standard Avalonia `TextBox`. AvaloniaEdit's built-in macOS word navigation (Option+Arrow) behaves differently from the platform convention and from the standard text box:
  
  - **Wrong direction**: Option+Right moved to the *start* of the next word instead of the *end* of the current word (e.g. cursor after `T` in `This is` → jumped to before `is` instead of after `This`)
  - **No punctuation stops**: commas and periods were absorbed into the adjacent word rather than being their own navigation stop
  - **No newline stop**: the newline between subtitle lines was skipped entirely instead of producing a stop at the start of the next line 
    
  The result was inconsistent behavior between color-tags mode and non-color-tags mode, and between macOS apps and Subtitle Edit in color-tags mode.
    
  ## Fix
  
  Adds a tunneling `KeyDown` handler to `TextEditorWrapper` that intercepts Option+Left/Right on macOS and applies the same category-aware word boundary logic used by the standard `TextBox`:
  
  - Alphanumeric runs (`[a-zA-Z0-9_]`) and punctuation runs are separate stops 
  - Newlines are consumed alone — Option+Right lands at the start of the next line, Option+Left lands at the end of the previous line
  - Spaces and tabs are skipped without stopping
  - Shift+Option+Arrow extends the selection correctly, with a stable anchor that persists across consecutive keypresses

  Also fixes a pre-existing stale-key bug: the `OnKeyDownHandler` early-return guard for macOS Option+Arrow did not call `_shortcutManager.ClearKeys()`, unlike the equivalent Option+Backspace and Cmd+Delete handlers. A stale `Key.Left`/`Key.Right` in the active-key set could match an unintended chord on the next keypress if focus switched away before the key-up event fired.
  
  ## Scope
  
  - macOS only — on Windows/Linux, Alt+Left/Right are the video-seeking shortcuts (500 ms back/forward) and are left untouched
  - Applies to all `TextEditorWrapper` instances: main edit box (color tags on) and source view (F2) for files under 2 MB
    
  ## Testing
    
  With `Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit.` in the color-tags edit box, Option+Right from the start now stops at:
  
  `Lorem|` `ipsum|` `dolor|` `sit|` `amet|` `,|` `|consectetur` `consectetur|` `adipiscing|` `elit|` `.|`
  
  This matches the standard text box (no color tags) exactly.

  ## non-macOS

  I have no immediate access to Windows and Linux, but I suspect that the word navigation is inconsistent there as well, just in the opposite way. On Windows, Ctrl+Right should stop after the whitespace, so the behavior of the Avalonia TextEditor is correct. In contrast, the TextBox behavior, which stops right after the word, is incorrect and inconsistent with native platform editors like Notepad. Most likely, a tweak similar to what I just implemented could be applied to a TextBox wrapper. However, without the ability to test it, I only fixed the macOS inconsistency in this PR.