### PR TITLE
Add discard assignment to DataGridCheckboxMultiSelect instantiations

### DIFF
--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -479,7 +479,7 @@ public class OcrWindow : Window
         dataGridSubtitle.AddHandler(InputElement.PointerReleasedEvent, vm.DataGridSubtitleMacPointerReleased, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         dataGridSubtitle.SelectionChanged += vm.SubtitleGridSelectionChanged;
         vm.SubtitleGrid = dataGridSubtitle;
-        new DataGridCheckboxMultiSelect<OcrSubtitleItem>(dataGridSubtitle);
+        _ = new DataGridCheckboxMultiSelect<OcrSubtitleItem>(dataGridSubtitle);
 
         // Create a Flyout for the DataGrid
         var flyout = new MenuFlyout();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -608,7 +608,7 @@ public class BinaryEditWindow : Window
 
         vm.SubtitleGrid = dataGrid;
         dataGrid.SelectionChanged += vm.SubtitleGridSelectionChanged;
-        new DataGridCheckboxMultiSelect<BinarySubtitleItem>(
+        _ = new DataGridCheckboxMultiSelect<BinarySubtitleItem>(
             dataGrid,
             item => item.IsForced,
             (item, v) => item.IsForced = v);

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
@@ -183,7 +183,7 @@ public class ApplyDurationLimitsWindow : Window
                 },
             },
         };
-        new DataGridCheckboxMultiSelect<ApplyDurationLimitItem>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<ApplyDurationLimitItem>(dataGrid,
             item => item.Apply, (item, v) => item.Apply = v);
 
         grid.Add(labelFixesAvailable, 0);

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
@@ -113,7 +113,7 @@ public class BatchConvertFixCommonErrorsSettingsWindow : Window
                 },
             },
         };
-        new DataGridCheckboxMultiSelect<FixRuleDisplayItem>(rulesGrid,
+        _ = new DataGridCheckboxMultiSelect<FixRuleDisplayItem>(rulesGrid,
             item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         return UiUtil.MakeBorderForControl(rulesGrid);

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -189,7 +189,7 @@ public class BatchConvertWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchItem)) { Source = vm });
         vm.FileGrid = dataGrid;
-        new DataGridCheckboxMultiSelect<BatchConvertItem>(dataGrid);
+        _ = new DataGridCheckboxMultiSelect<BatchConvertItem>(dataGrid);
 
         var comboBoxSubtitleFormat = UiUtil.MakeComboBox(vm.TargetFormats, vm, nameof(vm.SelectedTargetFormat));
         comboBoxSubtitleFormat.SelectionChanged += (_, _) => vm.ComboBoxSubtitleFormatChanged();
@@ -475,7 +475,7 @@ public class BatchConvertWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchFunction)) { Source = vm });
-        new DataGridCheckboxMultiSelect<BatchConvertFunction>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<BatchConvertFunction>(dataGrid,
             item => item.IsSelected, (item, v) => item.IsSelected = v,
             onFocusedItemChanged: _ => vm.SelectedFunctionChanged());
         UiUtil.AttachMacContextFlyoutHandler(dataGrid);

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
@@ -144,7 +144,7 @@ public class FixNamesWindow : Window
             IsReadOnly = true,
         });
 
-        new DataGridCheckboxMultiSelect<FixNameItem>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<FixNameItem>(dataGrid,
             item => item.IsChecked, (item, v) => item.IsChecked = v);
 
         var flyout = new MenuFlyout();
@@ -212,7 +212,7 @@ public class FixNamesWindow : Window
             IsReadOnly = true
         });
 
-        new DataGridCheckboxMultiSelect<FixNameHitItem>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<FixNameHitItem>(dataGrid,
             item => item.IsEnabled, (item, v) => item.IsEnabled = v);
 
         var flyout = new MenuFlyout();

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -231,7 +231,7 @@ public class ConvertActorsWindow : Window
                 },
             },
         };
