### PR TITLE
Accessibility: name status-bar icons + label AutoTranslate/FixCommonErrors/SpeechToText controls (#11745)

### DIFF
--- a/src/ui/Features/Main/Layout/InitFooter.cs
+++ b/src/ui/Features/Main/Layout/InitFooter.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
@@ -91,6 +92,9 @@ public static class InitFooter
                         FontSize = 20,
                         [ToolTip.TipProperty] = Se.Language.General.LayerFilterOn,
                     },
+                    // The tooltip lives on the inner Icon, so the Button itself needs its own accessible
+                    // name for screen readers (a ToolTip is not exposed as the UIA Name) (#11745).
+                    [AutomationProperties.NameProperty] = Se.Language.General.LayerFilterOn,
                     [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowLayerFilterIcon)),
                     [!Button.CommandProperty] = new Binding(nameof(vm.ShowPickLayerFilterCommand)),
 
@@ -109,6 +113,7 @@ public static class InitFooter
                         FontSize = 20,
                         [ToolTip.TipProperty] = Se.Language.Main.Menu.SmpteTiming,
                     },
+                    [AutomationProperties.NameProperty] = Se.Language.Main.Menu.SmpteTiming,
                     [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSmpteTimingEnabled)),
                     [!Button.CommandProperty] = new Binding(nameof(vm.ShowSmpteTimingCommand)),
 
@@ -127,6 +132,7 @@ public static class InitFooter
                         FontSize = 20,
                         [ToolTip.TipProperty] = Se.Language.General.OffsetTimeCodes,
                     },
+                    [AutomationProperties.NameProperty] = Se.Language.General.OffsetTimeCodes,
                     [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsVideoOffsetVisible)),
                     [!Button.CommandProperty] = new Binding(nameof(vm.ShowVideoSetOffsetCommand)),
 

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -51,7 +52,8 @@ public class FixCommonErrorsWindow : Window
         labelStep2.Bind(Label.ContentProperty, new Binding(nameof(vm.Step2Title)));
         labelStep2.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
 
-        var textBoxSearch = UiUtil.MakeTextBox(250, vm, nameof(vm.SearchText)).WithMarginRight(25);
+        var textBoxSearch = UiUtil.MakeTextBox(250, vm, nameof(vm.SearchText)).WithMarginRight(25)
+            .WithAccessibleName(Se.Language.Tools.FixCommonErrors.SearchRulesDotDotDot);
         textBoxSearch.PlaceholderText = Se.Language.Tools.FixCommonErrors.SearchRulesDotDotDot;
         textBoxSearch.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
         textBoxSearch.TextChanged += vm.TextBoxSearch_TextChanged;
@@ -63,7 +65,8 @@ public class FixCommonErrorsWindow : Window
             Children =
             {
                 UiUtil.MakeTextBlock(Se.Language.General.Language).WithMarginRight(5),
-                UiUtil.MakeComboBox(vm.Languages, vm, nameof(vm.SelectedLanguage)),
+                UiUtil.MakeComboBox(vm.Languages, vm, nameof(vm.SelectedLanguage))
+                    .WithAccessibleName(Se.Language.General.Language),
             },
         };
 
@@ -95,6 +98,9 @@ public class FixCommonErrorsWindow : Window
                             {
                                 Focusable = false,
                                 [!ToggleButton.IsCheckedProperty] = new Binding(nameof(FixRuleDisplayItem.IsSelected)),
+                                // The checkbox is unfocusable, so name it after the rule it toggles so a
+                                // screen reader can tell which rule's enabled state it is on (#11745).
+                                [!AutomationProperties.NameProperty] = new Binding(nameof(FixRuleDisplayItem.Name)),
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
                         };
@@ -119,18 +125,20 @@ public class FixCommonErrorsWindow : Window
             },
         };
         rulesGrid.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
+        AutomationProperties.SetName(rulesGrid, Se.Language.General.Rules);
         _ = new DataGridCheckboxMultiSelect<FixRuleDisplayItem>(rulesGrid,
             item => item.IsSelected, (item, v) => item.IsSelected = v);
 
         var step2Grid = MakeStep2Grid();
         step2Grid.Bind(IsVisibleProperty, new Binding(nameof(_vm.Step2IsVisible)));
