### PR TITLE
Batch convert: add llama.cpp (with auto-detect/start/download)

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -30,6 +30,7 @@ using Nikse.SubtitleEdit.Features.Tools.BatchConvert.BatchErrorList;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
@@ -885,6 +886,11 @@ public partial class BatchConvertViewModel : ObservableObject
             return;
         }
 
+        if (!await EnsureLlamaCppAvailable(config))
+        {
+            return;
+        }
+
         _batchConverter.Initialize(config);
         var start = DateTime.UtcNow.Ticks;
 
@@ -1074,6 +1080,65 @@ public partial class BatchConvertViewModel : ObservableObject
         }
 
         return ready;
+    }
+
+    // For llama.cpp in local (server-managed) mode: auto-detect an already-running llama-server and
+    // reuse it, otherwise auto-download the engine + model (prompting) and auto-start the server, so
+    // batch translation works without opening the interactive Auto-translate window first. Remote mode
+    // (a user-supplied URL) is left untouched.
+    private async Task<bool> EnsureLlamaCppAvailable(BatchConvertConfig config)
+    {
+        if (Window == null)
+        {
+            return true;
+        }
+
+        if (!config.AutoTranslate.IsActive || config.AutoTranslate.Translator is not LlamaCppTranslate)
+        {
+            return true;
+        }
+
+        // Remote mode: the user pointed llama.cpp at their own running llama-server.
+        if (!string.IsNullOrWhiteSpace(AutoTranslateUrl))
+        {
+            return true;
+        }
+
+        // Auto-detect: reuse an already-running local server.
+        if (LlamaCppServerManager.IsServerRunning)
+        {
+            Configuration.Settings.Tools.LlamaCppApiUrl = LlamaCppServerManager.ApiUrl;
+            return true;
+        }
+
+        // Pick the last-used model, else the first available translate model.
+        var models = LlamaCppServerManager.GetAllTranslateModels();
+        var configuredName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
+        var model = models.FirstOrDefault(m => string.Equals(m.FileName, configuredName, StringComparison.OrdinalIgnoreCase))
+                    ?? models.FirstOrDefault();
+        if (model == null)
+        {
+            return true;
+        }
+
+        // Auto-download the llama-server binary + model if missing (prompts).
+        if (!await LlamaCppDownloadHelper.EnsureReadyAsync(Window, _windowService, model.FileName))
+        {
+            return false;
+        }
+
+        // Auto-start the local server - this points Configuration.Settings.Tools.LlamaCppApiUrl at it.
+        try
+        {
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return false;
+        }
+
+        return true;
     }
 
     private static bool IsImageBasedInput(BatchConvertItem item)

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -356,6 +356,7 @@ public partial class BatchConvertViewModel : ObservableObject
             new OllamaTranslate(),
             new LibreTranslate(),
             new LmStudioTranslate(),
+            new LlamaCppTranslate(),
             new NoLanguageLeftBehindServe(),
             new NoLanguageLeftBehindApi(),
             new DeepLTranslate(),
@@ -2071,6 +2072,18 @@ public partial class BatchConvertViewModel : ObservableObject
             Configuration.Settings.Tools.LmStudioModel = AutoTranslateModel.Trim();
         }
 
+        if (engineType == typeof(LlamaCppTranslate))
+        {
+            if (!string.IsNullOrEmpty(AutoTranslateUrl.Trim()))
+            {
+                Configuration.Settings.Tools.LlamaCppApiUrl = AutoTranslateUrl.Trim();
+            }
+            else if (!string.IsNullOrEmpty(Se.Settings.AutoTranslate.LlamaCppApiUrl))
+            {
+                Configuration.Settings.Tools.LlamaCppApiUrl = Se.Settings.AutoTranslate.LlamaCppApiUrl;
+            }
+        }
+
         if (engineType == typeof(OllamaTranslate))
         {
             if (!string.IsNullOrEmpty(Se.Settings.AutoTranslate.OllamaUrl))
@@ -2258,6 +2271,16 @@ public partial class BatchConvertViewModel : ObservableObject
             AutoTranslateModelBrowseIsVisible = false;
             AutoTranslateModelIsVisible = false;
             AutoTranslateUrl = Se.Settings.AutoTranslate.LmStudioApiUrl;
+            AutoTranslateUrlIsVisible = true;
+            AutoTranslateApiKey = string.Empty;
+            AutoTranslateApiKeyIsVisible = false;
+        }
+        else if (engine is LlamaCppTranslate)
+        {
+            AutoTranslateModel = string.Empty;
+            AutoTranslateModelBrowseIsVisible = false;
+            AutoTranslateModelIsVisible = false;
+            AutoTranslateUrl = Se.Settings.AutoTranslate.LlamaCppApiUrl;
             AutoTranslateUrlIsVisible = true;
             AutoTranslateApiKey = string.Empty;
             AutoTranslateApiKeyIsVisible = false;


### PR DESCRIPTION
Adds **llama.cpp** to Batch convert (it was only in the interactive Auto-translate window), and makes it work without any manual server setup.

## What it does
1. **Engine entry** — adds `LlamaCppTranslate` to the batch engine list, mirroring the existing LM Studio handling (URL field → `Configuration.Settings.Tools.LlamaCppApiUrl`). So a user-supplied **remote** `llama-server` URL just works, like Ollama / LM Studio.
2. **Auto-detect / auto-start / auto-download (local mode)** — when llama.cpp is selected and no URL is entered, `Convert()` now runs `EnsureLlamaCppAvailable` before translating (same slot as the existing `EnsurePaddleOcrAvailable` / `EnsureCrispAsrAvailable` checks):
   - **Auto-detect:** reuse an already-running `llama-server` if present (points the URL at it).
   - **Auto-download:** otherwise download the engine + a model if missing (prompted), via the same `LlamaCppDownloadHelper.EnsureReadyAsync` the main window uses.
   - **Auto-start:** start the local server via `LlamaCppServerManager.EnsureServerRunningAsync`, which sets `LlamaCppApiUrl` to the running server.
   - Model choice: the last-used model, else the first available translate model (batch has no picker).

Reuses the exact helpers from the interactive Auto-translate window, so behavior matches. Builds clean.

## Verification note
The engine-list/remote-URL path is straightforward and mirrors LM Studio. The **local auto-download + auto-start** path reuses the proven main-window helpers but I couldn't exercise it end-to-end here (it downloads a multi-GB model and launches a server), so a quick interactive run — select llama.cpp in Batch convert with no URL and start a conversion — would be worth doing before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)