### PR TITLE
Open source view with the caret at the selected subtitle

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1140,16 +1140,16 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ShowSourceView()
     {
+        var oldSelectedIndex = SelectedSubtitleIndex ?? 0;
         var result = await ShowDialogAsync<SourceViewWindow, SourceViewViewModel>(vm =>
         {
-            var text = GetUpdateSubtitle().ToText(SelectedSubtitleFormat);
+            var subtitle = GetUpdateSubtitle();
+            var text = subtitle.ToText(SelectedSubtitleFormat);
             var title = string.Format(Se.Language.General.SourceViewX, (string.IsNullOrEmpty(_subtitleFileName)
                 ? Se.Language.General.Untitled
                 : Path.GetFileName(_subtitleFileName)));
-            vm.Initialize(title, text, SelectedSubtitleFormat);
+            vm.Initialize(title, text, SelectedSubtitleFormat, subtitle, oldSelectedIndex);
         });
-
-        var oldSelectedIndex = SelectedSubtitleIndex ?? 0;
 
         if (result.OkPressed)
         {

--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -32,9 +32,9 @@ public partial class SourceViewViewModel : ObservableObject
 
     public SubtitleFormat _subtitleFormat { get; private set; }
     public ITextBoxWrapper SourceViewTextBox { get; set; }
-    public Border TextBoxContainer { get; set; }
 
     private readonly System.Timers.Timer _cursorTimer;
+    private int _initialCaretIndex;
 
     public SourceViewViewModel()
     {
@@ -44,7 +44,6 @@ public partial class SourceViewViewModel : ObservableObject
         LineAndColumnInfo = string.Empty;
         Subtitle = new Subtitle();
         _subtitleFormat = new SubRip();
-        TextBoxContainer = new Border();
 
         _cursorTimer = new System.Timers.Timer(200);
         _cursorTimer.Elapsed += (sender, args) =>
@@ -81,33 +80,67 @@ public partial class SourceViewViewModel : ObservableObject
         };
     }
 
-    internal void Initialize(string title, string text, SubtitleFormat subtitleFormat)
+    internal void Initialize(
+        string title,
+        string text,
+        SubtitleFormat subtitleFormat,
+        Subtitle subtitle,
+        int selectedParagraphIndex)
     {
         Title = title;
         Text = text;
         _subtitleFormat = subtitleFormat;
         _cursorTimer.Start();
-
-        Dispatcher.UIThread.Post(async () =>
+        _initialCaretIndex = FindSelectedParagraphCaretIndex(text, subtitle, subtitleFormat, selectedParagraphIndex);
+        if (text.Length > 2_000_000)
         {
-            await Task.Delay(50); // Slight delay to ensure control is ready
+            SourceViewTextBox = CreateSimpleTextBoxWrapper();
+        }
+        else
+        {
+            SourceViewTextBox = CreateAdvancedTextBoxWrapper(text, subtitleFormat);
+        }
+    }
 
-            var useSimpleTextBox = text.Length > 2_000_000;
-            if (useSimpleTextBox)
-            {
-                SourceViewTextBox = CreateSimpleTextBoxWrapper();
-            }
-            else
-            {
-                SourceViewTextBox = CreateAdvancedTextBoxWrapper(text, subtitleFormat);
-            }
-
-            TextBoxContainer.Child = SourceViewTextBox.ContentControl;
-
-            await Task.Delay(50); // Slight delay to ensure control is ready
+    internal void FocusEditor()
+    {
+        SourceViewTextBox.CaretIndex = _initialCaretIndex;
+        if (SourceViewTextBox.TextControl is TextEditor textEditor)
+        {
+            textEditor.TextArea.Focus();
+            textEditor.TextArea.Caret.BringCaretToView();
+        }
+        else
+        {
             SourceViewTextBox.Focus();
-            SourceViewTextBox.CaretIndex = 0;
-        }, DispatcherPriority.Input);
+        }
+    }
+
+    private static int FindSelectedParagraphCaretIndex(
+        string source,
+        Subtitle subtitle,
+        SubtitleFormat subtitleFormat,
+        int selectedParagraphIndex)
+    {
+        if (selectedParagraphIndex < 0 || selectedParagraphIndex >= subtitle.Paragraphs.Count)
+        {
+            return 0;
+        }
+
+        var modifiedSubtitle = new Subtitle(subtitle, false);
+        var paragraph = modifiedSubtitle.Paragraphs[selectedParagraphIndex];
+        var markerPrefix = paragraph.Text.StartsWith('A') ? "B" : "A";
+        paragraph.Text = markerPrefix + "__SOURCE_VIEW_CARET__";
+        var modifiedSource = modifiedSubtitle.ToText(subtitleFormat);
+
+        var length = Math.Min(source.Length, modifiedSource.Length);
+        var index = 0;
+        while (index < length && source[index] == modifiedSource[index])
+        {
+            index++;
+        }
+
+        return index < source.Length ? index : 0;
     }
 
     private TextBoxWrapper CreateSimpleTextBoxWrapper()

--- a/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
@@ -25,8 +25,8 @@ public class SourceViewWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
             Width = double.NaN,
             Height = double.NaN,
+            Child = vm.SourceViewTextBox.ContentControl,
         };
-        vm.TextBoxContainer = contentBorder;
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
@@ -58,6 +58,7 @@ public class SourceViewWindow : Window
 
         Content = grid;
 
+        Opened += delegate { Avalonia.Threading.Dispatcher.UIThread.Post(vm.FocusEditor); };
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }


### PR DESCRIPTION
## Summary

Source View now opens with the caret positioned at the subtitle currently selected in the main subtitle grid.

## Background

Source View always opened at the beginning of the document, making the corresponding source entry inconvenient to locate in larger subtitle files.

SE4 already provided similar behavior by positioning the Source View caret at the currently selected subtitle.

## Implementation

The selected paragraph index and subtitle are passed to `SourceViewViewModel`.

To locate the corresponding position across different subtitle formats, the selected paragraph is replaced with a temporary marker in a cloned subtitle. The modified source is then compared with the original serialized source, and the first differing character identifies the beginning of the selected subtitle text.

This avoids format-specific numbering and ambiguity when multiple subtitles contain identical text.

The editor is also created and attached before the window opens. This allows the `Opened` handler to:

- Position the caret at the selected subtitle
- Focus the underlying AvaloniaEdit `TextArea`
- Scroll the caret into view

This replaces the previous delay-based editor initialization with a deterministic window lifecycle event.

## Screenshots

| Before | After |
|---|---|
| Source View opens at the beginning of the document | Source View opens with the caret at the selected subtitle |
| <img width="600" alt="Source View before the change" src="https://github.com/user-attachments/assets/f08a2f61-a7a8-446f-986c-2c46f824762c" /> | <img width="600" alt="Source View after the change" src="https://github.com/user-attachments/assets/80db6db7-2e2a-4937-93ff-8833506dfb95" /> |

## Testing

Tested on Windows 11 x64 (local build) with the following subtitle formats:

- SubRip (SRT)
- WebVTT
- SAMI (SMI)
- Advanced SubStation Alpha (ASS)

Verified that Source View focuses and scrolls to the selected subtitle in each format.