-        var comboProfile = UiUtil.MakeComboBox(vm.Profiles, vm, nameof(vm.SelectedProfile));
+        var comboProfile = UiUtil.MakeComboBox(vm.Profiles, vm, nameof(vm.SelectedProfile))
+            .WithAccessibleName(Se.Language.General.Profile);
         var buttonPanelRules = UiUtil.MakeButtonBar(
             UiUtil.MakeButton(Se.Language.General.SelectAll, vm.RulesSelectAllCommand),
             UiUtil.MakeButton(Se.Language.General.InvertSelection, vm.RulesInverseSelectedCommand),
             UiUtil.MakeTextBlock(Se.Language.General.Profile).WithMarginLeft(25).WithMarginRight(10),
             comboProfile,
-            UiUtil.MakeButton("...", vm.ShowProfileCommand).Compact()
+            UiUtil.MakeButton("...", vm.ShowProfileCommand).Compact().WithAccessibleName(Se.Language.General.Profiles)
         );
         buttonPanelRules.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
 
@@ -314,6 +322,9 @@ public class FixCommonErrorsWindow : Window
                             {
                                 Focusable = false,
                                 [!ToggleButton.IsCheckedProperty] = new Binding(nameof(FixDisplayItem.IsSelected)),
+                                // Unfocusable checkbox - name it after the fix it applies so a screen
+                                // reader can tell which fix's apply state it is on (#11745).
+                                [!AutomationProperties.NameProperty] = new Binding(nameof(FixDisplayItem.ActionDisplay)),
                                 HorizontalAlignment = HorizontalAlignment.Center
                             }
                         };
@@ -370,6 +381,7 @@ public class FixCommonErrorsWindow : Window
                 },
             },
         };
+        AutomationProperties.SetName(dataGridFixes, Se.Language.Tools.FixCommonErrors.Fixes);
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
         _ = new DataGridCheckboxMultiSelect<FixDisplayItem>(dataGridFixes,
             item => item.IsSelected, (item, v) => item.IsSelected = v,
@@ -555,6 +567,7 @@ public class FixCommonErrorsWindow : Window
             },
         };
         dataGridSubtitles.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedParagraph)));
+        AutomationProperties.SetName(dataGridSubtitles, Se.Language.General.Preview);
         _vm.GridSubtitles = dataGridSubtitles;
         dataGridSubtitles.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
@@ -636,6 +649,8 @@ public class FixCommonErrorsWindow : Window
         {
             textBox.FontFamily = new FontFamily(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName);
         }
+
+        AutomationProperties.SetName(textBox, Se.Language.General.Text);
 
         textEditGrid.Add(textBox, 0, 0);
 

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -117,6 +117,7 @@ public class AutoTranslateWindow : Window
 
         var engineCombo = UiUtil.MakeComboBox(vm.AutoTranslators, vm, nameof(vm.SelectedAutoTranslator));
         engineCombo.MinWidth = 220;
+        engineCombo.WithLabeledBy(engineLabel);
         engineCombo.ItemTemplate = BuildTranslatorItemTemplate();
         engineCombo.SelectionChanged += (s, e) =>
         {
@@ -143,6 +144,7 @@ public class AutoTranslateWindow : Window
 
         var sourceCombo = UiUtil.MakeComboBox(vm.SourceLanguages!, vm, nameof(vm.SelectedSourceLanguage));
         sourceCombo.MinWidth = 180;
+        sourceCombo.WithLabeledBy(fromLabel);
 
         var swapButton = UiUtil.MakeButton(vm.SwapLanguagesCommand, IconNames.SwapVertical, Se.Language.Translate.SwapLanguages);
         swapButton.Margin = new Thickness(8, 0);
@@ -154,6 +156,7 @@ public class AutoTranslateWindow : Window
 
         var targetCombo = UiUtil.MakeComboBox(vm.TargetLanguages!, vm, nameof(vm.SelectedTargetLanguage));
         targetCombo.MinWidth = 180;
+        targetCombo.WithLabeledBy(toLabel);
 
         var controlsPanel = new StackPanel
         {
@@ -269,12 +272,14 @@ public class AutoTranslateWindow : Window
             model => model.Engine.IsModelInstalled(model.Model)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled);
+        crispAsrModelCombo.WithAccessibleName(Se.Language.General.Model);
 
         var llamaCppModelCombo = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel), nameof(vm.LlamaCppModelComboIsVisible)).WithWidth(220);
         llamaCppModelCombo.ItemTemplate = StatusDots.ComboItemTemplate<LlamaCppModelDisplay>(
             model => model.Model.DisplayName,
             GetLlamaCppModelSize,
             GetLlamaCppModelDotStatus);
