### PR TITLE
Blu-ray SUP export: fix invalid PTS/DTS on exported segments

### DIFF
--- a/src/libse/BluRaySup/BluRaySupPicture.cs
+++ b/src/libse/BluRaySup/BluRaySupPicture.cs
@@ -557,16 +557,15 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
 
             var fpsId = GetFpsId(fps);
 
-            /* time (in 90kHz resolution) needed to initialize (clear) the screen buffer
-                based on the composition pixel rate of 256e6 bit/s - always rounded up */
-            var frameInitTime = (pic.Width * pic.Height * 9 + 3199) / 3200; // better use default height here
-            /* time (in 90kHz resolution) needed to initialize (clear) the window area
-                based on the composition pixel rate of 256e6 bit/s - always rounded up
-                Note: no cropping etc. -> window size == image size */
-            var windowInitTime = (bm.Width * bm.Height * 9 + 3199) / 3200;
-            /* time (in 90kHz resolution) needed to decode the image
-                based on the decoding pixel rate of 128e6 bit/s - always rounded up  */
-            var imageDecodeTime = (bm.Width * bm.Height * 9 + 1599) / 1600;
+            // Timestamps: every segment of a display set carries the display set's
+            // presentation time as PTS, and DTS is left at 0 ("unset"). This mirrors how
+            // .sup files extracted from retail discs look, and is what the common consumers
+            // expect: ffmpeg's sup demuxer explicitly treats DTS 0 as unset, SupMover shifts
+            // the PTS of every segment (so they must all carry the real presentation time),
+            // and muxers like tsMuxeR re-derive decode timing from the PCS when authoring
+            // an m2ts. The previous writer put decode-model values into DTS and zeroed the
+            // ODS/END PTS, producing segments with DTS > PTS (issue #10219).
+
             // write PCS start - Presentation Composition Segment (also called the Control Segment)
             packetHeader[10] = 0x16; // ID
 
@@ -577,10 +576,9 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             _lastEndTimeForWrite = pic.EndTimeForWrite;
-            var dts = (uint)(pts - (frameInitTime + windowInitTime + imageDecodeTime)); //int dts = pic.StartTimeForWrite - windowInitTime; ???
 
             ToolBox.SetDWord(packetHeader, 2, (uint)pts);                     // PTS
