### PR TITLE
TimeCodeUpDown: handle clipboard paste and copy (#12056)

### DIFF
--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -11,6 +12,8 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Globalization;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Controls
 {
@@ -80,6 +83,7 @@ namespace Nikse.SubtitleEdit.Controls
                 _textBox.RemoveHandler(TextInputEvent, OnTextInput);
                 _textBox.RemoveHandler(KeyDownEvent, OnTextBoxKeyDown);
                 _textBox.GotFocus -= OnTextBoxGotFocus;
+                _textBox.PastingFromClipboard -= OnPastingFromClipboard;
             }
 
             _textBox = e.NameScope.Find<TextBox>("PART_TextBox");
@@ -104,6 +108,7 @@ namespace Nikse.SubtitleEdit.Controls
                 _textBox.AddHandler(TextInputEvent, OnTextInput, RoutingStrategies.Tunnel);
                 _textBox.AddHandler(KeyDownEvent, OnTextBoxKeyDown, RoutingStrategies.Tunnel);
                 _textBox.GotFocus += OnTextBoxGotFocus;
+                _textBox.PastingFromClipboard += OnPastingFromClipboard;
             }
 
             // Initial MinWidth calculation with text measurement
@@ -293,6 +298,102 @@ namespace Nikse.SubtitleEdit.Controls
             e.Handled = true;
         }
 
