### PR TITLE
BatchConvert: persist settings when window is closed via X/Escape

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -2504,6 +2504,11 @@ public partial class BatchConvertViewModel : ObservableObject
     internal void OnClosing(object? sender, WindowClosingEventArgs e)
     {
         UiUtil.SaveWindowPosition(Window);
+
+        // Persist target format and function options also when the window is closed via
+        // X/Escape - especially important in /batchconvertui mode, where this window is the
+        // main window and nothing else flushes settings to disk on exit (#11699).
+        SaveSettings();
     }
 
     internal void ComboBoxSubtitleFormatChanged()


### PR DESCRIPTION
Fixes #11699.

The batch convert window's `SaveSettings()` (target format, active functions, and all function-panel options) was only invoked from the **Done** and **Convert** buttons. Closing the window via the X button or Escape ran `OnClosing`, which only records the window position in memory.

In the embedded flow this was masked, because the main window's close handler flushes settings to disk later. But with `/batchconvertui`, the batch convert window *is* the main window and the app exits without any flush — so the selected target format (and any option changes) were lost unless the user happened to click Convert or Done in that session. This matches the "sometimes remembered, sometimes not" behavior in the issue.

Fix: call `SaveSettings()` from `OnClosing`, covering both modes.

Notes from the analysis:
- The **output folder** was never affected: the settings sub-dialog already writes it and calls `Se.SaveSettings()` on OK.
- The EBU STL header/justification chosen via the target-format settings dialog live in runtime-only properties and are not persisted at all (also not in SE-embedded mode). Left out of this PR as a separate design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)