### PR TITLE
Settings: "Color text if more than N lines" now tracks Max number of lines live (#12028)

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -365,7 +365,8 @@ public class SettingsPage : UserControl
                     UiUtil.MakeButtonBrowse(_vm.EditTextTooWideSettingsCommand)
                 )),
 
-            MakeCheckboxSetting(Se.Language.Options.Settings.ColorTextTooManyLines, nameof(_vm.ColorTextTooManyLines)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.ColorTextTooManyLines, nameof(_vm.ColorTextTooManyLines),
+                labelBindingPath: nameof(_vm.ColorTextTooManyLinesLabel)),
             MakeSeparator(),
             MakeCheckboxSetting(Se.Language.Options.Settings.ColorCharactersPerSecond, nameof(_vm.ColorCharactersPerSecond)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ColorWordsPerMinute, nameof(_vm.ColorWordsPerMinute)),
@@ -1156,9 +1157,9 @@ public class SettingsPage : UserControl
         return numericUpDown;
     }
 
-    private SettingsItem MakeCheckboxSetting(string label, string bindingProperty, Binding? bindingEnabled = null)
+    private SettingsItem MakeCheckboxSetting(string label, string bindingProperty, Binding? bindingEnabled = null, string? labelBindingPath = null)
     {
-        var item = new SettingsItem(label, () =>
+        Control Factory()
         {
             var cb = new CheckBox
             {
@@ -1172,9 +1173,11 @@ public class SettingsPage : UserControl
             }
 
             return cb;
-        });
+        }
 
-        return item;
+        return labelBindingPath != null
+            ? new SettingsItem(label, _vm, labelBindingPath, Factory)
+            : new SettingsItem(label, Factory);
     }
 
     protected override void OnLoaded(RoutedEventArgs e)

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -72,7 +72,17 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
     [ObservableProperty] private int? _maxLines;
+    [ObservableProperty] private string _colorTextTooManyLinesLabel = string.Empty;
     [ObservableProperty] private int? _unbreakLinesShorterThan;
+
+    // "Color text if more than N lines" must track the live "Max number of lines"
+    // value instead of a hardcoded "2" (#12028), including while typing (nullable/
+    // out-of-range values fall back to the coloring logic's own default of 2).
+    partial void OnMaxLinesChanged(int? value)
+    {
+        var lineCount = value is > 0 ? value.Value : 2;
+        ColorTextTooManyLinesLabel = string.Format(Se.Language.Options.Settings.ColorTextTooManyLinesX, lineCount);
+    }
     [ObservableProperty] private ObservableCollection<DialogStyleDisplay> _dialogStyles;
     [ObservableProperty] private DialogStyleDisplay _dialogStyle;
     [ObservableProperty] private ObservableCollection<ContinuationStyleDisplay> _continuationStyles;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -122,6 +122,7 @@ public class LanguageSettings
     public string ColorTextTooLong { get; set; }
     public string ColorTextTooWide { get; set; }
     public string ColorTextTooManyLines { get; set; }
+    public string ColorTextTooManyLinesX { get; set; }
     public string ColorCharactersPerSecond { get; set; }
     public string ColorWordsPerMinute { get; set; }
     public string ColorOverlap { get; set; }
@@ -438,6 +439,7 @@ public class LanguageSettings
         ColorTextTooLong = "Color text if too long";
         ColorTextTooWide = "Color text if too wide (pixels)";
         ColorTextTooManyLines = "Color text if more than 2 lines";
+        ColorTextTooManyLinesX = "Color text if more than {0} lines";
         ColorCharactersPerSecond = "Color characters/sec if too high";
         ColorWordsPerMinute = "Color words/min if too high";
         ColorOverlap = "Color time code overlap";


### PR DESCRIPTION
## "Color text if more than N lines" now tracks Max number of lines live

Fixes #12028 (per niksedk's confirmation in the issue thread).

### Problem
The Settings label under Syntax Coloring read "Color text if more than 2 lines" with the 2 hardcoded as literal text. Changing "Max number of lines" to anything else left the label unchanged, even though the coloring logic itself already used the real setting correctly, so the label just lied about the threshold.

### Fix
- Added a computed `ColorTextTooManyLinesLabel` on `SettingsViewModel`, recalculated in a `partial void OnMaxLinesChanged(int? value)` hook, so it updates live the moment "Max number of lines" changes in the Settings dialog. This also covers switching profiles, since loading a profile sets `MaxLines` through the same property.
- While the field is mid-edit and the value is null or not positive, the label falls back to the coloring logic's own default of 2 instead of showing something like "more than 0 lines".
- Added a new `ColorTextTooManyLinesX` format string ("Color text if more than {0} lines") rather than changing the existing `ColorTextTooManyLines` key, so already-translated non-English language files are not affected; they will show the English default for the new string until translated, consistent with how #11594 added its new strings.
- Extended `MakeCheckboxSetting` with an optional `labelBindingPath` so a settings row's label can bind live to a view-model property, reusing the constructor `SettingsItem` already had for exactly this.

### Files
- `src/ui/Features/Options/Settings/SettingsViewModel.cs`
- `src/ui/Features/Options/Settings/SettingsPage.cs`
- `src/ui/Logic/Config/Language/Options/LanguageSettings.cs`
