### PR TITLE
TimeCodeUpDown: prevent crash when pasting an out-of-range value

### DIFF
--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -375,6 +375,11 @@ namespace Nikse.SubtitleEdit.Controls
 
             if (long.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out var milliseconds))
             {
+                if (milliseconds > TimeCode.MaxTimeTotalMilliseconds)
+                {
+                    return false; // beyond the control's range (max 99:59:59,999) - reject rather than overflow
+                }
+
                 value = RemoveVideoOffset(TimeSpan.FromMilliseconds(milliseconds));
                 return true;
             }
@@ -387,9 +392,23 @@ namespace Nikse.SubtitleEdit.Controls
                 return false; // ParseXxx returns 0 for junk, so reject anything that isn't clearly a time code
             }
 
-            var ms = useFrameMode
-                ? TimeCode.ParseHHMMSSFFToMilliseconds(text)
-                : TimeCode.ParseToMilliseconds(text);
+            double ms;
+            try
+            {
+                ms = useFrameMode
+                    ? TimeCode.ParseHHMMSSFFToMilliseconds(text)
+                    : TimeCode.ParseToMilliseconds(text);
+            }
+            catch (Exception exception) when (exception is OverflowException or ArgumentOutOfRangeException)
+            {
+                return false; // int-parseable but out-of-range parts (e.g. "999999999:0:0,0") overflow the TimeSpan ctor
+            }
+
+            if (ms > TimeCode.MaxTimeTotalMilliseconds)
+            {
+                return false;
+            }
+
             value = RemoveVideoOffset(TimeSpan.FromMilliseconds(ms));
             return true;
         }

--- a/tests/UI/Controls/TimeCodeUpDownPasteTests.cs
+++ b/tests/UI/Controls/TimeCodeUpDownPasteTests.cs
@@ -30,6 +30,7 @@ public class TimeCodeUpDownPasteTests
     [InlineData("00:00:05:500", 5500)]
     [InlineData("01:02,300", 62300)]      // mm:ss,fff
     [InlineData("01:00:00,000", 3600000)]
+    [InlineData("359999999", 359999999)]  // max in-range milliseconds (99:59:59,999)
     public void ParsesAcceptedInput(string input, int expectedMs)
     {
         var (ok, value) = Parse(input);
@@ -43,6 +44,9 @@ public class TimeCodeUpDownPasteTests
     [InlineData("abc")]
     [InlineData("-5")]           // negative not a valid time code
     [InlineData("5:5")]          // too few parts to be a time code
+    [InlineData("360000000")]    // one ms past the max range
+    [InlineData("99999999999999999")] // huge bare number: would overflow TimeSpan.FromMilliseconds
+    [InlineData("999999999:0:0,0")]   // int-parseable but overflows the TimeSpan ctor
     [InlineData(null)]
     public void RejectsInvalidInput(string? input)
     {


### PR DESCRIPTION
## What
Fixes an app crash when pasting a pathological value into a time-code field.

## Why
`TryParsePastedValue` fed unbounded clipboard input straight into `TimeSpan`/`TimeCode` construction:
- a bare number like `99999999999999999` (valid `long`) overflows `TimeSpan.FromMilliseconds`;
- a separator form like `999999999:0:0,0` (int-parseable parts) overflows the `TimeSpan` constructor inside `ParseToMilliseconds`.

Since the parse runs from the `async void` `PastingFromClipboard` handler with no try/catch, the exception was unobserved and terminated the process. (Follow-up to #12057; the original tests only covered small values.)

## How
- Reject bare milliseconds beyond the control's range (max `99:59:59,999` = `TimeCode.MaxTimeTotalMilliseconds`).
- Guard the time-code parse with a try/catch for `OverflowException`/`ArgumentOutOfRangeException`, returning `false` (paste ignored).
- Reject computed results past the max.

## Tests
Added regression cases to `TimeCodeUpDownPasteTests` for the overflow inputs and the max in-range value (19 cases, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)