+        // The text box is masked and edits character-by-character via OnTextInput, but paste bypasses
+        // that path, so without this the pasted text would corrupt the mask and leave Value out of sync.
+        // We take over paste entirely: parse the clipboard as a time code (or a bare number of
+        // milliseconds) and replace the whole value.
+        private async void OnPastingFromClipboard(object? sender, RoutedEventArgs e)
+        {
+            e.Handled = true; // suppress the default paste (must be set before the first await)
+
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard == null)
+            {
+                return;
+            }
+
+            var text = await ClipboardExtensions.TryGetTextAsync(clipboard);
+            if (TryParsePastedValue(text, out var value))
+            {
+                SetValue(ValueProperty, value); // OnPropertyChanged clamps, reformats the text and raises ValueChanged
+                if (_textBox != null)
+                {
+                    _textBox.CaretIndex = 0;
+                }
+            }
+        }
+
+        // Symmetric with paste: with no selection, copy grabs the whole time code (as shown, so it
+        // round-trips back through paste). Handled from the key gesture rather than the
+        // CopyingToClipboard event, because the text box's built-in copy does nothing when there is no
+        // selection, so that event never fires in this case. An explicit selection copies natively.
+        private bool TryHandleCopyWholeValue(KeyEventArgs e)
+        {
+            if (_textBox == null || _textBox.SelectionStart != _textBox.SelectionEnd)
+            {
+                return false; // let the text box copy an explicit selection itself
+            }
+
+            // Copy is Cmd+C on macOS, Ctrl+C elsewhere.
+            var commandModifier = OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
+            if (e.Key != Key.C || e.KeyModifiers != commandModifier)
+            {
+                return false;
+            }
+
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard != null)
+            {
+                _ = clipboard.SetTextAsync(_textBuffer);
+            }
+
+            return true;
+        }
+
+        // A bare number is taken as milliseconds and replaces the whole time code (e.g. "231" ->
+        // 00:00:00,231), which is the common paste intent (#12056). Anything with separators is parsed
+        // as a full or partial time code ("00:00:05,500", "01:02,300"; frames when in frame mode).
+        private bool TryParsePastedValue(string? clipboardText, out TimeSpan value)
+        {
+            value = TimeSpan.Zero;
+            if (string.IsNullOrWhiteSpace(clipboardText))
+            {
+                return false;
+            }
+
+            var text = clipboardText.Trim();
+            var newlineIndex = text.IndexOfAny(new[] { '\r', '\n' });
+            if (newlineIndex >= 0)
+            {
+                text = text.Substring(0, newlineIndex).Trim();
+            }
+
+            if (text.Length == 0)
+            {
+                return false;
+            }
+
+            if (long.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out var milliseconds))
+            {
+                value = RemoveVideoOffset(TimeSpan.FromMilliseconds(milliseconds));
+                return true;
+            }
+
+            var useFrameMode = Se.Settings.General.UseFrameMode;
+            var parts = text.Split(TimeCode.TimeSplitChars, StringSplitOptions.RemoveEmptyEntries);
+            var validCount = useFrameMode ? parts.Length == 4 : parts.Length is 3 or 4;
+            if (!validCount || !parts.All(p => int.TryParse(p, out _)))
+            {
+                return false; // ParseXxx returns 0 for junk, so reject anything that isn't clearly a time code
+            }
+
+            var ms = useFrameMode
+                ? TimeCode.ParseHHMMSSFFToMilliseconds(text)
+                : TimeCode.ParseToMilliseconds(text);
+            value = RemoveVideoOffset(TimeSpan.FromMilliseconds(ms));
+            return true;
+        }
+
         private TimeSpan ParseTime(string text)
         {
             // Try parsing with milliseconds format (00:00:00:000 or 00:00:00.000)
@@ -342,6 +443,12 @@ namespace Nikse.SubtitleEdit.Controls
         {
             if (_textBox == null)
             {
+                return;
+            }
+
+            if (TryHandleCopyWholeValue(e))
+            {
+                e.Handled = true;
                 return;
             }
 

--- a/tests/UI/Controls/TimeCodeUpDownPasteTests.cs
+++ b/tests/UI/Controls/TimeCodeUpDownPasteTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Reflection;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Controls;
+
+namespace UITests.Controls;
+
+// Covers the paste parsing added for #12056: a bare number is milliseconds and replaces the
+// whole time code; separator forms parse as (partial) time codes.
+public class TimeCodeUpDownPasteTests
+{
+    private static readonly MethodInfo TryParse =
+        typeof(TimeCodeUpDown).GetMethod("TryParsePastedValue", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static (bool ok, TimeSpan value) Parse(string? input)
+    {
+        var control = new TimeCodeUpDown();
+        var args = new object?[] { input, null };
+        var ok = (bool)TryParse.Invoke(control, args)!;
+        return (ok, ok ? (TimeSpan)args[1]! : TimeSpan.Zero);
+    }
+
+    [AvaloniaTheory]
+    [InlineData("231", 231)]
+    [InlineData("5500", 5500)]
+    [InlineData(" 231 ", 231)]
+    [InlineData("231\r\n", 231)]
+    [InlineData("00:00:05,500", 5500)]
+    [InlineData("00:00:05.500", 5500)]
+    [InlineData("00:00:05:500", 5500)]
+    [InlineData("01:02,300", 62300)]      // mm:ss,fff
+    [InlineData("01:00:00,000", 3600000)]
+    public void ParsesAcceptedInput(string input, int expectedMs)
+    {
+        var (ok, value) = Parse(input);
+        Assert.True(ok, $"expected '{input}' to parse");
+        Assert.Equal(expectedMs, (int)value.TotalMilliseconds);
+    }
+
+    [AvaloniaTheory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("-5")]           // negative not a valid time code
+    [InlineData("5:5")]          // too few parts to be a time code
+    [InlineData(null)]
+    public void RejectsInvalidInput(string? input)
+    {
+        var (ok, _) = Parse(input);
+        Assert.False(ok, $"expected '{input}' to be rejected");
+    }
+}


### PR DESCRIPTION
## What
Adds clipboard support to the `TimeCodeUpDown` control.

- **Paste** (Ctrl+V / Cmd+V / context menu): parses the clipboard and replaces the whole value.
  - A bare number is milliseconds: `231` → `00:00:00,231`, `5500` → `00:00:05,500`.
  - A separator form is parsed as a full/partial time code: `00:00:05,500`, `00:00:05.500`, `00:00:05:500`, `01:02,300` (mm:ss,fff); frames when in frame mode.
  - Unparseable input is ignored (never silently zeroes the field).
- **Copy** (Ctrl+C / Cmd+C) with no selection: copies the whole time code as shown, so it round-trips through paste. An explicit selection still copies natively.

## Why
The control is a masked editor that edits digit-by-digit via `OnTextInput`. Paste bypasses that path, so a paste corrupted the mask and left `Value` out of sync (reported in #12056). There was also no way to copy the whole value without selecting all text first.

## How
- Paste is intercepted via the `PastingFromClipboard` event; value goes through the normal `SetValue` path so it clamps, reformats, and raises `ValueChanged`.
- Copy is handled from the key gesture (in the existing tunnel key handler) rather than `CopyingToClipboard`, because the text box's built-in copy does nothing without a selection, so that event never fires in the no-selection case.
- Reuses `TimeCode.ParseToMilliseconds` / `ParseHHMMSSFFToMilliseconds`.

## Tests
`tests/UI/Controls/TimeCodeUpDownPasteTests.cs` — 15 cases covering accepted/rejected paste input (bare ms, time codes, partial, whitespace/newline trimming, junk, negatives).

Fixes #12056

🤖 Generated with [Claude Code](https://claude.com/claude-code)