### PR TITLE
Perf: single-raise timing notifications + cheaper ASSA event-line parsing

### DIFF
--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -1512,11 +1512,12 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
 
             var header = new StringBuilder();
             var footer = new StringBuilder();
+            var textBuilder = new StringBuilder();
             foreach (var line in lines)
             {
                 lineNumber++;
                 var trimmedLine = line.Trim();
-                
+
                 if (!eventsStarted && !fontsStarted && !graphicsStarted &&
                     !trimmedLine.Equals("[fonts]", StringComparison.InvariantCultureIgnoreCase) &&
                     !trimmedLine.Equals("[graphics]", StringComparison.InvariantCultureIgnoreCase))
@@ -1524,11 +1525,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                     header.AppendLine(line);
                 }
 
-                if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith(';'))
+                if (string.IsNullOrWhiteSpace(line) || trimmedLine.StartsWith(';'))
                 {
                     // skip empty and comment lines
                 }
-                else if (line.TrimStart().StartsWith("dialog:", StringComparison.OrdinalIgnoreCase) || line.TrimStart().StartsWith("dialogue:", StringComparison.OrdinalIgnoreCase))
+                else if (trimmedLine.StartsWith("dialog:", StringComparison.OrdinalIgnoreCase) || trimmedLine.StartsWith("dialogue:", StringComparison.OrdinalIgnoreCase))
                 {
                     eventsStarted = true;
                     fontsStarted = false;
@@ -1583,8 +1584,10 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 }
                 else if (eventsStarted)
                 {
-                    var s = trimmedLine.ToLowerInvariant();
-                    if (line.Length > 10 && s.StartsWith("format:", StringComparison.Ordinal))
+                    // No full-line ToLowerInvariant here - this runs for every event line
+                    // (case-insensitive prefix checks instead; only the short format field
+                    // list below is lowercased).
+                    if (line.Length > 10 && trimmedLine.StartsWith("format:", StringComparison.OrdinalIgnoreCase))
                     {
                         indexLayer = -1;
                         indexStart = -1;
@@ -1598,7 +1601,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                         indexEffect = -1;
                         indexText = -1;
 
-                        var format = s.Substring(8).Split(',');
+                        var format = trimmedLine.Substring(8).ToLowerInvariant().Split(',');
                         for (int i = 0; i < format.Length; i++)
                         {
                             var formatTrimmed = format[i].Trim();
@@ -1640,9 +1643,9 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                             }
                         }
                     }
-                    else if (!string.IsNullOrEmpty(s))
+                    else if (trimmedLine.Length > 0)
                     {
-                        var text = string.Empty;
+                        textBuilder.Clear();
                         var start = string.Empty;
                         var end = string.Empty;
                         var style = string.Empty;
@@ -1654,11 +1657,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                         var layer = 0;
 
                         string[] splitLine;
-                        if (s.StartsWith("dialog:", StringComparison.Ordinal))
+                        if (trimmedLine.StartsWith("dialog:", StringComparison.OrdinalIgnoreCase))
                         {
                             splitLine = line.Remove(0, 7).Split(',');
                         }
-                        else if (s.StartsWith("dialogue:", StringComparison.Ordinal))
+                        else if (trimmedLine.StartsWith("dialogue:", StringComparison.OrdinalIgnoreCase))
                         {
                             splitLine = line.Remove(0, 9).Split(',');
                         }
@@ -1711,13 +1714,17 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                             }
                             else if (i == indexText)
                             {
-                                text = splitLine[i];
+                                textBuilder.Append(splitLine[i]);
                             }
                             else if (i > indexText)
                             {
-                                text += "," + splitLine[i];
+                                // The text field may itself contain commas; rebuild via the
+                                // pooled builder instead of O(commas^2) string concatenation.
+                                textBuilder.Append(',').Append(splitLine[i]);
                             }
                         }
+
+                        var text = textBuilder.ToString();
 
                         try
                         {
@@ -1759,7 +1766,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                             }
 
                             p.Layer = layer;
-                            p.IsComment = s.StartsWith("comment:", StringComparison.Ordinal);
+                            p.IsComment = trimmedLine.StartsWith("comment:", StringComparison.OrdinalIgnoreCase);
                             subtitle.Paragraphs.Add(p);
                         }
                         catch

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -434,7 +434,6 @@ public partial class SubtitleLineViewModel : ObservableObject
         }
 
         OnPropertyChanged(nameof(GapBackgroundBrush));
