### PR TITLE
OCR: select downloaded spell-check dictionary on any UI language

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -482,15 +482,22 @@ public partial class OcrViewModel : ObservableObject
         if (result.OkPressed && result.SelectedDictionary != null)
         {
             LoadDictionaries();
-            SelectedDictionary = Dictionaries
-                .FirstOrDefault(d =>
-                    d.Name.Contains(result.SelectedDictionary.EnglishName, StringComparison.OrdinalIgnoreCase) ||
-                    d.Name.Contains(result.SelectedDictionary.NativeName, StringComparison.OrdinalIgnoreCase));
 
-            if (SelectedDictionary == null)
-            {
-                SelectedDictionary = Dictionaries.FirstOrDefault();
-            }
+            // Select the just-downloaded dictionary by its file name. Matching on the display name
+            // fails on non-English UIs, because the list shows the localized culture name (e.g.
+            // "slovensk") while the catalog entry carries the English/native name ("Slovenian").
+            var downloadedFileName = Path.GetFileName(result.DictionaryFileName ?? string.Empty);
+            SelectedDictionary =
+                (!string.IsNullOrEmpty(downloadedFileName)
+                    ? Dictionaries.FirstOrDefault(d => string.Equals(
+                        Path.GetFileName(d.DictionaryFileName),
+                        downloadedFileName,
+                        StringComparison.OrdinalIgnoreCase))
+                    : null)
+                ?? Dictionaries.FirstOrDefault(d =>
+                    d.Name.Contains(result.SelectedDictionary.EnglishName, StringComparison.OrdinalIgnoreCase) ||
+                    d.Name.Contains(result.SelectedDictionary.NativeName, StringComparison.OrdinalIgnoreCase))
+                ?? Dictionaries.FirstOrDefault();
         }
     }
 


### PR DESCRIPTION
## What
After downloading a spell-check dictionary from the OCR window, the just-downloaded entry is now selected in the dictionary combobox regardless of the UI language.

## Why
The post-download selection matched the list's **localized** display name (e.g. `slovensk (Slovenien) [sl_SI]`) against the catalog entry's **English/native** name (`Slovenian` / `Slovenščina`). On any non-English UI that match failed, so the combobox fell back to "None" and the freshly downloaded dictionary looked like it wasn't installed.

## How
Match by the downloaded `.dic` file name (locale-independent), which the download dialog already exposes via `DictionaryFileName`. The previous name match and first-entry selection remain as fallbacks.

`src/ui/Features/Ocr/OcrViewModel.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)