+        llamaCppModelCombo.WithAccessibleName(Se.Language.General.Model);
 
         var buttonDownloadLlamaCpp = UiUtil.MakeButton(string.Empty, vm.DownloadLlamaCppCommand)
             .WithIconLeftBindText(IconNames.Download, nameof(vm.LlamaCppDownloadButtonText))
@@ -296,27 +301,27 @@ public class AutoTranslateWindow : Window
         };
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Id, vm, null, nameof(vm.ApiIdIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiIdText), nameof(vm.ApiIdIsVisible)).WithMarginRight(15));
+        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiIdText), nameof(vm.ApiIdIsVisible)).WithMarginRight(15).WithAccessibleName(Se.Language.General.Id));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.ApiSecret, vm, null, nameof(vm.ApiSecretIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiSecretText), nameof(vm.ApiSecretIsVisible)).WithMarginRight(15));
+        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiSecretText), nameof(vm.ApiSecretIsVisible)).WithMarginRight(15).WithAccessibleName(Se.Language.General.ApiSecret));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.ApiKey, vm, null, nameof(vm.ApiKeyIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiKeyText), nameof(vm.ApiKeyIsVisible)).WithMarginRight(15));
+        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiKeyText), nameof(vm.ApiKeyIsVisible)).WithMarginRight(15).WithAccessibleName(Se.Language.General.ApiKey));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Formality, vm, null, nameof(vm.FormalityIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeComboBox(vm.Formalities, vm, nameof(vm.SelectedFormality), nameof(vm.FormalityIsVisible)).WithWidth(220).WithMarginRight(15));
+        settingsPanel.Children.Add(UiUtil.MakeComboBox(vm.Formalities, vm, nameof(vm.SelectedFormality), nameof(vm.FormalityIsVisible)).WithWidth(220).WithMarginRight(15).WithAccessibleName(Se.Language.General.Formality));
 
         var checkBoxLlamaCppRemote = UiUtil.MakeCheckBox(Se.Language.General.LlamaCppUseRemoteServer, vm, nameof(vm.LlamaCppUseRemoteServer)).WithMarginRight(15);
         checkBoxLlamaCppRemote.Bind(CheckBox.IsVisibleProperty, new Binding(nameof(vm.LlamaCppRemoteToggleIsVisible)));
         settingsPanel.Children.Add(checkBoxLlamaCppRemote);
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Url, vm, null, nameof(vm.ApiUrlIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeTextBox(200, vm, nameof(vm.ApiUrlText), nameof(vm.ApiUrlIsVisible)).WithMarginRight(15));
+        settingsPanel.Children.Add(UiUtil.MakeTextBox(200, vm, nameof(vm.ApiUrlText), nameof(vm.ApiUrlIsVisible)).WithMarginRight(15).WithAccessibleName(Se.Language.General.Url));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.ModelIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ModelText), nameof(vm.ModelIsVisible)));
-        settingsPanel.Children.Add(UiUtil.MakeButtonBrowse(vm.BrowseModelCommand, nameof(vm.ModelBrowseIsVisible)).WithMarginLeft(5));
+        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ModelText), nameof(vm.ModelIsVisible)).WithAccessibleName(Se.Language.General.Model));
+        settingsPanel.Children.Add(UiUtil.MakeButtonBrowse(vm.BrowseModelCommand, nameof(vm.ModelBrowseIsVisible), Se.Language.General.Model).WithMarginLeft(5));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.CrispAsrModelComboIsVisible)).WithMarginRight(5));
         settingsPanel.Children.Add(crispAsrModelCombo);
@@ -410,6 +415,7 @@ public class AutoTranslateWindow : Window
         dataGrid.Bind(DataGrid.ItemsSourceProperty, new Binding(nameof(vm.Rows)));
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedTranslateRow)));
         UiUtil.AttachMacContextFlyoutHandler(dataGrid);
+        dataGrid.WithAccessibleName(Se.Language.General.Lines);
         vm.RowGrid = dataGrid;
 
         var dataGridBorder = UiUtil.MakeBorderForControlNoPadding(dataGrid);
@@ -429,6 +435,7 @@ public class AutoTranslateWindow : Window
         };
         progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
         progressBar.Bind(ProgressBar.IsVisibleProperty, new Binding(nameof(vm.IsProgressEnabled)));
