### PR TITLE
Fix original-subtitle dirty hash using object ToString instead of file name

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17747,7 +17747,7 @@ public partial class MainViewModel :
     public int GetFastHashOriginal()
     {
         _subtitleOriginal ??= new Subtitle();
-        var pre = _subtitleOriginal + SelectedEncoding.DisplayName;
+        var pre = _subtitleFileNameOriginal + SelectedEncoding.DisplayName;
 
         unchecked
         {


### PR DESCRIPTION
`GetFastHashOriginal` built its prefix with `_subtitleOriginal + SelectedEncoding.DisplayName` — string-concatenating the `Subtitle` **object**, whose default `ToString()` is constant — instead of `_subtitleFileNameOriginal`. So the original subtitle's file name never contributed to the change-detection hash, unlike `GetFastHash`, which correctly uses `_subtitleFileName`.

One-line fix: use `_subtitleFileNameOriginal`, mirroring `GetFastHash`.

Found while profiling the slow-timer hash passes in the performance review (#12069).

🤖 Generated with [Claude Code](https://claude.com/claude-code)