### PR TITLE
Fix frame stepping in time code / duration up-down controls

### DIFF
--- a/src/ui/Controls/SecondsUpDown.cs
+++ b/src/ui/Controls/SecondsUpDown.cs
@@ -209,8 +209,11 @@ public class SecondsUpDown : TemplatedControl
 
         if (Se.Settings.General.UseFrameMode)
         {
-            var ms = SubtitleFormat.FramesToMilliseconds(delta);
-            val = val.Add(TimeSpan.FromMilliseconds(ms));
+            // Step by whole frames via the total frame count, so an unaligned value is
+            // aligned to the nearest frame first - just adding one frame duration in ms
+            // can otherwise round/cap back to the same displayed frame number.
+            var totalFrames = SubtitleFormat.MillisecondsToFrames(val.TotalMilliseconds);
+            val = TimeSpan.FromMilliseconds(SubtitleFormat.FramesToMilliseconds(totalFrames + delta));
         }
         else
         {

--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -415,6 +415,23 @@ namespace Nikse.SubtitleEdit.Controls
 
         private TimeSpan ParseTime(string text)
         {
+            if (Se.Settings.General.UseFrameMode)
+            {
+                // In frame mode the last section is a frame number, not milliseconds
+                var frameParts = text.Split(':', ',', '.');
+                if (frameParts.Length == 4 &&
+                    int.TryParse(frameParts[0], out var frameHours) &&
+                    int.TryParse(frameParts[1], out var frameMinutes) &&
+                    int.TryParse(frameParts[2], out var frameSeconds) &&
+                    int.TryParse(frameParts[3], out var frames))
+                {
+                    var frameMs = SubtitleFormat.FramesToMillisecondsMax999(frames);
+                    return RemoveVideoOffset(new TimeSpan(0, frameHours, frameMinutes, frameSeconds, frameMs));
+                }
+
+                return TimeSpan.Zero;
+            }
+
             // Try parsing with milliseconds format (00:00:00:000 or 00:00:00.000)
             if (TimeSpan.TryParseExact(text, @"hh\:mm\:ss\:fff", null, out var result))
             {
@@ -544,9 +561,11 @@ namespace Nikse.SubtitleEdit.Controls
             {
                 if (Se.Settings.General.UseFrameMode)
                 {
-                    //TODO: align to nearest frame before adjusting?
-                    var ms = SubtitleFormat.FramesToMilliseconds(delta);
-                    newVal = newVal.Add(TimeSpan.FromMilliseconds(ms));
+                    // Step by whole frames via the total frame count, so an unaligned value is
+                    // aligned to the nearest frame first - just adding one frame duration in ms
+                    // can otherwise round/cap back to the same displayed frame number.
+                    var totalFrames = SubtitleFormat.MillisecondsToFrames(newVal.TotalMilliseconds);
+                    newVal = TimeSpan.FromMilliseconds(SubtitleFormat.FramesToMilliseconds(totalFrames + delta));
                 }
                 else
                 {


### PR DESCRIPTION
In frame mode, the up/down step in `TimeCodeUpDown` and `SecondsUpDown` added one frame duration in milliseconds to a value that may not be frame-aligned. The new value could round to the next frame number but then get capped back by `MillisecondsToFramesMaxFrameRate`, so e.g. at 25 fps pressing up on frame 24 kept showing frame 24 instead of rolling over to `:00` with the seconds counting up.

Changes:
- Step via the total frame count instead: align to the nearest frame, add the delta, convert back (`MillisecondsToFrames` → `FramesToMilliseconds`). This resolves the existing `//TODO: align to nearest frame before adjusting?` in `TimeCodeUpDown.ChangeValue`.
- Same fix in `SecondsUpDown.ChangeValue` (duration control).
- `TimeCodeUpDown.ParseTime` now interprets the last section as a frame number in frame mode — typed input was parsed as milliseconds, corrupting the underlying value.

Verified the stepping sequence with the libse rounding formulas at 25, 23.976 and 29.97 fps in both directions — every step changes the frame number and wraps correctly at second boundaries (e.g. `00:24 → 01:00 → 01:01 …` at 25 fps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)