+        progressBar.WithAccessibleName(Se.Language.General.Translation);
 
         var progressLabel = new TextBlock
         {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -49,7 +50,8 @@ public class SpeechToTextWindow : Window
         var comboEngine = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine))
             .WithMinWidth(260)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
-            .WithMarginTop(10);
+            .WithMarginTop(10)
+            .WithLabeledBy(labelEngine);
         comboEngine.ItemTemplate = MakeEngineItemTemplate();
         comboEngine.SelectionChanged += vm.OnEngineChanged;
 
@@ -64,7 +66,8 @@ public class SpeechToTextWindow : Window
             .WithMarginLeft(5)
             .WithMarginTop(10)
             .BindIsVisible(vm, nameof(vm.IsEngineDownloadButtonVisible))
-            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
+            .WithAccessibleName(Se.Language.General.Download);
         buttonEngineDownload.Bind(ToolTip.TipProperty, new Binding(nameof(vm.EngineDownloadHint))
         {
             Source = vm,
@@ -76,7 +79,8 @@ public class SpeechToTextWindow : Window
             .WithMarginLeft(5)
             .WithMarginTop(10)
             .BindIsVisible(vm, nameof(vm.IsEngineSettingsButtonVisible))
-            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
+            .WithAccessibleName(Se.Language.Video.AudioToText.BackendAndUpdateStatus);
         ToolTip.SetTip(buttonEngineSettings, Se.Language.Video.AudioToText.BackendAndUpdateStatus);
 
         var panelEngineControls = new StackPanel
@@ -99,21 +103,24 @@ public class SpeechToTextWindow : Window
             .WithMinWidth(220)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
             .WithMarginTop(10)
-            .BindIsVisible(vm, nameof(vm.IsWhisperCppSelected));
+            .BindIsVisible(vm, nameof(vm.IsWhisperCppSelected))
+            .WithLabeledBy(labelBackend);
         var comboCrispAsrBackend = UiUtil.MakeComboBox(vm.CrispAsrBackends, vm, nameof(vm.SelectedCrispAsrBackend))
             .WithMinWidth(220)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
             .WithMarginTop(10)
-            .BindIsVisible(vm, nameof(vm.IsCrispAsrSelected));
+            .BindIsVisible(vm, nameof(vm.IsCrispAsrSelected))
+            .WithLabeledBy(labelBackend);
 
         var labelForcedAligner = UiUtil.MakeTextBlock("Forced aligner").WithMarginTop(10)
             .BindIsVisible(vm, nameof(vm.IsForcedAlignerVisible));
         var comboForcedAligner = UiUtil.MakeComboBox(vm.ForcedAligners, vm, nameof(vm.SelectedForcedAligner))
             .WithMinWidth(220)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
-            .WithMarginTop(10);
+            .WithMarginTop(10)
+            .WithLabeledBy(labelForcedAligner);
         comboForcedAligner.ItemTemplate = MakeForcedAlignerItemTemplate();
-        var buttonForcedAlignerDownload = UiUtil.MakeButtonBrowse(vm.DownloadForcedAlignerCommand)
+        var buttonForcedAlignerDownload = UiUtil.MakeButtonBrowse(vm.DownloadForcedAlignerCommand, accessibleName: Se.Language.General.Download)
             .WithMarginTop(10)
             .WithMarginLeft(5)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
@@ -135,7 +142,8 @@ public class SpeechToTextWindow : Window
             .WithMinWidth(220)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
             .WithMarginTop(10)
-            .BindIsVisible(vm, nameof(vm.IsLanguageSelectionVisible));
+            .BindIsVisible(vm, nameof(vm.IsLanguageSelectionVisible))
+            .WithLabeledBy(labelLanguage);
 
         var labelModel = UiUtil.MakeTextBlock(Se.Language.General.Model).WithMarginTop(10)
             .BindIsVisible(vm, nameof(vm.IsModelSelectionVisible));
@@ -143,10 +151,11 @@ public class SpeechToTextWindow : Window
             .WithMinWidth(220)
             .WithMarginTop(10)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
-            .BindIsVisible(vm, nameof(vm.IsModelSelectionVisible));
+            .BindIsVisible(vm, nameof(vm.IsModelSelectionVisible))
+            .WithLabeledBy(labelModel);
         comboModel.ItemTemplate = MakeModelItemTemplate();
 
-        var buttonModelDownload = UiUtil.MakeButtonBrowse(vm.DownloadModelCommand)
+        var buttonModelDownload = UiUtil.MakeButtonBrowse(vm.DownloadModelCommand, accessibleName: Se.Language.General.Download)
             .WithMarginTop(10)
             .WithMarginLeft(5)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
@@ -170,12 +179,15 @@ public class SpeechToTextWindow : Window
         var checkTranslateToEnglish = UiUtil.MakeCheckBox(vm, nameof(vm.DoTranslateToEnglish))
             .WithMarginTop(20)
             .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
-            .BindIsVisible(vm, nameof(vm.IsTranslateVisible));
+            .BindIsVisible(vm, nameof(vm.IsTranslateVisible))
+            .WithLabeledBy(labelTranslateToEnglish);
 
         var labelPostProcessing = UiUtil.MakeTextBlock(Se.Language.General.PostProcessing).WithMarginTop(15);
-        var checkPostProcessing = UiUtil.MakeCheckBox(vm, nameof(vm.DoPostProcessing)).BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
+        var checkPostProcessing = UiUtil.MakeCheckBox(vm, nameof(vm.DoPostProcessing)).BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
+            .WithLabeledBy(labelPostProcessing);
         var buttonPostProcessing = UiUtil.MakeButton(vm.ShowPostProcessingSettingsCommand, IconNames.Settings)
-                    .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
+                    .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
+                    .WithAccessibleName(Se.Language.General.PostProcessing);
 
         var panelPostProcessingControls = new StackPanel
         {
@@ -198,7 +210,8 @@ public class SpeechToTextWindow : Window
         var buttonAdvancedSettings = UiUtil.MakeButton(vm.ShowAdvancedSettingsCommand, IconNames.Settings)
                     .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled))
                     .WithMarginTop(15)
-                    .BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible));
+                    .BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible))
+                    .WithAccessibleName(Se.Language.General.AdvancedSettings);
 
         var textBoxAdvancedSettings = new TextBox()
         {
@@ -210,7 +223,8 @@ public class SpeechToTextWindow : Window
             Opacity = 0.6,
             BorderThickness = new Thickness(0),
             MaxWidth = 320,
-        }.BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible));
+        }.BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible))
+            .WithLabeledBy(labelAdvancedSettings);
         textBoxAdvancedSettings.Bind(TextBox.TextProperty, new Binding
         {
             Path = nameof(vm.Parameters),
@@ -220,6 +234,7 @@ public class SpeechToTextWindow : Window
         });
 
         var progressBar = UiUtil.MakeProgressBar();
