### PR TITLE
CrispASR: fix MADLAD dead download links and add new model quants

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -4,6 +4,7 @@ Subtitle Edit Changelog
 v5.1.0-beta5 (TBD)
 
 * Add copy/paste support to the time code boxes (a bare number is milliseconds) - thx RobertoHN
+* Speech to text: add smaller model quants for FunASR nano/MLT-nano and Parakeet Japanese, and fix dead MADLAD download links
 * OCR: select the just-downloaded spell-check dictionary on any UI language
 * Spell check: clean up dictionary names with variant suffixes (e.g. de_DE_frami)
 * Fix keyboard shortcuts in "Adjust all times" not working, now moving 1 frame / 10 frames / 1 second - thx KaDeeKe

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrMltNano.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrMltNano.cs
@@ -57,8 +57,26 @@ public class CrispAsrFunAsrMltNano : CrispAsrEngineBase
         {
             new WhisperModel
             {
+                Name = "funasr-mlt-nano-2512-q4_k.gguf",
+                Size = "0.90 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/funasr-mlt-nano-GGUF/resolve/main/funasr-mlt-nano-2512-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "funasr-mlt-nano-2512-q8_0.gguf",
+                Size = "1.27 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/funasr-mlt-nano-GGUF/resolve/main/funasr-mlt-nano-2512-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
                 Name = "funasr-mlt-nano-2512-f16.gguf",
-                Size = "1.84 GB",
+                Size = "1.98 GB",
                 Urls =
                 [
                     "https://huggingface.co/cstr/funasr-mlt-nano-GGUF/resolve/main/funasr-mlt-nano-2512-f16.gguf",

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrNano.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrNano.cs
@@ -31,8 +31,26 @@ public class CrispAsrFunAsrNano : CrispAsrEngineBase
         {
             new WhisperModel
             {
+                Name = "funasr-nano-2512-q4_k.gguf",
+                Size = "0.90 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/funasr-nano-GGUF/resolve/main/funasr-nano-2512-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "funasr-nano-2512-q8_0.gguf",
+                Size = "1.27 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/funasr-nano-GGUF/resolve/main/funasr-nano-2512-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
                 Name = "funasr-nano-2512-f16.gguf",
-                Size = "1.84 GB",
+                Size = "1.98 GB",
                 Urls =
                 [
                     "https://huggingface.co/cstr/funasr-nano-GGUF/resolve/main/funasr-nano-2512-f16.gguf",

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMadlad.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMadlad.cs
@@ -27,31 +27,15 @@ public class CrispAsrMadlad : CrispAsrEngineBase
     public override List<WhisperModel> Models =>
        new()
        {
+            // Only the q4_k quant is published upstream now - the q8_0/f16 files were
+            // removed from the Hugging Face repo, so offering them would just 404.
             new WhisperModel
             {
                 Name = "madlad400-3b-mt-q4_k.gguf",
-                Size = "1.8 GB",
+                Size = "2.04 GB",
                 Urls =
                 [
                     "https://huggingface.co/cstr/madlad400-3b-mt-GGUF/resolve/main/madlad400-3b-mt-q4_k.gguf",
-                ],
-            },
-            new WhisperModel
-            {
-                Name = "madlad400-3b-mt-q8_0.gguf",
-                Size = "3.1 GB",
-                Urls =
-                [
-                    "https://huggingface.co/cstr/madlad400-3b-mt-GGUF/resolve/main/madlad400-3b-mt-q8_0.gguf",
-                ],
-            },
-            new WhisperModel
-            {
-                Name = "madlad400-3b-mt-f16.gguf",
-                Size = "5.7 GB",
-                Urls =
-                [
-                    "https://huggingface.co/cstr/madlad400-3b-mt-GGUF/resolve/main/madlad400-3b-mt-f16.gguf",
                 ],
             },
        };

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -77,6 +77,15 @@ public class CrispAsrParakeet : CrispAsrEngineBase
             },
             new WhisperModel
             {
+                Name = "parakeet-tdt-0.6b-ja-q4_k.gguf",
+                Size = "470 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt-0.6b-ja-GGUF/resolve/main/parakeet-tdt-0.6b-ja-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
                 Name = "parakeet-tdt-0.6b-ja.gguf",
                 Size = "1.24 GB",
                 Urls =


### PR DESCRIPTION
From an audit of all 21 `cstr/*-GGUF` Hugging Face repos referenced by the CrispASR engines (file lists + sizes via the HF API, every URL HEAD-verified):

### Fixed
- **MADLAD-400**: `madlad400-3b-mt-q8_0.gguf` and `madlad400-3b-mt-f16.gguf` were deleted upstream — those two download options 404'ed. Only the q4_k quant (2.04 GB) is published now, so the list is reduced to that.

### New quants added (published upstream since the engines were added)
- `funasr-nano-2512` q4_k (0.90 GB) and q8_0 (1.27 GB) — previously f16 only
- `funasr-mlt-nano-2512` q4_k (0.90 GB) and q8_0 (1.27 GB) — previously f16 only
- `parakeet-tdt-0.6b-ja` q4_k (470 MB) — previously full precision only

### Deliberately unchanged
- `qwen3-forced-aligner-0.6b` gained q4_k/q5_0/f16 quants upstream, but it's the internal aligner model (not a user-facing size choice) — kept at q8_0 for alignment accuracy.
- `firered-vad`: new `firered-aed-vad`/`firered-stream-vad` variants exist, but the current pairing (`firered-vad.gguf`) is unchanged upstream.

All other referenced files resolve fine. SE ships CrispASR v0.8.6, which is the latest upstream release. All 512 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)