### PR TITLE
macOS: default to Helvetica Neue to fix caret positioning (#12009)

### DIFF
--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -77,7 +77,10 @@ public class SeAppearance
         IconTheme = string.Empty;
         MatchIconColorToDarkTheme = false;
         LayoutScale = 1.0;
-        FontName = "Default";
+        // On macOS default to Helvetica Neue rather than the hidden system font (.AppleSystemUIFont /
+        // San Francisco): SetFontName applies this family explicitly to every control, and Helvetica
+        // Neue avoids Avalonia's caret-misplacement with San Francisco's overhanging glyphs (#12009).
+        FontName = System.OperatingSystem.IsMacOS() ? "Helvetica Neue" : "Default";
         SubtitleTextBoxAndGridFontName = "Default";
         SubtitleGridFontSize = 13d;
         SubtitleGridTextSingleLineSeparator = " ⏎ "; // "<br />";

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -91,8 +91,10 @@ namespace Nikse.SubtitleEdit
                 // minimal Linux installs that ship without fontconfig-discoverable fonts
                 // (e.g. Debian 13 trixie base — issue #11355). Forcing Inter as the default on macOS and
                 // Windows, however, overrides the system font and its CJK fallback, so Korean/Japanese/
-                // Chinese UI text renders as boxes (Inter has no CJK glyphs). Those platforms always have
-                // system fonts with proper fallback, so let them use the system default there.
+                // Chinese UI text renders as boxes (Inter has no CJK glyphs). Windows always has system
+                // fonts with proper fallback, so it uses the system default; macOS is handled below - a
+                // fixed default font works around an Avalonia caret-positioning bug with the hidden
+                // system font, while keeping CJK fallback.
                 if (OperatingSystem.IsLinux())
                 {
                     // Inter is the default here, but it has no CJK glyphs and Avalonia does not fall
@@ -120,6 +122,28 @@ namespace Nikse.SubtitleEdit
                                 new FontFallback { FontFamily = new FontFamily("UnDotum") },
                                 new FontFallback { FontFamily = new FontFamily("WenQuanYi Zen Hei") },
                                 new FontFallback { FontFamily = new FontFamily("WenQuanYi Micro Hei") },
+                            }
+                        });
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    // macOS exposes its default UI font (San Francisco) only as the private family
+                    // ".AppleSystemUIFont", and Avalonia mis-positions the caret / selection edge with it:
+                    // it places the caret at each glyph's advance width and ignores ink that overruns the
+                    // advance box (e.g. the ellipsis), so the caret lands inside the rendered glyph. Use a
+                    // real, always-present font (Helvetica Neue) as the default instead - it has no such
+                    // overhang - and name the macOS CJK families explicitly so Korean/Japanese/Chinese still
+                    // render (Helvetica Neue has no CJK glyphs). (#12009 follow-up)
+                    appBuilder = appBuilder
+                        .With(new FontManagerOptions
+                        {
+                            DefaultFamilyName = "Helvetica Neue",
+                            FontFallbacks = new[]
+                            {
+                                new FontFallback { FontFamily = new FontFamily("PingFang SC") },
+                                new FontFallback { FontFamily = new FontFamily("PingFang TC") },
+                                new FontFallback { FontFamily = new FontFamily("Hiragino Sans") },
+                                new FontFallback { FontFamily = new FontFamily("Apple SD Gothic Neo") },
                             }
                         });
                 }


### PR DESCRIPTION
Follow-up to the discussion in #12009 (thanks @mjuhasz for the diagnosis).

## Problem
On macOS the caret / selection edge is slightly misplaced for some characters (e.g. the ellipsis `…` in the Find/Replace boxes). It's an **Avalonia** limitation: it positions the caret at each glyph's *advance width* and ignores ink that overruns the advance box. macOS's default UI font, **San Francisco** (exposed only as the private family `.AppleSystemUIFont`), has several such glyphs, so the caret lands inside the rendered glyph.

## Fix (two layers)
Default macOS to **Helvetica Neue** — a real, always-present font with no such overhang — with explicit CJK fallbacks so Korean/Japanese/Chinese still render.

1. **`SeAppearance`**: default the appearance `FontName` to `"Helvetica Neue"` on macOS (was `"Default"`). This is the layer that actually controls the UI font — `UiUtil.SetFontName` runs at startup and applies the `FontName` family *explicitly* to every control (TextBlock/TextBox/Button/Menu/…), taking precedence over the Avalonia default. Existing users on `"Default"` still get Helvetica Neue via the fallback in (2); users who explicitly chose "System Font" (`.AppleSystemUIFont`) keep San Francisco by choice.
2. **`Program.cs`**: set the Avalonia `DefaultFamilyName` = Helvetica Neue and add macOS CJK `FontFallbacks` (**PingFang SC/TC, Hiragino Sans, Apple SD Gothic Neo**), mirroring the existing Linux branch — covers the `"Default"`-fallback path and provides CJK glyphs (Helvetica Neue has none).

This is @mjuhasz's recommended "option 2", made robust against SE's own font-application layer.

## Notes
- **Trade-off:** the UI no longer renders in the exact system font (San Francisco) — a deliberate visual choice, as agreed in the thread.
- Verified: builds clean; UI renders cleanly in Helvetica Neue. The caret-placement improvement is font-specific and best eyeballed in the Find/Replace box with an ellipsis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)