+        AutomationProperties.SetName(progressBar, Se.Language.Video.AudioToText.Transcribe);
         progressBar.Margin = new Thickness(10, 0, 10, 8);
         progressBar.Width = double.NaN;
         progressBar.VerticalAlignment = VerticalAlignment.Center;
@@ -430,6 +445,9 @@ public class SpeechToTextWindow : Window
 
         foreach (var (label, control) in openAiRows)
         {
+            // Link each OpenAI-compatible input to its visible label so a screen reader announces the
+            // label as the control's name instead of a bare "edit"/"combo box" (#11745).
+            AutomationProperties.SetLabeledBy(control, label);
             grid.Add(label, row, 0);
             grid.Add(control, row, 1);
             row++;
@@ -472,6 +490,7 @@ public class SpeechToTextWindow : Window
             IsReadOnly = true,
             Margin = new Thickness(0, 0, 0, 10),
         };
+        AutomationProperties.SetName(textBoxConsoleLog, Se.Language.General.ConsoleLog);
         textBoxConsoleLog.Bind(TextBox.TextProperty, new Binding
         {
             Path = nameof(vm.ConsoleLog),
@@ -520,6 +539,7 @@ public class SpeechToTextWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchItem)) { Source = vm });
+        AutomationProperties.SetName(dataGrid, Se.Language.General.BatchMode);
         vm.BatchGrid = dataGrid;
 
         var buttonAdd = UiUtil.MakeButton(Se.Language.General.AddDotDotDot, vm.AddCommand).BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
@@ -602,6 +622,7 @@ public class SpeechToTextWindow : Window
             IsReadOnly = true,
             Margin = new Thickness(10),
         };
