### PR TITLE
flatpak: bundle Noto Sans CJK so Korean/CJK text renders

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -318,6 +318,23 @@ modules:
         url: https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata
         sha256: daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
 
+  # --- CJK fonts (Noto Sans CJK) ---
+  #
+  # The org.freedesktop.Platform runtime ships no CJK fonts, so Korean/Japanese/Chinese UI text
+  # rendered as boxes in the Flatpak build (reported for Korean). On Linux the app forces Inter as
+  # the default UI font and relies on font fallbacks named "Noto Sans CJK KR/JP/SC/TC" etc.
+  # (see Program.cs) - which need the family to actually be present. The portable build works
+  # because it uses the host's fonts; the sandbox has none. Bundle Noto Sans CJK so CJK renders
+  # in-sandbox regardless of the host. fontconfig picks up /app/share/fonts automatically.
+  - name: noto-cjk-fonts
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 NotoSansCJK-Regular.ttc /app/share/fonts/NotoSansCJK-Regular.ttc
+    sources:
+      - type: file
+        url: https://raw.githubusercontent.com/notofonts/noto-cjk/f8d157532fbfaeda587e826d4cd5b21a49186f7c/Sans/OTC/NotoSansCJK-Regular.ttc
+        sha256: b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a
+
   # --- SubtitleEdit application ---
 
   - name: subtitleedit


### PR DESCRIPTION
## Problem
A user reported that **Korean UI text is garbled (boxes) in the Flatpak build**, while the portable (git .tar.gz) build renders Korean fine.

## Cause
On Linux the app forces **Inter** as the default UI font (to avoid Avalonia's `$Default` glyph-typeface crash on minimal installs) and relies on **font fallbacks** naming `Noto Sans CJK KR/JP/SC/TC`, `Noto Sans KR`, `NanumGothic`, … (`Program.cs`). Inter has no CJK glyphs, so CJK only renders if one of those fallback families is actually installed.

- **Portable** build runs natively → uses the **host's** fontconfig → finds the user's Korean fonts → renders.
- **Flatpak** runs in the `org.freedesktop.Platform` 24.08 sandbox, which **ships no CJK fonts**, and the manifest bundled none → the fallbacks resolve to nothing → CJK = boxes.

## Fix
Bundle **Noto Sans CJK** (Regular OTC — covers KR/JP/SC/TC, matching the app's fallback family names) into `/app/share/fonts/`, which fontconfig picks up automatically. Now CJK renders in-sandbox regardless of the host.

- Pinned to a specific noto-cjk commit with sha256 (`NotoSansCJK-Regular.ttc`, ~19 MB).
- Family names verified to match the `Program.cs` fallback list.

Manifest YAML validated. Resolves the Flatpak-Korean report (follow-up to #12009).

🤖 Generated with [Claude Code](https://claude.com/claude-code)