### PR TITLE
change-log: add beta4 entries for recent fixes

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -12,6 +12,10 @@ v5.1.0-beta4 (TBD)
 * Fix icon-button hints not showing in dialogs on macOS
 * Fix Google Lens OCR including server retry messages in the OCR text - thx LurkingNinja
 * Fix bare Alt not activating the main menu bar on Windows
+* Fix small custom-millisecond video seeks being unreliable on a single key press - thx AndryOut
+* Fix Option+Arrow word navigation in the color-tag / source-view text editors on macOS - thx mjuhasz
+* Fix Escape closing the Binary edit window when a dialog was opened from its context menu - thx mjuhasz
+* Fix the status dot and description in the "Get dictionaries" window - thx ivandrofly
 
 -----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds beta4 changelog lines for the fixes merged since beta3 was finalized (#12011):

* Fix small custom-millisecond video seeks being unreliable on a single key press - thx AndryOut (#12027, #12033)
* Fix Option+Arrow word navigation in the color-tag / source-view text editors on macOS - thx mjuhasz (#12026)
* Fix Escape closing the Binary edit window when a dialog was opened from its context menu - thx mjuhasz (#12032)
* Fix the status dot and description in the "Get dictionaries" window - thx ivandrofly (#12025, #12031)

Attribution note: the seek fix was implemented by @muaz978 (PR #12033) and reported by @AndryOut — credited the reporter per the usual style; adjust if you'd prefer the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)