-            ToolBox.SetDWord(packetHeader, 6, dts);                           // DTS
+            ToolBox.SetDWord(packetHeader, 6, 0);                             // DTS (0 = unset)
             ToolBox.SetWord(packetHeader, 11, headerPcsStart.Length);     // size
             for (var i = 0; i < packetHeader.Length; i++)
             {
@@ -600,9 +598,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             // write WDS
-            packetHeader[10] = 0x17;                                            // ID
-            var timestamp = pts - windowInitTime;
-            ToolBox.SetDWord(packetHeader, 2, (uint)timestamp);            // PTS (keep DTS)
+            packetHeader[10] = 0x17;                                            // ID (keep PTS & DTS)
             ToolBox.SetWord(packetHeader, 11, headerWds.Length);       // size
             for (var i = 0; i < packetHeader.Length; i++)
             {
@@ -619,9 +615,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             // write PDS - Palette Definition Segment
-            packetHeader[10] = 0x14;                                            // ID
-            ToolBox.SetDWord(packetHeader, 2, dts);                        // PTS (=DTS of PCS/WDS)
-            ToolBox.SetDWord(packetHeader, 6, 0);                      // DTS (0)
+            packetHeader[10] = 0x14;                                            // ID (keep PTS & DTS)
             ToolBox.SetWord(packetHeader, 11, 2 + palSize * 5);        // size
             for (var i = 0; i < packetHeader.Length; i++)
             {
@@ -647,10 +641,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 bufSize = 0xffe4;
             }
 
-            packetHeader[10] = 0x15;                                                    // ID
-            timestamp = 0;
-            ToolBox.SetDWord(packetHeader, 2, (uint)timestamp);                    // PTS
-            ToolBox.SetDWord(packetHeader, 6, dts);                                // DTS
+            packetHeader[10] = 0x15;                                                    // ID (keep PTS & DTS)
             ToolBox.SetWord(packetHeader, 11, headerOdsFirst.Length + bufSize); // size
             for (var i = 0; i < packetHeader.Length; i++)
             {
@@ -701,8 +692,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             // write END
-            packetHeader[10] = 0x80;                                             // ID
-            ToolBox.SetDWord(packetHeader, 6, 0);                       // DTS (0) (keep PTS of ODS)
+            packetHeader[10] = 0x80;                                             // ID (keep PTS & DTS)
             ToolBox.SetWord(packetHeader, 11, 0);                       // size
             for (var i = 0; i < packetHeader.Length; i++)
             {
@@ -712,8 +702,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             // write PCS end
             packetHeader[10] = 0x16;                                            // ID
             ToolBox.SetDWord(packetHeader, 2, (uint)pic.EndTimeForWrite);        // PTS
-            dts = (uint)(pic.EndTimeForWrite - 90);
-            ToolBox.SetDWord(packetHeader, 6, dts);                        // DTS
+            ToolBox.SetDWord(packetHeader, 6, 0);                          // DTS (0 = unset)
             ToolBox.SetWord(packetHeader, 11, headerPcsEnd.Length);     // size
             for (var i = 0; i < packetHeader.Length; i++)
             {
@@ -730,10 +719,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             // write WDS - Window Definition Segment
-            packetHeader[10] = 0x17;                                                     // ID
-            timestamp = pic.EndTimeForWrite - windowInitTime;
-            ToolBox.SetDWord(packetHeader, 2, (uint)timestamp);                    // PTS
-            ToolBox.SetDWord(packetHeader, 6, (uint)(dts - windowInitTime));   // DTS
+            packetHeader[10] = 0x17;                                                     // ID (keep PTS & DTS)
             ToolBox.SetWord(packetHeader, 11, headerWds.Length);                // size
             for (var i = 0; i < packetHeader.Length; i++)
             {
@@ -750,9 +736,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             // write END
-            packetHeader[10] = 0x80;                                            // ID
-            ToolBox.SetDWord(packetHeader, 2, dts);                        // PTS (DTS of end PCS)
-            ToolBox.SetDWord(packetHeader, 6, 0);                       // DTS (0)
+            packetHeader[10] = 0x80;                                            // ID (keep PTS & DTS)
             ToolBox.SetWord(packetHeader, 11, 0);                       // size
             for (var i = 0; i < packetHeader.Length; i++)
             {


### PR DESCRIPTION
Fixes #10219.

### What was wrong
`BluRaySupPicture.CreateSupFrame` (a port of BDSup2Sub's writer) mixed up the timestamp fields:
- The ODS segment got **PTS=0** with the decode-model value in **DTS** — the exact `PTS 0, DTS 13097155` segment from the issue, violating "decoding must finish before presentation" (DTS ≤ PTS).
- The first END segment inherited the ODS's PTS=0.
- `dts = (uint)(pts - decodeTimes)` **underflowed** to a huge value for captions starting in the first ~150 ms.
- WDS/PDS carried assorted offset PTS values; the original BDSup2Sub code writes DTS=0 on *every* segment.

Tools like SupMover shift the PTS of every segment when applying a delay, so the zeroed/garbled fields made every caption trigger "starts before the full delay amount" on negative delays (MonoS/SupMover#30).

### The fix
Every segment of a display set now carries the display set's presentation time as PTS, and DTS stays 0 ("unset"). Rationale, checked against the ecosystem:
- This is how `.sup` files extracted from retail discs look (per the segment traces in the SupMover issue) — uniform PTS per display set, empty DTS.
- ffmpeg's `sup` demuxer has an explicit code path: *"Many files have DTS set to 0 for all packets, so assume 0 means unset"*.
- SupMover shifts each segment's PTS uniformly, which now works.
- Muxers (tsMuxeR etc.) re-derive PES decode timing from the PCS when authoring an m2ts; the standalone `.sup` DTS field is informational.
- Uniform PTS within a display set also keeps packets monotonic, so `ffmpeg -c copy` remuxing produces no "non-monotonous DTS" warnings (staggered per-segment PTS would).

### Verification
Generated test sups via libse (caption at t=0, small gaps, and a 900×300 noisy bitmap forcing a 5-packet ODS chain):
- **Segment validator** (python, parses every `PG` header): DTS=0 everywhere, DTS ≤ PTS, uniform PTS per display set, monotonic across sets, clean PCS…END structure. ✔
- **ffmpeg 4.4** remux to mkv: all 44 segments copied, zero warnings, timestamps intact. ✔
- **ffmpeg PGS decode** (overlay onto black + per-frame signalstats): captions appear *and clear* at exactly the authored times, including the multi-packet ODS. ✔
- **SupMover** (built from source): `--delay -335` on a shifted file → zero warnings, all display sets moved exactly 335 ms, output still passes the validator. The only warnings left are for a caption genuinely starting at t=0, which is correct clamping. ✔
- **SE roundtrip**: `BluRaySupParser` re-imports all captions with correct times, sizes, and forced flags. ✔
- All 997 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)