### PR TITLE
Accessibility: fix text-editor Tab focus trap and label Settings/Shortcuts controls (#11745)

### DIFF
--- a/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
+++ b/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using AvaloniaEdit;
@@ -63,6 +64,37 @@ public class TextEditorBindingHelper
         {
             textArea.GotFocus -= OnTextAreaGotFocus;
             textArea.LostFocus -= OnTextAreaLostFocus;
+            textArea.RemoveHandler(InputElement.KeyDownEvent, OnTextAreaKeyDownTunnel);
+        }
+    }
+
+    /// <summary>
+    /// Makes Tab / Shift+Tab move keyboard focus out of the AvaloniaEdit text editor instead of
+    /// inserting indentation, so keyboard-only and screen-reader users are not trapped in the editor
+    /// (issue #11745). Other Tab modifier combos (e.g. Ctrl+Tab) are left to their normal handling.
+    /// </summary>
+    private void OnTextAreaKeyDownTunnel(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Tab || e.KeyModifiers is not (KeyModifiers.None or KeyModifiers.Shift))
+        {
+            return;
+        }
+
+        var focusManager = TopLevel.GetTopLevel(_textEditor)?.FocusManager;
+        if (focusManager == null)
+        {
+            return;
+        }
+
+        var direction = e.KeyModifiers == KeyModifiers.Shift
+            ? NavigationDirection.Previous
+            : NavigationDirection.Next;
+
+        // TryMoveFocus walks the tab order from the currently focused element (the TextArea), the same
+        // path the Tab key normally takes - so focus lands on the next/previous control outside the editor.
+        if (focusManager.TryMoveFocus(direction))
+        {
+            e.Handled = true;
         }
     }
 
@@ -85,6 +117,14 @@ public class TextEditorBindingHelper
             textArea.FocusAdorner = null;
             textArea.GotFocus += OnTextAreaGotFocus;
             textArea.LostFocus += OnTextAreaLostFocus;
+
+            // AvaloniaEdit's TextArea consumes Tab to insert indentation, which traps keyboard and
+            // screen-reader users inside the editor: once focus lands here they can never Tab out to
+            // the grid, waveform, or video controls (issue #11745). Subtitle text never needs a literal
+            // tab, so intercept Tab/Shift+Tab on the tunnel - before AvaloniaEdit sees it - and move
+            // focus like every other field instead (matches SE4/WinForms behavior).
+            textArea.RemoveHandler(InputElement.KeyDownEvent, OnTextAreaKeyDownTunnel);
+            textArea.AddHandler(InputElement.KeyDownEvent, OnTextAreaKeyDownTunnel, RoutingStrategies.Tunnel);
         }
 
         _textEditorBorder.BorderThickness = DefaultBorderThickness;

--- a/src/ui/Features/Options/Settings/SettingsItem.cs
+++ b/src/ui/Features/Options/Settings/SettingsItem.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
@@ -69,6 +70,17 @@ public class SettingsItem
             });
         }
 
+        var control = _controlFactory();
+
+        // Associate the row's label with its input control so screen readers announce the label as the
+        // control's name. Without this the settings controls (numeric fields, combo boxes, check boxes,
+        // ...) are exposed to UI Automation as unnamed/generic elements and NVDA cannot identify them
+        // (issue #11745). A live LabeledBy link also keeps the name correct for bound/localized labels.
+        if (!string.IsNullOrEmpty(_label) || _labelBindingPath != null)
+        {
+            AutomationProperties.SetLabeledBy(control, labelTextBlock);
+        }
+
         var stackPanel = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -77,7 +89,7 @@ public class SettingsItem
             Children =
             {
                 labelTextBlock,
-                _controlFactory()
+                control
             }
         };
 

--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -40,6 +41,9 @@ public class ShortcutsWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
         _searchBox.Bind(TextBox.TextProperty, new Binding(nameof(vm.SearchText)) { Source = vm });
