### PR TITLE
macOS: migrate legacy UI font defaults

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
@@ -359,6 +359,7 @@ public partial class SettingsImportExportViewModel : ObservableObject
             if (importData.Appearance != null)
             {
                 Se.Settings.Appearance = importData.Appearance;
+                Se.MigrateMacOsFontSettings(Se.Settings.Appearance, OperatingSystem.IsMacOS(), true);
             }
         }
 
@@ -510,4 +511,3 @@ public partial class SettingsImportExportViewModel : ObservableObject
         }
     }
 }
-

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -709,10 +709,7 @@ public partial class SettingsViewModel : ObservableObject
         LayoutScale = (int)Math.Round(appearance.LayoutScale * 100.0, MidpointRounding.AwayFromZero);
         if (OperatingSystem.IsMacOS())
         {
-            SelectedFontName = appearance.FontName is ".AppleSystemUIFont" or "Default"
-                               || FontNames.All(p => p != appearance.FontName)
-                ? "System Font"
-                : appearance.FontName;
+            SelectedFontName = MapMacOsFontNameForDisplay(appearance.FontName, FontNames);
         }
         else
         {
@@ -919,6 +916,21 @@ public partial class SettingsViewModel : ObservableObject
         ExistsSettingsFile = File.Exists(Se.GetSettingsFilePath());
 
         WriteToolsLog = Se.Settings.Tools.WriteToolsLog;
+    }
+
+    internal static string MapMacOsFontNameForDisplay(string fontName, IReadOnlyList<string> fontNames)
+    {
+        if (fontName == ".AppleSystemUIFont")
+        {
+            return "System Font";
+        }
+
+        if (fontName == "Default")
+        {
+            return "Helvetica Neue";
+        }
+
+        return fontNames.FirstOrDefault(p => p == fontName) ?? fontNames.First();
     }
 
     // Display label <-> stored extension for the waveform "Extract audio" format.
