### PR TITLE
Optimize waveform render loop and per-line string utility hot paths

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -657,21 +657,71 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return input;
             }
 
-            var text = input;
-            var idx = text.IndexOfAny(UppercaseTags, StringComparison.Ordinal);
-            while (idx >= 0)
+            // Single forward pass - the old rescan-from-zero loop did eight IndexOf passes plus
+            // two full-string copies per fixed tag, and this runs per line from AutoBreakLine.
+            char[] chars = null;
+            var i = 0;
+            while (i < input.Length)
             {
-                var endIdx = text.IndexOf('>', idx + 2);
-                if (endIdx < idx)
+                if (input[i] == '<' && StartsWithUppercaseTag(input, i))
                 {
-                    break;
+                    var endIdx = input.IndexOf('>', i + 2);
+                    if (endIdx < 0)
+                    {
+                        break;
+                    }
+
+                    chars ??= input.ToCharArray();
+                    for (var k = i; k < endIdx; k++)
+                    {
+                        chars[k] = char.ToLowerInvariant(chars[k]);
+                    }
+
+                    i = endIdx + 1;
+                    continue;
                 }
 
-                var tag = text.Substring(idx, endIdx - idx).ToLowerInvariant();
-                text = text.Remove(idx, endIdx - idx).Insert(idx, tag);
-                idx = text.IndexOfAny(UppercaseTags, StringComparison.Ordinal);
+                i++;
             }
