### PR TITLE
Bump version to v5.1.0-beta5 and update change log

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,13 +1,18 @@
 
 Subtitle Edit Changelog
 
-v5.1.0-beta5 (2nd of July 2026)
+v5.1.0-beta5 (TBD)
 
-* Improve performance (waveform rendering, subtitle grid, string utilities, ASSA loading)
+* Add copy/paste support to the time code boxes (a bare number is milliseconds) - thx RobertoHN
+* OCR: select the just-downloaded spell-check dictionary on any UI language
+* Spell check: clean up dictionary names with variant suffixes (e.g. de_DE_frami)
 * Fix keyboard shortcuts in "Adjust all times" not working, now moving 1 frame / 10 frames / 1 second - thx KaDeeKe
 * Fix up/down time code and duration stepping in frame mode not wrapping frames correctly - thx KaDeeKe
 * Fix invalid PTS/DTS in exported Blu-ray sup files (broke SupMover negative delay) - thx GCRaistlin/MonoS
 * Fix batch convert forgetting settings when the window is closed via X/Escape - thx MonsterSe7en
+* Fix batch convert llama.cpp auto-start never running
+* Fix crash when pasting an out-of-range value into a time code box
+* Fix stale RTL text-box selection anchor after mouse/native selection changes - thx muaz978
 * Fix change detection not including the original subtitle file name
 * Update Korean translation - thx 12si27
 

--- a/change-log.txt
+++ b/change-log.txt
@@ -1,6 +1,18 @@
 
 Subtitle Edit Changelog
 
+v5.1.0-beta5 (2nd of July 2026)
+
+* Improve performance (waveform rendering, subtitle grid, string utilities, ASSA loading)
+* Fix keyboard shortcuts in "Adjust all times" not working, now moving 1 frame / 10 frames / 1 second - thx KaDeeKe
+* Fix up/down time code and duration stepping in frame mode not wrapping frames correctly - thx KaDeeKe
+* Fix invalid PTS/DTS in exported Blu-ray sup files (broke SupMover negative delay) - thx GCRaistlin/MonoS
+* Fix batch convert forgetting settings when the window is closed via X/Escape - thx MonsterSe7en
+* Fix change detection not including the original subtitle file name
+* Update Korean translation - thx 12si27
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-beta4 (1st of July 2026)
 
 * Add CSV import/export to Multiple replace - thx faon-92

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.1.0-beta4",
+  "version": "v5.1.0-beta5",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-beta4";
+    public static string Version { get; set; } = "v5.1.0-beta5";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
- change-log.txt: new v5.1.0-beta5 section covering everything merged since the beta4 tag (#12064, #12067–#12074)
- Version bumped to v5.1.0-beta5 in Se.cs and English.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)