### PR TITLE
Batch convert: fix llama.cpp auto-start never running

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1098,8 +1098,11 @@ public partial class BatchConvertViewModel : ObservableObject
             return true;
         }
 
-        // Remote mode: the user pointed llama.cpp at their own running llama-server.
-        if (!string.IsNullOrWhiteSpace(AutoTranslateUrl))
+        // Remote mode: the user pointed llama.cpp at their own running llama-server. Detect it the same
+        // way the interactive Auto-translate window does - via the LlamaCppUseRemoteServer flag - not by
+        // whether AutoTranslateUrl is set, since that is pre-filled with the default localhost URL and so
+        // is never empty (which previously short-circuited the whole auto-start path).
+        if (Se.Settings.AutoTranslate.LlamaCppUseRemoteServer)
         {
             return true;
         }


### PR DESCRIPTION
## What
Makes the llama.cpp local-mode auto-detect / auto-download / auto-start actually run in Batch Convert.

## Why
`EnsureLlamaCppAvailable` returned early ("remote mode") whenever `AutoTranslateUrl` was non-empty. But selecting the llama.cpp engine pre-fills `AutoTranslateUrl` with the default `http://localhost:8080/v1/chat/completions` (`SeAutoTranslate.cs`), so it is **never empty** — the entire auto-start feature was dead code. With no server running, batch translation just POSTed to localhost and failed.

## How
Gate on `Se.Settings.AutoTranslate.LlamaCppUseRemoteServer` — the same boolean the interactive Auto-translate window uses to tell remote from local mode — instead of URL presence.

`src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)