-            return text;
+
+            return chars == null ? input : new string(chars);
+        }
+
+        private static bool StartsWithUppercaseTag(string input, int index)
+        {
+            // Matches UppercaseTags: <I> <U> <B> <FONT </I> </U> </B> </FONT>
+            var remaining = input.Length - index;
+            if (remaining < 3)
+            {
+                return false;
+            }
+
+            var c1 = input[index + 1];
+            if (c1 == 'I' || c1 == 'U' || c1 == 'B')
+            {
+                return input[index + 2] == '>';
+            }
+
+            if (c1 == 'F')
+            {
+                return remaining >= 5 && input[index + 2] == 'O' && input[index + 3] == 'N' && input[index + 4] == 'T';
+            }
+
+            if (c1 == '/' && remaining >= 4)
+            {
+                var c2 = input[index + 2];
+                if (c2 == 'I' || c2 == 'U' || c2 == 'B')
+                {
+                    return input[index + 3] == '>';
+                }
+
+                if (c2 == 'F')
+                {
+                    return remaining >= 7 && input[index + 3] == 'O' && input[index + 4] == 'N' && input[index + 5] == 'T' && input[index + 6] == '>';
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -1399,9 +1449,11 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         /// <param name="input">The string from which to remove color tags.</param>
         /// <returns>A new string with color tags removed.</returns>
+        private static readonly Regex ColorAttributeRegex = new Regex("[ ]*(COLOR|color|Color)=[\"']*[#\\dA-Za-z]*[\"']*[ ]*", RegexOptions.Compiled);
+
         public static string RemoveColorTags(string input)
         {
-            var r = new Regex("[ ]*(COLOR|color|Color)=[\"']*[#\\dA-Za-z]*[\"']*[ ]*");
+            var r = ColorAttributeRegex;
             var s = input;
             var match = r.Match(s);
             while (match.Success)
@@ -1409,8 +1461,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 s = s.Remove(match.Index, match.Value.Length).Insert(match.Index, " ");
                 if (match.Index > 4)
                 {
-                    var font = s.Substring(match.Index - 5);
-                    if (font.StartsWith("<font >", StringComparison.OrdinalIgnoreCase))
+                    if (string.Compare(s, match.Index - 5, "<font >", 0, 7, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         s = s.Remove(match.Index - 5, 7);
                         var endIndex = s.IndexOf("</font>", match.Index - 5, StringComparison.OrdinalIgnoreCase);
@@ -1447,6 +1498,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             return s.Trim();
         }
 
+        private static readonly Regex FontFaceAttributeRegex = new Regex("[ ]*(FACE|face|Face)=[\"']*[\\d\\p{L} ]*[\"']*[ ]*", RegexOptions.Compiled);
+        private static readonly Regex AssaFontNameOnlyTagRegex = new Regex("{\\\\fn[a-zA-Z \\d]+}", RegexOptions.Compiled);
+        private static readonly Regex AssaFontNameLastTagRegex = new Regex("\\\\fn[a-zA-Z \\d]+}", RegexOptions.Compiled);
+        private static readonly Regex AssaFontNameInnerTagRegex = new Regex("\\\\fn[a-zA-Z \\d]+\\\\", RegexOptions.Compiled);
+
         /// <summary>
         /// Remove font tag from HTML or ASSA.
         /// </summary>
@@ -1457,15 +1513,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var x = input;
                 if (x.Contains("\\fn"))
                 {
-                    x = Regex.Replace(x, "{\\\\fn[a-zA-Z \\d]+}", string.Empty);
-                    x = Regex.Replace(x, "\\\\fn[a-zA-Z \\d]+}", "}");
-                    x = Regex.Replace(x, "\\\\fn[a-zA-Z \\d]+\\\\", "\\");
+                    x = AssaFontNameOnlyTagRegex.Replace(x, string.Empty);
+                    x = AssaFontNameLastTagRegex.Replace(x, "}");
+                    x = AssaFontNameInnerTagRegex.Replace(x, "\\");
                 }
 
                 return x;
             }
 
-            var r = new Regex("[ ]*(FACE|face|Face)=[\"']*[\\d\\p{L} ]*[\"']*[ ]*");
+            var r = FontFaceAttributeRegex;
             var s = input;
             var match = r.Match(s);
             while (match.Success)
@@ -1473,8 +1529,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 s = s.Remove(match.Index, match.Value.Length).Insert(match.Index, " ");
                 if (match.Index > 4)
                 {
-                    var font = s.Substring(match.Index - 5);
-                    if (font.StartsWith("<font >", StringComparison.OrdinalIgnoreCase))
+                    if (string.Compare(s, match.Index - 5, "<font >", 0, 7, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         s = s.Remove(match.Index - 5, 7);
                         var endIndex = s.IndexOf("</font>", match.Index - 5, StringComparison.OrdinalIgnoreCase);

--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -259,13 +259,31 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             // Match/return with line-feed-normalized line breaks so a pattern's \n (see FixNewLine)
             // matches regardless of whether the in-memory text uses \n or \r\n (#11956).
+
+            // Fast path (runs per replace rule per subtitle line): text without \r or U+2028 round-trips
+            // unchanged through the SplitToLines+Join normalization, so skip the four allocations.
+            if (!ContainsNonLineFeedNewLine(text) && !ContainsNonLineFeedNewLine(replaceWith))
+            {
+                return regularExpression.Replace(text, replaceWith, count, startIndex);
+            }
+
             text = regularExpression.Replace(string.Join("\n", text.SplitToLines()), replaceWith, count, startIndex);
             return string.Join("\n", text.SplitToLines());
         }
 
         public static int CountNewLineSafe(Regex regularExpression, string text)
         {
+            if (!ContainsNonLineFeedNewLine(text))
+            {
+                return regularExpression.Matches(text).Count;
+            }
+
             return regularExpression.Matches(string.Join("\n", text.SplitToLines())).Count;
+        }
+
+        private static bool ContainsNonLineFeedNewLine(string text)
+        {
+            return text.IndexOf('\r') >= 0 || text.IndexOf('\u2028') >= 0;
         }
     }
 }

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -177,7 +177,26 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static int CountWords(this string source)
         {
-            return HtmlUtil.RemoveHtmlTags(source, true).Split(new[] { ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries).Length;
+            // Called per line on grid repaints (words-per-minute) - count boundaries directly
+            // instead of allocating a separator array plus one substring per word.
+            var text = HtmlUtil.RemoveHtmlTags(source, true);
+            var count = 0;
+            var inWord = false;
+            for (var i = 0; i < text.Length; i++)
+            {
+                var ch = text[i];
+                if (ch == ' ' || ch == '\n' || ch == '\r')
+                {
+                    inWord = false;
+                }
+                else if (!inWord)
+                {
+                    inWord = true;
+                    count++;
+                }
+            }
+
+            return count;
         }
 
         // http://www.codeproject.com/Articles/43726/Optimizing-string-operations-in-C
@@ -598,9 +617,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var ch = input[index];
 
                 if (!tagOn && isAssa && ch == '\\'
-                           && (input.Substring(index).StartsWith("\\N")
-                               || input.Substring(index).StartsWith("\\n")
-                               || input.Substring(index).StartsWith("\\h")))
+                           && index + 1 < input.Length
+                           && (input[index + 1] == 'N' || input[index + 1] == 'n' || input[index + 1] == 'h'))
                 {
                     tags.Add(new KeyValuePair<int, string>(index, input.Substring(index, 2)));
                     skipNext = true;
@@ -618,7 +636,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 if (!tagOn && ch == '<')
                 {
-                    var s = input.Substring(index);
+                    var s = input.AsSpan(index);
                     if (
                         s.StartsWith("<i>", StringComparison.OrdinalIgnoreCase) ||
                         s.StartsWith("</i>", StringComparison.OrdinalIgnoreCase) ||
@@ -647,7 +665,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else if (!tagOn && ch == '{')
                 {
-                    var s = input.Substring(index);
+                    var s = input.AsSpan(index);
                     if (s.StartsWith("{\\", StringComparison.Ordinal))
                     {
                         tagOn = true;

--- a/src/libse/Common/TextLengthCalculator/CalcFactory.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcFactory.cs
@@ -22,8 +22,18 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
 
         public static ICalcLength MakeCalculator(string strategy)
         {
-            var c = Calculators.FirstOrDefault(calculator => calculator.GetType().Name == strategy);
-            return c ?? new CalcAll();
+            // Called per line on grid repaints (characters-per-second) - avoid the
+            // LINQ closure and the fallback allocation; the list entries are shared anyway.
+            var calculators = Calculators;
+            for (var i = 0; i < calculators.Count; i++)
+            {
+                if (calculators[i].GetType().Name == strategy)
+                {
+                    return calculators[i];
+                }
+            }
+
+            return calculators[0]; // CalcAll
         }
     }
 }

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -224,8 +224,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             string s2 = s.Substring(0, index);
             if (Configuration.Settings.Tools.UseNoLineBreakAfter)
             {
-                var noBreakList = NoBreakAfterList(language).ToArray();
-                foreach (NoBreakAfterItem ending in noBreakList)
+                foreach (NoBreakAfterItem ending in NoBreakAfterList(language))
                 {
                     if (ending.IsMatch(s2))
                     {

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -316,6 +316,7 @@ public class AudioVisualizer : Control
     private readonly Pen _centerLinePen = new Pen(Brushes.DarkGray, 0.5);
     private readonly HashSet<int> _paragraphStartPositions = new();
     private readonly HashSet<int> _paragraphEndPositions = new();
+    private readonly HashSet<SubtitleLineViewModel> _selectedParagraphsRenderSet = new();
     private double _fontSize = Se.Settings.Waveform.WaveformTextFontSize;
     private static readonly Cursor _cursorArrow = new Cursor(StandardCursorType.Arrow);
     private static readonly Cursor _cursorHand = new Cursor(StandardCursorType.Hand);
@@ -1528,12 +1529,17 @@ public class AudioVisualizer : Control
         var pointX = point.X;
         var startPosSeconds = StartPositionSeconds;
 
+        // Runs per pointer move for every displayable paragraph; SecondsToXPosition reads the
+        // WavePeaks/ZoomFactor StyledProperties on each call, so resolve the factor once here.
+        var xFactor = WavePeaks == null ? 0.0 : WavePeaks.SampleRate * ZoomFactor;
+        int ToX(double seconds) => (int)Math.Round(seconds * xFactor, MidpointRounding.AwayFromZero);
+
         // Check NewSelectionParagraph first as it's typically the active interaction target
         var newSelection = NewSelectionParagraph;
         if (newSelection != null)
         {
-            var left = SecondsToXPosition(newSelection.StartTime.TotalSeconds - startPosSeconds);
-            var right = SecondsToXPosition(newSelection.EndTime.TotalSeconds - startPosSeconds);
+            var left = ToX(newSelection.StartTime.TotalSeconds - startPosSeconds);
+            var right = ToX(newSelection.EndTime.TotalSeconds - startPosSeconds);
 
             if (pointX >= left - ResizeMargin && pointX <= right + ResizeMargin)
             {
@@ -1557,8 +1563,8 @@ public class AudioVisualizer : Control
         for (var i = 0; i < _displayableParagraphs.Count; i++)
         {
             var p = _displayableParagraphs[i];
-            var left = SecondsToXPosition(p.StartTime.TotalSeconds - startPosSeconds);
-            var right = SecondsToXPosition(p.EndTime.TotalSeconds - startPosSeconds);
+            var left = ToX(p.StartTime.TotalSeconds - startPosSeconds);
+            var right = ToX(p.EndTime.TotalSeconds - startPosSeconds);
 
             // Check if in middle (not near edges)
             if (pointX >= left + ResizeMargin && pointX <= right - ResizeMargin)
@@ -1595,7 +1601,7 @@ public class AudioVisualizer : Control
             {
                 // Check if previous paragraph's right edge is closer
                 var prev = _displayableParagraphs[closestEdgeIndex - 1];
-                var prevRight = SecondsToXPosition(prev.EndTime.TotalSeconds - startPosSeconds);
+                var prevRight = ToX(prev.EndTime.TotalSeconds - startPosSeconds);
                 var distToPrevRight = Math.Abs(pointX - prevRight);
 
                 if (distToPrevRight <= ResizeMargin && distToPrevRight < closestEdgeDistance)
@@ -1607,7 +1613,7 @@ public class AudioVisualizer : Control
             {
                 // Check if next paragraph's left edge is closer
                 var next = _displayableParagraphs[closestEdgeIndex + 1];
-                var nextLeft = SecondsToXPosition(next.StartTime.TotalSeconds - startPosSeconds);
+                var nextLeft = ToX(next.StartTime.TotalSeconds - startPosSeconds);
                 var distToNextLeft = Math.Abs(pointX - nextLeft);
 
                 if (distToNextLeft <= ResizeMargin && distToNextLeft < closestEdgeDistance)
@@ -1790,6 +1796,13 @@ public class AudioVisualizer : Control
     {
         if (!_timeLineTextCache.TryGetValue(text, out var formatted))
         {
+            // Same cap as the paragraph text caches - in frame mode at high zoom every
+            // distinct label is a new entry, so without a bound this grows for hours.
+            if (_timeLineTextCache.Count > 8000)
+            {
+                _timeLineTextCache.Clear();
+            }
+
             formatted = new FormattedText(
                 text,
                 CultureInfo.CurrentCulture,
@@ -2256,6 +2269,12 @@ public class AudioVisualizer : Control
         var invMediumMinusLow = 1.0 / (mediumThreshold - lowThreshold);
         var invHighMinusMedium = 1.0 / (highestPeak - mediumThreshold);
 
+        // StyledProperty getters go through Avalonia's value store - keep them out of the
+        // per-pixel loop below.
+        var waveformColor = WaveformColor;
+        var waveformSelectedColor = WaveformSelectedColor;
+        var waveformFancyHighColor = WaveformFancyHighColor;
+
         // Reset pooled batches for this render
         var batches = _fancyBatches;
         var keysInUse = _fancyBatchKeysInUse;
@@ -2309,7 +2328,7 @@ public class AudioVisualizer : Control
             int colorKey;
 
             // Determine base color (selected or normal)
-            var baseColor = isSelected ? WaveformSelectedColor : WaveformColor;
+            var baseColor = isSelected ? waveformSelectedColor : waveformColor;
             var baseColorKeyOffset = isSelected ? 10000 : 0; // Use different cache key range for selected
 
             // Dynamic coloring based on amplitude - quantize to reduce cache variations
@@ -2323,7 +2342,7 @@ public class AudioVisualizer : Control
             {
                 // Medium amplitude - blend from base to high color
                 var blend = (amplitude - lowThreshold) * invMediumMinusLow;
-                var highColor = WaveformFancyHighColor;
+                var highColor = waveformFancyHighColor;
                 var r = (byte)(baseColor.R + blend * (highColor.R - baseColor.R));
                 var g = (byte)(baseColor.G + blend * (highColor.G - baseColor.G));
                 var b = (byte)(baseColor.B + blend * (highColor.B - baseColor.B));
@@ -2336,7 +2355,7 @@ public class AudioVisualizer : Control
             {
                 // High amplitude - use high color with increased opacity
                 var blend = Math.Min(1.0, (amplitude - mediumThreshold) * invHighMinusMedium);
-                var highColor = WaveformFancyHighColor;
+                var highColor = waveformFancyHighColor;
                 var a = (byte)Math.Min(255, highColor.A + blend * (255 - highColor.A));
                 color = Color.FromArgb(a, highColor.R, highColor.G, highColor.B);
                 // Quantize blend to 10 steps for caching
@@ -2620,6 +2639,18 @@ public class AudioVisualizer : Control
         var startPositionMilliseconds = renderCtx.StartPositionSeconds * 1000.0;
         var endPositionMilliseconds = RelativeXPositionToSecondsOptimized(renderCtx.Width, renderCtx.SampleRate, renderCtx.StartPositionSeconds, renderCtx.ZoomFactor) * 1000.0;
 
+        // List.Contains per visible paragraph is O(selection) - with "select all" on a large
+        // subtitle that is millions of compares per frame, so probe a set instead.
+        _selectedParagraphsRenderSet.Clear();
+        var allSelected = AllSelectedParagraphs;
+        if (allSelected != null)
+        {
+            foreach (var selected in allSelected)
+            {
+                _selectedParagraphsRenderSet.Add(selected);
+            }
+        }
+
         foreach (var p in paragraphs)
         {
             if (p.EndTime.TotalMilliseconds >= startPositionMilliseconds && p.StartTime.TotalMilliseconds <= endPositionMilliseconds)
@@ -2693,7 +2724,7 @@ public class AudioVisualizer : Control
         var height = renderCtx.Height;
 
         // Draw background rectangle
-        context.FillRectangle(AllSelectedParagraphs.Contains(paragraph) ? _paintParagraphSelectedBackground : _paintParagraphBackground,
+        context.FillRectangle(_selectedParagraphsRenderSet.Contains(paragraph) ? _paintParagraphSelectedBackground : _paintParagraphBackground,
             new Rect(currentRegionLeft, 0, currentRegionWidth, height));
 
         // Draw left and right borders
@@ -2814,7 +2845,11 @@ public class AudioVisualizer : Control
 
     private void DrawShotChanges(DrawingContext context, ref RenderContext renderCtx)
     {
-        var index = 0;
+        if (_shotChanges.Count == 0)
+        {
+            return;
+        }
+
         var currentPositionPos = SecondsToXPositionOptimized(renderCtx.CurrentVideoPositionSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
 
         var startPositionMilliseconds = renderCtx.StartPositionSeconds * 1000.0;
@@ -2830,12 +2865,34 @@ public class AudioVisualizer : Control
             }
         }
 
-        while (index < _shotChanges.Count)
+        // The list is sorted, so binary search the first shot change at/after the visible window
+        // instead of walking all shot changes before it, and stop once past the right edge.
+        var low = 0;
+        var high = _shotChanges.Count;
+        while (low < high)
         {
-            var time = _shotChanges[index++];
+            var mid = low + (high - low) / 2;
+            if (_shotChanges[mid] < renderCtx.StartPositionSeconds)
+            {
+                low = mid + 1;
+            }
+            else
+            {
+                high = mid;
+            }
+        }
+
+        for (var index = low; index < _shotChanges.Count; index++)
+        {
+            var time = _shotChanges[index];
             var pos = SecondsToXPositionOptimized(time - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
 
-            if (pos > 0 && pos < renderCtx.Width)
+            if (pos >= renderCtx.Width)
+            {
+                break;
+            }
+
+            if (pos > 0)
             {
                 if (currentPositionPos == pos)
                 {
@@ -3142,28 +3199,43 @@ public class AudioVisualizer : Control
 
     internal int GetShotChangeIndex(double seconds)
     {
-        if (ShotChanges == null)
+        var shotChanges = ShotChanges;
+        if (shotChanges == null || shotChanges.Count == 0)
         {
             return -1;
         }
 
-        try
+        // The list is sorted, so binary search the insertion point and check the two neighbors
+        // (called per frame from the render loop to pick the cursor pen).
+        var low = 0;
+        var high = shotChanges.Count;
+        while (low < high)
         {
-            for (var index = 0; index < ShotChanges.Count; index++)
+            var mid = low + (high - low) / 2;
+            if (shotChanges[mid] < seconds)
             {
-                var shotChange = ShotChanges[index];
-                if (Math.Abs(shotChange - seconds) < 0.04)
-                {
-                    return index;
-                }
+                low = mid + 1;
+            }
+            else
+            {
+                high = mid;
             }
         }
-        catch
+
+        var bestIndex = -1;
+        var bestDistance = 0.04;
+        if (low < shotChanges.Count && Math.Abs(shotChanges[low] - seconds) < bestDistance)
         {
-            // ignored
+            bestIndex = low;
+            bestDistance = Math.Abs(shotChanges[low] - seconds);
         }
 
-        return -1;
+        if (low > 0 && Math.Abs(shotChanges[low - 1] - seconds) < bestDistance)
+        {
+            bestIndex = low - 1;
+        }
+
+        return bestIndex;
     }
 
     internal void SetSpectrogram(SpectrogramData2? spectrogram)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20376,6 +20376,11 @@ public partial class MainViewModel :
                             for (var i = 0; i < subtitle.Count; i++)
                             {
                                 var p = subtitle[i];
+                                if (p.StartTime.TotalSeconds > mediaPlayerSeconds)
+                                {
+                                    break; // sorted by start time, no later line can contain the position
+                                }
+
                                 if (mediaPlayerSeconds >= p.StartTime.TotalSeconds &&
                                     mediaPlayerSeconds <= p.EndTime.TotalSeconds)
                                 {


### PR DESCRIPTION
Performance pass over the AudioVisualizer render path, the MainViewModel position timer, and the libse string utilities called per subtitle line. No caching added per request — these are algorithmic fixes (binary search, early exit, single-pass rewrites, hoisted invariants, static compiled regexes).

All changes verified with BenchmarkDotNet (Apple M4, .NET 10). Each old/new pair was asserted to produce **identical output** before timing.

### Waveform / render loop (runs at ~60 fps during playback)
- `GetShotChangeIndex`: linear scan over all shot changes per frame → binary search on the sorted list: **1013 ns → 7.6 ns (134×)** with 2000 shot changes.
- `DrawShotChanges`: returns immediately when there are no shot changes (the common case — it previously still rebuilt the paragraph position sets every frame); binary-searches the first visible entry and breaks past the right edge instead of computing X positions for every shot change in the movie.
- `DrawParagraph`: selection check was `List.Contains` per visible paragraph (O(selection) each — with select-all on a large subtitle that's millions of compares per frame); now a `HashSet` rebuilt once per render.
- `BuildWaveFormFancy`: `WaveformColor`/`WaveformSelectedColor`/`WaveformFancyHighColor` StyledProperty reads hoisted out of the per-pixel loop (they went through Avalonia's value store once per pixel column while scrolling/zooming).
- `HitTestParagraph`: resolves `WavePeaks.SampleRate * ZoomFactor` once per pointer move instead of twice per paragraph.
- Timeline `FormattedText` cache gets the same 8000-entry cap as the paragraph text caches (it grew unbounded when scrubbing in frame mode).
- MainViewModel 50 ms position timer: the current-line scan now stops at the first line starting after the playhead (the buffer is sorted by start time) instead of always scanning the entire subtitle.

### String utilities (called per line from casing fixes, batch convert, multiple replace, auto-break, grid repaints)
| Method | Old | New | Speedup | Alloc |
|---|---|---|---|---|
| `HtmlUtil.RemoveColorTags` | 1882 ns | 282 ns | 6.7× | −78% |
| `HtmlUtil.RemoveFontName` | 2170 ns | 358 ns | 6.1× | −79% |
| `HtmlUtil.FixUpperTags` | 548 ns | 64 ns | 8.6× | −86% |
| `RegexUtils.ReplaceNewLineSafe` (\n-only text) | 182 ns | 73 ns | 2.5× | −85% |
| `StringExtensions.CountWords` | 184 ns | 134 ns | 1.4× | −82% |
| `StringExtensions.RemoveAndSaveTags` (ASSA) | 359 ns | 198 ns | 1.8× | −39% |

- `RemoveColorTags`/`RemoveFontName`: the regex was re-parsed on **every call** (uncompiled `new Regex(...)`) — now static compiled; also dropped the rest-of-string `Substring` per match.
- `FixUpperTags`: rescan-from-zero loop (8 `IndexOf` passes + `Remove`+`Insert` full copies per tag) → single forward pass over a char buffer.
- `ReplaceNewLineSafe`/`CountNewLineSafe`: skip the two `SplitToLines`+`Join` round-trips when the text contains no `\r`/U+2028 (always true after the first rule in a multiple-replace run).
- `RemoveAndSaveTags`: `input.Substring(index)` (rest of string) allocated per `<`/`{`/`\` just for a `StartsWith` check — now `AsSpan`. The plain-HTML micro-case is ~13% slower on M4 but allocates 30% less and no longer degrades quadratically with line length; the ASSA case is 1.8× faster.
- `CalcFactory.MakeCalculator` (hit per grid cell repaint via CPS): dropped the LINQ closure and per-call fallback `new CalcAll()`; returns the existing shared instances.
- `Utilities.CanBreak`: dropped the per-call `ToArray()` copy of the cached no-break list.

Not addressed (fix would require caching, excluded by request): the spectrogram path rebuilding + converting a full bitmap every frame, and the position timer's per-tick copy+sort of all subtitles.

All 1003 tests pass (libse 485, UI 512, libuilogic 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)