### PR TITLE
Adjust all times: make shortcuts work and use frame-based steps

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2182,7 +2182,7 @@
     "pointSyncViaOther": "Point sync via other subtitle",
     "adjustmentX": "Adjustment: {0}",
     "totalAdjustmentX": "Total adjustment: {0}",
-    "adjustAllShortcuts": "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 10 ms\r\n• Ctrl + Left/Right: Move 100 ms\r\n• Alt + Left/Right: Move 500 ms",
+    "adjustAllShortcuts": "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 1 frame\r\n• Ctrl + Left/Right: Move 10 frames\r\n• Alt + Left/Right: Move 1 second",
     "offsetInSeconds": "Offset in seconds",
     "speedFactor": "Speed factor"
   },

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
@@ -190,33 +190,50 @@ public partial class AdjustAllTimesViewModel : ObservableObject
         }
         else if ((e.Key == Key.Right || e.Key == Key.FnRightArrow) && e.KeyModifiers == KeyModifiers.Shift)
         {
-            ShowLaterTimeSpan(TimeSpan.FromMilliseconds(10));
+            e.Handled = true;
+            ShowLaterTimeSpan(GetFrameDuration(1));
         }
         else if ((e.Key == Key.Right || e.Key == Key.FnRightArrow) && e.KeyModifiers == KeyModifiers.Control)
         {
-            ShowLaterTimeSpan(TimeSpan.FromMilliseconds(100));
+            e.Handled = true;
+            ShowLaterTimeSpan(GetFrameDuration(10));
         }
         else if ((e.Key == Key.Right || e.Key == Key.FnRightArrow) && e.KeyModifiers == KeyModifiers.Alt)
         {
-            ShowLaterTimeSpan(TimeSpan.FromMilliseconds(500));
+            e.Handled = true;
+            ShowLaterTimeSpan(TimeSpan.FromSeconds(1));
         }
         else if ((e.Key == Key.Left || e.Key == Key.FnLeftArrow) && e.KeyModifiers == KeyModifiers.Shift)
         {
-            ShowEarlierTimeSpan(TimeSpan.FromMilliseconds(10));
+            e.Handled = true;
+            ShowEarlierTimeSpan(GetFrameDuration(1));
         }
         else if ((e.Key == Key.Left || e.Key == Key.FnLeftArrow) && e.KeyModifiers == KeyModifiers.Control)
         {
-            ShowEarlierTimeSpan(TimeSpan.FromMilliseconds(100));
+            e.Handled = true;
+            ShowEarlierTimeSpan(GetFrameDuration(10));
         }
         else if ((e.Key == Key.Left || e.Key == Key.FnLeftArrow) && e.KeyModifiers == KeyModifiers.Alt)
         {
-            ShowEarlierTimeSpan(TimeSpan.FromMilliseconds(500));
+            e.Handled = true;
+            ShowEarlierTimeSpan(TimeSpan.FromSeconds(1));
         }
         else if (UiUtil.IsHelp(e))
         {
             e.Handled = true;
             UiUtil.ShowHelp("features/adjust-all-times");
         }
+    }
+
+    private static TimeSpan GetFrameDuration(int frames)
+    {
+        var frameRate = Se.Settings.General.CurrentFrameRate;
+        if (frameRate < 10 || frameRate > 500)
+        {
+            frameRate = 25.0;
+        }
+
+        return TimeSpan.FromMilliseconds(Math.Round(frames * 1000.0 / frameRate, MidpointRounding.AwayFromZero));
     }
 
     internal void OnClosing(WindowClosingEventArgs e)

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Logic;
@@ -109,7 +110,7 @@ public class AdjustAllTimesWindow : Window
             buttonOk.Focus(); // hack to make OnKeyDown work
             UiUtil.RestoreWindowPosition(this);
         };
-        KeyDown += (_, e) => vm.OnKeyDown(e);
+        AddHandler(KeyDownEvent, (_, e) => vm.OnKeyDown(e), RoutingStrategies.Tunnel);
         Closing += (_, e) => vm.OnClosing(e);
     }
 }

--- a/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
+++ b/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
@@ -65,7 +65,7 @@ public class LanguageSync
         PointSyncViaOther = "Point sync via other subtitle";
         AdjustmentX = "Adjustment: {0}";
         TotalAdjustmentX = "Total adjustment: {0}";
-        AdjustAllShortcuts = "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 10 ms\r\n• Ctrl + Left/Right: Move 100 ms\r\n• Alt + Left/Right: Move 500 ms";
+        AdjustAllShortcuts = "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 1 frame\r\n• Ctrl + Left/Right: Move 10 frames\r\n• Alt + Left/Right: Move 1 second";
         OffsetInSeconds = "Offset in seconds";
         SpeedFactor = "Speed factor";
         ShowEarlierLaterDotDotDot = "Show earlier/later...";


### PR DESCRIPTION
Addresses part 2 of #12066.

The keyboard shortcuts in the "Adjust all times" window (Shift/Ctrl/Alt + Left/Right) never fired when focus was inside the time code box: `TimeCodeUpDown`'s inner TextBox registers a tunnel KeyDown handler that marks Left/Right as handled unconditionally, so the window's bubble `KeyDown` handler never saw them.

Changes:
- Register the window key handler with `RoutingStrategies.Tunnel` so it runs before the TextBox handler, and mark the shortcut keys as handled so the caret doesn't also move.
- Change the shortcut step sizes from 10 / 100 / 500 ms to **1 frame / 10 frames / 1 second**, using the current frame rate (fallback 25 fps if out of range).
- Update the help text (English defaults + English.json) to match the new steps.

The shortcuts apply the adjustment via the same code path as the Show earlier/later buttons, so they respect the selected scope (all / selected lines / selected and forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)