### PR TITLE
Fix Escape closing BinaryEdit window when a dialog is opened from its context menu

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2188,8 +2188,11 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (e.Key == Key.Escape)
         {
-            e.Handled = true;
-            Cancel();
+            if (!e.Handled && Window?.OwnedWindows.Count == 0)
+            {
+                e.Handled = true;
+                Cancel();
+            }
             return;
         }
 

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -163,6 +163,7 @@ namespace Nikse.SubtitleEdit.Logic
             // behind them in undocked mode. (#11971)
             KeepTopmostWhileOwnerActive(window, owner);
 
+            await YieldForPendingFlyoutDismissAsync();
             await window.ShowDialog(owner);
 
             return window;
@@ -197,9 +198,20 @@ namespace Nikse.SubtitleEdit.Logic
             // behind them in undocked mode. (#11971)
             KeepTopmostWhileOwnerActive(window, owner);
 
+            await YieldForPendingFlyoutDismissAsync();
             await window.ShowDialog(owner);
 
             return viewModel;
+        }
+
+        // When a dialog is launched from a context menu item, the command runs synchronously while the
+        // MenuFlyout is still mid-dismiss. Opening the modal dialog at that moment (notably on macOS)
+        // leaves it without keyboard focus, so it cannot receive key input such as Escape. Yielding a
+        // dispatcher cycle at Background priority lets the flyout finish its light-dismiss and focus
+        // restoration first, so the dialog then opens and takes focus cleanly.
+        private static Task YieldForPendingFlyoutDismissAsync()
+        {
+            return Dispatcher.UIThread.InvokeAsync(static () => { }, DispatcherPriority.Background).GetTask();
         }
 
         /// <summary>


### PR DESCRIPTION
  ## Problem

  In the BinaryEdit window, opening a dialog from the **context menu** (e.g. right-click a line → *Adjust Durations*) and pressing **Escape** closed *both* the dialog and the BinaryEdit window. Only the dialog should close.

  The same dialogs opened from the **Tools menu** behaved correctly.

  ## Root cause

  A context-menu command runs synchronously while the `MenuFlyout` is still mid-dismiss. On macOS, opening the modal dialog at that moment leaves it **without keyboard focus**, so Escape never reaches the dialog. It instead falls through to the BinaryEdit window's key handler (registered with `handledEventsToo: true`), which calls `Cancel()` and closes the window — auto-closing the owned modal dialog along with it. That made it *look* like Escape closed both.

  The Tools menu uses a native NSMenu, which hands focus back to the app cleanly before the command runs, so the dialog gets focus normally — hence no bug there.

  ## Fix

  - **`WindowsService.ShowDialogAsync`**: yield one dispatcher cycle (`Background` priority) before showing a modal dialog, letting any in-flight flyout finish its light-dismiss and focus restoration first. The dialog then opens and takes keyboard focus cleanly. This also fixes the same latent lost-focus issue for *any* context-menu-launched dialog across the app.
  - **`BinaryEditViewModel.OnKeyDown`**: guard the Escape→`Cancel()` path so it only fires when no owned dialog is open (`Window?.OwnedWindows.Count == 0`), as defense-in-depth.

  ## Testing

  - Right-click a line in BinaryEdit → *Adjust Durations* → **Esc**: closes only the dialog; BinaryEdit stays open ✅
  - Same via *Apply Duration Limits*, *Adjust All Times*, and other context-menu dialogs ✅
  - Tools menu dialogs still close correctly on Esc ✅
  - With no dialog open, **Esc** still closes the BinaryEdit window ✅
  - **Ctrl+Enter** (OK) still accepts and closes BinaryEdit ✅