-        OnPropertyChanged(nameof(DurationBackgroundBrush));
         OnPropertyChanged(nameof(EndTimeBackgroundBrush));
     }
 
@@ -536,16 +535,12 @@ public partial class SubtitleLineViewModel : ObservableObject
             return;
         }
 
+        // UpdateDuration raises the timing-derived notifications (CPS/WPM/brushes);
+        // raising them here as well made every EndTime assignment notify twice, and the
+        // grid re-evaluates the bound getters per notification.
         _skipUpdate = true;
         UpdateDuration();
         _skipUpdate = false;
-
-        OnPropertyChanged(nameof(CharactersPerSecond));
-        OnPropertyChanged(nameof(TextBackgroundBrush));
-        OnPropertyChanged(nameof(DurationBackgroundBrush));
-        OnPropertyChanged(nameof(CpsBackgroundBrush));
-        OnPropertyChanged(nameof(WordsPerMinute));
-        OnPropertyChanged(nameof(WpmBackgroundBrush));
     }
 
     partial void OnDurationChanged(TimeSpan value)
@@ -561,7 +556,6 @@ public partial class SubtitleLineViewModel : ObservableObject
             EndTime = newEndTime;
 
             OnPropertyChanged(nameof(CharactersPerSecond));
-            OnPropertyChanged(nameof(TextBackgroundBrush));
             OnPropertyChanged(nameof(DurationBackgroundBrush));
             OnPropertyChanged(nameof(CpsBackgroundBrush));
             OnPropertyChanged(nameof(WordsPerMinute));
@@ -576,10 +570,16 @@ public partial class SubtitleLineViewModel : ObservableObject
         {
             Duration = EndTime - StartTime;
 
+            // Single raise site for everything derived from the times. TextBackgroundBrush
+            // is deliberately absent: it depends only on Text (see the getter), and its
+            // getter shapes the text with HarfBuzz - raising it at waveform-drag rate is
+            // expensive. CpsBackgroundBrush/WpmBackgroundBrush are raised here so start-time
+            // drags repaint them too (previously only end-time changes did).
             OnPropertyChanged(nameof(CharactersPerSecond));
             OnPropertyChanged(nameof(WordsPerMinute));
-            OnPropertyChanged(nameof(TextBackgroundBrush));
             OnPropertyChanged(nameof(DurationBackgroundBrush));
+            OnPropertyChanged(nameof(CpsBackgroundBrush));
+            OnPropertyChanged(nameof(WpmBackgroundBrush));
         }
     }
 


### PR DESCRIPTION
Two hot-path fixes from the second performance review round.

### Subtitle line timing notifications (grid / waveform drags)
- `TextBackgroundBrush` was raised from `OnEndTimeChanged`, `OnDurationChanged`, and `UpdateDuration`, but its getter depends **only on `Text`** (line length / pixel width / line count) — and it strips HTML and shapes text with HarfBuzz per evaluation. Waveform drags assign `StartTime`/`EndTime` per pointer move (60–120 Hz), so realized rows re-shaped their text up to ~3× per mouse event for no reason.
- `OnEndTimeChanged` first called `UpdateDuration` (which raises CPS/WPM/brushes) and then raised the same set again — every end-time assignment notified twice.
- `OnGapChanged` raised `DurationBackgroundBrush`, which doesn't read `Gap`.

`UpdateDuration` is now the single raise site for timing-derived properties (all timing mutations — `OnStartTimeChanged`, `OnEndTimeChanged`, `SetTimes`, `SetStartTimeOnly` — funnel through it). It also gains `CpsBackgroundBrush`/`WpmBackgroundBrush`, fixing a latent staleness bug: dragging the **start** edge changed CPS but never repainted the CPS/WPM cell backgrounds.

`TextBackgroundBrush` keeps its two correct raise sites: `OnTextChanged` and the settings-dependent refresh.

### ASSA `LoadSubtitle`
- Every event line was copied with `ToLowerInvariant()` just for a handful of prefix checks (`format:`, `dialogue:`, `comment:`) — for a 100k-line .ass that's 100k full-line lowercase copies, doubled by the `IsMine` pre-parse. Now uses `StartsWith(..., OrdinalIgnoreCase)`; only the short format field list is lowercased.
- The text-field rejoin (`text += "," + part` per comma in the dialogue text) is now a pooled `StringBuilder`.
- Reuses the already-computed `trimmedLine` instead of three extra `TrimStart()` calls per line.

All 997 tests pass (libse 485, UI 512).

🤖 Generated with [Claude Code](https://claude.com/claude-code)