@@ -2283,6 +2295,7 @@ public partial class SettingsViewModel : ObservableObject
             if (result.ResetAppearance)
             {
                 Se.Settings.Appearance = new SeAppearance();
+                Se.MigrateMacOsFontSettings(Se.Settings.Appearance, OperatingSystem.IsMacOS(), false);
             }
 
             if (result.ResetAutoTranslate)

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -15,6 +15,8 @@ namespace Nikse.SubtitleEdit.Logic.Config;
 
 public class Se
 {
+    internal const int CurrentMacOsFontMigrationVersion = 1;
+
     public static string Version { get; set; } = "v5.1.0-beta4";
 
     public SeGeneral General { get; set; } = new();
@@ -264,6 +266,7 @@ public class Se
     {
         if (!System.IO.File.Exists(settingsFileName))
         {
+            MigrateMacOsFontSettings(Settings.Appearance, OperatingSystem.IsMacOS(), false);
             return;
         }
 
@@ -282,7 +285,25 @@ public class Se
 
         SetDefaultValues();
 
+        MigrateMacOsFontSettings(Settings.Appearance, OperatingSystem.IsMacOS(), true);
+
         UpdateLibSeSettings();
+    }
+
+    internal static void MigrateMacOsFontSettings(SeAppearance appearance, bool isMacOs, bool isLegacySettings)
+    {
+        if (!isMacOs || appearance.MacOsFontMigrationVersion.GetValueOrDefault() >= CurrentMacOsFontMigrationVersion)
+        {
+            return;
+        }
+
+        if (isLegacySettings && appearance.FontName is ".AppleSystemUIFont" or "Default")
+        {
+            appearance.FontName = "Helvetica Neue";
+        }
+
+        // Once marked, a later explicit System Font selection must remain untouched.
+        appearance.MacOsFontMigrationVersion = CurrentMacOsFontMigrationVersion;
     }
 
     /// <summary>

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -6,6 +6,11 @@ namespace Nikse.SubtitleEdit.Logic.Config;
 
 public class SeAppearance
 {
+    // Null in settings written before the one-time switch from the macOS system font to Helvetica Neue.
+    // Keep this nullable: System.Text.Json runs this constructor for legacy files, so a non-null default
+    // would make an absent migration marker indistinguishable from a completed migration.
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public int? MacOsFontMigrationVersion { get; set; }
     public string Theme { get; set; }
     public string IconTheme { get; set; }
     public bool MatchIconColorToDarkTheme { get; set; }

--- a/tests/UI/Logic/Config/MacOsFontMigrationTests.cs
+++ b/tests/UI/Logic/Config/MacOsFontMigrationTests.cs
@@ -1,0 +1,103 @@
+using Nikse.SubtitleEdit.Features.Options.Settings;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic.Config;
+
+public class MacOsFontMigrationTests
+{
+    [Theory]
+    [InlineData(".AppleSystemUIFont")]
+    [InlineData("Default")]
+    public void LegacyDefaultFontMigratesToHelveticaNeue(string fontName)
+    {
+        var appearance = new SeAppearance
+        {
+            FontName = fontName,
+            MacOsFontMigrationVersion = null,
+        };
+
+        Se.MigrateMacOsFontSettings(appearance, true, true);
+
+        Assert.Equal("Helvetica Neue", appearance.FontName);
+        Assert.Equal(Se.CurrentMacOsFontMigrationVersion, appearance.MacOsFontMigrationVersion);
+    }
+
+    [Fact]
+    public void LegacyCustomFontIsPreservedAndMarkedMigrated()
+    {
+        var appearance = new SeAppearance
+        {
+            FontName = "Avenir Next",
+            MacOsFontMigrationVersion = null,
+        };
+
+        Se.MigrateMacOsFontSettings(appearance, true, true);
+
+        Assert.Equal("Avenir Next", appearance.FontName);
+        Assert.Equal(Se.CurrentMacOsFontMigrationVersion, appearance.MacOsFontMigrationVersion);
+    }
+
+    [Fact]
+    public void ExplicitSystemFontAfterMigrationIsPreserved()
+    {
+        var appearance = new SeAppearance
+        {
+            FontName = ".AppleSystemUIFont",
+            MacOsFontMigrationVersion = Se.CurrentMacOsFontMigrationVersion,
+        };
+
+        Se.MigrateMacOsFontSettings(appearance, true, true);
+
+        Assert.Equal(".AppleSystemUIFont", appearance.FontName);
+    }
+
+    [Fact]
+    public void FreshSettingsAreMarkedWithoutChangingFont()
+    {
+        var appearance = new SeAppearance
+        {
+            FontName = ".AppleSystemUIFont",
+            MacOsFontMigrationVersion = null,
+        };
+
+        Se.MigrateMacOsFontSettings(appearance, true, false);
+
+        Assert.Equal(".AppleSystemUIFont", appearance.FontName);
+        Assert.Equal(Se.CurrentMacOsFontMigrationVersion, appearance.MacOsFontMigrationVersion);
+    }
+
+    [Fact]
+    public void NonMacOsSettingsAreNotChanged()
+    {
+        var appearance = new SeAppearance
+        {
+            FontName = ".AppleSystemUIFont",
+            MacOsFontMigrationVersion = null,
+        };
+
+        Se.MigrateMacOsFontSettings(appearance, false, true);
+
+        Assert.Equal(".AppleSystemUIFont", appearance.FontName);
+        Assert.Null(appearance.MacOsFontMigrationVersion);
+    }
+
+    [Fact]
+    public void LegacyDefaultDisplaysAsHelveticaNeueInSettings()
+    {
+        var fontNames = new List<string> { "System Font", "Helvetica Neue", "Avenir Next" };
+
+        var selectedFont = SettingsViewModel.MapMacOsFontNameForDisplay("Default", fontNames);
+
+        Assert.Equal("Helvetica Neue", selectedFont);
+    }
+
+    [Fact]
+    public void ExplicitSystemFontDisplaysAsSystemFontInSettings()
+    {
+        var fontNames = new List<string> { "System Font", "Helvetica Neue", "Avenir Next" };
+
+        var selectedFont = SettingsViewModel.MapMacOsFontNameForDisplay(".AppleSystemUIFont", fontNames);
+
+        Assert.Equal("System Font", selectedFont);
+    }
+}


### PR DESCRIPTION
This is a follow-up to #12038. Note that there is a trade-off: merging this will add migration complexity to the app, which we could drop later but will need to accept in the meantime. Also, users who explicitly preferred System Font will need to select it again once after upgrading. Their choice is then preserved. However, this PR may reduce your support load by addressing complaints from users with legacy font settings. I leave the decision to you: merge this now, keep it for later ("let's see if we get more complaints"), or close it.

Without this migration, affected users still get San Francisco font as their General UI font and you'll have to ask them to go to Settings and select "Helvetica Neue"

## Summary

  Migrate legacy macOS UI font settings to Helvetica Neue so the general UI, subtitle editor, and OCR editor use a consistent default font.

  ## Background

  The macOS font changes make Helvetica Neue the default:

  - **General UI:** uses `Appearance.FontName` and Avalonia’s platform default.
  - **Subtitle textbox/grid:** keeps `"Default"`, which resolves to Helvetica Neue.
  - **OCR textbox:** inherits the subtitle textbox font unless the user selected a custom OCR font through **Set font…**.

  ## Problem

  Legacy macOS configurations can contain either:

  ```json
  "FontName": "Default"
```

  or:

```json
  "FontName": ".AppleSystemUIFont"
```

  The Settings page previously displayed "Default" as System Font. Saving Settings—even without changing the font—then persisted .AppleSystemUIFont, explicitly selecting San Francisco and bypassing the new Helvetica Neue default.

  Without migration, affected users get:

  - General UI: San Francisco.
  - Subtitle textbox/grid: Helvetica Neue.
  - OCR textbox: Helvetica Neue unless customized.

  This produces inconsistent fonts and can reintroduce Avalonia’s caret/selection-positioning issue in ordinary UI textboxes.

  The existing settings cannot distinguish between .AppleSystemUIFont saved as the former default and an explicit user choice.

  ## Migration decision

  This PR silently migrates all legacy "Default" and .AppleSystemUIFont values to Helvetica Neue _once_.

  This prioritizes consistent rendering and the caret-positioning fix. Users who explicitly preferred System Font will need to select it again once after upgrading. Their choice is then preserved.

  ## Changes

  - Migrate legacy "Default" and .AppleSystemUIFont values to "Helvetica Neue".
  - Store a migration-version marker so the conversion runs only once.
  - Preserve an explicit System Font selection made after migration.
  - Preserve existing custom font selections.
  - Mark fresh and reset appearance settings as current.
  - Apply the migration to imported legacy appearance settings.
  - Display legacy "Default" as Helvetica Neue instead of System Font in Settings.
  - Add eight tests covering migration, custom fonts, fresh settings, non-macOS settings, explicit post-migration choices, and Settings-page mapping.
