### PR TITLE
SpellCheck: clean up dictionary names with variant suffixes

### DIFF
--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -46,30 +46,65 @@ public class SpellChecker : ISpellChecker, IDoSpell
 
         foreach (var dic in Directory.GetFiles(dictionaryFolder, "*.dic"))
         {
-            var name = Path.GetFileNameWithoutExtension(dic);
-            if (!name.StartsWith("hyph", StringComparison.Ordinal))
+            var fileName = Path.GetFileNameWithoutExtension(dic);
+            if (fileName.StartsWith("hyph", StringComparison.Ordinal))
             {
-                try
-                {
-                    var ci = CultureInfo.GetCultureInfo(name.Replace('_', '-'));
-                    name = ci.DisplayName + " [" + name + "]";
-                }
-                catch (Exception exception)
-                {
-                    System.Diagnostics.Debug.WriteLine(exception.Message);
-                    name = "[" + name + "]";
-                }
-
-                var item = new SpellCheckDictionaryDisplay
-                {
-                    DictionaryFileName = dic,
-                    Name = name,
-                };
-                list.Add(item);
+                continue;
             }
+
+            var name = TryGetDictionaryCulture(fileName, out var ci)
+                ? ci.DisplayName + " [" + fileName + "]"
+                : "[" + fileName + "]";
+
+            list.Add(new SpellCheckDictionaryDisplay
+            {
+                DictionaryFileName = dic,
+                Name = name,
+            });
         }
 
         return list;
+    }
+
+    // Resolves a dictionary file name (e.g. "sl_SI", "de_DE_frami", "be-official") to a culture for
+    // display. Dictionary file names sometimes carry a trailing variant segment ("frami", "official")
+    // that CultureInfo would otherwise surface as an ugly upper-case variant like "German (Germany,
+    // FRAMI)". Keep the language, an optional 4-letter script (e.g. sr-Latn) and an optional 2-letter /
+    // 3-digit region, and drop everything from the first variant segment on.
+    private static bool TryGetDictionaryCulture(string fileName, out CultureInfo culture)
+    {
+        var segments = fileName.Replace('_', '-').Split('-', StringSplitOptions.RemoveEmptyEntries);
+        var kept = new List<string>();
+        foreach (var segment in segments)
+        {
+            if (kept.Count == 0)
+            {
+                kept.Add(segment); // language subtag
+                continue;
+            }
+
+            var isScript = segment.Length == 4 && segment.All(char.IsLetter);
+            var isRegion = (segment.Length == 2 && segment.All(char.IsLetter)) ||
+                           (segment.Length == 3 && segment.All(char.IsDigit));
+            if (!isScript && !isRegion)
+            {
+                break; // first variant / unrecognized segment ends the useful part
+            }
+
+            kept.Add(segment);
+        }
+
+        try
+        {
+            culture = CultureInfo.GetCultureInfo(string.Join('-', kept));
+            return true;
+        }
+        catch (Exception exception)
+        {
+            System.Diagnostics.Debug.WriteLine(exception.Message);
+            culture = CultureInfo.InvariantCulture;
+            return false;
+        }
     }
 
     public bool Initialize(string dictionaryFile, string twoLetterLanguageCode)

--- a/tests/libuilogic/SpellCheck/GetDictionaryLanguagesTests.cs
+++ b/tests/libuilogic/SpellCheck/GetDictionaryLanguagesTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Linq;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+
+namespace LibUiLogicTests.SpellCheck;
+
+public class GetDictionaryLanguagesTests
+{
+    private static string CreateFolderWith(params string[] baseNames)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "se_dicts_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        foreach (var name in baseNames)
+        {
+            File.WriteAllText(Path.Combine(dir, name + ".dic"), "1\nword\n");
+            File.WriteAllText(Path.Combine(dir, name + ".aff"), "SET UTF-8\n");
+        }
+
+        return dir;
+    }
+
+    [Fact]
+    public void VariantSuffixes_AreStripped_ButFileStillIdentified()
+    {
+        var dir = CreateFolderWith("de_DE_frami", "de_AT_frami", "de_CH_frami", "be-official", "sl_SI", "en_US");
+        try
+        {
+            var list = new SpellChecker().GetDictionaryLanguages(dir);
+
+            // No ugly upper-case variant tokens leak into the display name.
+            Assert.DoesNotContain(list, d => d.Name.Contains("FRAMI"));
+            Assert.DoesNotContain(list, d => d.Name.Contains("OFFICIAL"));
+
+            // The original file name is still shown in brackets so the file is identifiable.
+            Assert.Contains(list, d => d.Name.Contains("[de_DE_frami]"));
+            Assert.Contains(list, d => d.Name.Contains("[be-official]"));
+
+            // Every entry resolved to a real language name, not the "[name]" fallback.
+            Assert.All(list, d => Assert.False(d.Name.StartsWith("[", StringComparison.Ordinal)));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void Script_IsPreserved()
+    {
+        var dir = CreateFolderWith("sr-Latn");
+        try
+        {
+            var list = new SpellChecker().GetDictionaryLanguages(dir);
+            var entry = Assert.Single(list);
+            // Resolves (no "[name]" fallback) and keeps the script tag rather than dropping it.
+            Assert.False(entry.Name.StartsWith("[", StringComparison.Ordinal));
+            Assert.Contains("[sr-Latn]", entry.Name);
+            // ICU renders the kept script as a qualifier in parentheses (locale-independent structure);
+            // had "Latn" been stripped, plain "sr" would have no qualifier.
+            Assert.Contains("(", entry.Name);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}


### PR DESCRIPTION
## What
Cleans up the displayed language name for spell-check dictionaries whose file name carries a variant suffix.

Before → after (in the language list):
- `de_DE_frami` → ~~German (Germany, FRAMI)~~ → **German (Germany)** `[de_DE_frami]`
- `de_AT_frami`, `de_CH_frami` → likewise
- `be-official` → ~~Belarusian (OFFICIAL)~~ → **Belarusian** `[be-official]`

## Why
`GetDictionaryLanguages` passed the raw file name to `CultureInfo.GetCultureInfo`, so a trailing variant segment (`frami`, `official`) surfaced as an ugly upper-case culture variant. The language was still detected correctly — it just read oddly.

## How
Before the culture lookup, keep the language subtag, an optional 4-letter script (so `sr-Latn` stays "Serbian (Latin)") and an optional 2-letter / 3-digit region, and drop everything from the first variant segment on. The original file name is still shown in brackets so the file stays identifiable.

Checked the whole `HunspellDictionaries.json` catalog: all entries already resolve to a known language; these 4 were the only ones with an ugly variant label.

## Tests
`tests/libuilogic/SpellCheck/GetDictionaryLanguagesTests.cs` — verifies the variant suffixes are stripped, the file stays identifiable, and script tags (`sr-Latn`) are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)