+        // Give the interactive controls accessible names so screen readers announce them instead of
+        // reading a generic "edit"/"combo box"/"check box" (issue #11745).
+        AutomationProperties.SetName(_searchBox, language.SearchShortcuts);
 
         var labelBadgeCount = new Border
         {
@@ -64,6 +68,7 @@ public class ShortcutsWindow : Window
             .WithMinWidth(120)
             .WithMargin(5, 0, 10, 0);
         comboBoxFilter.SelectionChanged += vm.ComboBoxFilter_SelectionChanged;
+        AutomationProperties.SetLabeledBy(comboBoxFilter, labelFilter);
 
         var topGrid = new Grid
         {
@@ -197,24 +202,28 @@ public class ShortcutsWindow : Window
         editPanel.Children.Add(UiUtil.MakeTextBlock(shiftLabel).WithMarginRight(3));
         var checkBoxShift = UiUtil.MakeCheckBox(vm, nameof(vm.ShiftIsSelected));
         checkBoxShift.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
+        AutomationProperties.SetName(checkBoxShift, shiftLabel);
         editPanel.Children.Add(checkBoxShift);
 
         // Control checkbox and label
         editPanel.Children.Add(UiUtil.MakeTextBlock(ctrlLabel).WithMarginRight(3));
         var controlCheckBox = UiUtil.MakeCheckBox(vm, nameof(vm.CtrlIsSelected));
         controlCheckBox.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
+        AutomationProperties.SetName(controlCheckBox, ctrlLabel);
         editPanel.Children.Add(controlCheckBox);
 
         // Alt checkbox and label
         editPanel.Children.Add(UiUtil.MakeTextBlock(altLabel).WithMarginRight(3));
         var checkBoxAlt = UiUtil.MakeCheckBox(vm, nameof(vm.AltIsSelected));
         checkBoxAlt.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
+        AutomationProperties.SetName(checkBoxAlt, altLabel);
         editPanel.Children.Add(checkBoxAlt);
 
         // Win key checkbox and label
         editPanel.Children.Add(UiUtil.MakeTextBlock(winLabel).WithMarginRight(3));
         var checkBoxWin = UiUtil.MakeCheckBox(vm, nameof(vm.WinIsSelected));
         checkBoxWin.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
+        AutomationProperties.SetName(checkBoxWin, winLabel);
         editPanel.Children.Add(checkBoxWin);
 
         // Key combobox
@@ -226,6 +235,7 @@ public class ShortcutsWindow : Window
         comboBoxKeys.Bind(ItemsControl.ItemsSourceProperty, new Binding(nameof(vm.Shortcuts)) { Source = vm });
         comboBoxKeys.Bind(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty, new Binding(nameof(vm.SelectedShortcut)) { Source = vm });
         comboBoxKeys.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
+        AutomationProperties.SetName(comboBoxKeys, Se.Language.General.Shortcut);
         editPanel.Children.Add(comboBoxKeys);
 
         // browse button

--- a/tests/UI/Logic/Accessibility/SettingsAccessibilityLabelTests.cs
+++ b/tests/UI/Logic/Accessibility/SettingsAccessibilityLabelTests.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Options.Settings;
+
+namespace UITests.Logic.Accessibility;
+
+/// <summary>
+/// Every row in the Settings window pairs a label with an input control. Without an explicit
+/// association the controls are exposed to UI Automation as unnamed/generic elements, so a screen
+/// reader cannot tell the user which setting they are on (issue #11745). <see cref="SettingsItem.Build"/>
+/// links the control to its label via <see cref="AutomationProperties.LabeledByProperty"/>; these tests
+/// pin that wiring down.
+/// </summary>
+public class SettingsAccessibilityLabelTests
+{
+    private static (Control control, TextBlock label) BuildRow(SettingsItem item)
+    {
+        var panel = (StackPanel)item.Build();
+        var label = panel.Children.OfType<TextBlock>().First();
+        var control = panel.Children.Last();
+        return (control, label);
+    }
+
+    [AvaloniaFact]
+    public void Build_LinksControlToItsLabel()
+    {
+        var (control, label) = BuildRow(new SettingsItem("Single line max length", () => new NumericUpDown()));
+
+        Assert.Equal("Single line max length", label.Text);
+        Assert.Same(label, AutomationProperties.GetLabeledBy(control));
+    }
+
+    [AvaloniaFact]
+    public void Build_LinksComboBoxControlToItsLabel()
+    {
+        var (control, label) = BuildRow(new SettingsItem("Default encoding", () => new ComboBox()));
+
+        Assert.IsType<ComboBox>(control);
+        Assert.Same(label, AutomationProperties.GetLabeledBy(control));
+    }
+
+    [AvaloniaFact]
+    public void Build_DoesNotLinkWhenLabelIsEmpty()
+    {
+        // Separator/anonymous rows have no label, so there is nothing meaningful to announce.
+        var (control, _) = BuildRow(new SettingsItem(string.Empty, () => new CheckBox()));
+
+        Assert.Null(AutomationProperties.GetLabeledBy(control));
+    }
+}


### PR DESCRIPTION
Follow-up to the main-menu accessibility work, addressing [NVDA beta feedback on #11745](https://github.com/SubtitleEdit/subtitleedit/issues/11745#issuecomment-4852394632).

## 1. Focus trap in the main window (the app-breaker)
The subtitle **Text** editor uses AvaloniaEdit, whose `TextArea` consumes **Tab** to insert indentation and marks the event handled. Once focus reached the editor — right after Start/End/Duration/Layer in the tab order — neither Tab nor Shift+Tab could leave it, so a keyboard-only / screen-reader user was stranded and had to restart the app.

Fix: a tunnel `KeyDown` handler on the `TextArea` turns **Tab / Shift+Tab** into normal focus movement via `IFocusManager.TryMoveFocus` (matches SE4/WinForms; subtitle text never needs a literal tab). Other combos like Ctrl+Tab are left alone. Covers both the main and original/translation editors.

## 2. Settings window — controls exposed as unnamed/generic
Every Settings row pairs a label `TextBlock` with an input control that had **no accessible name**, so NVDA announced a bare "edit"/"combo box"/"check box". `SettingsItem.Build` now links each control to its label via `AutomationProperties.LabeledBy` — one change fixes the whole window, and a live link keeps the name correct for bound/localized labels.

## 3. Shortcuts window — unlabeled controls
Added accessible names to the search box, filter combo, the four modifier check boxes, and the key combo.

## Tests
Added headless automation tests for the Settings `LabeledBy` wiring. All UI accessibility tests pass (8/8).

## Not in this PR
- **Combo/spin value not announced on change** (report item 3): a UIA value-changed-event concern, likely a shared Avalonia peer issue — needs its own investigation.
- **Escape not closing menus** (follow-up comment): a two-stage Escape fix already landed in b3177615a (PR #11949) after the tester's beta build — should be retested rather than re-fixed.

⚠️ These are keyboard/screen-reader behaviors I can't exercise headlessly — worth a manual NVDA pass on Windows: Tab/Shift+Tab in the Text box should move focus (not insert a tab), and Settings/Shortcuts controls should announce their labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)