### PR TITLE
Restore keyboard/focus efficiency in several windows (#12029)

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -43,6 +43,10 @@ public partial class MultipleReplaceViewModel : ObservableObject
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
     public Subtitle FixedSubtitle { get; private set; }
+
+    // Invoked by the re-usable "Apply" button: applies the checked replacements to the document
+    // (subtitle, number applied) without closing the window, so several rounds can be run (#12029).
+    public Action<Subtitle, int>? OnApply { get; set; }
     public int TotalReplaced { get; private set; }
 
     private readonly IWindowService _windowService;
@@ -257,6 +261,21 @@ public partial class MultipleReplaceViewModel : ObservableObject
         UndoUnchecked();
         OkPressed = true;
         Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Apply()
+    {
+        GeneratePreview();
+        UndoUnchecked();
+
+        // Apply the currently checked replacements to the document, then make the result the new
+        // working subtitle so the next round operates on the already-fixed text - without closing
+        // the window (Subtitle Edit 4 had this re-usable "Apply" button - #12029).
+        OnApply?.Invoke(new Subtitle(FixedSubtitle), Fixes.Count(f => f.Apply));
+        _subtitle = new Subtitle(FixedSubtitle);
+        _dirty = true;
+        GeneratePreview();
     }
 
     private void UndoUnchecked()

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -58,8 +58,10 @@ public class MultipleReplaceWindow : Window
         };
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonApply = UiUtil.MakeButton(Se.Language.General.Apply, vm.ApplyCommand);
         var panelButtons = UiUtil.MakeButtonBar(
             buttonOk,
+            buttonApply,
             UiUtil.MakeButtonCancel(vm.CancelCommand)
         );
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10741,7 +10741,18 @@ public partial class MainViewModel :
         }
 
         var result =
-            await ShowDialogAsync<MultipleReplaceWindow, MultipleReplaceViewModel>(vm => { vm.Initialize(GetUpdateSubtitle()); });
+            await ShowDialogAsync<MultipleReplaceWindow, MultipleReplaceViewModel>(vm =>
+            {
+                vm.Initialize(GetUpdateSubtitle());
+
+                // "Apply" applies the replacements live without closing, so several rounds can be run (#12029).
+                vm.OnApply = (fixedSubtitle, count) =>
+                {
+                    SetSubtitles(fixedSubtitle);
+                    SelectAndScrollToRow(0);
+                    ShowStatus(string.Format(Se.Language.Main.ReplacedXOccurrences, count));
+                };
+            });
 
         if (result.OkPressed)
         {
@@ -15471,6 +15482,10 @@ public partial class MainViewModel :
                                     await VideoOpenFile(fileName);
                                 }
                             }
+
+                            // Put keyboard focus on the grid so shortcuts (e.g. Ctrl+S) work right
+                            // away after an "Open with" mkv extract, without a manual click (#12029).
+                            Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
                         }
                     }
                 }
@@ -15527,6 +15542,12 @@ public partial class MainViewModel :
                 {
                     // Image track data was fully extracted before the OCR dialog was posted, so matroska is safe to dispose now.
                     matroska.Dispose();
+                }
+
+                if (!IsImageSubtitleTrack(subtitleList[0]))
+                {
+                    // Focus the grid so shortcuts (e.g. Ctrl+S) work immediately after the extract (#12029).
+                    Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
                 }
             }
             else

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -7,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Threading;
 using System;
 using System.Collections;
 using Nikse.SubtitleEdit.Features.Files.Compare;