+        AutomationProperties.SetName(textBoxConsoleLog, Se.Language.General.ConsoleLog);
         textBoxConsoleLog.Bind(TextBox.TextProperty, new Binding
         {
             Path = nameof(vm.ConsoleLog),

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -406,6 +406,11 @@ public static class UiUtil
 
         Attached.SetIcon(button, iconName);
 
+        // An icon-only button has no text content, so expose the hint as the accessible name for
+        // screen readers (a ToolTip is not surfaced as the UIA Name). Done unconditionally - unlike the
+        // visual tooltip, the name should be available even when hints are turned off (#11745).
+        AutomationProperties.SetName(button, hint);
+
         if (Se.Settings.Appearance.ShowHints)
         {
             AttachHoverTooltip(button, hint);
@@ -452,7 +457,7 @@ public static class UiUtil
     }
 
 
-    public static Button MakeButtonBrowse(IRelayCommand? command, string? propertyIsVisiblePath = null)
+    public static Button MakeButtonBrowse(IRelayCommand? command, string? propertyIsVisiblePath = null, string? accessibleName = null)
     {
         var button = new Button
         {
@@ -472,6 +477,13 @@ public static class UiUtil
         }
 
         Attached.SetIcon(button, IconNames.DotsHorizontal);
+
+        // The browse "…" glyph carries no text, so screen readers announce a nameless button. Callers
+        // that can describe the target should pass an accessible name so NVDA can announce it (#11745).
+        if (!string.IsNullOrEmpty(accessibleName))
+        {
+            AutomationProperties.SetName(button, accessibleName);
+        }
 
         return button;
     }
@@ -1577,6 +1589,27 @@ public static class UiUtil
     public static TextBlock WithMinwidth(this TextBlock control, int width)
     {
         control.MinWidth = width;
+        return control;
+    }
+
+    /// <summary>
+    /// Sets an accessible name (UIA Name) so a screen reader announces this control instead of a bare
+    /// "edit"/"combo box"/"button". Use when there is no separate visible label to point at (#11745).
+    /// </summary>
+    public static T WithAccessibleName<T>(this T control, string name) where T : Control
+    {
+        AutomationProperties.SetName(control, name);
+        return control;
+    }
+
+    /// <summary>
+    /// Links this control to an existing visible label so a screen reader announces the label as the
+    /// control's name (UIA LabeledBy). Prefer this over a hard-coded name when a label already exists,
+    /// as it stays correct for bound/localized label text (#11745).
+    /// </summary>
+    public static T WithLabeledBy<T>(this T control, Control label) where T : Control
+    {
+        AutomationProperties.SetLabeledBy(control, label);
         return control;
     }
 


### PR DESCRIPTION
Follow-up screen-reader (UIA/NVDA) pass, extending the earlier main-menu / focus-trap / Settings work (#12052) to more of the app.

## Systemic `UiUtil` helpers (highest leverage — app-wide)
- `MakeButton(command, icon, hint)` now exposes the **hint as the accessible name** unconditionally — a ToolTip is *not* surfaced as the UIA Name, so every icon-only button built through the hint overload is named across the whole app for free.
- `MakeButtonBrowse` gains an optional `accessibleName` so the "…" browse button can be announced.
- New fluent `.WithAccessibleName(name)` / `.WithLabeledBy(label)` extensions.

## Main window — status bar
The three status-bar icon buttons (layer filter, SMPTE timing, offset time codes) now expose UIA names; their tooltips were on the inner `Icon`, invisible to a screen reader.

## Auto-Translate / Fix Common Errors / Speech-to-Text
Named the primary interactive controls (engine/language/model combos, text boxes, data grids, progress bars) via `LabeledBy` to the existing visible label, or an accessible name reusing the label's localized string.

Highlight — **Fix Common Errors**: the two unfocusable checkbox columns (rule *Enabled* / fix *Apply*) now carry per-row names bound to the rule/fix name, so a screen reader can tell which enabled/apply state each row represents (the audit's top issue). `Focusable=false` and the toggle behavior are untouched.

## Limitation
Avalonia 12 exposes no `AutomationLiveSetting` API, so **automatic announcement of Speech-to-Text progress** during a long run isn't achievable; the progress texts remain readable on demand.

## Verification
- Full build: 0 errors.
- Existing headless accessibility tests: 8/8 pass.
- Names only — no layout, behavior, binding, or visible-text changes.

⚠️ These are screen-reader behaviors that can't be exercised headlessly — worth a manual NVDA pass on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)