-        new DataGridCheckboxMultiSelect<ConvertActorsDisplayItem>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<ConvertActorsDisplayItem>(dataGrid,
             item => item.IsChecked, (item, v) => item.IsChecked = v);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -119,7 +119,7 @@ public class FixCommonErrorsWindow : Window
             },
         };
         rulesGrid.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
-        new DataGridCheckboxMultiSelect<FixRuleDisplayItem>(rulesGrid,
+        _ = new DataGridCheckboxMultiSelect<FixRuleDisplayItem>(rulesGrid,
             item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         var step2Grid = MakeStep2Grid();
@@ -371,12 +371,15 @@ public class FixCommonErrorsWindow : Window
             },
         };
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
-        new DataGridCheckboxMultiSelect<FixDisplayItem>(dataGridFixes,
+        _ = new DataGridCheckboxMultiSelect<FixDisplayItem>(dataGridFixes,
             item => item.IsSelected, (item, v) => item.IsSelected = v,
-            onFocusedItemChanged: item => { if (item != null)
+            onFocusedItemChanged: item =>
             {
-                _vm.SelectAndScrollTo(item);
-            } });
+                if (item != null)
+                {
+                    _vm.SelectAndScrollTo(item);
+                }
+            });
 
         var leftButtons = new StackPanel
         {
@@ -540,6 +543,7 @@ public class FixCommonErrorsWindow : Window
                         {
                             textBlock.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
                         }
+
                         return new Border
                         {
                             Padding = new Thickness(4, 2),
@@ -632,6 +636,7 @@ public class FixCommonErrorsWindow : Window
         {
             textBox.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         }
+
         textEditGrid.Add(textBox, 0, 0);
 
         var panelSingleLineLengths = new StackPanel
@@ -662,5 +667,4 @@ public class FixCommonErrorsWindow : Window
         base.OnKeyDown(e);
         _vm.OnKeyDown(e);
     }
-
 }

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
@@ -136,7 +136,7 @@ public class FixNetflixErrorsWindow : Window
             IsReadOnly = true,
             Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
         });
-        new DataGridCheckboxMultiSelect<NetflixCheckDisplayItem>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<NetflixCheckDisplayItem>(dataGrid,
             item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         var grid = new Grid
@@ -231,7 +231,7 @@ public class FixNetflixErrorsWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
-        new DataGridCheckboxMultiSelect<FixNetflixErrorsItem>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<FixNetflixErrorsItem>(dataGrid,
             item => item.Apply, (item, v) => item.Apply = v,
             canToggle: item => item.CanBeFixed);
 

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -194,7 +194,7 @@ public class MergeContinuationLinesWindow : Window
                 },
             },
         };
-        new DataGridCheckboxMultiSelect<MergeContinuationLinesCandidate>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<MergeContinuationLinesCandidate>(dataGrid,
             item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         grid.Add(labelInfo, 0);

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -344,7 +344,7 @@ public class RemoveTextForHearingImpairedWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
-        new DataGridCheckboxMultiSelect<RemoveItem>(dataGrid,
+        _ = new DataGridCheckboxMultiSelect<RemoveItem>(dataGrid,
             item => item.Apply, (item, v) => item.Apply = v);
 
         var labelLinesFound = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.LinesFoundText));


### PR DESCRIPTION
## Summary
- Prefix all statement-level `new DataGridCheckboxMultiSelect<T>(...)` calls with `_ =` to explicitly discard the unused return value
- Covers OCR, BinaryEdit, and the Tools windows (ApplyDurationLimits, BatchConvert, ChangeCasing/FixNames, ConvertActors, FixCommonErrors, FixNetflixErrors, MergeContinuationLines, RemoveTextForHearingImpaired)
- Minor formatting cleanup in FixCommonErrorsWindow

## Test plan
- [x] Solution builds without warnings for the affected files
- [x] Open each affected window and confirm the checkbox multi-select behavior is unchanged
- [x] Confirm no functional/runtime differences (discard only affects the unused return value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)