@@ -20,6 +21,7 @@ namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 public class FixCommonErrorsWindow : Window
 {
     private readonly FixCommonErrorsViewModel _vm;
+    private Button? _buttonApplySelectedFixes;
 
     public FixCommonErrorsWindow(FixCommonErrorsViewModel vm)
     {
@@ -142,7 +144,6 @@ public class FixCommonErrorsWindow : Window
 
         var buttonDone = UiUtil.MakeButton(Se.Language.General.Done, vm.OkCommand)
             .BindIsVisible(vm, nameof(vm.Step2IsVisible));
-        buttonDone.IsDefault = true;
 
         var buttonPanelRight = UiUtil.MakeButtonBar(
             buttonBackToFixList,
@@ -212,7 +213,54 @@ public class FixCommonErrorsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { Focus(); }; // hack to make OnKeyDown work
+        // Make Enter trigger - and put focus on - the current step's primary button, so the keyboard
+        // flow works without a manual click: step 1 -> "Go to apply fixes", step 2 -> "Apply selected
+        // fixes" (the repeated apply+re-scan action, not "Done"/close). Focusing a button (instead of
+        // the window) still lets the window's OnKeyDown fire, as key events bubble up. (#12029)
+        void FocusStepButton()
+        {
+            var step2 = vm.Step2IsVisible;
+            buttonToApplyFixes.IsDefault = !step2;
+            buttonDone.IsDefault = false;
+            if (_buttonApplySelectedFixes != null)
+            {
+                _buttonApplySelectedFixes.IsDefault = step2;
+            }
+
+            Control? target = step2 ? _buttonApplySelectedFixes : buttonToApplyFixes;
+            if (target != null)
+            {
+                Dispatcher.UIThread.Post(() => target.Focus());
+            }
+        }
+
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(vm.Step1IsVisible) or nameof(vm.Step2IsVisible))
+            {
+                FocusStepButton();
+            }
+            else if (e.PropertyName == nameof(vm.FixesAppliedText) && vm.Step2IsVisible && !string.IsNullOrEmpty(vm.FixesAppliedText))
+            {
+                // After "Apply selected fixes": if nothing is left to fix, move focus/default to
+                // "Done" so the next Return finishes; otherwise keep it on "Apply selected fixes"
+                // for another round (matches SE4). (#12029)
+                var done = vm.Fixes.Count == 0;
+                buttonDone.IsDefault = done;
+                if (_buttonApplySelectedFixes != null)
+                {
+                    _buttonApplySelectedFixes.IsDefault = !done;
+                }
+
+                Control? target = done ? buttonDone : _buttonApplySelectedFixes;
+                if (target != null)
+                {
+                    Dispatcher.UIThread.Post(() => target.Focus());
+                }
+            }
+        };
+
+        Activated += delegate { FocusStepButton(); };
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
@@ -348,7 +396,8 @@ public class FixCommonErrorsWindow : Window
             Spacing = 0,
         };
         rightButtons.Children.Add(UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.RefreshFixes, _vm.DoRefreshFixesCommand));
-        rightButtons.Children.Add(UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.ApplySelectedFixes, _vm.DoApplyFixesCommand));
+        _buttonApplySelectedFixes = UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.ApplySelectedFixes, _vm.DoApplyFixesCommand);
+        rightButtons.Children.Add(_buttonApplySelectedFixes);
 
         var buttonBarFixes = new Grid
         {


### PR DESCRIPTION
Addresses #12029 — v4 let you drive these flows with shortcuts + Return; v5 had lost some of it. Three independent fixes:

## 1) Ctrl+S right after "Open with" an mkv
After extracting a text subtitle from a Matroska file (both the *pick-a-track/language* path and the single-track path), focus is now put on the subtitle grid (`Dispatcher.UIThread.Post(() => SubtitleGrid.Focus())`). So **Ctrl+S** (and other shortcuts) work immediately, without a manual click first.

## 2) Fix common errors — Return drives the flow
The current step's primary button now gets keyboard focus and is the default button, toggled per step:
- **Step 1** → **"Go to apply fixes →"**
- **Step 2** → **"Apply selected fixes"** — the repeated *apply + re-scan* action (stays open), **not** "Done"/close.
- After applying, if **no fixes remain**, focus/default moves to **"Done"** so the next Return finishes; if fixes remain, it stays on **"Apply selected fixes"** for another round.

This mirrors SE4, which set `AcceptButton`/focus to `buttonNextFinish` on step 1, to `buttonFixesApply` on step 2, and back to the finish button once `listViewFixes.Items.Count == 0`.

## 3) Multiple replace — re-usable "Apply" button
Added an **Apply** button next to OK (as in SE4's `buttonApply`). It applies the checked replacements to the document and **keeps the window open**, making the result the new working subtitle so several rounds can be run without reopening (Ctrl+Shift+R each time). OK still applies-and-closes as before.

Builds clean; verified #2 and #3 interactively. #1 is on the mkv "Open with" path (please confirm on a real mkv).

Fixes #12029

🤖 Generated with [Claude Code](https://claude.com/claude-code)