### PR TITLE
Prevent UI tests from overwriting user settings

### DIFF
--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -66,6 +66,7 @@ public class Se
     public static readonly bool IsPortable;
     public static readonly string ExePath;
     public static readonly string DataFolder;
+    internal static string? SettingsFilePathOverride { get; set; }
 
     static Se()
     {
@@ -257,7 +258,7 @@ public class Se
 
     public static string GetSettingsFilePath()
     {
-        return Path.Combine(DataFolder, "Settings.json");
+        return SettingsFilePathOverride ?? Path.Combine(DataFolder, "Settings.json");
     }
 
     public static void LoadSettings(string settingsFileName)

--- a/tests/UI/SettingsIsolationFixture.cs
+++ b/tests/UI/SettingsIsolationFixture.cs
@@ -1,0 +1,40 @@
+using Nikse.SubtitleEdit.Logic.Config;
+
+[assembly: AssemblyFixture(typeof(UITests.SettingsIsolationFixture))]
+
+namespace UITests;
+
+public sealed class SettingsIsolationFixture : IDisposable
+{
+    public static string SettingsDirectory { get; private set; } = string.Empty;
+
+    public SettingsIsolationFixture()
+    {
+        SettingsDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "SubtitleEdit.UITests",
+            Guid.NewGuid().ToString("N"));
+        Se.SettingsFilePathOverride = Path.Combine(SettingsDirectory, "Settings.json");
+    }
+
+    public void Dispose()
+    {
+        Se.SettingsFilePathOverride = null;
+
+        if (Directory.Exists(SettingsDirectory))
+        {
+            Directory.Delete(SettingsDirectory, recursive: true);
+        }
+    }
+}
+
+public class SettingsIsolationTests
+{
+    [Fact]
+    public void SettingsFilePath_IsRedirectedToTestDirectory()
+    {
+        Assert.Equal(
+            Path.Combine(SettingsIsolationFixture.SettingsDirectory, "Settings.json"),
+            Se.GetSettingsFilePath());
+    }
+}


### PR DESCRIPTION
  ## Summary

  Prevent UI tests from reading or writing the user's live `Settings.json`.

  ## Problem

  Some UI tests execute commands that call `Se.SaveSettings()`. On macOS, the default settings path resolves to:

  `~/Library/Application Support/Subtitle Edit/Settings.json`

  Running these tests therefore overwrite the user's actual application settings.

  ## Changes

  - Add an internal settings-file path override to `Se`.
  - Configure the UI test assembly to use a unique temporary settings directory.
  - Reset the override and remove temporary files after the test suite.
  - Add a regression test verifying that the settings path is redirected during UI tests.
  - Keep production settings behavior unchanged.

  ## Verification

  - All 490 UI tests pass.
  - The live `Settings.json` hash and timestamp remain unchanged after the full UI test suite.
  - Temporary test settings are removed after the run.
