### PR TITLE
change-log: Flatpak CJK, macOS font, waveform pause

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -16,6 +16,9 @@ v5.1.0-beta4 (TBD)
 * Fix Option+Arrow word navigation in the color-tag / source-view text editors on macOS - thx mjuhasz
 * Fix Escape closing the Binary edit window when a dialog was opened from its context menu - thx mjuhasz
 * Fix the status dot and description in the "Get dictionaries" window - thx ivandrofly
+* Fix garbled Korean/CJK text in the Linux Flatpak build (bundle Noto Sans CJK)
+* Fix caret misplacement on macOS by defaulting the UI font to Helvetica Neue - thx mjuhasz
+* Fix the waveform cursor lagging/jittering when pausing playback - thx AndryOut
 
 -----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds beta4 entries for the latest merged fixes:

* Fix garbled Korean/CJK text in the Linux Flatpak build (bundle Noto Sans CJK) — #12037
* Fix caret misplacement on macOS by defaulting the UI font to Helvetica Neue — #12038 (thx mjuhasz)
* Fix the waveform cursor lagging/jittering when pausing playback — #12039 (thx AndryOut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)